### PR TITLE
feat: redesign DocumentCard footer with actions context

### DIFF
--- a/frontend/apps/desktop/src/components/document-actions-provider.tsx
+++ b/frontend/apps/desktop/src/components/document-actions-provider.tsx
@@ -1,0 +1,187 @@
+import {BranchDialog} from '@/components/branch-dialog'
+import {useDeleteDialog} from '@/components/delete-dialog'
+import {MoveDialog} from '@/components/move-dialog'
+import {useBookmarks} from '@/models/bookmarks'
+import {useMyAccountIds} from '@/models/daemon'
+import {useAccountDraftList} from '@/models/documents'
+import {useSelectedAccountId} from '@/selected-account'
+import {convertBlocksToMarkdown} from '@/utils/blocks-to-markdown'
+import {HMBlockNode, HMDocument, HMListedDraft, UnpackedHypermediaId} from '@shm/shared/hm-types'
+import {pathMatches} from '@shm/shared/utils/entity-id-url'
+import {hmBlocksToEditorContent} from '@shm/shared/client/hmblock-to-editorblock'
+import {DocumentActionsProvider} from '@shm/shared/document-actions-context'
+import {useUniversalAppContext} from '@shm/shared'
+import {useAppContext} from '@/app-context'
+import {useAppDialog} from '@shm/ui/universal-dialog'
+import {client} from '@/trpc'
+import {invalidateQueries} from '@shm/shared/models/query-client'
+import {queryKeys} from '@shm/shared/models/query-keys'
+import {useNavigate} from '@shm/shared/utils/navigation'
+import {nanoid} from 'nanoid'
+import {PropsWithChildren, useCallback, useMemo} from 'react'
+import {useMutation} from '@tanstack/react-query'
+import {SizableText} from '@shm/ui/text'
+import {toast} from 'sonner'
+
+export function DesktopDocumentActionsProvider({children}: PropsWithChildren) {
+  const selectedAccountId = useSelectedAccountId()
+  const myAccountIds = useMyAccountIds()
+  const bookmarks = useBookmarks()
+  const navigate = useNavigate()
+  const {exportDocument, openDirectory} = useAppContext()
+  const {onCopyReference} = useUniversalAppContext()
+  const drafts = useAccountDraftList(selectedAccountId ?? undefined)
+
+  const moveDialog = useAppDialog(MoveDialog)
+  const branchDialog = useAppDialog(BranchDialog)
+  const deleteDialog = useDeleteDialog()
+
+  const setBookmark = useMutation({
+    mutationFn: (input: {url: string; isBookmark: boolean}) => client.bookmarks.setBookmark.mutate(input),
+    onSuccess: () => {
+      invalidateQueries([queryKeys.BOOKMARKS])
+    },
+  })
+
+  const isBookmarked = useCallback(
+    (id: UnpackedHypermediaId) => {
+      return bookmarks?.some((bookmark) => bookmark && bookmark.id === id.id) ?? false
+    },
+    [bookmarks],
+  )
+
+  const onBookmarkToggle = useCallback(
+    (id: UnpackedHypermediaId) => {
+      const bookmarked = bookmarks?.some((bookmark) => bookmark && bookmark.id === id.id) ?? false
+      setBookmark.mutate({url: id.id, isBookmark: !bookmarked})
+    },
+    [bookmarks, setBookmark],
+  )
+
+  const onEditDocument = useCallback(
+    (id: UnpackedHypermediaId, existingDraftId?: string) => {
+      if (existingDraftId) {
+        navigate({key: 'draft', id: existingDraftId, panel: null})
+      } else {
+        navigate({
+          key: 'draft',
+          id: nanoid(10),
+          editUid: id.uid,
+          editPath: id.path || [],
+          deps: id.version ? [id.version] : undefined,
+          panel: null,
+        })
+      }
+    },
+    [navigate],
+  )
+
+  const onMoveDocument = useCallback(
+    (id: UnpackedHypermediaId) => {
+      moveDialog.open({id})
+    },
+    [moveDialog],
+  )
+
+  const onDeleteDocument = useCallback(
+    (id: UnpackedHypermediaId, onSuccess?: () => void) => {
+      deleteDialog.open({id, onSuccess})
+    },
+    [deleteDialog],
+  )
+
+  const onBranchDocument = useCallback(
+    (id: UnpackedHypermediaId) => {
+      branchDialog.open(id)
+    },
+    [branchDialog],
+  )
+
+  const onExportDocument = useCallback(
+    async (doc: HMDocument) => {
+      const title = doc.metadata.name || 'document'
+      const blocks: HMBlockNode[] | undefined = doc.content || undefined
+      const editorBlocks = hmBlocksToEditorContent(blocks, {childrenType: 'Group'})
+      const {markdownContent, mediaFiles} = await convertBlocksToMarkdown(editorBlocks, doc)
+      exportDocument(title, markdownContent, mediaFiles)
+        .then((res) => {
+          toast.success(
+            <div className="flex max-w-[700px] flex-col gap-1.5">
+              <SizableText className="text-wrap break-all">
+                Successfully exported document &quot;{title}&quot; to: <b>{`${res}`}</b>.
+              </SizableText>
+              <SizableText
+                className="text-current underline"
+                onClick={() => {
+                  // @ts-expect-error
+                  openDirectory(res)
+                }}
+              >
+                Show directory
+              </SizableText>
+            </div>,
+          )
+        })
+        .catch((err) => {
+          toast.error(err)
+        })
+    },
+    [exportDocument, openDirectory],
+  )
+
+  const onCopyLink = useCallback(
+    (id: UnpackedHypermediaId) => {
+      onCopyReference?.(id)
+    },
+    [onCopyReference],
+  )
+
+  const getDraftId = useCallback(
+    (id: UnpackedHypermediaId) => {
+      const draft = drafts.data?.find((d: HMListedDraft) => {
+        if (!d.editUid) return false
+        return id.uid === d.editUid && pathMatches(d.editPath || [], id.path)
+      })
+      return draft?.id
+    },
+    [drafts.data],
+  )
+
+  const value = useMemo(
+    () => ({
+      selectedAccountUid: selectedAccountId ?? undefined,
+      myAccountIds: myAccountIds.data,
+      isBookmarked,
+      onBookmarkToggle,
+      onEditDocument,
+      onMoveDocument,
+      onDeleteDocument,
+      onBranchDocument,
+      onExportDocument,
+      onCopyLink,
+      getDraftId,
+    }),
+    [
+      selectedAccountId,
+      myAccountIds.data,
+      isBookmarked,
+      onBookmarkToggle,
+      onEditDocument,
+      onMoveDocument,
+      onDeleteDocument,
+      onBranchDocument,
+      onExportDocument,
+      onCopyLink,
+      getDraftId,
+    ],
+  )
+
+  return (
+    <DocumentActionsProvider {...value}>
+      {children}
+      {moveDialog.content}
+      {branchDialog.content}
+      {deleteDialog.content}
+    </DocumentActionsProvider>
+  )
+}

