### PR TITLE
Add login confirmation email template

### DIFF
--- a/frontend/apps/emails/.gitignore
+++ b/frontend/apps/emails/.gitignore
@@ -1,0 +1,1 @@
+*-preview.html

--- a/frontend/apps/emails/email-confirmation.tsx
+++ b/frontend/apps/emails/email-confirmation.tsx
@@ -1,0 +1,109 @@
+import {
+  Mjml,
+  MjmlBody,
+  MjmlButton,
+  MjmlColumn,
+  MjmlHead,
+  MjmlImage,
+  MjmlPreview,
+  MjmlSection,
+  MjmlText,
+  MjmlTitle,
+} from '@faire/mjml-react'
+import {renderReactToMjml} from './notifier'
+
+export type LoginConfirmationEmailProps = {
+  loginUrl: string
+}
+
+export function createLoginConfirmationEmail({
+  loginUrl,
+}: LoginConfirmationEmailProps) {
+  const subject = 'Your login link for Seed Hypermedia'
+  const text = `Your login link for Seed Hypermedia
+
+Click the link below to log in:
+${loginUrl}
+
+This link will expire in 15 minutes. If you didn't request this, you can safely ignore this email.
+
+Seed Hypermedia`
+
+  const {html} = renderReactToMjml(
+    <Mjml>
+      <MjmlHead>
+        <MjmlTitle>{subject}</MjmlTitle>
+        <MjmlPreview>Click to log in to Seed Hypermedia</MjmlPreview>
+      </MjmlHead>
+      <MjmlBody width={500} backgroundColor="#f4f4f5">
+        <MjmlSection padding="40px 0 20px">
+          <MjmlColumn>
+            <MjmlImage
+              src="https://iili.io/FJ0pBl1.png"
+              alt="Seed Logo"
+              width="24px"
+              height="30px"
+              padding="0"
+              align="center"
+            />
+            <MjmlText
+              fontSize="18px"
+              fontWeight="bold"
+              color="#068f7b"
+              padding="10px 0 0"
+              align="center"
+            >
+              Seed Hypermedia
+            </MjmlText>
+          </MjmlColumn>
+        </MjmlSection>
+
+        <MjmlSection
+          backgroundColor="#ffffff"
+          borderRadius="8px"
+          padding="32px 24px"
+        >
+          <MjmlColumn>
+            <MjmlText
+              fontSize="24px"
+              fontWeight="bold"
+              color="#1a1a1a"
+              padding="0 0 24px"
+            >
+              Your login link
+            </MjmlText>
+
+            <MjmlButton
+              href={loginUrl}
+              backgroundColor="#068f7b"
+              color="#ffffff"
+              fontSize="16px"
+              fontWeight="600"
+              borderRadius="6px"
+              padding="0 0 24px"
+              innerPadding="14px 28px"
+              align="left"
+            >
+              Log in to Seed Hypermedia
+            </MjmlButton>
+
+            <MjmlText fontSize="14px" color="#71717a" lineHeight="1.5" padding="0">
+              This link will expire in 15 minutes. If you didn't request this,
+              you can safely ignore this email.
+            </MjmlText>
+          </MjmlColumn>
+        </MjmlSection>
+
+        <MjmlSection padding="24px 0">
+          <MjmlColumn>
+            <MjmlText fontSize="12px" color="#a1a1aa" align="center">
+              Seed Hypermedia
+            </MjmlText>
+          </MjmlColumn>
+        </MjmlSection>
+      </MjmlBody>
+    </Mjml>,
+  )
+
+  return {subject, text, html}
+}

--- a/frontend/apps/emails/package.json
+++ b/frontend/apps/emails/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "main": "render.ts",
   "scripts": {
-    "render": "tsx render.tsx"
+    "render": "tsx render.tsx",
+    "render:login": "tsx render-login.tsx"
   },
   "dependencies": {
     "@faire/mjml-react": "^3.5.0",

--- a/frontend/apps/emails/render-email-config.tsx
+++ b/frontend/apps/emails/render-email-config.tsx
@@ -1,0 +1,14 @@
+import fs from 'fs'
+import {createLoginConfirmationEmail} from './email-confirmation'
+
+const {html, text, subject} = createLoginConfirmationEmail({
+  loginUrl: 'https://example.com/login?token=abc123xyz',
+})
+
+// Write HTML to file for preview in browser
+fs.writeFileSync('./login-preview.html', html)
+
+console.log('Subject:', subject)
+console.log('\nPlain text version:')
+console.log(text)
+console.log('\n✅ HTML preview written to login-preview.html')

--- a/frontend/apps/emails/sender.tsx
+++ b/frontend/apps/emails/sender.tsx
@@ -1,4 +1,8 @@
 import nodemailer from 'nodemailer'
+import {
+  createLoginConfirmationEmail,
+  LoginConfirmationEmailProps,
+} from './email-confirmation'
 import {createNotificationsEmail, FullNotification} from './notifier'
 
 const transporter = nodemailer.createTransport({
@@ -54,4 +58,12 @@ export const sendNotificationsEmail = async (
     {text, html},
     `Hypermedia Updates for ${Array.from(subscriberNames).join(', ')}`,
   )
+}
+
+export const sendLoginConfirmationEmail = async (
+  email: string,
+  props: LoginConfirmationEmailProps,
+) => {
+  const {subject, text, html} = createLoginConfirmationEmail(props)
+  await sendEmail(email, subject, {text, html}, 'Seed Hypermedia')
 }


### PR DESCRIPTION
Add new email template for signup/login confirmation emails.

Includes responsive MJML-based template with Seed Hypermedia branding, login button, and disclaimer text. Adds `sendLoginConfirmationEmail` function to sender for easy integration. Template accepts a `loginUrl` parameter and generates both HTML and plain text versions.

Test the template with: `yarn workspace @shm/emails render:login`