### PR TITLE
fix(onboarding): restore SKIP button on profile step in full-screen flow

### DIFF
--- a/frontend/apps/desktop/src/__tests__/onboarding-flow.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/onboarding-flow.test.tsx
@@ -190,7 +190,7 @@ vi.mock('@sentry/electron/preload', () => ({}))
 
 import {Onboarding} from '../components/onboarding'
 
-function renderComponent() {
+function renderComponent({modal = true}: {modal?: boolean} = {}) {
   const container = document.createElement('div')
   document.body.appendChild(container)
   const root = createRoot(container)
@@ -204,7 +204,7 @@ function renderComponent() {
     act(() => {
       root.render(
         <QueryClientProvider client={queryClient}>
-          <Onboarding modal={true} onComplete={onCompleteMock} />
+          <Onboarding modal={modal} onComplete={onCompleteMock} />
         </QueryClientProvider>,
       )
     })
@@ -313,6 +313,27 @@ describe('Onboarding flow', () => {
 
   afterEach(() => {
     document.body.innerHTML = ''
+  })
+
+  it('exposes a SKIP button on the profile step in the full-screen (non-modal) flow', async () => {
+    const {container, root, queryClient} = renderComponent({modal: false})
+
+    await act(async () => {
+      findButton(container, 'NEXT')?.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+      await Promise.resolve()
+    })
+
+    const skipButton = findButton(container, 'SKIP')
+    expect(skipButton).toBeDefined()
+
+    await act(async () => {
+      skipButton?.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+      await Promise.resolve()
+    })
+
+    expect(onCompleteMock).toHaveBeenCalled()
+
+    cleanupRendered(root, container, queryClient)
   })
 
   it('shows vault choice before create, restore, and import actions', async () => {

--- a/frontend/apps/desktop/src/components/onboarding.tsx
+++ b/frontend/apps/desktop/src/components/onboarding.tsx
@@ -367,9 +367,7 @@ export function Onboarding({onComplete, modal = false}: OnboardingProps) {
   return (
     <div className={cn('bg-background window-drag flex flex-1 flex-col', !modal && 'size-full')}>
       {currentStep === 'welcome' && <WelcomeStep onNext={handleNext} />}
-      {currentStep === 'profile' && (
-        <ProfileStep onSkip={modal ? handleSkip : undefined} onNext={handleNext} onPrev={handlePrev} />
-      )}
+      {currentStep === 'profile' && <ProfileStep onSkip={handleSkip} onNext={handleNext} onPrev={handlePrev} />}
       {currentStep === 'vault' && (
         <VaultStep
           initialAccountIdCount={globalState.initialAccountIdCount}


### PR DESCRIPTION
Commit b60dfb2 ("Remove vault banner over whole app") gated the SKIP
button on the Profile step to modal mode only:

  <ProfileStep onSkip={modal ? handleSkip : undefined} ... />

That removed the ability to skip onboarding entirely from the main
full-screen flow — users landing on the Profile step had no way out
except completing account creation. The handleSkip handler, the SKIP
JSX inside ProfileStep, and the hasSkippedOnboarding persistence path
were all still intact; only the prop pass-through was gated.

Always pass handleSkip to ProfileStep. The skip path already:
  - sets hasSkippedOnboarding=true in the onboarding-v001 store
  - calls cleanupOnboardingFormData() to clear partial form state
  - invokes onComplete() so root.tsx hides the onboarding overlay

root.tsx:250 already respects hasSkippedOnboarding on subsequent
launches, and OnboardingDialog remains available for users who want
to set up an account later.

Add a regression test that renders Onboarding in non-modal mode,
advances to the Profile step, and asserts the SKIP button is present
and invokes the completion callback.