### PR TITLE
feat(links): enhance URL generation for comments and blocks with version/panel support

### DIFF
--- a/frontend/apps/desktop/src/components/copy-reference-button.tsx
+++ b/frontend/apps/desktop/src/components/copy-reference-button.tsx
@@ -13,7 +13,7 @@ import {useNavRoute} from '@shm/shared/utils/navigation'
 import {Button, ButtonProps} from '@shm/ui/button'
 import {ExternalLink, Link} from '@shm/ui/icons'
 import {Tooltip} from '@shm/ui/tooltip'
-import React, {PropsWithChildren, ReactNode, useCallback, useState} from 'react'
+import React, {PropsWithChildren, ReactNode, useState} from 'react'
 
 export function useDocumentUrl({
   docId,
@@ -170,23 +170,4 @@ export function CopyReferenceButton({
       {reference.content}
     </>
   )
-}
-
-export function useCopyReferenceButton(docId?: UnpackedHypermediaId) {
-  const [isCopied, setIsCopied] = useState(false)
-
-  const onCopy = useCallback(() => {
-    if (isCopied) return
-    if (docId) {
-      const accountId = hmId(docId.uid)
-      // @ts-expect-error
-      copy(accountId)
-      setIsCopied(true)
-      setTimeout(() => {
-        setIsCopied(false)
-      }, 5000)
-    }
-  }, [docId])
-
-  return {onCopy}
 }

--- a/frontend/apps/web/app/web-utils.tsx
+++ b/frontend/apps/web/app/web-utils.tsx
@@ -82,8 +82,20 @@ export function useWebMenuItems(docId: UnpackedHypermediaId): MenuItemType[] {
       createWebHMUrl(docId.uid, {
         path: docId.path,
         hostname: gwUrl,
+        version: docId.version,
+        blockRef: docId.blockRef,
+        blockRange: docId.blockRange,
+        latest: docId.latest,
       }),
-    [docId.uid, docId.path, gwUrl],
+    [
+      docId.uid,
+      docId.path,
+      docId.version,
+      docId.blockRef,
+      docId.blockRange,
+      docId.latest,
+      gwUrl,
+    ],
   )
 
   return useMemo(

--- a/frontend/packages/shared/src/utils/__tests__/entity-id-url.test.ts
+++ b/frontend/packages/shared/src/utils/__tests__/entity-id-url.test.ts
@@ -1,9 +1,15 @@
 import {describe, expect, test} from 'vitest'
 import {
+  createCommentUrl,
+  createSiteUrl,
+  createWebHMUrl,
   hmId,
+  idToUrl,
   packHmId,
   parseCustomURL,
   parseFragment,
+  routeToUrl,
+  serializeBlockRange,
   unpackHmId,
 } from '../entity-id-url'
 
@@ -312,5 +318,559 @@ describe('parseFragment', () => {
       blockId: 'UyXozrafan',
       expanded: false,
     })
+  })
+})
+
+describe('serializeBlockRange', () => {
+  test('null returns empty string', () => {
+    expect(serializeBlockRange(null)).toBe('')
+  })
+  test('undefined returns empty string', () => {
+    expect(serializeBlockRange(undefined)).toBe('')
+  })
+  test('expanded: true returns +', () => {
+    expect(serializeBlockRange({expanded: true})).toBe('+')
+  })
+  test('expanded: false returns empty string', () => {
+    expect(serializeBlockRange({expanded: false})).toBe('')
+  })
+  test('range returns [start:end]', () => {
+    expect(serializeBlockRange({start: 10, end: 20})).toBe('[10:20]')
+  })
+})
+
+describe('createWebHMUrl', () => {
+  test('basic doc URL with hostname', () => {
+    expect(createWebHMUrl('abc123', {hostname: 'https://gw.com'})).toBe(
+      'https://gw.com/hm/abc123',
+    )
+  })
+
+  test('doc URL with path', () => {
+    expect(
+      createWebHMUrl('abc', {
+        hostname: 'https://gw.com',
+        path: ['docs', 'intro'],
+      }),
+    ).toBe('https://gw.com/hm/abc/docs/intro')
+  })
+
+  test('doc URL with version', () => {
+    expect(
+      createWebHMUrl('abc', {hostname: 'https://gw.com', version: 'v1hash'}),
+    ).toBe('https://gw.com/hm/abc?v=v1hash')
+  })
+
+  test('doc URL with latest', () => {
+    expect(
+      createWebHMUrl('abc', {hostname: 'https://gw.com', latest: true}),
+    ).toBe('https://gw.com/hm/abc?l')
+  })
+
+  test('latest=true ignores version', () => {
+    expect(
+      createWebHMUrl('abc', {
+        hostname: 'https://gw.com',
+        latest: true,
+        version: 'v1hash',
+      }),
+    ).toBe('https://gw.com/hm/abc?l')
+  })
+
+  test('doc URL with blockRef', () => {
+    expect(
+      createWebHMUrl('abc', {
+        hostname: 'https://gw.com',
+        blockRef: 'XK6l8B4d',
+      }),
+    ).toBe('https://gw.com/hm/abc#XK6l8B4d')
+  })
+
+  test('doc URL with expanded blockRef', () => {
+    expect(
+      createWebHMUrl('abc', {
+        hostname: 'https://gw.com',
+        blockRef: 'XK6l8B4d',
+        blockRange: {expanded: true},
+      }),
+    ).toBe('https://gw.com/hm/abc#XK6l8B4d+')
+  })
+
+  test('doc URL with block range', () => {
+    expect(
+      createWebHMUrl('abc', {
+        hostname: 'https://gw.com',
+        blockRef: 'XK6l8B4d',
+        blockRange: {start: 21, end: 41},
+      }),
+    ).toBe('https://gw.com/hm/abc#XK6l8B4d[21:41]')
+  })
+
+  test('doc URL with version + blockRef', () => {
+    expect(
+      createWebHMUrl('abc', {
+        hostname: 'https://gw.com',
+        version: 'v1hash',
+        blockRef: 'blk1',
+      }),
+    ).toBe('https://gw.com/hm/abc?v=v1hash#blk1')
+  })
+
+  test('doc URL with panel param', () => {
+    expect(
+      createWebHMUrl('abc', {
+        hostname: 'https://gw.com',
+        panel: 'discussions',
+      }),
+    ).toBe('https://gw.com/hm/abc?panel=discussions')
+  })
+
+  test('doc URL with viewTerm', () => {
+    expect(
+      createWebHMUrl('abc', {
+        hostname: 'https://gw.com',
+        viewTerm: ':activity',
+      }),
+    ).toBe('https://gw.com/hm/abc/:activity')
+  })
+
+  test('doc URL with originHomeId omits /hm/uid prefix', () => {
+    const originHome = hmId('abc')
+    expect(
+      createWebHMUrl('abc', {
+        hostname: 'https://mysite.com',
+        path: ['docs'],
+        originHomeId: originHome,
+      }),
+    ).toBe('https://mysite.com/docs')
+  })
+
+  test('null hostname produces no host prefix', () => {
+    expect(createWebHMUrl('abc', {hostname: null})).toBe('/hm/abc')
+  })
+
+  test('undefined hostname uses default gateway', () => {
+    const url = createWebHMUrl('abc', {})
+    expect(url).toContain('/hm/abc')
+    // Should start with some https:// URL (DEFAULT_GATEWAY_URL)
+    expect(url).toMatch(/^https?:\/\//)
+  })
+
+  test('all params combined', () => {
+    expect(
+      createWebHMUrl('uid1', {
+        hostname: 'https://gw.com',
+        path: ['a', 'b'],
+        version: 'v1',
+        blockRef: 'blk',
+        blockRange: {expanded: true},
+        panel: 'activity',
+        viewTerm: ':discussions',
+      }),
+    ).toBe('https://gw.com/hm/uid1/a/b/:discussions?v=v1&panel=activity#blk+')
+  })
+})
+
+describe('createSiteUrl', () => {
+  test('basic site URL', () => {
+    expect(createSiteUrl({hostname: 'https://mysite.com', path: null})).toBe(
+      'https://mysite.com',
+    )
+  })
+
+  test('site URL with path', () => {
+    expect(
+      createSiteUrl({hostname: 'https://mysite.com', path: ['docs', 'intro']}),
+    ).toBe('https://mysite.com/docs/intro')
+  })
+
+  test('site URL with version', () => {
+    expect(
+      createSiteUrl({
+        hostname: 'https://mysite.com',
+        path: ['page'],
+        version: 'v1hash',
+      }),
+    ).toBe('https://mysite.com/page?v=v1hash')
+  })
+
+  test('site URL with latest', () => {
+    expect(
+      createSiteUrl({
+        hostname: 'https://mysite.com',
+        path: ['page'],
+        latest: true,
+      }),
+    ).toBe('https://mysite.com/page?l')
+  })
+
+  test('site URL with blockRef + expanded', () => {
+    expect(
+      createSiteUrl({
+        hostname: 'https://mysite.com',
+        path: ['page'],
+        blockRef: 'blk1',
+        blockRange: {expanded: true},
+      }),
+    ).toBe('https://mysite.com/page#blk1+')
+  })
+
+  test('site URL with blockRef + range', () => {
+    expect(
+      createSiteUrl({
+        hostname: 'https://mysite.com',
+        path: ['page'],
+        blockRef: 'blk1',
+        blockRange: {start: 5, end: 15},
+      }),
+    ).toBe('https://mysite.com/page#blk1[5:15]')
+  })
+})
+
+describe('routeToUrl', () => {
+  test('document route produces correct URL', () => {
+    const url = routeToUrl(
+      {
+        key: 'document',
+        id: hmId('uid1', {path: ['docs']}),
+      },
+      {hostname: 'https://gw.com'},
+    )
+    expect(url).toBe('https://gw.com/hm/uid1/docs')
+  })
+
+  test('document route with blockRef includes fragment', () => {
+    const url = routeToUrl(
+      {
+        key: 'document',
+        id: hmId('uid1', {
+          version: 'v1',
+          blockRef: 'blk1',
+          blockRange: {expanded: true},
+        }),
+      },
+      {hostname: 'https://gw.com'},
+    )
+    expect(url).toBe('https://gw.com/hm/uid1?v=v1#blk1+')
+  })
+
+  test('activity route includes :activity viewTerm', () => {
+    const url = routeToUrl(
+      {
+        key: 'activity',
+        id: hmId('uid1'),
+      },
+      {hostname: 'https://gw.com'},
+    )
+    expect(url).toBe('https://gw.com/hm/uid1/:activity')
+  })
+
+  test('discussions route includes :discussions viewTerm', () => {
+    const url = routeToUrl(
+      {
+        key: 'discussions',
+        id: hmId('uid1'),
+      },
+      {hostname: 'https://gw.com'},
+    )
+    expect(url).toBe('https://gw.com/hm/uid1/:discussions')
+  })
+
+  test('discussions route with openComment includes panel param', () => {
+    const url = routeToUrl(
+      {
+        key: 'discussions',
+        id: hmId('uid1'),
+        openComment: 'comment123',
+      },
+      {hostname: 'https://gw.com'},
+    )
+    expect(url).toBe(
+      'https://gw.com/hm/uid1/:discussions?panel=comment/comment123',
+    )
+  })
+
+  test('feed route includes :feed viewTerm', () => {
+    const url = routeToUrl(
+      {
+        key: 'feed',
+        id: hmId('uid1'),
+      },
+      {hostname: 'https://gw.com'},
+    )
+    expect(url).toBe('https://gw.com/hm/uid1/:feed')
+  })
+
+  test('document route with originHomeId for site URL', () => {
+    const originHome = hmId('uid1')
+    const url = routeToUrl(
+      {
+        key: 'document',
+        id: hmId('uid1', {path: ['page']}),
+      },
+      {hostname: 'https://mysite.com', originHomeId: originHome},
+    )
+    expect(url).toBe('https://mysite.com/page')
+  })
+})
+
+describe('idToUrl', () => {
+  test('converts UnpackedHypermediaId to web URL', () => {
+    const id = hmId('abc', {
+      path: ['docs'],
+      version: 'v1',
+      blockRef: 'blk',
+    })
+    id.hostname = 'https://gw.com'
+    const url = idToUrl(id)
+    expect(url).toBe('https://gw.com/hm/abc/docs?v=v1#blk')
+  })
+})
+
+describe('createSiteUrl with viewTerm and panel', () => {
+  test('site URL with viewTerm', () => {
+    expect(
+      createSiteUrl({
+        hostname: 'https://mysite.com',
+        path: ['doc'],
+        viewTerm: ':discussions',
+      }),
+    ).toBe('https://mysite.com/doc/:discussions')
+  })
+
+  test('site URL with panel param', () => {
+    expect(
+      createSiteUrl({
+        hostname: 'https://mysite.com',
+        path: ['doc'],
+        panel: 'comment/z6Mk/abc',
+      }),
+    ).toBe('https://mysite.com/doc?panel=comment/z6Mk/abc')
+  })
+
+  test('site URL with viewTerm + panel + latest', () => {
+    expect(
+      createSiteUrl({
+        hostname: 'https://mysite.com',
+        path: ['doc'],
+        viewTerm: ':discussions',
+        panel: 'comment/z6Mk/abc',
+        latest: true,
+      }),
+    ).toBe('https://mysite.com/doc/:discussions?l&panel=comment/z6Mk/abc')
+  })
+
+  test('site URL with viewTerm + panel + blockRef', () => {
+    expect(
+      createSiteUrl({
+        hostname: 'https://mysite.com',
+        path: ['doc'],
+        viewTerm: ':discussions',
+        panel: 'comment/z6Mk/abc',
+        blockRef: 'blk1',
+        blockRange: {expanded: true},
+      }),
+    ).toBe('https://mysite.com/doc/:discussions?panel=comment/z6Mk/abc#blk1+')
+  })
+})
+
+describe('createCommentUrl', () => {
+  const docId = hmId('z6MkOwner', {path: ['human-interface-library']})
+
+  test('discussions view with siteUrl', () => {
+    expect(
+      createCommentUrl({
+        docId,
+        commentId: 'z6MkAuthor/tsid123',
+        siteUrl: 'https://seedteamtalks.hyper.media',
+        isDiscussionsView: true,
+      }),
+    ).toBe(
+      'https://seedteamtalks.hyper.media/human-interface-library/:discussions?panel=comment/z6MkAuthor/tsid123',
+    )
+  })
+
+  test('discussions view with siteUrl + latest', () => {
+    expect(
+      createCommentUrl({
+        docId,
+        commentId: 'z6MkAuthor/tsid123',
+        siteUrl: 'https://seedteamtalks.hyper.media',
+        isDiscussionsView: true,
+        latest: true,
+      }),
+    ).toBe(
+      'https://seedteamtalks.hyper.media/human-interface-library/:discussions?l&panel=comment/z6MkAuthor/tsid123',
+    )
+  })
+
+  test('discussions view with siteUrl + blockRef', () => {
+    expect(
+      createCommentUrl({
+        docId,
+        commentId: 'z6MkAuthor/tsid123',
+        siteUrl: 'https://seedteamtalks.hyper.media',
+        isDiscussionsView: true,
+        blockRef: 'XK6l8B4d',
+        blockRange: {expanded: true},
+      }),
+    ).toBe(
+      'https://seedteamtalks.hyper.media/human-interface-library/:discussions?panel=comment/z6MkAuthor/tsid123#XK6l8B4d+',
+    )
+  })
+
+  test('panel view with siteUrl (not discussions main view)', () => {
+    expect(
+      createCommentUrl({
+        docId,
+        commentId: 'z6MkAuthor/tsid123',
+        siteUrl: 'https://seedteamtalks.hyper.media',
+        isDiscussionsView: false,
+      }),
+    ).toBe(
+      'https://seedteamtalks.hyper.media/human-interface-library?panel=comment/z6MkAuthor/tsid123',
+    )
+  })
+
+  test('panel view with siteUrl + latest + blockRef', () => {
+    expect(
+      createCommentUrl({
+        docId,
+        commentId: 'z6MkAuthor/tsid123',
+        siteUrl: 'https://seedteamtalks.hyper.media',
+        isDiscussionsView: false,
+        latest: true,
+        blockRef: 'blk1',
+        blockRange: {start: 10, end: 20},
+      }),
+    ).toBe(
+      'https://seedteamtalks.hyper.media/human-interface-library?l&panel=comment/z6MkAuthor/tsid123#blk1[10:20]',
+    )
+  })
+
+  test('discussions view without siteUrl (gateway)', () => {
+    expect(
+      createCommentUrl({
+        docId,
+        commentId: 'z6MkAuthor/tsid123',
+        isDiscussionsView: true,
+        latest: true,
+      }),
+    ).toContain(
+      '/hm/z6MkOwner/human-interface-library/:discussions?l&panel=comment/z6MkAuthor/tsid123',
+    )
+  })
+
+  test('panel view without siteUrl (gateway)', () => {
+    expect(
+      createCommentUrl({
+        docId,
+        commentId: 'z6MkAuthor/tsid123',
+        isDiscussionsView: false,
+      }),
+    ).toContain(
+      '/hm/z6MkOwner/human-interface-library?panel=comment/z6MkAuthor/tsid123',
+    )
+  })
+
+  test('gateway view with blockRef', () => {
+    expect(
+      createCommentUrl({
+        docId,
+        commentId: 'z6MkAuthor/tsid123',
+        isDiscussionsView: true,
+        blockRef: 'blk1',
+        blockRange: {expanded: true},
+      }),
+    ).toContain(
+      '/hm/z6MkOwner/human-interface-library/:discussions?panel=comment/z6MkAuthor/tsid123#blk1+',
+    )
+  })
+
+  // Root path (no doc path) — matches user's gabo.es example
+  test('root doc discussions view with siteUrl + latest', () => {
+    const rootDocId = hmId('z6MkOwner', {path: []})
+    expect(
+      createCommentUrl({
+        docId: rootDocId,
+        commentId: 'zDnae.../z6FK...',
+        siteUrl: 'https://gabo.es',
+        isDiscussionsView: true,
+        latest: true,
+      }),
+    ).toBe('https://gabo.es/:discussions?l&panel=comment/zDnae.../z6FK...')
+  })
+
+  test('root doc panel view with siteUrl + latest', () => {
+    const rootDocId = hmId('z6MkOwner', {path: []})
+    expect(
+      createCommentUrl({
+        docId: rootDocId,
+        commentId: 'zDnae.../z6FK...',
+        siteUrl: 'https://gabo.es',
+        isDiscussionsView: false,
+        latest: true,
+      }),
+    ).toBe('https://gabo.es?l&panel=comment/zDnae.../z6FK...')
+  })
+})
+
+describe('roundtrip: createWebHMUrl -> unpackHmId', () => {
+  test('basic doc URL roundtrips', () => {
+    const url = createWebHMUrl('abc123', {hostname: 'https://gw.com'})
+    const unpacked = unpackHmId(url)
+    expect(unpacked?.uid).toBe('abc123')
+    expect(unpacked?.path).toEqual([])
+    expect(unpacked?.hostname).toBe('gw.com')
+  })
+
+  test('doc URL with version roundtrips', () => {
+    const url = createWebHMUrl('abc', {
+      hostname: 'https://gw.com',
+      version: 'v1hash',
+    })
+    const unpacked = unpackHmId(url)
+    expect(unpacked?.uid).toBe('abc')
+    expect(unpacked?.version).toBe('v1hash')
+    expect(unpacked?.latest).toBe(false)
+  })
+
+  test('doc URL with blockRef roundtrips', () => {
+    const url = createWebHMUrl('abc', {
+      hostname: 'https://gw.com',
+      version: 'v1',
+      blockRef: 'XK6l8B4d',
+      blockRange: {expanded: true},
+    })
+    const unpacked = unpackHmId(url)
+    expect(unpacked?.uid).toBe('abc')
+    expect(unpacked?.version).toBe('v1')
+    expect(unpacked?.blockRef).toBe('XK6l8B4d')
+    expect(unpacked?.blockRange).toEqual({expanded: true})
+    expect(unpacked?.latest).toBe(false)
+  })
+
+  test('doc URL with path roundtrips', () => {
+    const url = createWebHMUrl('abc', {
+      hostname: 'https://gw.com',
+      path: ['docs', 'intro'],
+      version: 'v1',
+    })
+    const unpacked = unpackHmId(url)
+    expect(unpacked?.uid).toBe('abc')
+    expect(unpacked?.path).toEqual(['docs', 'intro'])
+    expect(unpacked?.version).toBe('v1')
+  })
+
+  test('doc URL with block range roundtrips', () => {
+    const url = createWebHMUrl('abc', {
+      hostname: 'https://gw.com',
+      version: 'v1',
+      blockRef: 'XK6l8B4d',
+      blockRange: {start: 21, end: 41},
+    })
+    const unpacked = unpackHmId(url)
+    expect(unpacked?.blockRef).toBe('XK6l8B4d')
+    expect(unpacked?.blockRange).toEqual({start: 21, end: 41})
   })
 })


### PR DESCRIPTION
## Summary

- **New URL builders**: Added `createCommentUrl()` and enhanced `createSiteUrl()` to support `viewTerm` and `panel` parameters for building links to specific comment discussions and document panels
- **Version tracking**: Extended `createWebHMUrl()` to include `version`, `blockRef`, `blockRange`, and `latest` parameters, ensuring shared block links preserve the document version context
- **Unified link copying**: Replaced `useResourceUrl()` hook with new URL builder functions across comments, feed, and resource page components
- **Block link improvements**: Block sharing now includes document version and respects site URLs when available
- **Extended test coverage**: Added 550+ lines of comprehensive tests for `serializeBlockRange()`, `createWebHMUrl()`, `createSiteUrl()`, `routeToUrl()`, `idToUrl()`, and `createCommentUrl()`
- **Code cleanup**: Removed unused `useCallback` import and deprecated `useCopyReferenceButton()` hook

## Breaking Changes

None - all changes are additive with proper backward compatibility.

fixes SHM-2187