### PR TITLE
Show drafts in directory listing

### DIFF
--- a/frontend/packages/ui/src/document-list-item.tsx
+++ b/frontend/packages/ui/src/document-list-item.tsx
@@ -14,6 +14,7 @@ import {
 import {MessageSquare} from 'lucide-react'
 import {LibraryEntryUpdateSummary} from './activity'
 import {Button} from './button'
+import {DraftBadge} from './draft-badge'
 import {FacePile} from './face-pile'
 import {useHighlighter} from './highlight-context'
 import {HMIcon} from './hm-icon'
@@ -32,6 +33,7 @@ interface DocumentListItemProps {
   activitySummary?: HMActivitySummary | null
   latestComment?: HMComment | null
   interactionSummary?: InteractionSummaryPayload | null
+  draftId?: string
   isRead?: boolean
   indent?: boolean
   onClick?: (id: UnpackedHypermediaId) => void
@@ -46,11 +48,13 @@ export function DocumentListItem({
   activitySummary,
   latestComment,
   interactionSummary,
+  draftId: draftIdProp,
   isRead,
   indent = false,
   onClick,
 }: DocumentListItemProps) {
   const id = item.id
+  const draftId = draftIdProp
 
   const metadata = item.metadata
   const visibility = 'visibility' in item ? item.visibility : undefined
@@ -79,7 +83,10 @@ export function DocumentListItem({
   const showAuthors =
     !!accountsMetadata && Object.keys(accountsMetadata).length > 0
 
-  const linkProps = useRouteLink({key: 'document', id})
+  const route = draftId
+    ? {key: 'draft' as const, id: draftId}
+    : {key: 'document' as const, id}
+  const linkProps = useRouteLink(route)
 
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     // Stop propagation to prevent parent handlers (like EmbedWrapper) from firing.
@@ -119,6 +126,7 @@ export function DocumentListItem({
               >
                 {getMetadataName(metadata)}
               </SizableText>
+              {!!draftId && <DraftBadge />}
               {isPrivate && <PrivateBadge size="sm" />}
             </div>
             {interactionSummary && interactionSummary.comments > 0 && (
@@ -126,13 +134,13 @@ export function DocumentListItem({
                 count={interactionSummary.comments}
               />
             )}
-            {showAuthors && (
+            {showAuthors && 'authors' in item && (
               <FacePile
                 accounts={item.authors}
                 accountsMetadata={accountsMetadata}
               />
             )}
-            {!showAuthors && !itemActivitySummary && (
+            {!showAuthors && !itemActivitySummary && 'updateTime' in item && (
               <SizableText size="xs" color="muted" className="font-sans">
                 {formattedDate(item.updateTime)}
               </SizableText>

--- a/frontend/packages/ui/src/private-badge.tsx
+++ b/frontend/packages/ui/src/private-badge.tsx
@@ -1,17 +1,22 @@
 import {Lock} from 'lucide-react'
+import {Badge} from './components/badge'
 import {cn} from './utils'
 
-export function PrivateBadge({size = 'md'}: {size?: 'sm' | 'md'} = {}) {
-  const iconSize = size === 'sm' ? 10 : 12
+export function PrivateBadge({
+  size = 'md',
+  className,
+}: {size?: 'sm' | 'md'; className?: string} = {}) {
   return (
-    <div
+    <Badge
+      variant="outline"
       className={cn(
-        'inline-flex w-fit shrink-0 items-center gap-1 rounded-full border border-gray-300 bg-gray-100 px-2 py-0.5 font-medium text-gray-600 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300',
+        'text-muted-foreground gap-0.5',
         size === 'sm' ? 'text-[10px]' : 'text-xs',
+        className,
       )}
     >
-      <Lock size={iconSize} strokeWidth={2} />
+      <Lock size={size === 'sm' ? 10 : 12} strokeWidth={2} />
       Private
-    </div>
+    </Badge>
   )
 }


### PR DESCRIPTION
## Summary
- Show unpublished drafts in the directory page view alongside published documents
- Show "Draft" badge on published documents that have pending drafts
- Navigate to draft route when clicking a published doc with a draft
- Restyle PrivateBadge to use the same Badge component as DraftBadge for visual consistency
- Unpublished draft items use the same card wrapper (shadow, border) as published items

Closes SHM-2103

## Test plan
- [ ] Open a directory that has unpublished drafts — they should appear in the list with a "Draft" badge
- [ ] Published docs with pending drafts should show a "Draft" badge inline next to the name
- [ ] Clicking a published doc with a draft should navigate to the draft editor
- [ ] Private badge should look visually similar to the Draft badge (same border/pill style, with lock icon)
- [ ] Unpublished draft items should have the same card appearance (shadow, hover) as published items

🤖 Generated with [Claude Code](https://claude.com/claude-code)