### PR TITLE
fix(editor): improve text + block selection contrast in dark mode

### DIFF
--- a/frontend/apps/desktop/src/tailwind.css
+++ b/frontend/apps/desktop/src/tailwind.css
@@ -52,6 +52,8 @@
   --border: oklch(0.9276 0.0058 264.5313);
   --input: var(--muted);
   --ring: oklch(0.5726 0.1056 177.0838);
+  --selection: color-mix(in oklab, var(--primary) 22%, transparent);
+  --selection-strong: color-mix(in oklab, var(--primary) 30%, transparent);
   --chart-1: oklch(0.7686 0.1647 70.0804);
   --chart-2: oklch(0.6658 0.1574 58.3183);
   --chart-3: oklch(0.5553 0.1455 48.9975);
@@ -124,6 +126,8 @@
   --border: oklch(0.2686 0 0);
   --input: var(--muted);
   --ring: oklch(0.7155 0 0);
+  --selection: color-mix(in oklab, var(--primary) 32%, transparent);
+  --selection-strong: color-mix(in oklab, var(--primary) 40%, transparent);
   --chart-1: oklch(0.8369 0.1644 84.4286);
   --chart-2: oklch(0.6658 0.1574 58.3183);
   --chart-3: oklch(0.4732 0.1247 46.2007);
@@ -197,6 +201,8 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+  --color-selection: var(--selection);
+  --color-selection-strong: var(--selection-strong);
   --color-chart-1: var(--chart-1);
   --color-chart-2: var(--chart-2);
   --color-chart-3: var(--chart-3);

--- a/frontend/apps/web/app/tailwind.css
+++ b/frontend/apps/web/app/tailwind.css
@@ -52,6 +52,8 @@
   --border: oklch(0.9276 0.0058 264.5313);
   --input: var(--muted);
   --ring: oklch(0.5726 0.1056 177.0838);
+  --selection: color-mix(in oklab, var(--primary) 22%, transparent);
+  --selection-strong: color-mix(in oklab, var(--primary) 30%, transparent);
   --chart-1: oklch(0.7686 0.1647 70.0804);
   --chart-2: oklch(0.6658 0.1574 58.3183);
   --chart-3: oklch(0.5553 0.1455 48.9975);
@@ -124,6 +126,8 @@
   --border: oklch(0.2686 0 0);
   --input: var(--muted);
   --ring: oklch(0.7155 0 0);
+  --selection: color-mix(in oklab, var(--primary) 32%, transparent);
+  --selection-strong: color-mix(in oklab, var(--primary) 40%, transparent);
   --chart-1: oklch(0.8369 0.1644 84.4286);
   --chart-2: oklch(0.6658 0.1574 58.3183);
   --chart-3: oklch(0.4732 0.1247 46.2007);
@@ -197,6 +201,8 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+  --color-selection: var(--selection);
+  --color-selection-strong: var(--selection-strong);
   --color-chart-1: var(--chart-1);
   --color-chart-2: var(--chart-2);
   --color-chart-3: var(--chart-3);

--- a/frontend/packages/editor/src/blocknote/core/extensions/FullBlockSelection/full-block-selection.css
+++ b/frontend/packages/editor/src/blocknote/core/extensions/FullBlockSelection/full-block-selection.css
@@ -1,5 +1,5 @@
 .bn-full-block-selected {
-  background-color: #b4d5fe;
+  background-color: var(--selection-strong);
   border-radius: 4px;
   transition: background-color 0.15s ease;
 }
@@ -7,4 +7,9 @@
 .bn-full-block-selected ::selection,
 .bn-full-block-selected::selection {
   background: transparent;
+}
+
+.bn-container ::selection,
+.bn-container::selection {
+  background-color: var(--selection);
 }


### PR DESCRIPTION
## Summary
- Introduces `--selection` and `--selection-strong` design tokens (defined in both `frontend/apps/desktop/src/tailwind.css` and `frontend/apps/web/app/tailwind.css`) derived from `--primary` via `color-mix`, with tuned opacities per theme (22%/30% light, 32%/40% dark).
- Replaces the hardcoded `#b4d5fe` in `full-block-selection.css` with `var(--selection-strong)` and adds a `.bn-container ::selection` rule that uses `var(--selection)`, so both text and block selection read correctly against light- and dark-mode text.
- Fixes #489 — selected blocks no longer wash out the light-mode editor text in dark mode.

## Test plan
- [ ] `./dev build-desktop` → launch the app in dark mode, drag-select text across a paragraph → translucent teal highlight, text still legible
- [ ] Use the block drag handle (or shift-click) to fully select one or more blocks → stronger teal band, text stays readable, inner `::selection` remains transparent on selected blocks
- [ ] Toggle light mode → selection reads as a subtler teal, text still fully legible
- [ ] `pnpm web:prod` run → same behavior in the web app
- [ ] `pnpm test && pnpm typecheck && pnpm format:write && pnpm audit` all pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)