### PR TITLE
Fix: Fallback to using IDs instead of saying 'Unititled Document'

### DIFF
--- a/frontend/apps/desktop/src/pages/contacts-page.tsx
+++ b/frontend/apps/desktop/src/pages/contacts-page.tsx
@@ -5,7 +5,7 @@ import {useListProfileDocuments} from '@/models/documents'
 import {useEntities} from '@/models/entities'
 import {useNavigate} from '@/utils/useNavigate'
 import {PlainMessage} from '@bufbuild/protobuf'
-import {DocumentListItem, getMetadataName, hmId} from '@shm/shared'
+import {DocumentListItem, getAccountName, hmId} from '@shm/shared'
 import {
   Button,
   Container,
@@ -137,8 +137,7 @@ function ContactListItem({entry}: {entry: PlainMessage<DocumentListItem>}) {
               whiteSpace="nowrap"
               overflow="hidden"
             >
-              {getMetadataName(entry.metadata) ||
-                `${entry.account.slice(0, 5)}...${entry.account.slice(-5)}`}
+              {getAccountName(entry)}
             </SizableText>
           </XStack>
         </YStack>

--- a/frontend/packages/shared/src/content.ts
+++ b/frontend/packages/shared/src/content.ts
@@ -32,7 +32,7 @@ export function clipContentBlocks(
 }
 
 export function getDocumentTitle(document?: HMDocument | null) {
-  return getMetadataName(document?.metadata)
+  return document?.metadata?.name || document?.account! + document?.path!
 }
 
 export function getMetadataName(metadata?: HMDocument['metadata'] | null) {
@@ -40,5 +40,5 @@ export function getMetadataName(metadata?: HMDocument['metadata'] | null) {
 }
 
 export function getAccountName(profile: HMDocument | null | undefined) {
-  return profile?.metadata?.name || 'Untitled Account'
+  return profile?.metadata?.name || profile?.account
 }


### PR DESCRIPTION
On the contacts page it says 'Untitled Document' (not 'Untitled Account' btw, for which I also have seen a function available). I changed to fall back to using IDs instead of this, because it's impossible to distinguish dozens of 'Untitled Documents' from one another.

Before:

<img width="1512" alt="Screenshot 2024-09-10 at 18 31 32" src="https://github.com/user-attachments/assets/a04c6272-8cab-48e2-bf60-9cc61190d149">

After:

<img width="1514" alt="Screenshot 2024-09-10 at 18 30 22" src="https://github.com/user-attachments/assets/37a3bc08-6f5b-4ecc-82d8-87b479a746e2">

We could truncate the IDs, but they seem to be short-enough to be shown in full.

