### PR TITLE
Fix: add margin to embedded block nodes for spacing

### DIFF
--- a/frontend/packages/ui/src/blocks-content.tsx
+++ b/frontend/packages/ui/src/blocks-content.tsx
@@ -816,6 +816,7 @@ export function BlockNodeContent({
         'blocknode-content',
         isHighlight ? 'bg-brand-12' : 'bg-transparent',
         hover && !isHighlight && 'bg-background',
+        isEmbed && 'my-2',
       )}
       style={{
         borderRadius: layoutUnit / 4,


### PR DESCRIPTION
Fix cards collapsing their margins by adding vertical spacing to embedded block nodes.

This prevents margin collapse and ensures consistent spacing between cards.

Fixes SHM-2131.