### PR TITLE
extract useRouteBreadcrumbs hook from titlebar-title

### DIFF
--- a/frontend/apps/desktop/src/hooks/__tests__/use-route-breadcrumbs.test.ts
+++ b/frontend/apps/desktop/src/hooks/__tests__/use-route-breadcrumbs.test.ts
@@ -1,0 +1,516 @@
+import {describe, expect, it} from 'vitest'
+import {
+  computeContactBreadcrumbs,
+  computeDraftEntityParams,
+  computeEntityBreadcrumbs,
+  computeProfileBreadcrumbs,
+  computeSimpleRouteBreadcrumbs,
+  EntityContent,
+  getIconForRoute,
+  getWindowTitle,
+} from '../route-breadcrumbs'
+import {hmId, UnpackedHypermediaId} from '@shm/shared'
+
+function makeId(uid: string, path?: string[] | null): UnpackedHypermediaId {
+  return hmId(uid, {path: path ?? undefined})
+}
+
+describe('getIconForRoute', () => {
+  it('contacts -> contact', () => {
+    expect(getIconForRoute('contacts')).toBe('contact')
+  })
+  it('contact -> contact', () => {
+    expect(getIconForRoute('contact')).toBe('contact')
+  })
+  it('profile -> contact', () => {
+    expect(getIconForRoute('profile')).toBe('contact')
+  })
+  it('bookmarks -> star', () => {
+    expect(getIconForRoute('bookmarks')).toBe('star')
+  })
+  it('drafts -> file', () => {
+    expect(getIconForRoute('drafts')).toBe('file')
+  })
+  it('draft -> file', () => {
+    expect(getIconForRoute('draft')).toBe('file')
+  })
+  it('document -> null', () => {
+    expect(getIconForRoute('document')).toBeNull()
+  })
+  it('library -> null', () => {
+    expect(getIconForRoute('library')).toBeNull()
+  })
+  it('feed -> null', () => {
+    expect(getIconForRoute('feed')).toBeNull()
+  })
+})
+
+describe('getWindowTitle', () => {
+  it('contacts -> Contacts', () => {
+    expect(getWindowTitle('contacts')).toBe('Contacts')
+  })
+  it('bookmarks -> Bookmarks', () => {
+    expect(getWindowTitle('bookmarks')).toBe('Bookmarks')
+  })
+  it('library -> Library', () => {
+    expect(getWindowTitle('library')).toBe('Library')
+  })
+  it('drafts -> Drafts', () => {
+    expect(getWindowTitle('drafts')).toBe('Drafts')
+  })
+  it('contact with name', () => {
+    expect(getWindowTitle('contact', 'Alice')).toBe('Contact: Alice')
+  })
+  it('contact without name', () => {
+    expect(getWindowTitle('contact')).toBe('Contact')
+  })
+  it('profile with name', () => {
+    expect(getWindowTitle('profile', 'Bob')).toBe('Profile: Bob')
+  })
+  it('profile without name', () => {
+    expect(getWindowTitle('profile')).toBe('Profile')
+  })
+  it('draft with name', () => {
+    expect(getWindowTitle('draft', 'My Draft')).toBe('Draft: My Draft')
+  })
+  it('draft without name', () => {
+    expect(getWindowTitle('draft')).toBe('Draft')
+  })
+  it('document with name', () => {
+    expect(getWindowTitle('document', 'My Doc')).toBe('My Doc')
+  })
+  it('document without name', () => {
+    expect(getWindowTitle('document')).toBe('Document')
+  })
+  it('unknown key -> null', () => {
+    expect(getWindowTitle('settings')).toBeNull()
+  })
+})
+
+describe('computeSimpleRouteBreadcrumbs', () => {
+  it('contacts', () => {
+    const result = computeSimpleRouteBreadcrumbs('contacts')
+    expect(result).not.toBeNull()
+    expect(result!.items).toHaveLength(1)
+    expect(result!.items[0].name).toBe('Contacts')
+    expect(result!.icon).toBe('contact')
+    expect(result!.windowTitle).toBe('Contacts')
+  })
+  it('bookmarks', () => {
+    const result = computeSimpleRouteBreadcrumbs('bookmarks')
+    expect(result).not.toBeNull()
+    expect(result!.items).toHaveLength(1)
+    expect(result!.items[0].name).toBe('Bookmarks')
+    expect(result!.icon).toBe('star')
+  })
+  it('drafts', () => {
+    const result = computeSimpleRouteBreadcrumbs('drafts')
+    expect(result).not.toBeNull()
+    expect(result!.items).toHaveLength(1)
+    expect(result!.items[0].name).toBe('Drafts')
+    expect(result!.icon).toBe('file')
+  })
+  it('library', () => {
+    const result = computeSimpleRouteBreadcrumbs('library')
+    expect(result).not.toBeNull()
+    expect(result!.items).toHaveLength(1)
+    expect(result!.items[0].name).toBe('Library')
+    expect(result!.icon).toBeNull()
+  })
+  it('unknown key -> null', () => {
+    expect(computeSimpleRouteBreadcrumbs('document')).toBeNull()
+    expect(computeSimpleRouteBreadcrumbs('draft')).toBeNull()
+    expect(computeSimpleRouteBreadcrumbs('settings')).toBeNull()
+  })
+})
+
+describe('computeContactBreadcrumbs', () => {
+  it('with name', () => {
+    const items = computeContactBreadcrumbs('Alice')
+    expect(items).toHaveLength(2)
+    expect(items[0].name).toBe('Contacts')
+    expect(items[1].name).toBe('Alice')
+  })
+  it('without name', () => {
+    const items = computeContactBreadcrumbs()
+    expect(items).toHaveLength(2)
+    expect(items[0].name).toBe('Contacts')
+    expect(items[1].name).toBe('Untitled Contact')
+  })
+  it('with undefined name', () => {
+    const items = computeContactBreadcrumbs(undefined)
+    expect(items[1].name).toBe('Untitled Contact')
+  })
+})
+
+describe('computeProfileBreadcrumbs', () => {
+  it('with name', () => {
+    const items = computeProfileBreadcrumbs('Bob')
+    expect(items).toHaveLength(2)
+    expect(items[0].name).toBe('Profile')
+    expect(items[1].name).toBe('Bob')
+  })
+  it('without name', () => {
+    const items = computeProfileBreadcrumbs()
+    expect(items).toHaveLength(2)
+    expect(items[1].name).toBe('Untitled Profile')
+  })
+})
+
+describe('computeEntityBreadcrumbs', () => {
+  function makeEntityContent(
+    id: UnpackedHypermediaId,
+    doc?: {metadata?: {name?: string}; content?: any},
+    flags?: {
+      isTombstone?: boolean
+      isNotFound?: boolean
+      isDiscovering?: boolean
+    },
+  ): EntityContent {
+    if (flags?.isTombstone) {
+      return {id, entity: {id: id.id, isTombstone: true}, isDiscovering: false}
+    }
+    if (flags?.isNotFound) {
+      return {id, entity: {id: id.id, isNotFound: true}, isDiscovering: false}
+    }
+    if (doc) {
+      return {
+        id,
+        entity: {id: id.id, document: doc},
+        isDiscovering: flags?.isDiscovering ?? false,
+      }
+    }
+    return {id, entity: undefined, isDiscovering: flags?.isDiscovering ?? false}
+  }
+
+  it('single root entity', () => {
+    const id = makeId('abc123')
+    const items = computeEntityBreadcrumbs({
+      entityIds: [id],
+      entityContents: [makeEntityContent(id, {metadata: {name: 'My Site'}})],
+      contacts: [],
+    })
+    expect(items).toHaveLength(1)
+    // root uses getContactMetadata which returns contact name or metadata name
+    expect(items[0].crumbKey).toBe('id-0')
+    expect(items[0].id).toBe(id)
+  })
+
+  it('nested path produces multiple crumbs', () => {
+    const rootId = makeId('abc123')
+    const childId = makeId('abc123', ['docs'])
+    const items = computeEntityBreadcrumbs({
+      entityIds: [rootId, childId],
+      entityContents: [
+        makeEntityContent(rootId, {metadata: {name: 'My Site'}}),
+        makeEntityContent(childId, {metadata: {name: 'Docs Page'}}),
+      ],
+      contacts: [],
+    })
+    expect(items).toHaveLength(2)
+    expect(items[0].crumbKey).toBe('id-0')
+    expect(items[1].crumbKey).toBe('id-1')
+    expect(items[1].name).toBe('Docs Page')
+  })
+
+  it('sets fallbackName from path', () => {
+    const id = makeId('abc123', ['my-page'])
+    const items = computeEntityBreadcrumbs({
+      entityIds: [id],
+      entityContents: [makeEntityContent(id, {metadata: {name: 'My Page'}})],
+      contacts: [],
+    })
+    expect(items[0].fallbackName).toBe('my-page')
+  })
+
+  it('sets fallbackName from uid prefix when no path', () => {
+    const id = makeId('abcdefghijklmnop')
+    const items = computeEntityBreadcrumbs({
+      entityIds: [id],
+      entityContents: [makeEntityContent(id, {metadata: {name: 'Root'}})],
+      contacts: [],
+    })
+    expect(items[0].fallbackName).toBe('abcdefgh')
+  })
+
+  it('tombstone entity', () => {
+    const id = makeId('abc123')
+    const items = computeEntityBreadcrumbs({
+      entityIds: [id],
+      entityContents: [makeEntityContent(id, undefined, {isTombstone: true})],
+      contacts: [],
+    })
+    expect(items[0].isTombstone).toBe(true)
+    expect(items[0].isNotFound).toBe(false)
+  })
+
+  it('not-found entity', () => {
+    const id = makeId('abc123')
+    const items = computeEntityBreadcrumbs({
+      entityIds: [id],
+      entityContents: [makeEntityContent(id, undefined, {isNotFound: true})],
+      contacts: [],
+    })
+    expect(items[0].isNotFound).toBe(true)
+    expect(items[0].isTombstone).toBe(false)
+  })
+
+  it('discovering entity shows loading', () => {
+    const id = makeId('abc123')
+    const items = computeEntityBreadcrumbs({
+      entityIds: [id],
+      entityContents: [
+        makeEntityContent(
+          id,
+          {metadata: {name: 'Test'}},
+          {isDiscovering: true},
+        ),
+      ],
+      contacts: [],
+    })
+    expect(items[0].isLoading).toBe(true)
+  })
+
+  it('error entity (has entity but no document, not tombstone/notFound)', () => {
+    const id = makeId('abc123')
+    const items = computeEntityBreadcrumbs({
+      entityIds: [id],
+      entityContents: [{id, entity: {id: id.id}, isDiscovering: false}],
+      contacts: [],
+    })
+    expect(items[0].isError).toBeTruthy()
+  })
+
+  it('appends draftName', () => {
+    const id = makeId('abc123')
+    const items = computeEntityBreadcrumbs({
+      entityIds: [id],
+      entityContents: [makeEntityContent(id, {metadata: {name: 'Root'}})],
+      contacts: [],
+      draftName: 'New Draft',
+    })
+    expect(items).toHaveLength(2)
+    expect(items[1].name).toBe('New Draft')
+    expect(items[1].crumbKey).toBe('draft-New Draft')
+  })
+
+  it('replaceLastItem removes last entity crumb before appending draft', () => {
+    const rootId = makeId('abc123')
+    const childId = makeId('abc123', ['page'])
+    const items = computeEntityBreadcrumbs({
+      entityIds: [rootId, childId],
+      entityContents: [
+        makeEntityContent(rootId, {metadata: {name: 'Root'}}),
+        makeEntityContent(childId, {metadata: {name: 'Page'}}),
+      ],
+      contacts: [],
+      draftName: 'Updated Page',
+      replaceLastItem: true,
+    })
+    // Root + draft (child replaced)
+    expect(items).toHaveLength(2)
+    expect(items[0].crumbKey).toBe('id-0')
+    expect(items[1].name).toBe('Updated Page')
+  })
+
+  it('appends directory panel crumb', () => {
+    const id = makeId('abc123')
+    const items = computeEntityBreadcrumbs({
+      entityIds: [id],
+      entityContents: [makeEntityContent(id, {metadata: {name: 'Root'}})],
+      contacts: [],
+      panel: {key: 'directory'},
+    })
+    expect(items.at(-1)?.name).toBe('Directory')
+    expect(items.at(-1)?.crumbKey).toBe('directory')
+  })
+
+  it('appends collaborators panel crumb', () => {
+    const id = makeId('abc123')
+    const items = computeEntityBreadcrumbs({
+      entityIds: [id],
+      entityContents: [makeEntityContent(id, {metadata: {name: 'Root'}})],
+      contacts: [],
+      panel: {key: 'collaborators'},
+    })
+    expect(items.at(-1)?.name).toBe('Collaborators')
+  })
+
+  it('appends activity panel crumb', () => {
+    const id = makeId('abc123')
+    const items = computeEntityBreadcrumbs({
+      entityIds: [id],
+      entityContents: [makeEntityContent(id, {metadata: {name: 'Root'}})],
+      contacts: [],
+      panel: {key: 'activity'},
+    })
+    expect(items.at(-1)?.name).toBe('Activity')
+  })
+
+  it('appends discussions panel crumb', () => {
+    const id = makeId('abc123')
+    const items = computeEntityBreadcrumbs({
+      entityIds: [id],
+      entityContents: [makeEntityContent(id, {metadata: {name: 'Root'}})],
+      contacts: [],
+      panel: {key: 'discussions'},
+    })
+    expect(items.at(-1)?.name).toBe('Discussions')
+    expect(items.at(-1)?.crumbKey).toBe('discussions')
+  })
+
+  it('discussions with openComment and author name', () => {
+    const id = makeId('abc123')
+    const items = computeEntityBreadcrumbs({
+      entityIds: [id],
+      entityContents: [makeEntityContent(id, {metadata: {name: 'Root'}})],
+      contacts: [],
+      panel: {key: 'discussions', openComment: 'someComment'},
+      commentAuthorName: 'Alice',
+    })
+    expect(items.at(-1)?.name).toBe('Comment by Alice')
+    expect(items.at(-1)?.crumbKey).toBe('comment')
+  })
+
+  it('discussions with openComment but no author name', () => {
+    const id = makeId('abc123')
+    const items = computeEntityBreadcrumbs({
+      entityIds: [id],
+      entityContents: [makeEntityContent(id, {metadata: {name: 'Root'}})],
+      contacts: [],
+      panel: {key: 'discussions', openComment: 'someComment'},
+    })
+    expect(items.at(-1)?.name).toBe('Comment')
+  })
+
+  it('discussions with openComment shows loading state', () => {
+    const id = makeId('abc123')
+    const items = computeEntityBreadcrumbs({
+      entityIds: [id],
+      entityContents: [makeEntityContent(id, {metadata: {name: 'Root'}})],
+      contacts: [],
+      panel: {key: 'discussions', openComment: 'someComment'},
+      commentIsLoading: true,
+    })
+    expect(items.at(-1)?.isLoading).toBe(true)
+  })
+
+  it('empty entityIds produces empty crumbs', () => {
+    const items = computeEntityBreadcrumbs({
+      entityIds: [],
+      entityContents: [],
+      contacts: [],
+    })
+    expect(items).toHaveLength(0)
+  })
+})
+
+describe('computeDraftEntityParams', () => {
+  const draftRoute = {
+    key: 'draft' as const,
+    id: 'draft-123',
+    locationUid: undefined,
+    locationPath: undefined,
+    editUid: undefined,
+    editPath: undefined,
+    panel: null,
+    visibility: undefined,
+  }
+
+  it('with locationId from draft data', () => {
+    const locationId = makeId('uid1', ['path1'])
+    const result = computeDraftEntityParams(
+      {metadata: {name: 'My Draft'}, visibility: 'PUBLIC'},
+      draftRoute as any,
+      locationId,
+      undefined,
+      undefined,
+    )
+    expect(result.entityId).toBe(locationId)
+    expect(result.draftName).toBe('My Draft')
+    expect(result.hideControls).toBe(true)
+    expect(result.isFallback).toBe(false)
+    expect(result.replaceLastItem).toBe(false)
+    expect(result.isNewDraft).toBe(false)
+  })
+
+  it('with editId', () => {
+    const editId = makeId('uid2', ['page'])
+    const result = computeDraftEntityParams(
+      {metadata: {name: 'Edited Page'}, deps: ['dep1']},
+      draftRoute as any,
+      undefined,
+      editId,
+      'Original Page',
+    )
+    expect(result.entityId).toBe(editId)
+    expect(result.draftName).toBe('Edited Page')
+    expect(result.replaceLastItem).toBe(true)
+    expect(result.isNewDraft).toBe(false)
+    expect(result.isFallback).toBe(false)
+  })
+
+  it('editId with no deps -> isNewDraft', () => {
+    const editId = makeId('uid2', ['page'])
+    const result = computeDraftEntityParams(
+      {metadata: {name: 'New Page'}, deps: []},
+      draftRoute as any,
+      undefined,
+      editId,
+      undefined,
+    )
+    expect(result.isNewDraft).toBe(true)
+  })
+
+  it('editId with no draft name uses editDocName', () => {
+    const editId = makeId('uid2', ['page'])
+    const result = computeDraftEntityParams(
+      {metadata: {}},
+      draftRoute as any,
+      undefined,
+      editId,
+      'Original Title',
+    )
+    expect(result.draftName).toBe('Original Title')
+    expect(result.replaceLastItem).toBe(true)
+  })
+
+  it('private draft strips path to account root', () => {
+    const locationId = makeId('uid1', ['secret', 'path'])
+    const privateRoute = {...draftRoute, visibility: 'PRIVATE' as const}
+    const result = computeDraftEntityParams(
+      {metadata: {name: 'Private Draft'}},
+      privateRoute as any,
+      locationId,
+      undefined,
+      undefined,
+    )
+    expect(result.entityId?.uid).toBe('uid1')
+    expect(result.entityId?.path).toEqual([])
+  })
+
+  it('fallback when no locationId or editId', () => {
+    const result = computeDraftEntityParams(
+      {metadata: {name: 'Orphan Draft'}},
+      draftRoute as any,
+      undefined,
+      undefined,
+      undefined,
+    )
+    expect(result.isFallback).toBe(true)
+    expect(result.entityId).toBeUndefined()
+    expect(result.fallbackDraftName).toBe('Orphan Draft')
+  })
+
+  it('fallback with no draft name', () => {
+    const result = computeDraftEntityParams(
+      null,
+      draftRoute as any,
+      undefined,
+      undefined,
+      undefined,
+    )
+    expect(result.isFallback).toBe(true)
+    expect(result.fallbackDraftName).toBe('New Draft')
+  })
+})

