### PR TITLE
fix: remove double titlebar on error page

### DIFF
--- a/frontend/apps/desktop/src/pages/main.tsx
+++ b/frontend/apps/desktop/src/pages/main.tsx
@@ -37,7 +37,7 @@ import {
   Panel,
   PanelGroup,
 } from 'react-resizable-panels'
-import {AppErrorPage} from '../components/app-error'
+import {AppErrorPage, RootAppError} from '../components/app-error'
 import {AutoUpdater} from '../components/auto-updater'
 import Footer from '../components/footer'
 import {HypermediaHighlight} from '../components/hypermedia-highlight'
@@ -129,7 +129,7 @@ export default function Main({className}: {className?: string}) {
           <Panel id="page" order={2} className="pl-1">
             <ErrorBoundary
               key={routeKey}
-              FallbackComponent={AppErrorPage}
+              FallbackComponent={RootAppError}
               onReset={() => {
                 window.location.reload()
               }}


### PR DESCRIPTION
## Summary
- Use `RootAppError` instead of `AppErrorPage` for inner ErrorBoundary in main window
- Fixes double titlebar when errors occur since main `TitleBar` renders outside ErrorBoundary

Fixes SHM-2042

## Test plan
- [x] Add `throw new Error('test')` to a page component (e.g., library.tsx)
- [x] Verify only one titlebar appears when error page shows
- [x] yarn typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)