### PR TITLE
chore: remove format/typecheck/test from build-desktop

### DIFF
--- a/dev
+++ b/dev
@@ -128,10 +128,6 @@ def main():
             os.environ["REACT_PROFILER"] = "1"
             args = [a for a in args if a != "--profiler"]
 
-        run("pnpm format:write")
-        run("pnpm typecheck")
-        run("pnpm test")
-
         env_prefix = "VITE_DESKTOP_APPDATA=Seed-local SHOW_OB_RESET_BTN=0 VITE_SEED_HOST_URL=https://host.seed.hyper.media"
         if os.environ.get("REACT_PROFILER"):
             env_prefix = f"REACT_PROFILER=1 {env_prefix}"


### PR DESCRIPTION
## Summary
- Remove format:write, typecheck, and test steps from `./dev build-desktop`
- These steps slow down local builds and can be run separately when needed

## Test plan
- [x] Run `./dev build-desktop` and verify it skips directly to building

🤖 Generated with [Claude Code](https://claude.com/claude-code)