### PR TITLE
feat(query-block): render child drafts inline in self-referential query blocks

### DIFF
--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -9,7 +9,7 @@ import {InlineNewDocumentCard} from '@/components/inline-new-document-card'
 import {MoveDialog} from '@/components/move-dialog'
 import {roleCanWrite, useSelectedAccountCapability} from '@/models/access-control'
 import {useMyAccountIds} from '@/models/daemon'
-import {useChildDrafts, useCreateInlineDraft} from '@/models/documents'
+import {useChildDrafts, useCreateInlineDraft, useDeleteDraft, useUpdateDraftMetadata} from '@/models/documents'
 import {useExistingDraft} from '@/models/drafts'
 import {useSelectedAccount} from '@/selected-account'
 import {client} from '@/trpc'
@@ -17,6 +17,8 @@ import {useHackyAuthorsSubscriptions} from '@/use-hacky-authors-subscriptions'
 import {convertBlocksToMarkdown} from '@/utils/blocks-to-markdown'
 import {useNavigate} from '@/utils/useNavigate'
 import {hmId} from '@shm/shared'
+import {findSelfQueryBlock} from '@shm/shared/content'
+import {QueryBlockDraftsProvider} from '@shm/shared/query-block-drafts-context'
 import {hmBlocksToEditorContent} from '@shm/shared/client/hmblock-to-editorblock'
 import {CommentsProvider, isRouteEqualToCommentTarget, useDeleteComment} from '@shm/shared/comments-service-provider'
 import {HMBlockNode, HMComment} from '@shm/shared/hm-types'
@@ -76,9 +78,21 @@ export default function DesktopResourcePage() {
   // Inline document creation
   const childDrafts = useChildDrafts(docId)
   const createInlineDraft = useCreateInlineDraft(docId)
+  const deleteDraft = useDeleteDraft()
+  const updateDraftMetadata = useUpdateDraftMetadata()
   const [lastCreatedDraftId, setLastCreatedDraftId] = useState<string | null>(null)
+
+  // Detect self-referential query block
+  const selfQueryBlock = useMemo(() => {
+    if (!doc?.content) return null
+    return findSelfQueryBlock(doc.content, docId.uid, docId.path || null)
+  }, [doc?.content, docId.uid, docId.path])
+
+  const hasSelfQuery = !!selfQueryBlock
+
+  // When self-query exists, drafts render inside query block; otherwise at the bottom
   const inlineCards = useMemo(() => {
-    if (!childDrafts.length) return null
+    if (!childDrafts.length || hasSelfQuery) return null
     return (
       <div className="mt-6 grid grid-cols-1 gap-4 px-4 sm:grid-cols-2 lg:grid-cols-3">
         {childDrafts.map((draft) => (
@@ -86,7 +100,30 @@ export default function DesktopResourcePage() {
         ))}
       </div>
     )
-  }, [childDrafts, lastCreatedDraftId])
+  }, [childDrafts, lastCreatedDraftId, hasSelfQuery])
+
+  // Context value for query block draft rendering
+  const queryBlockDraftsValue = useMemo(
+    () => ({
+      targetBlockId: selfQueryBlock?.id ?? null,
+      drafts: hasSelfQuery
+        ? childDrafts
+            .slice()
+            .reverse()
+            .map((d) => ({draft: d, autoFocus: d.id === lastCreatedDraftId}))
+        : [],
+      onOpenDraft: (draftId: string) => {
+        navigate({key: 'draft', id: draftId})
+      },
+      onDeleteDraft: (draftId: string) => {
+        deleteDraft.mutate(draftId)
+      },
+      onUpdateDraftName: (draftId: string, name: string) => {
+        updateDraftMetadata.mutate({draftId, metadata: {name}})
+      },
+    }),
+    [selfQueryBlock?.id, hasSelfQuery, childDrafts, lastCreatedDraftId, navigate, deleteDraft, updateDraftMetadata],
+  )
 
   // Comment deletion
   const selectedAccount = useSelectedAccount()
