### PR TITLE
fix: properly serialize targetId in citation/change/capability APIs

### DIFF
--- a/frontend/packages/shared/src/api-capabilities.ts
+++ b/frontend/packages/shared/src/api-capabilities.ts
@@ -1,7 +1,8 @@
-import {HMRequestImplementation} from './api-types'
+import {HMRequestImplementation, HMRequestParams} from './api-types'
 import {BIG_INT} from './constants'
 import {GRPCClient} from './grpc-client'
 import {HMListCapabilitiesRequest} from './hm-types'
+import {packHmId, unpackHmId} from './utils'
 import {hmIdPathToEntityQueryPath} from './utils/path-api'
 
 export const ListCapabilities: HMRequestImplementation<HMListCapabilitiesRequest> =
@@ -22,5 +23,17 @@ export const ListCapabilities: HMRequestImplementation<HMListCapabilitiesRequest
             c.toJson({emitDefaultValues: true, enumAsInteger: false}) as any,
         ),
       }
+    },
+  }
+
+export const ListCapabilitiesParams: HMRequestParams<HMListCapabilitiesRequest> =
+  {
+    inputToParams: (input) => ({targetId: packHmId(input.targetId)}),
+    paramsToInput: (params) => {
+      const targetId = unpackHmId(params.targetId)
+      if (!targetId) {
+        throw new Error(`Invalid targetId query param: ${params.targetId}`)
+      }
+      return {targetId}
     },
   }

--- a/frontend/packages/shared/src/api-changes.ts
+++ b/frontend/packages/shared/src/api-changes.ts
@@ -1,7 +1,8 @@
-import {HMRequestImplementation} from './api-types'
+import {HMRequestImplementation, HMRequestParams} from './api-types'
 import {BIG_INT} from './constants'
 import {GRPCClient} from './grpc-client'
 import {HMListChangesRequest} from './hm-types'
+import {packHmId, unpackHmId} from './utils'
 import {hmIdPathToEntityQueryPath} from './utils/path-api'
 
 export const ListChanges: HMRequestImplementation<HMListChangesRequest> = {
@@ -32,5 +33,16 @@ export const ListChanges: HMRequestImplementation<HMListChangesRequest> = {
       ),
       latestVersion: latestDoc.version,
     }
+  },
+}
+
+export const ListChangesParams: HMRequestParams<HMListChangesRequest> = {
+  inputToParams: (input) => ({targetId: packHmId(input.targetId)}),
+  paramsToInput: (params) => {
+    const targetId = unpackHmId(params.targetId)
+    if (!targetId) {
+      throw new Error(`Invalid targetId query param: ${params.targetId}`)
+    }
+    return {targetId}
   },
 }

--- a/frontend/packages/shared/src/api-citations.ts
+++ b/frontend/packages/shared/src/api-citations.ts
@@ -1,8 +1,8 @@
-import {HMRequestImplementation} from './api-types'
+import {HMRequestImplementation, HMRequestParams} from './api-types'
 import {BIG_INT} from './constants'
 import {GRPCClient} from './grpc-client'
 import {HMListCitationsRequest} from './hm-types'
-import {packHmId} from './utils'
+import {packHmId, unpackHmId} from './utils'
 
 export const ListCitations: HMRequestImplementation<HMListCitationsRequest> = {
   async getData(
@@ -18,5 +18,16 @@ export const ListCitations: HMRequestImplementation<HMListCitationsRequest> = {
         (m) => m.toJson({emitDefaultValues: true, enumAsInteger: false}) as any,
       ),
     }
+  },
+}
+
+export const ListCitationsParams: HMRequestParams<HMListCitationsRequest> = {
+  inputToParams: (input) => ({targetId: packHmId(input.targetId)}),
+  paramsToInput: (params) => {
+    const targetId = unpackHmId(params.targetId)
+    if (!targetId) {
+      throw new Error(`Invalid targetId query param: ${params.targetId}`)
+    }
+    return {targetId}
   },
 }

--- a/frontend/packages/shared/src/api.ts
+++ b/frontend/packages/shared/src/api.ts
@@ -3,9 +3,9 @@ import {Account, AccountParams} from './api-account'
 import {Comment} from './api-comment'
 import {AccountContacts} from './api-account-contacts'
 import {ListEvents} from './api-activity'
-import {ListCapabilities} from './api-capabilities'
-import {ListChanges} from './api-changes'
-import {ListCitations} from './api-citations'
+import {ListCapabilities, ListCapabilitiesParams} from './api-capabilities'
+import {ListChanges, ListChangesParams} from './api-changes'
+import {ListCitations, ListCitationsParams} from './api-citations'
 import {
   GetCommentReplyCount,
   ListComments,
@@ -52,4 +52,7 @@ export const APIParams: {
   Account: AccountParams,
   Resource: ResourceParams,
   ResourceMetadata: ResourceMetadataParams,
+  ListCitations: ListCitationsParams,
+  ListChanges: ListChangesParams,
+  ListCapabilities: ListCapabilitiesParams,
 }


### PR DESCRIPTION
Fix issue where targetId was being serialized as a full JSON object in the URL query string instead of a packed HM ID string. This caused 500 errors in the explore app when fetching citations, changes, and capabilities.

Added APIParams for ListCitations, ListChanges, and ListCapabilities to properly convert targetId between the object format and packed string format for URL serialization.

🤖 Generated with Claude Code