### PR TITLE
syncing scheduler priorities

### DIFF
--- a/.ai/prioritized-syncing.md
+++ b/.ai/prioritized-syncing.md
@@ -1,0 +1,42 @@
+---
+name: Prioritized Content and Peer Syncing
+summary: Two-tier scheduler that prioritizes user-initiated syncs over background subscriptions with preemption and demotion
+---
+
+# Problem
+
+When a user opens a document in the desktop app, the daemon needs to sync it from the network. These on-demand ("hot") sync tasks compete for worker slots with background subscription syncs ("cold" tasks) that run periodically.
+
+The prior scheduler had several issues:
+
+- Hot and cold tasks shared a single FIFO queue — users waited behind background subscriptions.
+- A persistent-worker model with a buffered channel hid saturation from the dispatch loop, preventing preemption.
+- Unbounded goroutine fan-out per peer sync caused resource spikes.
+- No per-task cancellation — busy workers couldn't be reclaimed.
+- Peers contacted in arbitrary order, wasting time on unreachable nodes.
+
+# Solution
+
+## Two-tier priority queue
+
+Single heap with two tiers: hot tasks (LIFO by heartbeat deadline) always dispatch before cold tasks (FIFO by next run time). Expired hot tasks are lazily demoted or dropped during dispatch.
+
+## Preemption
+
+Each task gets a cancellation context. When the pool is full and a hot task arrives: first, cancel a running subscription; if all workers are hot, demote the oldest one (cancel + re-enqueue for incremental resume).
+
+## Heartbeat lifecycle
+
+The frontend refreshes a task's heartbeat via periodic DiscoverEntity polling (40s TTL, 20s refresh). When polling stops, the heartbeat expires and the scheduler cancels the task and reclaims the slot.
+
+## Direct dispatch
+
+Replaced persistent-worker pool + buffered channel with errgroup.TryGo — saturation is unambiguous, enabling the preemption logic above.
+
+## Peer sync
+
+- Bounded per-task peer concurrency to 50 (was unbounded).
+- Gateway-first ordering — sync with well-connected peers before the long tail.
+- 10s dial timeout to fail fast on unreachable nodes.
+- MaxWorkers reduced from 16 to 4.
+- Follow-up tuning: MaxWorkers raised 4 → 6 (UI-driven bursts of ~9 hot tasks were saturating the pool on document open), and per-task peer window narrowed 50 → 20 (sliding window + gateway-first already rotated peers on completion/failure, so a tighter window trims overlapping RBSR+bitswap fan-out). Net system-wide bound: 6 × 20 = 120 concurrent peer syncs (down from 4 × 50 = 200).

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"runtime"
 	"seed/backend/ipfs"
 	"seed/backend/util/must"
 	"strings"
@@ -303,22 +302,19 @@ type Syncing struct {
 	Interval        time.Duration
 	TimeoutPerPeer  time.Duration
 	RefreshInterval time.Duration
-	MinWorkers      int
-	MaxWorkers      int
+	MaxWorkers int
 	NoPull          bool
 	NoDiscovery     bool
 	AllowPush       bool
 }
 
 func (c Syncing) Default() Syncing {
-	numCPU := runtime.NumCPU()
 	return Syncing{
 		WarmupDuration:  time.Second * 20,
 		Interval:        time.Minute,
 		TimeoutPerPeer:  time.Minute * 5,
 		RefreshInterval: time.Second * 50,
-		MinWorkers:      max(min(numCPU, 8), 2),
-		MaxWorkers:      max(min(numCPU*2, 16), 4),
+		MaxWorkers:      4,
 	}
 }
 
@@ -328,7 +324,6 @@ func (c *Syncing) BindFlags(fs *flag.FlagSet) {
 	fs.DurationVar(&c.Interval, "syncing.interval", c.Interval, "Periodic interval at which sync loop is triggered")
 	fs.DurationVar(&c.TimeoutPerPeer, "syncing.timeout-per-peer", c.TimeoutPerPeer, "Maximum duration for syncing with a single peer")
 	fs.DurationVar(&c.RefreshInterval, "syncing.refresh-interval", c.RefreshInterval, "Periodic interval at which list of subscriptions is refreshed")
-	fs.IntVar(&c.MinWorkers, "syncing.min-workers", c.MinWorkers, "Minimum number of workers for syncing")
 	fs.IntVar(&c.MaxWorkers, "syncing.max-workers", c.MaxWorkers, "Maximum number of workers for syncing")
 	fs.BoolVar(&c.AllowPush, "syncing.allow-push", c.AllowPush, "Allows direct content push. Anyone could force push content")
 	fs.BoolVar(&c.NoPull, "syncing.no-pull", c.NoPull, "Disables periodic content pulling.")

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -314,7 +314,7 @@ func (c Syncing) Default() Syncing {
 		Interval:        time.Minute,
 		TimeoutPerPeer:  time.Minute * 5,
 		RefreshInterval: time.Second * 50,
-		MaxWorkers:      4,
+		MaxWorkers:      6,
 	}
 }
 

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -314,7 +314,7 @@ func (c Syncing) Default() Syncing {
 		Interval:        time.Minute,
 		TimeoutPerPeer:  time.Minute * 2,
 		RefreshInterval: time.Second * 50,
-		MaxWorkers:      4,
+		MaxWorkers:      6,
 	}
 }
 

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"runtime"
 	"seed/backend/ipfs"
 	"seed/backend/util/must"
 	"strings"
@@ -303,22 +302,19 @@ type Syncing struct {
 	Interval        time.Duration
 	TimeoutPerPeer  time.Duration
 	RefreshInterval time.Duration
-	MinWorkers      int
-	MaxWorkers      int
+	MaxWorkers int
 	NoPull          bool
 	NoDiscovery     bool
 	AllowPush       bool
 }
 
 func (c Syncing) Default() Syncing {
-	numCPU := runtime.NumCPU()
 	return Syncing{
 		WarmupDuration:  time.Second * 20,
 		Interval:        time.Minute,
 		TimeoutPerPeer:  time.Minute * 2,
 		RefreshInterval: time.Second * 50,
-		MinWorkers:      max(min(numCPU, 8), 2),
-		MaxWorkers:      max(min(numCPU*2, 16), 4),
+		MaxWorkers:      4,
 	}
 }
 
