### PR TITLE
feat(desktop): add inline document creation with draft cards

### DIFF
--- a/frontend/apps/desktop/inline-document-creation.md
+++ b/frontend/apps/desktop/inline-document-creation.md
@@ -1,0 +1,55 @@
+# Creating Documents Where You Are
+
+One of the most common actions in Seed is creating a new document inside an existing one. Until now, clicking "New
+Document" would take you away from what you were looking at — you'd land on a blank draft page, write your content,
+publish it, and then go back to the parent to see it appear as a card.
+
+That flow works, but it breaks your context. You lose sight of the document you were working in, and the mental
+connection between "I want to add something here" and "here's where it lives" gets disrupted.
+
+## What's Changing
+
+Starting now, when you click **New** on a document, the new subdocument appears right there — as a card at the bottom of
+the page you're viewing. No navigation, no context switch.
+
+You'll see a new card with an editable title. Type the name of your new document directly on the card. When you're ready
+to write the full content, click the card to open the draft editor. When you publish that subdocument, it becomes a
+permanent part of the parent document — just like before, but without the detour.
+
+## How It Works
+
+1. **You're viewing a document.** Maybe it's a project page with several sub-pages already listed as cards.
+2. **You click "New".** A card immediately appears at the bottom with an empty title field, ready for you to type.
+3. **You name it.** The title auto-saves as you type. This creates a draft that persists even if you navigate away.
+4. **You open it (when ready).** Click the card or press Enter to go to the full draft editor. Write your content, add
+   images, embed other documents — everything works as before.
+5. **You publish.** When you publish the subdocument, it automatically gets embedded as a card in the parent document.
+   The draft card is replaced by the real published card.
+
+If you change your mind, you can delete the draft card at any time. Since the parent document isn't modified until you
+publish, there's nothing to undo.
+
+## Details That Matter
+
+**All your child drafts are visible.** Whether you created a draft from the inline flow or from anywhere else, if it's a
+child of the document you're viewing, it shows up as a card. This gives you a clear picture of what's in progress under
+any document.
+
+**Drafts survive navigation.** Leave the page, come back, restart the app — your draft cards are still there. They're
+not stored in temporary UI state; they're real drafts that persist until you publish or delete them.
+
+**No parent document changes until publish.** The parent document stays exactly as it was until you publish the child.
+This means no accidental draft states on the parent, no "phantom changes" to discard, and no confusion about what's
+published and what isn't.
+
+## What's Next
+
+This is the first step toward making document creation feel more natural and contextual. In future updates, we're
+looking at:
+
+- **Reordering cards** — drag subdocument cards to different positions within the parent
+- **Web app support** — bringing the same inline creation flow to the web experience
+- **Richer inline editing** — more than just the title, directly on the card
+
+We believe the best tools stay out of your way. Creating a new document should feel like adding a thought, not launching
+a process.

--- a/frontend/apps/desktop/src/components/create-doc-button.tsx
+++ b/frontend/apps/desktop/src/components/create-doc-button.tsx
@@ -1,7 +1,7 @@
 import {roleCanWrite, useSelectedAccountCapability} from '@/models/access-control'
 import {useMyAccountIds} from '@/models/daemon'
 import {useCreateDraft} from '@/models/documents'
