### PR TITLE
fix: show recents when clearing omnibar url

### DIFF
--- a/frontend/apps/desktop/src/components/titlebar-common.tsx
+++ b/frontend/apps/desktop/src/components/titlebar-common.tsx
@@ -698,7 +698,7 @@ function useOmnibarState(currentUrl: string | null) {
           value.startsWith('hm://') ||
           (value.includes('.') && !value.includes(' '))
 
-        if (!looksLikeUrl && value.length > 0) {
+        if (!looksLikeUrl) {
           setMode('search')
         }
       }


### PR DESCRIPTION
## Summary
Remove length check in omnibar's search mode transition so clearing the URL immediately displays recents instead of requiring the 4-step workaround.

## What Changed
When user clicks omnibar (focused mode) and clears the URL, the component now transitions to search mode and shows recent documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)