@@ -328,7 +324,6 @@ func (c *Syncing) BindFlags(fs *flag.FlagSet) {
 	fs.DurationVar(&c.Interval, "syncing.interval", c.Interval, "Periodic interval at which sync loop is triggered")
 	fs.DurationVar(&c.TimeoutPerPeer, "syncing.timeout-per-peer", c.TimeoutPerPeer, "Maximum duration for syncing with a single peer")
 	fs.DurationVar(&c.RefreshInterval, "syncing.refresh-interval", c.RefreshInterval, "Periodic interval at which list of subscriptions is refreshed")
-	fs.IntVar(&c.MinWorkers, "syncing.min-workers", c.MinWorkers, "Minimum number of workers for syncing")
 	fs.IntVar(&c.MaxWorkers, "syncing.max-workers", c.MaxWorkers, "Maximum number of workers for syncing")
 	fs.BoolVar(&c.AllowPush, "syncing.allow-push", c.AllowPush, "Allows direct content push. Anyone could force push content")
 	fs.BoolVar(&c.NoPull, "syncing.no-pull", c.NoPull, "Disables periodic content pulling.")

--- a/backend/hmnet/connect.go
+++ b/backend/hmnet/connect.go
@@ -13,6 +13,7 @@ import (
 	"seed/backend/util/dqb"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"seed/backend/util/sqlite"
@@ -201,13 +202,12 @@ func (n *Node) storeRemotePeers(id peer.ID) (err error) {
 	}
 
 	if len(res.Peers) > 0 {
-		// Store-first: persist peer metadata immediately without connecting or
-		// verifying the protocol. Verification happens lazily when the sync
-		// scheduler actually needs to sync with a peer — the connection and
-		// protocol check are free at that point since we're connecting anyway.
-		// This eliminates the goroutine/dial/handshake storm that previously
-		// caused RAM spikes, 1400+ goroutines, and system-wide slowdowns.
+		// Store-first: persist peer metadata immediately without blocking on
+		// per-peer dials or protocol checks. A background goroutine below
+		// dials the freshly-stored peers so discovery.go's Connectedness
+		// filter sees them without forcing the caller to wait.
 		var vals []any
+		var toDial []peer.AddrInfo
 		sqlStr := "INSERT INTO peers (pid, addresses, explicitly_connected, updated_at) VALUES "
 
 		for _, p := range res.Peers {
@@ -228,6 +228,9 @@ func (n *Node) storeRemotePeers(id peer.ID) (err error) {
 			sort.Strings(p.Addrs)
 			sqlStr += "(?, ?, ?, ?),"
 			vals = append(vals, p.Id, strings.Join(p.Addrs, ","), false, p.UpdatedAt.Seconds)
+			if info, err := netutil.AddrInfoFromStrings(p.Addrs...); err == nil {
+				toDial = append(toDial, info)
+			}
 		}
 
 		if len(vals) != 0 {
@@ -238,9 +241,52 @@ func (n *Node) storeRemotePeers(id peer.ID) (err error) {
 				return err
 			}
 		}
+
+		if len(toDial) > 0 {
+			go n.dialStoredPeers(toDial)
+		}
 	}
 
 	return nil
+}
+
+// dialStoredPeers opens libp2p connections to freshly-stored peers in the
+// background. Discovery filters known peers by Connectedness, so peers we've
+// only persisted to the DB are invisible until something dials them. This runs
+// detached from the caller's context with bounded concurrency; failures are
+// logged at debug level only.
+func (n *Node) dialStoredPeers(infos []peer.AddrInfo) {
+	const maxConcurrentDials = 20
+	const perPeerDialTimeout = 10 * time.Second
+
+	ctx, cancel := context.WithTimeout(context.Background(), PeerSharingTimeout)
+	defer cancel()
+
+	sem := make(chan struct{}, maxConcurrentDials)
+	var wg sync.WaitGroup
+	for _, info := range infos {
+		if info.ID == "" || len(info.Addrs) == 0 {
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			wg.Wait()
+			return
+		case sem <- struct{}{}:
+		}
+		wg.Add(1)
+		go func(info peer.AddrInfo) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			dialCtx, dialCancel := context.WithTimeout(ctx, perPeerDialTimeout)
+			defer dialCancel()
+			n.p2p.Peerstore().AddAddrs(info.ID, info.Addrs, peerstore.TempAddrTTL)
+			if err := n.p2p.Host.Connect(dialCtx, info); err != nil {
+				n.log.Debug("BackgroundPeerDialFailed", zap.String("PID", info.ID.String()), zap.Error(err))
+			}
+		}(info)
+	}
+	wg.Wait()
 }
 func (n *Node) onLibp2pConnection(_ context.Context, event event.EvtPeerConnectednessChanged) {
 	// Clear authentication for disconnected peers.

--- a/backend/hmnet/connect.go
+++ b/backend/hmnet/connect.go
@@ -148,7 +148,7 @@ func (n *Node) connect(ctx context.Context, info peer.AddrInfo, force bool) (err
 	sort.Strings(addrsStr)
 	initialAddrs := strings.ReplaceAll(strings.Join(addrsStr, ","), " ", "")
 
-	if initialAddrs != "" {
+	if initialAddrs != "" && !n.peerWriteIsRedundant(ctx, info.ID.String(), initialAddrs) {
 		if err = n.db.WithTx(ctx, func(conn *sqlite.Conn) error {
 			// On direct contact we always bump updated_at, whether or not the address
 			// set changed. Gating the update on address change would let an active
@@ -166,6 +166,34 @@ func (n *Node) connect(ctx context.Context, info peer.AddrInfo, force bool) (err
 		}
 	}
 	return nil
+}
+
+// peerWriteIsRedundant returns true when the peers-table row for pid already
+// holds the given addresses and was updated within the last 60s. Callers use
+// it to short-circuit an INSERT-on-conflict write whose only effect would be
+// bumping updated_at by milliseconds — the kind of write that stacks up when
+// the scheduler dials the same peer repeatedly or dialStoredPeers re-dials
+// peers we bulk-inserted a moment ago. A failed lookup falls through to the
+// write rather than silently dropping it.
+func (n *Node) peerWriteIsRedundant(ctx context.Context, pid, incomingAddrs string) bool {
+	var skip bool
+	if err := n.db.WithSave(ctx, func(conn *sqlite.Conn) error {
+		return sqlitex.Exec(conn, "SELECT addresses, updated_at FROM peers WHERE pid = ? LIMIT 1;", func(stmt *sqlite.Stmt) error {
+			stored := stmt.ColumnText(0)
+			updatedAt := stmt.ColumnInt64(1)
+			recent := time.Now().Unix()-updatedAt < 60
+			// If we have no new addresses to contribute the INSERT would only
+			// bump the timestamp; if we do have addresses they must match the
+			// stored set for the write to be truly redundant.
+			unchanged := incomingAddrs == "" || stored == incomingAddrs
+			skip = recent && unchanged
+			return nil
+		}, pid)
+	}); err != nil {
+		n.log.Debug("Peer freshness check failed, falling through to write", zap.String("PID", pid), zap.Error(err))
+		return false
+	}
+	return skip
 }
 
 // maxSharedPeers caps how many peers we request from a remote node's peer
@@ -411,32 +439,7 @@ func (n *Node) onLibp2pIdentification(ctx context.Context, event event.EvtPeerId
 	sort.Strings(addrsString)
 	incomingAddrs := strings.ReplaceAll(strings.Join(addrsString, ","), " ", "")
 
-	// Short-circuit the INSERT when the peer-table row is already fresh and
-	// unchanged. The identify-handler fires once per successful libp2p
-	// connection, including every dial we kick off from dialStoredPeers right
-	// after bulk-inserting the same peers from peer-exchange. Re-writing the
-	// same addresses with a timestamp bumped by milliseconds produces nothing
-	// but BEGIN IMMEDIATE collisions with the scheduler's blob-reconcile
-	// writers. The check is an indexed lookup on the UNIQUE pid column, so it
-	// costs ~nothing next to the write we're avoiding.
-	skip := false
-	if err := n.db.WithSave(ctx, func(conn *sqlite.Conn) error {
-		return sqlitex.Exec(conn, "SELECT addresses, updated_at FROM peers WHERE pid = ? LIMIT 1;", func(stmt *sqlite.Stmt) error {
-			stored := stmt.ColumnText(0)
-			updatedAt := stmt.ColumnInt64(1)
-			recent := time.Now().Unix()-updatedAt < 60
-			// If we have no new addresses to contribute, the INSERT would only
-			// bump updated_at; if we do have addresses, they must match what's
-			// already stored for the write to be truly redundant.
-			unchanged := incomingAddrs == "" || stored == incomingAddrs
-			skip = recent && unchanged
-			return nil
-		}, event.Peer.String())
-	}); err != nil {
-		n.log.Debug("Peer freshness check failed, falling through to write", zap.String("PID", event.Peer.String()), zap.Error(err))
-	}
-
-	if !skip {
+	if !n.peerWriteIsRedundant(ctx, event.Peer.String(), incomingAddrs) {
 		if err := n.db.WithTx(ctx, func(conn *sqlite.Conn) error {
 			// Identify completed — we have direct first-hand evidence this peer exists
 			// right now. Always bump updated_at, regardless of whether addresses changed,

--- a/backend/hmnet/connect.go
+++ b/backend/hmnet/connect.go
@@ -409,15 +409,43 @@ func (n *Node) onLibp2pIdentification(ctx context.Context, event event.EvtPeerId
 		addrsString = append(addrsString, strings.ReplaceAll(addrs.String(), "/p2p/"+event.Peer.String(), "")+"/p2p/"+event.Peer.String())
 	}
 	sort.Strings(addrsString)
+	incomingAddrs := strings.ReplaceAll(strings.Join(addrsString, ","), " ", "")
 
-	if err := n.db.WithTx(ctx, func(conn *sqlite.Conn) error {
-		// Identify completed — we have direct first-hand evidence this peer exists
-		// right now. Always bump updated_at, regardless of whether addresses changed,
-		// so TTL pruning doesn't evict long-lived peers with stable addrs. Addresses
-		// only overwrite the stored set when the newly observed set is non-empty.
-		return sqlitex.Exec(conn, "INSERT INTO peers (pid, addresses, explicitly_connected) VALUES (?, ?, ?) ON CONFLICT(pid) DO UPDATE SET addresses=CASE WHEN excluded.addresses!='' THEN excluded.addresses ELSE addresses END, updated_at=strftime('%s', 'now');", nil, event.Peer.String(), strings.ReplaceAll(strings.Join(addrsString, ","), " ", ""), bootstrapped)
+	// Short-circuit the INSERT when the peer-table row is already fresh and
+	// unchanged. The identify-handler fires once per successful libp2p
+	// connection, including every dial we kick off from dialStoredPeers right
+	// after bulk-inserting the same peers from peer-exchange. Re-writing the
+	// same addresses with a timestamp bumped by milliseconds produces nothing
+	// but BEGIN IMMEDIATE collisions with the scheduler's blob-reconcile
+	// writers. The check is an indexed lookup on the UNIQUE pid column, so it
+	// costs ~nothing next to the write we're avoiding.
+	skip := false
+	if err := n.db.WithSave(ctx, func(conn *sqlite.Conn) error {
+		return sqlitex.Exec(conn, "SELECT addresses, updated_at FROM peers WHERE pid = ? LIMIT 1;", func(stmt *sqlite.Stmt) error {
+			stored := stmt.ColumnText(0)
+			updatedAt := stmt.ColumnInt64(1)
+			recent := time.Now().Unix()-updatedAt < 60
+			// If we have no new addresses to contribute, the INSERT would only
+			// bump updated_at; if we do have addresses, they must match what's
+			// already stored for the write to be truly redundant.
+			unchanged := incomingAddrs == "" || stored == incomingAddrs
+			skip = recent && unchanged
+			return nil
+		}, event.Peer.String())
 	}); err != nil {
-		n.log.Warn("Could not store new peer", zap.String("PID", event.Peer.String()), zap.Error(err))
+		n.log.Debug("Peer freshness check failed, falling through to write", zap.String("PID", event.Peer.String()), zap.Error(err))
+	}
+
+	if !skip {
+		if err := n.db.WithTx(ctx, func(conn *sqlite.Conn) error {
+			// Identify completed — we have direct first-hand evidence this peer exists
+			// right now. Always bump updated_at, regardless of whether addresses changed,
+			// so TTL pruning doesn't evict long-lived peers with stable addrs. Addresses
+			// only overwrite the stored set when the newly observed set is non-empty.
+			return sqlitex.Exec(conn, "INSERT INTO peers (pid, addresses, explicitly_connected) VALUES (?, ?, ?) ON CONFLICT(pid) DO UPDATE SET addresses=CASE WHEN excluded.addresses!='' THEN excluded.addresses ELSE addresses END, updated_at=strftime('%s', 'now');", nil, event.Peer.String(), incomingAddrs, bootstrapped)
+		}); err != nil {
+			n.log.Warn("Could not store new peer", zap.String("PID", event.Peer.String()), zap.Error(err))
+		}
 	}
 
 	n.p2p.ConnManager().Protect(event.Peer, ProtocolSupportKey)

--- a/backend/hmnet/connect.go
+++ b/backend/hmnet/connect.go
@@ -196,10 +196,16 @@ func (n *Node) peerWriteIsRedundant(ctx context.Context, pid, incomingAddrs stri
 	return skip
 }
 
-// maxSharedPeers caps how many peers we request from a remote node's peer
-// table. Requesting the full table (previously math.MaxInt32) caused massive
-// protobuf allocations, multiaddr parsing, and downstream goroutine storms.
-const maxSharedPeers = 200
+// maxSharedPeersPerPage caps how many rows we ask a remote node for per
+// ListPeers request. The old code asked for math.MaxInt32, which some remote
+// implementations interpreted literally and returned every row they had ever
+// seen — leading to massive protobuf payloads. The right answer is not a
+// tight cap on *total* rows (we want the full peer graph the remote knows
+// about) but a sane cap on a single *page*, combined with the pagination
+// loop below. 2000 is large enough that any real deployment returns its
+// whole table in one round-trip; the loop is a correctness belt for the
+// degenerate case where a remote genuinely has more.
+const maxSharedPeersPerPage = 2000
 
 func (n *Node) storeRemotePeers(id peer.ID) (err error) {
 	n.log.Debug("storeRemotePeers Called", zap.String("PID", id.String()))
@@ -238,28 +244,57 @@ func (n *Node) storeRemotePeers(id peer.ID) (err error) {
 	}
 	hash := sha256.Sum256(orderedPeersBytes)
 
-	res, err := c.ListPeers(ctxStore, &p2p.ListPeersRequest{PageSize: maxSharedPeers, ListHash: hex.EncodeToString(hash[:])})
-	if err != nil {
-		return fmt.Errorf("Could not get list of peers from %s: %w", id.String(), err)
+	// Pull the remote's full peer table across as many pages as it takes.
+	// Only the first request carries ListHash: that's a "we already agree on
+	// the whole list, skip the round-trip" optimization; it's meaningless once
+	// we're mid-cursor. A defensive page cap stops us from looping forever
+	// against a pathological remote that keeps returning NextPageToken.
+	var allPeers []*p2p.PeerInfo
+	const maxPages = 50 // 50 * 2000 = 100k rows — more than any real deployment
+	pageToken := ""
+	localHash := hex.EncodeToString(hash[:])
+	for page := 0; page < maxPages; page++ {
+		req := &p2p.ListPeersRequest{PageSize: maxSharedPeersPerPage, PageToken: pageToken}
+		if page == 0 {
+			req.ListHash = localHash
+		}
+		res, err := c.ListPeers(ctxStore, req)
+		if err != nil {
+			return fmt.Errorf("Could not get list of peers from %s: %w", id.String(), err)
+		}
+		if res == nil {
+			// Remote short-circuited on ListHash: our tables match, nothing to do.
+			return nil
+		}
+		allPeers = append(allPeers, res.Peers...)
+		if res.NextPageToken == "" {
+			break
+		}
+		pageToken = res.NextPageToken
+	}
+	if len(allPeers) >= maxSharedPeersPerPage*maxPages {
+		n.log.Warn("Peer-exchange hit page cap, remote has an unusually large table",
+			zap.String("PID", id.String()),
+			zap.Int("received", len(allPeers)))
 	}
 
 	// Ingress freshness filter: drop stale entries from the shared list before
 	// we process them. Even if the sharer still remembers a long-dead peer, we
 	// shouldn't accept it — it would bloat our table, waste our dial budget,
 	// and (if later re-shared by us) re-pollute the peer graph.
-	if len(res.Peers) > 0 {
+	if len(allPeers) > 0 {
 		freshnessThreshold := time.Now().Add(-PeerFreshnessWindow).Unix()
-		fresh := res.Peers[:0]
+		fresh := allPeers[:0]
 		staleCount := 0
-		for _, p := range res.Peers {
+		for _, p := range allPeers {
 			if p.UpdatedAt != nil && p.UpdatedAt.Seconds >= freshnessThreshold {
 				fresh = append(fresh, p)
 			} else {
 				staleCount++
 			}
 		}
-		total := len(res.Peers)
-		res.Peers = fresh
+		total := len(allPeers)
+		allPeers = fresh
 		if staleCount > 0 && float64(staleCount)/float64(total) >= suspiciousStaleShare {
 			n.log.Warn("Peer-exchange source shared mostly stale data",
 				zap.String("PID", id.String()),
@@ -274,7 +309,7 @@ func (n *Node) storeRemotePeers(id peer.ID) (err error) {
 		}
 	}
 
-	if len(res.Peers) > 0 {
+	if len(allPeers) > 0 {
 		// Store-first: persist peer metadata immediately without blocking on
 		// per-peer dials or protocol checks. A background goroutine below
 		// dials the freshly-stored peers so discovery.go's Connectedness
@@ -283,7 +318,7 @@ func (n *Node) storeRemotePeers(id peer.ID) (err error) {
 		var toDial []peer.AddrInfo
 		sqlStr := "INSERT INTO peers (pid, addresses, explicitly_connected, updated_at) VALUES "
 
-		for _, p := range res.Peers {
+		for _, p := range allPeers {
 			if p.Id == n.client.me.String() {
 				continue
 			}

--- a/backend/hmnet/connect.go
+++ b/backend/hmnet/connect.go
@@ -8,15 +8,11 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/rand"
 	p2p "seed/backend/genproto/p2p/v1alpha"
 	"seed/backend/hmnet/netutil"
 	"seed/backend/util/dqb"
 	"sort"
 	"strings"
-	"sync"
-	"sync/atomic"
-
 	"time"
 
 	"seed/backend/util/sqlite"
@@ -40,24 +36,11 @@ const (
 	PeerSharingTimeout = time.Second * 30
 	// CheckProtocolTimeout is the maximum time spent trying to check for protocols.
 	CheckProtocolTimeout = time.Second * 12
-	// PeerBatchTimeout is the maximum time spent pert batch of checking.
-	PeerBatchTimeout = time.Second * 10
-	// StorePeersBatchSize is the number of shared peers to check at once for protocols.
-	StorePeersBatchSize = 20
-	// maxNonSeedPeersAllowed caps how many peers from a bootstrap-shared list can
-	// fail the hypermedia protocol check before we stop processing the remainder.
-	// The limit guards against a malicious or misconfigured bootstrap peer feeding
-	// us garbage. The list is shuffled on each exchange, so successive rounds
-	// sample different subsets and coverage accumulates over time. We raised the
-	// cap modestly from 15 to give legitimate noise (identify-timeouts under
-	// batch pressure, transient IPFS-only peers) headroom without abandoning the
-	// fail-closed guarantee against a malicious bootstrap.
-	maxNonSeedPeersAllowed = 30
 	// PeerFreshnessWindow is the maximum age of a peer record before we treat it
 	// as stale. Peers older than this are rejected on ingress (won't be accepted
-	// from peer-exchange), excluded on egress (won't be shared with others), and
-	// pruned on daemon startup. Active peers bump their updated_at on every
-	// direct contact, so only genuinely unseen records age out.
+	// from peer-exchange) and excluded on egress (won't be shared with others).
+	// Active peers bump their updated_at on every direct contact, so only
+	// genuinely unseen records age out.
 	PeerFreshnessWindow = 30 * 24 * time.Hour
 	// suspiciousStaleShare is the fraction of stale rows in a single peer-exchange
 	// response above which we log the sharer as suspicious. A healthy peer will
@@ -184,7 +167,10 @@ func (n *Node) connect(ctx context.Context, info peer.AddrInfo, force bool) (err
 	return nil
 }
 
-var rng = rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec
+// maxSharedPeers caps how many peers we request from a remote node's peer
+// table. Requesting the full table (previously math.MaxInt32) caused massive
+// protobuf allocations, multiaddr parsing, and downstream goroutine storms.
+const maxSharedPeers = 200
 
 func (n *Node) storeRemotePeers(id peer.ID) (err error) {
 	n.log.Debug("storeRemotePeers Called", zap.String("PID", id.String()))
@@ -223,7 +209,7 @@ func (n *Node) storeRemotePeers(id peer.ID) (err error) {
 	}
 	hash := sha256.Sum256(orderedPeersBytes)
 
-	res, err := c.ListPeers(ctxStore, &p2p.ListPeersRequest{PageSize: math.MaxInt32, ListHash: hex.EncodeToString(hash[:])})
+	res, err := c.ListPeers(ctxStore, &p2p.ListPeersRequest{PageSize: maxSharedPeers, ListHash: hex.EncodeToString(hash[:])})
 	if err != nil {
 		return fmt.Errorf("Could not get list of peers from %s: %w", id.String(), err)
 	}
@@ -260,119 +246,37 @@ func (n *Node) storeRemotePeers(id peer.ID) (err error) {
 	}
 
 	if len(res.Peers) > 0 {
+		// Store-first: persist peer metadata immediately without connecting or
+		// verifying the protocol. Verification happens lazily when the sync
+		// scheduler actually needs to sync with a peer — the connection and
+		// protocol check are free at that point since we're connecting anyway.
+		// This eliminates the goroutine/dial/handshake storm that previously
+		// caused RAM spikes, 1400+ goroutines, and system-wide slowdowns.
 		var vals []any
 		sqlStr := "INSERT INTO peers (pid, addresses, explicitly_connected, updated_at) VALUES "
-		var nonSeedPeers uint32
-		var xerr []error
-		var mu sync.Mutex
 
-		var wg sync.WaitGroup
-
-		rng.Shuffle(len(res.Peers), func(i, j int) { res.Peers[i], res.Peers[j] = res.Peers[j], res.Peers[i] })
-		var waitThreshold = int(math.Min(float64(len(res.Peers)), StorePeersBatchSize))
-		ctxBatch, cancelBatch := context.WithTimeout(ctxStore, PeerBatchTimeout)
-		defer cancelBatch()
-		for i, p := range res.Peers {
-			wg.Add(1)
-			go func() {
-				// In order not to get spammed with thousands of peers and make us waste computing
-				// resources, we abort early
-				defer wg.Done()
-				if nonSeedPeers >= maxNonSeedPeersAllowed {
-					return
-				}
-				pid, err := peer.Decode(p.Id)
-				if err != nil {
-					mu.Lock()
-					xerr = append(xerr, fmt.Errorf("Could not decode shared peer %s", p))
-					mu.Unlock()
-					atomic.AddUint32(&nonSeedPeers, 1)
-					n.p2p.ConnManager().Unprotect(pid, ProtocolSupportKey)
-					return
-				}
-				if _, ok := om.Get(p.Id); ok {
-					if n.p2p.Host.Network().Connectedness(pid) == network.Connected {
-						n.p2p.ConnManager().Protect(pid, ProtocolSupportKey)
-						return
-					}
-					// Known peer but not connected — fall through to reconnect.
-				}
-
-				if len(p.Addrs) > 0 {
-					// Skipping our own node.
-					if p.Id == n.client.me.String() {
-						return
-					}
-
-					// Skipping bootstrap nodes where the code is the only source of truth.
-					if n.cfg.IsBootstrap(pid) {
-						return
-					}
-					info, err := netutil.AddrInfoFromStrings(p.Addrs...)
-					if err != nil {
-						mu.Lock()
-						xerr = append(xerr, fmt.Errorf("Could not get peer info from shared addresses: %w", err))
-						mu.Unlock()
-						atomic.AddUint32(&nonSeedPeers, 1)
-
-						return
-					}
-					// Dial failure does not mean the peer isn't a seed peer — it may be
-					// behind NAT, temporarily offline, or otherwise unreachable right now.
-					// We still record its address so that (a) future reconnect attempts can
-					// find it, and (b) peer-exchange with us propagates the full graph we
-					// were told about, not just the subset we happened to reach on first
-					// try. storeRemotePeers is only invoked for bootstrap peers, which are
-					// already in our trust root, so we accept their assertion that this is
-					// a seed peer without a local protocol check.
-					if err := n.p2p.Host.Connect(ctxBatch, info); err != nil {
-						mu.Lock()
-						sqlStr += "(?, ?, ?, ?),"
-						sort.Strings(p.Addrs)
-						vals = append(vals, p.Id, strings.Join(p.Addrs, ","), false, p.UpdatedAt.Seconds)
-						mu.Unlock()
-						return
-					}
-					n.p2p.ConnManager().Protect(pid, ProtocolSupportKey)
-					if err := n.CheckHyperMediaProtocolVersion(ctxBatch, pid, n.protocol.Version); err != nil {
-						atomic.AddUint32(&nonSeedPeers, 1)
-						mu.Lock()
-						xerr = append(xerr, fmt.Errorf("Peer [%s] failed to pass seed-protocol-check: %w", p.Id, err))
-						mu.Unlock()
-						n.p2p.ConnManager().Unprotect(pid, ProtocolSupportKey)
-
-						return
-					}
-					mu.Lock()
-					sqlStr += "(?, ?, ?, ?),"
-					sort.Strings(p.Addrs)
-					vals = append(vals, p.Id, strings.Join(p.Addrs, ","), false, p.UpdatedAt.Seconds)
-					mu.Unlock()
-				} else {
-					atomic.AddUint32(&nonSeedPeers, 1)
-					mu.Lock()
-					xerr = append(xerr, fmt.Errorf("Invalid peer [%s] with no addresses", p))
-					mu.Unlock()
-					return
-				}
-			}()
-			if i >= waitThreshold {
-				wg.Wait()
-				waitThreshold = i + int(math.Min(float64(StorePeersBatchSize), float64(len(res.Peers)-i)-1))
-				ctxBatch, cancelBatch = context.WithTimeout(ctxStore, PeerBatchTimeout)
-				defer cancelBatch()
+		for _, p := range res.Peers {
+			if p.Id == n.client.me.String() {
+				continue
+			}
+			pid, err := peer.Decode(p.Id)
+			if err != nil {
+				continue
+			}
+			if n.cfg.IsBootstrap(pid) {
+				continue
+			}
+			if len(p.Addrs) == 0 {
+				continue
 			}
 
-			if nonSeedPeers >= maxNonSeedPeersAllowed {
-				break
-			}
+			sort.Strings(p.Addrs)
+			sqlStr += "(?, ?, ?, ?),"
+			vals = append(vals, p.Id, strings.Join(p.Addrs, ","), false, p.UpdatedAt.Seconds)
 		}
-		wg.Wait()
-		if nonSeedPeers > 0 {
-			n.log.Debug("Some of the remote shared peers are not running up to date seed protocol", zap.Uint32("Number of non-seed (outdated) peers", nonSeedPeers), zap.Int("Number of actual Seed-peers at the moment we stopped", len(vals)/4) /*since we insert four params at a time*/, zap.Errors("errors", xerr))
-		}
+
 		if len(vals) != 0 {
-			sqlStr = sqlStr[0:len(sqlStr)-1] + " ON CONFLICT(pid) DO UPDATE SET addresses=excluded.addresses, updated_at=excluded.updated_at WHERE addresses!=excluded.addresses AND excluded.addresses !='' AND excluded.updated_at > updated_at"
+			sqlStr = sqlStr[:len(sqlStr)-1] + " ON CONFLICT(pid) DO UPDATE SET addresses=excluded.addresses, updated_at=excluded.updated_at WHERE addresses!=excluded.addresses AND excluded.addresses !='' AND excluded.updated_at > updated_at"
 			peerCount := len(vals) / 4
 			// Give the bulk INSERT its own timeout rather than inheriting ctxStore.
 			// ctxStore is scoped to the whole peer-exchange (dial + verify + insert),
@@ -416,9 +320,6 @@ func (n *Node) storeRemotePeers(id peer.ID) (err error) {
 					zap.Int("peers_lost", peerCount),
 					zap.Error(insertErr))
 			}
-		}
-		if nonSeedPeers > 0 {
-			return fmt.Errorf("We encounter at least %d non-seed (outdated) peers on the sharing table", nonSeedPeers)
 		}
 	}
 

--- a/backend/hmnet/connect.go
+++ b/backend/hmnet/connect.go
@@ -13,6 +13,7 @@ import (
 	"seed/backend/util/dqb"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"seed/backend/util/sqlite"
@@ -246,13 +247,12 @@ func (n *Node) storeRemotePeers(id peer.ID) (err error) {
 	}
 
 	if len(res.Peers) > 0 {
-		// Store-first: persist peer metadata immediately without connecting or
-		// verifying the protocol. Verification happens lazily when the sync
-		// scheduler actually needs to sync with a peer — the connection and
-		// protocol check are free at that point since we're connecting anyway.
-		// This eliminates the goroutine/dial/handshake storm that previously
-		// caused RAM spikes, 1400+ goroutines, and system-wide slowdowns.
+		// Store-first: persist peer metadata immediately without blocking on
+		// per-peer dials or protocol checks. A background goroutine below
+		// dials the freshly-stored peers so discovery.go's Connectedness
+		// filter sees them without forcing the caller to wait.
 		var vals []any
+		var toDial []peer.AddrInfo
 		sqlStr := "INSERT INTO peers (pid, addresses, explicitly_connected, updated_at) VALUES "
 
 		for _, p := range res.Peers {
@@ -273,6 +273,9 @@ func (n *Node) storeRemotePeers(id peer.ID) (err error) {
 			sort.Strings(p.Addrs)
 			sqlStr += "(?, ?, ?, ?),"
 			vals = append(vals, p.Id, strings.Join(p.Addrs, ","), false, p.UpdatedAt.Seconds)
+			if info, err := netutil.AddrInfoFromStrings(p.Addrs...); err == nil {
+				toDial = append(toDial, info)
+			}
 		}
 
 		if len(vals) != 0 {
@@ -321,9 +324,52 @@ func (n *Node) storeRemotePeers(id peer.ID) (err error) {
 					zap.Error(insertErr))
 			}
 		}
+
+		if len(toDial) > 0 {
+			go n.dialStoredPeers(toDial)
+		}
 	}
 
 	return nil
+}
+
+// dialStoredPeers opens libp2p connections to freshly-stored peers in the
+// background. Discovery filters known peers by Connectedness, so peers we've
+// only persisted to the DB are invisible until something dials them. This runs
+// detached from the caller's context with bounded concurrency; failures are
+// logged at debug level only.
+func (n *Node) dialStoredPeers(infos []peer.AddrInfo) {
+	const maxConcurrentDials = 20
+	const perPeerDialTimeout = 10 * time.Second
+
+	ctx, cancel := context.WithTimeout(context.Background(), PeerSharingTimeout)
+	defer cancel()
+
+	sem := make(chan struct{}, maxConcurrentDials)
+	var wg sync.WaitGroup
+	for _, info := range infos {
+		if info.ID == "" || len(info.Addrs) == 0 {
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			wg.Wait()
+			return
+		case sem <- struct{}{}:
+		}
+		wg.Add(1)
+		go func(info peer.AddrInfo) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			dialCtx, dialCancel := context.WithTimeout(ctx, perPeerDialTimeout)
+			defer dialCancel()
+			n.p2p.Peerstore().AddAddrs(info.ID, info.Addrs, peerstore.TempAddrTTL)
+			if err := n.p2p.Host.Connect(dialCtx, info); err != nil {
+				n.log.Debug("BackgroundPeerDialFailed", zap.String("PID", info.ID.String()), zap.Error(err))
+			}
+		}(info)
+	}
+	wg.Wait()
 }
 func (n *Node) onLibp2pConnection(_ context.Context, event event.EvtPeerConnectednessChanged) {
 	// Clear authentication for disconnected peers.

--- a/backend/hmnet/connect.go
+++ b/backend/hmnet/connect.go
@@ -8,15 +8,11 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/rand"
 	p2p "seed/backend/genproto/p2p/v1alpha"
 	"seed/backend/hmnet/netutil"
 	"seed/backend/util/dqb"
 	"sort"
 	"strings"
-	"sync"
-	"sync/atomic"
-
 	"time"
 
 	"seed/backend/util/sqlite"
@@ -40,11 +36,6 @@ const (
 	PeerSharingTimeout = time.Second * 30
 	// CheckProtocolTimeout is the maximum time spent trying to check for protocols.
 	CheckProtocolTimeout = time.Second * 12
-	// PeerBatchTimeout is the maximum time spent pert batch of checking.
-	PeerBatchTimeout = time.Second * 10
-	// StorePeersBatchSize is the number of shared peers to check at once for protocols.
-	StorePeersBatchSize    = 20
-	maxNonSeedPeersAllowed = 15
 )
 
 var (
@@ -162,7 +153,10 @@ func (n *Node) connect(ctx context.Context, info peer.AddrInfo, force bool) (err
 	return nil
 }
 
-var rng = rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec
+// maxSharedPeers caps how many peers we request from a remote node's peer
+// table. Requesting the full table (previously math.MaxInt32) caused massive
+// protobuf allocations, multiaddr parsing, and downstream goroutine storms.
+const maxSharedPeers = 200
 
 func (n *Node) storeRemotePeers(id peer.ID) (err error) {
 	n.log.Debug("storeRemotePeers Called", zap.String("PID", id.String()))
@@ -201,121 +195,48 @@ func (n *Node) storeRemotePeers(id peer.ID) (err error) {
 	}
 	hash := sha256.Sum256(orderedPeersBytes)
 
-	res, err := c.ListPeers(ctxStore, &p2p.ListPeersRequest{PageSize: math.MaxInt32, ListHash: hex.EncodeToString(hash[:])})
+	res, err := c.ListPeers(ctxStore, &p2p.ListPeersRequest{PageSize: maxSharedPeers, ListHash: hex.EncodeToString(hash[:])})
 	if err != nil {
 		return fmt.Errorf("Could not get list of peers from %s: %w", id.String(), err)
 	}
 
 	if len(res.Peers) > 0 {
+		// Store-first: persist peer metadata immediately without connecting or
+		// verifying the protocol. Verification happens lazily when the sync
+		// scheduler actually needs to sync with a peer — the connection and
+		// protocol check are free at that point since we're connecting anyway.
+		// This eliminates the goroutine/dial/handshake storm that previously
+		// caused RAM spikes, 1400+ goroutines, and system-wide slowdowns.
 		var vals []any
 		sqlStr := "INSERT INTO peers (pid, addresses, explicitly_connected, updated_at) VALUES "
-		var nonSeedPeers uint32
-		var xerr []error
-		var mu sync.Mutex
 
-		var wg sync.WaitGroup
-
-		rng.Shuffle(len(res.Peers), func(i, j int) { res.Peers[i], res.Peers[j] = res.Peers[j], res.Peers[i] })
-		var waitThreshold = int(math.Min(float64(len(res.Peers)), StorePeersBatchSize))
-		ctxBatch, cancelBatch := context.WithTimeout(ctxStore, PeerBatchTimeout)
-		defer cancelBatch()
-		for i, p := range res.Peers {
-			wg.Add(1)
-			go func() {
-				// In order not to get spammed with thousands of peers and make us waste computing
-				// resources, we abort early
-				defer wg.Done()
-				if nonSeedPeers >= maxNonSeedPeersAllowed {
-					return
-				}
-				pid, err := peer.Decode(p.Id)
-				if err != nil {
-					mu.Lock()
-					xerr = append(xerr, fmt.Errorf("Could not decode shared peer %s", p))
-					mu.Unlock()
-					atomic.AddUint32(&nonSeedPeers, 1)
-					n.p2p.ConnManager().Unprotect(pid, ProtocolSupportKey)
-					return
-				}
-				if _, ok := om.Get(p.Id); ok {
-					if n.p2p.Host.Network().Connectedness(pid) == network.Connected {
-						n.p2p.ConnManager().Protect(pid, ProtocolSupportKey)
-						return
-					}
-					// Known peer but not connected — fall through to reconnect.
-				}
-
-				if len(p.Addrs) > 0 {
-					// Skipping our own node.
-					if p.Id == n.client.me.String() {
-						return
-					}
-
-					// Skipping bootstrap nodes where the code is the only source of truth.
-					if n.cfg.IsBootstrap(pid) {
-						return
-					}
-					info, err := netutil.AddrInfoFromStrings(p.Addrs...)
-					if err != nil {
-						mu.Lock()
-						xerr = append(xerr, fmt.Errorf("Could not get peer info from shared addresses: %w", err))
-						mu.Unlock()
-						atomic.AddUint32(&nonSeedPeers, 1)
-
-						return
-					}
-					// If it's offline does not mean its not a seed peer
-					if err := n.p2p.Host.Connect(ctxBatch, info); err != nil {
-						return
-					}
-					n.p2p.ConnManager().Protect(pid, ProtocolSupportKey)
-					if err := n.CheckHyperMediaProtocolVersion(ctxBatch, pid, n.protocol.Version); err != nil {
-						atomic.AddUint32(&nonSeedPeers, 1)
-						mu.Lock()
-						xerr = append(xerr, fmt.Errorf("Peer [%s] failed to pass seed-protocol-check: %w", p.Id, err))
-						mu.Unlock()
-						n.p2p.ConnManager().Unprotect(pid, ProtocolSupportKey)
-
-						return
-					}
-					mu.Lock()
-					sqlStr += "(?, ?, ?, ?),"
-					sort.Strings(p.Addrs)
-					vals = append(vals, p.Id, strings.Join(p.Addrs, ","), false, p.UpdatedAt.Seconds)
-					mu.Unlock()
-				} else {
-					atomic.AddUint32(&nonSeedPeers, 1)
-					mu.Lock()
-					xerr = append(xerr, fmt.Errorf("Invalid peer [%s] with no addresses", p))
-					mu.Unlock()
-					return
-				}
-			}()
-			if i >= waitThreshold {
-				wg.Wait()
-				waitThreshold = i + int(math.Min(float64(StorePeersBatchSize), float64(len(res.Peers)-i)-1))
-				ctxBatch, cancelBatch = context.WithTimeout(ctxStore, PeerBatchTimeout)
-				defer cancelBatch()
+		for _, p := range res.Peers {
+			if p.Id == n.client.me.String() {
+				continue
+			}
+			pid, err := peer.Decode(p.Id)
+			if err != nil {
+				continue
+			}
+			if n.cfg.IsBootstrap(pid) {
+				continue
+			}
+			if len(p.Addrs) == 0 {
+				continue
 			}
 
-			if nonSeedPeers >= maxNonSeedPeersAllowed {
-				break
-			}
+			sort.Strings(p.Addrs)
+			sqlStr += "(?, ?, ?, ?),"
+			vals = append(vals, p.Id, strings.Join(p.Addrs, ","), false, p.UpdatedAt.Seconds)
 		}
-		wg.Wait()
-		if nonSeedPeers > 0 {
-			n.log.Debug("Some of the remote shared peers are not running up to date seed protocol", zap.Uint32("Number of non-seed (outdated) peers", nonSeedPeers), zap.Int("Number of actual Seed-peers at the moment we stopped", len(vals)/4) /*since we insert four params at a time*/, zap.Errors("errors", xerr))
-		}
+
 		if len(vals) != 0 {
-			sqlStr = sqlStr[0:len(sqlStr)-1] + " ON CONFLICT(pid) DO UPDATE SET addresses=excluded.addresses, updated_at=excluded.updated_at WHERE addresses!=excluded.addresses AND excluded.addresses !='' AND excluded.updated_at > updated_at"
+			sqlStr = sqlStr[:len(sqlStr)-1] + " ON CONFLICT(pid) DO UPDATE SET addresses=excluded.addresses, updated_at=excluded.updated_at WHERE addresses!=excluded.addresses AND excluded.addresses !='' AND excluded.updated_at > updated_at"
 			if err := n.db.WithTx(ctxStore, func(conn *sqlite.Conn) error {
 				return sqlitex.ExecTransient(conn, sqlStr, nil, vals...)
 			}); err != nil && !errors.Is(err, sqlitex.ErrBeginImmediateTx) {
 				return err
 			}
-		}
-		if nonSeedPeers > 0 {
-			return fmt.Errorf("We encounter at least %d non-seed (outdated) peers on the sharing table", nonSeedPeers)
 		}
 	}
 

--- a/backend/hmnet/connect.go
+++ b/backend/hmnet/connect.go
@@ -260,7 +260,7 @@ func (n *Node) storeRemotePeers(id peer.ID) (err error) {
 		}
 		res, err := c.ListPeers(ctxStore, req)
 		if err != nil {
-			return fmt.Errorf("Could not get list of peers from %s: %w", id.String(), err)
+			return fmt.Errorf("could not get list of peers from %s: %w", id.String(), err)
 		}
 		if res == nil {
 			// Remote short-circuited on ListHash: our tables match, nothing to do.

--- a/backend/hmnet/syncing/discovery.go
+++ b/backend/hmnet/syncing/discovery.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/multiformats/go-multicodec"
 	"github.com/tidwall/gjson"
 	"go.uber.org/zap"
@@ -88,6 +89,11 @@ func (s *Service) DiscoverObjectWithProgress(ctx context.Context, entityID blob.
 
 	subsMap := make(subscriptionMap)
 	allPeers := []peer.ID{} // TODO:(juligasa): Remove this when we have providers store
+	// knownPeers holds DB-persisted peers that aren't currently in the Connected
+	// state. We use them as a fallback before the DHT when no peer is connected,
+	// since syncWithPeer will dial on demand.
+	const maxKnownPeerFallback = 20
+	var knownPeers []peer.ID
 	if err = s.db.WithSave(ctxLocalPeers, func(conn *sqlite.Conn) error {
 		return sqlitex.Exec(conn, qListPeersWithPid(), func(stmt *sqlite.Stmt) error {
 			addresStr := stmt.ColumnText(0)
@@ -100,12 +106,18 @@ func (s *Service) DiscoverObjectWithProgress(ctx context.Context, entityID blob.
 			}
 			if s.host.Network().Connectedness(info.ID) == network.Connected {
 				allPeers = append(allPeers, info.ID)
+			} else if len(knownPeers) < maxKnownPeerFallback {
+				s.host.Peerstore().AddAddrs(info.ID, info.Addrs, peerstore.TempAddrTTL)
+				knownPeers = append(knownPeers, info.ID)
 			}
 
 			return nil
 		})
 	}); err != nil {
 		return "", err
+	}
+	if len(allPeers) == 0 && len(knownPeers) > 0 {
+		allPeers = knownPeers
 	}
 
 	// Create RBSR store once for reuse across all peers.

--- a/backend/hmnet/syncing/discovery.go
+++ b/backend/hmnet/syncing/discovery.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/multiformats/go-multicodec"
 	"github.com/tidwall/gjson"
 	"go.uber.org/zap"
@@ -98,6 +99,11 @@ func (s *Service) DiscoverObjectWithProgress(ctx context.Context, entityID blob.
 	subsMap := make(subscriptionMap)
 	allPeers := []peer.ID{} // TODO:(juligasa): Remove this when we have providers store
 	peerSelectStart := time.Now()
+	// knownPeers holds DB-persisted peers that aren't currently in the Connected
+	// state. We use them as a fallback before the DHT when no peer is connected,
+	// since syncWithPeer will dial on demand.
+	const maxKnownPeerFallback = 20
+	var knownPeers []peer.ID
 	if err = s.db.WithSave(ctxLocalPeers, func(conn *sqlite.Conn) error {
 		return sqlitex.Exec(conn, qListPeersWithPid(), func(stmt *sqlite.Stmt) error {
 			addresStr := stmt.ColumnText(0)
@@ -110,6 +116,9 @@ func (s *Service) DiscoverObjectWithProgress(ctx context.Context, entityID blob.
 			}
 			if s.host.Network().Connectedness(info.ID) == network.Connected {
 				allPeers = append(allPeers, info.ID)
+			} else if len(knownPeers) < maxKnownPeerFallback {
+				s.host.Peerstore().AddAddrs(info.ID, info.Addrs, peerstore.TempAddrTTL)
+				knownPeers = append(knownPeers, info.ID)
 			}
 
 			return nil
@@ -119,6 +128,9 @@ func (s *Service) DiscoverObjectWithProgress(ctx context.Context, entityID blob.
 		return "", err
 	}
 	MDiscoverPhaseSeconds.WithLabelValues("peer_select").Observe(time.Since(peerSelectStart).Seconds())
+	if len(allPeers) == 0 && len(knownPeers) > 0 {
+		allPeers = knownPeers
+	}
 
 	// Create RBSR store once for reuse across all peers.
 	dkeys := colx.HashSet[DiscoveryKey]{

--- a/backend/hmnet/syncing/scheduler.go
+++ b/backend/hmnet/syncing/scheduler.go
@@ -16,13 +16,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// Task timing defaults. Installed into every new scheduler and may be
-// overridden per-instance before run() is called (tests exercise heartbeat
-// expiry and rate-limit behavior on human-friendly timescales).
-const (
-	defaultHotTTL      = 40 * time.Second
-	defaultHotInterval = 20 * time.Second
-)
+const defaultHotTTL = 40 * time.Second
 
 // Queue priority tiers. Lower value = higher priority.
 const (
@@ -56,7 +50,7 @@ type taskHandle struct {
 
 	// Scheduling fields.
 	queueIndex   maybe.Value[int]
-	queueTier    uint8 // tierHot or tierCold. Snapshot of the task's tier at last enqueue; may go stale.
+	queueTier    uint8 // tierHot or tierCold. Assigned at enqueue; re-evaluated lazily at dispatch.
 	nextRunTime  time.Time
 	subscription bool
 	hotDeadline  time.Time
@@ -117,11 +111,9 @@ type scheduler struct {
 	// preemption decisions.
 	inProgress int
 
-	// Task timing knobs. Installed from defaults in newScheduler. Tests may
-	// assign smaller values before calling run() to exercise heartbeat and
-	// rate-limit behavior on compressed timescales.
-	hotTTL      time.Duration
-	hotInterval time.Duration
+	// Heartbeat TTL for hot tasks. Installed from defaultHotTTL in newScheduler.
+	// Tests may assign a smaller value before calling run().
+	hotTTL time.Duration
 }
 
 // newScheduler creates a new scheduler.
@@ -135,8 +127,7 @@ func newScheduler(disc discoverer, cfg config.Syncing) *scheduler {
 		cfg:         cfg,
 		timer:       time.NewTimer(0),
 		tasks:       make(map[DiscoveryKey]*taskHandle),
-		hotTTL:      defaultHotTTL,
-		hotInterval: defaultHotInterval,
+		hotTTL: defaultHotTTL,
 		// Two-tier priority: hot tasks always before cold. Within hot tier,
 		// LIFO by hotDeadline desc (most recently touched wins); within cold
 		// tier, FIFO by nextRunTime asc (earliest due wins). nextRunTime is
@@ -224,10 +215,9 @@ func (s *scheduler) executeTask(task *taskHandle) {
 
 	now := time.Now()
 
-	// Demotion detection: a hot task whose context was cancelled while its
+	// Preemption detection: a hot task whose context was cancelled while its
 	// heartbeat is still fresh was preempted to make room for a newer hot
-	// task. Reset its state and re-enqueue at the top of whichever tier it
-	// belongs in so it can resume as soon as a worker frees up.
+	// task. Re-enqueue it so it resumes as soon as a worker frees up.
 	if errors.Is(err, context.Canceled) && !task.subscription && task.IsHot(now) {
 		task.state = TaskStateIdle
 		task.progress = nil
@@ -353,8 +343,7 @@ func (s *scheduler) dispatchReadyTasks(ctx context.Context) (nextWake time.Durat
 		now := time.Now()
 
 		// Lazy migration: if the head task's tier flag is stale (e.g. a hot
-		// task whose deadline expired while queued, or a rate-limited hot
-		// task whose cooldown just ended), fix its position before dispatching.
+		// task whose heartbeat expired while queued), fix its position.
 		wantTier := tierCold
 		if task.IsHot(now) && !task.nextRunTime.After(now) {
 			wantTier = tierHot
@@ -401,14 +390,14 @@ func (s *scheduler) dispatchReadyTasks(ctx context.Context) (nextWake time.Durat
 		}
 
 		// Worker pool is full. For hot tasks, try to make room by preempting
-		// a running subscription or demoting the oldest in-flight hot task.
-		// The new task goes back into the queue; when the preempted worker
-		// unwinds, its tail calls resetTimer so we get re-entered and retry.
+		// a running subscription or the oldest in-flight hot task. The new
+		// task goes back into the queue; when the preempted worker unwinds,
+		// its tail calls resetTimer so we get re-entered and retry.
 		preempted := false
 		if task.queueTier == tierHot {
 			if s.preemptSubscriptionLocked() {
 				preempted = true
-			} else if s.demoteOldestHotLocked(task, now) {
+			} else if s.preemptOldestHotLocked(task, now) {
 				preempted = true
 			}
 		}
@@ -449,15 +438,8 @@ func (s *scheduler) dispatchReadyTasks(ctx context.Context) (nextWake time.Durat
 	return s.boundedWake(wake, now)
 }
 
-// enqueueLocked inserts or reorders the task in the queue based on its current
-// hot state and rate-limit. Caller must hold s.mu. Must not be called while
-// task.state == TaskStateInProgress.
-//
-// A task belongs in the hot tier iff its heartbeat is still fresh AND its
-// nextRunTime rate-limit has elapsed. Rate-limited hot tasks (just finished
-// a run, cooling down for hotInterval) sit in the cold tier sorted by their
-// cooldown expiry; lazy migration in dispatchReadyTasks promotes them back
-// when their cooldown ends.
+// enqueueLocked inserts or reorders the task in the queue. Caller must hold
+// s.mu. Must not be called while task.state == TaskStateInProgress.
 func (s *scheduler) enqueueLocked(task *taskHandle, now time.Time) {
 	if task.IsHot(now) && !task.nextRunTime.After(now) {
 		task.queueTier = tierHot
@@ -491,12 +473,12 @@ func (s *scheduler) preemptSubscriptionLocked() bool {
 	return false
 }
 
-// demoteOldestHotLocked cancels the in-flight ephemeral hot task with the
+// preemptOldestHotLocked cancels the in-flight ephemeral hot task with the
 // oldest hotDeadline so a newer hot task (`incoming`) can take its worker
-// slot. The demoted task will re-enter the hot tier via executeTask's
-// cancellation branch. Returns true if a task was demoted. Caller must
+// slot. The preempted task re-enters the hot tier via executeTask's
+// cancellation branch. Returns true if a task was preempted. Caller must
 // hold s.mu.
-func (s *scheduler) demoteOldestHotLocked(incoming *taskHandle, now time.Time) bool {
+func (s *scheduler) preemptOldestHotLocked(incoming *taskHandle, now time.Time) bool {
 	var victim *taskHandle
 	for _, t := range s.tasks {
 		if t.state != TaskStateInProgress {
@@ -516,7 +498,7 @@ func (s *scheduler) demoteOldestHotLocked(incoming *taskHandle, now time.Time) b
 			continue
 		}
 		// Victim must have a strictly older heartbeat than the incoming task;
-		// otherwise demoting just delays the user's most recent request.
+		// otherwise preempting just delays the user's most recent request.
 		if !t.hotDeadline.Before(incoming.hotDeadline) {
 			continue
 		}
@@ -580,27 +562,21 @@ func (s *scheduler) boundedWake(candidate time.Duration, now time.Time) time.Dur
 }
 
 // scheduleNext calculates the next run time and enqueues/fixes the task.
-// If the task should not be rescheduled (not hot, not subscription), it is deleted.
+// Subscriptions are rescheduled on their configured interval. Ephemeral tasks
+// (hot or not) run once and are dropped; the frontend re-touch recreates them.
 // Caller must hold s.mu.
 func (s *scheduler) scheduleNext(task *taskHandle, now time.Time, forceImmediate bool) {
-	isHot := task.IsHot(now)
-
 	switch {
 	case forceImmediate || task.runCount == 0:
 		task.nextRunTime = now
-	case isHot:
-		task.nextRunTime = now.Add(s.hotInterval)
-	case !isHot && task.subscription:
+	case task.subscription:
 		task.nextRunTime = now.Add(s.cfg.Interval)
-	case !isHot && !task.subscription:
-		// Not hot, nor a subscription: drop the task.
+	default:
 		if task.queueIndex.IsSet() {
 			s.queue.Remove(task.queueIndex.Value())
 		}
 		delete(s.tasks, task.key)
 		return
-	default:
-		panic("BUG: unreachable")
 	}
 
 	s.enqueueLocked(task, now)

--- a/backend/hmnet/syncing/scheduler.go
+++ b/backend/hmnet/syncing/scheduler.go
@@ -16,13 +16,18 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// Task timing constants.
+// Task timing defaults. Installed into every new scheduler and may be
+// overridden per-instance before run() is called (tests exercise heartbeat
+// expiry and rate-limit behavior on human-friendly timescales).
 const (
-	// hotTTL is how long the hot mode lasts after the last heartbeat.
-	hotTTL = 40 * time.Second
+	defaultHotTTL      = 40 * time.Second
+	defaultHotInterval = 20 * time.Second
+)
 
-	// hotInterval is how often a task refreshes while in on-demand mode.
-	hotInterval = 20 * time.Second
+// Queue priority tiers. Lower value = higher priority.
+const (
+	tierHot  uint8 = 0
+	tierCold uint8 = 1
 )
 
 // TaskState represents the current state of a discovery task.
@@ -51,10 +56,15 @@ type taskHandle struct {
 
 	// Scheduling fields.
 	queueIndex   maybe.Value[int]
+	queueTier    uint8 // tierHot or tierCold. Snapshot of the task's tier at last enqueue; may go stale.
 	nextRunTime  time.Time
 	subscription bool
 	hotDeadline  time.Time
 	runCount     uint64 // Number of times task has been executed.
+
+	// Cancellation. Set by dispatchReadyTasks under s.mu before dispatching, cleared in executeTask's unwind.
+	cancelFunc context.CancelFunc
+	runCtx     context.Context
 
 	// Observable fields.
 	state       TaskState
@@ -83,34 +93,64 @@ type discoverer interface {
 	DiscoverObjectWithProgress(ctx context.Context, entityID blob.IRI, version blob.Version, recursive bool, prog *Progress) (blob.Version, error)
 }
 
-// scheduler manages discovery tasks with a bounded worker pool,
-// allowing for bursts of hot tasks.
+// scheduler manages discovery tasks with a bounded worker pool.
+//
+// Worker capacity is bounded by cfg.MaxWorkers via an errgroup limit. Each
+// dispatched task spawns a fresh goroutine via errgroup.TryGo; the limit
+// enforces the concurrency cap. We intentionally avoid a buffered work
+// channel here because a buffer would absorb new tasks when workers are
+// busy, hiding saturation from the dispatch loop — which would defeat the
+// hot-over-cold priority model and preemption machinery below.
 type scheduler struct {
 	workers errgroup.Group
 
 	disc discoverer
 	cfg  config.Syncing
 
-	mu      sync.Mutex
-	timer   *time.Timer
-	tasks   map[DiscoveryKey]*taskHandle
-	queue   *heap.Heap[*taskHandle]
-	workerc chan *taskHandle // Channel for sending tasks to persistent workers.
+	mu    sync.Mutex
+	timer *time.Timer
+	tasks map[DiscoveryKey]*taskHandle
+	queue *heap.Heap[*taskHandle]
+
+	// inProgress counts tasks that are currently being executed by a worker
+	// goroutine. Bounded by cfg.MaxWorkers. Used to detect saturation for
+	// preemption decisions.
+	inProgress int
+
+	// Task timing knobs. Installed from defaults in newScheduler. Tests may
+	// assign smaller values before calling run() to exercise heartbeat and
+	// rate-limit behavior on compressed timescales.
+	hotTTL      time.Duration
+	hotInterval time.Duration
 }
 
 // newScheduler creates a new scheduler.
 func newScheduler(disc discoverer, cfg config.Syncing) *scheduler {
-	if cfg.MinWorkers == 0 || cfg.MaxWorkers == 0 || cfg.MaxWorkers < cfg.MinWorkers {
+	if cfg.MaxWorkers == 0 {
 		panic("BUG: invalid worker count")
 	}
 
 	s := &scheduler{
-		disc:    disc,
-		cfg:     cfg,
-		timer:   time.NewTimer(0),
-		tasks:   make(map[DiscoveryKey]*taskHandle),
-		workerc: make(chan *taskHandle, cfg.MinWorkers),
+		disc:        disc,
+		cfg:         cfg,
+		timer:       time.NewTimer(0),
+		tasks:       make(map[DiscoveryKey]*taskHandle),
+		hotTTL:      defaultHotTTL,
+		hotInterval: defaultHotInterval,
+		// Two-tier priority: hot tasks always before cold. Within hot tier,
+		// LIFO by hotDeadline desc (most recently touched wins); within cold
+		// tier, FIFO by nextRunTime asc (earliest due wins). nextRunTime is
+		// a stable secondary key in both tiers for deterministic ordering
+		// when primary keys tie.
 		queue: heap.New(func(a, b *taskHandle) bool {
+			if a.queueTier != b.queueTier {
+				return a.queueTier < b.queueTier
+			}
+			if a.queueTier == tierHot {
+				if !a.hotDeadline.Equal(b.hotDeadline) {
+					return a.hotDeadline.After(b.hotDeadline)
+				}
+			}
 			return a.nextRunTime.Before(b.nextRunTime)
 		}),
 	}
@@ -132,19 +172,8 @@ func newScheduler(disc discoverer, cfg config.Syncing) *scheduler {
 // run is the main scheduler loop. It should be called in a goroutine.
 func (s *scheduler) run(ctx context.Context) (err error) {
 	defer func() {
-		close(s.workerc)
 		err = errors.Join(err, s.workers.Wait())
 	}()
-
-	// Start persistent workers.
-	for range s.cfg.MinWorkers {
-		s.workers.Go(func() error {
-			for task := range s.workerc {
-				s.executeTask(ctx, task)
-			}
-			return nil
-		})
-	}
 
 	// Add random jitter to warmup to avoid thundering herd at startup.
 	//nolint:gosec // Using math/rand is acceptable for non-cryptographic jitter.
@@ -165,13 +194,17 @@ func (s *scheduler) run(ctx context.Context) (err error) {
 	}
 }
 
-// executeTask runs discovery and updates task state directly.
-func (s *scheduler) executeTask(ctx context.Context, task *taskHandle) {
-	// Read progress pointer (set by scheduler before dispatch).
+// executeTask runs discovery and updates task state directly. It runs in a
+// goroutine spawned by the dispatch loop via errgroup.TryGo and owns a single
+// MaxWorkers slot for its lifetime.
+func (s *scheduler) executeTask(task *taskHandle) {
+	s.mu.Lock()
+	taskCtx := task.runCtx
 	prog := task.progress
+	s.mu.Unlock()
 
 	result, err := s.disc.DiscoverObjectWithProgress(
-		ctx,
+		taskCtx,
 		task.key.IRI,
 		task.key.Version,
 		task.key.Recursive,
@@ -181,7 +214,28 @@ func (s *scheduler) executeTask(ctx context.Context, task *taskHandle) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// Release the per-task context and the worker slot.
+	if task.cancelFunc != nil {
+		task.cancelFunc()
+		task.cancelFunc = nil
+	}
+	task.runCtx = nil
+	s.inProgress--
+
 	now := time.Now()
+
+	// Demotion detection: a hot task whose context was cancelled while its
+	// heartbeat is still fresh was preempted to make room for a newer hot
+	// task. Reset its state and re-enqueue at the top of whichever tier it
+	// belongs in so it can resume as soon as a worker frees up.
+	if errors.Is(err, context.Canceled) && !task.subscription && task.IsHot(now) {
+		task.state = TaskStateIdle
+		task.progress = nil
+		task.nextRunTime = now
+		s.enqueueLocked(task, now)
+		s.resetTimer(now)
+		return
+	}
 
 	task.state = TaskStateCompleted
 	task.result = result
@@ -241,11 +295,22 @@ func (s *scheduler) scheduleTaskLocked(key DiscoveryKey, now time.Time, opts sch
 	}
 
 	if opts.isHot {
-		task.hotDeadline = now.Add(hotTTL)
+		task.hotDeadline = now.Add(s.hotTTL)
 	}
 
-	if (forceImmediate || task.runCount == 0) && task.state != TaskStateInProgress {
+	if task.state == TaskStateInProgress {
+		// Re-touching a running task only updates the heartbeat deadline.
+		// Re-running decisions happen when the current run completes.
+		return task.Info()
+	}
+
+	if forceImmediate || task.runCount == 0 {
 		s.scheduleNext(task, now, forceImmediate)
+	} else if opts.isHot && task.queueIndex.IsSet() {
+		// Re-touching an already-queued task: its hot deadline changed, which
+		// may move it up in the hot tier (LIFO ordering) or migrate it from
+		// cold into hot. Re-seat it in the queue without changing nextRunTime.
+		s.enqueueLocked(task, now)
 	}
 
 	return task.Info()
@@ -287,52 +352,231 @@ func (s *scheduler) dispatchReadyTasks(ctx context.Context) (nextWake time.Durat
 
 		now := time.Now()
 
-		// Because this scheduler runs on end-user devices we want to clump up the tasks,
-		// instead of spreading them out for a steady stream. This should be more forgiving for device batteries,
-		// and overall efficiency on constrained devices. This is why we don't add any jitter when scheduling,
-		// and instead look ahead a little bit into the future when dequeuing tasks — to group them while we are awake.
-		const lookAhead = 10 * time.Second
-		if task.nextRunTime.After(now.Add(lookAhead)) {
-			// Most urgent task is not due yet.
-			// Sleep until then.
-			return task.nextRunTime.Sub(now)
+		// Lazy migration: if the head task's tier flag is stale (e.g. a hot
+		// task whose deadline expired while queued, or a rate-limited hot
+		// task whose cooldown just ended), fix its position before dispatching.
+		wantTier := tierCold
+		if task.IsHot(now) && !task.nextRunTime.After(now) {
+			wantTier = tierHot
+		}
+		if wantTier != task.queueTier {
+			// Ephemeral (non-subscription) hot task with expired deadline:
+			// there's nothing to run and no owner to resume it. Drop it.
+			if wantTier == tierCold && !task.subscription {
+				s.queue.Pop()
+				delete(s.tasks, task.key)
+				continue
+			}
+			task.queueTier = wantTier
+			s.queue.Fix(task.queueIndex.Value())
+			continue
 		}
 
-		// Task is ready. Pop it from the queue.
-		s.queue.Pop()
+		// Clump cold tasks slightly into the future to save battery on
+		// end-user devices. Hot tasks always dispatch immediately.
+		const lookAhead = 10 * time.Second
+		if task.queueTier == tierCold && task.nextRunTime.After(now.Add(lookAhead)) {
+			s.cleanupExpiredHotTasksLocked(now)
+			wake := task.nextRunTime.Sub(now)
+			return s.boundedWake(wake, time.Now())
+		}
 
-		// Prepare the task for execution.
+		// Task is ready. Pop it from the queue and prepare its run context.
+		s.queue.Pop()
 		task.state = TaskStateInProgress
 		task.progress = &Progress{}
+		taskCtx, cancel := context.WithCancel(ctx)
+		task.runCtx = taskCtx
+		task.cancelFunc = cancel
 
-		// Try to send to persistent workers first.
-		select {
-		case s.workerc <- task:
+		// Dispatch via errgroup.TryGo. TryGo respects the MaxWorkers limit
+		// set in newScheduler, so saturation is authoritative here — either
+		// we get a goroutine slot or we don't.
+		if s.inProgress < s.cfg.MaxWorkers && s.workers.TryGo(func() error {
+			s.executeTask(task)
+			return nil
+		}) {
+			s.inProgress++
 			continue
-		default:
-			// Workers busy. Try burst worker for hot tasks.
-			if task.IsHot(now) && s.workers.TryGo(func() error {
-				s.executeTask(ctx, task)
-				return nil
-			}) {
-				// Dispatched to burst worker.
-				// Move to next task.
-				continue
+		}
+
+		// Worker pool is full. For hot tasks, try to make room by preempting
+		// a running subscription or demoting the oldest in-flight hot task.
+		// The new task goes back into the queue; when the preempted worker
+		// unwinds, its tail calls resetTimer so we get re-entered and retry.
+		preempted := false
+		if task.queueTier == tierHot {
+			if s.preemptSubscriptionLocked() {
+				preempted = true
+			} else if s.demoteOldestHotLocked(task, now) {
+				preempted = true
 			}
 		}
 
-		// All workers are busy. Can't dispatch.
-		// Reset and re-queue the current task,
-		// and stop processing the queue.
+		// Release the unused context and reset the task.
+		cancel()
+		task.runCtx = nil
+		task.cancelFunc = nil
 		task.state = TaskStateIdle
 		task.progress = nil
-		s.enqueue(task)
+		s.enqueueLocked(task, now)
+
+		if preempted {
+			// A slot will open shortly. Stop dispatching; we'll be woken again.
+			break
+		}
+		// Fully saturated with no preemption candidate.
 		break
 	}
 
-	// Nothing in the queue, or workers are busy.
-	// Sleep forever until woken up by an available worker.
-	return time.Duration(math.MaxInt64)
+	now := time.Now()
+	s.cleanupExpiredHotTasksLocked(now)
+
+	// Sleep forever unless an in-progress hot task's heartbeat is about to
+	// expire (so we can cancel it promptly), or a queued cold task becomes due.
+	wake := time.Duration(math.MaxInt64)
+	if s.queue.Len() > 0 {
+		top := s.queue.Peek()
+		if top.queueTier == tierCold {
+			if d := top.nextRunTime.Sub(now); d < wake {
+				wake = d
+			}
+		}
+		// Hot tasks at the head are always "ready"; if we got here without
+		// dispatching them it means workers are saturated. Wait for a worker
+		// completion to wake us.
+	}
+	return s.boundedWake(wake, now)
+}
+
+// enqueueLocked inserts or reorders the task in the queue based on its current
+// hot state and rate-limit. Caller must hold s.mu. Must not be called while
+// task.state == TaskStateInProgress.
+//
+// A task belongs in the hot tier iff its heartbeat is still fresh AND its
+// nextRunTime rate-limit has elapsed. Rate-limited hot tasks (just finished
+// a run, cooling down for hotInterval) sit in the cold tier sorted by their
+// cooldown expiry; lazy migration in dispatchReadyTasks promotes them back
+// when their cooldown ends.
+func (s *scheduler) enqueueLocked(task *taskHandle, now time.Time) {
+	if task.IsHot(now) && !task.nextRunTime.After(now) {
+		task.queueTier = tierHot
+	} else {
+		task.queueTier = tierCold
+	}
+	if task.queueIndex.IsSet() {
+		s.queue.Fix(task.queueIndex.Value())
+		return
+	}
+	s.queue.Push(task)
+}
+
+// preemptSubscriptionLocked cancels an in-flight subscription so its worker
+// slot can be reused by a higher-priority hot task. Returns true if a
+// subscription was cancelled. Caller must hold s.mu.
+func (s *scheduler) preemptSubscriptionLocked() bool {
+	for _, t := range s.tasks {
+		if t.state != TaskStateInProgress {
+			continue
+		}
+		if !t.subscription {
+			continue
+		}
+		if t.cancelFunc == nil {
+			continue
+		}
+		t.cancelFunc()
+		return true
+	}
+	return false
+}
+
+// demoteOldestHotLocked cancels the in-flight ephemeral hot task with the
+// oldest hotDeadline so a newer hot task (`incoming`) can take its worker
+// slot. The demoted task will re-enter the hot tier via executeTask's
+// cancellation branch. Returns true if a task was demoted. Caller must
+// hold s.mu.
+func (s *scheduler) demoteOldestHotLocked(incoming *taskHandle, now time.Time) bool {
+	var victim *taskHandle
+	for _, t := range s.tasks {
+		if t.state != TaskStateInProgress {
+			continue
+		}
+		if t.subscription {
+			continue
+		}
+		if !t.IsHot(now) {
+			// Heartbeat already expired; cleanupExpiredHotTasksLocked will reap it.
+			continue
+		}
+		if t.cancelFunc == nil {
+			continue
+		}
+		if t.key == incoming.key {
+			continue
+		}
+		// Victim must have a strictly older heartbeat than the incoming task;
+		// otherwise demoting just delays the user's most recent request.
+		if !t.hotDeadline.Before(incoming.hotDeadline) {
+			continue
+		}
+		if victim == nil || t.hotDeadline.Before(victim.hotDeadline) {
+			victim = t
+		}
+	}
+	if victim == nil {
+		return false
+	}
+	victim.cancelFunc()
+	return true
+}
+
+// cleanupExpiredHotTasksLocked cancels in-progress ephemeral hot tasks whose
+// heartbeat deadline has expired (the frontend stopped polling, meaning the
+// user is no longer viewing that document) and drops any queued ephemeral
+// hot tasks in the same state. Caller must hold s.mu.
+func (s *scheduler) cleanupExpiredHotTasksLocked(now time.Time) {
+	var toDelete []*taskHandle
+	for _, t := range s.tasks {
+		if t.subscription {
+			continue
+		}
+		if t.IsHot(now) {
+			continue
+		}
+		switch t.state {
+		case TaskStateInProgress:
+			if t.cancelFunc != nil {
+				t.cancelFunc()
+			}
+		default:
+			if t.queueIndex.IsSet() {
+				toDelete = append(toDelete, t)
+			}
+		}
+	}
+	for _, t := range toDelete {
+		s.queue.Remove(t.queueIndex.Value())
+		delete(s.tasks, t.key)
+	}
+}
+
+// boundedWake narrows `candidate` by the earliest in-progress hot-task
+// heartbeat expiry so cleanup runs promptly. Caller must hold s.mu.
+func (s *scheduler) boundedWake(candidate time.Duration, now time.Time) time.Duration {
+	for _, t := range s.tasks {
+		if t.state != TaskStateInProgress || t.subscription {
+			continue
+		}
+		if t.hotDeadline.IsZero() {
+			continue
+		}
+		d := max(t.hotDeadline.Sub(now), 0)
+		if d < candidate {
+			candidate = d
+		}
+	}
+	return candidate
 }
 
 // scheduleNext calculates the next run time and enqueues/fixes the task.
@@ -345,40 +589,35 @@ func (s *scheduler) scheduleNext(task *taskHandle, now time.Time, forceImmediate
 	case forceImmediate || task.runCount == 0:
 		task.nextRunTime = now
 	case isHot:
-		task.nextRunTime = now.Add(hotInterval)
+		task.nextRunTime = now.Add(s.hotInterval)
 	case !isHot && task.subscription:
 		task.nextRunTime = now.Add(s.cfg.Interval)
 	case !isHot && !task.subscription:
-		// Not hot, nor a subscription, delete the task.
+		// Not hot, nor a subscription: drop the task.
+		if task.queueIndex.IsSet() {
+			s.queue.Remove(task.queueIndex.Value())
+		}
 		delete(s.tasks, task.key)
 		return
 	default:
 		panic("BUG: unreachable")
 	}
 
-	if task.queueIndex.IsSet() {
-		s.queue.Fix(task.queueIndex.Value())
-	} else {
-		s.queue.Push(task)
-	}
-}
-
-// enqueue adds a task to the queue. Caller must hold s.mu.
-func (s *scheduler) enqueue(task *taskHandle) {
-	if task.queueIndex.IsSet() {
-		return // Already in queue.
-	}
-	s.queue.Push(task)
+	s.enqueueLocked(task, now)
 }
 
 // resetTimer resets the timer for the scheduler.
 // Caller must hold s.mu.
 func (s *scheduler) resetTimer(now time.Time) {
 	if s.queue.Len() == 0 {
-		// If nothing is in the queue we sleep forever until woken up by new tasks.
-		s.timer.Reset(time.Duration(math.MaxInt64))
-	} else {
-		// If there are tasks in the queue, wake up at the next scheduled time.
-		s.timer.Reset(s.queue.Peek().nextRunTime.Sub(now))
+		wake := s.boundedWake(time.Duration(math.MaxInt64), now)
+		s.timer.Reset(wake)
+		return
 	}
+	top := s.queue.Peek()
+	wake := time.Duration(0)
+	if top.queueTier != tierHot {
+		wake = max(top.nextRunTime.Sub(now), 0)
+	}
+	s.timer.Reset(s.boundedWake(wake, now))
 }

--- a/backend/hmnet/syncing/scheduler.go
+++ b/backend/hmnet/syncing/scheduler.go
@@ -16,7 +16,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const defaultHotTTL = 40 * time.Second
+const (
+	defaultHotTTL      = 40 * time.Second
+	defaultHotCooldown = 20 * time.Second
+)
 
 // Queue priority tiers. Lower value = higher priority.
 const (
@@ -562,8 +565,11 @@ func (s *scheduler) boundedWake(candidate time.Duration, now time.Time) time.Dur
 }
 
 // scheduleNext calculates the next run time and enqueues/fixes the task.
-// Subscriptions are rescheduled on their configured interval. Ephemeral tasks
-// (hot or not) run once and are dropped; the frontend re-touch recreates them.
+// Subscriptions reschedule on the configured interval. Ephemeral hot tasks
+// whose heartbeat is still fresh stay in the map with a short cooldown so
+// polling callers can read the last result; cleanupExpiredHotTasksLocked
+// drops them once the heartbeat expires. Ephemeral tasks whose heartbeat
+// has already expired are dropped immediately.
 // Caller must hold s.mu.
 func (s *scheduler) scheduleNext(task *taskHandle, now time.Time, forceImmediate bool) {
 	switch {
@@ -571,6 +577,8 @@ func (s *scheduler) scheduleNext(task *taskHandle, now time.Time, forceImmediate
 		task.nextRunTime = now
 	case task.subscription:
 		task.nextRunTime = now.Add(s.cfg.Interval)
+	case task.IsHot(now):
+		task.nextRunTime = now.Add(defaultHotCooldown)
 	default:
 		if task.queueIndex.IsSet() {
 			s.queue.Remove(task.queueIndex.Value())

--- a/backend/hmnet/syncing/scheduler_test.go
+++ b/backend/hmnet/syncing/scheduler_test.go
@@ -335,12 +335,10 @@ func TestScheduler_TaskNotLostWhenWorkersBusy(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond, "all tasks must be processed")
 }
 
-// withHotTimingKnobs overrides the scheduler's hotTTL and hotInterval to
-// exercise heartbeat and rate-limit behavior on compressed timescales. Must
-// be called after newScheduler but before s.run.
-func withHotTimingKnobs(s *scheduler, ttl, interval time.Duration) {
+// withHotTTL overrides the scheduler's hotTTL to exercise heartbeat expiry
+// on compressed timescales. Must be called after newScheduler but before s.run.
+func withHotTTL(s *scheduler, ttl time.Duration) {
 	s.hotTTL = ttl
-	s.hotInterval = interval
 }
 
 // waitForState blocks until the given task reaches the expected state or the
@@ -401,7 +399,7 @@ func TestScheduler_HotPreemptsSubscription(t *testing.T) {
 }
 
 // TestScheduler_MultiWindowParallelism verifies that multiple hot tasks
-// whose count fits within MaxWorkers all run concurrently, with no demotion.
+// whose count fits within MaxWorkers all run concurrently, with no preemption.
 func TestScheduler_MultiWindowParallelism(t *testing.T) {
 	blockCh := make(chan struct{})
 
@@ -433,14 +431,14 @@ func TestScheduler_MultiWindowParallelism(t *testing.T) {
 		s.scheduleTask(k, time.Now(), schedOpts{isHot: true})
 	}
 
-	// All three must reach InProgress simultaneously (i.e. no one got demoted).
+	// All three must reach InProgress simultaneously (i.e. no one got preempted).
 	require.Eventually(t, func() bool {
 		inFlightMu.Lock()
 		defer inFlightMu.Unlock()
 		return inFlight[keys[0].IRI] && inFlight[keys[1].IRI] && inFlight[keys[2].IRI]
 	}, 2*time.Second, 10*time.Millisecond, "all three hot tasks must run in parallel")
 
-	// None of them should have been cancelled (no demotion when there's capacity).
+	// None of them should have been cancelled (no preemption when there's capacity).
 	s.mu.Lock()
 	for _, k := range keys {
 		task := s.tasks[k]
@@ -452,10 +450,10 @@ func TestScheduler_MultiWindowParallelism(t *testing.T) {
 	close(blockCh)
 }
 
-// TestScheduler_DemoteOldestHotWhenSaturated verifies that when every worker
+// TestScheduler_PreemptOldestHotWhenSaturated verifies that when every worker
 // is occupied by a hot task, scheduling a newer hot task cancels the
 // least-recently-touched in-flight hot task and lets it resume later.
-func TestScheduler_DemoteOldestHotWhenSaturated(t *testing.T) {
+func TestScheduler_PreemptOldestHotWhenSaturated(t *testing.T) {
 	blockCh := make(chan struct{})
 
 	var seenMu sync.Mutex
@@ -484,26 +482,26 @@ func TestScheduler_DemoteOldestHotWhenSaturated(t *testing.T) {
 	s.scheduleTask(keyA, time.Now(), schedOpts{isHot: true})
 	waitForState(t, s, keyA, TaskStateInProgress, "A must start running")
 
-	// Give B a strictly later hotDeadline so the demotion logic will pick A as the victim.
+	// Give B a strictly later hotDeadline so the preemption logic will pick A as the victim.
 	time.Sleep(5 * time.Millisecond)
 	s.scheduleTask(keyB, time.Now(), schedOpts{isHot: true})
 
 	// A's context should be cancelled; when A's mock returns, lastErr is
-	// context.Canceled before the demotion-detection branch re-enqueues it.
+	// context.Canceled before the preemption-detection branch re-enqueues it.
 	// Observationally: A must re-reach Idle (re-enqueued) and B must start.
 	require.Eventually(t, func() bool {
 		seenMu.Lock()
 		defer seenMu.Unlock()
 		return firstRunSeen[keyB.IRI]
-	}, 2*time.Second, 10*time.Millisecond, "B must run after A is demoted")
+	}, 2*time.Second, 10*time.Millisecond, "B must run after A is preempted")
 
-	// A should still be tracked (demoted, not deleted) and be back in the queue
+	// A should still be tracked (preempted, not deleted) and be back in the queue
 	// at the hot tier waiting for a worker.
 	s.mu.Lock()
 	taskA, ok := s.tasks[keyA]
-	require.True(t, ok, "A must not be deleted; it should be demoted and re-queued")
+	require.True(t, ok, "A must not be deleted; it should be preempted and re-queued")
 	// A is either queued waiting, or already running again (if B finished fast).
-	require.NotEqual(t, TaskStateCompleted, taskA.state, "A should not be in completed state after demotion")
+	require.NotEqual(t, TaskStateCompleted, taskA.state, "A should not be in completed state after preemption")
 	s.mu.Unlock()
 
 	close(blockCh)
@@ -516,7 +514,7 @@ func TestScheduler_HeartbeatCleanupCancelsRunningHot(t *testing.T) {
 	disc := &mockDiscoverer{calls: make(map[blob.IRI]int), blockCh: blockCh}
 
 	s := newScheduler(disc, testConfig(10*time.Second, 2))
-	withHotTimingKnobs(s, 150*time.Millisecond, 50*time.Millisecond)
+	withHotTTL(s, 150*time.Millisecond)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() { _ = s.run(ctx) }()
@@ -527,7 +525,7 @@ func TestScheduler_HeartbeatCleanupCancelsRunningHot(t *testing.T) {
 
 	// Don't touch it again. The heartbeat (150ms) expires. On the next
 	// dispatch tick, the scheduler should cancel the running context and,
-	// because the task is ephemeral and its cooldown expires, delete it.
+	// because the task is ephemeral, delete it.
 	require.Eventually(t, func() bool {
 		s.mu.Lock()
 		defer s.mu.Unlock()

--- a/backend/hmnet/syncing/scheduler_test.go
+++ b/backend/hmnet/syncing/scheduler_test.go
@@ -2,6 +2,7 @@ package syncing
 
 import (
 	"context"
+	"errors"
 	"seed/backend/blob"
 	"seed/backend/config"
 	"sync"
@@ -12,10 +13,9 @@ import (
 )
 
 // testConfig creates a config.Syncing for tests with sensible defaults.
-func testConfig(interval time.Duration, minWorkers, maxWorkers int) config.Syncing {
+func testConfig(interval time.Duration, maxWorkers int) config.Syncing {
 	return config.Syncing{
 		Interval:       interval,
-		MinWorkers:     minWorkers,
 		MaxWorkers:     maxWorkers,
 		WarmupDuration: time.Millisecond, // Very short warmup for tests.
 	}
@@ -58,7 +58,7 @@ func TestScheduler_Basic(t *testing.T) {
 		calls:    make(map[blob.IRI]int),
 		interval: 100 * time.Millisecond,
 	}
-	s := newScheduler(disc, testConfig(disc.interval, 1, 2))
+	s := newScheduler(disc, testConfig(disc.interval, 2))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -81,7 +81,7 @@ func TestScheduler_RefreshesSubscription(t *testing.T) {
 		calls:    make(map[blob.IRI]int),
 		interval: 100 * time.Millisecond,
 	}
-	s := newScheduler(disc, testConfig(disc.interval, 1, 2))
+	s := newScheduler(disc, testConfig(disc.interval, 2))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -123,7 +123,7 @@ func TestScheduler_ExtendOnDemandWhileRunning(t *testing.T) {
 		blockCh:  blockCh,
 		interval: 100 * time.Millisecond,
 	}
-	s := newScheduler(disc, testConfig(disc.interval, 1, 2))
+	s := newScheduler(disc, testConfig(disc.interval, 2))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -174,7 +174,7 @@ func TestScheduler_WakesOnNewTask(t *testing.T) {
 		calls:    make(map[blob.IRI]int),
 		interval: 100 * time.Millisecond,
 	}
-	s := newScheduler(disc, testConfig(disc.interval, 1, 2))
+	s := newScheduler(disc, testConfig(disc.interval, 2))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -209,7 +209,7 @@ func TestScheduler_OnDemandDeadlineExpiry(t *testing.T) {
 		calls:    make(map[blob.IRI]int),
 		interval: 100 * time.Millisecond,
 	}
-	s := newScheduler(disc, testConfig(disc.interval, 1, 2))
+	s := newScheduler(disc, testConfig(disc.interval, 2))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -246,7 +246,7 @@ func TestScheduler_HeapIndexCorrectness(t *testing.T) {
 		interval: 100 * time.Millisecond,
 	}
 
-	s := newScheduler(disc, testConfig(disc.interval, 1, 2))
+	s := newScheduler(disc, testConfig(disc.interval, 2))
 
 	// Create 3 tasks with different nextRunTime values.
 	now := time.Now()
@@ -298,7 +298,7 @@ func TestScheduler_TaskNotLostWhenWorkersBusy(t *testing.T) {
 	disc := &mockDiscoverer{calls: make(map[blob.IRI]int), blockCh: blockCh, interval: 100 * time.Millisecond}
 
 	// 1 min worker, 1 max worker = limited capacity.
-	s := newScheduler(disc, testConfig(disc.interval, 1, 1))
+	s := newScheduler(disc, testConfig(disc.interval, 1))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() { _ = s.run(ctx) }()
@@ -333,4 +333,300 @@ func TestScheduler_TaskNotLostWhenWorkersBusy(t *testing.T) {
 		defer disc.mu.Unlock()
 		return disc.calls["hm://task1"] > 0 && disc.calls["hm://task2"] > 0 && disc.calls["hm://task3"] > 0
 	}, 2*time.Second, 10*time.Millisecond, "all tasks must be processed")
+}
+
+// withHotTimingKnobs overrides the scheduler's hotTTL and hotInterval to
+// exercise heartbeat and rate-limit behavior on compressed timescales. Must
+// be called after newScheduler but before s.run.
+func withHotTimingKnobs(s *scheduler, ttl, interval time.Duration) {
+	s.hotTTL = ttl
+	s.hotInterval = interval
+}
+
+// waitForState blocks until the given task reaches the expected state or the
+// deadline elapses. Returns once the state matches; fails the test otherwise.
+func waitForState(t *testing.T, s *scheduler, key DiscoveryKey, want TaskState, msg string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		task, ok := s.tasks[key]
+		return ok && task.state == want
+	}, 2*time.Second, 5*time.Millisecond, msg)
+}
+
+// TestScheduler_HotPreemptsSubscription verifies that when the worker pool is
+// saturated by a running subscription, a newly arriving hot task cancels the
+// subscription's context so its slot can be reclaimed.
+func TestScheduler_HotPreemptsSubscription(t *testing.T) {
+	blockCh := make(chan struct{})
+	disc := &mockDiscoverer{calls: make(map[blob.IRI]int), blockCh: blockCh}
+
+	// Single worker so the subscription saturates the pool.
+	s := newScheduler(disc, testConfig(10*time.Second, 1))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.run(ctx) }()
+
+	subKey := DiscoveryKey{IRI: "hm://alice/sub"}
+	hotKey := DiscoveryKey{IRI: "hm://alice/hot"}
+
+	s.scheduleTask(subKey, time.Now(), schedOpts{forceSubscription: true})
+	waitForState(t, s, subKey, TaskStateInProgress, "subscription must start running")
+
+	// Fire a hot task. Workers are saturated, so the scheduler should cancel
+	// the subscription via preemption.
+	s.scheduleTask(hotKey, time.Now(), schedOpts{isHot: true})
+
+	// The subscription task's context should be cancelled; when its mock
+	// returns, its lastErr is set to context.Canceled.
+	require.Eventually(t, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		task, ok := s.tasks[subKey]
+		if !ok {
+			return false
+		}
+		return errors.Is(task.lastErr, context.Canceled)
+	}, 2*time.Second, 10*time.Millisecond, "subscription must be cancelled by preemption")
+
+	// Unblock the mock so the hot task (now in the freed worker) can finish.
+	close(blockCh)
+
+	require.Eventually(t, func() bool {
+		disc.mu.Lock()
+		defer disc.mu.Unlock()
+		return disc.calls[hotKey.IRI] > 0
+	}, 2*time.Second, 10*time.Millisecond, "hot task must run after preemption")
+}
+
+// TestScheduler_MultiWindowParallelism verifies that multiple hot tasks
+// whose count fits within MaxWorkers all run concurrently, with no demotion.
+func TestScheduler_MultiWindowParallelism(t *testing.T) {
+	blockCh := make(chan struct{})
+
+	var inFlightMu sync.Mutex
+	inFlight := make(map[blob.IRI]bool)
+
+	disc := &mockDiscoverer{
+		calls:   make(map[blob.IRI]int),
+		blockCh: blockCh,
+		onDiscoverFn: func(iri blob.IRI) {
+			inFlightMu.Lock()
+			inFlight[iri] = true
+			inFlightMu.Unlock()
+		},
+	}
+
+	// 3 workers so all three hot tasks fit in parallel.
+	s := newScheduler(disc, testConfig(10*time.Second, 3))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.run(ctx) }()
+
+	keys := []DiscoveryKey{
+		{IRI: "hm://doc/a"},
+		{IRI: "hm://doc/b"},
+		{IRI: "hm://doc/c"},
+	}
+	for _, k := range keys {
+		s.scheduleTask(k, time.Now(), schedOpts{isHot: true})
+	}
+
+	// All three must reach InProgress simultaneously (i.e. no one got demoted).
+	require.Eventually(t, func() bool {
+		inFlightMu.Lock()
+		defer inFlightMu.Unlock()
+		return inFlight[keys[0].IRI] && inFlight[keys[1].IRI] && inFlight[keys[2].IRI]
+	}, 2*time.Second, 10*time.Millisecond, "all three hot tasks must run in parallel")
+
+	// None of them should have been cancelled (no demotion when there's capacity).
+	s.mu.Lock()
+	for _, k := range keys {
+		task := s.tasks[k]
+		require.NotNil(t, task)
+		require.Equal(t, TaskStateInProgress, task.state, "task %s should still be running", k.IRI)
+	}
+	s.mu.Unlock()
+
+	close(blockCh)
+}
+
+// TestScheduler_DemoteOldestHotWhenSaturated verifies that when every worker
+// is occupied by a hot task, scheduling a newer hot task cancels the
+// least-recently-touched in-flight hot task and lets it resume later.
+func TestScheduler_DemoteOldestHotWhenSaturated(t *testing.T) {
+	blockCh := make(chan struct{})
+
+	var seenMu sync.Mutex
+	firstRunSeen := make(map[blob.IRI]bool)
+
+	disc := &mockDiscoverer{
+		calls:   make(map[blob.IRI]int),
+		blockCh: blockCh,
+		onDiscoverFn: func(iri blob.IRI) {
+			seenMu.Lock()
+			firstRunSeen[iri] = true
+			seenMu.Unlock()
+		},
+	}
+
+	// 1 worker so each hot task fully saturates the pool.
+	s := newScheduler(disc, testConfig(10*time.Second, 1))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.run(ctx) }()
+
+	keyA := DiscoveryKey{IRI: "hm://doc/a"}
+	keyB := DiscoveryKey{IRI: "hm://doc/b"}
+
+	// Schedule A first. It'll start executing and block on blockCh.
+	s.scheduleTask(keyA, time.Now(), schedOpts{isHot: true})
+	waitForState(t, s, keyA, TaskStateInProgress, "A must start running")
+
+	// Give B a strictly later hotDeadline so the demotion logic will pick A as the victim.
+	time.Sleep(5 * time.Millisecond)
+	s.scheduleTask(keyB, time.Now(), schedOpts{isHot: true})
+
+	// A's context should be cancelled; when A's mock returns, lastErr is
+	// context.Canceled before the demotion-detection branch re-enqueues it.
+	// Observationally: A must re-reach Idle (re-enqueued) and B must start.
+	require.Eventually(t, func() bool {
+		seenMu.Lock()
+		defer seenMu.Unlock()
+		return firstRunSeen[keyB.IRI]
+	}, 2*time.Second, 10*time.Millisecond, "B must run after A is demoted")
+
+	// A should still be tracked (demoted, not deleted) and be back in the queue
+	// at the hot tier waiting for a worker.
+	s.mu.Lock()
+	taskA, ok := s.tasks[keyA]
+	require.True(t, ok, "A must not be deleted; it should be demoted and re-queued")
+	// A is either queued waiting, or already running again (if B finished fast).
+	require.NotEqual(t, TaskStateCompleted, taskA.state, "A should not be in completed state after demotion")
+	s.mu.Unlock()
+
+	close(blockCh)
+}
+
+// TestScheduler_HeartbeatCleanupCancelsRunningHot verifies that an in-flight
+// ephemeral hot task whose heartbeat expires is cancelled and removed.
+func TestScheduler_HeartbeatCleanupCancelsRunningHot(t *testing.T) {
+	blockCh := make(chan struct{})
+	disc := &mockDiscoverer{calls: make(map[blob.IRI]int), blockCh: blockCh}
+
+	s := newScheduler(disc, testConfig(10*time.Second, 2))
+	withHotTimingKnobs(s, 150*time.Millisecond, 50*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.run(ctx) }()
+
+	key := DiscoveryKey{IRI: "hm://doc/abandoned"}
+	s.scheduleTask(key, time.Now(), schedOpts{isHot: true})
+	waitForState(t, s, key, TaskStateInProgress, "task must start running")
+
+	// Don't touch it again. The heartbeat (150ms) expires. On the next
+	// dispatch tick, the scheduler should cancel the running context and,
+	// because the task is ephemeral and its cooldown expires, delete it.
+	require.Eventually(t, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		_, exists := s.tasks[key]
+		return !exists
+	}, 2*time.Second, 10*time.Millisecond, "abandoned hot task must be cancelled and removed")
+
+	// The mock saw its context cancellation and returned early; no deadlock.
+	close(blockCh)
+}
+
+// TestScheduler_HotOrderingByHotDeadline verifies that when two hot tasks are
+// both ready to dispatch, the one with the more recent hotDeadline (i.e. the
+// more recently touched) runs first. This exercises the LIFO property of the
+// hot tier comparator.
+func TestScheduler_HotOrderingByHotDeadline(t *testing.T) {
+	s := newScheduler(nil, testConfig(10*time.Second, 1))
+
+	now := time.Now()
+	older := &taskHandle{
+		key:         DiscoveryKey{IRI: "hm://older"},
+		hotDeadline: now.Add(100 * time.Millisecond),
+		nextRunTime: now,
+		queueTier:   tierHot,
+	}
+	newer := &taskHandle{
+		key:         DiscoveryKey{IRI: "hm://newer"},
+		hotDeadline: now.Add(200 * time.Millisecond),
+		nextRunTime: now,
+		queueTier:   tierHot,
+	}
+
+	// Push in "wrong" order to prove the comparator reorders them.
+	s.queue.Push(older)
+	s.queue.Push(newer)
+
+	top := s.queue.Peek()
+	require.Equal(t, newer.key, top.key, "hot task with more recent hotDeadline must sit at the head")
+}
+
+// TestScheduler_HotTierBeatsColdTier verifies that any hot-tier task outranks
+// any cold-tier task, regardless of their nextRunTimes.
+func TestScheduler_HotTierBeatsColdTier(t *testing.T) {
+	s := newScheduler(nil, testConfig(10*time.Second, 1))
+
+	now := time.Now()
+	cold := &taskHandle{
+		key:         DiscoveryKey{IRI: "hm://cold"},
+		nextRunTime: now.Add(-time.Second), // very overdue
+		queueTier:   tierCold,
+	}
+	hot := &taskHandle{
+		key:         DiscoveryKey{IRI: "hm://hot"},
+		hotDeadline: now.Add(time.Minute),
+		nextRunTime: now.Add(time.Second), // slightly future, but still hot tier
+		queueTier:   tierHot,
+	}
+
+	s.queue.Push(cold)
+	s.queue.Push(hot)
+
+	require.Equal(t, hot.key, s.queue.Peek().key, "hot tier must outrank cold tier")
+}
+
+// TestScheduler_RetouchPromotesColdToHot verifies that touching a subscription
+// (which lives in the cold tier) with isHot fixes its heap position so it
+// dispatches ahead of other cold-tier tasks.
+func TestScheduler_RetouchPromotesColdToHot(t *testing.T) {
+	blockCh := make(chan struct{})
+	disc := &mockDiscoverer{calls: make(map[blob.IRI]int), blockCh: blockCh}
+
+	// 1 worker saturated by a blocking filler task so queued order matters.
+	s := newScheduler(disc, testConfig(10*time.Second, 1))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.run(ctx) }()
+
+	filler := DiscoveryKey{IRI: "hm://filler"}
+	s.scheduleTask(filler, time.Now(), schedOpts{forceSubscription: true})
+	waitForState(t, s, filler, TaskStateInProgress, "filler must start")
+
+	// Two queued subscriptions.
+	subA := DiscoveryKey{IRI: "hm://sub/a"}
+	subB := DiscoveryKey{IRI: "hm://sub/b"}
+	s.scheduleTask(subA, time.Now(), schedOpts{forceSubscription: true})
+	time.Sleep(2 * time.Millisecond)
+	s.scheduleTask(subB, time.Now(), schedOpts{forceSubscription: true})
+
+	// Touch subB with isHot. It should now sit at the hot tier and become
+	// the head of the queue, even though subA was enqueued earlier.
+	s.scheduleTask(subB, time.Now(), schedOpts{isHot: true})
+
+	s.mu.Lock()
+	// filler is in progress so it should not be the head; peek the queue top.
+	require.Greater(t, s.queue.Len(), 0, "queue must be non-empty")
+	top := s.queue.Peek()
+	require.Equal(t, subB, top.key, "touched-hot task must move to the head of the queue")
+	require.Equal(t, tierHot, top.queueTier, "touched-hot task must be in the hot tier")
+	s.mu.Unlock()
+
+	close(blockCh)
 }

--- a/backend/hmnet/syncing/syncing.go
+++ b/backend/hmnet/syncing/syncing.go
@@ -379,7 +379,7 @@ func (s *Service) syncWithManyPeers(ctx context.Context, subsMap subscriptionMap
 		}
 	}
 
-	g.Wait()
+	_ = g.Wait()
 
 	return res
 }

--- a/backend/hmnet/syncing/syncing.go
+++ b/backend/hmnet/syncing/syncing.go
@@ -309,9 +309,12 @@ type SyncResult struct {
 }
 
 // maxPeerConcurrency bounds the number of peers a single discovery task syncs
-// with simultaneously. With MaxWorkers=4 tasks and 50 peers each, the system-wide
-// concurrent peer syncs are bounded at 200.
-const maxPeerConcurrency = 50
+// with simultaneously. The per-task peer pool is a rolling sliding window:
+// gateways fill the first slots, then the remaining slots stream non-gateway
+// peers in, with a new peer dispatched the moment any in-flight peer returns
+// (see errgroup.SetLimit usage in syncWithManyPeers). With MaxWorkers=6 tasks
+// and 20 peers each, the system-wide concurrent peer syncs are bounded at 120.
+const maxPeerConcurrency = 20
 
 // gatewayPIDs is the set of well-known gateway peer IDs. Gateways are
 // well-connected infrastructure peers that are most likely to have content,

--- a/backend/hmnet/syncing/syncing.go
+++ b/backend/hmnet/syncing/syncing.go
@@ -2,7 +2,6 @@ package syncing
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"seed/backend/blob"
 	"seed/backend/config"
@@ -13,7 +12,6 @@ import (
 	p2p "seed/backend/genproto/p2p/v1alpha"
 	"seed/backend/hmnet/syncing/rbsr"
 	"slices"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -31,6 +29,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 )
 
 // Metrics. This is exported as a temporary measure,
@@ -186,7 +185,7 @@ func NewService(cfg config.Syncing, log *zap.Logger, db *sqlitex.Pool, indexer I
 		version: net.ProtocolVersion(),
 	}
 
-	if cfg.MinWorkers == 0 || cfg.MaxWorkers == 0 {
+	if cfg.MaxWorkers == 0 {
 		panic("BUG: invalid config for syncing service")
 	}
 
@@ -309,41 +308,78 @@ type SyncResult struct {
 	Errs          []error
 }
 
-// syncWithManyPeers syncs with many peers in parallel.
+// maxPeerConcurrency bounds the number of peers a single discovery task syncs
+// with simultaneously. With MaxWorkers=4 tasks and 50 peers each, the system-wide
+// concurrent peer syncs are bounded at 200.
+const maxPeerConcurrency = 50
+
+// gatewayPIDs is the set of well-known gateway peer IDs. Gateways are
+// well-connected infrastructure peers that are most likely to have content,
+// so we sync with them first.
+var gatewayPIDs = func() map[peer.ID]bool {
+	m := make(map[peer.ID]bool, 3)
+	for _, s := range []string{
+		ipfs.ProductionGatewayPID,
+		ipfs.StagingGatewayPID,
+		ipfs.DevGatewayPID,
+	} {
+		pid, err := peer.Decode(s)
+		if err == nil {
+			m[pid] = true
+		}
+	}
+	return m
+}()
+
+// syncWithManyPeers syncs with many peers in parallel, bounded by maxPeerConcurrency.
+// Gateways are synced first because they are better-connected and more likely to
+// have the requested content.
 func (s *Service) syncWithManyPeers(ctx context.Context, subsMap subscriptionMap, store *authorizedStore, prog *Progress, auth *authInfo) (res SyncResult) {
-	var i int
-	var wg sync.WaitGroup
-	wg.Add(len(subsMap))
 	res.Peers = make([]peer.ID, len(subsMap))
 	res.Errs = make([]error, len(subsMap))
 
-	for pid, eids := range subsMap {
-		go func(i int, pid peer.ID, eids map[string]bool) {
+	var g errgroup.Group
+	g.SetLimit(maxPeerConcurrency)
+
+	dispatch := func(i int, pid peer.ID, eids map[string]bool) {
+		res.Peers[i] = pid
+		g.Go(func() error {
 			var err error
-			defer func() {
-				res.Errs[i] = err
-				if err == nil {
-					atomic.AddInt64(&res.NumSyncOK, 1)
-					prog.PeersSyncedOK.Add(1)
-				} else {
-					atomic.AddInt64(&res.NumSyncFailed, 1)
-					prog.PeersFailed.Add(1)
-				}
-
-				wg.Done()
-			}()
-
-			res.Peers[i] = pid
 			s.log.Debug("Syncing with peer", zap.String("PID", pid.String()))
 			if xerr := s.syncWithPeer(ctx, pid, eids, store, prog, auth); xerr != nil {
 				s.log.Debug("Could not sync with content", zap.String("PID", pid.String()), zap.Error(xerr))
-				err = errors.Join(err, fmt.Errorf("failed to sync objects: %w", xerr))
+				err = fmt.Errorf("failed to sync objects: %w", xerr)
 			}
-		}(i, pid, eids)
-		i++
+
+			res.Errs[i] = err
+			if err == nil {
+				atomic.AddInt64(&res.NumSyncOK, 1)
+				prog.PeersSyncedOK.Add(1)
+			} else {
+				atomic.AddInt64(&res.NumSyncFailed, 1)
+				prog.PeersFailed.Add(1)
+			}
+			return nil
+		})
 	}
 
-	wg.Wait()
+	// First pass: gateways get the first concurrency slots.
+	var i int
+	for pid, eids := range subsMap {
+		if gatewayPIDs[pid] {
+			dispatch(i, pid, eids)
+			i++
+		}
+	}
+	// Second pass: everyone else.
+	for pid, eids := range subsMap {
+		if !gatewayPIDs[pid] {
+			dispatch(i, pid, eids)
+			i++
+		}
+	}
+
+	g.Wait()
 
 	return res
 }
@@ -373,7 +409,11 @@ func (s *Service) syncWithPeer(ctx context.Context, pid peer.ID, eids map[string
 		}
 	}
 
-	c, err := s.rbsrClient(ctx, pid)
+	c, err := func() (p2p.SyncingClient, error) {
+		dialCtx, dialCancel := context.WithTimeout(ctx, 10*time.Second)
+		defer dialCancel()
+		return s.rbsrClient(dialCtx, pid)
+	}()
 	if err != nil {
 		return err
 	}

--- a/backend/hmnet/syncing/syncing.go
+++ b/backend/hmnet/syncing/syncing.go
@@ -511,7 +511,7 @@ func (s *Service) syncWithManyPeers(ctx context.Context, subsMap subscriptionMap
 		}
 	}
 
-	g.Wait()
+	_ = g.Wait()
 
 	return res
 }

--- a/backend/hmnet/syncing/syncing.go
+++ b/backend/hmnet/syncing/syncing.go
@@ -441,9 +441,12 @@ type SyncResult struct {
 }
 
 // maxPeerConcurrency bounds the number of peers a single discovery task syncs
-// with simultaneously. With MaxWorkers=4 tasks and 50 peers each, the system-wide
-// concurrent peer syncs are bounded at 200.
-const maxPeerConcurrency = 50
+// with simultaneously. The per-task peer pool is a rolling sliding window:
+// gateways fill the first slots, then the remaining slots stream non-gateway
+// peers in, with a new peer dispatched the moment any in-flight peer returns
+// (see errgroup.SetLimit usage in syncWithManyPeers). With MaxWorkers=6 tasks
+// and 20 peers each, the system-wide concurrent peer syncs are bounded at 120.
+const maxPeerConcurrency = 20
 
 // gatewayPIDs is the set of well-known gateway peer IDs. Gateways are
 // well-connected infrastructure peers that are most likely to have content,

--- a/backend/hmnet/syncing/syncing.go
+++ b/backend/hmnet/syncing/syncing.go
@@ -14,7 +14,6 @@ import (
 	"seed/backend/hmnet/syncing/rbsr"
 	"slices"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -32,6 +31,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 )
 
 // Metrics. This is exported as a temporary measure,
@@ -317,7 +317,7 @@ func NewService(cfg config.Syncing, log *zap.Logger, db *sqlitex.Pool, indexer I
 		version: net.ProtocolVersion(),
 	}
 
-	if cfg.MinWorkers == 0 || cfg.MaxWorkers == 0 {
+	if cfg.MaxWorkers == 0 {
 		panic("BUG: invalid config for syncing service")
 	}
 
@@ -440,41 +440,78 @@ type SyncResult struct {
 	Errs          []error
 }
 
-// syncWithManyPeers syncs with many peers in parallel.
+// maxPeerConcurrency bounds the number of peers a single discovery task syncs
+// with simultaneously. With MaxWorkers=4 tasks and 50 peers each, the system-wide
+// concurrent peer syncs are bounded at 200.
+const maxPeerConcurrency = 50
+
+// gatewayPIDs is the set of well-known gateway peer IDs. Gateways are
+// well-connected infrastructure peers that are most likely to have content,
+// so we sync with them first.
+var gatewayPIDs = func() map[peer.ID]bool {
+	m := make(map[peer.ID]bool, 3)
+	for _, s := range []string{
+		ipfs.ProductionGatewayPID,
+		ipfs.StagingGatewayPID,
+		ipfs.DevGatewayPID,
+	} {
+		pid, err := peer.Decode(s)
+		if err == nil {
+			m[pid] = true
+		}
+	}
+	return m
+}()
+
+// syncWithManyPeers syncs with many peers in parallel, bounded by maxPeerConcurrency.
+// Gateways are synced first because they are better-connected and more likely to
+// have the requested content.
 func (s *Service) syncWithManyPeers(ctx context.Context, subsMap subscriptionMap, store *authorizedStore, prog *Progress, auth *authInfo) (res SyncResult) {
-	var i int
-	var wg sync.WaitGroup
-	wg.Add(len(subsMap))
 	res.Peers = make([]peer.ID, len(subsMap))
 	res.Errs = make([]error, len(subsMap))
 
-	for pid, eids := range subsMap {
-		go func(i int, pid peer.ID, eids map[string]bool) {
+	var g errgroup.Group
+	g.SetLimit(maxPeerConcurrency)
+
+	dispatch := func(i int, pid peer.ID, eids map[string]bool) {
+		res.Peers[i] = pid
+		g.Go(func() error {
 			var err error
-			defer func() {
-				res.Errs[i] = err
-				if err == nil {
-					atomic.AddInt64(&res.NumSyncOK, 1)
-					prog.PeersSyncedOK.Add(1)
-				} else {
-					atomic.AddInt64(&res.NumSyncFailed, 1)
-					prog.PeersFailed.Add(1)
-				}
-
-				wg.Done()
-			}()
-
-			res.Peers[i] = pid
 			s.log.Debug("Syncing with peer", zap.String("PID", pid.String()))
 			if xerr := s.syncWithPeer(ctx, pid, eids, store, prog, auth); xerr != nil {
 				s.log.Debug("Could not sync with content", zap.String("PID", pid.String()), zap.Error(xerr))
-				err = errors.Join(err, fmt.Errorf("failed to sync objects: %w", xerr))
+				err = fmt.Errorf("failed to sync objects: %w", xerr)
 			}
-		}(i, pid, eids)
-		i++
+
+			res.Errs[i] = err
+			if err == nil {
+				atomic.AddInt64(&res.NumSyncOK, 1)
+				prog.PeersSyncedOK.Add(1)
+			} else {
+				atomic.AddInt64(&res.NumSyncFailed, 1)
+				prog.PeersFailed.Add(1)
+			}
+			return nil
+		})
 	}
 
-	wg.Wait()
+	// First pass: gateways get the first concurrency slots.
+	var i int
+	for pid, eids := range subsMap {
+		if gatewayPIDs[pid] {
+			dispatch(i, pid, eids)
+			i++
+		}
+	}
+	// Second pass: everyone else.
+	for pid, eids := range subsMap {
+		if !gatewayPIDs[pid] {
+			dispatch(i, pid, eids)
+			i++
+		}
+	}
+
+	g.Wait()
 
 	return res
 }
@@ -517,7 +554,11 @@ func (s *Service) syncWithPeer(ctx context.Context, pid peer.ID, eids map[string
 	// reused_conn when the gRPC conn was already cached.
 	connCachedBefore := s.isConnCached != nil && s.isConnCached(pid)
 
-	c, err := s.rbsrClient(ctx, pid)
+	c, err := func() (p2p.SyncingClient, error) {
+		dialCtx, dialCancel := context.WithTimeout(ctx, 10*time.Second)
+		defer dialCancel()
+		return s.rbsrClient(dialCtx, pid)
+	}()
 	MSyncPeerPhaseSeconds.WithLabelValues("dial").Observe(time.Since(dialStart).Seconds())
 	if err != nil {
 		return err

--- a/backend/util/sqlite/sqlitex/rand_id_test.go
+++ b/backend/util/sqlite/sqlitex/rand_id_test.go
@@ -36,14 +36,14 @@ func TestRandID(t *testing.T) {
 	stmt.SetText("$val", "value")
 
 	for i := 0; i < 10; i++ {
-		const min, max = 1000, 1_000_000_000
+		const minID, maxID = 1000, 1_000_000_000
 
-		id, err := sqlitex.InsertRandID(stmt, "$key", min, max)
+		id, err := sqlitex.InsertRandID(stmt, "$key", minID, maxID)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if id < min || id >= max {
-			t.Errorf("id %d out of range [%d, %d)", id, min, max)
+		if id < minID || id >= maxID {
+			t.Errorf("id %d out of range [%d, %d)", id, minID, maxID)
 		}
 
 		countStmt := conn.Prep("SELECT count(*) FROM t WHERE key = $key;")

--- a/backend/util/sqlite/sqlitex/rand_id_test.go
+++ b/backend/util/sqlite/sqlitex/rand_id_test.go
@@ -36,7 +36,7 @@ func TestRandID(t *testing.T) {
 	stmt.SetText("$val", "value")
 
 	for i := 0; i < 10; i++ {
-		const min, max = 1000, 10000
+		const min, max = 1000, 1_000_000_000
 
 		id, err := sqlitex.InsertRandID(stmt, "$key", min, max)
 		if err != nil {

--- a/backend/util/sqlite/sqlitex/savepoint.go
+++ b/backend/util/sqlite/sqlitex/savepoint.go
@@ -119,13 +119,29 @@ func savepoint(conn *sqlite.Conn, name string) (releaseFn func(*error), err erro
 		oldDoneCh := conn.SetInterrupt(nil)
 		defer conn.SetInterrupt(oldDoneCh)
 
-		err := Exec(conn, fmt.Sprintf("ROLLBACK TO %q;", name), nil)
-		if err != nil {
-			panic(orig + err.Error())
+		if err := Exec(conn, fmt.Sprintf("ROLLBACK TO %q;", name), nil); err != nil {
+			wrapped := fmt.Errorf("%ssqlitex.savepoint: rollback failed: %w", orig, err)
+			if *errp == nil {
+				*errp = wrapped
+			} else {
+				*errp = fmt.Errorf("%w (also: rollback failed: %v)", *errp, err)
+			}
+			if recoverP != nil {
+				panic(recoverP)
+			}
+			return
 		}
-		err = Exec(conn, fmt.Sprintf("RELEASE %q;", name), nil)
-		if err != nil {
-			panic(orig + err.Error())
+		if err := Exec(conn, fmt.Sprintf("RELEASE %q;", name), nil); err != nil {
+			wrapped := fmt.Errorf("%ssqlitex.savepoint: release failed: %w", orig, err)
+			if *errp == nil {
+				*errp = wrapped
+			} else {
+				*errp = fmt.Errorf("%w (also: release failed: %v)", *errp, err)
+			}
+			if recoverP != nil {
+				panic(recoverP)
+			}
+			return
 		}
 
 		if recoverP != nil {

--- a/backend/util/sqlite/sqlitex/savepoint.go
+++ b/backend/util/sqlite/sqlitex/savepoint.go
@@ -124,7 +124,7 @@ func savepoint(conn *sqlite.Conn, name string) (releaseFn func(*error), err erro
 			if *errp == nil {
 				*errp = wrapped
 			} else {
-				*errp = fmt.Errorf("%w (also: rollback failed: %v)", *errp, err)
+				*errp = fmt.Errorf("%w (also: rollback failed: %w)", *errp, err)
 			}
 			if recoverP != nil {
 				panic(recoverP)
@@ -136,7 +136,7 @@ func savepoint(conn *sqlite.Conn, name string) (releaseFn func(*error), err erro
 			if *errp == nil {
 				*errp = wrapped
 			} else {
-				*errp = fmt.Errorf("%w (also: release failed: %v)", *errp, err)
+				*errp = fmt.Errorf("%w (also: release failed: %w)", *errp, err)
 			}
 			if recoverP != nil {
 				panic(recoverP)


### PR DESCRIPTION
We should not allow scheduled syncing (sites we joined, subscriptions, etc) to interfere with what the user wants in real time. We should identify hot task to take preccedence over backgorund syncing
Also there are some performance side issues with the way we sync peers causing slow down of the important syncing path
