### PR TITLE
Remove syncing channels

### DIFF
--- a/backend/api/activity/v1alpha/activity.go
+++ b/backend/api/activity/v1alpha/activity.go
@@ -51,6 +51,8 @@ func NewServer(db *sqlitex.Pool, log *zap.Logger, clean *cleanup.Stack) *Server 
 	}
 }
 
+// SetSyncer includes the syncer into the server in case it
+// was not available during initialization.
 func (srv *Server) SetSyncer(sync syncer) {
 	srv.syncer = sync
 }

--- a/backend/daemon/daemon.go
+++ b/backend/daemon/daemon.go
@@ -168,7 +168,7 @@ func Load(ctx context.Context, cfg config.Config, r Storage, oo ...Option) (a *A
 	if err != nil {
 		return nil, err
 	}
-
+	activitySrv.SetSyncer(a.Syncing)
 	a.Wallet = wallet.New(ctx, logging.New("seed/wallet", cfg.LogLevel), a.Storage.DB(), a.Storage.KeyStore(), "main", a.Net, cfg.Lndhub.Mainnet)
 
 	a.GRPCServer, a.GRPCListener, a.RPC, err = initGRPC(ctx, cfg.GRPC.Port, &a.clean, a.g, a.Storage, a.Storage.DB(), a.Net,

--- a/backend/syncing/syncing.go
+++ b/backend/syncing/syncing.go
@@ -736,15 +736,6 @@ func syncPeerRbsr(
 		return fmt.Errorf("Failed to Init Syncing Session: %w", err)
 	}
 
-	var qListBlobs = dqb.Str(`
-		SELECT
-			blobs.codec,
-			blobs.multihash,
-			blobs.insert_time
-		FROM blobs INDEXED BY blobs_metadata LEFT JOIN structural_blobs sb ON sb.id = blobs.id
-		WHERE blobs.size >= 0 
-		ORDER BY sb.ts, blobs.multihash;
-	`)
 	conn, release, err := db.Conn(ctx)
 	if err != nil {
 		return fmt.Errorf("Could not get connection: %w", err)
@@ -891,3 +882,13 @@ var qSaveCursor = dqb.Str(`
 		:cursor
 	);
 `)
+
+var qListBlobs = dqb.Str(`
+		SELECT
+			blobs.codec,
+			blobs.multihash,
+			blobs.insert_time
+		FROM blobs INDEXED BY blobs_metadata LEFT JOIN structural_blobs sb ON sb.id = blobs.id
+		WHERE blobs.size >= 0 
+		ORDER BY sb.ts, blobs.multihash;
+	`)

--- a/backend/syncing/worker.go
+++ b/backend/syncing/worker.go
@@ -197,6 +197,7 @@ func (sw *worker) sync(ctx context.Context) {
 			sw.log.Warn("Failed to list subscriptions in smart syncing", zap.Error(err))
 			return
 		}
+		sw.log.Debug("Periodic subscription update", zap.Int("Number of subscriptions to update", len(ret.Subscriptions)))
 		if len(ret.Subscriptions) == 0 {
 			return
 		}


### PR DESCRIPTION
Another "gotcha" with this approach of doing event-based code is that this channel can (or must) only be read by one reader.

If multiple goroutines call GetSubsEventCh or GetSubsSyncEventCh first of all there will be a data race, because srv.subsCh gets read and written inside of those methods with no synchronization.

And secondly the same channel will be shared between multiple goroutines, hence none of the goroutines will get all the data, because data will be shared arbitrarily among them.

Normally the caller creates the channel and passes it to the "event producer". See how https://pkg.go.dev/os/signal#Notify is implemented.

I'm not entirely sure why we are doing this event-based code because I didn't look at it more deeply, but I hope those subscription methods are not used from multiple goroutines because there will be troubles (unless I'm terribly wrong about my above assumptions, which I might be, but I'm 99% I'm not).
Actually running tests with race detector enabled (go test -race ./backend/...) shows data races in subscription-related code.