### PR TITLE
feat(documents): add duplicate document functionality

### DIFF
--- a/frontend/apps/desktop/src/pages/draft.tsx
+++ b/frontend/apps/desktop/src/pages/draft.tsx
@@ -957,6 +957,7 @@ function DraftMetadataEditor({
   })
   const inputName = useRef<HTMLTextAreaElement | null>(null)
   const inputSummary = useRef<HTMLTextAreaElement | null>(null)
+  const duplicateFocusTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     const target = inputName.current
@@ -967,6 +968,26 @@ function DraftMetadataEditor({
       applyInputResize(target)
     }
   }, [name])
+
+  // Focus and select the title when navigating from a duplicate action.
+  // Uses a ref-held timer so React re-renders don't cancel it via effect cleanup.
+  useEffect(() => {
+    if (!name) return
+    const flagDraftId = sessionStorage.getItem('duplicate-draft-focus')
+    if (!flagDraftId || route.id !== flagDraftId) return
+    sessionStorage.removeItem('duplicate-draft-focus')
+
+    if (duplicateFocusTimer.current) {
+      clearTimeout(duplicateFocusTimer.current)
+    }
+    duplicateFocusTimer.current = setTimeout(() => {
+      duplicateFocusTimer.current = null
+      const target = inputName.current
+      if (!target) return
+      target.focus()
+      target.select()
+    }, 300)
+  }, [name, route.id])
 
   useEffect(() => {
     const target = inputSummary.current

--- a/frontend/packages/shared/src/document-actions-context.tsx
+++ b/frontend/packages/shared/src/document-actions-context.tsx
@@ -15,6 +15,7 @@ export type DocumentActionsContextValue = {
   onMoveDocument?: (id: UnpackedHypermediaId) => void
   onDeleteDocument?: (id: UnpackedHypermediaId, onSuccess?: () => void) => void
   onBranchDocument?: (id: UnpackedHypermediaId) => void
+  onDuplicateDocument?: (id: UnpackedHypermediaId) => void
   onExportDocument?: (doc: HMDocument) => void
   onCopyLink?: (id: UnpackedHypermediaId) => void
 
@@ -36,6 +37,7 @@ export function DocumentActionsProvider({children, ...value}: PropsWithChildren<
       value.onMoveDocument,
       value.onDeleteDocument,
       value.onBranchDocument,
+      value.onDuplicateDocument,
       value.onExportDocument,
       value.onCopyLink,
       value.getDraftId,

--- a/frontend/packages/ui/src/document-list-item.tsx
+++ b/frontend/packages/ui/src/document-list-item.tsx
@@ -15,7 +15,7 @@ import {
 import {useDocumentActions} from '@shm/shared/document-actions-context'
 import {useInteractionSummary} from '@shm/shared/models/interaction-summary'
 import {useNavigate} from '@shm/shared/utils/navigation'
-import {Bookmark, Forward, GitFork, Link, MessageSquare, Pencil} from 'lucide-react'
+import {Bookmark, Copy, Forward, GitFork, Link, MessageSquare, Pencil} from 'lucide-react'
 import {useMemo} from 'react'
 import {LibraryEntryUpdateSummary} from './activity'
 import {Button} from './button'
@@ -112,6 +112,17 @@ export function DocumentListItem({
         },
       })
     }
+    if (actions.onDuplicateDocument && isOwner && hasPath) {
+      items.push({
+        key: 'duplicate',
+        label: 'Duplicate Document',
+        icon: <Copy className="size-3.5" />,
+        onClick: (e) => {
+          e?.stopPropagation()
+          actions.onDuplicateDocument!(id)
+        },
+      })
+    }
     if (actions.onCopyLink) {
       items.push({
         key: 'copy-link',
@@ -171,6 +182,7 @@ export function DocumentListItem({
     return items
   }, [
     actions.onEditDocument,
+    actions.onDuplicateDocument,
     actions.onCopyLink,
     actions.onMoveDocument,
     actions.onBranchDocument,

--- a/frontend/packages/ui/src/newspaper.tsx
+++ b/frontend/packages/ui/src/newspaper.tsx
@@ -9,7 +9,7 @@ import {
 import {useDocumentActions} from '@shm/shared/document-actions-context'
 import {useInteractionSummary} from '@shm/shared/models/interaction-summary'
 import {useNavigate} from '@shm/shared/utils/navigation'
-import {Bookmark, Forward, GitFork, Link, MessageSquare, Pencil} from 'lucide-react'
+import {Bookmark, Copy, Forward, GitFork, Link, MessageSquare, Pencil} from 'lucide-react'
 import {HTMLAttributes, useMemo} from 'react'
 import {Button} from './button'
 import {DraftBadge} from './draft-badge'
@@ -72,6 +72,17 @@ export function DocumentCard({
         onClick: (e) => {
           e?.stopPropagation()
           actions.onEditDocument!(docId, draftId)
+        },
+      })
+    }
+    if (actions.onDuplicateDocument && isOwner && hasPath) {
+      items.push({
+        key: 'duplicate',
+        label: 'Duplicate Document',
+        icon: <Copy className="size-4" />,
+        onClick: (e) => {
+          e?.stopPropagation()
+          actions.onDuplicateDocument!(docId)
         },
       })
     }


### PR DESCRIPTION
## Summary

- Add document duplication feature that creates a copy with " Copy" appended to the original name
- Implement duplicate action in DocumentActionsProvider with full error handling and user feedback
- Add duplicate option to document list items and newspaper card components
- Auto-focus and select title in duplicated draft for quick renaming
- Preserve document metadata, content, visibility, and location in hierarchy

## Breaking Changes

None