-import {UnpackedHypermediaId} from '@shm/shared'
+import {HMResourceVisibility, UnpackedHypermediaId} from '@shm/shared'
 import {Button} from '@shm/ui/button'
 import {
   DropdownMenu,
@@ -46,7 +46,20 @@ function ImportMenuItem({
   )
 }
 
-export function CreateDocumentButton({locationId, siteUrl}: {locationId?: UnpackedHypermediaId; siteUrl?: string}) {
+/**
+ * When `onInlineCreate` is provided, menu items call it to create a draft
+ * inline (card at bottom of current page). When omitted, falls back to
+ * `createDraft()` which navigates to a new draft page.
+ */
+export function CreateDocumentButton({
+  locationId,
+  siteUrl,
+  onInlineCreate,
+}: {
+  locationId?: UnpackedHypermediaId
+  siteUrl?: string
+  onInlineCreate?: (opts?: {visibility?: HMResourceVisibility}) => void
+}) {
   const capability = useSelectedAccountCapability(locationId)
   const canEdit = roleCanWrite(capability?.role)
   const isHomeDoc = !locationId?.path?.length
@@ -78,7 +91,7 @@ export function CreateDocumentButton({locationId, siteUrl}: {locationId?: Unpack
             <DropdownMenuContent align="end" className="w-56">
               {isHomeDoc ? (
                 <>
-                  <DropdownMenuItem onClick={() => createDraft()}>
+                  <DropdownMenuItem onClick={() => (onInlineCreate ? onInlineCreate() : createDraft())}>
                     <FilePlus2 className="size-4" />
                     Public Document
                   </DropdownMenuItem>
@@ -123,7 +136,7 @@ export function CreateDocumentButton({locationId, siteUrl}: {locationId?: Unpack
                   )}
                 </>
               ) : (
-                <DropdownMenuItem onClick={() => createDraft()}>
+                <DropdownMenuItem onClick={() => (onInlineCreate ? onInlineCreate() : createDraft())}>
                   <FilePlus2 className="size-4" />
                   New Document
                 </DropdownMenuItem>

--- a/frontend/apps/desktop/src/components/inline-new-document-card.tsx
+++ b/frontend/apps/desktop/src/components/inline-new-document-card.tsx
@@ -1,0 +1,150 @@
+import {useDeleteDraft, useUpdateDraftMetadata} from '@/models/documents'
+import {useNavigate} from '@/utils/useNavigate'
+import {HMListedDraft} from '@shm/shared/hm-types'
+import {Button} from '@shm/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@shm/ui/components/dropdown-menu'
+import {DraftBadge} from '@shm/ui/draft-badge'
+import {toast} from '@shm/ui/toast'
+import {ImageIcon, MoreVertical, Pencil, Trash2} from 'lucide-react'
+import {useCallback, useEffect, useRef, useState} from 'react'
+
+export function InlineNewDocumentCard({draft, autoFocus}: {draft: HMListedDraft; autoFocus?: boolean}) {
+  const navigate = useNavigate()
+  const deleteDraft = useDeleteDraft()
+  const updateMetadata = useUpdateDraftMetadata()
+  const [title, setTitle] = useState(draft.metadata?.name || '')
+  const inputRef = useRef<HTMLInputElement>(null)
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout>>()
+
+  useEffect(() => {
+    if (autoFocus && inputRef.current) {
+      inputRef.current.focus()
+    }
+  }, [autoFocus])
+
+  // Sync external changes
+  useEffect(() => {
+    setTitle(draft.metadata?.name || '')
+  }, [draft.metadata?.name])
+
+  const saveName = useCallback(
+    (name: string) => {
+      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current)
+      saveTimeoutRef.current = setTimeout(() => {
+        updateMetadata.mutate(
+          {draftId: draft.id, metadata: {name}},
+          {
+            onError: () => {
+              toast.error('Failed to save draft title')
+            },
+          },
+        )
+      }, 500)
+    },
+    [draft.id, updateMetadata],
+  )
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current)
+    }
+  }, [])
+
+  const openDraft = useCallback(() => {
+    // Cancel any pending debounced save to prevent duplicate mutations
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current)
+      saveTimeoutRef.current = undefined
+    }
+    // Flush save then navigate
+    updateMetadata.mutate(
+      {draftId: draft.id, metadata: {name: title}},
+      {
+        onSuccess: () => navigate({key: 'draft', id: draft.id}),
+        onError: () => {
+          toast.error('Failed to save draft title')
+          navigate({key: 'draft', id: draft.id})
+        },
+      },
+    )
+  }, [navigate, draft.id, title, updateMetadata])
+
+  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value
+    setTitle(val)
+    saveName(val)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      openDraft()
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      inputRef.current?.blur()
+    }
+  }
+
+  return (
+    <div className="@container flex min-h-[200px] flex-1 overflow-hidden rounded-lg border-2 border-dashed border-yellow-400/50 bg-white shadow-sm transition-colors duration-300 dark:bg-black">
+      <div className="flex max-w-full flex-1 flex-col @md:flex-row">
+        {/* Image placeholder */}
+        <div
+          className="relative flex h-40 w-full shrink-0 cursor-pointer items-center justify-center bg-gray-50 @md:h-auto @md:w-1/2 dark:bg-gray-900"
+          onClick={openDraft}
+        >
+          <ImageIcon className="text-muted-foreground size-12 opacity-30" />
+        </div>
+        {/* Content */}
+        <div className="flex min-h-0 flex-1 flex-col justify-between">
+          <div className="p-4">
+            <div className="flex items-center gap-2">
+              <input
+                ref={inputRef}
+                type="text"
+                value={title}
+                onChange={handleTitleChange}
+                onKeyDown={handleKeyDown}
+                placeholder="Untitled document"
+                className="text-foreground block w-full border-none bg-transparent font-sans text-lg leading-tight font-bold outline-none placeholder:text-gray-400"
+              />
+            </div>
+            <div className="mt-2 flex items-center gap-2">
+              <DraftBadge />
+            </div>
+          </div>
+          <div className="flex items-center justify-between py-3 pr-2 pl-4">
+            <Button variant="ghost" size="sm" onClick={openDraft} className="gap-1">
+              <Pencil className="size-3" />
+              Edit
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="iconSm">
+                  <MoreVertical className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={openDraft}>
+                  <Pencil className="size-4" />
+                  Open Draft
+                </DropdownMenuItem>
+                <DropdownMenuItem className="text-destructive" onClick={() => deleteDraft.mutate(draft.id)}>
+                  <Trash2 className="size-4" />
+                  Delete Draft
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -155,6 +155,8 @@ export interface ResourcePageProps {
   pageFooter?: ReactNode
 
   floatingButtons?: ReactNode
+  /** Inline child draft cards rendered after document content */
+  inlineCards?: ReactNode
 }
 
 /** Get panel title for display */
@@ -182,6 +184,7 @@ export function ResourcePage({
   floatingButtons,
   collaboratorForm,
   pageFooter,
+  inlineCards,
 }: ResourcePageProps) {
   // Load document data via React Query (hydrated from SSR prefetch)
   const resource = useResource(docId, {
@@ -299,6 +302,7 @@ export function ResourcePage({
         floatingButtons={floatingButtons}
         collaboratorForm={collaboratorForm}
         pageFooter={pageFooter}
+        inlineCards={inlineCards}
       />
     </PageWrapper>
   )
@@ -615,6 +619,7 @@ function DocumentBody({
   floatingButtons,
   collaboratorForm,
   pageFooter,
+  inlineCards,
 }: {
   docId: UnpackedHypermediaId
   document: HMDocument
@@ -626,6 +631,7 @@ function DocumentBody({
   floatingButtons?: ReactNode
   collaboratorForm?: ReactNode
   pageFooter?: ReactNode
+  inlineCards?: ReactNode
 }) {
   const route = useNavRoute()
   const navigate = useNavigate()
@@ -1010,6 +1016,7 @@ function DocumentBody({
           directory={directory.data}
           collaboratorForm={collaboratorForm}
           siteUrl={siteUrl}
+          inlineCards={inlineCards}
         />
       </div>
       {pageFooter ? <div className="mt-auto">{pageFooter}</div> : null}
@@ -1184,6 +1191,7 @@ function MainContent({
   directory,
   collaboratorForm,
   siteUrl,
+  inlineCards,
 }: {
   docId: UnpackedHypermediaId
   resourceId: UnpackedHypermediaId
@@ -1216,6 +1224,7 @@ function MainContent({
   directory?: import('@shm/shared').HMDocumentInfo[]
   collaboratorForm?: ReactNode
   siteUrl?: string
+  inlineCards?: ReactNode
 }) {
   switch (activeView) {
     case 'directory':
@@ -1285,6 +1294,7 @@ function MainContent({
           onBlockCommentClick={onBlockCommentClick}
           onBlockSelect={onBlockSelect}
           directory={directory}
+          inlineCards={inlineCards}
         />
       )
   }
@@ -1304,6 +1314,7 @@ function ContentViewWithOutline({
   onBlockCommentClick,
   onBlockSelect,
   directory,
+  inlineCards,
 }: {
   docId: UnpackedHypermediaId
   resourceId: UnpackedHypermediaId
@@ -1322,6 +1333,7 @@ function ContentViewWithOutline({
   ) => void
   onBlockSelect?: (blockId: string, opts?: BlockRangeSelectOptions) => void
   directory?: import('@shm/shared').HMDocumentInfo[]
+  inlineCards?: ReactNode
 }) {
   const outline = useNodesOutline(document, docId)
 
@@ -1359,6 +1371,7 @@ function ContentViewWithOutline({
         >
           <BlocksContent blocks={document.content} />
         </BlocksContentProvider>
+        {inlineCards}
         <UnreferencedDocuments docId={docId} content={document.content} directory={directory} />
       </div>
 


### PR DESCRIPTION
## Summary

- Add ability to create new subdocuments inline as draft cards on the parent document page
- Draft cards appear at the bottom of the document with editable titles that auto-save
- New `InlineNewDocumentCard` component displays draft cards with edit, open, and delete actions
- Extended `CreateDocumentButton` with optional `onInlineCreate` callback for inline flow
- Added `useChildDrafts`, `useCreateInlineDraft`, and `useUpdateDraftMetadata` hooks to manage draft lifecycle
- Draft changes persist even if user navigates away, eliminating context switching during document creation

## Key Changes

**Components:**
- `inline-new-document-card.tsx`: New card component displaying draft metadata with title input, edit button, and delete option
- `create-doc-button.tsx`: Enhanced to accept `onInlineCreate` callback while maintaining backward compatibility

**Hooks:**
- `useChildDrafts()`: Filters drafts by parent document ID
- `useCreateInlineDraft()`: Creates new draft with specified visibility (PUBLIC/PRIVATE) and location
- `useUpdateDraftMetadata()`: Updates draft title and metadata with debounced saves

**Pages:**
- `desktop-resource.tsx`: Integrates inline draft creation with `CreateDocumentButton` and renders child drafts
- `resource-page-common.tsx`: Thread `inlineCards` prop through page components to render below document content

**Documentation:**
- Added `inline-document-creation.md` explaining the feature, workflow, and future improvements

## Manual Test Checklist

### Setup
- [ ] Run the desktop app (`./dev run-desktop`)
- [ ] Navigate to a published document that you own (not private)

### Creating Inline Drafts
- [x] Click the "New" button — dropdown shows "Public Document" / "Private Document" / "Import..."
- [x] Click "Public Document" — a new card appears at the bottom of the document content
- [ ] The card's title input is auto-focused
- [x] Type a title — after ~500ms it saves (no errors/toasts)
- [x] Click "New" again — a second card appears, this one gets auto-focus
- [x] On home doc with a site URL configured: click "Private Document" — card appears for a private draft

### Inline Card Interactions
- [x] Type a title and press **Enter** — navigates to the draft editor with the title saved
- [x] Type a title, wait for debounce, then click **Edit** button — navigates to draft editor
- [ ] Type a title and immediately click **Edit** (before debounce) — title is still saved, no duplicate save toasts
- [x] Press **Escape** while in the title input — input loses focus
- [x] Click the image placeholder area — navigates to draft editor
- [x] Click the **three-dot menu** → "Open Draft" — navigates to draft editor
- [x] Click the **three-dot menu** → "Delete Draft" — card disappears

### Persistence & Reactivity
- [x] Create an inline draft, navigate away, come back — the card still appears
- [x] Open the draft from the card, edit it, go back to parent — card still shows
- [x] Publish the child draft — card disappears from parent (it's no longer a draft)
- [x] Delete the child draft from the drafts list page — card disappears from parent

### All Child Drafts Show
- [x] Create a draft the "old way" (if possible, via another path targeting same parent) — it should also appear as an inline card

### Edge Cases
- [x] Private documents should **not** show the "New" button at all
- [x] Documents you don't have write access to — no "New" button
- [x] Empty title — card shows "Untitled document" placeholder
- [x] Rapidly click "New" multiple times — each creates a separate card, no errors

### Error Handling
- [ ] If metadata save fails (e.g., disconnect network briefly) — toast error "Failed to save draft title" appears
- [x] Even on save error, clicking Edit still navigates to the draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)