### PR TITLE
feat(query-block): add latest activity sort option

### DIFF
--- a/frontend/apps/desktop/src/editor/query-block.tsx
+++ b/frontend/apps/desktop/src/editor/query-block.tsx
@@ -437,6 +437,10 @@ function QuerySettings({
                   //   value: 'Path',
                   // },
                   {
+                    label: 'Latest activity',
+                    value: 'ActivityTime',
+                  },
+                  {
                     label: 'By Title',
                     value: 'Title',
                   },

--- a/frontend/packages/client/src/hm-types.ts
+++ b/frontend/packages/client/src/hm-types.ts
@@ -649,6 +649,7 @@ export const HMQuerySortSchema = z.object({
     z.literal('CreateTime'),
     z.literal('UpdateTime'),
     z.literal('DisplayTime'),
+    z.literal('ActivityTime'),
   ]),
 })
 export type HMQuerySort = z.infer<typeof HMQuerySortSchema>

--- a/frontend/packages/shared/src/__tests__/query-block-sort.test.ts
+++ b/frontend/packages/shared/src/__tests__/query-block-sort.test.ts
@@ -1,0 +1,166 @@
+import {describe, expect, it} from 'vitest'
+import {queryBlockSortedItems} from '../content'
+import {HMDocumentInfo} from '@seed-hypermedia/client/hm-types'
+
+/** Minimal HMDocumentInfo factory — only fields the sort functions inspect */
+function makeEntry(
+  overrides: Partial<{
+    name: string
+    createTime: string
+    updateTime: string
+    displayPublishTime: string
+    latestChangeTime: string
+    latestCommentTime: string
+  }>,
+): HMDocumentInfo {
+  return {
+    type: 'document',
+    id: {type: 'd', uid: 'test', path: null},
+    path: [],
+    authors: [],
+    createTime: overrides.createTime ?? '2024-01-01T00:00:00Z',
+    updateTime: overrides.updateTime ?? '2024-01-01T00:00:00Z',
+    sortTime: new Date(overrides.updateTime ?? '2024-01-01T00:00:00Z'),
+    genesis: '',
+    version: '',
+    breadcrumbs: [],
+    activitySummary: {
+      latestChangeTime: overrides.latestChangeTime ?? overrides.updateTime ?? '2024-01-01T00:00:00Z',
+      latestCommentTime: overrides.latestCommentTime,
+      latestCommentId: '',
+      commentCount: 0,
+      isUnread: false,
+    },
+    generationInfo: {genesis: '', generation: 0n},
+    metadata: {
+      name: overrides.name ?? 'Untitled',
+      displayPublishTime: overrides.displayPublishTime,
+    },
+    visibility: 'PUBLIC',
+  } as unknown as HMDocumentInfo
+}
+
+describe('queryBlockSortedItems', () => {
+  const docA = makeEntry({name: 'A', updateTime: '2024-01-01T00:00:00Z', createTime: '2024-01-01T00:00:00Z'})
+  const docB = makeEntry({name: 'B', updateTime: '2024-03-01T00:00:00Z', createTime: '2024-02-01T00:00:00Z'})
+  const docC = makeEntry({name: 'C', updateTime: '2024-02-01T00:00:00Z', createTime: '2024-03-01T00:00:00Z'})
+
+  it('returns empty for empty entries', () => {
+    expect(queryBlockSortedItems({entries: [], sort: [{term: 'UpdateTime', reverse: false}]})).toEqual([])
+  })
+
+  it('returns empty when sort array has != 1 element', () => {
+    expect(queryBlockSortedItems({entries: [docA], sort: []})).toEqual([])
+  })
+
+  it('sorts by UpdateTime descending by default', () => {
+    const result = queryBlockSortedItems({entries: [docA, docB, docC], sort: [{term: 'UpdateTime', reverse: false}]})
+    expect(result.map((d) => d.metadata.name)).toEqual(['B', 'C', 'A'])
+  })
+
+  it('sorts by UpdateTime ascending when reversed', () => {
+    const result = queryBlockSortedItems({entries: [docA, docB, docC], sort: [{term: 'UpdateTime', reverse: true}]})
+    expect(result.map((d) => d.metadata.name)).toEqual(['A', 'C', 'B'])
+  })
+
+  it('sorts by CreateTime descending by default', () => {
+    const result = queryBlockSortedItems({entries: [docA, docB, docC], sort: [{term: 'CreateTime', reverse: false}]})
+    expect(result.map((d) => d.metadata.name)).toEqual(['C', 'B', 'A'])
+  })
+
+  it('sorts by Title alphabetically', () => {
+    const result = queryBlockSortedItems({entries: [docC, docA, docB], sort: [{term: 'Title', reverse: false}]})
+    expect(result.map((d) => d.metadata.name)).toEqual(['A', 'B', 'C'])
+  })
+
+  it('sorts by Title reversed', () => {
+    const result = queryBlockSortedItems({entries: [docC, docA, docB], sort: [{term: 'Title', reverse: true}]})
+    expect(result.map((d) => d.metadata.name)).toEqual(['C', 'B', 'A'])
+  })
+})
+
+describe('queryBlockSortedItems — ActivityTime', () => {
+  it('sorts by latest activity (comment time wins over change time)', () => {
+    const oldEditRecentComment = makeEntry({
+      name: 'OldEditRecentComment',
+      updateTime: '2024-01-01T00:00:00Z',
+      latestChangeTime: '2024-01-01T00:00:00Z',
+      latestCommentTime: '2024-06-01T00:00:00Z',
+    })
+    const recentEditNoComment = makeEntry({
+      name: 'RecentEditNoComment',
+      updateTime: '2024-05-01T00:00:00Z',
+      latestChangeTime: '2024-05-01T00:00:00Z',
+    })
+    const veryOld = makeEntry({
+      name: 'VeryOld',
+      updateTime: '2023-01-01T00:00:00Z',
+      latestChangeTime: '2023-01-01T00:00:00Z',
+    })
+
+    const result = queryBlockSortedItems({
+      entries: [recentEditNoComment, veryOld, oldEditRecentComment],
+      sort: [{term: 'ActivityTime', reverse: false}],
+    })
+    // oldEditRecentComment has comment at June, recentEditNoComment at May, veryOld at Jan 2023
+    expect(result.map((d) => d.metadata.name)).toEqual(['OldEditRecentComment', 'RecentEditNoComment', 'VeryOld'])
+  })
+
+  it('sorts by latest activity reversed (oldest activity first)', () => {
+    const recent = makeEntry({
+      name: 'Recent',
+      updateTime: '2024-06-01T00:00:00Z',
+      latestChangeTime: '2024-06-01T00:00:00Z',
+    })
+    const old = makeEntry({
+      name: 'Old',
+      updateTime: '2024-01-01T00:00:00Z',
+      latestChangeTime: '2024-01-01T00:00:00Z',
+    })
+
+    const result = queryBlockSortedItems({
+      entries: [recent, old],
+      sort: [{term: 'ActivityTime', reverse: true}],
+    })
+    expect(result.map((d) => d.metadata.name)).toEqual(['Old', 'Recent'])
+  })
+
+  it('falls back to updateTime when activitySummary times are missing', () => {
+    const recentUpdate = makeEntry({
+      name: 'RecentUpdate',
+      updateTime: '2024-06-01T00:00:00Z',
+    })
+    const oldUpdate = makeEntry({
+      name: 'OldUpdate',
+      updateTime: '2024-01-01T00:00:00Z',
+    })
+
+    const result = queryBlockSortedItems({
+      entries: [oldUpdate, recentUpdate],
+      sort: [{term: 'ActivityTime', reverse: false}],
+    })
+    expect(result.map((d) => d.metadata.name)).toEqual(['RecentUpdate', 'OldUpdate'])
+  })
+
+  it('uses max(latestChangeTime, latestCommentTime) for activity', () => {
+    const changeWins = makeEntry({
+      name: 'ChangeWins',
+      updateTime: '2024-01-01T00:00:00Z',
+      latestChangeTime: '2024-07-01T00:00:00Z',
+      latestCommentTime: '2024-03-01T00:00:00Z',
+    })
+    const commentWins = makeEntry({
+      name: 'CommentWins',
+      updateTime: '2024-01-01T00:00:00Z',
+      latestChangeTime: '2024-02-01T00:00:00Z',
+      latestCommentTime: '2024-08-01T00:00:00Z',
+    })
+
+    const result = queryBlockSortedItems({
+      entries: [changeWins, commentWins],
+      sort: [{term: 'ActivityTime', reverse: false}],
+    })
+    // commentWins has Aug activity, changeWins has Jul
+    expect(result.map((d) => d.metadata.name)).toEqual(['CommentWins', 'ChangeWins'])
+  })
+})

