### PR TITLE
fix: add fs-xattr to onlyBuiltDependencies for DMG maker

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
       "better-sqlite3",
       "electron",
       "esbuild",
+      "fs-xattr",
       "sharp"
     ],
     "overrides": {


### PR DESCRIPTION
fs-xattr is a native addon needed by appdmg (used by
@electron-forge/maker-dmg). Without it in the whitelist,
its node-gyp install script is skipped and the macOS DMG
build fails at runtime.

https://claude.ai/code/session_01TvfJEdjBa2FHS8iXrZSPMm