### PR TITLE
fix(editor): restore #<space> heading shortcut in nested blocks

### DIFF
--- a/frontend/packages/editor/src/blocknote/core/__tests__/heading-input-rule.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/__tests__/heading-input-rule.test.ts
@@ -1,0 +1,139 @@
+import {TextSelection} from 'prosemirror-state'
+import {describe, expect, it} from 'vitest'
+import {BlockNoteEditor} from '../BlockNoteEditor'
+import type {Block, PartialBlock} from '../extensions/Blocks/api/blockTypes'
+
+/**
+ * Regression tests for issue #490 — the `#<space>` markdown shortcut must
+ * convert a paragraph into a heading regardless of where the paragraph sits
+ * in the block tree.
+ *
+ * The hmBlockSchema editor uses HMHeadingBlockContent, which historically
+ * resolved the enclosing block with hard-coded `$pos.start() - 2` math. That
+ * only worked for paragraphs directly under the top-level `blockChildren`
+ * node; nesting the paragraph (under another block, blockquote, grid cell)
+ * shifted the depth and the rule silently no-oped, leaving `# ` literal.
+ */
+
+type PartialAnyBlock = PartialBlock<any>
+
+function createEditor(initialContent: PartialAnyBlock[]) {
+  return new BlockNoteEditor({
+    initialContent,
+  })
+}
+
+/**
+ * Drive a character through the same `handleTextInput` pipeline the browser
+ * would — that's where prosemirror/tiptap input rules hook in. A bare
+ * `tr.insertText` would bypass the rules.
+ */
+function typeText(editor: BlockNoteEditor<any>, text: string) {
+  const view = editor._tiptapEditor.view
+  const {from, to} = view.state.selection
+  const handled = view.someProp('handleTextInput', (fn) => fn(view, from, to, text))
+  if (!handled) {
+    view.dispatch(view.state.tr.insertText(text, from, to))
+  }
+}
+
+function placeCursorInBlock(editor: BlockNoteEditor<any>, blockId: string, offset = 0) {
+  const view = editor._tiptapEditor.view
+  let target: number | null = null
+  view.state.doc.descendants((node, pos) => {
+    if (target !== null) return false
+    if (node.type.name === 'blockNode' && node.attrs.id === blockId) {
+      target = pos + 1 /* enter blockNode */ + 1 /* enter blockContent */ + offset
+      return false
+    }
+    return true
+  })
+  if (target === null) throw new Error(`Block "${blockId}" not found`)
+  const tr = view.state.tr.setSelection(TextSelection.create(view.state.doc, target))
+  view.dispatch(tr)
+}
+
+function findBlockById(blocks: Block<any>[], id: string): Block<any> | undefined {
+  for (const block of blocks) {
+    if (block.id === id) return block
+    const nested = findBlockById(block.children, id)
+    if (nested) return nested
+  }
+  return undefined
+}
+
+describe('Heading `#<space>` input rule (issue #490)', () => {
+  it('converts a top-level paragraph to a heading on `# `', () => {
+    const editor = createEditor([{id: 'b1', type: 'paragraph'}])
+    placeCursorInBlock(editor, 'b1')
+
+    typeText(editor, '#')
+    typeText(editor, ' ')
+
+    const block = findBlockById(editor.topLevelBlocks, 'b1')
+    expect(block?.type).toBe('heading')
+
+    editor._tiptapEditor.destroy()
+  })
+
+  it('converts a NESTED paragraph (child of another block) to a heading on `# `', () => {
+    // The regression case from issue #490: a paragraph nested as a child of
+    // another block sits one depth deeper in the doc, so the old
+    // `$pos.start() - 2` math pointed at the wrong node and silently no-oped.
+    const editor = createEditor([
+      {
+        id: 'parent',
+        type: 'paragraph',
+        content: 'parent text',
+        children: [{id: 'child', type: 'paragraph'}],
+      },
+    ])
+    placeCursorInBlock(editor, 'child')
+
+    typeText(editor, '#')
+    typeText(editor, ' ')
+
+    const block = findBlockById(editor.topLevelBlocks, 'child')
+    expect(block?.type).toBe('heading')
+
+    editor._tiptapEditor.destroy()
+  })
+
+  it('converts a paragraph inside a Grid-children container to a heading on `# `', () => {
+    // Per product decision, heading creation IS allowed inside grid cells
+    // (unlike list/blockquote shortcuts which are blocked there).
+    const editor = createEditor([
+      {
+        id: 'parent',
+        type: 'paragraph',
+        content: 'parent text',
+        props: {childrenType: 'Grid'},
+        children: [{id: 'cell', type: 'paragraph'}],
+      },
+    ])
+    placeCursorInBlock(editor, 'cell')
+
+    typeText(editor, '#')
+    typeText(editor, ' ')
+
+    const block = findBlockById(editor.topLevelBlocks, 'cell')
+    expect(block?.type).toBe('heading')
+
+    editor._tiptapEditor.destroy()
+  })
+
+  it('does NOT convert when `#` is typed after existing text in the block', () => {
+    const editor = createEditor([{id: 'b1', type: 'paragraph', content: 'hello '}])
+    // Place cursor at end of "hello " — typing `# ` here must not match the
+    // `^#\s$` regex because there's already text at the block's start.
+    placeCursorInBlock(editor, 'b1', 'hello '.length)
+
+    typeText(editor, '#')
+    typeText(editor, ' ')
+
+    const block = findBlockById(editor.topLevelBlocks, 'b1')
+    expect(block?.type).toBe('paragraph')
+
+    editor._tiptapEditor.destroy()
+  })
+})

