### PR TITLE
hide subdocument creation buttons for private documents

### DIFF
--- a/frontend/apps/desktop/src/components/document-accessory.tsx
+++ b/frontend/apps/desktop/src/components/document-accessory.tsx
@@ -6,6 +6,7 @@ import {useCreateDraft} from '@/models/documents'
 import {draftMachine, DraftMachineState} from '@/models/draft-machine'
 import {useSelectedAccount} from '@/selected-account'
 import {HMBlockNode, UnpackedHypermediaId} from '@shm/shared/hm-types'
+import {useResource} from '@shm/shared/models/entity'
 import {DocSelectionOption} from '@shm/shared/routes'
 import {getRouteKey, useNavRoute} from '@shm/shared/utils/navigation'
 import {PanelContent} from '@shm/ui/accessories'
@@ -184,7 +185,12 @@ export function useDocumentSelection({
   const selectionOptions: Array<DocSelectionOption> = []
 
   const selectedAccount = useSelectedAccount()
-  const canCreateSubDoc = useCanCreateSubDocument(docId)
+  const docResource = useResource(docId)
+  const isPrivateDoc =
+    docResource.data?.type === 'document'
+      ? docResource.data.document?.visibility === 'PRIVATE'
+      : false
+  const canCreateSubDoc = useCanCreateSubDocument(docId) && !isPrivateDoc
 
   if (panelKey === 'collaborators') {
     // @ts-expect-error

--- a/frontend/apps/desktop/src/pages/desktop-legacy-document.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-legacy-document.tsx
@@ -480,6 +480,7 @@ function _MainDocumentPage({
   const docId =
     resource.data?.type === 'document' ? resource.data.id : undefined
   const metadata = document?.metadata
+  const isPrivateDoc = document?.visibility === 'PRIVATE'
   // IMPORTANT: Always call hooks at the top level, before any early returns
   // This ensures hooks are called in the same order on every render
   const isHomeDoc = !id.path?.length
@@ -589,10 +590,12 @@ function _MainDocumentPage({
                 )}
               >
                 <EditDocButton />
-                <CreateDocumentButton
-                  locationId={id}
-                  siteUrl={siteHomeEntityData?.document?.metadata?.siteUrl}
-                />
+                {!isPrivateDoc && (
+                  <CreateDocumentButton
+                    locationId={id}
+                    siteUrl={siteHomeEntityData?.document?.metadata?.siteUrl}
+                  />
+                )}
               </div>
             ) : (
               <OpenInPanelButton
@@ -618,7 +621,7 @@ function _MainDocumentPage({
             // header={
             //   canCreate ? <NewSubDocumentButton locationId={id} /> : undefined
             // }
-            canCreate={canCreate}
+            canCreate={canCreate && !isPrivateDoc}
             showTitle={false}
             contentMaxWidth={contentMaxWidth}
           />
@@ -757,10 +760,12 @@ function _MainDocumentPage({
             )}
           >
             <EditDocButton />
-            <CreateDocumentButton
-              locationId={id}
-              siteUrl={siteHomeEntityData?.document?.metadata?.siteUrl}
-            />
+            {!isPrivateDoc && (
+              <CreateDocumentButton
+                locationId={id}
+                siteUrl={siteHomeEntityData?.document?.metadata?.siteUrl}
+              />
+            )}
           </div>
         ) : null}
         <ScrollArea>

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -78,6 +78,7 @@ export default function DesktopResourcePage() {
   const resource = useResource(docId)
   const doc =
     resource.data?.type === 'document' ? resource.data.document : undefined
+  const isPrivate = doc?.visibility === 'PRIVATE'
   const {exportDocument, openDirectory} = useAppContext()
   const gwUrl = useGatewayUrl().data || DEFAULT_GATEWAY_URL
   const [copyGatewayContent, onCopyGateway] = useCopyReferenceUrl(gwUrl)
@@ -219,7 +220,9 @@ export default function DesktopResourcePage() {
           <Pencil className="size-4" />
         </Button>
       </Tooltip>
-      <CreateDocumentButton locationId={docId} siteUrl={siteUrl} />
+      {!isPrivate && (
+        <CreateDocumentButton locationId={docId} siteUrl={siteUrl} />
+      )}
     </>
   ) : null
 


### PR DESCRIPTION
backend doesn't support subdocuments in private docs, so hide
CreateDocumentButton and NewSubDocumentButton when viewing a
private document across all document views.

https://claude.ai/code/session_01L9mBL9eWYvevSrNxXoLXbH