### PR TITLE
fix(web): enable scrolling in discussions and feed panels

### DIFF
--- a/frontend/packages/ui/src/accessories.tsx
+++ b/frontend/packages/ui/src/accessories.tsx
@@ -57,7 +57,10 @@ export function SelectionContent({
   )
 
   return (
-    <div className="flex h-full flex-1 flex-col overflow-hidden" {...props}>
+    <div
+      className="scroll-area-full-height flex h-full flex-1 flex-col overflow-hidden"
+      {...props}
+    >
       <ScrollArea ref={scrollRef}>
         {header ? (
           <div


### PR DESCRIPTION
## Summary
- Add `scroll-area-full-height` class to `SelectionContent` wrapper in `accessories.tsx`
- This CSS class was already defined in `tailwind.css` but never applied
- Fixes ScrollArea viewport lacking explicit height constraints needed for Radix UI scrolling

## Root Cause
The Radix UI ScrollArea requires explicit height constraints on its viewport. Without `height: 100%`, the viewport expands to fit all content, disabling native scrolling.

Fixes SHM-2096

## Test plan
- [ ] Open a discussions panel on web (e.g., `/:discussions`)
- [ ] Hover cursor over a comment
- [ ] Verify scrolling works with mouse wheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)