### PR TITLE
fix(feed): open comment items in main panel (closes #434)

### DIFF
--- a/frontend/packages/ui/src/feed.tsx
+++ b/frontend/packages/ui/src/feed.tsx
@@ -36,26 +36,15 @@ export function Feed({
   filterEventType,
   targetDomain,
   size = 'md',
-  navigationContext,
 }: {
   size?: 'sm' | 'md'
   filterResource: HMListEventsParams['filterResource']
   filterAuthors?: HMListEventsParams['filterAuthors']
   filterEventType?: HMListEventsParams['filterEventType']
   targetDomain?: string
-  navigationContext?: 'page' | 'panel'
 }) {
   const observerRef = useRef<IntersectionObserver>()
   const lastElementNodeRef = useRef<HTMLDivElement>(null)
-  const currentRoute = useNavRoute()
-
-  // Determine navigation context: 'page' means navigate to full discussions page
-  // 'panel' means navigate to document with discussions panel open
-  const useFullPageNavigation = useMemo(() => {
-    if (navigationContext) return navigationContext === 'page'
-    // Auto-detect: if we're on activity or discussions page, use full page navigation
-    return currentRoute.key === 'activity' || currentRoute.key === 'comments'
-  }, [navigationContext, currentRoute.key])
 
   const {data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, error, refetch} = useActivityFeed({
     filterResource,
@@ -153,7 +142,7 @@ export function Feed({
     <SelectionContent>
       <div>
         {allEvents.map((e) => {
-          const route = getEventRoute(e, useFullPageNavigation)
+          const route = getEventRoute(e)
 
           if (e.type == 'comment' && e.replyingComment) {
             return (
@@ -719,29 +708,15 @@ function formatUTC(date: Date) {
   return `${year}-${month}-${day} ${hours}:${minutes} (UTC)`
 }
 
-function getEventRoute(event: LoadedEvent, useFullPageNavigation: boolean = false): NavRoute | null {
+function getEventRoute(event: LoadedEvent): NavRoute | null {
   if (event.type == 'comment') {
-    // Navigate to the target document with discussions open and the comment focused
+    // Navigate to the full comments page with the comment focused in the main panel
     if (!event.target?.id || !event.comment) return null
 
-    if (useFullPageNavigation) {
-      // Navigate to full discussions page
-      return {
-        key: 'comments' as const,
-        id: event.target.id,
-        openComment: event.comment.id,
-      }
-    }
-
-    // Navigate to document with discussions panel
     return {
-      key: 'document' as const,
+      key: 'comments' as const,
       id: event.target.id,
-      panel: {
-        key: 'comments' as const,
-        id: event.target.id,
-        openComment: event.comment.id,
-      },
+      openComment: event.comment.id,
     }
   }
 
@@ -790,23 +765,12 @@ function getEventRoute(event: LoadedEvent, useFullPageNavigation: boolean = fals
     // Navigate to the target document (the document being cited)
     if (!event.source?.id) return null
 
-    // For comment citations, open the comment in discussions
+    // For comment citations, open the comment in the full comments page
     if (event.citationType === 'c' && event.comment) {
-      if (useFullPageNavigation) {
-        return {
-          key: 'comments' as const,
-          id: event.source.id,
-          openComment: event.comment.id,
-        }
-      }
       return {
-        key: 'document' as const,
+        key: 'comments' as const,
         id: event.source.id,
-        panel: {
-          key: 'comments' as const,
-          id: event.source.id,
-          openComment: event.comment.id,
-        },
+        openComment: event.comment.id,
       }
     }
 
@@ -840,11 +804,7 @@ function EventItem({
   size?: 'sm' | 'md'
 }) {
   const currentRoute = useNavRoute()
-  const linkProps = useRouteLink(route ? _.merge({}, currentRoute, route) : currentRoute, {
-    onClick: () => {
-      console.log('== link props clicked!!')
-    },
-  })
+  const linkProps = useRouteLink(route ? _.merge({}, currentRoute, route) : currentRoute)
 
   const tx = useTx()
   return (


### PR DESCRIPTION
## Summary
- Clicking a comment feed item now opens the comment in the **main panel** instead of the narrow right panel.
- URL shape changes from `<SITE>/<PATH>?panel=comments/<COMMENT_ID>` → `<SITE>/<PATH>/:comments/<COMMENT_ID>`.
- Applies to every context where the feed is rendered: home feed, `:activity`, account profile feed, desktop drafts feed, and the document's right-panel activity feed.
- Also covers comment citation events (citations of comments), which took the same right-panel path.

Closes #434.

## Implementation
Single-file change in `frontend/packages/ui/src/feed.tsx`:
- `getEventRoute()` now always returns `{ key: 'comments', id, openComment }` for comment and comment-citation events, dropping the old conditional that emitted a `{ key: 'document', panel: {...} }` route outside of `activity`/`comments` pages.
- Removed the unused `navigationContext` prop on `<Feed/>` and its `useFullPageNavigation` auto-detect memo (no caller was passing it).
- Cleaned up a stray `console.log('== link props clicked!!')` debug statement in `EventItem`.

Route serialization and parsing for the main-panel comments URL already existed on both web (`frontend/apps/web/app/routes/$.tsx`) and desktop (`frontend/apps/desktop/src/pages/main.tsx:383`), so no routing infrastructure changes were needed.

## Test plan
- [ ] Web: open a site with existing comments. Click a comment in the home feed → URL becomes `<site>/<path>/:comments/<commentId>` (no `?panel=`); comment renders in the main view.
- [ ] Web: repeat on `:activity`, account profile feed, and the document right-panel activity feed.
- [ ] Web: click a comment citation in the feed → navigates to the cited document's `/:comments/<commentId>`.
- [ ] Desktop: same scenarios; full-page comments view opens (no right panel sidecar).
- [ ] Cmd/meta-click a feed comment → opens the main-panel URL in a new window.

## Checks run
- `./dev build-desktop` ✅
- `pnpm web:prod` ✅
- `pnpm test` ✅ (373 passed / 39 files)
- `pnpm typecheck` ✅
- `pnpm format:write` ✅
- `pnpm audit` — 74 pre-existing dependency vulnerabilities (identical to `origin/main`); this PR does not touch dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)