### PR TITLE
fix: Delete comment option not reliably visible for comment author

### DIFF
--- a/frontend/apps/desktop/src/components/discussions-panel.tsx
+++ b/frontend/apps/desktop/src/components/discussions-panel.tsx
@@ -1,4 +1,4 @@
-import {useSelectedAccount} from '@/selected-account'
+import {useSelectedAccountId} from '@/selected-account'
 import {useDeleteComment} from '@shm/shared/comments-service-provider'
 import {UnpackedHypermediaId} from '@shm/shared/hm-types'
 import {useResource} from '@shm/shared/models/entity'
@@ -15,7 +15,11 @@ function _DiscussionsPanel(props: {docId: UnpackedHypermediaId; selection: Comme
   const {docId, selection} = props
   // Use selection.id if available (panel's own target), otherwise fall back to docId
   const targetDocId = selection.id ?? docId
-  const selectedAccount = useSelectedAccount()
+  // useSelectedAccountId reads the UID directly from the stream (synchronous),
+  // avoiding the async document fetch that useSelectedAccount() requires.
+  // This ensures the delete option is visible immediately when the user
+  // has a selected account, without waiting for the account document to load.
+  const currentAccountId = useSelectedAccountId() ?? undefined
   const homeDoc = useResource(hmId(targetDocId.uid))
   const targetDomain = homeDoc.data?.type === 'document' ? homeDoc.data.document.metadata.siteUrl : undefined
 
@@ -46,10 +50,8 @@ function _DiscussionsPanel(props: {docId: UnpackedHypermediaId; selection: Comme
         },
       })
     },
-    [targetDocId, selectedAccount?.id?.uid],
+    [targetDocId, currentAccountId],
   )
-
-  const currentAccountId = selectedAccount?.id.uid
 
   if (selection.targetBlockId) {
     const targetId = hmId(targetDocId.uid, {

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -11,7 +11,7 @@ import {roleCanWrite, useSelectedAccountCapability} from '@/models/access-contro
 import {useMyAccountIds} from '@/models/daemon'
 import {useChildDrafts, useCreateInlineDraft, useDeleteDraft, useUpdateDraftMetadata} from '@/models/documents'
 import {useExistingDraft} from '@/models/drafts'
-import {useSelectedAccount} from '@/selected-account'
+import {useSelectedAccountId} from '@/selected-account'
 import {client} from '@/trpc'
 import {useHackyAuthorsSubscriptions} from '@/use-hacky-authors-subscriptions'
 import {convertBlocksToMarkdown} from '@/utils/blocks-to-markdown'
@@ -126,10 +126,13 @@ export default function DesktopResourcePage() {
   )
 
   // Comment deletion
-  const selectedAccount = useSelectedAccount()
+  // useSelectedAccountId reads the UID directly from the stream (synchronous),
+  // avoiding the async document fetch that useSelectedAccount() requires.
+  // This ensures the delete option is visible immediately when the user
+  // has a selected account, without waiting for the account document to load.
+  const currentAccountId = useSelectedAccountId() ?? undefined
   const deleteComment = useDeleteComment()
   const deleteCommentDialog = useDeleteCommentDialog()
-  const currentAccountId = selectedAccount?.id.uid
   const onCommentDelete = useCallback(
     (commentId: string, signingAccountId?: string) => {
       if (!signingAccountId) return

--- a/frontend/packages/shared/src/__tests__/comment-delete.test.ts
+++ b/frontend/packages/shared/src/__tests__/comment-delete.test.ts
@@ -19,7 +19,7 @@ describe('comment deletion', () => {
     it('should show delete when currentAccountId matches comment.author', () => {
       const currentAccountId = 'z6Mk123'
       const commentAuthor = 'z6Mk123'
-      // This is the same check used in comments.tsx:674
+      // This is the same check used in comments.tsx
       expect(currentAccountId == commentAuthor).toBe(true)
     })
 
@@ -33,6 +33,29 @@ describe('comment deletion', () => {
       const currentAccountId: string | undefined = undefined
       const commentAuthor = 'z6Mk123'
       expect(currentAccountId == commentAuthor).toBe(false)
+    })
+
+    it('should show delete immediately when account UID is available from stream (no async document fetch required)', () => {
+      // This test documents the fix for issue #279:
+      // Previously, currentAccountId was derived from useSelectedAccount().id.uid which
+      // requires an async account document fetch. While loading, currentAccountId was
+      // undefined and the delete button was hidden even for the comment's author.
+      //
+      // The fix uses useSelectedAccountId() which reads the UID synchronously from the
+      // selectedIdentity stream, so it's available immediately without waiting for
+      // the account document to load.
+
+      // Simulate the fixed behavior: UID is available directly from the stream
+      const selectedAccountUidFromStream = 'z6Mk123' // sync, from useSelectedAccountId()
+      const commentAuthor = 'z6Mk123'
+
+      // With the fix, this comparison yields true immediately
+      expect(selectedAccountUidFromStream == commentAuthor).toBe(true)
+
+      // Simulate the old broken behavior: UID came from the async account document
+      const selectedAccountDocumentUid: string | undefined = undefined // undefined while loading
+      // This used to be false during the loading window, hiding the delete option
+      expect(selectedAccountDocumentUid == commentAuthor).toBe(false)
     })
 
     it('should hide delete when onCommentDelete is not provided', () => {


### PR DESCRIPTION
## Summary

The delete option on comments was intermittently hidden for the comment author because `currentAccountId` was derived from `useSelectedAccount().id.uid`, which requires an async fetch of the full account document. During the loading window, `selectedAccount` is `undefined`, so `currentAccountId` is `undefined`, causing the owner check (`currentAccountId == comment.author`) to return `false` and hiding the delete button.

The fix is to use `useSelectedAccountId()` instead, which reads the UID synchronously from the `selectedIdentity` stream — no document fetch needed. The UID is available immediately when a user has a selected account.

## Changes

- **`frontend/apps/desktop/src/pages/desktop-resource.tsx`**: Replace `useSelectedAccount().id.uid` with `useSelectedAccountId()` for deriving `currentAccountId`. Remove now-unused `useSelectedAccount` import/call.
- **`frontend/apps/desktop/src/components/discussions-panel.tsx`**: Same fix — replace `useSelectedAccount()` with `useSelectedAccountId()` for `currentAccountId`. Update `useCallback` dependency array accordingly.
- **`frontend/packages/shared/src/__tests__/comment-delete.test.ts`**: Add regression test documenting the root cause (undefined account ID during async load) and the expected fix behavior.

## Testing

- All existing tests pass (`354 passed`, 2 pre-existing unrelated failures in `blobs.test.ts` and `hmauth.test.ts` due to missing dependencies).
- New regression test added in `comment-delete.test.ts` explicitly documents the fixed behavior.
- TypeScript: no new type errors introduced in changed files (pre-existing errors in other files are unrelated).

Fixes seed-hypermedia/seed#279