### PR TITLE
fix(web): open the profile view when "My Profile" is clicked

### DIFF
--- a/frontend/apps/web/app/web-utils.tsx
+++ b/frontend/apps/web/app/web-utils.tsx
@@ -153,7 +153,7 @@ export function WebAccountFooter({
         className="hover:bg-accent flex w-full items-center gap-3 px-4 py-3 text-left"
         onClick={() => {
           if (accountId) {
-            navigate({key: 'profile', id: hmId(accountId, {latest: true})})
+            navigate({key: 'site-profile', id: hmId(accountId, {latest: true}), tab: 'profile'})
           }
           setMobileMenuOpen(false)
         }}
@@ -224,7 +224,7 @@ export function WebAccountFooter({
             <DropdownMenuItem
               onClick={() => {
                 if (accountId) {
-                  navigate({key: 'profile', id: hmId(accountId, {latest: true})})
+                  navigate({key: 'site-profile', id: hmId(accountId, {latest: true}), tab: 'profile'})
                 }
               }}
             >


### PR DESCRIPTION
The account menu used `key: 'profile'` to navigate, but on web the
profile view is rendered for `key: 'site-profile'`. Even though the
URL produced by both was equivalent, the in-memory NavContext kept
the wrong key after internal navigation, so `ResourcePage` fell
through to render the home document instead of the profile.

Use `key: 'site-profile'` with `tab: 'profile'` (matching the rest
of the web app) so both the mobile sheet and the desktop dropdown
in the account footer open the account's profile.