--- a/frontend/apps/desktop/src/hooks/route-breadcrumbs.ts
+++ b/frontend/apps/desktop/src/hooks/route-breadcrumbs.ts
@@ -1,0 +1,342 @@
+import {
+  findContentBlock,
+  getBlockText,
+  getContactMetadata,
+  getDocumentTitle,
+  HMContactRecord,
+  hmId,
+  UnpackedHypermediaId,
+} from '@shm/shared'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type BreadcrumbIconKey = 'contact' | 'star' | 'file' | null
+
+export type BreadcrumbItem = {
+  name?: string
+  fallbackName?: string
+  id: UnpackedHypermediaId | null
+  isError?: boolean
+  isLoading?: boolean
+  isTombstone?: boolean
+  isNotFound?: boolean
+  crumbKey: string
+}
+
+export type RouteBreadcrumbsResult = {
+  items: BreadcrumbItem[]
+  icon: BreadcrumbIconKey
+  windowTitle: string | null
+  isDraft: boolean
+  isAllError: boolean
+  entityId: UnpackedHypermediaId | null
+  isLatest: boolean
+  hideControls: boolean
+}
+
+export type EntityContent = {
+  id: UnpackedHypermediaId
+  entity:
+    | {
+        id: any
+        document?: any
+        isTombstone?: boolean
+        isNotFound?: boolean
+      }
+    | undefined
+  isDiscovering?: boolean
+}
+
+export type DraftEntityParams = {
+  entityId: UnpackedHypermediaId | undefined
+  panel: any
+  draftName: string | undefined
+  replaceLastItem: boolean
+  isNewDraft: boolean
+  hideControls: boolean
+  isFallback: boolean
+  fallbackDraftName: string
+}
+
+// ---------------------------------------------------------------------------
+// Pure functions (exported for testing)
+// ---------------------------------------------------------------------------
+
+export function getIconForRoute(routeKey: string): BreadcrumbIconKey {
+  switch (routeKey) {
+    case 'contacts':
+    case 'contact':
+    case 'profile':
+      return 'contact'
+    case 'bookmarks':
+      return 'star'
+    case 'drafts':
+    case 'draft':
+      return 'file'
+    default:
+      return null
+  }
+}
+
+export function getWindowTitle(
+  routeKey: string,
+  activeName?: string,
+): string | null {
+  switch (routeKey) {
+    case 'contacts':
+      return 'Contacts'
+    case 'bookmarks':
+      return 'Bookmarks'
+    case 'library':
+      return 'Library'
+    case 'drafts':
+      return 'Drafts'
+    case 'contact':
+      return activeName ? `Contact: ${activeName}` : 'Contact'
+    case 'profile':
+      return activeName ? `Profile: ${activeName}` : 'Profile'
+    case 'draft':
+      return activeName ? `Draft: ${activeName}` : 'Draft'
+    case 'document':
+    case 'feed':
+    case 'directory':
+    case 'collaborators':
+    case 'activity':
+    case 'discussions':
+      return activeName || 'Document'
+    default:
+      return null
+  }
+}
+
+export function computeSimpleRouteBreadcrumbs(routeKey: string): {
+  items: BreadcrumbItem[]
+  icon: BreadcrumbIconKey
+  windowTitle: string | null
+} | null {
+  switch (routeKey) {
+    case 'contacts':
+      return {
+        items: [{name: 'Contacts', id: null, crumbKey: 'contacts'}],
+        icon: 'contact',
+        windowTitle: 'Contacts',
+      }
+    case 'bookmarks':
+      return {
+        items: [{name: 'Bookmarks', id: null, crumbKey: 'bookmarks'}],
+        icon: 'star',
+        windowTitle: 'Bookmarks',
+      }
+    case 'drafts':
+      return {
+        items: [{name: 'Drafts', id: null, crumbKey: 'drafts'}],
+        icon: 'file',
+        windowTitle: 'Drafts',
+      }
+    case 'library':
+      return {
+        items: [{name: 'Library', id: null, crumbKey: 'library'}],
+        icon: null,
+        windowTitle: 'Library',
+      }
+    default:
+      return null
+  }
+}
+
+export function computeContactBreadcrumbs(name?: string): BreadcrumbItem[] {
+  return [
+    {name: 'Contacts', id: null, crumbKey: 'contacts-parent'},
+    {
+      name: name || 'Untitled Contact',
+      id: null,
+      crumbKey: 'contact',
+    },
+  ]
+}
+
+export function computeProfileBreadcrumbs(name?: string): BreadcrumbItem[] {
+  return [
+    {name: 'Profile', id: null, crumbKey: 'profile-parent'},
+    {
+      name: name || 'Untitled Profile',
+      id: null,
+      crumbKey: 'profile',
+    },
+  ]
+}
+
+export function computeEntityBreadcrumbs(params: {
+  entityIds: UnpackedHypermediaId[]
+  entityContents: EntityContent[]
+  contacts: HMContactRecord[] | null | undefined
+  draftName?: string
+  replaceLastItem?: boolean
+  blockRef?: string | null
+  activeDocContent?: any
+  panel?: {key: string; openComment?: string} | null
+  commentAuthorName?: string
+  commentIsLoading?: boolean
+  commentAuthorIsLoading?: boolean
+}): BreadcrumbItem[] {
+  const {
+    entityIds,
+    entityContents,
+    contacts,
+    draftName,
+    replaceLastItem,
+    blockRef,
+    activeDocContent,
+    panel,
+    commentAuthorName,
+    commentIsLoading,
+    commentAuthorIsLoading,
+  } = params
+
+  const crumbs: BreadcrumbItem[] = []
+
+  const items = entityIds.flatMap((id, idIndex) => {
+    const contents = entityContents[idIndex]
+    let name: string
+    if (id.path?.length) {
+      name = getDocumentTitle(contents?.entity?.document) || ''
+    } else {
+      name = getContactMetadata(
+        id.uid,
+        contents?.entity?.document?.metadata,
+        contacts ?? undefined,
+      ).name
+    }
+    const isNotFound = contents?.entity?.isNotFound || false
+    const isTombstone = contents?.entity?.isTombstone || false
+    const isLoading = !!contents?.isDiscovering
+    return [
+      {
+        name,
+        fallbackName: id.path?.at(-1) || id.uid.slice(0, 8),
+        isError:
+          contents?.entity &&
+          !contents.entity.document &&
+          !isTombstone &&
+          !isNotFound,
+        isTombstone,
+        isNotFound,
+        isLoading,
+        id,
+        crumbKey: `id-${idIndex}`,
+      },
+    ]
+  })
+
+  crumbs.push(...items)
+
+  if (draftName && replaceLastItem) {
+    crumbs.pop()
+  }
+
+  if (draftName) {
+    crumbs.push({
+      name: draftName,
+      fallbackName: draftName,
+      id: null,
+      crumbKey: `draft-${draftName}`,
+    })
+  }
+
+  if (!panel?.key && blockRef) {
+    const blockNode = activeDocContent
+      ? findContentBlock(activeDocContent, blockRef)
+      : null
+    const blockText =
+      (blockNode?.block && getBlockText(blockNode?.block)) || 'Block'
+    const truncatedBlockText =
+      blockText.length > 50 ? blockText.slice(0, 50) + '...' : blockText
+    crumbs.push({
+      name: truncatedBlockText,
+      id: null,
+      crumbKey: 'content',
+    })
+  }
+
+  if (panel?.key === 'collaborators') {
+    crumbs.push({name: 'Collaborators', id: null, crumbKey: 'collaborators'})
+  }
+  if (panel?.key === 'discussions') {
+    if (panel.openComment) {
+      crumbs.push({
+        name: commentAuthorName ? `Comment by ${commentAuthorName}` : 'Comment',
+        isLoading: commentIsLoading || commentAuthorIsLoading,
+        id: null,
+        crumbKey: 'comment',
+      })
+    } else {
+      crumbs.push({name: 'Discussions', id: null, crumbKey: 'discussions'})
+    }
+  }
+  if (panel?.key === 'directory') {
+    crumbs.push({name: 'Directory', id: null, crumbKey: 'directory'})
+  }
+  if (panel?.key === 'activity') {
+    crumbs.push({name: 'Activity', id: null, crumbKey: 'activity'})
+  }
+
+  return crumbs
+}
+
+export function computeDraftEntityParams(
+  draftData: any,
+  route: {
+    visibility?: string
+    panel?: any
+    locationUid?: string
+    locationPath?: string[]
+    editUid?: string
+    editPath?: string[]
+  },
+  locationId: UnpackedHypermediaId | undefined,
+  editId: UnpackedHypermediaId | undefined,
+  editDocName: string | undefined,
+): DraftEntityParams {
+  const isPrivate =
+    route.visibility === 'PRIVATE' || draftData?.visibility === 'PRIVATE'
+  const displayName = draftData?.metadata?.name || editDocName
+
+  if (locationId) {
+    return {
+      entityId: isPrivate ? hmId(locationId.uid) : locationId,
+      panel: route.panel,
+      draftName: draftData?.metadata?.name || 'New Draft',
+      replaceLastItem: false,
+      isNewDraft: false,
+      hideControls: true,
+      isFallback: false,
+      fallbackDraftName: draftData?.metadata?.name || 'New Draft',
+    }
+  }
+
+  if (editId) {
+    return {
+      entityId: editId,
+      panel: route.panel,
+      draftName: displayName,
+      replaceLastItem: !!displayName,
+      isNewDraft: !draftData?.deps?.length,
+      hideControls: true,
+      isFallback: false,
+      fallbackDraftName: draftData?.metadata?.name || 'New Draft',
+    }
+  }
+
+  return {
+    entityId: undefined,
+    panel: null,
+    draftName: undefined,
+    replaceLastItem: false,
+    isNewDraft: false,
+    hideControls: true,
+    isFallback: true,
+    fallbackDraftName: draftData?.metadata?.name || 'New Draft',
+  }
+}