@@ -367,19 +404,21 @@ export default function DesktopResourcePage() {
         onReplyCountClick={onReplyCountClick}
       >
         <DesktopDocumentActionsProvider>
-          <ResourcePage
-            docId={docId}
-            CommentEditor={CommentBox}
-            extraMenuItems={menuItems}
-            editActions={editActions}
-            existingDraft={existingDraft}
-            collaboratorForm={<AddCollaboratorForm id={docId} />}
-            inlineCards={inlineCards}
-            rightActions={<SubscriptionButton id={docId} />}
-            currentAccountId={currentAccountId}
-            onCommentDelete={onCommentDelete}
-            deleteCommentDialogContent={deleteCommentDialog.content}
-          />
+          <QueryBlockDraftsProvider {...queryBlockDraftsValue}>
+            <ResourcePage
+              docId={docId}
+              CommentEditor={CommentBox}
+              extraMenuItems={menuItems}
+              editActions={editActions}
+              existingDraft={existingDraft}
+              collaboratorForm={<AddCollaboratorForm id={docId} />}
+              inlineCards={inlineCards}
+              rightActions={<SubscriptionButton id={docId} />}
+              currentAccountId={currentAccountId}
+              onCommentDelete={onCommentDelete}
+              deleteCommentDialogContent={deleteCommentDialog.content}
+            />
+          </QueryBlockDraftsProvider>
         </DesktopDocumentActionsProvider>
       </CommentsProvider>
       {deleteEntity.content}

--- a/frontend/packages/shared/src/__tests__/content-refs.test.ts
+++ b/frontend/packages/shared/src/__tests__/content-refs.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest'
-import {extractAllContentRefs, hasQueryBlockTargetingSelf} from '../content'
+import {extractAllContentRefs, findSelfQueryBlock, hasQueryBlockTargetingSelf} from '../content'
 import {HMBlockNode} from '../hm-types'
 
 function makeBlock(block: any, children?: HMBlockNode[]): HMBlockNode {
@@ -207,5 +207,123 @@ describe('hasQueryBlockTargetingSelf', () => {
       ]),
     ]
     expect(hasQueryBlockTargetingSelf(blocks, 'uid1', null)).toBe(true)
+  })
+})
+
+describe('findSelfQueryBlock', () => {
+  it('returns null for empty content', () => {
+    expect(findSelfQueryBlock([], 'uid', ['path'])).toBeNull()
+  })
+
+  it('returns null when no Query blocks exist', () => {
+    const blocks: HMBlockNode[] = [makeBlock({type: 'Paragraph', id: 'p1', text: 'hello'})]
+    expect(findSelfQueryBlock(blocks, 'uid', ['path'])).toBeNull()
+  })
+
+  it('returns the block when Query targets same uid and path', () => {
+    const queryBlock = {
+      type: 'Query',
+      id: 'q1',
+      attributes: {
+        query: {
+          includes: [{space: 'myuid', path: 'my/path', mode: 'Children'}],
+        },
+      },
+    }
+    const blocks: HMBlockNode[] = [makeBlock(queryBlock)]
+    const result = findSelfQueryBlock(blocks, 'myuid', ['my', 'path'])
+    expect(result).not.toBeNull()
+    expect(result!.id).toBe('q1')
+  })
+
+  it('returns the block for root doc with empty path', () => {
+    const blocks: HMBlockNode[] = [
+      makeBlock({
+        type: 'Query',
+        id: 'q1',
+        attributes: {
+          query: {
+            includes: [{space: 'uid1', path: '', mode: 'Children'}],
+          },
+        },
+      }),
+    ]
+    expect(findSelfQueryBlock(blocks, 'uid1', null)).not.toBeNull()
+    expect(findSelfQueryBlock(blocks, 'uid1', [])).not.toBeNull()
+  })
+
+  it('returns null when Query targets different uid', () => {
+    const blocks: HMBlockNode[] = [
+      makeBlock({
+        type: 'Query',
+        id: 'q1',
+        attributes: {
+          query: {
+            includes: [{space: 'other-uid', path: 'path', mode: 'Children'}],
+          },
+        },
+      }),
+    ]
+    expect(findSelfQueryBlock(blocks, 'myuid', ['path'])).toBeNull()
+  })
+
+  it('returns null when Query targets different path', () => {
+    const blocks: HMBlockNode[] = [
+      makeBlock({
+        type: 'Query',
+        id: 'q1',
+        attributes: {
+          query: {
+            includes: [{space: 'uid1', path: 'other/path', mode: 'Children'}],
+          },
+        },
+      }),
+    ]
+    expect(findSelfQueryBlock(blocks, 'uid1', ['my', 'path'])).toBeNull()
+  })
+
+  it('returns the first match when multiple self-referential blocks exist', () => {
+    const blocks: HMBlockNode[] = [
+      makeBlock({
+        type: 'Query',
+        id: 'q1',
+        attributes: {
+          query: {
+            includes: [{space: 'uid1', path: '', mode: 'Children'}],
+          },
+        },
+      }),
+      makeBlock({
+        type: 'Query',
+        id: 'q2',
+        attributes: {
+          query: {
+            includes: [{space: 'uid1', path: '', mode: 'AllDescendants'}],
+          },
+        },
+      }),
+    ]
+    const result = findSelfQueryBlock(blocks, 'uid1', null)
+    expect(result).not.toBeNull()
+    expect(result!.id).toBe('q1')
+  })
+
+  it('finds Query block in nested children', () => {
+    const blocks: HMBlockNode[] = [
+      makeBlock({type: 'Paragraph', id: 'p1', text: 'parent'}, [
+        makeBlock({
+          type: 'Query',
+          id: 'q1',
+          attributes: {
+            query: {
+              includes: [{space: 'uid1', path: '', mode: 'Children'}],
+            },
+          },
+        }),
+      ]),
+    ]
+    const result = findSelfQueryBlock(blocks, 'uid1', null)
+    expect(result).not.toBeNull()
+    expect(result!.id).toBe('q1')
   })
 })

