### PR TITLE
Render unsupported blocks instead of crashing

### DIFF
--- a/frontend/packages/shared/src/client/hmblock-to-editorblock.ts
+++ b/frontend/packages/shared/src/client/hmblock-to-editorblock.ts
@@ -84,10 +84,10 @@ export function hmBlocksToEditorContent(
     .filter((block): block is EditorBlock => block !== null)
 }
 
-export function hmBlockToEditorBlock(block: HMBlock): EditorBlock {
+export function hmBlockToEditorBlock(block: HMBlock): EditorBlock | null {
   const blockType = toEditorBlockType(block.type)
 
-  if (!blockType) throw new Error('Unsupported block type ' + block.type)
+  if (!blockType) return null
 
   let out: EditorBlock = {
     id: block.id,

--- a/frontend/packages/shared/src/hm-types.ts
+++ b/frontend/packages/shared/src/hm-types.ts
@@ -1133,7 +1133,12 @@ export const HMBlockKnownSchema = z.discriminatedUnion('type', [
 export const HMBlockUnknownSchema = z
   .object({
     type: z.string(),
-    ...blockBaseProperties,
+    id: z.string(),
+    revision: z.string().optional(),
+    attributes: z.record(z.any()).optional(),
+    annotations: z.array(z.any()).optional(),
+    text: z.string().optional(),
+    link: z.string().optional(),
   })
   .passthrough()
 

--- a/frontend/packages/ui/src/blocks-content.tsx
+++ b/frontend/packages/ui/src/blocks-content.tsx
@@ -1109,7 +1109,7 @@ function BlockContentParagraph({
 
   let inline = useMemo(() => {
     const editorBlock = hmBlockToEditorBlock(block)
-    return editorBlock.content
+    return editorBlock?.content ?? []
   }, [block])
   return (
     <Text
@@ -1136,7 +1136,10 @@ export function BlockContentHeading({
   ...props
 }: BlockContentProps<HMBlockHeading>) {
   const {debug} = useBlocksContentContext()
-  let inline = useMemo(() => hmBlockToEditorBlock(block).content, [block])
+  let inline = useMemo(
+    () => hmBlockToEditorBlock(block)?.content ?? [],
+    [block],
+  )
 
   return (
     <SeedHeading
@@ -1176,7 +1179,10 @@ function BlockContentImage({
   parentBlockId,
   ...props
 }: BlockContentProps<HMBlockImage>) {
-  let inline = useMemo(() => hmBlockToEditorBlock(block).content, [block])
+  let inline = useMemo(
+    () => hmBlockToEditorBlock(block)?.content ?? [],
+    [block],
+  )
   const {textUnit} = useBlocksContentContext()
   const imageUrl = useImageUrl()
   const [modalState, setModalState] = useState<'closed' | 'opening' | 'open'>(
@@ -1331,7 +1337,10 @@ function BlockContentVideo({
   parentBlockId,
   ...props
 }: BlockContentProps<HMBlockVideo>) {
-  let inline = useMemo(() => hmBlockToEditorBlock(block).content, [block])
+  let inline = useMemo(
+    () => hmBlockToEditorBlock(block)?.content ?? [],
+    [block],
+  )
   const link = block.link || ''
   const {textUnit} = useBlocksContentContext()
   const fileUrl = useFileUrl()
@@ -2280,9 +2289,9 @@ function BlockContentQuery({block}: {block: HMBlockQuery}) {
 }
 
 export function BlockContentUnknown(props: BlockContentProps<HMBlock>) {
-  let message = 'Unrecognized Block'
+  let message = `Unsupported Block: ${props.block.type}`
   if (props.block.type == 'Embed') {
-    message = `Unrecognized Embed: ${props.block.link}`
+    message = `Unsupported Embed: ${props.block.link}`
   }
   return <ErrorBlock message={message} debugData={props.block} />
 }


### PR DESCRIPTION
## Summary
- Unknown block types now render gracefully instead of crashing
- Modified schema to accept arbitrary text/attributes in unknown blocks
- Updated error UI to show "Unsupported Block" with collapsible raw data view

## Implementation
Changed `hmBlockToEditorBlock` to return null for unknown types, made `HMBlockUnknownSchema` more permissive, and updated error messages for clarity.

Now if there's a block that is not supported, instead of breaking the whole document we show this:
<img width="789" height="138" alt="Screenshot 2026-01-23 at 11 36 17" src="https://github.com/user-attachments/assets/542754ab-b923-44ba-8a2a-43436b2f5498" />