--- a/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/BlockContent/HeadingBlockContent/HeadingBlockContent.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/BlockContent/HeadingBlockContent/HeadingBlockContent.ts
@@ -2,6 +2,7 @@ import {updateBlockCommand} from '../../../../../api/blockManipulation/commands/
 import {InputRule, mergeAttributes} from '@tiptap/core'
 import {mergeCSSClasses} from '../../../../../shared/utils'
 import {createTipTapBlock} from '../../../api/block'
+import {getBlockInfoFromPos} from '../../../helpers/getBlockInfoFromPos'
 import styles from '../../Block.module.css'
 
 export const HeadingBlockContent = createTipTapBlock<'heading'>({
@@ -30,22 +31,20 @@ export const HeadingBlockContent = createTipTapBlock<'heading'>({
         return new InputRule({
           find: new RegExp(`^(#{${parseInt(level)}})\\s$`),
           handler: ({state, chain, range}) => {
+            // Resolve the nearest enclosing block regardless of nesting depth.
+            // The previous `$pos.start() - 2` math only held for paragraphs
+            // directly under the top-level blockChildren and silently no-oped
+            // when the cursor was inside a nested block.
+            const blockInfo = getBlockInfoFromPos(state, state.selection.from)
             chain()
-              // .BNUpdateBlock(state.selection.from, {
-              //   type: 'heading',
-              //   props: {
-              //     level: level,
-              //   },
-              // })
               .command(
-                updateBlockCommand(state.doc.resolve(state.selection.from).start() - 2, {
+                updateBlockCommand(blockInfo.block.beforePos, {
                   type: 'heading',
                   props: {
                     level: level,
                   },
                 }),
               )
-              // Removes the "#" character(s) used to set the heading.
               .deleteRange({from: range.from, to: range.to})
           },
         })

--- a/frontend/packages/editor/src/heading-component-plugin.tsx
+++ b/frontend/packages/editor/src/heading-component-plugin.tsx
@@ -1,5 +1,6 @@
 import {createTipTapBlock} from './blocknote/core/extensions/Blocks/api/block'
 import {updateBlockCommand} from './blocknote/core/api/blockManipulation/commands/updateBlock'
+import {getBlockInfoFromPos} from './blocknote/core/extensions/Blocks/helpers/getBlockInfoFromPos'
 import styles from './blocknote/core/extensions/Blocks/nodes/Block.module.css'
 import {InputRule, mergeAttributes} from '@tiptap/core'
 
@@ -24,23 +25,25 @@ export const HMHeadingBlockContent = createTipTapBlock<'heading'>({
 
   addInputRules() {
     return [
-      ...['1'].map((level) => {
-        return new InputRule({
-          find: new RegExp(`^#\\s$`),
-          handler: ({state, chain, range}) => {
-            chain()
-              .command(
-                updateBlockCommand(state.doc.resolve(state.selection.from).start() - 2, {
-                  type: 'heading',
-                  props: {
-                    level: '2',
-                  },
-                }),
-              )
-              // Removes the "#" character(s) used to set the heading.
-              .deleteRange({from: range.from, to: range.to})
-          },
-        })
+      new InputRule({
+        find: new RegExp(`^#\\s$`),
+        handler: ({state, chain, range}) => {
+          // Resolve the enclosing block regardless of nesting depth — the
+          // old `$pos.start() - 2` math assumed the paragraph was a direct
+          // child of the top-level blockChildren and silently no-oped for
+          // any nested paragraph (issue #490).
+          const blockInfo = getBlockInfoFromPos(state, state.selection.from)
+          chain()
+            .command(
+              updateBlockCommand(blockInfo.block.beforePos, {
+                type: 'heading',
+                props: {
+                  level: '2',
+                },
+              }),
+            )
+            .deleteRange({from: range.from, to: range.to})
+        },
       }),
     ]
   },


### PR DESCRIPTION
## Summary

- Fixes issue #490 — `#<space>` heading shortcut intermittently failed.
- Root cause: both heading input-rule handlers (`HMHeadingBlockContent` and core `HeadingBlockContent`) computed the target block position with hard-coded `state.doc.resolve(state.selection.from).start() - 2` arithmetic. That offset only resolves to the enclosing `blockNode`'s beforePos when the paragraph is a direct child of the top-level `blockChildren`. Any deeper nesting (list item children, grid cells, blockquote children, etc.) shifted the offset and the update silently no-oped, leaving `# ` as literal text. Intermittent repro on both new drafts and published docs matched the content-shape dependency.
- Fix: resolve the enclosing block via the existing `getBlockInfoFromPos` helper, which walks up to the nearest `blockNode` regardless of depth.

## Test plan

- [x] New regression test `frontend/packages/editor/src/blocknote/core/__tests__/heading-input-rule.test.ts` covers top-level, nested-under-another-block, grid-cell, and the mid-paragraph no-convert case — fails on `main`, passes with this fix.
- [x] `pnpm --filter @shm/editor test` — 92/92 pass.
- [x] `pnpm test` root aggregate — 373/373 pass.
- [x] `pnpm typecheck` — all 9 workspaces pass.
- [x] `./dev build-desktop` — packages successfully.
- [x] `pnpm web:prod` — SSR build succeeds.
- [x] `pnpm format:write` — clean.
- [ ] Manual desktop smoke test: `pnpm --filter @shm/desktop dev`, open a published document, enter edit mode, type `# <space>` at the start of an empty paragraph at top level, nested under a list item, and inside a grid cell — each should convert to a heading. Confirm typing `# <space>` after existing text does NOT convert.

## Follow-up (out of scope of this PR)

Headings no longer scale by nesting depth in the unified renderer (separate regression traced to commits `4cfa075dc` and `38fc1db75`). Plan drafted locally for a decoration-plugin + CSS restoration — will land in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)