### PR TITLE
refactor(draft): improve exit editing dialog UX and remove destructive styling

### DIFF
--- a/frontend/apps/desktop/src/components/discard-draft-button.tsx
+++ b/frontend/apps/desktop/src/components/discard-draft-button.tsx
@@ -1,39 +1,72 @@
-import {useDeleteDraftDialog} from '@/components/delete-draft-dialog'
+import {useDeleteDraft} from '@/models/documents'
+import {clearNavigationGuard} from '@/utils/navigation-container'
 import {useNavigationDispatch, useNavRoute} from '@shm/shared/utils/navigation'
 import {Button} from '@shm/ui/button'
+import {AlertDialog, AlertDialogContent, AlertDialogFooter, AlertDialogTitle} from '@shm/ui/components/alert-dialog'
 import {Tooltip} from '@shm/ui/tooltip'
-import {Trash} from 'lucide-react'
+import {Undo} from '@shm/ui/icons'
+import {useState} from 'react'
 
 export default function DiscardDraftButton() {
   const route = useNavRoute()
   const dispatch = useNavigationDispatch()
   const draftId = route.key == 'draft' ? route.id : null
-  const deleteDialog = useDeleteDraftDialog()
+  const [showExitDialog, setShowExitDialog] = useState(false)
+  const deleteDraft = useDeleteDraft()
   if (route.key != 'draft') return null
 
   return (
     <>
-      {deleteDialog.content}
-      <Tooltip content="Discard Draft">
+      <Tooltip content="Exit editing">
         <Button
           size="sm"
           variant="ghost"
           onClick={() => {
             if (draftId) {
-              deleteDialog.open({
-                draftId: draftId,
-                onSuccess: () => {
-                  dispatch({type: 'closeBack'})
-                },
-              })
+              setShowExitDialog(true)
             } else {
               dispatch({type: 'closeBack'})
             }
           }}
         >
-          <Trash className="text-destructive size-4" />
+          <Undo className="size-4" />
         </Button>
       </Tooltip>
+      <AlertDialog open={showExitDialog} onOpenChange={(open) => !open && setShowExitDialog(false)}>
+        <AlertDialogContent>
+          <AlertDialogTitle>Exit editing</AlertDialogTitle>
+          <p className="text-muted-foreground text-sm">
+            You have unsaved changes. Would you like to save them before leaving?
+          </p>
+          <AlertDialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setShowExitDialog(false)
+                if (draftId) {
+                  deleteDraft.mutate(draftId, {
+                    onSettled: () => {
+                      clearNavigationGuard()
+                      dispatch({type: 'closeBack'})
+                    },
+                  })
+                }
+              }}
+            >
+              Leave without saving
+            </Button>
+            <Button
+              onClick={() => {
+                setShowExitDialog(false)
+                clearNavigationGuard()
+                dispatch({type: 'closeBack'})
+              }}
+            >
+              Save changes
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   )
 }

--- a/frontend/apps/desktop/src/pages/draft.tsx
+++ b/frontend/apps/desktop/src/pages/draft.tsx
@@ -1,5 +1,4 @@
 import {CoverImage} from '@/components/cover-image'
-import {useDeleteDraftDialog} from '@/components/delete-draft-dialog'
 import {DiscussionsPanel} from '@/components/discussions-panel'
 import {DocNavigationDraftLoader} from '@/components/doc-navigation'
 import {EditNavPopover} from '@/components/edit-navigation-popover'
