### PR TITLE
fix(desktop): Cmd+F find-in-page not working SHM-2127

### DIFF
--- a/frontend/apps/desktop/src/find-in-page.tsx
+++ b/frontend/apps/desktop/src/find-in-page.tsx
@@ -1,34 +1,153 @@
-import React, {useEffect, useState} from 'react'
-import ReactDOM from 'react-dom/client'
-import {FindInPage} from './pages/find-in-page'
+// Find-in-page UI using vanilla JS to avoid React duplication issues
 import './tailwind.css'
 
-function FindInPageView() {
-  const [darkMode, setDarkMode] = useState(false)
+// Use window.ipc from preload (type-cast to avoid conflicts with main app types)
+const ipc = (window as any).ipc as {send: (cmd: string, args?: any) => void}
+const appWindowEvents = (window as any).appWindowEvents as
+  | {subscribe: (handler: (event: any) => void) => () => void}
+  | undefined
+const darkModeStream = (window as any).darkMode as
+  | {subscribe: (handler: (value: boolean) => void) => () => void}
+  | undefined
 
-  useEffect(() => {
-    const unsubscribe = window.darkMode?.subscribe((value: boolean) => {
-      setDarkMode(value)
-    })
-    return () => unsubscribe?.()
-  }, [])
+// Create the UI
+function createFindInPageUI() {
+  const root = document.getElementById('root')
+  if (!root) return
 
-  return (
-    <div
-      className={darkMode ? 'dark' : 'light'}
-      style={{width: '100%', height: '100%'}}
-    >
-      <FindInPage />
-    </div>
-  )
+  // Create wrapper with dark/light mode
+  const wrapper = document.createElement('div')
+  wrapper.className = 'light'
+  wrapper.style.width = '100%'
+  wrapper.style.height = '100%'
+
+  // Subscribe to dark mode changes
+  darkModeStream?.subscribe((isDark: boolean) => {
+    wrapper.className = isDark ? 'dark' : 'light'
+  })
+
+  // Create container
+  const container = document.createElement('div')
+  container.className =
+    'fixed inset-0 flex items-center justify-center gap-2 p-4'
+
+  // Create input wrapper
+  const inputWrapper = document.createElement('div')
+  inputWrapper.className = 'flex flex-1 items-center'
+
+  // Create input
+  const input = document.createElement('input')
+  input.type = 'text'
+  input.placeholder = 'Find in page...'
+  input.className =
+    'bg-panel border-border text-foreground h-8 flex-1 rounded-sm border px-2 text-sm outline-none focus:ring-1 focus:ring-ring'
+
+  // Create button container
+  const buttonContainer = document.createElement('div')
+  buttonContainer.className =
+    'border-border bg-panel flex items-center overflow-hidden rounded-sm border'
+
+  // Create up button
+  const upButton = document.createElement('button')
+  upButton.type = 'button'
+  upButton.className =
+    'flex size-8 items-center justify-center text-foreground hover:bg-muted'
+  upButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"/></svg>`
+
+  // Create down button
+  const downButton = document.createElement('button')
+  downButton.type = 'button'
+  downButton.className =
+    'flex size-8 items-center justify-center text-foreground hover:bg-muted'
+  downButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>`
+
+  // Create close button
+  const closeButton = document.createElement('button')
+  closeButton.type = 'button'
+  closeButton.className =
+    'flex size-8 items-center justify-center text-foreground hover:bg-muted'
+  closeButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>`
+
+  // State
+  let query = ''
+
+  function clearFind() {
+    query = ''
+    input.value = ''
+    ipc.send('find_in_page_cancel')
+  }
+
+  function search(forward: boolean = true) {
+    if (query.length > 0) {
+      ipc.send('find_in_page_query', {
+        query,
+        findNext: false,
+        forward,
+      })
+    }
+  }
+
+  // Event handlers
+  input.addEventListener('input', (e) => {
+    query = (e.target as HTMLInputElement).value
+    if (query.length === 0) {
+      ipc.send('find_in_page_cancel')
+    } else {
+      ipc.send('find_in_page_query', {query, findNext: true})
+    }
+  })
+
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      clearFind()
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      search(true)
+    }
+  })
+
+  upButton.addEventListener('click', () => search(false))
+  downButton.addEventListener('click', () => search(true))
+  closeButton.addEventListener('click', clearFind)
+
+  // Global escape handler
+  window.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      clearFind()
+    }
+  })
+
+  // Focus input on load and when find_in_page event is received
+  setTimeout(() => {
+    input.focus()
+    input.select()
+  }, 10)
+
+  appWindowEvents?.subscribe((event: any) => {
+    if (event.type === 'find_in_page') {
+      setTimeout(() => {
+        input.focus()
+        input.select()
+      }, 10)
+    }
+  })
+
+  // Assemble the UI
+  inputWrapper.appendChild(input)
+  buttonContainer.appendChild(upButton)
+  buttonContainer.appendChild(downButton)
+  buttonContainer.appendChild(closeButton)
+  container.appendChild(inputWrapper)
+  container.appendChild(buttonContainer)
+  wrapper.appendChild(container)
+  root.appendChild(wrapper)
 }
 
