### PR TITLE
fix(#321): prevent duplicate options menu at intermediate viewport widths

### DIFF
--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -991,7 +991,15 @@ function DocumentBody({
   const hasActionButtons = hasOptions || editActions
   const actionButtons = hasActionButtons ? (
     <>
-      {hasOptions && <OptionsDropdown menuItems={allMenuItems} align="end" side="bottom" />}
+      {/* Only show in the floating overlay on md+ screens — on mobile the same
+          button is rendered inside DocumentTools rightActions (md:hidden), so
+          hiding it here prevents both from showing simultaneously around the
+          md breakpoint (issue #321). */}
+      {hasOptions && (
+        <div className="hidden md:block">
+          <OptionsDropdown menuItems={allMenuItems} align="end" side="bottom" />
+        </div>
+      )}
       {editActions}
     </>
   ) : null


### PR DESCRIPTION
## Problem

At certain intermediate viewport widths (around the `md` / 768px breakpoint) two identical ⋯ options menu buttons appear simultaneously — one in the floating overlay, one in the DocumentTools toolbar.

Fixes #321

## Root Cause

Two `OptionsDropdown` components are rendered for the same menu:
1. **Floating overlay** (`actionButtons`) — no breakpoint restriction, always visible
2. **DocumentTools `rightActions`** — wrapped in `md:hidden`, visible only below 768px

At viewport widths around the md breakpoint, CSS transitions and JS `isMobile` state can get out of sync, causing both to be visible at once.

## Fix

Wrap the floating overlay's `OptionsDropdown` in `hidden md:block` so it is only visible on `md+` screens, making it the exact complement of the `md:hidden` one in DocumentTools:

| Viewport | Floating overlay button | DocumentTools button |
|---|---|---|
| `< 768px` | hidden | visible (`md:hidden`) |
| `≥ 768px` | visible (`hidden md:block`) | hidden (`md:hidden`) |