### PR TITLE
refactor(desktop): consolidate find-in-page into app-windows

### DIFF
--- a/frontend/apps/desktop/src/app-api.ts
+++ b/frontend/apps/desktop/src/app-api.ts
@@ -7,7 +7,7 @@ import {grpcClient} from '@/grpc-client'
 import {HMHostConfigSchema, SiteDiscoverRequest} from '@seed-hypermedia/client/hm-types'
 import {defaultRoute, NavRoute, navRouteSchema} from '@shm/shared/routes'
 import {hypermediaUrlToRoute} from '@shm/shared/utils/url-to-route'
-import {app, BrowserWindow, dialog, ipcMain, NativeImage, WebContentsView} from 'electron'
+import {app, BrowserWindow, dialog, ipcMain, NativeImage} from 'electron'
 import {createIPCHandler} from 'electron-trpc/main'
 import {writeFile} from 'fs-extra'
 import path from 'path'
@@ -49,6 +49,7 @@ import {
   getSelectedIdentityFromWindowState,
   getWindowNavState,
   getWindowsState,
+  hideFindView,
 } from './app-windows'
 import * as log from './logger'
 ipcMain.on('invalidate_queries', (_event, info) => {
@@ -99,24 +100,19 @@ ipcMain.on('close_window', (_event, _info) => {
   getFocusedWindow()?.close()
 })
 
-ipcMain.on('find_in_page_query', (_event, _info) => {
-  getFocusedWindow()?.webContents?.findInPage(_info.query, {
-    findNext: _info.findNext,
-    forward: _info.forward,
+ipcMain.on('find_in_page_query', (_event, info: {query: string; findNext?: boolean; forward?: boolean}) => {
+  const focusedWindow = getFocusedWindow()
+  if (!focusedWindow || focusedWindow.webContents.isDestroyed()) return
+  focusedWindow.webContents.findInPage(info.query, {
+    findNext: info.findNext,
+    forward: info.forward,
   })
 })
 
 ipcMain.on('find_in_page_cancel', () => {
-  console.log('Cancelling search - empty query')
-  let focusedWindow = getFocusedWindow()
-  focusedWindow?.webContents?.stopFindInPage('keepSelection')
-  let findInPageView = focusedWindow?.contentView.children[0] as WebContentsView | undefined
-  if (findInPageView) {
-    findInPageView.setBounds({
-      ...findInPageView.getBounds(),
-      y: -200,
-    })
-  }
+  const focusedWindow = getFocusedWindow()
+  if (!focusedWindow) return
+  hideFindView(focusedWindow)
 })
 
 // duplicated logic with app-windows

--- a/frontend/apps/desktop/src/app-windows.ts
+++ b/frontend/apps/desktop/src/app-windows.ts
@@ -19,6 +19,18 @@ let windowIdCount = 1
 
 const allWindows = new Map<string, BrowserWindow>()
 
+// Per-window find-in-page overlay view. Kept alive after first show so
+// subsequent Ctrl+F presses are instant, but detached from the window's
+// contentView while hidden so transparent regions don't swallow clicks.
+const findViews = new WeakMap<BrowserWindow, WebContentsView>()
+
+const FIND_VIEW_WIDTH = 320
+const FIND_VIEW_HEIGHT = 44
+const FIND_VIEW_MARGIN = 12
+// Offset the view below the draggable title bar region so clicks on the card
+// don't get eaten by the window-drag handler.
+const FIND_VIEW_TOP_OFFSET = 48
+
 export function getAllWindows() {
   return allWindows
 }
@@ -105,9 +117,8 @@ export function broadcastUseDarkColors() {
   const darkColors = settingsTheme === 'system' ? nativeTheme.shouldUseDarkColors : settingsTheme === 'dark'
   allWindows.forEach((window) => {
     window.webContents.send('darkMode', darkColors)
-    // Also send to find-in-page view if it exists
-    const findView = window.contentView.children[0] as WebContentsView | undefined
-    if (findView) {
+    const findView = findViews.get(window)
+    if (findView && !findView.webContents.isDestroyed()) {
       findView.webContents.send('darkMode', darkColors)
     }
   })
@@ -409,8 +420,6 @@ export function createAppWindow(input: Partial<AppWindow> & {id?: string}): Brow
     trafficLightPosition: windowType.trafficLightPosition || undefined,
   })
 
-  createFindView(browserWindow)
-
   debug('Window created', {windowId})
 
   const windowLogger = childLogger(`seed/${windowId}`)
@@ -620,6 +629,8 @@ export function createAppWindow(input: Partial<AppWindow> & {id?: string}): Brow
   })
 
   browserWindow.on('close', () => {
+    destroyFindView(browserWindow)
+
     // Clean up daemon listener
     releaseDaemonListener()
 
@@ -662,49 +673,7 @@ export function createAppWindow(input: Partial<AppWindow> & {id?: string}): Brow
     globalShortcut.register('CommandOrControl+F', () => {
       const focusedWindow = getLastFocusedWindow()
       if (focusedWindow) {
-        let findInPageView = focusedWindow.contentView.children[0] as WebContentsView | undefined
-
-        info(`== ~ globalShortcut.register ~ findInPageView:`)
-
-        // Get current dark mode state
-        const darkColors = shouldUseDarkColors()
-
-        if (!findInPageView) {
-          info('[CMD+F]: no view present')
-          createFindView(focusedWindow)
-          // Get the newly created view and show it after it loads
-          findInPageView = focusedWindow.contentView.children[0] as WebContentsView | undefined
-          if (findInPageView) {
-            findInPageView.webContents.once('did-finish-load', () => {
-              // Send dark mode state to the view
-              findInPageView?.webContents.send('darkMode', darkColors)
-              findInPageView?.setBounds({
-                ...findInPageView.getBounds(),
-                y: 20,
-              })
-              setTimeout(() => {
-                findInPageView?.webContents.focus()
-                findInPageView?.webContents.send('appWindowEvent', {
-                  type: 'find_in_page',
-                })
-              }, 10)
-            })
-          }
-        } else {
-          info('[CMD+F]: view present', {bounds: findInPageView.getBounds()})
-          // Send dark mode state to the view
-          findInPageView.webContents.send('darkMode', darkColors)
-          findInPageView.setBounds({
-            ...findInPageView.getBounds(),
-            y: 20,
-          })
-          setTimeout(() => {
-            findInPageView?.webContents.focus()
-            findInPageView?.webContents.send('appWindowEvent', {
-              type: 'find_in_page',
-            })
-          }, 10)
-        }
+        showFindView(focusedWindow)
       }
     })
 
@@ -723,10 +692,14 @@ export function createAppWindow(input: Partial<AppWindow> & {id?: string}): Brow
     }
   })
 
-  browserWindow.webContents.on('found-in-page', (event, result) => {
-    // if (result.finalUpdate) {
-    //   browserWindow.webContents.stopFindInPage('clearSelection')
-    // }
+  browserWindow.webContents.on('found-in-page', (_event, result) => {
+    const view = findViews.get(browserWindow)
+    if (!view || view.webContents.isDestroyed()) return
+    view.webContents.send('find_in_page_result', {
+      activeMatchOrdinal: result.activeMatchOrdinal,
+      matches: result.matches,
+      finalUpdate: result.finalUpdate,
+    })
   })
 
   browserWindow.on('blur', () => {
@@ -762,39 +735,34 @@ export function createAppWindow(input: Partial<AppWindow> & {id?: string}): Brow
 }
 
 function updateFindInPageView(win: BrowserWindow) {
-  const bounds = win.getBounds()
-  const view = win.contentView.children[0] as WebContentsView | undefined
-  if (view) {
-    view.setBounds({
-      ...view.getBounds(),
-      x: bounds.width - 320,
-    })
-  }
+  const view = findViews.get(win)
+  if (!view || !win.contentView.children.includes(view)) return
+  positionFindView(win, view)
 }
 
-function createFindView(win: BrowserWindow) {
-  const {width} = win.getBounds()
+function positionFindView(win: BrowserWindow, view: WebContentsView) {
+  // Use content size (not getBounds().width) so the view stays inside the
+  // contentView coordinate space — getBounds() can include window chrome on
+  // some platforms and push the right edge past where child views render.
+  const [contentWidth] = win.getContentSize()
+  view.setBounds({
+    x: Math.max(FIND_VIEW_MARGIN, contentWidth - FIND_VIEW_WIDTH - FIND_VIEW_MARGIN),
+    y: FIND_VIEW_TOP_OFFSET,
+    width: FIND_VIEW_WIDTH,
+    height: FIND_VIEW_HEIGHT,
+  })
+}
 
+function createFindView(win: BrowserWindow): WebContentsView {
   const findView = new WebContentsView({
     webPreferences: {
       preload: path.join(__dirname, 'preload-find-in-page.js'),
     },
   })
 
-  // Set transparent background
+  // Set transparent background so the card rounded corners blend with the page.
   findView.setBackgroundColor('#00000000')
 
-  // Add the view to the window's content view
-  win.contentView.addChildView(findView)
-
-  findView.setBounds({
-    x: width - 320,
-    y: -200,
-    width: 320,
-    height: 100,
-  })
-
-  // Log errors from the find view
   findView.webContents.on('did-fail-load', (event, errorCode, errorDescription) => {
     warn('[FIND-VIEW]: Failed to load', {errorCode, errorDescription})
   })
@@ -815,6 +783,75 @@ function createFindView(win: BrowserWindow) {
     const filePath = path.join(__dirname, `../renderer/${FIND_IN_PAGE_VITE_NAME}/find.html`)
     info('[FIND-VIEW]: Loading file', {filePath})
     findView.webContents.loadFile(filePath)
+  }
+
+  findViews.set(win, findView)
+  return findView
+}
+
+export function showFindView(win: BrowserWindow) {
+  if (win.isDestroyed()) return
+  let view = findViews.get(win)
+  const darkColors = shouldUseDarkColors()
+
+  if (!view || view.webContents.isDestroyed()) {
+    view = createFindView(win)
+    const attach = () => {
+      if (win.isDestroyed() || !view) return
+      if (!win.contentView.children.includes(view)) {
+        win.contentView.addChildView(view)
+      }
+      positionFindView(win, view)
+      view.webContents.send('darkMode', darkColors)
+      view.webContents.focus()
+      view.webContents.send('appWindowEvent', {type: 'find_in_page'})
+    }
+    if (view.webContents.isLoading()) {
+      view.webContents.once('did-finish-load', attach)
+    } else {
+      attach()
+    }
+    return
+  }
+
+  if (!win.contentView.children.includes(view)) {
+    win.contentView.addChildView(view)
+  }
+  positionFindView(win, view)
+  view.webContents.send('darkMode', darkColors)
+  // Give the view focus on the next tick so keyboard targets the input.
+  setTimeout(() => {
+    if (view && !view.webContents.isDestroyed()) {
+      view.webContents.focus()
+      view.webContents.send('appWindowEvent', {type: 'find_in_page'})
+    }
+  }, 10)
+}
+
+export function hideFindView(win: BrowserWindow) {
+  if (win.isDestroyed()) return
+  const view = findViews.get(win)
+  if (view && win.contentView.children.includes(view)) {
+    win.contentView.removeChildView(view)
+  }
+  if (!win.webContents.isDestroyed()) {
+    win.webContents.stopFindInPage('clearSelection')
+  }
+  // Return focus to the host page so typing doesn't fall into a detached view.
+  if (!win.webContents.isDestroyed()) {
+    win.webContents.focus()
+  }
+}
+
+function destroyFindView(win: BrowserWindow) {
+  const view = findViews.get(win)
+  if (!view) return
+  findViews.delete(win)
+  if (!win.isDestroyed() && win.contentView.children.includes(view)) {
+    win.contentView.removeChildView(view)
+  }
+  if (!view.webContents.isDestroyed()) {
+    view.webContents.close()
   }
 }
 

--- a/frontend/apps/desktop/src/find-in-page.tsx
+++ b/frontend/apps/desktop/src/find-in-page.tsx
@@ -1,95 +1,142 @@
 // Find-in-page UI using vanilla JS to avoid React duplication issues
 import './tailwind.css'
 
-// Use window.ipc from preload (type-cast to avoid conflicts with main app types)
-const ipc = (window as any).ipc as {send: (cmd: string, args?: any) => void}
+type FindInPageResult = {
+  activeMatchOrdinal: number
+  matches: number
+  finalUpdate: boolean
+}
+
+const ipc = (window as any).ipc as {
+  send: (cmd: string, args?: any) => void
+}
 const appWindowEvents = (window as any).appWindowEvents as
   | {subscribe: (handler: (event: any) => void) => () => void}
   | undefined
 const darkModeStream = (window as any).darkMode as
   | {subscribe: (handler: (value: boolean) => void) => () => void}
   | undefined
+const findInPageResults = (window as any).findInPageResults as
+  | {subscribe: (handler: (result: FindInPageResult) => void) => () => void}
+  | undefined
 
-// Create the UI
 function createFindInPageUI() {
   const root = document.getElementById('root')
   if (!root) return
 
-  // Create wrapper with dark/light mode
   const wrapper = document.createElement('div')
   wrapper.className = 'light'
   wrapper.style.width = '100%'
   wrapper.style.height = '100%'
 
-  // Subscribe to dark mode changes
   darkModeStream?.subscribe((isDark: boolean) => {
     wrapper.className = isDark ? 'dark' : 'light'
   })
 
-  // Create container
-  const container = document.createElement('div')
-  container.className = 'fixed inset-0 flex items-center justify-center gap-2 p-4'
+  // Single-card container that fills the WebContentsView bounds exactly.
+  const card = document.createElement('div')
+  card.className = 'bg-panel border-border flex h-full w-full items-center overflow-hidden rounded-md border shadow-sm'
 
-  // Create input wrapper
-  const inputWrapper = document.createElement('div')
-  inputWrapper.className = 'flex flex-1 items-center'
+  // Input lives inside a relative wrap so the counter can sit absolutely over
+  // the right side of the field — this keeps the overall layout stable when
+  // the counter appears/disappears.
+  const inputWrap = document.createElement('div')
+  inputWrap.className = 'relative flex h-full min-w-0 flex-1 items-center'
 
-  // Create input
   const input = document.createElement('input')
   input.type = 'text'
-  input.placeholder = 'Find in page...'
-  input.className =
-    'bg-panel border-border text-foreground h-8 flex-1 rounded-sm border px-2 text-sm outline-none focus:ring-1 focus:ring-ring'
+  input.placeholder = 'Find in page…'
+  input.className = 'text-foreground h-full w-full border-0 bg-transparent pl-3 pr-16 text-sm outline-none focus:ring-0'
 
-  // Create button container
-  const buttonContainer = document.createElement('div')
-  buttonContainer.className = 'border-border bg-panel flex h-8 items-center overflow-hidden rounded-sm border'
+  const counter = document.createElement('span')
+  counter.className =
+    'text-muted-foreground pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-xs tabular-nums select-none'
+  counter.textContent = ''
 
-  // Create up button
-  const upButton = document.createElement('button')
-  upButton.type = 'button'
-  upButton.className = 'flex size-8 items-center justify-center text-foreground hover:bg-muted'
-  upButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"/></svg>`
+  inputWrap.appendChild(input)
+  inputWrap.appendChild(counter)
 
-  // Create down button
-  const downButton = document.createElement('button')
-  downButton.type = 'button'
-  downButton.className = 'flex size-8 items-center justify-center text-foreground hover:bg-muted'
-  downButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>`
+  const divider = document.createElement('div')
+  divider.className = 'bg-border mx-1 h-5 w-px'
 
-  // Create close button
-  const closeButton = document.createElement('button')
-  closeButton.type = 'button'
-  closeButton.className = 'flex size-8 items-center justify-center text-foreground hover:bg-muted'
-  closeButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>`
+  const makeIconButton = (svg: string, ariaLabel: string) => {
+    const btn = document.createElement('button')
+    btn.type = 'button'
+    btn.setAttribute('aria-label', ariaLabel)
+    btn.className = 'text-foreground hover:bg-muted flex size-9 shrink-0 items-center justify-center'
+    btn.innerHTML = svg
+    return btn
+  }
 
-  // State
+  const upButton = makeIconButton(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"/></svg>`,
+    'Previous match',
+  )
+  const downButton = makeIconButton(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>`,
+    'Next match',
+  )
+  const closeButton = makeIconButton(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>`,
+    'Close find',
+  )
+
   let query = ''
+  let matches = 0
+  let activeMatchOrdinal = 0
+  let hasActiveSearch = false
+
+  function updateCounter() {
+    if (query.length === 0 || matches === 0) {
+      counter.textContent = ''
+      divider.style.visibility = 'hidden'
+    } else {
+      counter.textContent = `${activeMatchOrdinal}/${matches}`
+      divider.style.visibility = ''
+    }
+  }
+  updateCounter()
+
+  function resetResult() {
+    matches = 0
+    activeMatchOrdinal = 0
+    hasActiveSearch = false
+    updateCounter()
+  }
 
   function clearFind() {
     query = ''
     input.value = ''
+    resetResult()
     ipc.send('find_in_page_cancel')
   }
 
-  function search(forward: boolean = true) {
-    if (query.length > 0) {
-      ipc.send('find_in_page_query', {
-        query,
-        findNext: false,
-        forward,
-      })
+  function navigate(forward: boolean) {
+    if (query.length === 0) return
+    if (!hasActiveSearch) {
+      // First query after a cleared/empty state: start a new search.
+      ipc.send('find_in_page_query', {query, findNext: false, forward})
+      hasActiveSearch = true
+    } else {
+      // Advance the cursor within the existing request so Chromium cycles.
+      ipc.send('find_in_page_query', {query, findNext: true, forward})
     }
   }
 
-  // Event handlers
   input.addEventListener('input', (e) => {
     query = (e.target as HTMLInputElement).value
     if (query.length === 0) {
+      resetResult()
       ipc.send('find_in_page_cancel')
-    } else {
-      ipc.send('find_in_page_query', {query, findNext: true})
+      return
     }
+    // `findNext: true` forces Chromium to stop the previous session and start
+    // a new one with this query — that's what makes each keystroke visibly
+    // repaint the page. `false` is "continue", which the engine coalesces
+    // when calls arrive faster than a scan completes (symptom: page only
+    // updates after Enter).
+    hasActiveSearch = true
+    ipc.send('find_in_page_query', {query, findNext: true, forward: true})
   })
 
   input.addEventListener('keydown', (e) => {
@@ -98,15 +145,14 @@ function createFindInPageUI() {
       clearFind()
     } else if (e.key === 'Enter') {
       e.preventDefault()
-      search(true)
+      navigate(!e.shiftKey)
     }
   })
 
-  upButton.addEventListener('click', () => search(false))
-  downButton.addEventListener('click', () => search(true))
+  upButton.addEventListener('click', () => navigate(false))
+  downButton.addEventListener('click', () => navigate(true))
   closeButton.addEventListener('click', clearFind)
 
-  // Global escape handler
   window.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') {
       e.preventDefault()
@@ -114,7 +160,13 @@ function createFindInPageUI() {
     }
   })
 
-  // Focus input on load and when find_in_page event is received
+  findInPageResults?.subscribe((result: FindInPageResult) => {
+    if (!result) return
+    matches = result.matches ?? 0
+    activeMatchOrdinal = result.activeMatchOrdinal ?? 0
+    updateCounter()
+  })
+
   setTimeout(() => {
     input.focus()
     input.select()
@@ -129,18 +181,15 @@ function createFindInPageUI() {
     }
   })
 
-  // Assemble the UI
-  inputWrapper.appendChild(input)
-  buttonContainer.appendChild(upButton)
-  buttonContainer.appendChild(downButton)
-  buttonContainer.appendChild(closeButton)
-  container.appendChild(inputWrapper)
-  container.appendChild(buttonContainer)
-  wrapper.appendChild(container)
+  card.appendChild(inputWrap)
+  card.appendChild(divider)
+  card.appendChild(upButton)
+  card.appendChild(downButton)
+  card.appendChild(closeButton)
+  wrapper.appendChild(card)
   root.appendChild(wrapper)
 }
 
-// Initialize when DOM is ready
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', createFindInPageUI)
 } else {

--- a/frontend/apps/desktop/src/main.ts
+++ b/frontend/apps/desktop/src/main.ts
@@ -550,17 +550,6 @@ function initializeIpcHandlers() {
     closeLoadingWindow()
   })
 
-  ipcMain.on('find_in_page_query', (_event, _info) => {
-    getFocusedWindow()?.webContents?.findInPage(_info.query, {
-      findNext: _info.findNext,
-      forward: _info.forward,
-    })
-  })
-
-  ipcMain.on('find_in_page_cancel', (_event) => {
-    getFocusedWindow()?.webContents?.stopFindInPage('clearSelection')
-  })
-
   // File and system operation handlers
   ipcMain.on('save-file', saveCidAsFile)
   ipcMain.on('export-document', saveMarkdownFile)

--- a/frontend/apps/desktop/src/preload-find-in-page.ts
+++ b/frontend/apps/desktop/src/preload-find-in-page.ts
@@ -25,6 +25,21 @@ ipcRenderer.addListener('darkMode', (info, state) => {
   updateDarkMode(state)
 })
 
+// Find-in-page result stream. Using the event-stream pattern (not the generic
+// ipc.listen) because contextBridge can't clone the IpcRendererEvent object
+// across isolated worlds, which silently drops the callback.
+type FindInPageResult = {
+  activeMatchOrdinal: number
+  matches: number
+  finalUpdate: boolean
+}
+const [dispatchFindInPageResult, findInPageResults] = eventStream<FindInPageResult>()
+contextBridge.exposeInMainWorld('findInPageResults', findInPageResults)
+
+ipcRenderer.addListener('find_in_page_result', (_info, payload: FindInPageResult) => {
+  dispatchFindInPageResult(payload)
+})
+
 contextBridge.exposeInMainWorld('ipc', {
   // @ts-expect-error
   send: (cmd, args) => {


### PR DESCRIPTION
## Summary

- **Fixes #392** — adds a match counter (`2/5`) to the find-in-page bar and fixes navigation cycling through occurrences
- Moves all find-in-page lifecycle logic (`createFindView`, `showFindView`, `hideFindView`, `destroyFindView`) into `app-windows.ts`, removing duplicated IPC handlers from `main.ts` and `app-api.ts`
- Introduces a `WeakMap<BrowserWindow, WebContentsView>` (`findViews`) so the overlay is created once per window and reused on subsequent Ctrl+F presses — avoiding cold-load delay after first open
- Switches view mounting strategy: the view is detached from `contentView` while hidden (instead of moved off-screen to `y: -200`), so transparent regions no longer swallow clicks on the host page
- Forwards `found-in-page` results from the host `BrowserWindow` to the overlay via a new `find_in_page_result` IPC event, exposing `activeMatchOrdinal` and `matches` to the UI
- Adds `findInPageResults` stream to the find-in-page preload via `contextBridge`, using the `eventStream` pattern to avoid `IpcRendererEvent` serialization issues across isolated worlds
- Uses `win.getContentSize()` instead of `win.getBounds().width` for overlay positioning so the card stays inside the `contentView` coordinate space on all platforms
- Restores focus to the host page (`win.webContents.focus()`) when the find bar is dismissed, preventing input from falling into a detached view
- Cleans up the view on `BrowserWindow` `close` via `destroyFindView` to prevent memory leaks
- Fixes the `findNext` flag semantics: each keystroke sends `findNext: true` to force Chromium to restart the scan, while navigation arrows send `findNext: true` to cycle within the existing session


---

Fixes #392