### PR TITLE
fix: allow scrolling at minimum window width in desktop app

### DIFF
--- a/frontend/packages/ui/src/feed-page-common.tsx
+++ b/frontend/packages/ui/src/feed-page-common.tsx
@@ -1,4 +1,5 @@
 import {HMDocument, hmId, UnpackedHypermediaId} from '@shm/shared'
+import {IS_DESKTOP} from '@shm/shared/constants'
 import {useDirectory, useResource} from '@shm/shared/models/entity'
 import {useNavRoute} from '@shm/shared/utils/navigation'
 import {useMemo} from 'react'
@@ -90,7 +91,8 @@ function FeedBody({
   })
 
   const media = useMedia()
-  const isMobile = media.xs
+  // In Electron (IS_DESKTOP), always use element scroll regardless of window width
+  const isMobile = media.xs && !IS_DESKTOP
 
   const menuItems = extraMenuItems || []
 

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -12,7 +12,7 @@ import {
   unpackHmId,
   useUniversalAppContext,
 } from '@shm/shared'
-import {NOTIFY_SERVICE_HOST} from '@shm/shared/constants'
+import {IS_DESKTOP, NOTIFY_SERVICE_HOST} from '@shm/shared/constants'
 import {useAccountsMetadata, useDirectory, useIsLatest, useResource, useResources} from '@shm/shared/models/entity'
 import {useInteractionSummary} from '@shm/shared/models/interaction-summary'
 import {getRoutePanel} from '@shm/shared/routes'
@@ -635,8 +635,9 @@ export function PageWrapper({
 }) {
   // Mobile: let content flow naturally (document scroll)
   // Desktop: fixed height container (element scroll via ScrollArea in children)
+  // Note: IS_DESKTOP (Electron) never uses document scroll regardless of window width
   const media = useMedia()
-  const isMobile = media.xs
+  const isMobile = media.xs && !IS_DESKTOP
 
   return (
     <div
@@ -870,9 +871,11 @@ function DocumentBody({
     })
   }, [document.authors, accountsMetadata.data])
 
-  // Use document scroll on mobile, element scroll on desktop
+  // Use document scroll on mobile web, element scroll on desktop/large screens
+  // In Electron (IS_DESKTOP), always use element scroll regardless of window width,
+  // because the layout uses overflow-hidden containers that prevent document scroll.
   const media = useMedia()
-  const isMobile = media.xs
+  const isMobile = media.xs && !IS_DESKTOP
 
   // Block tools handlers
   const blockCitations = useMemo(() => interactionSummary.data?.blocks || null, [interactionSummary.data?.blocks])


### PR DESCRIPTION
## Summary

At minimum window width (600px on Mac), the `xs` media query (`max-width: 660px`) triggers the mobile layout path. This mobile path relies on natural document scroll, which does not work in the Electron desktop app — the layout uses `overflow-hidden` containers (`h-screen`, `flex-1 overflow-hidden`) that prevent document-level scrolling. The result is that content is clipped and the user cannot scroll.

## Changes

- **`packages/ui/src/resource-page-common.tsx`**: In `PageWrapper` and `DocumentBody`, changed `const isMobile = media.xs` to `const isMobile = media.xs && !IS_DESKTOP`. This ensures the Electron app always uses element scroll (via `ScrollArea`) regardless of window width, while the web app continues to use natural document scroll on narrow viewports.
- **`packages/ui/src/feed-page-common.tsx`**: Applied the same fix for the feed page layout.
- Imported `IS_DESKTOP` from `@shm/shared/constants` in both files.

## Testing

- TypeScript compilation passes for the affected files (pre-existing unrelated TS errors in the package are not introduced by this change).
- The fix is minimal and only affects the Electron desktop app (where `IS_DESKTOP === true`), leaving web behavior unchanged.
- On the desktop app, even at 600px width, the `ScrollArea` element scroll is now used instead of document scroll, matching the behavior at wider widths.

Fixes seed-hypermedia/seed#261