-// Wait for DOM to be ready
-const root = document.getElementById('root')
-if (root) {
-  ReactDOM.createRoot(root).render(
-    <React.StrictMode>
-      <FindInPageView />
-    </React.StrictMode>,
-  )
+// Initialize when DOM is ready
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', createFindInPageUI)
+} else {
+  createFindInPageUI()
 }

--- a/frontend/apps/desktop/src/pages/find-in-page.tsx
+++ b/frontend/apps/desktop/src/pages/find-in-page.tsx
@@ -1,13 +1,66 @@
 import {ipc} from '@/ipc'
 import type {AppWindowEvent} from '@/utils/window-events'
-import {Button} from '@shm/ui/button'
-import {Input} from '@shm/ui/components/input'
-import {ChevronDown, ChevronUp, Close} from '@shm/ui/icons'
 import {useEffect, useRef, useState} from 'react'
+
+// Inline SVG icons to avoid importing from @shm/ui which causes React duplication
+function ChevronUpIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="m18 15-6-6-6 6" />
+    </svg>
+  )
+}
+
+function ChevronDownIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  )
+}
+
+function CloseIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M18 6 6 18" />
+      <path d="m6 6 12 12" />
+    </svg>
+  )
+}
 
 export function FindInPage() {
   const [query, setQuery] = useState('')
-  const queryInput = useRef<any>(null)
+  const queryInput = useRef<HTMLInputElement>(null)
 
   function clearFind() {
     setQuery('')
@@ -48,15 +101,13 @@ export function FindInPage() {
     return () => unsubscribe?.()
   }, [])
 
-  function handleKeyPress(event: React.KeyboardEvent<HTMLInputElement>) {
+  function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
     const key = event.key
     if (key === 'Escape') {
       event.preventDefault()
       clearFind()
     } else if (key === 'Enter') {
       event.preventDefault()
-      console.log('Enter pressed - find next occurrence')
-
       if (query.length > 0) {
         ipc.send('find_in_page_query', {
           query,
@@ -67,39 +118,33 @@ export function FindInPage() {
     }
   }
 
-  // Start search when typing (but not on Enter key)
+  // Start search when typing
   useEffect(() => {
-    console.log('useEffect triggered, query:', query)
-
     if (query.length === 0) {
-      console.log('Cancelling search - empty query')
       ipc.send('find_in_page_cancel')
       return
     }
-
-    console.log('Starting initial search')
     ipc.send('find_in_page_query', {query, findNext: true})
   }, [query])
 
   return (
     <div className="fixed inset-0 flex items-center justify-center gap-2 p-4">
       <div className="flex flex-1 items-center">
-        <Input
+        <input
           ref={queryInput}
+          type="text"
           placeholder="Find in page..."
           value={query}
-          onChangeText={setQuery}
-          onKeyDown={handleKeyPress}
-          className="bg-panel border-border flex-1"
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          className="bg-panel border-border focus:ring-ring h-8 flex-1 rounded-sm border px-2 text-sm outline-none focus:ring-1"
         />
       </div>
       <div className="border-border bg-panel flex items-center overflow-hidden rounded-sm border">
-        <Button
-          variant="ghost"
-          className="size-8 rounded-none"
-          size="icon"
+        <button
+          type="button"
+          className="hover:bg-muted flex size-8 items-center justify-center"
           onClick={() => {
-            console.log('Up button clicked - sending IPC from button')
             ipc.send('find_in_page_query', {
               query,
               findNext: false,
@@ -107,15 +152,13 @@ export function FindInPage() {
             })
           }}
         >
-          <ChevronUp className="size-4" />
-        </Button>
+          <ChevronUpIcon />
+        </button>
 
-        <Button
-          variant="ghost"
-          className="size-8 rounded-none"
-          size="icon"
+        <button
+          type="button"
+          className="hover:bg-muted flex size-8 items-center justify-center"
           onClick={() => {
-            console.log('Down button clicked - sending IPC from button')
             ipc.send('find_in_page_query', {
               query,
               findNext: false,
@@ -123,17 +166,16 @@ export function FindInPage() {
             })
           }}
         >
-          <ChevronDown className="size-4" />
-        </Button>
+          <ChevronDownIcon />
+        </button>
 
-        <Button
-          variant="ghost"
-          size="icon"
+        <button
+          type="button"
           onClick={clearFind}
-          className="size-8 rounded-none"
+          className="hover:bg-muted flex size-8 items-center justify-center"
         >
-          <Close className="size-4" />
-        </Button>
+          <CloseIcon />
+        </button>
       </div>
     </div>
   )

--- a/frontend/apps/desktop/src/preload-find-in-page.ts
+++ b/frontend/apps/desktop/src/preload-find-in-page.ts
@@ -3,7 +3,7 @@ import {contextBridge, ipcRenderer} from 'electron'
 import {exposeElectronTRPC} from 'electron-trpc/main'
 // import directly from this deep path for shared/utils/stream! Bad things happen if you try to directly import from @shm/shared
 import {AppWindowEvent} from '@/utils/window-events'
-import {eventStream} from '@shm/shared/utils/stream'
+import {eventStream, writeableStateStream} from '@shm/shared/utils/stream'
 // import directly from this deep path for shared/utils/stream! Bad things happen if you try to directly import from @shm/shared
 
 process.once('loaded', async () => {
@@ -15,6 +15,14 @@ contextBridge.exposeInMainWorld('appWindowEvents', appWindowEvents)
 
 ipcRenderer.addListener('appWindowEvent', (info, event) => {
   dispatchAppWindow(event)
+})
+
+// Dark mode support
+const [updateDarkMode, darkMode] = writeableStateStream<boolean>(false)
+contextBridge.exposeInMainWorld('darkMode', darkMode)
+
+ipcRenderer.addListener('darkMode', (info, state) => {
+  updateDarkMode(state)
 })
 
 contextBridge.exposeInMainWorld('ipc', {

--- a/frontend/apps/desktop/src/renderer-find.ts
+++ b/frontend/apps/desktop/src/renderer-find.ts
@@ -1,1 +1,1 @@
-import './find-in-page.jsx'
+import './find-in-page'

--- a/frontend/apps/desktop/vite.renderer.find-in-page.config.mts
+++ b/frontend/apps/desktop/vite.renderer.find-in-page.config.mts
@@ -1,7 +1,7 @@
 import {sentryVitePlugin} from '@sentry/vite-plugin'
 import tailwindcss from '@tailwindcss/vite'
 
-import react from '@vitejs/plugin-react'
+import path from 'path'
 import {defineConfig} from 'vite'
 import tsConfigPaths from 'vite-tsconfig-paths'
 
@@ -30,12 +30,30 @@ export default defineConfig(({command, mode}) => {
         },
       },
     },
-    plugins: [tsConfigPaths(), react(), tailwindcss()],
+    plugins: [
+      tsConfigPaths({
+        root: '../../',
+      }),
+      tailwindcss(),
+    ],
     resolve: {
       extensions,
-    },
-    alias: {
-      'react-native': 'react-native-web',
+      dedupe: [
+        '@shm/shared',
+        '@shm/shared/*',
+        '@shm/editor',
+        '@shm/editor/*',
+        '@shm/ui',
+        '@shm/ui/*',
+        'react',
+        'react-dom',
+      ],
+      alias: {
+        '@shm/shared': path.resolve(__dirname, '../../packages/shared/src'),
+        '@shm/editor': path.resolve(__dirname, '../../packages/editor/src'),
+        '@shm/ui': path.resolve(__dirname, '../../packages/ui/src'),
+        'react-native': 'react-native-web',
+      },
     },
     optimizeDeps: {
       esbuildOptions: {


### PR DESCRIPTION
## Summary
- Fix Cmd+F keyboard shortcut not showing find-in-page view
- First press now correctly shows and focuses the find input
- Rewrote find-in-page UI to vanilla JS to avoid React duplication issues between renderers

## Changes
- **app-windows.ts**: Wait for `did-finish-load` before showing view on first Cmd+F, fix event format to `{type: 'find_in_page'}`, add debug logging
- **find-in-page.tsx**: Rewrite to vanilla JS (no React) to avoid multiple React instances error
- **preload-find-in-page.ts**: Add dark mode support
- **vite.renderer.find-in-page.config.mts**: Add proper resolve settings, remove React plugin

## Test plan
- [ ] Press Cmd+F on any page, find-in-page view should appear immediately
- [ ] Type to search, results should highlight
- [ ] Press Escape or click X to close
- [ ] Verify dark mode works correctly

Fixes SHM-2127

🤖 Generated with [Claude Code](https://claude.com/claude-code)