--- a/frontend/apps/desktop/src/pages/desktop-feed.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-feed.tsx
@@ -1,5 +1,6 @@
 import {triggerCommentDraftFocus} from '@/components/commenting'
 import {useCopyReferenceUrl} from '@/components/copy-reference-url'
+import {DesktopDocumentActionsProvider} from '@/components/document-actions-provider'
 import {useGatewayUrl} from '@/models/gateway-settings'
 import {useSelectedAccount} from '@/selected-account'
 import {useHackyAuthorsSubscriptions} from '@/use-hacky-authors-subscriptions'
@@ -126,7 +127,9 @@ export default function DesktopFeedPage() {
         onReplyClick={onReplyClick}
         onReplyCountClick={onReplyCountClick}
       >
-        <FeedPage docId={docId} extraMenuItems={menuItems} currentAccountUid={selectedAccount?.id?.uid} />
+        <DesktopDocumentActionsProvider>
+          <FeedPage docId={docId} extraMenuItems={menuItems} currentAccountUid={selectedAccount?.id?.uid} />
+        </DesktopDocumentActionsProvider>
       </CommentsProvider>
       {copyGatewayContent}
       {copySiteUrlContent}

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -4,6 +4,7 @@ import {AddCollaboratorForm} from '@/components/collaborators-panel'
 import {CommentBox, triggerCommentDraftFocus} from '@/components/commenting'
 import {CreateDocumentButton} from '@/components/create-doc-button'
 import {useDeleteDialog} from '@/components/delete-dialog'
+import {DesktopDocumentActionsProvider} from '@/components/document-actions-provider'
 import {InlineNewDocumentCard} from '@/components/inline-new-document-card'
 import {MoveDialog} from '@/components/move-dialog'
 import {roleCanWrite, useSelectedAccountCapability} from '@/models/access-control'
@@ -171,11 +172,9 @@ export default function DesktopResourcePage() {
     <>
       <Tooltip content={existingDraft ? 'Resume Editing' : 'Edit'}>
         <Button
-          size="sm"
+          size="icon"
           variant="outline"
-          className={cn(
-            existingDraft ? 'bg-yellow-200 hover:bg-yellow-300' : 'hover:bg-hover dark:bg-background bg-white',
-          )}
+          className={cn(existingDraft ? 'bg-yellow-200 hover:bg-yellow-300' : '')}
           onClick={() => {
             if (existingDraft) {
               navigate({
@@ -195,7 +194,7 @@ export default function DesktopResourcePage() {
             }
           }}
         >
-          <Pencil className="size-4" />
+          <Pencil className="size-3.5" />
         </Button>
       </Tooltip>
       {!isPrivate && (
@@ -292,16 +291,18 @@ export default function DesktopResourcePage() {
         onReplyClick={onReplyClick}
         onReplyCountClick={onReplyCountClick}
       >
-        <ResourcePage
-          docId={docId}
-          CommentEditor={CommentBox}
-          extraMenuItems={menuItems}
-          editActions={editActions}
-          existingDraft={existingDraft}
-          collaboratorForm={<AddCollaboratorForm id={docId} />}
-          inlineCards={inlineCards}
-          rightActions={<SubscriptionButton id={docId} />}
-        />
+        <DesktopDocumentActionsProvider>
+          <ResourcePage
+            docId={docId}
+            CommentEditor={CommentBox}
+            extraMenuItems={menuItems}
+            editActions={editActions}
+            existingDraft={existingDraft}
+            collaboratorForm={<AddCollaboratorForm id={docId} />}
+            inlineCards={inlineCards}
+            rightActions={<SubscriptionButton id={docId} />}
+          />
+        </DesktopDocumentActionsProvider>
       </CommentsProvider>
       {deleteEntity.content}
       {branchDialog.content}

--- a/frontend/packages/shared/src/document-actions-context.tsx
+++ b/frontend/packages/shared/src/document-actions-context.tsx
@@ -1,0 +1,49 @@
+import {createContext, PropsWithChildren, useContext, useMemo} from 'react'
+import {HMDocument, UnpackedHypermediaId} from './hm-types'
+
+export type DocumentActionsContextValue = {
+  // Account info — card checks ownership/capabilities itself
+  selectedAccountUid?: string
+  myAccountIds?: string[]
+
+  // Bookmark
+  isBookmarked?: (id: UnpackedHypermediaId) => boolean
+  onBookmarkToggle?: (id: UnpackedHypermediaId) => void
+
+  // Document actions — dialogs hoisted to provider
+  onEditDocument?: (id: UnpackedHypermediaId, existingDraftId?: string) => void
+  onMoveDocument?: (id: UnpackedHypermediaId) => void
+  onDeleteDocument?: (id: UnpackedHypermediaId, onSuccess?: () => void) => void
+  onBranchDocument?: (id: UnpackedHypermediaId) => void
+  onExportDocument?: (doc: HMDocument) => void
+  onCopyLink?: (id: UnpackedHypermediaId) => void
+
+  // Draft lookup
+  getDraftId?: (id: UnpackedHypermediaId) => string | undefined
+}
+
+const DocumentActionsContext = createContext<DocumentActionsContextValue>({})
+
+export function DocumentActionsProvider({children, ...value}: PropsWithChildren<DocumentActionsContextValue>) {
+  const ctx = useMemo(
+    () => value,
+    [
+      value.selectedAccountUid,
+      value.myAccountIds,
+      value.isBookmarked,
+      value.onBookmarkToggle,
+      value.onEditDocument,
+      value.onMoveDocument,
+      value.onDeleteDocument,
+      value.onBranchDocument,
+      value.onExportDocument,
+      value.onCopyLink,
+      value.getDraftId,
+    ],
+  )
+  return <DocumentActionsContext.Provider value={ctx}>{children}</DocumentActionsContext.Provider>
+}
+
+export function useDocumentActions(): DocumentActionsContextValue {
+  return useContext(DocumentActionsContext)
+}

--- a/frontend/packages/ui/src/blocks-content.tsx
+++ b/frontend/packages/ui/src/blocks-content.tsx
@@ -2586,7 +2586,7 @@ export function DocumentCardGrid({
   firstItem: HMDocumentInfo | undefined
   items: Array<HMDocumentInfo>
   getEntity: (id: UnpackedHypermediaId) => HMResourceFetchResult | null
-  accountsMetadata: HMAccountsMetadata
+  accountsMetadata?: HMAccountsMetadata
   columnCount?: number
   isDiscovering?: boolean
 }) {

--- a/frontend/packages/ui/src/button.tsx
+++ b/frontend/packages/ui/src/button.tsx
@@ -58,8 +58,8 @@ export const buttonVariants = cva(
         sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5 text-sm',
         default: 'h-9 px-4 py-2 has-[>svg]:px-3',
         lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
-        icon: 'h-6 min-w-6 rounded-md has-[>svg]:px-2',
-        iconSm: 'h-4 min-w-4 rounded-md has-[>svg]:px-1',
+        icon: 'h-8 w-8 rounded-md has-[>svg]:px-2',
+        iconSm: 'h-6 w-6 rounded-md has-[>svg]:px-1',
       },
     },
 

--- a/frontend/packages/ui/src/newspaper.tsx
+++ b/frontend/packages/ui/src/newspaper.tsx
@@ -1,25 +1,32 @@
 import {
-  formattedDateDayOnly,
   getDocumentImage,
   HMAccountsMetadata,
+  hmId,
   HMResourceFetchResult,
-  plainTextOfContent,
   UnpackedHypermediaId,
   useRouteLink,
 } from '@shm/shared'
+import {useDocumentActions} from '@shm/shared/document-actions-context'
+import {useInteractionSummary} from '@shm/shared/models/interaction-summary'
+import {useNavigate} from '@shm/shared/utils/navigation'
+import {Bookmark, Forward, GitFork, Link, MessageSquare, Pencil} from 'lucide-react'
 import {HTMLAttributes, useMemo} from 'react'
-import {FacePile} from './face-pile'
+import {Button} from './button'
+import {DraftBadge} from './draft-badge'
 import {useImageUrl} from './get-file-url'
 import {useHighlighter} from './highlight-context'
+import {Download, Trash} from './icons'
+import {MenuItemType, OptionsDropdown} from './options-dropdown'
 import {PrivateBadge} from './private-badge'
 import {SizableText} from './text'
+import {Tooltip} from './tooltip'
 import {cn} from './utils'
 
 export function DocumentCard({
   docId,
   entity,
   accountsMetadata,
-  navigate = true,
+  navigate: navigateProp = true,
   onMouseEnter,
   onMouseLeave,
   banner = false,
@@ -27,7 +34,7 @@ export function DocumentCard({
 }: HTMLAttributes<HTMLDivElement> & {
   docId: UnpackedHypermediaId
   entity: HMResourceFetchResult | null | undefined
-  accountsMetadata: HMAccountsMetadata
+  accountsMetadata?: HMAccountsMetadata
   navigate?: boolean
   onMouseEnter?: (id: UnpackedHypermediaId) => void
   onMouseLeave?: (id: UnpackedHypermediaId) => void
@@ -36,17 +43,96 @@ export function DocumentCard({
   const highlighter = useHighlighter()
   const linkProps = useRouteLink(docId ? {key: 'document', id: docId} : null)
   const imageUrl = useImageUrl()
+  const navigate = useNavigate()
+  const actions = useDocumentActions()
 
-  let textContent = useMemo(() => {
-    if (entity?.document?.metadata?.summary) {
-      return entity.document.metadata.summary
-    }
-    return plainTextOfContent(entity?.document?.content)
-  }, [entity?.document])
+  const summaryId = useMemo(() => (docId ? hmId(docId.uid, {path: docId.path}) : null), [docId?.uid, docId?.path])
+  const interactionSummary = useInteractionSummary(summaryId)
+  const commentCount = interactionSummary.data?.comments ?? 0
 
   const coverImage = entity?.document ? getDocumentImage(entity?.document) : undefined
-
   const isPrivate = entity?.document?.visibility === 'PRIVATE'
+  const doc = entity?.document
+
+  // Context-driven state
+  const draftId = actions.getDraftId?.(docId)
+  const bookmarked = actions.isBookmarked?.(docId) ?? false
+  const isOwner = actions.selectedAccountUid === docId.uid
+  const isLoggedIn = !!actions.myAccountIds?.length
+  const hasPath = !!docId.path?.length
+
+  // Self-assemble menu items from context
+  const menuItems = useMemo(() => {
+    const items: MenuItemType[] = []
+    if (actions.onEditDocument && isOwner) {
+      items.push({
+        key: 'edit',
+        label: draftId ? 'Resume Editing' : 'Edit',
+        icon: <Pencil className="size-4" />,
+        onClick: (e) => {
+          e?.stopPropagation()
+          actions.onEditDocument!(docId, draftId)
+        },
+      })
+    }
+    if (actions.onCopyLink) {
+      items.push({
+        key: 'copy-link',
+        label: 'Copy Link',
+        icon: <Link className="size-4" />,
+        onClick: (e) => {
+          e?.stopPropagation()
+          actions.onCopyLink!(docId)
+        },
+      })
+    }
+    if (actions.onMoveDocument && isOwner && hasPath) {
+      items.push({
+        key: 'move',
+        label: 'Move Document',
+        icon: <Forward className="size-4" />,
+        onClick: (e) => {
+          e?.stopPropagation()
+          actions.onMoveDocument!(docId)
+        },
+      })
+    }
+    if (actions.onBranchDocument && isLoggedIn) {
+      items.push({
+        key: 'branch',
+        label: 'Create Document Branch',
+        icon: <GitFork className="size-4" />,
+        onClick: (e) => {
+          e?.stopPropagation()
+          actions.onBranchDocument!(docId)
+        },
+      })
+    }
+    if (actions.onExportDocument && doc) {
+      items.push({
+        key: 'export',
+        label: 'Export',
+        icon: <Download className="size-4" />,
+        onClick: (e) => {
+          e?.stopPropagation()
+          actions.onExportDocument!(doc)
+        },
+      })
+    }
+    if (actions.onDeleteDocument && isOwner && hasPath) {
+      items.push({
+        key: 'delete',
+        label: 'Delete Document',
+        icon: <Trash className="size-4" />,
+        variant: 'destructive' as const,
+        onClick: (e) => {
+          e?.stopPropagation()
+          actions.onDeleteDocument!(docId)
+        },
+      })
+    }
+    return items
+  }, [actions, docId, doc, isOwner, isLoggedIn, hasPath])
 
   const sharedProps = {
     ...highlighter(docId),
@@ -66,37 +152,63 @@ export function DocumentCard({
         )}
         <div className={cn('flex min-h-0 flex-1 flex-col justify-between')}>
           <div className="p-4">
-            <div className="flex items-center gap-2">
-              <p
-                className={cn(
-                  'text-foreground block font-sans leading-tight! font-bold',
-                  banner ? 'text-2xl' : 'text-lg',
-                )}
-              >
-                {entity?.document?.metadata?.name}
-              </p>
-              {isPrivate && <PrivateBadge size="sm" />}
-            </div>
-            <p className={cn('text-muted-foreground mt-2 line-clamp-3 font-sans', !banner && 'text-sm')}>
-              {textContent}
+            <p
+              className={cn(
+                'text-foreground block font-sans leading-tight! font-bold',
+                banner ? 'text-2xl' : 'text-lg',
+              )}
+            >
+              {entity?.document?.metadata?.name}
             </p>
           </div>
           <div className="flex items-center justify-between py-3 pr-2 pl-4">
-            {(entity?.document?.metadata?.displayPublishTime || entity?.document?.updateTime) && (
-              <SizableText color="muted" size="xs" className="font-sans opacity-75 hover:cursor-default">
-                {entity?.document?.metadata?.displayPublishTime
-                  ? formattedDateDayOnly(new Date(entity.document.metadata.displayPublishTime))
-                  : formattedDateDayOnly(entity.document.updateTime)}
-              </SizableText>
-            )}
-            <FacePile accounts={entity?.document?.authors || []} accountsMetadata={accountsMetadata} />
+            <div className="flex items-center gap-1.5">
+              {!!draftId && <DraftBadge />}
+              {!draftId && isPrivate && <PrivateBadge size="sm" />}
+            </div>
+            <div className="flex items-center gap-1">
+              {actions.onBookmarkToggle && (
+                <Tooltip content={bookmarked ? 'Remove from Bookmarks' : 'Add to Bookmarks'}>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="no-window-drag"
+                    onClick={(e) => {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      actions.onBookmarkToggle!(docId)
+                    }}
+                  >
+                    {bookmarked ? <Bookmark className="size-4 fill-current" /> : <Bookmark className="size-4" />}
+                  </Button>
+                </Tooltip>
+              )}
+              {commentCount > 0 && (
+                <Tooltip content="View discussions">
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="no-window-drag flex items-center gap-1"
+                    onClick={(e) => {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      navigate({key: 'comments', id: docId})
+                    }}
+                  >
+                    <MessageSquare className="size-3" />
+                    <SizableText size="xs">{commentCount}</SizableText>
+                  </Button>
+                </Tooltip>
+              )}
+              {menuItems.length > 0 && <OptionsDropdown menuItems={menuItems} align="end" side="top" />}
+            </div>
           </div>
         </div>
       </div>
     </>
   )
 
-  if (navigate && linkProps) {
+  if (navigateProp && linkProps) {
     return (
       <a {...sharedProps} {...linkProps} {...(props as any)}>
         {content}

--- a/frontend/packages/ui/src/options-dropdown.tsx
+++ b/frontend/packages/ui/src/options-dropdown.tsx
@@ -47,15 +47,8 @@ export function OptionsDropdown({
       )}
     >
       <DropdownMenu open={popoverState.open} onOpenChange={popoverState.onOpenChange}>
-        <DropdownMenuTrigger
-          className={cn(
-            buttonVariants({variant: 'outline'}),
-            'no-window-drag',
-            'hover:bg-hover dark:bg-background bg-white',
-          )}
-          style={{width: '32px', height: '32px', padding: 0}}
-        >
-          <MoreHorizontal className="size-4" />
+        <DropdownMenuTrigger className={cn(buttonVariants({variant: 'outline', size: 'icon'}), 'no-window-drag')}>
+          <MoreHorizontal className="size-3.5" />
         </DropdownMenuTrigger>
         <DropdownMenuContent className="p-1" side={side} align={align}>
           <div className="flex flex-col">


### PR DESCRIPTION
Replace date/FacePile footer with action buttons (bookmark, comments, options dropdown).
Add DocumentActionsContext for cross-cutting document actions (edit, move, delete, branch, export, copy link).
Each card self-assembles its menu items from context + its own entity data.

- New DocumentActionsProvider pattern alongside CommentsProvider
- Bookmark icon (lucide), comment count with navigation to /:comments view
- Edit option in dropdown with "Resume Editing" when draft exists
- Remove summary text from card (cover image + title + footer only)
- Desktop-specific provider with dialog hoisting for move/branch/delete
