### PR TITLE
Improve FTS performance

### DIFF
--- a/backend/blob/index_sql.go
+++ b/backend/blob/index_sql.go
@@ -62,17 +62,98 @@ func dbFTSInsertOrReplace(conn *sqlite.Conn, FTSContent, FTSType string, FTSBlob
 		return nil
 	}
 
-	err := sqlitegen.ExecStmt(conn, qFTSInsertOrReplace(), before, onStep)
+	err := sqlitegen.ExecStmt(conn, qFTSInsert(), before, onStep)
 	if err != nil {
-		err = fmt.Errorf("failed query: FTSInsertOrReplace: %w", err)
+		err = fmt.Errorf("failed query: FTSInsert: %w", err)
+	}
+
+	before = func(stmt *sqlite.Stmt) {
+		stmt.SetText(":FTSType", FTSType)
+		stmt.SetInt64(":FTSBlobID", FTSBlobID)
+		stmt.SetText(":FTSBlockID", FTSBlockID)
+		stmt.SetText(":FTSVersion", FTSVersion)
+		stmt.SetText(":FTSRowID", "last_insert_rowid()")
+	}
+
+	err = sqlitegen.ExecStmt(conn, qFTSIndexInsert(), before, onStep)
+	if err != nil {
+		err = fmt.Errorf("failed query: FTSCheck: %w", err)
+	}
+
+	before = func(stmt *sqlite.Stmt) {
+		stmt.SetText(":FTSType", FTSType)
+		stmt.SetInt64(":FTSBlobID", FTSBlobID)
+		stmt.SetText(":FTSBlockID", FTSBlockID)
+	}
+	rowsToUpdate := []int64{}
+	onStep = func(_ int, stmt *sqlite.Stmt) error {
+		rowsToUpdate = append(rowsToUpdate, stmt.ColumnInt64(0))
+		return nil
+	}
+
+	err = sqlitegen.ExecStmt(conn, qFTSCheck(), before, onStep)
+	if err != nil {
+		err = fmt.Errorf("failed query: FTSCheck: %w", err)
+	}
+
+	var idx int = 0
+	if len(rowsToUpdate) > 0 {
+		before := func(stmt *sqlite.Stmt) {
+			stmt.SetInt64(":FTSBlobID", FTSBlobID)
+			stmt.SetInt64(":FTSRowID", rowsToUpdate[idx])
+			stmt.SetText(":FTSVersion", FTSVersion)
+			idx++
+		}
+
+		onStep := func(_ int, _ *sqlite.Stmt) error {
+			return nil
+		}
+		err = sqlitegen.ExecStmt(conn, qFTSUpdate(), before, onStep)
+		if err != nil {
+			err = fmt.Errorf("failed query: FTSUpdate: %w", err)
+		}
 	}
 
 	return err
 }
 
-var qFTSInsertOrReplace = dqb.Str(`
+var qFTSCheck = dqb.Str(`
+    SELECT
+		rowid
+    FROM fts_index
+	 WHERE
+      block_id != :FTSBlockID
+      AND type      = :FTSType
+      AND blob_id  < :FTSBlobID
+      AND blob_id IN (
+        SELECT id
+        FROM structural_blobs
+        WHERE genesis_blob = IFNULL(
+          (SELECT genesis_blob
+             FROM structural_blobs
+            WHERE id = :FTSBlobID),
+          :FTSBlobID
+        )
+      )
+`)
+
+var qFTSUpdate = dqb.Str(`
+    UPDATE fts
+    SET
+      blob_id = :FTSBlobID,
+      version = :FTSVersion
+    WHERE
+      rowid = :FTSRowID
+`)
+
+var qFTSInsert = dqb.Str(`
 	INSERT OR REPLACE INTO fts(raw_content, type, blob_id, block_id, version)
 	VALUES (:FTSContent, :FTSType, :FTSBlobID, :FTSBlockID, :FTSVersion)
+`)
+
+var qFTSIndexInsert = dqb.Str(`
+	INSERT OR REPLACE INTO fts_index(rowid, type, blob_id, block_id, version)
+	VALUES (:FTSRowID, :FTSType, :FTSBlobID, :FTSBlockID, :FTSVersion)
 `)
 
 func dbResourceLinksInsert(conn *sqlite.Conn, sourceBlob, targetResource int64, ltype string, isPinned bool, meta []byte) error {

--- a/backend/storage/schema.gen.go
+++ b/backend/storage/schema.gen.go
@@ -192,6 +192,26 @@ const (
 	C_FtsIdxTerm  = "fts_idx.term"
 )
 
+// Table fts_index.
+const (
+	FtsIndex        sqlitegen.Table  = "fts_index"
+	FtsIndexBlobID  sqlitegen.Column = "fts_index.blob_id"
+	FtsIndexBlockID sqlitegen.Column = "fts_index.block_id"
+	FtsIndexRowid   sqlitegen.Column = "fts_index.rowid"
+	FtsIndexType    sqlitegen.Column = "fts_index.type"
+	FtsIndexVersion sqlitegen.Column = "fts_index.version"
+)
+
+// Table fts_index. Plain strings.
+const (
+	T_FtsIndex        = "fts_index"
+	C_FtsIndexBlobID  = "fts_index.blob_id"
+	C_FtsIndexBlockID = "fts_index.block_id"
+	C_FtsIndexRowid   = "fts_index.rowid"
+	C_FtsIndexType    = "fts_index.type"
+	C_FtsIndexVersion = "fts_index.version"
+)
+
 // Table kv.
 const (
 	KV      sqlitegen.Table  = "kv"
@@ -465,6 +485,11 @@ var Schema = sqlitegen.Schema{
 		FtsIdxPgno:                              {Table: FtsIdx, SQLType: ""},
 		FtsIdxSegid:                             {Table: FtsIdx, SQLType: ""},
 		FtsIdxTerm:                              {Table: FtsIdx, SQLType: ""},
+		FtsIndexBlobID:                          {Table: FtsIndex, SQLType: "INTEGER"},
+		FtsIndexBlockID:                         {Table: FtsIndex, SQLType: "TEXT"},
+		FtsIndexRowid:                           {Table: FtsIndex, SQLType: "INTEGER"},
+		FtsIndexType:                            {Table: FtsIndex, SQLType: "TEXT"},
+		FtsIndexVersion:                         {Table: FtsIndex, SQLType: "TEXT"},
 		KVKey:                                   {Table: KV, SQLType: "TEXT"},
 		KVValue:                                 {Table: KV, SQLType: "TEXT"},
 		PeersAddresses:                          {Table: Peers, SQLType: "TEXT"},

--- a/backend/storage/schema.gensum
+++ b/backend/storage/schema.gensum
@@ -1,2 +1,2 @@
-srcs: 3e847f4ca9932d49f9160b7910a95dde
-outs: bda9b3b63786ee38492a2e74233aaebd
+srcs: 70dd9430680de2518d12be2edcd1ae6e
+outs: e0dbe662c3fc273ebe634f179b7f756b


### PR DESCRIPTION
Now we precompute the most expensive data (updating the latest version where a match has been seen) when indexing. 
Indexing overhead is unnoticeable from before due to a creation of a new indexed table. This was necessary because the fts table is a virtual table and we could not create the necessary indexes to speed up the query, leading to large reindexing times. 
Precomputing the information needed unburden the search engine with excessive computation work, which should alleviate server requirements