### PR TITLE
fix(documents): preserve Block attributes when publishing embeds

### DIFF
--- a/frontend/apps/desktop/src/models/documents.ts
+++ b/frontend/apps/desktop/src/models/documents.ts
@@ -29,7 +29,7 @@ import {BlockNoteEditor} from '@shm/editor/blocknote/core'
 import {createHypermediaDocLinkPlugin} from '@shm/editor/hypermedia-link-plugin'
 import {getSlashMenuItems} from '@shm/editor/slash-menu-items'
 import {getCommentTargetId, getParentPaths, UniversalClient, useUniversalClient} from '@shm/shared'
-import {ResourceVisibility} from '@shm/shared/client/.generated/documents/v3alpha/documents_pb'
+import {Block, DocumentChange, ResourceVisibility} from '@shm/shared/client/.generated/documents/v3alpha/documents_pb'
 import {AnnounceBlobsProgress} from '@shm/shared/client/.generated/p2p/v1alpha/syncing_pb'
 import {hmBlocksToEditorContent} from '@shm/shared/client/hmblock-to-editorblock'
 import {BIG_INT, DEFAULT_GATEWAY_URL} from '@shm/shared/constants'
@@ -1155,9 +1155,16 @@ export async function publishLinkToParentDocument(
   }
 
   // Create DocumentChange operations: MoveBlock then ReplaceBlock
+  // NOTE: Block.fromJson() is required to properly convert the attributes plain object
+  // into a google.protobuf.Struct. Without it, attributes like {view: 'Card'} are silently dropped.
+  // See: https://github.com/nicholasgasior/seed-hypermedia/issues/322
   const changes = [
-    {op: {case: 'moveBlock' as const, value: {blockId: newBlockId, parent: '', leftSibling: lastBlockId}}},
-    {op: {case: 'replaceBlock' as const, value: embedBlock}},
+    new DocumentChange({
+      op: {case: 'moveBlock', value: {blockId: newBlockId, parent: '', leftSibling: lastBlockId}},
+    }),
+    new DocumentChange({
+      op: {case: 'replaceBlock', value: Block.fromJson(embedBlock)},
+    }),
   ]
 
   // Check if signing account has write access (same as child publish)

--- a/frontend/packages/shared/src/client/__tests__/block-struct-roundtrip.test.ts
+++ b/frontend/packages/shared/src/client/__tests__/block-struct-roundtrip.test.ts
@@ -1,0 +1,84 @@
+import {describe, expect, test} from 'vitest'
+import {Block, DocumentChange} from '../.generated/documents/v3alpha/documents_pb'
+
+/**
+ * Regression tests for issue #322: Subdocuments published as embeds instead of cards.
+ *
+ * The Block.attributes field is a google.protobuf.Struct. When creating a Block
+ * from a plain JS object, Block.fromJson() must be used to properly convert
+ * the attributes into a Struct. Using new Block({attributes: {view: 'Card'}})
+ * via initPartial silently drops the attributes because the plain object
+ * doesn't match the Struct's internal {fields: {...}} structure.
+ */
+describe('Block Struct attributes round-trip', () => {
+  test('Block.fromJson preserves embed view attribute in Struct', () => {
+    const embedBlock = {
+      id: 'test-id',
+      type: 'Embed',
+      link: 'hm://test-uid/parent/child',
+      attributes: {view: 'Card'},
+    }
+    const block = Block.fromJson(embedBlock)
+    const json = block.toJson({emitDefaultValues: true}) as Record<string, any>
+    expect(json.attributes.view).toBe('Card')
+  })
+
+  test('DocumentChange with Block.fromJson preserves attributes through binary round-trip', () => {
+    const embedBlock = {
+      id: 'test-id',
+      type: 'Embed',
+      link: 'hm://test-uid/parent/child',
+      attributes: {view: 'Card'},
+    }
+    const change = new DocumentChange({
+      op: {case: 'replaceBlock' as const, value: Block.fromJson(embedBlock)},
+    })
+
+    // Serialize to binary and back (simulates gRPC transport)
+    const bytes = change.toBinary()
+    const restored = DocumentChange.fromBinary(bytes)
+
+    expect(restored.op.case).toBe('replaceBlock')
+    if (restored.op.case === 'replaceBlock') {
+      const restoredJson = restored.op.value.toJson({emitDefaultValues: true}) as Record<string, any>
+      expect(restoredJson.attributes.view).toBe('Card')
+    }
+  })
+
+  test('plain object without Block.fromJson loses Struct attributes (documents the bug)', () => {
+    // This test documents the broken behavior that caused issue #322.
+    // If this test ever starts passing (attributes preserved), the underlying
+    // protobuf library changed behavior and the Block.fromJson guard is no longer needed.
+    const embedBlock = {
+      id: 'test-id',
+      type: 'Embed',
+      link: 'hm://test-uid/parent/child',
+      attributes: {view: 'Card'},
+    }
+    const change = new DocumentChange({
+      op: {case: 'replaceBlock' as const, value: embedBlock},
+    } as any)
+
+    const bytes = change.toBinary()
+    const restored = DocumentChange.fromBinary(bytes)
+
+    if (restored.op.case === 'replaceBlock') {
+      const json = restored.op.value.toJson({emitDefaultValues: true}) as Record<string, any>
+      // Without Block.fromJson, the Struct attributes are lost in binary round-trip
+      expect(json.attributes?.view).toBeUndefined()
+    }
+  })
+
+  test('Block.fromJson preserves multiple attributes', () => {
+    const embedBlock = {
+      id: 'test-id',
+      type: 'Embed',
+      link: 'hm://test-uid/parent/child',
+      attributes: {view: 'Card', childrenType: 'Unordered'},
+    }
+    const block = Block.fromJson(embedBlock)
+    const json = block.toJson({emitDefaultValues: true}) as Record<string, any>
+    expect(json.attributes.view).toBe('Card')
+    expect(json.attributes.childrenType).toBe('Unordered')
+  })
+})


### PR DESCRIPTION
## Summary

- Fixed subdocuments being published as embeds with missing view attributes (issue #322)
- Now uses `Block.fromJson()` to properly convert embed block attributes into protobuf Struct format
- Added regression tests to verify Block attributes survive binary serialization round-trips
- Wraps DocumentChange operations with proper protobuf constructors instead of plain objects

## Details

When publishing a subdocument as an embed with `{view: 'Card'}` attributes, the attributes were silently dropped because Block.attributes is a `google.protobuf.Struct`. Creating a Block from a plain JS object doesn't automatically convert the attributes to the required Struct format—`Block.fromJson()` must be used for proper conversion.

The fix ensures embed blocks are created correctly and retain their view attributes through the gRPC serialization process.

---

Fixes #322