### PR TITLE
Make DocumentTools sticky in document page

### DIFF
--- a/frontend/packages/ui/src/document-tools.tsx
+++ b/frontend/packages/ui/src/document-tools.tsx
@@ -135,7 +135,7 @@ export function DocumentTools({
     },
   ]
   return (
-    <div className="flex w-full shrink-0 py-4">
+    <div className="flex w-full shrink-0">
       {/* Left spacer to balance the right actions */}
       {rightActions ? (
         <div style={{width: rightActionsWidth}} className="shrink-0" />
@@ -179,10 +179,7 @@ export function DocumentTools({
         ))}
       </div>
       {rightActions ? (
-        <div
-          ref={rightActionsRef}
-          className="flex shrink-0 items-center gap-2 p-1 md:gap-4 md:p-2"
-        >
+        <div ref={rightActionsRef} className="flex shrink-0 items-center px-4">
           {rightActions}
         </div>
       ) : null}


### PR DESCRIPTION
Implements sticky DocumentTools with smart button positioning. The toolbar sticks to the top while scrolling, with edit buttons transitioning from floating (top-right) to integrated (toolbar right-side) when the tools become sticky. Uses IntersectionObserver to detect sticky state.

- Document tools now remain visible while scrolling
- Edit buttons automatically move into toolbar when sticky
- Prevents collision between floating buttons and sticky toolbar
- Smooth transitions between states


https://github.com/user-attachments/assets/3f3375c2-636b-465b-a804-ee88f14e8daf

