### PR TITLE
Support expanded block range in document navigation

### DIFF
--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -672,7 +672,12 @@ function DocumentBody({
       id: {
         ...route.id,
         blockRef: fragment.blockId,
-        blockRange: 'start' in fragment && 'end' in fragment ? {start: fragment.start, end: fragment.end} : null,
+        blockRange:
+          'start' in fragment && 'end' in fragment
+            ? {start: fragment.start, end: fragment.end}
+            : 'expanded' in fragment && fragment.expanded
+            ? {expanded: true}
+            : null,
       },
     })
   }, []) // only on mount
@@ -838,7 +843,12 @@ function DocumentBody({
   const handleBlockSelect = useCallback(
     (blockId: string, opts?: BlockRangeSelectOptions) => {
       if (route.key !== 'document' && route.key !== 'feed') return
-      const blockRange = opts && 'start' in opts && 'end' in opts ? {start: opts.start, end: opts.end} : null
+      const blockRange =
+        opts && 'start' in opts && 'end' in opts
+          ? {start: opts.start, end: opts.end}
+          : opts && 'expanded' in opts && opts.expanded
+          ? {expanded: true}
+          : null
       const blockRoute = {
         ...route,
         id: {


### PR DESCRIPTION
## Summary
Added support for an `expanded` block range type in the document body component, allowing navigation and fragment handling to work with expanded block states in addition to the existing start/end range format.

## Key Changes
- Updated fragment-to-blockRange conversion logic to handle `expanded` property when `start` and `end` are not present
- Updated route options-to-blockRange conversion logic to handle `expanded` property when `start` and `end` are not present
- Both changes follow the same pattern: check for `expanded` property and set `{expanded: true}` as the blockRange value

## Implementation Details
The changes maintain backward compatibility by preserving the existing conditional logic for start/end ranges while adding a new branch to handle the `expanded` case. This allows the document navigation system to support both range-based (start/end) and expanded-state-based block selections.

https://claude.ai/code/session_01K5bJfAPadUq3qpjxzRxVs5