### PR TITLE
fix: sidebar items now take full container width

### DIFF
--- a/frontend/apps/desktop/src/components/sidebar-base.tsx
+++ b/frontend/apps/desktop/src/components/sidebar-base.tsx
@@ -148,7 +148,7 @@ export function GenericSidebarContainer({
         <div
           ref={panelContentRef}
           className={cn(
-            `flex h-full w-full flex-col pr-1 transition-all duration-200 ease-in-out`,
+            `flex h-full w-full flex-col transition-all duration-200 ease-in-out`,
             isLocked
               ? 'relative'
               : 'border-border bg-background absolute z-[51] rounded-tr-lg rounded-br-lg border shadow-lg dark:bg-black',
@@ -169,7 +169,7 @@ export function GenericSidebarContainer({
           <div
             className={cn(
               'flex-1 overflow-y-auto pb-8',
-              isLocked ? '' : 'py-2 pr-1',
+              isLocked ? '' : 'py-2',
             )}
           >
             {children}

--- a/frontend/packages/ui/src/list-item.tsx
+++ b/frontend/packages/ui/src/list-item.tsx
@@ -124,25 +124,27 @@ export function SmallListItem({
         ) : null}
         {children}
 
-        <div className="flex flex-1 items-center gap-1.5 overflow-hidden">
-          <SizableText
-            size="sm"
-            className={cn(
-              `${
-                multiline ? 'line-clamp-2' : 'truncate whitespace-nowrap'
-              } mobile-menu-item-label text-left select-none`.trim(),
-              bold && 'font-bold',
-              textClass,
-            )}
-            style={{
-              color: typeof color === 'string' ? color : undefined,
-            }}
-          >
-            {title}
-          </SizableText>
-          {isDraft ? <DraftBadge /> : null}
-          {accessory}
-        </div>
+        {title || isDraft || accessory ? (
+          <div className="flex flex-1 items-center gap-1.5 overflow-hidden">
+            <SizableText
+              size="sm"
+              className={cn(
+                `${
+                  multiline ? 'line-clamp-2' : 'truncate whitespace-nowrap'
+                } mobile-menu-item-label text-left select-none`.trim(),
+                bold && 'font-bold',
+                textClass,
+              )}
+              style={{
+                color: typeof color === 'string' ? color : undefined,
+              }}
+            >
+              {title}
+            </SizableText>
+            {isDraft ? <DraftBadge /> : null}
+            {accessory}
+          </div>
+        ) : null}
       </div>
       {isCollapsed != null ? (
         <Button


### PR DESCRIPTION
## Summary
- Remove `pr-1` padding from sidebar container that was creating gap on right side
- Conditionally render title wrapper in `SmallListItem` only when `title`, `isDraft`, or `accessory` props are present
- Fixes issue where items with custom children (like SubscriptionListItem) competed for space with empty title div

## Test plan
- [ ] Open desktop app and verify sidebar items extend to full width
- [ ] Verify subscription items show full text without unnecessary truncation
- [ ] Verify items with activity summary display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)