### PR TITLE
fix: prevent focus steal when opening publish popover

### DIFF
--- a/frontend/apps/desktop/src/pages/draft.tsx
+++ b/frontend/apps/desktop/src/pages/draft.tsx
@@ -494,7 +494,10 @@ function DocumentEditor({
           onClick={handleFocusAtMousePos}
           className="relative flex flex-1 flex-col overflow-hidden pt-12"
         >
-          <div className="bg-background absolute top-4 right-4 z-11 flex items-center rounded-sm p-1 shadow-sm">
+          <div
+            className="bg-background absolute top-4 right-4 z-11 flex items-center rounded-sm p-1 shadow-sm"
+            onClick={(e) => e.stopPropagation()}
+          >
             <DraftActionButtons route={route} />
           </div>
           <ScrollArea onScroll={() => dispatchScroll(true)}>


### PR DESCRIPTION
## Summary
Stop click propagation on the action buttons container so `handleFocusAtMousePos` doesn't run when opening the publish popover. This prevents the editor from stealing focus and immediately dismissing the popover when scrolled to the bottom of the page.

## Root Cause
The outer div had an onClick handler that called `handleFocusAtMousePos`, which would focus the editor when clicked. This bubbled up from the publish button, causing the popover to be dismissed due to focus loss detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)