### PR TITLE
feat(query-blocks): add create document button to self-referential query blocks

### DIFF
--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -118,8 +118,32 @@ export default function DesktopResourcePage() {
       onUpdateDraftName: (draftId: string, name: string) => {
         updateDraftMetadata.mutate({draftId, metadata: {name}})
       },
+      onCreateDraft:
+        canEdit && !isPrivate
+          ? () => {
+              createInlineDraft.mutate(
+                {},
+                {
+                  onSuccess: ({draftId}) => {
+                    setLastCreatedDraftId(draftId)
+                  },
+                },
+              )
+            }
+          : undefined,
     }),
-    [selfQueryBlock?.id, hasSelfQuery, childDrafts, lastCreatedDraftId, navigate, deleteDraft, updateDraftMetadata],
+    [
+      selfQueryBlock?.id,
+      hasSelfQuery,
+      childDrafts,
+      lastCreatedDraftId,
+      navigate,
+      deleteDraft,
+      updateDraftMetadata,
+      canEdit,
+      isPrivate,
+      createInlineDraft,
+    ],
   )
 
   const {exportDocument, openDirectory} = useAppContext()

--- a/frontend/packages/shared/src/query-block-drafts-context.tsx
+++ b/frontend/packages/shared/src/query-block-drafts-context.tsx
@@ -12,6 +12,7 @@ export type QueryBlockDraftsContextValue = {
   onOpenDraft?: (draftId: string) => void
   onDeleteDraft?: (draftId: string) => void
   onUpdateDraftName?: (draftId: string, name: string) => void
+  onCreateDraft?: () => void
 }
 
 const defaultValue: QueryBlockDraftsContextValue = {
@@ -24,7 +25,14 @@ const QueryBlockDraftsContext = createContext<QueryBlockDraftsContextValue>(defa
 export function QueryBlockDraftsProvider({children, ...value}: PropsWithChildren<QueryBlockDraftsContextValue>) {
   const ctx = useMemo(
     () => value,
-    [value.targetBlockId, value.drafts, value.onOpenDraft, value.onDeleteDraft, value.onUpdateDraftName],
+    [
+      value.targetBlockId,
+      value.drafts,
+      value.onOpenDraft,
+      value.onDeleteDraft,
+      value.onUpdateDraftName,
+      value.onCreateDraft,
+    ],
   )
   return <QueryBlockDraftsContext.Provider value={ctx}>{children}</QueryBlockDraftsContext.Provider>
 }

--- a/frontend/packages/ui/src/blocks-content.tsx
+++ b/frontend/packages/ui/src/blocks-content.tsx
@@ -90,6 +90,8 @@ import {HoverCard, HoverCardContent, HoverCardTrigger} from './hover-card'
 import {BlockQuote} from './icons'
 import {InlineDraftCard} from './inline-draft-card'
 import {InlineDraftListItem} from './inline-draft-list-item'
+import {NewDocumentCard} from './new-document-card'
+import {NewDocumentListItem} from './new-document-list-item'
 import {DocumentCard} from './newspaper'
 import {QueryBlockContent} from './query-block-content'
 import {Spinner} from './spinner'
@@ -1965,14 +1967,27 @@ function BlockContentQuery({block}: {block: HMBlockQuery}) {
   const accountsMetadata = useAccountsMetadata(authorIds)
 
   // Inline drafts for self-referential query blocks
-  const {targetBlockId, drafts, onOpenDraft, onDeleteDraft, onUpdateDraftName} = useQueryBlockDrafts()
-  const hasDrafts = targetBlockId === block.id && drafts.length > 0
+  const {targetBlockId, drafts, onOpenDraft, onDeleteDraft, onUpdateDraftName, onCreateDraft} = useQueryBlockDrafts()
+  const isSelfQuery = targetBlockId === block.id
+  const hasDrafts = isSelfQuery && drafts.length > 0
 
   const style = block.attributes.style || 'Card'
   const banner = block.attributes.banner || false
 
   const {prependItems, bannerContent} = useMemo(() => {
+    const createButton =
+      isSelfQuery && onCreateDraft ? (
+        style === 'Card' ? (
+          <NewDocumentCard key="new-doc-btn" onCreateDraft={onCreateDraft} />
+        ) : (
+          <NewDocumentListItem key="new-doc-btn" onCreateDraft={onCreateDraft} />
+        )
+      ) : null
+
     if (!hasDrafts || !onOpenDraft || !onDeleteDraft || !onUpdateDraftName) {
+      if (createButton) {
+        return {prependItems: [createButton], bannerContent: undefined}
+      }
       return {prependItems: undefined, bannerContent: undefined}
     }
 
@@ -2001,9 +2016,13 @@ function BlockContentQuery({block}: {block: HMBlockQuery}) {
             onUpdateDraftName={onUpdateDraftName}
           />
         )
-        return {prependItems: cards.slice(1), bannerContent: bannerEl}
+        const remainingCards = cards.slice(1)
+        return {
+          prependItems: createButton ? [createButton, ...remainingCards] : remainingCards,
+          bannerContent: bannerEl,
+        }
       }
-      return {prependItems: cards, bannerContent: undefined}
+      return {prependItems: createButton ? [createButton, ...cards] : cards, bannerContent: undefined}
     }
 
     // List view
@@ -2017,8 +2036,8 @@ function BlockContentQuery({block}: {block: HMBlockQuery}) {
         onUpdateDraftName={onUpdateDraftName}
       />
     ))
-    return {prependItems: listItems, bannerContent: undefined}
-  }, [hasDrafts, drafts, style, banner, onOpenDraft, onDeleteDraft, onUpdateDraftName])
+    return {prependItems: createButton ? [createButton, ...listItems] : listItems, bannerContent: undefined}
+  }, [isSelfQuery, hasDrafts, drafts, style, banner, onOpenDraft, onDeleteDraft, onUpdateDraftName, onCreateDraft])
 
   // Show discovering state (after all hooks)
   if (queryTarget.data?.type === 'not-found' && queryTarget.isDiscovering) {

--- a/frontend/packages/ui/src/new-document-card.tsx
+++ b/frontend/packages/ui/src/new-document-card.tsx
@@ -1,0 +1,25 @@
+import {Plus} from 'lucide-react'
+import {cn} from './utils'
+
+export interface NewDocumentCardProps {
+  onCreateDraft: () => void
+}
+
+export function NewDocumentCard({onCreateDraft}: NewDocumentCardProps) {
+  return (
+    <button
+      onClick={onCreateDraft}
+      className={cn(
+        'flex min-h-[200px] flex-1 cursor-pointer items-center justify-center rounded-lg border-2 border-dashed',
+        'border-muted-foreground/25 bg-white transition-colors duration-200',
+        'hover:border-muted-foreground/50 hover:bg-muted/30',
+        'dark:hover:bg-muted/20 dark:bg-black',
+      )}
+    >
+      <div className="flex flex-col items-center gap-2">
+        <Plus className="text-muted-foreground size-8" />
+        <span className="text-muted-foreground text-sm font-medium">New Document</span>
+      </div>
+    </button>
+  )
+}

--- a/frontend/packages/ui/src/new-document-list-item.tsx
+++ b/frontend/packages/ui/src/new-document-list-item.tsx
@@ -1,0 +1,27 @@
+import {Plus} from 'lucide-react'
+import {SizableText} from './text'
+import {cn} from './utils'
+
+export interface NewDocumentListItemProps {
+  onCreateDraft: () => void
+}
+
+export function NewDocumentListItem({onCreateDraft}: NewDocumentListItemProps) {
+  return (
+    <button
+      onClick={onCreateDraft}
+      className={cn(
+        'flex w-full items-center rounded border-2 border-dashed',
+        'border-muted-foreground/25 bg-white px-4 py-2 transition-colors duration-200',
+        'hover:border-muted-foreground/50 hover:bg-muted/30',
+        'dark:hover:bg-muted/20 dark:bg-black',
+        'cursor-pointer',
+      )}
+    >
+      <Plus className="text-muted-foreground mr-3 size-7 shrink-0" />
+      <SizableText size="sm" className="text-muted-foreground font-medium">
+        New Document
+      </SizableText>
+    </button>
+  )
+}


### PR DESCRIPTION
## Summary

- Added `onCreateDraft` callback to `QueryBlockDraftsContext` to support document creation from query blocks
- Created two new UI components (`NewDocumentCard` and `NewDocumentListItem`) for rendering the create button in card and list view styles
- Updated `BlockContentQuery` to display the "New Document" button at the top of self-referential query blocks when the user has edit permissions and the document is not private
- Modified desktop resource page to handle draft creation through the context callback with automatic focus on the newly created draft

<img width="863" height="438" alt="Screenshot 2026-03-10 at 19 02 01" src="https://github.com/user-attachments/assets/c302a48f-e437-4a94-8bb6-56872742472c" />
<img width="815" height="648" alt="Screenshot 2026-03-10 at 19 02 52" src="https://github.com/user-attachments/assets/2d72dc5a-59a5-4a9c-8e8f-cedc28837b41" />
<img width="874" height="651" alt="Screenshot 2026-03-10 at 19 03 18" src="https://github.com/user-attachments/assets/8f687ffd-16d8-4cbd-9840-43dd3b0caab9" />


## Key Changes

- New reusable components for the "New Document" creation flow in both display styles
- Conditional rendering of the create button based on user permissions and document privacy
- Integration with existing inline draft management system