### PR TITLE
Add import option to create doc button

### DIFF
--- a/frontend/apps/desktop/src/components/import-doc-button.tsx
+++ b/frontend/apps/desktop/src/components/import-doc-button.tsx
@@ -71,7 +71,7 @@ export function ImportDialog({
 }) {
   return (
     <>
-      <DialogTitle>Import Documents</DialogTitle>
+      <DialogTitle>Import Content</DialogTitle>
       <DialogDescription>
         Import Markdown or LaTeX files, folders, or websites.
       </DialogDescription>


### PR DESCRIPTION
## Summary
- Always show dropdown on create button
- Add "Import..." menu item that opens import dialog
- Dialog title updated to "Import Content"
- Reuse useImporting hook for all import actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)