### PR TITLE
refactor(frontend): use line break instead of comma for separating addresses

### DIFF
--- a/frontend/apps/desktop/src/models/contacts.ts
+++ b/frontend/apps/desktop/src/models/contacts.ts
@@ -90,7 +90,7 @@ export function useConnectPeer(
         }
       }
       if (!addrs) {
-        addrs = peer.trim().split(',')
+        addrs = peer.trim().split(/(?:,|\s|\n)+/) // Split by comma, space, or newline
       }
       if (!addrs) throw new Error('Invalid peer address(es) provided.')
       await grpcClient.networking.connect({addrs})

--- a/frontend/apps/desktop/src/pages/settings.tsx
+++ b/frontend/apps/desktop/src/pages/settings.tsx
@@ -878,7 +878,7 @@ function AppSettings() {
   }
   const {data: deviceInfo} = useDaemonInfo()
   const peer = usePeerInfo(deviceInfo?.peerId)
-  const addrs = peer.data?.addrs?.join(',')
+  const addrs = peer.data?.addrs?.join('\n')
   return (
     <YStack gap="$5">
       <TableList>
@@ -891,17 +891,18 @@ function AppSettings() {
                   size="$2"
                   icon={Copy}
                   onPress={() => {
-                    copyTextToClipboard(addrs)
+                    navigator.clipboard.writeText(addrs)
                     toast.success('Copied Routing Address successfully')
                   }}
                 >
-                  Copy Routing Address
+                  Copy Addresses
                 </Button>
               </Tooltip>
             ) : null
           }
         />
         <InfoListItem label="Peer ID" value={deviceInfo?.peerId} />
+        <InfoListItem label="Addresses" value={addrs} />
       </TableList>
       <TableList>
         <InfoListHeader title="Settings" />


### PR DESCRIPTION
This PR fixes some minor itches of my own, so feel free to ignore it, if there's anything wrong with it.

I figured that I could do it myself quite easily, instead of explaining what I want :)

I changed the way we copy addresses, and now, instead of being comma-separated they are newline-separated, which looks much nicer on the eyes when you paste them in Discord or elsewhere.

I didn't use the `copy-text-to-clipboard` NPM package that we use everywhere else, because it breaks the newlines and doesn't respect them properly when you paste the text.

Instead, I used the standard Web Clipboard API, which is now [stable in most major browsers](https://caniuse.com/mdn-api_clipboard_writetext) (and we only care about Chrome with Electron anyway). Maybe we should use this API everywhere else, because the `copy-text-to-clipboard` is [probably not needed anymore](https://github.com/sindresorhus/copy-text-to-clipboard/issues/35#issuecomment-1490789051).

I also exposed the addresses in the settings screen, which is nice to be able to debug any relay connectivity issues, to see if you actually have relay addresses or not. Feel free to remove that if it doesn't fit our product design ideas. I also, wanted to disable soft-wrapping in for this list of addresses (I think it's nicer to see each addresses cleanly on its own line, and they can get quite long), but I couldn't find a way to do it with Tamagui. 

The last thing I did is to adapt the "Add Connection" input to accept this new format of addresses. It will support multiple types of separators (just in case), which are a comma, a line break, and a space. So whichever of these separators it finds, it will split on it.
