### PR TITLE
fix(redirects): handle child document redirects automatically

### DIFF
--- a/frontend/apps/desktop/src/pages/activity.tsx
+++ b/frontend/apps/desktop/src/pages/activity.tsx
@@ -13,7 +13,7 @@ import {Feed} from '@shm/ui/feed'
 import {FeedFilters} from '@shm/ui/feed-filters'
 import {OpenInPanelButton} from '@shm/ui/open-in-panel'
 import {PageLayout} from '@shm/ui/page-layout'
-import {PageDiscovery, PageNotFound, PageRedirected} from '@shm/ui/page-message-states'
+import {PageDiscovery, PageNotFound} from '@shm/ui/page-message-states'
 import {SiteHeader} from '@shm/ui/site-header'
 import {toast} from '@shm/ui/toast'
 import {useScrollRestoration} from '@shm/ui/use-scroll-restoration'
@@ -77,16 +77,6 @@ function _ActivityContent({id, route}: {id: UnpackedHypermediaId; route: Activit
     resource.data?.type === 'document' ? resource.data.document : undefined
 
   if (resource.isInitialLoading) return null
-
-  if (resource.data?.type === 'redirect') {
-    return (
-      <PageRedirected
-        docId={id}
-        redirectTarget={resource.data.redirectTarget}
-        onNavigate={(target) => navigate({key: 'activity', id: target})}
-      />
-    )
-  }
 
   if (resource.data?.type === 'not-found') {
     if (resource.isDiscovering) {

--- a/frontend/packages/shared/src/api-capabilities.ts
+++ b/frontend/packages/shared/src/api-capabilities.ts
@@ -2,19 +2,28 @@ import {HMRequestImplementation, HMRequestParams} from './api-types'
 import {BIG_INT} from './constants'
 import {GRPCClient} from './grpc-client'
 import {HMListCapabilitiesRequest} from './hm-types'
+import {getErrorMessage, HMRedirectError} from './models/entity'
 import {packHmId, unpackHmId} from './utils'
 import {hmIdPathToEntityQueryPath} from './utils/path-api'
 
 export const ListCapabilities: HMRequestImplementation<HMListCapabilitiesRequest> = {
   async getData(grpcClient: GRPCClient, input): Promise<HMListCapabilitiesRequest['output']> {
-    const result = await grpcClient.accessControl.listCapabilities({
-      account: input.targetId.uid,
-      path: hmIdPathToEntityQueryPath(input.targetId.path),
-      pageSize: BIG_INT,
-    })
+    try {
+      const result = await grpcClient.accessControl.listCapabilities({
+        account: input.targetId.uid,
+        path: hmIdPathToEntityQueryPath(input.targetId.path),
+        pageSize: BIG_INT,
+      })
 
-    return {
-      capabilities: result.capabilities.map((c) => c.toJson({emitDefaultValues: true, enumAsInteger: false}) as any),
+      return {
+        capabilities: result.capabilities.map((c) => c.toJson({emitDefaultValues: true, enumAsInteger: false}) as any),
+      }
+    } catch (e) {
+      const err = getErrorMessage(e)
+      if (err instanceof HMRedirectError) {
+        return {capabilities: []}
+      }
+      throw e
     }
   },
 }

--- a/frontend/packages/shared/src/api-changes.ts
+++ b/frontend/packages/shared/src/api-changes.ts
@@ -2,6 +2,7 @@ import {HMRequestImplementation, HMRequestParams} from './api-types'
 import {BIG_INT} from './constants'
 import {GRPCClient} from './grpc-client'
 import {HMListChangesRequest} from './hm-types'
+import {getErrorMessage, HMRedirectError} from './models/entity'
 import {packHmId, unpackHmId} from './utils'
 import {hmIdPathToEntityQueryPath} from './utils/path-api'
 
@@ -9,24 +10,35 @@ export const ListChanges: HMRequestImplementation<HMListChangesRequest> = {
   async getData(grpcClient: GRPCClient, input): Promise<HMListChangesRequest['output']> {
     const path = hmIdPathToEntityQueryPath(input.targetId.path)
 
-    // Get the latest document to determine version
-    const latestDoc = await grpcClient.documents.getDocument({
-      account: input.targetId.uid,
-      path,
-      version: undefined,
-    })
+    try {
+      // Get the latest document to determine version
+      const latestDoc = await grpcClient.documents.getDocument({
+        account: input.targetId.uid,
+        path,
+        version: undefined,
+      })
 
-    // List changes for that version
-    const result = await grpcClient.documents.listDocumentChanges({
-      account: input.targetId.uid,
-      path,
-      version: latestDoc.version,
-      pageSize: BIG_INT,
-    })
+      // List changes for that version
+      const result = await grpcClient.documents.listDocumentChanges({
+        account: input.targetId.uid,
+        path,
+        version: latestDoc.version,
+        pageSize: BIG_INT,
+      })
 
-    return {
-      changes: result.changes.map((c) => c.toJson({emitDefaultValues: true, enumAsInteger: false}) as any),
-      latestVersion: latestDoc.version,
+      return {
+        changes: result.changes.map((c) => c.toJson({emitDefaultValues: true, enumAsInteger: false}) as any),
+        latestVersion: latestDoc.version,
+      }
+    } catch (e) {
+      // If the document has been redirected, return empty changes.
+      // queryResource handles following redirects, so this query will be
+      // re-fetched with the correct (target) ID after redirect resolution.
+      const err = getErrorMessage(e)
+      if (err instanceof HMRedirectError) {
+        return {changes: [], latestVersion: ''}
+      }
+      throw e
     }
   },
 }

--- a/frontend/packages/shared/src/api-interaction-summary.ts
+++ b/frontend/packages/shared/src/api-interaction-summary.ts
@@ -4,6 +4,7 @@ import {BIG_INT} from './constants'
 import {GRPCClient} from './grpc-client'
 import {HMInteractionSummaryRequest} from './hm-types'
 import {calculateInteractionSummary} from './interaction-summary'
+import {getErrorMessage, HMRedirectError} from './models/entity'
 import {hmIdPathToEntityQueryPath} from './utils'
 
 export const InteractionSummary: HMRequestImplementation<HMInteractionSummaryRequest> = {
@@ -12,34 +13,45 @@ export const InteractionSummary: HMRequestImplementation<HMInteractionSummaryReq
 
     const apiPath = hmIdPathToEntityQueryPath(id.path)
 
-    const [mentions, latestDoc, children] = await Promise.all([
-      grpcClient.entities.listEntityMentions({
-        id: id.id,
-        pageSize: BIG_INT,
-      }),
-      grpcClient.documents.getDocument({
+    try {
+      const [mentions, latestDoc, children] = await Promise.all([
+        grpcClient.entities.listEntityMentions({
+          id: id.id,
+          pageSize: BIG_INT,
+        }),
+        grpcClient.documents.getDocument({
+          account: id.uid,
+          path: apiPath,
+          version: undefined,
+        }),
+        grpcClient.documents.listDirectory({
+          account: id.uid,
+          directoryPath: apiPath,
+        }),
+      ])
+
+      const changes = await grpcClient.documents.listDocumentChanges({
         account: id.uid,
         path: apiPath,
-        version: undefined,
-      }),
-      grpcClient.documents.listDirectory({
-        account: id.uid,
-        directoryPath: apiPath,
-      }),
-    ])
+        version: latestDoc.version,
+      })
+      const childrenCount = toPlainMessage(children).documents.filter((d) => {
+        if (d.path === apiPath) return false
+        // filter out children of children
+        if (d.path.split('/').length > apiPath.split('/').length + 1) return false
+        return true
+      }).length
 
-    const changes = await grpcClient.documents.listDocumentChanges({
-      account: id.uid,
-      path: apiPath,
-      version: latestDoc.version,
-    })
-    const childrenCount = toPlainMessage(children).documents.filter((d) => {
-      if (d.path === apiPath) return false
-      // filter out children of children
-      if (d.path.split('/').length > apiPath.split('/').length + 1) return false
-      return true
-    }).length
-
-    return calculateInteractionSummary(mentions.mentions, changes.changes, id, childrenCount)
+      return calculateInteractionSummary(mentions.mentions, changes.changes, id, childrenCount)
+    } catch (e) {
+      // If the document has been redirected, return empty summary.
+      // queryResource handles following redirects, so this query will be
+      // re-fetched with the correct (target) ID after redirect resolution.
+      const err = getErrorMessage(e)
+      if (err instanceof HMRedirectError) {
+        return {citations: 0, comments: 0, changes: 0, children: 0, blocks: {}}
+      }
+      throw e
+    }
   },
 }

--- a/frontend/packages/shared/src/models/__tests__/queries.test.ts
+++ b/frontend/packages/shared/src/models/__tests__/queries.test.ts
@@ -1,0 +1,141 @@
+import {describe, expect, test, vi} from 'vitest'
+import {hmId} from '../../utils/entity-id-url'
+import {queryResource} from '../queries'
+
+function createMockClient(handler: (key: string, input: any) => any) {
+  return {
+    request: vi.fn(handler),
+  } as any
+}
+
+const docA = hmId('uid1', {path: ['old-name']})
+const docB = hmId('uid1', {path: ['new-name']})
+const docC = hmId('uid1', {path: ['newest-name']})
+
+const documentResponse = (id: ReturnType<typeof hmId>) => ({
+  type: 'document' as const,
+  id,
+  document: {
+    version: 'v1',
+    account: 'uid1',
+    path: '',
+    authors: [],
+    content: [],
+    metadata: {},
+    genesis: 'genesis1',
+    visibility: 'PUBLIC',
+    createTime: '',
+    updateTime: '',
+  },
+})
+
+const redirectResponse = (from: ReturnType<typeof hmId>, to: ReturnType<typeof hmId>) => ({
+  type: 'redirect' as const,
+  id: from,
+  redirectTarget: to,
+})
+
+const notFoundResponse = (id: ReturnType<typeof hmId>) => ({
+  type: 'not-found' as const,
+  id,
+})
+
+const tombstoneResponse = (id: ReturnType<typeof hmId>) => ({
+  type: 'tombstone' as const,
+  id,
+})
+
+describe('queryResource', () => {
+  test('returns document directly when no redirect', async () => {
+    const client = createMockClient(() => documentResponse(docA))
+    const query = queryResource(client, docA)
+    const result = await query.queryFn!()
+    expect(result).toMatchObject({type: 'document', id: docA})
+    expect(client.request).toHaveBeenCalledTimes(1)
+  })
+
+  test('follows a single redirect and returns resolved document', async () => {
+    const client = createMockClient((_key, input) => {
+      if (input.id === docA.id) return redirectResponse(docA, docB)
+      if (input.id === docB.id) return documentResponse(docB)
+      throw new Error(`Unexpected request: ${input.id}`)
+    })
+    const query = queryResource(client, docA)
+    const result = await query.queryFn!()
+    expect(result).toMatchObject({type: 'document', id: docB})
+    expect(client.request).toHaveBeenCalledTimes(2)
+  })
+
+  test('follows chained redirects (A→B→C)', async () => {
+    const client = createMockClient((_key, input) => {
+      if (input.id === docA.id) return redirectResponse(docA, docB)
+      if (input.id === docB.id) return redirectResponse(docB, docC)
+      if (input.id === docC.id) return documentResponse(docC)
+      throw new Error(`Unexpected request: ${input.id}`)
+    })
+    const query = queryResource(client, docA)
+    const result = await query.queryFn!()
+    expect(result).toMatchObject({type: 'document', id: docC})
+    expect(client.request).toHaveBeenCalledTimes(3)
+  })
+
+  test('handles redirect to not-found', async () => {
+    const client = createMockClient((_key, input) => {
+      if (input.id === docA.id) return redirectResponse(docA, docB)
+      if (input.id === docB.id) return notFoundResponse(docB)
+      throw new Error(`Unexpected request: ${input.id}`)
+    })
+    const query = queryResource(client, docA)
+    const result = await query.queryFn!()
+    expect(result).toMatchObject({type: 'not-found', id: docB})
+  })
+
+  test('handles redirect to tombstone', async () => {
+    const client = createMockClient((_key, input) => {
+      if (input.id === docA.id) return redirectResponse(docA, docB)
+      if (input.id === docB.id) return tombstoneResponse(docB)
+      throw new Error(`Unexpected request: ${input.id}`)
+    })
+    const query = queryResource(client, docA)
+    const result = await query.queryFn!()
+    expect(result).toMatchObject({type: 'tombstone', id: docB})
+  })
+
+  test('stops following redirects after max depth (5)', async () => {
+    // Create a chain of 6 redirects — should stop after 5
+    const ids = Array.from({length: 7}, (_, i) => hmId('uid1', {path: [`doc-${i}`]}))
+    const client = createMockClient((_key, input) => {
+      const idx = ids.findIndex((id) => id.id === input.id)
+      if (idx >= 0 && idx < ids.length - 1) {
+        return redirectResponse(ids[idx]!, ids[idx + 1]!)
+      }
+      return documentResponse(ids[idx]!)
+    })
+    const query = queryResource(client, ids[0]!)
+    const result = await query.queryFn!()
+    // After 5 redirects, we're at ids[5] which still redirects to ids[6],
+    // but we've hit the limit. The result is the redirect response itself.
+    expect(result).toMatchObject({type: 'redirect'})
+    // 1 initial + 5 follows = 6 total requests
+    expect(client.request).toHaveBeenCalledTimes(6)
+  })
+
+  test('returns null for null id', async () => {
+    const client = createMockClient(() => {
+      throw new Error('Should not be called')
+    })
+    const query = queryResource(client, null)
+    const result = await query.queryFn!()
+    expect(result).toBeNull()
+    expect(client.request).not.toHaveBeenCalled()
+  })
+
+  test('returns error when request throws', async () => {
+    const client = createMockClient(() => {
+      throw new Error('Network failure')
+    })
+    const query = queryResource(client, docA)
+    const result = await query.queryFn!()
+    expect(result).toMatchObject({type: 'error', message: 'Network failure'})
+  })
+})

--- a/frontend/packages/shared/src/models/entity.ts
+++ b/frontend/packages/shared/src/models/entity.ts
@@ -1,6 +1,6 @@
 import {PlainMessage, Struct, Timestamp, toPlainMessage} from '@bufbuild/protobuf'
 import {Code, ConnectError} from '@connectrpc/connect'
-import {useInfiniteQuery, useQueries, useQuery, UseQueryOptions} from '@tanstack/react-query'
+import {useInfiniteQuery, useQueries, useQuery, useQueryClient, UseQueryOptions} from '@tanstack/react-query'
 import {useEffect, useMemo, useRef, useState} from 'react'
 import {DocumentInfo, RedirectErrorDetails} from '../client'
 import {DISCOVERY_TIMEOUT_MS} from '../constants'
@@ -160,14 +160,29 @@ export function useResource(
     result.data?.type === 'not-found' &&
     (!!discoveryInProgress || result.isFetching)
 
-  // Redirect handling
-  const redirectTarget = result.data?.type === 'redirect' ? result.data.redirectTarget : null
+  // Redirect handling — queryResource follows redirects, so data.type is never
+  // 'redirect'. Instead, detect redirects by comparing the returned id with the
+  // requested id. Also populate the cache for the target id so other components
+  // querying the target directly get an instant cache hit.
+  const queryClient = useQueryClient()
+  const redirectTarget = (() => {
+    if (!result.data || !id) return null
+    if (result.data.type !== 'document' && result.data.type !== 'comment') return null
+    if (result.data.id?.id !== id.id) return result.data.id
+    return null
+  })()
   const onRedirectOrDeletedRef = useRef(onRedirectOrDeleted)
   onRedirectOrDeletedRef.current = onRedirectOrDeleted
   const handledRedirectRef = useRef<string | null>(null)
   useEffect(() => {
     if (redirectTarget && handledRedirectRef.current !== redirectTarget.id) {
       handledRedirectRef.current = redirectTarget.id
+      // Cache the resolved data under the target's key so other components
+      // querying the target id get an instant cache hit instead of re-fetching.
+      queryClient.setQueryData(
+        [queryKeys.ENTITY, redirectTarget.id, redirectTarget.version || undefined, redirectTarget.latest || false],
+        result.data,
+      )
       onRedirectOrDeletedRef.current?.({isDeleted: false, redirectTarget})
     }
   }, [redirectTarget])

--- a/frontend/packages/shared/src/models/queries.ts
+++ b/frontend/packages/shared/src/models/queries.ts
@@ -70,7 +70,12 @@ export function queryResource(client: UniversalClient, id: UnpackedHypermediaId 
     queryFn: async (): Promise<HMResource | null> => {
       if (!id) return null
       try {
-        const res = await client.request<HMResourceRequest>('Resource', id)
+        let res = await client.request<HMResourceRequest>('Resource', id)
+        // Follow redirects automatically so consumers never see {type: 'redirect'}
+        let maxRedirects = 5
+        while (res?.type === 'redirect' && maxRedirects-- > 0) {
+          res = await client.request<HMResourceRequest>('Resource', res.redirectTarget)
+        }
         return HMResourceSchema.parse(res)
       } catch (e) {
         const message = e instanceof Error ? e.message : 'Unknown error'

--- a/frontend/packages/ui/src/blocks-content.tsx
+++ b/frontend/packages/ui/src/blocks-content.tsx
@@ -1435,7 +1435,7 @@ export function BlockEmbedCard({
   if (doc.data?.type === 'error') {
     return <ErrorBlock message={doc.data.message} />
   }
-  if (doc.isError || !doc.data || doc.data.type == 'redirect') return <ErrorBlock message="Could not load embed" />
+  if (doc.isError || !doc.data) return <ErrorBlock message="Could not load embed" />
 
   const accountsMetadata = Object.fromEntries(
     authors

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -269,16 +269,6 @@ export function ResourcePage({
     )
   }
 
-  // Handle redirect - for now just show not found, redirect handling comes later
-  if (resource.data.type === 'redirect') {
-    return (
-      <PageWrapper siteHomeId={siteHomeId} docId={docId} headerData={headerData} rightActions={rightActions}>
-        <PageNotFound />
-        {pageFooter}
-      </PageWrapper>
-    )
-  }
-
   // Handle comment - render target document's discussions view with comment open
   if (resource.data.type === 'comment') {
     return (


### PR DESCRIPTION
## Summary

- Move redirect handling into `queryResource` to automatically follow redirects up to 5 levels deep
- API handlers (`listCapabilities`, `listChanges`, `getInteractionSummary`) now gracefully handle redirect errors by returning empty results
- Update consumers to detect redirects via ID comparison instead of checking response type
- Remove explicit redirect UI handling from activity and resource pages

## Breaking Changes

None. Consumers no longer see `{type: 'redirect'}` responses from `queryResource`, but redirect handling is automatic and transparent.

This fixes the `[failed_precondition]` error that occurred when accessing documents with child redirects by ensuring redirects are followed at the query layer before API handlers are invoked.

---

Fixes #255