### PR TITLE
fix(api): handle deleted/not-found documents in interaction summary

### DIFF
--- a/frontend/packages/shared/src/__tests__/api-interaction-summary.test.ts
+++ b/frontend/packages/shared/src/__tests__/api-interaction-summary.test.ts
@@ -1,0 +1,86 @@
+import {describe, expect, it, vi} from 'vitest'
+import {ConnectError, Code} from '@connectrpc/connect'
+import {InteractionSummary} from '../api-interaction-summary'
+import {hmId} from '../utils/entity-id-url'
+
+const targetDocId = hmId('z6MkTestAccount', {path: ['test-doc']})
+
+function makeGrpcClient({
+  getDocument = vi.fn().mockResolvedValue({version: 'v1'}),
+  listDirectory = vi.fn().mockResolvedValue({documents: []}),
+  listDocumentChanges = vi.fn().mockResolvedValue({changes: []}),
+  listEntityMentions = vi.fn().mockResolvedValue({mentions: []}),
+} = {}) {
+  return {
+    documents: {getDocument, listDirectory, listDocumentChanges},
+    entities: {listEntityMentions},
+  } as any
+}
+
+const dummyQueryDaemon = (() => Promise.resolve(null)) as any
+
+const emptySummary = {
+  citations: 0,
+  comments: 0,
+  changes: 0,
+  children: 0,
+  authorUids: [],
+  blocks: {},
+}
+
+describe('InteractionSummary.getData', () => {
+  it('returns empty summary when document is marked as deleted', async () => {
+    const grpcClient = makeGrpcClient({
+      getDocument: vi
+        .fn()
+        .mockRejectedValue(
+          new ConnectError(
+            "rpc error: code = FailedPrecondition desc = document 'hm://z6Mk.../test-doc' is marked as deleted",
+            Code.FailedPrecondition,
+          ),
+        ),
+    })
+
+    const result = await InteractionSummary.getData(grpcClient, {id: targetDocId}, dummyQueryDaemon)
+    expect(result).toEqual(emptySummary)
+  })
+
+  it('returns empty summary when document is not found', async () => {
+    const grpcClient = makeGrpcClient({
+      getDocument: vi.fn().mockRejectedValue(new ConnectError('not found', Code.NotFound)),
+    })
+
+    const result = await InteractionSummary.getData(grpcClient, {id: targetDocId}, dummyQueryDaemon)
+    expect(result).toEqual(emptySummary)
+  })
+
+  it('rethrows unexpected errors', async () => {
+    const grpcClient = makeGrpcClient({
+      getDocument: vi.fn().mockRejectedValue(new ConnectError('internal server error', Code.Internal)),
+    })
+
+    await expect(InteractionSummary.getData(grpcClient, {id: targetDocId}, dummyQueryDaemon)).rejects.toThrow()
+  })
+
+  it('returns empty summary when listEntityMentions fails with deleted doc', async () => {
+    const grpcClient = makeGrpcClient({
+      listEntityMentions: vi
+        .fn()
+        .mockRejectedValue(
+          new ConnectError("document 'hm://z6Mk.../test-doc' is marked as deleted", Code.FailedPrecondition),
+        ),
+    })
+
+    const result = await InteractionSummary.getData(grpcClient, {id: targetDocId}, dummyQueryDaemon)
+    expect(result).toEqual(emptySummary)
+  })
+
+  it('returns empty summary when listDirectory fails with not found', async () => {
+    const grpcClient = makeGrpcClient({
+      listDirectory: vi.fn().mockRejectedValue(new ConnectError('not found', Code.NotFound)),
+    })
+
+    const result = await InteractionSummary.getData(grpcClient, {id: targetDocId}, dummyQueryDaemon)
+    expect(result).toEqual(emptySummary)
+  })
+})

--- a/frontend/packages/shared/src/api-interaction-summary.ts
+++ b/frontend/packages/shared/src/api-interaction-summary.ts
@@ -4,7 +4,7 @@ import {BIG_INT} from './constants'
 import {GRPCClient} from './grpc-client'
 import {HMInteractionSummaryRequest} from '@seed-hypermedia/client/hm-types'
 import {calculateInteractionSummary} from './interaction-summary'
-import {getErrorMessage, HMRedirectError} from './models/entity'
+import {getErrorMessage, HMNotFoundError, HMRedirectError, HMResourceTombstoneError} from './models/entity'
 import {hmIdPathToEntityQueryPath} from './utils'
 
 export const InteractionSummary: HMRequestImplementation<HMInteractionSummaryRequest> = {
@@ -48,7 +48,7 @@ export const InteractionSummary: HMRequestImplementation<HMInteractionSummaryReq
       // queryResource handles following redirects, so this query will be
       // re-fetched with the correct (target) ID after redirect resolution.
       const err = getErrorMessage(e)
-      if (err instanceof HMRedirectError) {
+      if (err instanceof HMRedirectError || err instanceof HMResourceTombstoneError || err instanceof HMNotFoundError) {
         return {citations: 0, comments: 0, changes: 0, children: 0, authorUids: [], blocks: {}}
       }
       throw e


### PR DESCRIPTION
## Summary

- Added error handling for deleted documents (FailedPrecondition) in interaction summary API
- Added error handling for not-found documents (NotFound) across multiple API calls
- Returns empty summary object instead of throwing errors when documents are inaccessible
- Added comprehensive test coverage for deleted and not-found document scenarios

## Changes

Updated `InteractionSummary.getData()` to gracefully handle cases where:
- `getDocument` returns FailedPrecondition (document marked as deleted) or NotFound
- `listEntityMentions` fails due to deleted document
- `listDirectory` returns NotFound

These scenarios now return an empty interaction summary `{citations: 0, comments: 0, changes: 0, children: 0, authorUids: [], blocks: {}}` instead of propagating the error up the call stack.