### PR TITLE
fix(desktop): edit profile writes Account Profile blob (fixes #494)

### DIFF
--- a/.ai/todo.md
+++ b/.ai/todo.md
@@ -67,3 +67,30 @@ The advisories don't reach runtime code — `xmldom` is pulled in via `@electron
 - [ ] Revisit `ip < 2.0.2` (SSRF, no patch) — reaches us via `lighthouse > puppeteer-core` and `react-devtools`. Both are devDeps only. Track whether upstream publishes a fix, or swap `react-devtools` for the browser-extension equivalent so we stop shipping it as a dep.
 
 **Estimate:** 30 min if option 1 works; half a day if option 2 is needed; no-go otherwise.
+
+## 3. Web Edit Profile — switch to Account Profile blob (own PR)
+
+**Why:** Issue #494 fixed the desktop `EditProfileDialog` to call `grpcClient.documents.updateProfile` (writes the Account Profile blob) instead of `desktopUniversalClient.publishDocument` (which appended a `setMetadata` change to the home document). The web app's `updateProfile` helper in `frontend/apps/web/app/auth.tsx:240-271` still does the wrong thing — it builds `setMetadata` ops and calls `seedClient.publishDocument(..., signer)`, mutating the home doc.
+
+We deferred the web fix because the `UpdateProfile` RPC expects a daemon-resolved `signing_key_name`, but the web app holds a browser-held `CryptoKeyPair` and has no path to produce a server-signed Profile blob.
+
+**Scope (rough order):**
+
+- [ ] Add a `prepareProfileChange` (or similarly named) helper to `@shm/client` / `@shm/shared` that takes a `CryptoKeyPair` + `{ name, icon, description, account, timestamp }` and produces a signed Profile blob `{ data, cid }`. Mirror `backend/api/documents/v3alpha/blob_profile.go::NewProfile` so the browser-produced blob validates identically on the daemon side.
+- [ ] Publish via `seedClient.publish({ blobs: [{ data, cid }] })` — the existing icon-upload path already uses this primitive.
+- [ ] Rewrite `frontend/apps/web/app/auth.tsx::updateProfile` (≈lines 240-271) to build the Profile blob from form state and publish it. Preserve existing `description` by reading from the current `Account.profile.description` (not from `HMDocument.metadata`).
+- [ ] Update the `EditProfileDialog` caller at `auth.tsx:674` — the signature changes (it no longer needs `document`).
+- [ ] Walk other callers of `updateProfile` in `auth.tsx` (check `auth.tsx:659-708` and the account-creation flow around `createAccount`/`createIdentity` to confirm whether they should also write a Profile blob immediately instead of only a home-doc change).
+- [ ] Add a Vitest for the new `prepareProfileChange` helper (round-trip the blob through the daemon's verifier if possible).
+- [ ] Add an integration test (`tests/`) that signs in on web, edits profile, and asserts `Account.profile.name/icon` updates while the home document history does NOT gain a new change.
+- [ ] `pnpm --filter @shm/web typecheck`, `pnpm --filter @shm/web test`, manual smoke test in browser.
+
+**Reference files:**
+
+- Desktop fix (done): `frontend/apps/desktop/src/components/edit-profile-dialog.tsx`.
+- Desktop test pattern: `frontend/apps/desktop/src/__tests__/edit-profile-dialog.test.tsx`.
+- Server-side Profile blob: `backend/api/documents/v3alpha/blob_profile.go::NewProfile`, `backend/api/documents/v3alpha/documents.go:927-967`.
+- Proto: `proto/documents/v3alpha/documents.proto::UpdateProfile` / `Profile`.
+- Read path (already coalesces profile → home-doc fallback): `frontend/packages/shared/src/account-metadata.ts:41-49`, `frontend/packages/shared/src/api-account.ts:22-47`.
+
+**Estimate:** ~half a day (most of it is getting the client-side Profile blob signing + CID generation to match the daemon exactly).

--- a/frontend/apps/desktop/src/__tests__/edit-profile-dialog.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/edit-profile-dialog.test.tsx
@@ -1,0 +1,246 @@
+import React from 'react'
+import {createRoot, Root} from 'react-dom/client'
+;(globalThis as typeof globalThis & {React?: typeof React}).React = React
+import {act} from 'react-dom/test-utils'
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+const updateProfileMock = vi.hoisted(() => vi.fn())
+const fileUploadMock = vi.hoisted(() => vi.fn())
+const invalidateQueriesMock = vi.hoisted(() => vi.fn())
+const useAccountMock = vi.hoisted(() => vi.fn())
+const toastSuccessMock = vi.hoisted(() => vi.fn())
+const capturedFormProps = vi.hoisted(() => ({current: null as any}))
+
+vi.mock('@/grpc-client', () => ({
+  grpcClient: {
+    documents: {
+      updateProfile: updateProfileMock,
+    },
+  },
+}))
+
+vi.mock('@/utils/file-upload', () => ({
+  fileUpload: fileUploadMock,
+}))
+
+vi.mock('@shm/shared', () => ({
+  queryKeys: {
+    ACCOUNT: 'ACCOUNT',
+    LIST_ACCOUNTS: 'LIST_ACCOUNTS',
+  },
+}))
+
+vi.mock('@shm/shared/models/entity', () => ({
+  useAccount: useAccountMock,
+}))
+
+vi.mock('@shm/shared/models/query-client', () => ({
+  invalidateQueries: invalidateQueriesMock,
+}))
+
+vi.mock('@shm/ui/components/dialog', async () => {
+  const React = await import('react')
+  return {
+    DialogTitle: ({children}: {children: React.ReactNode}) =>
+      React.createElement('h2', {'data-testid': 'dialog-title'}, children),
+  }
+})
+
+vi.mock('@shm/ui/edit-profile-form', async () => {
+  const React = await import('react')
+  return {
+    EditProfileForm: (props: any) => {
+      capturedFormProps.current = props
+      return React.createElement('div', {'data-testid': 'edit-profile-form'})
+    },
+  }
+})
+
+vi.mock('@shm/ui/spinner', async () => {
+  const React = await import('react')
+  return {
+    Spinner: () => React.createElement('div', {'data-testid': 'spinner'}),
+  }
+})
+
+vi.mock('@shm/ui/toast', () => ({
+  toast: {
+    success: toastSuccessMock,
+  },
+}))
+
+vi.mock('@shm/ui/universal-dialog', () => ({
+  useAppDialog: vi.fn(),
+}))
+
+import {EditProfileDialog} from '../components/edit-profile-dialog'
+
+const ACCOUNT_UID = 'z6MkaccountExampleUid'
+
+function renderDialog(onClose: () => void) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  const queryClient = new QueryClient({
+    defaultOptions: {queries: {retry: false}},
+  })
+
+  act(() => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <EditProfileDialog onClose={onClose} input={{accountUid: ACCOUNT_UID}} />
+      </QueryClientProvider>,
+    )
+  })
+
+  return {container, root, queryClient}
+}
+
+function cleanup(root: Root, container: HTMLDivElement, queryClient: QueryClient) {
+  act(() => {
+    root.unmount()
+  })
+  queryClient.clear()
+  container.remove()
+}
+
+describe('EditProfileDialog', () => {
+  beforeEach(() => {
+    ;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+    updateProfileMock.mockReset()
+    updateProfileMock.mockResolvedValue(undefined)
+    fileUploadMock.mockReset()
+    invalidateQueriesMock.mockReset()
+    useAccountMock.mockReset()
+    toastSuccessMock.mockReset()
+    capturedFormProps.current = null
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('calls UpdateProfile RPC with current name, existing ipfs icon, and preserved description on submit', async () => {
+    useAccountMock.mockReturnValue({
+      isLoading: false,
+      data: {
+        metadata: {
+          name: 'Old Name',
+          icon: 'ipfs://oldiconcid',
+          summary: 'Existing description',
+        },
+      },
+    })
+
+    const onClose = vi.fn()
+    const {container, root, queryClient} = renderDialog(onClose)
+
+    expect(capturedFormProps.current).not.toBeNull()
+    expect(capturedFormProps.current.defaultValues).toEqual({
+      name: 'Old Name',
+      icon: 'ipfs://oldiconcid',
+    })
+
+    await act(async () => {
+      await capturedFormProps.current.onSubmit({name: 'New Name', icon: 'ipfs://oldiconcid'})
+    })
+
+    expect(fileUploadMock).not.toHaveBeenCalled()
+    expect(updateProfileMock).toHaveBeenCalledTimes(1)
+    expect(updateProfileMock).toHaveBeenCalledWith({
+      account: ACCOUNT_UID,
+      profile: {
+        name: 'New Name',
+        icon: 'ipfs://oldiconcid',
+        description: 'Existing description',
+      },
+      signingKeyName: ACCOUNT_UID,
+    })
+    expect(invalidateQueriesMock).toHaveBeenCalledWith(['ACCOUNT', ACCOUNT_UID])
+    expect(invalidateQueriesMock).toHaveBeenCalledWith(['LIST_ACCOUNTS'])
+    expect(toastSuccessMock).toHaveBeenCalledWith('Profile updated')
+    expect(onClose).toHaveBeenCalledTimes(1)
+
+    cleanup(root, container, queryClient)
+  })
+
+  it('uploads a new icon blob and passes the resulting ipfs URI', async () => {
+    useAccountMock.mockReturnValue({
+      isLoading: false,
+      data: {
+        metadata: {
+          name: 'Alice',
+          icon: '',
+          summary: '',
+        },
+      },
+    })
+    fileUploadMock.mockResolvedValue('newcid123')
+
+    const onClose = vi.fn()
+    const {container, root, queryClient} = renderDialog(onClose)
+
+    const blob = new Blob([new Uint8Array([1, 2, 3])], {type: 'image/png'})
+    await act(async () => {
+      await capturedFormProps.current.onSubmit({name: 'Alice', icon: blob})
+    })
+
+    expect(fileUploadMock).toHaveBeenCalledTimes(1)
+    const uploadedFile = fileUploadMock.mock.calls[0][0]
+    expect(uploadedFile).toBeInstanceOf(File)
+    expect((uploadedFile as File).name).toBe('icon')
+
+    expect(updateProfileMock).toHaveBeenCalledWith({
+      account: ACCOUNT_UID,
+      profile: {
+        name: 'Alice',
+        icon: 'ipfs://newcid123',
+        description: '',
+      },
+      signingKeyName: ACCOUNT_UID,
+    })
+
+    cleanup(root, container, queryClient)
+  })
+
+  it('passes an empty icon string when no icon is set', async () => {
+    useAccountMock.mockReturnValue({
+      isLoading: false,
+      data: {
+        metadata: {
+          name: '',
+          icon: undefined,
+          summary: undefined,
+        },
+      },
+    })
+
+    const onClose = vi.fn()
+    const {container, root, queryClient} = renderDialog(onClose)
+
+    await act(async () => {
+      await capturedFormProps.current.onSubmit({name: 'Bob', icon: null})
+    })
+
+    expect(fileUploadMock).not.toHaveBeenCalled()
+    expect(updateProfileMock).toHaveBeenCalledWith({
+      account: ACCOUNT_UID,
+      profile: {name: 'Bob', icon: '', description: ''},
+      signingKeyName: ACCOUNT_UID,
+    })
+
+    cleanup(root, container, queryClient)
+  })
+
+  it('renders spinner while account is loading', () => {
+    useAccountMock.mockReturnValue({isLoading: true, data: undefined})
+
+    const {container, root, queryClient} = renderDialog(() => {})
+
+    expect(container.querySelector('[data-testid="spinner"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="edit-profile-form"]')).toBeNull()
+
+    cleanup(root, container, queryClient)
+  })
+})

--- a/frontend/apps/desktop/src/components/edit-profile-dialog.tsx
+++ b/frontend/apps/desktop/src/components/edit-profile-dialog.tsx
@@ -1,57 +1,50 @@
-import {desktopUniversalClient} from '@/desktop-universal-client'
+import {grpcClient} from '@/grpc-client'
 import {fileUpload} from '@/utils/file-upload'
-import {HMPrepareDocumentChangeInput} from '@seed-hypermedia/client/hm-types'
-import {hmId, queryKeys} from '@shm/shared'
-import {useAccount, useResource} from '@shm/shared/models/entity'
+import {queryKeys} from '@shm/shared'
+import {useAccount} from '@shm/shared/models/entity'
 import {invalidateQueries} from '@shm/shared/models/query-client'
 import {DialogTitle} from '@shm/ui/components/dialog'
 import {EditProfileForm, SiteMetaFields} from '@shm/ui/edit-profile-form'
 import {Spinner} from '@shm/ui/spinner'
+import {toast} from '@shm/ui/toast'
 import {useAppDialog} from '@shm/ui/universal-dialog'
 
 export function useEditProfileDialog() {
   return useAppDialog<{accountUid: string}>(EditProfileDialog)
 }
 
-function EditProfileDialog({onClose, input}: {onClose: () => void; input: {accountUid: string}}) {
+export function EditProfileDialog({onClose, input}: {onClose: () => void; input: {accountUid: string}}) {
   const {accountUid} = input
   const account = useAccount(accountUid)
-  const accountDocument = useResource(account.data?.id)
-  const document = accountDocument?.data?.type === 'document' ? accountDocument.data.document : undefined
+  const metadata = account.data?.metadata ?? undefined
 
   async function handleSubmit(updates: SiteMetaFields) {
-    const changes: HMPrepareDocumentChangeInput['changes'] = []
-
-    if (updates.name && updates.name !== document?.metadata?.name) {
-      changes.push({op: {case: 'setMetadata', value: {key: 'name', value: updates.name}}})
-    }
-
-    if (updates.icon && typeof updates.icon !== 'string') {
+    let iconUri = ''
+    if (updates.icon instanceof Blob) {
       const cid = await fileUpload(new File([updates.icon], 'icon'))
-      changes.push({op: {case: 'setMetadata', value: {key: 'icon', value: `ipfs://${cid}`}}})
+      iconUri = `ipfs://${cid}`
+    } else if (typeof updates.icon === 'string' && updates.icon) {
+      iconUri = updates.icon
     }
 
-    if (changes.length === 0) {
-      onClose()
-      return
-    }
-
-    await desktopUniversalClient.publishDocument!({
-      signerAccountUid: accountUid,
+    await grpcClient.documents.updateProfile({
       account: accountUid,
-      changes,
+      profile: {
+        name: updates.name ?? '',
+        icon: iconUri,
+        description: metadata?.summary ?? '',
+      },
+      signingKeyName: accountUid,
     })
 
-    const id = hmId(accountUid)
-    invalidateQueries([queryKeys.ENTITY, id.id])
-    invalidateQueries([queryKeys.RESOLVED_ENTITY, id.id])
-    invalidateQueries([queryKeys.ACCOUNT, id.uid])
-    invalidateQueries([queryKeys.DOCUMENT_ACTIVITY])
+    invalidateQueries([queryKeys.ACCOUNT, accountUid])
+    invalidateQueries([queryKeys.LIST_ACCOUNTS])
 
+    toast.success('Profile updated')
     onClose()
   }
 
-  if (account.isLoading || accountDocument?.isLoading) {
+  if (account.isLoading) {
     return (
       <>
         <DialogTitle>Edit Profile</DialogTitle>
@@ -67,8 +60,8 @@ function EditProfileDialog({onClose, input}: {onClose: () => void; input: {accou
       <DialogTitle>Edit Profile</DialogTitle>
       <EditProfileForm
         defaultValues={{
-          name: account.data?.metadata?.name || '',
-          icon: account.data?.metadata?.icon || null,
+          name: metadata?.name || '',
+          icon: metadata?.icon || null,
         }}
         onSubmit={handleSubmit}
       />

--- a/frontend/apps/web/app/auth.tsx
+++ b/frontend/apps/web/app/auth.tsx
@@ -698,7 +698,10 @@ export function EditProfileDialog({onClose, input}: {onClose: () => void; input:
             icon: account.data?.metadata?.icon || null,
           }}
           onSubmit={(newValues) => {
-            update.mutateAsync(newValues).then(() => onClose())
+            update.mutateAsync(newValues).then(() => {
+              toast.success(tx('Profile updated'))
+              onClose()
+            })
           }}
           processImage={optimizeImage}
         />


### PR DESCRIPTION
## Summary

- Fixes #494. Desktop `EditProfileDialog` now calls `grpcClient.documents.updateProfile` (writes the Account Profile blob) instead of `desktopUniversalClient.publishDocument` (which was appending a `setMetadata` change to the home document). Onboarding already did this correctly; the edit-profile flow had drifted.
- Adds a "Profile updated" success toast on both desktop and web.
- Adds Vitest coverage for the updated desktop dialog (4 cases: name-only edit preserves description, Blob icon triggers `fileUpload` → `ipfs://<cid>`, empty icon stays empty, spinner while loading — and asserts the success toast).
- Logs a follow-up in `.ai/todo.md` to migrate the web `updateProfile` helper off `publishDocument` (requires a client-signed Profile blob helper since browser-held `CryptoKeyPair` cannot call the server-managed `UpdateProfile` RPC).

The shared read path (`frontend/packages/shared/src/account-metadata.ts::accountMetadataFromAccount`, `api-account.ts::loadAccount`) already prefers `Account.profile.{name,icon,description}` over the deprecated `Account.metadata.*`, so once desktop writes to the Profile blob, `useAccount(uid)` reflects the update without any read-path change.

## Test plan

- [x] `./dev build-desktop`
- [x] `pnpm web:prod`
- [x] `pnpm test` (377 desktop unit + 4 new edit-profile-dialog cases pass)
- [x] `pnpm typecheck`
- [x] `pnpm format:write` (no diff)
- [ ] `pnpm audit` — fails, but only on pre-existing CVEs on `main` (electron <39.8.5, xmldom, ip, etc.); my commit has zero dep changes. Tracked in `.ai/todo.md` section 2.
- [ ] Manual: open desktop app, Edit Profile, change name + icon, save; confirm no new home-doc history entry, profile name/icon updates, success toast fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)