--- a/frontend/apps/desktop/src/hooks/use-route-breadcrumbs.ts
+++ b/frontend/apps/desktop/src/hooks/use-route-breadcrumbs.ts
@@ -1,0 +1,329 @@
+import {useDraft} from '@/models/accounts'
+import {useContact, useSelectedAccountContacts} from '@/models/contacts'
+import {draftEditId, draftLocationId} from '@/models/drafts'
+import {
+  commentIdToHmId,
+  getParentPaths,
+  hmId,
+  UnpackedHypermediaId,
+} from '@shm/shared'
+import {getDocumentTitle} from '@shm/shared/content'
+import {useAccount, useResource, useResources} from '@shm/shared/models/entity'
+import {
+  ContactRoute,
+  DocumentPanelRoute,
+  DraftRoute,
+  ProfileRoute,
+} from '@shm/shared/routes'
+import {useNavRoute} from '@shm/shared/utils/navigation'
+import {useMemo} from 'react'
+import {
+  computeContactBreadcrumbs,
+  computeDraftEntityParams,
+  computeEntityBreadcrumbs,
+  computeProfileBreadcrumbs,
+  computeSimpleRouteBreadcrumbs,
+  EntityContent,
+  getIconForRoute,
+  getWindowTitle,
+  RouteBreadcrumbsResult,
+} from './route-breadcrumbs'
+
+// Re-export types and pure functions for consumers
+export type {
+  BreadcrumbIconKey,
+  BreadcrumbItem,
+  DraftEntityParams,
+  EntityContent,
+  RouteBreadcrumbsResult,
+} from './route-breadcrumbs'
+export {
+  computeContactBreadcrumbs,
+  computeDraftEntityParams,
+  computeEntityBreadcrumbs,
+  computeProfileBreadcrumbs,
+  computeSimpleRouteBreadcrumbs,
+  getIconForRoute,
+  getWindowTitle,
+} from './route-breadcrumbs'
+
+// ---------------------------------------------------------------------------
+// React hook
+// ---------------------------------------------------------------------------
+
+const EMPTY_RESULT: RouteBreadcrumbsResult = {
+  items: [],
+  icon: null,
+  windowTitle: null,
+  isDraft: false,
+  isAllError: false,
+  entityId: null,
+  isLatest: true,
+  hideControls: false,
+}
+
+export function useRouteBreadcrumbs(): RouteBreadcrumbsResult {
+  const route = useNavRoute()
+
+  // --- Draft data (noop for non-draft routes) ---
+  const isDraft = route.key === 'draft'
+  const draftRoute = isDraft ? (route as DraftRoute) : undefined
+  const draft = useDraft(draftRoute?.id)
+
+  const locationId = useMemo(() => {
+    if (!draftRoute) return undefined
+    const lid = draftLocationId(draft.data)
+    if (lid) return lid
+    if (draftRoute.locationUid) {
+      return hmId(draftRoute.locationUid, {path: draftRoute.locationPath})
+    }
+    return undefined
+  }, [draftRoute, draft.data])
+
+  const editId = useMemo(() => {
+    if (!draftRoute) return undefined
+    const eid = draftEditId(draft.data)
+    if (eid) return eid
+    if (draftRoute.editUid) {
+      return hmId(draftRoute.editUid, {path: draftRoute.editPath})
+    }
+    return undefined
+  }, [draftRoute, draft.data])
+
+  const editDocument = useResource(editId)
+  const editDocName =
+    editDocument.data?.type === 'document'
+      ? getDocumentTitle(editDocument.data.document)
+      : undefined
+
+  const draftParams = useMemo(() => {
+    if (!draftRoute) return undefined
+    return computeDraftEntityParams(
+      draft.data,
+      draftRoute,
+      locationId,
+      editId,
+      editDocName,
+    )
+  }, [draftRoute, draft.data, locationId, editId, editDocName])
+
+  // --- Determine entityId and panel for entity-based routes ---
+  const entityId = useMemo((): UnpackedHypermediaId | undefined => {
+    if (isDraft) return draftParams?.entityId
+    if (
+      route.key === 'document' ||
+      route.key === 'feed' ||
+      route.key === 'directory' ||
+      route.key === 'collaborators' ||
+      route.key === 'activity' ||
+      route.key === 'discussions'
+    ) {
+      return route.id
+    }
+    return undefined
+  }, [route, isDraft, draftParams?.entityId])
+
+  const panel = useMemo((): DocumentPanelRoute | null | undefined => {
+    if (isDraft) return draftParams?.panel
+    if (route.key === 'document' || route.key === 'feed') return null
+    if (route.key === 'directory')
+      return {key: 'directory' as const} as DocumentPanelRoute
+    if (route.key === 'collaborators')
+      return {key: 'collaborators' as const} as DocumentPanelRoute
+    if (route.key === 'activity')
+      return {key: 'activity' as const} as DocumentPanelRoute
+    if (route.key === 'discussions')
+      return {
+        key: 'discussions' as const,
+        openComment: route.openComment,
+      } as DocumentPanelRoute
+    return undefined
+  }, [route, isDraft, draftParams?.panel])
+
+  // --- Entity data (noop when entityId is undefined) ---
+  const contacts = useSelectedAccountContacts()
+  const latestDoc = useResource(
+    entityId ? {...entityId, version: null, latest: true} : null,
+  )
+  const isLatest =
+    !entityId ||
+    entityId.latest ||
+    entityId.version ===
+      (latestDoc.data?.type === 'document'
+        ? latestDoc.data.document?.version
+        : undefined)
+
+  const isNewDraft = isDraft ? draftParams?.isNewDraft ?? false : false
+
+  const entityIds = useMemo(() => {
+    if (!entityId) return []
+    const paths = getParentPaths(entityId.path)
+    const subscribablePaths =
+      isNewDraft && paths.length > 0 ? paths.slice(0, -1) : paths
+    return subscribablePaths.map((path) => hmId(entityId.uid, {path}))
+  }, [entityId, isNewDraft])
+
+  const entityResults = useResources(entityIds, {subscribed: true})
+
+  const entityContents: EntityContent[] = useMemo(
+    () =>
+      entityIds.map((id, i) => {
+        const result = entityResults[i]
+        const data = result?.data
+        const isDiscovering = result?.isDiscovering
+        if (!data) return {id, entity: undefined, isDiscovering}
+        if (data.type === 'tombstone')
+          return {id, entity: {id: data.id, isTombstone: true}, isDiscovering}
+        if (data.type === 'not-found')
+          return {id, entity: {id: data.id, isNotFound: true}, isDiscovering}
+        if (data.type === 'document')
+          return {
+            id,
+            entity: {id: data.id, document: data.document},
+            isDiscovering,
+          }
+        return {id, entity: undefined, isDiscovering}
+      }),
+    [entityIds, entityResults],
+  )
+
+  // --- Comment data for discussions panel ---
+  const openCommentId = useMemo(() => {
+    if (panel?.key === 'discussions' && panel.openComment) {
+      return commentIdToHmId(panel.openComment)
+    }
+    return null
+  }, [panel])
+
+  const comment = useResource(openCommentId)
+  const commentData =
+    comment.data?.type === 'comment' ? comment.data.comment : null
+  const commentAuthorId = commentData?.author ? hmId(commentData.author) : null
+  const commentAuthor = useAccount(commentAuthorId?.uid, {
+    enabled: !!commentAuthorId,
+  })
+
+  // --- Contact/profile data (noop for non-matching routes) ---
+  const contact = useContact(
+    route.key === 'contact' ? (route as ContactRoute).id : undefined,
+  )
+  const profile = useAccount(
+    route.key === 'profile' ? (route as ProfileRoute).id.uid : undefined,
+  )
+
+  // --- Compute result ---
+  return useMemo((): RouteBreadcrumbsResult => {
+    // Simple routes
+    const simple = computeSimpleRouteBreadcrumbs(route.key)
+    if (simple) {
+      return {
+        ...simple,
+        isDraft: false,
+        isAllError: false,
+        entityId: null,
+        isLatest: true,
+        hideControls: false,
+      }
+    }
+
+    // Contact route
+    if (route.key === 'contact') {
+      const name = contact.data?.metadata?.name
+      return {
+        items: computeContactBreadcrumbs(name),
+        icon: 'contact',
+        windowTitle: getWindowTitle('contact', name),
+        isDraft: false,
+        isAllError: false,
+        entityId: null,
+        isLatest: true,
+        hideControls: false,
+      }
+    }
+
+    // Profile route
+    if (route.key === 'profile') {
+      const name = profile.data?.metadata?.name
+      return {
+        items: computeProfileBreadcrumbs(name),
+        icon: 'contact',
+        windowTitle: getWindowTitle('profile', name),
+        isDraft: false,
+        isAllError: false,
+        entityId: null,
+        isLatest: true,
+        hideControls: false,
+      }
+    }
+
+    // Draft fallback (no locationId, no editId)
+    if (isDraft && draftParams?.isFallback) {
+      return {
+        items: [
+          {name: 'Drafts', id: null, crumbKey: 'drafts-parent'},
+          {
+            name: draftParams.fallbackDraftName,
+            id: null,
+            crumbKey: 'draft-name',
+          },
+        ],
+        icon: 'file',
+        windowTitle: getWindowTitle('draft', draftParams.fallbackDraftName),
+        isDraft: true,
+        isAllError: false,
+        entityId: null,
+        isLatest: true,
+        hideControls: true,
+      }
+    }
+
+    // Entity routes (document, feed, directory, collaborators, activity, discussions, draft with entity)
+    if (!entityId) return EMPTY_RESULT
+
+    const activeDocContent =
+      entityContents.at(-1)?.entity?.document?.content ?? undefined
+
+    const items = computeEntityBreadcrumbs({
+      entityIds,
+      entityContents,
+      contacts: contacts.data,
+      draftName: isDraft ? draftParams?.draftName : undefined,
+      replaceLastItem: isDraft ? draftParams?.replaceLastItem : false,
+      blockRef: entityId.blockRef,
+      activeDocContent,
+      panel: panel ?? null,
+      commentAuthorName: commentAuthor.data?.metadata?.name,
+      commentIsLoading: comment.isLoading,
+      commentAuthorIsLoading: commentAuthor.isLoading,
+    })
+
+    const activeItem = items.at(-1)
+    const isAllError = items.every((item) => item.isError)
+
+    return {
+      items,
+      icon: getIconForRoute(route.key),
+      windowTitle: getWindowTitle(route.key, activeItem?.name),
+      isDraft,
+      isAllError,
+      entityId,
+      isLatest,
+      hideControls: isDraft ? draftParams?.hideControls ?? true : false,
+    }
+  }, [
+    route,
+    isDraft,
+    draftParams,
+    entityId,
+    entityIds,
+    entityContents,
+    contacts.data,
+    panel,
+    comment.isLoading,
+    commentAuthor.data,
+    commentAuthor.isLoading,
+    contact.data,
+    profile.data,
+    isLatest,
+  ])
+}


### PR DESCRIPTION
## Summary
- Extracted breadcrumb data logic from `titlebar-title.tsx` into a standalone `useRouteBreadcrumbs()` hook
- Split pure computation functions (`route-breadcrumbs.ts`) from React hook wrapper (`use-route-breadcrumbs.ts`) for testability
- Refactored `TitleContent` to consume the hook, removing `ContactTitle`, `ProfileTitle`, `DraftTitle`, and the data-fetching `BreadcrumbTitle` component
- Added 57 tests covering all pure breadcrumb functions

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm format:write` passes
- [x] 57 new tests pass for pure breadcrumb functions
- [ ] Manual: verify breadcrumbs render correctly in desktop app titlebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)