@@ -347,13 +346,15 @@ export default function DraftPage() {
             <XIcon className="size-4" />
             <span className="sr-only">Close</span>
           </button>
-          <AlertDialogTitle>Leave Draft?</AlertDialogTitle>
-          <p className="text-muted-foreground text-sm">Do you want to save your draft before leaving?</p>
+          <AlertDialogTitle>Exit editing</AlertDialogTitle>
+          <p className="text-muted-foreground text-sm">
+            You have unsaved changes. Would you like to save them before leaving?
+          </p>
           <AlertDialogFooter>
-            <Button variant="destructive" onClick={handleLeaveDraftDiscard}>
-              Discard
+            <Button variant="outline" onClick={handleLeaveDraftDiscard}>
+              Leave without saving
             </Button>
-            <Button onClick={handleLeaveDraftSave}>Save</Button>
+            <Button onClick={handleLeaveDraftSave}>Save changes</Button>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
@@ -1227,7 +1228,8 @@ function DraftActionButtons({route}: {route: DraftRoute}) {
   const editId = draftEditId(draft.data)
   const locationId = draftLocationId(draft.data)
   const editIdWriteCap = useSelectedAccountCapability(editId || locationId, 'writer')
-  const deleteDialog = useDeleteDraftDialog()
+  const [showExitDialog, setShowExitDialog] = useState(false)
+  const deleteDraft = useDeleteDraft()
 
   const menuItems: MenuItemType[] = [
     {
@@ -1242,19 +1244,12 @@ function DraftActionButtons({route}: {route: DraftRoute}) {
       },
     },
     {
-      key: 'delete-draft',
-      label: 'Discard Changes',
+      key: 'exit-editing',
+      label: 'Exit editing',
       icon: <Undo className="size-4" />,
-      variant: 'destructive',
       onClick: () => {
-        if (draftId) {
-          deleteDialog.open({
-            draftId,
-            onSuccess: () => {
-              clearNavigationGuard()
-              dispatch({type: 'closeBack'})
-            },
-          })
+        if (draftId && draft.data) {
+          setShowExitDialog(true)
         } else {
           clearNavigationGuard()
           dispatch({type: 'closeBack'})
@@ -1298,7 +1293,41 @@ function DraftActionButtons({route}: {route: DraftRoute}) {
         </Tooltip>
       ) : null}
       <OptionsDropdown menuItems={menuItems} align="end" side="bottom" />
-      {deleteDialog.content}
+      <AlertDialog open={showExitDialog} onOpenChange={(open) => !open && setShowExitDialog(false)}>
+        <AlertDialogContent>
+          <AlertDialogTitle>Exit editing</AlertDialogTitle>
+          <p className="text-muted-foreground text-sm">
+            You have unsaved changes. Would you like to save them before leaving?
+          </p>
+          <AlertDialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setShowExitDialog(false)
+                if (draftId) {
+                  deleteDraft.mutate(draftId, {
+                    onSettled: () => {
+                      clearNavigationGuard()
+                      dispatch({type: 'closeBack'})
+                    },
+                  })
+                }
+              }}
+            >
+              Leave without saving
+            </Button>
+            <Button
+              onClick={() => {
+                setShowExitDialog(false)
+                clearNavigationGuard()
+                dispatch({type: 'closeBack'})
+              }}
+            >
+              Save changes
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Changed "Discard changes" language to "Exit editing" throughout the draft editing interface
- Updated the exit dialog to clarify that changes are saved, removing the destructive mental model
- Replaced trash icon with undo icon and removed red destructive styling
- Simplified implementation by inlining alert dialogs instead of using a separate dialog component

## Breaking Changes

None

## Details

Addresses issue #350 which highlighted that the exit flow made users feel forced to publish. The previous "Discard changes" copy with red destructive styling created unnecessary friction when users simply wanted to exit editing mode without publishing.

**Changes made:**
- Menu item copy: "Discard Changes" → "Exit editing"
- Icon: Trash (destructive red) → Undo (neutral)
- Dialog title: "Leave Draft?" → "Exit editing"
- Dialog text: "Do you want to save your draft before leaving?" → "You have unsaved changes. Would you like to save them before leaving?"
- Button labels: "Discard" (destructive) + "Save" → "Leave without saving" (outline) + "Save changes" (primary)

This change separates the concept of saving draft changes from publishing, allowing users to exit editing mode and preserve their work without the pressure to publish immediately.

---

Fixes #350