### PR TITLE
fix(editor): keep hyperlink toolbar open while its form has focus

### DIFF
--- a/frontend/packages/editor/src/blocknote/core/extensions/HyperlinkToolbar/HyperlinkToolbarPlugin.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/HyperlinkToolbar/HyperlinkToolbarPlugin.ts
@@ -51,7 +51,7 @@ class HyperlinkToolbarView<BSchema extends BlockSchema> {
   clickHandler = (event: MouseEvent) => {
     const target = event.target as Node | null
     if (!target) return
-    if ((target as HTMLElement).closest?.('.hyperlink-preview-toolbar')) {
+    if (isEventInsideToolbar(target)) {
       return
     }
 
@@ -306,6 +306,39 @@ class HyperlinkToolbarView<BSchema extends BlockSchema> {
   }
 
   update() {
+    // While the user is actively editing inside the toolbar form (e.g. typing
+    // a new URL or link text), the ProseMirror cursor can end up at the
+    // boundary of the link mark after a text-replace transaction, and
+    // $from.marks() stops returning the link mark. That would close the
+    // toolbar and unmount the inputs mid-keystroke. When the toolbar itself
+    // holds focus, keep the toolbar visible and re-resolve mark/range/url
+    // from the stored block id so the form stays in sync without closing.
+    if (this.hyperlinkToolbarState?.show && isToolbarFormFocused()) {
+      const {markOrNode, range} = getNodeAndRange(
+        undefined,
+        undefined,
+        this.hyperlinkToolbarState.id,
+        this.pmView,
+        this,
+        this.hyperlinkToolbarState.url,
+      )
+      if (markOrNode && range) {
+        this.selectedNode = markOrNode
+        this.selectedNodeRange = range
+        const currentState = this.hyperlinkToolbarState
+        const href = markOrNode instanceof Mark ? markOrNode.attrs.href : markOrNode.attrs.link ?? markOrNode.attrs.url
+        const text = markOrNode instanceof Mark ? this.pmView.state.doc.textBetween(range.from, range.to) : currentState.text
+        this.hyperlinkToolbarState = {
+          ...currentState,
+          url: typeof href === 'string' ? href : currentState.url,
+          text,
+          referencePos: posToDOMRect(this.pmView, range.from, range.to),
+        }
+        this.updateHyperlinkToolbar()
+      }
+      return
+    }
+
     const selectionState = this.updateFromSelection()
     if (selectionState) {
       this.hyperlinkToolbarState = selectionState
@@ -386,6 +419,23 @@ export class HyperlinkToolbarProsemirrorPlugin<BSchema extends BlockSchema> exte
   public resetHyperlink = () => {
     this.view!.resetHyperlink()
   }
+}
+
+// CSS class used on the root of every hypermedia link toolbar popover
+// (see HypermediaLinkPreview in `hm-link-preview.tsx`). Keep these two class
+// names in sync: the plugin uses them to detect "a click/focus is inside the
+// toolbar — don't close it".
+const TOOLBAR_ROOT_CLASS = 'link-preview-toolbar'
+
+function isEventInsideToolbar(target: Node): boolean {
+  return !!(target as HTMLElement).closest?.(`.${TOOLBAR_ROOT_CLASS}`)
+}
+
+function isToolbarFormFocused(): boolean {
+  if (typeof document === 'undefined') return false
+  const active = document.activeElement
+  if (!active) return false
+  return !!active.closest?.(`.${TOOLBAR_ROOT_CLASS}`)
 }
 
 function getNodeAndRange(

--- a/frontend/packages/editor/src/blocknote/core/extensions/HyperlinkToolbar/HyperlinkToolbarPlugin.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/HyperlinkToolbar/HyperlinkToolbarPlugin.ts
@@ -327,7 +327,8 @@ class HyperlinkToolbarView<BSchema extends BlockSchema> {
         this.selectedNodeRange = range
         const currentState = this.hyperlinkToolbarState
         const href = markOrNode instanceof Mark ? markOrNode.attrs.href : markOrNode.attrs.link ?? markOrNode.attrs.url
-        const text = markOrNode instanceof Mark ? this.pmView.state.doc.textBetween(range.from, range.to) : currentState.text
+        const text =
+          markOrNode instanceof Mark ? this.pmView.state.doc.textBetween(range.from, range.to) : currentState.text
         this.hyperlinkToolbarState = {
           ...currentState,
           url: typeof href === 'string' ? href : currentState.url,


### PR DESCRIPTION
## Summary

Three `selection-toolbar.e2e.ts` tests have been failing on `main` ever since ce76240 (`fix(editor): only show hypermedia link toolbar on focus, not hover`) removed the hover-based "keep toolbar open" mechanism.

Typing in the link preview form now unmounts the form mid-keystroke:

1. `plugin.updateHyperlink` dispatches a `tr` that replaces the link text and re-adds the `link` mark.
2. ProseMirror maps the empty selection to the *end* of the replacement.
3. For a non-inclusive `link` mark, a cursor at the end of the mark range is *outside* the mark. `$from.marks()` therefore returns no link, so `updateFromSelection` sets `selectedNode = undefined`.
4. `update()` sees `!this.selectedNode` and sets `show: false`. Tippy unmounts the toolbar content, React unmounts the form, and the input the user is typing into disappears.

That's what broke these three tests:
- `Should edit the link text in the link preview form` — `blur()` timed out because the input was gone.
- `Should edit the link url in the link preview form` — `link-resource-type` element was never found (form unmounted).
- `Change the link url with the search input` — 30s test timeout.

## Fix

In `HyperlinkToolbarPlugin.update()`, when the toolbar's own form currently owns focus (`document.activeElement` is inside `.link-preview-toolbar`), keep `show: true` and re-resolve the link mark / range / url from the stored block id rather than trusting the cursor position.

`clickHandler` uses the same "inside the toolbar" predicate — and this PR also fixes a typo that had `clickHandler` looking for `.hyperlink-preview-toolbar` (never matched) instead of `.link-preview-toolbar` (the actual root class set in `hm-link-preview.tsx`).

## Test plan

- [x] `pnpm typecheck` — passes.
- [x] `pnpm --filter @shm/editor test` — 88 unit tests pass.
- [ ] CI: editor E2E tests (`selection-toolbar.e2e.ts`) turn green on this branch.
- [ ] Manual verify: open a doc with a hyperlink, click the pencil in the preview, edit text / URL, confirm toolbar stays open while editing and the changes land in the doc.

https://claude.ai/code/session_01LfDcUje27uNxfcgMXpCsvP