### PR TITLE
fix(hydration): suppress warnings for timezone-dependent date displays

### DIFF
--- a/frontend/packages/ui/src/document-date.tsx
+++ b/frontend/packages/ui/src/document-date.tsx
@@ -33,7 +33,7 @@ export function DocumentDate({
     ? formattedDateDayOnly(new Date(metadata.displayPublishTime))
     : formattedDateMedium(updateTime)
   const content: React.ReactNode[] = [
-    <SizableText size="sm" color="muted" key="last-update">
+    <SizableText size="sm" color="muted" key="last-update" suppressHydrationWarning>
       {tx('Last Update')}: {formattedDateLong(updateTime)}
     </SizableText>,
     // // Disabled because this is always 1969 because the backend looks at the deterministic genesis blob instead of the actual creation time

--- a/frontend/packages/ui/src/site-header.tsx
+++ b/frontend/packages/ui/src/site-header.tsx
@@ -661,7 +661,7 @@ function GotoLatestBanner({
         <Button variant="ghost" size="icon" onClick={() => setHideVersionBanner(true)}>
           <X color="var(--color-muted-foreground)" size={20} />
         </Button>
-        <p className="text-muted-foreground text-sm">
+        <p className="text-muted-foreground text-sm" suppressHydrationWarning>
           {tx('version_from', ({date}: {date: string}) => `Version from ${date}`, {
             date: formattedDateLong(document.updateTime),
           })}


### PR DESCRIPTION
## Summary

- Suppress hydration warnings on date components that intentionally differ between server and client due to timezone rendering
- Adds `suppressHydrationWarning` to `DocumentDate` (Last Update) and site header version date elements
- Resolves issue #206: React hydration mismatch on blog pages

## Motivation

The server renders dates in UTC while the client renders them in the user's local timezone, causing React hydration mismatches and triggering full client-side re-renders. This degrades SSR performance and SEO effectiveness.

Rather than attempting to enforce identical formatting during hydration, this fix explicitly acknowledges the intentional difference by suppressing the warning on affected elements. This allows the initial server HTML to hydrate successfully while displaying timezone-localized dates to the user.

## Changes

- `frontend/packages/ui/src/document-date.tsx`: Added `suppressHydrationWarning` to SizableText for "Last Update" date
- `frontend/packages/ui/src/site-header.tsx`: Added `suppressHydrationWarning` to paragraph element for version date

## Notes

This is a pragmatic solution for a known limitation where server-side rendering cannot determine client timezones. Future improvements could implement timezone-agnostic formatting during SSR or defer date rendering to `useEffect`.

---

Fixes #206