### PR TITLE
fix: comment reply parent + trim trailing empty blocks

### DIFF
--- a/frontend/apps/desktop/src/components/commenting.tsx
+++ b/frontend/apps/desktop/src/components/commenting.tsx
@@ -7,7 +7,13 @@ import {handleDragMedia} from '@/utils/media-drag'
 import {useNavigate} from '@/utils/useNavigate'
 import {toPlainMessage} from '@bufbuild/protobuf'
 import {CommentEditor} from '@shm/editor/comment-editor'
-import {commentIdToHmId, packHmId, queryClient, queryKeys} from '@shm/shared'
+import {
+  commentIdToHmId,
+  packHmId,
+  queryClient,
+  queryKeys,
+  trimTrailingEmptyBlocks,
+} from '@shm/shared'
 import {BlockNode} from '@shm/shared/client/.generated/documents/v3alpha/documents_pb'
 import {
   HMBlockNode,
@@ -295,11 +301,14 @@ function _CommentBox(props: {
       try {
         // For desktop, we handle file uploads differently - files are already uploaded
         // So we just need to get the content without re-uploading
-        const {blockNodes} = await getContent(async (binaries) => {
-          // Desktop handles media uploads inline via handleDragMedia
-          // which already returns URLs, so no additional upload needed
-          return {blobs: [], resultCIDs: []}
-        })
+        const {blockNodes: rawBlockNodes} = await getContent(
+          async (binaries) => {
+            // Desktop handles media uploads inline via handleDragMedia
+            // which already returns URLs, so no additional upload needed
+            return {blobs: [], resultCIDs: []}
+          },
+        )
+        const blockNodes = trimTrailingEmptyBlocks(rawBlockNodes)
 
         // Convert to BlockNode for gRPC
         const content = blockNodes.map((b) => new BlockNode(b as any))

--- a/frontend/packages/shared/src/comments.ts
+++ b/frontend/packages/shared/src/comments.ts
@@ -1,5 +1,27 @@
 import {useMemo} from 'react'
-import {HMComment, HMCommentGroup} from './hm-types'
+import {HMBlockNode, HMComment, HMCommentGroup} from './hm-types'
+
+/**
+ * Removes trailing empty blocks from comment content before publishing.
+ * The editor always keeps a trailing empty paragraph for UX, but we
+ * don't want to publish it.
+ */
+export function trimTrailingEmptyBlocks(blocks: HMBlockNode[]): HMBlockNode[] {
+  let end = blocks.length
+  while (end > 0) {
+    const node = blocks[end - 1]!
+    if (!isEmptyBlockNode(node)) break
+    end--
+  }
+  return blocks.slice(0, end)
+}
+
+function isEmptyBlockNode(node: HMBlockNode): boolean {
+  const {block, children} = node
+  if (children && children.length > 0) return false
+  if (block.type !== 'Paragraph' && block.type !== 'Heading') return false
+  return !block.text || block.text.trim() === ''
+}
 
 export function getCommentGroups(
   comments?: Array<HMComment>,


### PR DESCRIPTION
## Summary

- **Fix comment reply threading**: `WebCommenting` now accepts `commentId` from `CommentEditorProps` and resolves the comment's `version` (CID) via `useCommentsService`, so replies correctly set `replyParent`. Previously the prop name mismatch (`commentId` vs `replyCommentId`/`replyCommentVersion`) caused replies to be created as top-level comments.
- **Trim trailing empty blocks**: Added `trimTrailingEmptyBlocks()` in shared package, used in both web and desktop comment submission to strip empty paragraphs/headings the editor leaves at the end of content.

## Test plan

- [ ] Click "Reply" on a comment in web app, submit reply, verify it appears threaded under the parent
- [ ] Verify `replyParent` is set in the created comment
- [ ] Create a comment with trailing empty lines, verify they are stripped on publish
- [ ] Verify desktop comment replies still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)