--- a/frontend/packages/shared/src/content.ts
+++ b/frontend/packages/shared/src/content.ts
@@ -150,6 +150,17 @@ function displayPublishTimeOfEntry(entry: HMDocumentInfo): number {
   return normalizeDate(entry.updateTime)?.getTime() || 0
 }
 
+function activityTimeOfEntry(entry: HMDocumentInfo): number {
+  const activity = entry.activitySummary
+  const changeTime = normalizeDate(activity?.latestChangeTime)?.getTime() || 0
+  const commentTime = normalizeDate(activity?.latestCommentTime)?.getTime() || 0
+  return Math.max(changeTime, commentTime) || normalizeDate(entry.updateTime)?.getTime() || 0
+}
+
+function activityTimeSort(a: HMDocumentInfo, b: HMDocumentInfo) {
+  return activityTimeOfEntry(b) - activityTimeOfEntry(a)
+}
+
 function titleOfEntry(entry: HMDocumentInfo) {
   return entry.metadata.name
 }
@@ -188,6 +199,10 @@ export function queryBlockSortedItems({
 
   if (sortTerm === 'DisplayTime') {
     res = [...entries].sort(displayPublishTimeSort)
+  }
+
+  if (sortTerm === 'ActivityTime') {
+    res = [...entries].sort(activityTimeSort)
   }
 
   // if (sortTerm == 'Path') {


### PR DESCRIPTION
## Summary

- Add "Latest activity" sort option to query blocks that orders items by the most recent comment or content change
- Update HMQuerySort schema to include the new `ActivityTime` sort term
- Implement activity time sorting that considers both `latestChangeTime` and `latestCommentTime`, with fallback to `updateTime`
- Add comprehensive test coverage for ActivityTime sorting behavior including comment priority, reversed sorting, and time fallbacks