--- a/frontend/packages/shared/src/content.ts
+++ b/frontend/packages/shared/src/content.ts
@@ -292,6 +292,24 @@ export function hasQueryBlockTargetingSelf(
   })
 }
 
+export function findSelfQueryBlock(
+  children: HMBlockNode[],
+  parentUid: string,
+  parentPath: string[] | null,
+): HMBlockQuery | null {
+  const queryBlocks = extractQueryBlocks(children)
+  for (const qb of queryBlocks) {
+    const include = qb.attributes.query.includes[0]
+    if (!include) continue
+    if (include.space !== parentUid) continue
+    const includePath = entityQueryPathToHmIdPath(include.path)
+    const parentPathStr = (parentPath || []).join('/')
+    const includePathStr = (includePath || []).join('/')
+    if (includePathStr === parentPathStr) return qb
+  }
+  return null
+}
+
 export function extractQueryBlocks(children: HMBlockNode[]): HMBlockQuery[] {
   let queries: HMBlockQuery[] = []
   function extractQueriesFromBlock(block: HMBlockNode) {

--- a/frontend/packages/shared/src/query-block-drafts-context.tsx
+++ b/frontend/packages/shared/src/query-block-drafts-context.tsx
@@ -1,0 +1,34 @@
+import {createContext, PropsWithChildren, useContext, useMemo} from 'react'
+import {HMListedDraft} from './hm-types'
+
+export type QueryBlockDraftItem = {
+  draft: HMListedDraft
+  autoFocus?: boolean
+}
+
+export type QueryBlockDraftsContextValue = {
+  targetBlockId: string | null
+  drafts: QueryBlockDraftItem[]
+  onOpenDraft?: (draftId: string) => void
+  onDeleteDraft?: (draftId: string) => void
+  onUpdateDraftName?: (draftId: string, name: string) => void
+}
+
+const defaultValue: QueryBlockDraftsContextValue = {
+  targetBlockId: null,
+  drafts: [],
+}
+
+const QueryBlockDraftsContext = createContext<QueryBlockDraftsContextValue>(defaultValue)
+
+export function QueryBlockDraftsProvider({children, ...value}: PropsWithChildren<QueryBlockDraftsContextValue>) {
+  const ctx = useMemo(
+    () => value,
+    [value.targetBlockId, value.drafts, value.onOpenDraft, value.onDeleteDraft, value.onUpdateDraftName],
+  )
+  return <QueryBlockDraftsContext.Provider value={ctx}>{children}</QueryBlockDraftsContext.Provider>
+}
+
+export function useQueryBlockDrafts(): QueryBlockDraftsContextValue {
+  return useContext(QueryBlockDraftsContext)
+}

--- a/frontend/packages/ui/src/blocks-content.tsx
+++ b/frontend/packages/ui/src/blocks-content.tsx
@@ -58,6 +58,7 @@ import {common} from 'lowlight'
 import {AlertCircle, ChevronDown, ChevronRight, File, Link, MessageSquare, Undo2, X} from 'lucide-react'
 import React, {
   PropsWithChildren,
+  ReactNode,
   createContext,
   createElement,
   memo,
@@ -81,9 +82,12 @@ import {EmbedWrapper} from './embed-wrapper'
 import {BlankQueryBlockMessage} from './entity-card'
 import {extractIpfsUrlCid, getDaemonFileUrl, isIpfsUrl, useFileProxyUrl, useImageUrl} from './get-file-url'
 import {SeedHeading, marginClasses} from './heading'
+import {useQueryBlockDrafts} from '@shm/shared/query-block-drafts-context'
 import {HMIcon} from './hm-icon'
 import {HoverCard, HoverCardContent, HoverCardTrigger} from './hover-card'
 import {BlockQuote} from './icons'
+import {InlineDraftCard} from './inline-draft-card'
+import {InlineDraftListItem} from './inline-draft-list-item'
 import {DocumentCard} from './newspaper'
 import {QueryBlockContent} from './query-block-content'
 import {Spinner} from './spinner'
@@ -1957,6 +1961,62 @@ function BlockContentQuery({block}: {block: HMBlockQuery}) {
   // Get accounts metadata
   const accountsMetadata = useAccountsMetadata(authorIds)
 
+  // Inline drafts for self-referential query blocks
+  const {targetBlockId, drafts, onOpenDraft, onDeleteDraft, onUpdateDraftName} = useQueryBlockDrafts()
+  const hasDrafts = targetBlockId === block.id && drafts.length > 0
+
+  const style = block.attributes.style || 'Card'
+  const banner = block.attributes.banner || false
+
+  const {prependItems, bannerContent} = useMemo(() => {
+    if (!hasDrafts || !onOpenDraft || !onDeleteDraft || !onUpdateDraftName) {
+      return {prependItems: undefined, bannerContent: undefined}
+    }
+
+    if (style === 'Card') {
+      const cards = drafts.map(({draft, autoFocus}) => (
+        <InlineDraftCard
+          key={`draft-${draft.id}`}
+          draft={draft}
+          autoFocus={autoFocus}
+          onOpenDraft={onOpenDraft}
+          onDeleteDraft={onDeleteDraft}
+          onUpdateDraftName={onUpdateDraftName}
+        />
+      ))
+      if (banner && cards.length > 0) {
+        // First draft takes the banner slot
+        const bannerDraft = drafts[0]!
+        const bannerEl = (
+          <InlineDraftCard
+            key={`draft-banner-${bannerDraft.draft.id}`}
+            draft={bannerDraft.draft}
+            autoFocus={bannerDraft.autoFocus}
+            banner
+            onOpenDraft={onOpenDraft}
+            onDeleteDraft={onDeleteDraft}
+            onUpdateDraftName={onUpdateDraftName}
+          />
+        )
+        return {prependItems: cards.slice(1), bannerContent: bannerEl}
+      }
+      return {prependItems: cards, bannerContent: undefined}
+    }
+
+    // List view
+    const listItems = drafts.map(({draft, autoFocus}) => (
+      <InlineDraftListItem
+        key={`draft-${draft.id}`}
+        draft={draft}
+        autoFocus={autoFocus}
+        onOpenDraft={onOpenDraft}
+        onDeleteDraft={onDeleteDraft}
+        onUpdateDraftName={onUpdateDraftName}
+      />
+    ))
+    return {prependItems: listItems, bannerContent: undefined}
+  }, [hasDrafts, drafts, style, banner, onOpenDraft, onDeleteDraft, onUpdateDraftName])
+
   // Show discovering state (after all hooks)
   if (queryTarget.data?.type === 'not-found' && queryTarget.isDiscovering) {
     return (
@@ -1979,11 +2039,13 @@ function BlockContentQuery({block}: {block: HMBlockQuery}) {
   return (
     <QueryBlockContent
       items={sortedItems}
-      style={block.attributes.style || 'Card'}
+      style={style}
       columnCount={block.attributes.columnCount}
-      banner={block.attributes.banner || false}
+      banner={hasDrafts ? false : banner}
       accountsMetadata={accountsMetadata.data}
       getEntity={getEntity}
+      prependItems={prependItems}
+      bannerContent={bannerContent}
     />
   )
 }
@@ -2585,6 +2647,8 @@ export function DocumentCardGrid({
   accountsMetadata,
   columnCount = 1,
   isDiscovering,
+  prependItems,
+  bannerContent,
 }: {
   firstItem: HMDocumentInfo | undefined
   items: Array<HMDocumentInfo>
@@ -2592,13 +2656,19 @@ export function DocumentCardGrid({
   accountsMetadata?: HMAccountsMetadata
   columnCount?: number
   isDiscovering?: boolean
+  prependItems?: ReactNode[]
+  bannerContent?: ReactNode
 }) {
   const columnClasses = useMemo(() => {
     return cn('basis-full', columnCount == 2 && 'sm:basis-1/2', columnCount == 3 && 'sm:basis-1/2 md:basis-1/3')
   }, [columnCount])
+  const hasPrependItems = prependItems && prependItems.length > 0
+  const hasItems = items?.length > 0
   return (
     <div className="flex w-full flex-col">
-      {firstItem ? (
+      {bannerContent ? (
+        <div className="flex">{bannerContent}</div>
+      ) : firstItem ? (
         <div className="flex">
           <DocumentCard
             banner
@@ -2608,8 +2678,13 @@ export function DocumentCardGrid({
           />
         </div>
       ) : null}
-      {items?.length ? (
+      {hasPrependItems || hasItems ? (
         <div className="-mx-3 mt-2 flex flex-wrap justify-center">
+          {prependItems?.map((item, i) => (
+            <div className={cn(columnClasses, 'flex p-3')} key={`prepend-${i}`}>
+              {item}
+            </div>
+          ))}
           {items.map((item) => {
             if (!item) return null
             return (
@@ -2620,9 +2695,9 @@ export function DocumentCardGrid({
           })}
         </div>
       ) : null}
-      {items.length == 0 && isDiscovering ? (
+      {!hasItems && !hasPrependItems && isDiscovering ? (
         <BlankQueryBlockMessage message="Searching for documents..." />
-      ) : items.length == 0 ? (
+      ) : !hasItems && !hasPrependItems ? (
         <BlankQueryBlockMessage message="No Documents found in this Query Block." />
       ) : null}
     </div>

--- a/frontend/packages/ui/src/inline-draft-card.tsx
+++ b/frontend/packages/ui/src/inline-draft-card.tsx
@@ -1,0 +1,156 @@
+import {HMListedDraft} from '@shm/shared/hm-types'
+import {Button} from './button'
+import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from './components/dropdown-menu'
+import {DraftBadge} from './draft-badge'
+import {cn} from './utils'
+import {ImageIcon, MoreVertical, Pencil, Trash2} from 'lucide-react'
+import {useCallback, useEffect, useRef, useState} from 'react'
+
+export interface InlineDraftCardProps {
+  draft: HMListedDraft
+  autoFocus?: boolean
+  banner?: boolean
+  onOpenDraft: (draftId: string) => void
+  onDeleteDraft: (draftId: string) => void
+  onUpdateDraftName: (draftId: string, name: string) => void
+}
+
+export function InlineDraftCard({
+  draft,
+  autoFocus,
+  banner,
+  onOpenDraft,
+  onDeleteDraft,
+  onUpdateDraftName,
+}: InlineDraftCardProps) {
+  const [title, setTitle] = useState(draft.metadata?.name || '')
+  const inputRef = useRef<HTMLInputElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout>>()
+
+  useEffect(() => {
+    if (!autoFocus || !containerRef.current) return
+    containerRef.current.scrollIntoView({behavior: 'smooth', block: 'nearest'})
+    const timer = setTimeout(() => {
+      inputRef.current?.focus()
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [autoFocus])
+
+  // Sync external changes
+  useEffect(() => {
+    setTitle(draft.metadata?.name || '')
+  }, [draft.metadata?.name])
+
+  const saveName = useCallback(
+    (name: string) => {
+      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current)
+      saveTimeoutRef.current = setTimeout(() => {
+        onUpdateDraftName(draft.id, name)
+      }, 500)
+    },
+    [draft.id, onUpdateDraftName],
+  )
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current)
+    }
+  }, [])
+
+  const openDraft = useCallback(() => {
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current)
+      saveTimeoutRef.current = undefined
+    }
+    onUpdateDraftName(draft.id, title)
+    onOpenDraft(draft.id)
+  }, [draft.id, title, onOpenDraft, onUpdateDraftName])
+
+  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value
+    setTitle(val)
+    saveName(val)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      openDraft()
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      inputRef.current?.blur()
+    }
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      onClick={(e) => e.stopPropagation()}
+      className={cn(
+        '@container flex min-h-[200px] flex-1 overflow-hidden rounded-lg border-2 border-dashed border-yellow-400/50 bg-white shadow-sm transition-colors duration-300 dark:bg-black',
+        banner && 'rounded-xl md:min-h-[240px] lg:min-h-[280px]',
+      )}
+    >
+      <div className="flex max-w-full flex-1 flex-col @md:flex-row">
+        {/* Image placeholder */}
+        <div
+          className={cn(
+            'relative flex h-40 w-full shrink-0 cursor-pointer items-center justify-center bg-gray-50 @md:h-auto @md:w-1/2 dark:bg-gray-900',
+            banner && '@md:h-auto',
+          )}
+          onClick={openDraft}
+        >
+          <ImageIcon className="text-muted-foreground size-12 opacity-30" />
+        </div>
+        {/* Content */}
+        <div className="flex min-h-0 flex-1 flex-col justify-between">
+          <div className="p-4">
+            <div className="flex items-center gap-2">
+              <input
+                ref={inputRef}
+                type="text"
+                value={title}
+                onChange={handleTitleChange}
+                onKeyDown={handleKeyDown}
+                placeholder="Untitled document"
+                className={cn(
+                  'text-foreground block w-full border-none bg-transparent font-sans leading-tight font-bold outline-none placeholder:text-gray-400',
+                  banner ? 'text-2xl' : 'text-lg',
+                )}
+              />
+            </div>
+            <div className="mt-2 flex items-center gap-2">
+              <DraftBadge />
+            </div>
+          </div>
+          <div className="flex items-center justify-between py-3 pr-2 pl-4">
+            <Button variant="ghost" size="sm" onClick={openDraft} className="gap-1">
+              <Pencil className="size-3" />
+              Edit
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="iconSm">
+                  <MoreVertical className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={openDraft}>
+                  <Pencil className="size-4" />
+                  Open Draft
+                </DropdownMenuItem>
+                <DropdownMenuItem className="text-destructive" onClick={() => onDeleteDraft(draft.id)}>
+                  <Trash2 className="size-4" />
+                  Delete Draft
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/packages/ui/src/inline-draft-list-item.tsx
+++ b/frontend/packages/ui/src/inline-draft-list-item.tsx
@@ -1,0 +1,132 @@
+import {HMListedDraft} from '@shm/shared/hm-types'
+import {Button} from './button'
+import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from './components/dropdown-menu'
+import {DraftBadge} from './draft-badge'
+import {SizableText} from './text'
+import {FileText, MoreVertical, Pencil, Trash2} from 'lucide-react'
+import {useCallback, useEffect, useRef, useState} from 'react'
+
+export interface InlineDraftListItemProps {
+  draft: HMListedDraft
+  autoFocus?: boolean
+  onOpenDraft: (draftId: string) => void
+  onDeleteDraft: (draftId: string) => void
+  onUpdateDraftName: (draftId: string, name: string) => void
+}
+
+export function InlineDraftListItem({
+  draft,
+  autoFocus,
+  onOpenDraft,
+  onDeleteDraft,
+  onUpdateDraftName,
+}: InlineDraftListItemProps) {
+  const [title, setTitle] = useState(draft.metadata?.name || '')
+  const inputRef = useRef<HTMLInputElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout>>()
+
+  useEffect(() => {
+    if (!autoFocus || !containerRef.current) return
+    containerRef.current.scrollIntoView({behavior: 'smooth', block: 'nearest'})
+    const timer = setTimeout(() => {
+      inputRef.current?.focus()
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [autoFocus])
+
+  // Sync external changes
+  useEffect(() => {
+    setTitle(draft.metadata?.name || '')
+  }, [draft.metadata?.name])
+
+  const saveName = useCallback(
+    (name: string) => {
+      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current)
+      saveTimeoutRef.current = setTimeout(() => {
+        onUpdateDraftName(draft.id, name)
+      }, 500)
+    },
+    [draft.id, onUpdateDraftName],
+  )
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current)
+    }
+  }, [])
+
+  const openDraft = useCallback(() => {
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current)
+      saveTimeoutRef.current = undefined
+    }
+    onUpdateDraftName(draft.id, title)
+    onOpenDraft(draft.id)
+  }, [draft.id, title, onOpenDraft, onUpdateDraftName])
+
+  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value
+    setTitle(val)
+    saveName(val)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      openDraft()
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      inputRef.current?.blur()
+    }
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      onClick={(e) => e.stopPropagation()}
+      className="group/item flex w-full items-center rounded border-2 border-dashed border-yellow-400/50 bg-white px-4 py-2 shadow-sm dark:bg-black"
+    >
+      <FileText className="text-muted-foreground mr-3 size-7 shrink-0" />
+      <div className="flex flex-1 items-center gap-3 overflow-hidden">
+        <div className="flex flex-1 items-center gap-1.5 overflow-hidden">
+          <input
+            ref={inputRef}
+            type="text"
+            value={title}
+            onChange={handleTitleChange}
+            onKeyDown={handleKeyDown}
+            placeholder="Untitled document"
+            className="text-foreground w-full border-none bg-transparent font-sans text-sm font-bold outline-none placeholder:text-gray-400"
+          />
+          <DraftBadge />
+        </div>
+        <div className="flex items-center gap-1">
+          <Button variant="ghost" size="sm" onClick={openDraft} className="gap-1">
+            <Pencil className="size-3" />
+            <SizableText size="xs">Edit</SizableText>
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="iconSm">
+                <MoreVertical className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={openDraft}>
+                <Pencil className="size-4" />
+                Open Draft
+              </DropdownMenuItem>
+              <DropdownMenuItem className="text-destructive" onClick={() => onDeleteDraft(draft.id)}>
+                <Trash2 className="size-4" />
+                Delete Draft
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/packages/ui/src/query-block-content.tsx
+++ b/frontend/packages/ui/src/query-block-content.tsx
@@ -1,4 +1,5 @@
 import {HMAccountsMetadata, HMDocumentInfo, HMResourceFetchResult, UnpackedHypermediaId} from '@shm/shared'
+import {ReactNode} from 'react'
 import {DocumentCardGrid} from './blocks-content'
 import {DocumentListItem} from './document-list-item'
 
@@ -10,6 +11,8 @@ export interface QueryBlockContentProps {
   accountsMetadata: HMAccountsMetadata
   getEntity: (id: UnpackedHypermediaId) => HMResourceFetchResult | null
   isDiscovering?: boolean
+  prependItems?: ReactNode[]
+  bannerContent?: ReactNode
 }
 
 export function QueryBlockContent({
@@ -20,6 +23,8 @@ export function QueryBlockContent({
   accountsMetadata,
   getEntity,
   isDiscovering,
+  prependItems,
+  bannerContent,
 }: QueryBlockContentProps) {
   if (style === 'Card') {
     return (
@@ -30,11 +35,20 @@ export function QueryBlockContent({
         accountsMetadata={accountsMetadata}
         getEntity={getEntity}
         isDiscovering={isDiscovering}
+        prependItems={prependItems}
+        bannerContent={bannerContent}
       />
     )
   }
 
-  return <QueryBlockListView items={items} accountsMetadata={accountsMetadata} isDiscovering={isDiscovering} />
+  return (
+    <QueryBlockListView
+      items={items}
+      accountsMetadata={accountsMetadata}
+      isDiscovering={isDiscovering}
+      prependItems={prependItems}
+    />
+  )
 }
 
 function QueryBlockCardView({
@@ -44,6 +58,8 @@ function QueryBlockCardView({
   accountsMetadata,
   getEntity,
   isDiscovering,
+  prependItems,
+  bannerContent,
 }: {
   items: HMDocumentInfo[]
   banner: boolean
@@ -51,9 +67,12 @@ function QueryBlockCardView({
   accountsMetadata: HMAccountsMetadata
   getEntity: (id: UnpackedHypermediaId) => HMResourceFetchResult | null
   isDiscovering?: boolean
+  prependItems?: ReactNode[]
+  bannerContent?: ReactNode
 }) {
-  const firstItem = banner ? items[0] : undefined
-  const restItems = banner ? items.slice(1) : items
+  // When bannerContent is provided, it takes the banner slot — don't split items
+  const firstItem = banner && !bannerContent ? items[0] : undefined
+  const restItems = banner && !bannerContent ? items.slice(1) : items
 
   const columnCountNum = typeof columnCount === 'string' ? parseInt(columnCount, 10) : columnCount
 
@@ -65,6 +84,8 @@ function QueryBlockCardView({
       accountsMetadata={accountsMetadata}
       columnCount={columnCountNum}
       isDiscovering={isDiscovering}
+      prependItems={prependItems}
+      bannerContent={bannerContent}
     />
   )
 }
@@ -73,13 +94,17 @@ function QueryBlockListView({
   items,
   accountsMetadata,
   isDiscovering,
+  prependItems,
 }: {
   items: HMDocumentInfo[]
   accountsMetadata: HMAccountsMetadata
   isDiscovering?: boolean
+  prependItems?: ReactNode[]
 }) {
+  const hasPrependItems = prependItems && prependItems.length > 0
+
   // Show loading state when discovering and no items yet
-  if (items.length === 0 && isDiscovering) {
+  if (items.length === 0 && !hasPrependItems && isDiscovering) {
     return (
       <div className="bg-muted flex items-center rounded-lg p-4">
         <span className="text-muted-foreground italic">Searching for documents...</span>
@@ -89,6 +114,7 @@ function QueryBlockListView({
 
   return (
     <div className="my-4 flex w-full flex-col gap-1">
+      {prependItems}
       {items.map((item) => {
         return <DocumentListItem key={item.id.id} item={item} accountsMetadata={accountsMetadata} />
       })}


### PR DESCRIPTION
## Summary

- Detect self-referential query blocks (queries targeting their own document) using new `findSelfQueryBlock()` utility
- Create `QueryBlockDraftsProvider` context to pass draft management callbacks to query block renderers
- Add `InlineDraftCard` and `InlineDraftListItem` components for displaying drafts in card and list styles
- Integrate draft rendering into `BlockContentQuery`, allowing drafts to appear inside query blocks instead of at page bottom
- Support banner display for drafts in card-style query blocks
- Move child draft cards below ResourcePage when no self-referential query exists (preserves existing behavior)

## Breaking Changes

None. When documents don't have self-referential query blocks, inline draft cards continue to render at the bottom of the page as before.