### PR TITLE
fix(shared): unify block/comment copy-link into buildCopyLinkUrl + useCopyHmLink

### DIFF
--- a/frontend/apps/desktop/src/models/documents.ts
+++ b/frontend/apps/desktop/src/models/documents.ts
@@ -46,7 +46,7 @@ import {
   extractDeletes,
   getDocAttributeChanges,
 } from '@shm/shared/utils/document-changes'
-import {createWebHMUrl, hmId, hmIdToURL, packHmId, unpackHmId} from '@shm/shared/utils/entity-id-url'
+import {buildCopyLinkUrl, hmId, hmIdToURL, packHmId, unpackHmId} from '@shm/shared/utils/entity-id-url'
 import {useNavRoute} from '@shm/shared/utils/navigation'
 import {entityQueryPathToHmIdPath, hmIdPathToEntityQueryPath} from '@shm/shared/utils/path-api'
 import {eventStream} from '@shm/shared/utils/stream'
@@ -601,13 +601,17 @@ export function useDraftEditor() {
       if (!editId) return undefined
       const siteHomeDoc = editHomeEntity.data?.type === 'document' ? editHomeEntity.data.document : undefined
       const siteHomeUrl = siteHomeDoc?.metadata?.siteUrl
-      // When copying a block link, include the version to ensure
-      // the block can be found in the correct document version
-      return createWebHMUrl(editId.uid, {
-        path: editId.path,
-        hostname: siteHomeUrl || gwUrl.get(),
-        blockRef: blockId,
-        version: blockId ? editDocument?.version : undefined,
+      // Set hostname only for true site URLs so buildCopyLinkUrl produces the
+      // site-style `/path` form. Without a siteUrl, use the configured gateway
+      // so `/hm/<uid>/path` is served off the user's chosen gateway host.
+      return buildCopyLinkUrl({
+        id: {
+          ...editId,
+          hostname: siteHomeUrl || null,
+          blockRef: blockId ?? null,
+          version: blockId ? editDocument?.version ?? null : null,
+        },
+        gatewayUrl: siteHomeUrl ? undefined : gwUrl.get(),
       })
     }
   }, [editId, editHomeEntity.data, editDocument?.version])

--- a/frontend/apps/desktop/src/pages/draft.tsx
+++ b/frontend/apps/desktop/src/pages/draft.tsx
@@ -30,6 +30,7 @@ import {
   UnpackedHypermediaId,
 } from '@seed-hypermedia/client/hm-types'
 import {BlockNoteEditor} from '@shm/editor/blocknote'
+import {blockHighlightPluginKey} from '@shm/editor/blocknote/core/extensions/BlockHighlight/BlockHighlightPlugin'
 import '@shm/editor/editor.css'
 import {chromiumSupportedImageMimeTypes, chromiumSupportedVideoMimeTypes, generateBlockId} from '@shm/editor/utils'
 import {CommentsProvider} from '@shm/shared/comments-service-provider'
@@ -684,6 +685,11 @@ function DocumentEditor({
                       onSupernumberClick={
                         editId
                           ? (blockId) => {
+                              // Open the comments panel focused on the block
+                              // and highlight + scroll the block directly.
+                              // (Draft routes don't carry a blockRef, so we
+                              // dispatch on the editor instead of relying on
+                              // a focusBlockId prop.)
                               replace({
                                 ...route,
                                 panel: {
@@ -692,6 +698,17 @@ function DocumentEditor({
                                   targetBlockId: blockId,
                                 },
                               })
+                              const view = editor?._tiptapEditor?.view
+                              if (view) {
+                                view.dispatch(
+                                  view.state.tr.setMeta(blockHighlightPluginKey, {
+                                    type: 'focus',
+                                    blockId,
+                                  }),
+                                )
+                              }
+                              const el = window.document.getElementById(blockId)
+                              if (el) el.scrollIntoView({behavior: 'smooth', block: 'start'})
                             }
                           : undefined
                       }

--- a/frontend/apps/web/app/providers.tsx
+++ b/frontend/apps/web/app/providers.tsx
@@ -1,6 +1,6 @@
 import {useLocation, useNavigate, useNavigation} from '@remix-run/react'
 import {UnpackedHypermediaId} from '@seed-hypermedia/client'
-import {createWebHMUrl, NavRoute, OptimizedImageSize, routeToHref, UniversalAppProvider} from '@shm/shared'
+import {NavRoute, OptimizedImageSize, routeToHref, UniversalAppProvider} from '@shm/shared'
 import {DAEMON_FILE_URL, SEED_ASSET_HOST, SITE_BASE_URL} from '@shm/shared/constants'
 import {languagePacks} from '@shm/shared/language-packs'
 import {registerQueryClient} from '@shm/shared/models/query-client'
@@ -10,7 +10,7 @@ import {isHttpUrl, NavAction, NavContextProvider, NavState, navStateReducer} fro
 import {hypermediaUrlToRoute} from '@shm/shared/utils/url-to-route'
 import type {StateStream} from '@shm/shared/utils/stream'
 import {writeableStateStream} from '@shm/shared/utils/stream'
-import {copyTextToClipboard} from '@shm/ui/copy-to-clipboard'
+import {useCopyHmLink} from '@shm/ui/use-copy-hm-link'
 import {Spinner} from '@shm/ui/spinner'
 import {toast, Toaster} from '@shm/ui/toast'
 import {TooltipProvider} from '@shm/ui/tooltip'
@@ -273,6 +273,7 @@ export function WebSiteProvider(props: {
   // Track whether navigation was initiated by openRoute (vs browser back/forward)
   const isInternalNav = useMemo(() => ({current: false}), [])
   const location = useLocation()
+  const copyHmLink = useCopyHmLink()
 
   // Sync browser back/forward into NavContext
   // When Remix re-runs the loader on popstate, initialRoute updates but NavContext
@@ -354,12 +355,12 @@ export function WebSiteProvider(props: {
         }
       }}
       onCopyReference={async (hmId: UnpackedHypermediaId) => {
-        const url = createWebHMUrl(hmId.uid, {
-          ...hmId,
-          hostname: SITE_BASE_URL,
+        // Keep the link pointing at this deployment's origin (passed as the
+        // gateway URL) so gateway-format links (/hm/<uid>/...) resolve here.
+        await copyHmLink({
+          id: {...hmId, hostname: null},
+          gatewayUrl: SITE_BASE_URL,
         })
-        copyTextToClipboard(url)
-        toast.success('Comment link copied to clipboard')
       }}
     >
       <NavContextProvider value={navigation}>{props.children}</NavContextProvider>

--- a/frontend/packages/editor/src/blocknote/react/BlockHoverActions/BlockHoverActionsPositioner.tsx
+++ b/frontend/packages/editor/src/blocknote/react/BlockHoverActions/BlockHoverActionsPositioner.tsx
@@ -124,17 +124,22 @@ export function BlockHoverActionsPositioner<BSchema extends BlockSchema = BlockS
   const rect = hoverState.referenceRect
   const blockId = hoverState.blockId
 
-  // Position the card above the top-right corner of the block so it does not
-  // overlap block content. We use a wrapper with padding-bottom to create an
-  // invisible bridge between the card and the block, so the mouse can travel
-  // from the block to the card without triggering a mouseleave.
+  // Anchor the card to the top-right of the block, nudged up by 16px so it
+  // sits slightly above the block's first line (keeps positioning consistent
+  // regardless of block height — tall blocks no longer place the card in the
+  // middle). The wrapper overlaps the block by ~8px on its left side so the
+  // cursor can travel from the block into the buttons without crossing a gap
+  // and losing hover; small padding on the right keeps outward mouse travel
+  // forgiving too.
+  const OVERLAP_PX = 8
+  const TOP_OFFSET_PX = -16
   const style: React.CSSProperties = {
     position: 'fixed',
-    top: rect.top,
-    left: rect.right + 4,
-    transform: 'translate(-100%, -100%)',
+    top: rect.top + TOP_OFFSET_PX,
+    left: rect.right - OVERLAP_PX,
     zIndex: 50,
-    paddingBottom: 8,
+    paddingLeft: OVERLAP_PX,
+    paddingRight: 4,
   }
 
   return (

--- a/frontend/packages/editor/src/document-editor.tsx
+++ b/frontend/packages/editor/src/document-editor.tsx
@@ -509,7 +509,7 @@ export function DocumentEditor({
         <ImageGalleryOverlay editor={editor} resolveImageUrl={getImageUrl} />
         <BlockHoverActionsPositioner
           editor={editor}
-          onCopyBlockLink={onBlockCitationClick ? (blockId) => onBlockCitationClick(blockId) : undefined}
+          onCopyBlockLink={onBlockSelect ? (blockId) => onBlockSelect(blockId, {copyToClipboard: true}) : undefined}
           onStartComment={onBlockCommentClick ? (blockId) => onBlockCommentClick(blockId, undefined, true) : undefined}
         />
         <RangeSelectionPositioner

--- a/frontend/packages/shared/src/utils/__tests__/entity-id-url.test.ts
+++ b/frontend/packages/shared/src/utils/__tests__/entity-id-url.test.ts
@@ -1,5 +1,7 @@
 import {describe, expect, test} from 'vitest'
+import {DEFAULT_GATEWAY_URL} from '../../constants'
 import {
+  buildCopyLinkUrl,
   createCommentUrl,
   createOSProtocolUrl,
   createSiteUrl,
@@ -1184,5 +1186,161 @@ describe('packHmId with latest and version', () => {
 
   test('omits ?l when no version', () => {
     expect(packHmId(hmId('abc', {latest: true}))).toBe('hm://abc')
+  })
+})
+
+describe('buildCopyLinkUrl', () => {
+  const gatewayId = hmId('z6MkOwner', {path: ['doc-path']})
+  // Derived from the env so tests work under both hyper.media and dev.hyper.media
+  const GW = DEFAULT_GATEWAY_URL
+
+  test('plain document (gateway) — no version, no fragment', () => {
+    expect(buildCopyLinkUrl({id: gatewayId})).toBe(`${GW}/hm/z6MkOwner/doc-path`)
+  })
+
+  test('document with version → ?v=…', () => {
+    expect(
+      buildCopyLinkUrl({
+        id: hmId('z6MkOwner', {path: ['doc-path'], version: 'v1hash'}),
+      }),
+    ).toBe(`${GW}/hm/z6MkOwner/doc-path?v=v1hash`)
+  })
+
+  test('block link (blockRef + version, no blockRange) auto-expands with +', () => {
+    expect(
+      buildCopyLinkUrl({
+        id: hmId('z6MkOwner', {
+          path: ['doc-path'],
+          version: 'v1hash',
+          blockRef: 'XK6l8B4d',
+        }),
+      }),
+    ).toBe(`${GW}/hm/z6MkOwner/doc-path?v=v1hash#XK6l8B4d+`)
+  })
+
+  test('explicit {expanded:false} is respected (no +)', () => {
+    expect(
+      buildCopyLinkUrl({
+        id: hmId('z6MkOwner', {
+          path: ['doc-path'],
+          version: 'v1hash',
+          blockRef: 'XK6l8B4d',
+          blockRange: {expanded: false},
+        }),
+      }),
+    ).toBe(`${GW}/hm/z6MkOwner/doc-path?v=v1hash#XK6l8B4d`)
+  })
+
+  test('fragment link (blockRef + {start,end}) produces [start:end]', () => {
+    expect(
+      buildCopyLinkUrl({
+        id: hmId('z6MkOwner', {
+          path: ['doc-path'],
+          version: 'v1hash',
+          blockRef: 'blk1',
+          blockRange: {start: 10, end: 20},
+        }),
+      }),
+    ).toBe(`${GW}/hm/z6MkOwner/doc-path?v=v1hash#blk1[10:20]`)
+  })
+
+  test('site-style URL when hostname is set', () => {
+    expect(
+      buildCopyLinkUrl({
+        id: hmId('z6MkOwner', {
+          path: ['doc-path'],
+          version: 'v1hash',
+          blockRef: 'blk1',
+          hostname: 'https://example.com',
+        }),
+      }),
+    ).toBe('https://example.com/doc-path?v=v1hash#blk1+')
+  })
+
+  test('comment link only (no blockRef) — delegates to createCommentUrl', () => {
+    const commentId = hmId('z6MkAuthor', {path: ['tsid123']})
+    expect(
+      buildCopyLinkUrl({
+        id: hmId('z6MkOwner', {path: ['doc-path']}),
+        commentId,
+      }),
+    ).toContain('/hm/z6MkOwner/doc-path/:comments/z6MkAuthor/tsid123')
+  })
+
+  test('comment link with commentVersion (on commentId) and latest (on docId)', () => {
+    const commentId = hmId('z6MkAuthor', {path: ['tsid123'], version: 'cVer'})
+    expect(
+      buildCopyLinkUrl({
+        id: hmId('z6MkOwner', {path: ['doc-path'], latest: true, hostname: 'https://example.com'}),
+        commentId,
+      }),
+    ).toBe('https://example.com/doc-path/:comments/z6MkAuthor/tsid123?v=cVer&l')
+  })
+
+  test('comment + blockRef auto-expands with +', () => {
+    const commentId = hmId('z6MkAuthor', {path: ['tsid123']})
+    expect(
+      buildCopyLinkUrl({
+        id: hmId('z6MkOwner', {
+          path: ['doc-path'],
+          blockRef: 'blk1',
+          hostname: 'https://example.com',
+        }),
+        commentId,
+      }),
+    ).toBe('https://example.com/doc-path/:comments/z6MkAuthor/tsid123#blk1+')
+  })
+
+  test('comment + blockRef + {start,end}', () => {
+    const commentId = hmId('z6MkAuthor', {path: ['tsid123']})
+    expect(
+      buildCopyLinkUrl({
+        id: hmId('z6MkOwner', {
+          path: ['doc-path'],
+          blockRef: 'blk1',
+          blockRange: {start: 10, end: 20},
+          hostname: 'https://example.com',
+        }),
+        commentId,
+      }),
+    ).toBe('https://example.com/doc-path/:comments/z6MkAuthor/tsid123#blk1[10:20]')
+  })
+
+  test('gatewayUrl overrides the default gateway host', () => {
+    expect(
+      buildCopyLinkUrl({
+        id: hmId('z6MkOwner', {path: ['doc-path'], version: 'v1'}),
+        gatewayUrl: 'https://custom-gateway.example',
+      }),
+    ).toBe('https://custom-gateway.example/hm/z6MkOwner/doc-path?v=v1')
+  })
+
+  test('block link roundtrips through unpackHmId (blockRef + expanded)', () => {
+    const url = buildCopyLinkUrl({
+      id: hmId('abc123', {
+        path: ['some-doc'],
+        version: 'v1hash',
+        blockRef: 'XK6l8B4d',
+      }),
+    })
+    const unpacked = unpackHmId(url)
+    expect(unpacked?.uid).toBe('abc123')
+    expect(unpacked?.version).toBe('v1hash')
+    expect(unpacked?.blockRef).toBe('XK6l8B4d')
+    expect(unpacked?.blockRange).toEqual({expanded: true})
+  })
+
+  test('fragment link roundtrips through unpackHmId ({start,end})', () => {
+    const url = buildCopyLinkUrl({
+      id: hmId('abc123', {
+        path: ['some-doc'],
+        version: 'v1hash',
+        blockRef: 'blk1',
+        blockRange: {start: 3, end: 7},
+      }),
+    })
+    const unpacked = unpackHmId(url)
+    expect(unpacked?.blockRef).toBe('blk1')
+    expect(unpacked?.blockRange).toEqual({start: 3, end: 7})
   })
 })

--- a/frontend/packages/shared/src/utils/entity-id-url.ts
+++ b/frontend/packages/shared/src/utils/entity-id-url.ts
@@ -248,6 +248,80 @@ export function createCommentUrl({
   })
 }
 
+/**
+ * Input for the unified copy-link builder. Describes the link target as an
+ * `UnpackedHypermediaId` (document-like or a comment's containing document),
+ * optionally with a separate `commentId: UnpackedHypermediaId` for the comment
+ * itself. All other link parameters (version, blockRef, blockRange, latest,
+ * hostname) are read from the respective ids.
+ *
+ * `id.hostname` acts as the site-vs-gateway flag: when set the URL is built in
+ * site-style (`<hostname>/<path>`); when null/undefined it falls back to the
+ * gateway-style `<gatewayUrl>/hm/<uid>/<path>` form. Callers with a custom
+ * gateway (e.g. the desktop app's user-configurable gateway) can override the
+ * default gateway via `gatewayUrl`.
+ */
+export type CopyLinkInput = {
+  id: UnpackedHypermediaId
+  commentId?: UnpackedHypermediaId | null
+  gatewayUrl?: string | null
+}
+
+/**
+ * Build a shareable URL for a document, block, fragment, comment, or a
+ * block/fragment inside a comment — a single entry point that replaces the
+ * scattered site/gateway/comment URL-building used for "Copy link" actions.
+ *
+ * Behavior:
+ * - `input.id.hostname` set → site-style URL via `createSiteUrl`.
+ * - `input.id.hostname` unset → gateway URL via `createWebHMUrl`.
+ * - `input.commentId` present → delegates to `createCommentUrl` using the
+ *   comment's uid+tsid as the comment identifier and the comment id's own
+ *   `version` as `commentVersion`.
+ * - If `blockRef` is present on `input.id` and `blockRange` is `undefined`,
+ *   default to `{expanded: true}` so whole-block links end in `+`. Callers may
+ *   pass `{expanded: false}` or `{start,end}` to override.
+ */
+export function buildCopyLinkUrl(input: CopyLinkInput): string {
+  const {id, commentId, gatewayUrl} = input
+  const effectiveRange: BlockRange | null | undefined =
+    id.blockRef && (id.blockRange === undefined || id.blockRange === null) ? {expanded: true} : id.blockRange
+
+  if (commentId) {
+    const tsid = commentId.path?.[0]
+    const packedCommentId = tsid ? `${commentId.uid}/${tsid}` : commentId.uid
+    return createCommentUrl({
+      docId: id,
+      commentId: packedCommentId,
+      commentVersion: commentId.version ?? null,
+      siteUrl: id.hostname ?? null,
+      blockRef: id.blockRef,
+      blockRange: effectiveRange,
+      latest: id.latest ?? null,
+    })
+  }
+
+  if (id.hostname) {
+    return createSiteUrl({
+      path: id.path,
+      hostname: id.hostname,
+      version: id.version,
+      latest: id.latest ?? undefined,
+      blockRef: id.blockRef,
+      blockRange: effectiveRange,
+    })
+  }
+
+  return createWebHMUrl(id.uid, {
+    version: id.version,
+    blockRef: id.blockRef,
+    blockRange: effectiveRange,
+    latest: id.latest,
+    path: id.path,
+    hostname: gatewayUrl ?? undefined,
+  })
+}
+
 export function getCommentTargetId(comment: HMComment | undefined): UnpackedHypermediaId | undefined {
   if (!comment) return undefined
   return hmId(comment.targetAccount, {

--- a/frontend/packages/ui/src/comments.tsx
+++ b/frontend/packages/ui/src/comments.tsx
@@ -12,7 +12,6 @@ import {
 } from '@seed-hypermedia/client/hm-types'
 import {
   commentIdToHmId,
-  createCommentUrl,
   formattedDateShort,
   getCommentTargetId,
   hmId,
@@ -20,6 +19,7 @@ import {
   useCommentGroups,
   useCommentParents,
   useRouteLink,
+  useUniversalAppContext,
 } from '@shm/shared'
 
 import {HMListDiscussionsOutput} from '@seed-hypermedia/client/hm-types'
@@ -40,13 +40,12 @@ import {useTxString} from '@shm/shared/translation'
 import {useNavigate, useNavRoute} from '@shm/shared/utils/navigation'
 import {Link, MessageSquare, Pencil, Trash2, X} from 'lucide-react'
 import {memo, ReactNode, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react'
-import {toast} from 'sonner'
 import {SelectionContent} from './accessories'
 import {useReadOnlyViewer} from '@shm/shared/readonly-viewer-context'
 import {getBlockNodeById} from './blocks-content-utils'
 import {Button} from './button'
 import {Popover, PopoverContent, PopoverTrigger} from './components/popover'
-import {copyTextToClipboard, copyUrlToClipboardWithFeedback} from './copy-to-clipboard'
+import {useCopyHmLink} from './use-copy-hm-link'
 import {HMIcon} from './hm-icon'
 import {BlockQuote, ReplyArrow} from './icons'
 import {AuthorNameLink, getContextualProfileRoute, InlineDescriptor, Timestamp} from './inline-descriptor'
@@ -579,6 +578,8 @@ export const Comment = memo(function Comment({
   const authorHmId = comment.author || authorId ? hmId(authorId || comment.author) : null
   const docId = getCommentTargetId(comment)
   const authorLink = useRouteLink(getContextualProfileRoute(currentRoute, authorHmId, docId?.uid))
+  const copyHmLink = useCopyHmLink()
+  const {origin: appOrigin} = useUniversalAppContext()
 
   const externalTargetLink = useRouteLink(externalTarget ? {key: 'document', id: externalTarget.id} : null)
 
@@ -699,23 +700,22 @@ export const Comment = memo(function Comment({
                     variant="ghost"
                     className="text-muted-foreground hover-hover:opacity-0 hover-hover:group-hover:opacity-100 transition-opacity duration-200 ease-in-out"
                     onClick={() => {
-                      if (docId) {
-                        const routeLatest =
-                          currentRoute.key === 'document' ||
-                          currentRoute.key === 'comments' ||
-                          currentRoute.key === 'activity'
-                            ? currentRoute.id.latest
-                            : undefined
-                        const url = createCommentUrl({
-                          docId,
-                          commentId: comment.id,
-                          commentVersion: comment.version,
-                          siteUrl: targetDomain,
-                          latest: routeLatest,
-                        })
-                        copyTextToClipboard(url)
-                        toast.success('Copied Comment URL')
-                      }
+                      if (!docId) return
+                      const routeLatest =
+                        currentRoute.key === 'document' ||
+                        currentRoute.key === 'comments' ||
+                        currentRoute.key === 'activity'
+                          ? currentRoute.id.latest
+                          : undefined
+                      copyHmLink({
+                        id: {
+                          ...docId,
+                          hostname: targetDomain ?? null,
+                          latest: routeLatest ?? null,
+                        },
+                        commentId: commentIdToHmId(comment.id, comment.version),
+                        gatewayUrl: appOrigin ?? undefined,
+                      })
                     }}
                   >
                     <Link className="size-3" />
@@ -810,6 +810,8 @@ export function CommentContent({
   const textUnit = size === 'sm' ? 12 : 14
   const layoutUnit = size === 'sm' ? 14 : 16
 
+  const copyHmLink = useCopyHmLink()
+  const {origin: appOrigin} = useUniversalAppContext()
   const copyBlockUrl = useCallback(
     (blockId: string, blockRange?: BlockRange | null) => {
       if (!targetDocId) return
@@ -817,17 +819,19 @@ export function CommentContent({
         currentRoute.key === 'document' || currentRoute.key === 'comments' || currentRoute.key === 'activity'
           ? currentRoute.id.latest
           : undefined
-      const fullUrl = createCommentUrl({
-        docId: targetDocId,
-        commentId: comment.id,
-        siteUrl,
-        latest: routeLatest,
-        blockRef: blockId,
-        blockRange: blockRange ?? null,
+      copyHmLink({
+        id: {
+          ...targetDocId,
+          hostname: siteUrl ?? null,
+          latest: routeLatest ?? null,
+          blockRef: blockId,
+          blockRange: blockRange ?? null,
+        },
+        commentId: commentIdToHmId(comment.id),
+        gatewayUrl: appOrigin ?? undefined,
       })
-      copyUrlToClipboardWithFeedback(fullUrl, 'Comment Block')
     },
-    [targetDocId, currentRoute, comment.id, siteUrl],
+    [targetDocId, currentRoute, comment.id, siteUrl, copyHmLink, appOrigin],
   )
 
   const onCopyBlockLink = useCallback((blockId: string) => copyBlockUrl(blockId), [copyBlockUrl])

--- a/frontend/packages/ui/src/feed.tsx
+++ b/frontend/packages/ui/src/feed.tsx
@@ -3,22 +3,21 @@ import {HMBlockNode, HMTimestamp, UnpackedHypermediaId} from '@seed-hypermedia/c
 import {HMListEventsParams, LoadedCommentEvent, LoadedEvent} from '@shm/shared/models/activity-service'
 import {useResource, useSelectedAccountId} from '@shm/shared/models/entity'
 import {DocumentRoute, NavRoute} from '@shm/shared/routes'
-import {useRouteLink} from '@shm/shared/routing'
+import {useRouteLink, useUniversalAppContext} from '@shm/shared/routing'
 import {useTx, useTxString} from '@shm/shared/translation'
 import {useActivityFeed} from '@shm/shared/use-activity-feed'
 import {AnyTimestamp, formattedDateShort, normalizeDate} from '@shm/shared/utils/date'
-import {createCommentUrl, getCommentTargetId, hmId} from '@shm/shared/utils/entity-id-url'
+import {commentIdToHmId, getCommentTargetId, hmId} from '@shm/shared/utils/entity-id-url'
 import {useNavRoute} from '@shm/shared/utils/navigation'
 import _ from 'lodash'
 import {CircleAlert, Link, Trash2} from 'lucide-react'
 import {memo, useEffect, useMemo, useRef} from 'react'
-import {toast} from 'sonner'
 import {SelectionContent} from './accessories'
 import {useReadOnlyViewer} from '@shm/shared/readonly-viewer-context'
 import {Button} from './button'
 import {CommentContent, useDeleteCommentDialog} from './comments'
 import {SizableText} from './components/text'
-import {copyTextToClipboard} from './copy-to-clipboard'
+import {useCopyHmLink} from './use-copy-hm-link'
 import {HMIcon} from './hm-icon'
 import {ReplyArrow} from './icons'
 import {AuthorNameLink, DocumentNameLink, InlineDescriptor, Timestamp} from './inline-descriptor'
@@ -209,6 +208,8 @@ function EventHeaderContent({
   const currentAccount = useSelectedAccountId()
   const deleteCommentMutation = useDeleteComment()
   const deleteCommentDialog = useDeleteCommentDialog()
+  const copyHmLink = useCopyHmLink()
+  const {origin: appOrigin} = useUniversalAppContext()
   if (event.type == 'comment') {
     const options: MenuItemType[] = []
     if (event.comment && currentAccount && currentAccount == event.comment.author) {
@@ -253,22 +254,22 @@ function EventHeaderContent({
                     e.preventDefault()
                     e.stopPropagation()
                     const targetDocId = getCommentTargetId(event.comment!)
-                    if (targetDocId && event.comment) {
-                      const routeLatest =
-                        currentRoute.key === 'document' ||
-                        currentRoute.key === 'comments' ||
-                        currentRoute.key === 'activity'
-                          ? currentRoute.id.latest
-                          : undefined
-                      const url = createCommentUrl({
-                        docId: targetDocId,
-                        commentId: event.comment.id,
-                        siteUrl: targetDomain,
-                        latest: routeLatest,
-                      })
-                      copyTextToClipboard(url)
-                      toast.success('Copied Comment URL')
-                    }
+                    if (!targetDocId || !event.comment) return
+                    const routeLatest =
+                      currentRoute.key === 'document' ||
+                      currentRoute.key === 'comments' ||
+                      currentRoute.key === 'activity'
+                        ? currentRoute.id.latest
+                        : undefined
+                    copyHmLink({
+                      id: {
+                        ...targetDocId,
+                        hostname: targetDomain ?? null,
+                        latest: routeLatest ?? null,
+                      },
+                      commentId: commentIdToHmId(event.comment.id, event.comment.version),
+                      gatewayUrl: appOrigin ?? undefined,
+                    })
                   }}
                 >
                   <Link className="size-3" />

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -51,13 +51,7 @@ import {
 import {useEditorGate} from '@shm/shared/models/use-editor-gate'
 import {getRoutePanel} from '@shm/shared/routes'
 import {getBreadcrumbDocumentIds} from '@shm/shared/utils/breadcrumbs'
-import {
-  activityFilterToSlug,
-  createSiteUrl,
-  createWebHMUrl,
-  getCommentTargetId,
-  parseFragment,
-} from '@shm/shared/utils/entity-id-url'
+import {activityFilterToSlug, getCommentTargetId, parseFragment} from '@shm/shared/utils/entity-id-url'
 import {useNavigate, useNavRoute} from '@shm/shared/utils/navigation'
 import {Folder, Search, Settings} from 'lucide-react'
 import {CSSProperties, lazy, ReactNode, Suspense, useCallback, useEffect, useMemo, useRef, useState} from 'react'
@@ -75,6 +69,7 @@ import {
 } from './components/alert-dialog'
 import {ScrollArea} from './components/scroll-area'
 import {copyUrlToClipboardWithFeedback} from './copy-to-clipboard'
+import {useCopyHmLink} from './use-copy-hm-link'
 import {DirectoryPageContent} from './directory-page'
 import {DiscussionsPageContent} from './discussions-page'
 import {DocumentCover} from './document-cover'
@@ -986,6 +981,10 @@ function DocumentBody({
 
   // Block tools handlers
   const blockCitations = useMemo(() => interactionSummary.data?.blocks || null, [interactionSummary.data?.blocks])
+  const copyHmLink = useCopyHmLink()
+  // Current origin for gateway-format links (web: site's own URL; desktop: the
+  // configured gateway). Used as a fallback when the document has no site URL.
+  const {origin: appOrigin} = useUniversalAppContext()
 
   const handleBlockCitationClick = useCallback(
     (blockId?: string | null) => {
@@ -995,16 +994,21 @@ function DocumentBody({
         id: {
           ...route.id,
           blockRef: blockId || null,
-          blockRange: null,
+          // Mark the block as expanded so the editor highlight plugin focuses
+          // and highlights the whole block (not just a text range).
+          blockRange: blockId ? {expanded: true} : null,
         },
         panel: {
           key: 'comments',
           id: route.id,
-          blockId: blockId || undefined,
-        },
+          // DiscussionsPanel reads `targetBlockId` to scope the panel to a
+          // single block's discussions; `blockId` was the wrong field.
+          targetBlockId: blockId || undefined,
+        } as any,
       })
+      if (blockId) scrollToBlock(blockId)
     },
-    [route, navigate],
+    [route, navigate, scrollToBlock],
   )
 
   const handleBlockCommentClick = useCallback(
@@ -1053,32 +1057,45 @@ function DocumentBody({
       }
       const shouldCopy = opts?.copyToClipboard !== false
       if (blockId && shouldCopy) {
-        // Block links must include version (block tied to specific version)
-        // and use siteUrl hostname when available
-        const versionForLink = publishedVersion ?? document.version
-        const url = siteUrl
-          ? createSiteUrl({
-              path: docId.path,
-              hostname: siteUrl,
-              blockRef: blockId,
-              blockRange,
-              version: versionForLink,
-            })
-          : createWebHMUrl(docId.uid, {
-              path: docId.path,
-              blockRef: blockId,
-              blockRange,
-              version: versionForLink,
-            })
-        copyUrlToClipboardWithFeedback(url, 'Block')
+        // Pin to the published version only if the block actually exists there.
+        // Newly-added draft blocks aren't in any published version yet — emit
+        // a version-less, latest-resolving link so the URL stays valid once
+        // the next publish lands.
+        const publishedVersionCandidate = publishedVersion ?? document.version
+        const existsInPublished = !!findContentBlock(document.content ?? [], blockId)
+        const versionForLink = existsInPublished ? publishedVersionCandidate : null
+        copyHmLink({
+          id: {
+            ...docId,
+            version: versionForLink ?? null,
+            blockRef: blockId,
+            blockRange,
+            hostname: siteUrl ?? docId.hostname ?? null,
+            latest: existsInPublished ? null : true,
+          },
+          // Fall back to the app origin for gateway-format URLs so copied
+          // links on web point back to this deployment (instead of the
+          // default `hyper.media` gateway) when no site URL is set.
+          gatewayUrl: appOrigin ?? undefined,
+        })
       }
-      // Navigate to update route with blockRef (unless explicitly copy-only)
-      if (opts?.copyToClipboard !== true) {
-        scrollToBlock(blockId)
-        navigate(blockRoute)
-      }
+      // Always scroll + navigate so the URL updates and the target block gets
+      // visually focused/highlighted — even on copy clicks.
+      scrollToBlock(blockId)
+      navigate(blockRoute)
     },
-    [route, navigate, scrollToBlock, docId, document.version, siteUrl, publishedVersion],
+    [
+      route,
+      navigate,
+      scrollToBlock,
+      docId,
+      document.version,
+      document.content,
+      siteUrl,
+      publishedVersion,
+      copyHmLink,
+      appOrigin,
+    ],
   )
 
   // Activity filter change handler (main page)

--- a/frontend/packages/ui/src/use-copy-hm-link.ts
+++ b/frontend/packages/ui/src/use-copy-hm-link.ts
@@ -1,0 +1,46 @@
+import type {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import type {CopyLinkInput} from '@shm/shared'
+import {buildCopyLinkUrl} from '@shm/shared'
+import {useCallback} from 'react'
+import {copyUrlToClipboardWithFeedback} from './copy-to-clipboard'
+
+export type CopyHmLinkOptions = {
+  /** Override the default toast label (inferred from the input shape). */
+  label?: string
+}
+
+/**
+ * Returns a function that copies a Hypermedia link for the given `id` (and
+ * optional `commentId`) to the clipboard and shows a toast. The URL is built
+ * via `buildCopyLinkUrl` so all callsites share one source of truth.
+ *
+ * The returned function resolves with the URL it copied so callers can use it
+ * for logging, tests, or local UI feedback.
+ */
+export function useCopyHmLink() {
+  return useCallback(async (input: CopyLinkInput, opts?: CopyHmLinkOptions) => {
+    const url = buildCopyLinkUrl(input)
+    const label = opts?.label ?? defaultLabelForInput(input)
+    await copyUrlToClipboardWithFeedback(url, label)
+    return url
+  }, [])
+}
+
+function defaultLabelForInput({id, commentId}: CopyLinkInput): string {
+  const hasFragment = isFragmentRange(id)
+  const hasBlock = !!id.blockRef
+  if (commentId) {
+    if (hasFragment) return 'Comment Fragment'
+    if (hasBlock) return 'Comment Block'
+    return 'Comment'
+  }
+  if (hasFragment) return 'Fragment'
+  if (hasBlock) return 'Block'
+  return 'Link'
+}
+
+function isFragmentRange(id: UnpackedHypermediaId): boolean {
+  const range = id.blockRange
+  if (!range) return false
+  return typeof range.start === 'number' && typeof range.end === 'number'
+}


### PR DESCRIPTION
## Summary

- Fixes issue #491 where clicking the block "copy link" icon was opening the comments panel instead of copying the link to clipboard — caused by `onCopyBlockLink` being wired to `onBlockCitationClick` (panel navigation) instead of the copy path
- Adds `buildCopyLinkUrl` to `@shm/shared` as a single URL-building entry point for all copy-link actions (documents, blocks, fragments, comments, comment-blocks), replacing scattered `createWebHMUrl` / `createSiteUrl` / `createCommentUrl` call sites
- Adds `useCopyHmLink` hook to `@shm/ui` that calls `buildCopyLinkUrl`, writes to clipboard, and shows a toast with an auto-inferred label
- Fixes `onCopyBlockLink` in `document-editor.tsx` to use `onBlockSelect` with `{copyToClipboard: true}` instead of `onBlockCitationClick`
- Fixes block hover positioning — card now anchors to the top-right of the block with overlap padding so the mouse can travel without losing hover
- Fixes `handleBlockCitationClick` to pass `targetBlockId` (not `blockId`) to `DiscussionsPanel` and set `blockRange: {expanded: true}` when a block is selected
- Draft block links now emit version-less, latest-resolving URLs when the block doesn't yet exist in a published version
- Adds `onSupernumberClick` handler in draft editor to dispatch the `BlockHighlight` focus meta and scroll to the block, in addition to opening the comments panel
- Adds comprehensive unit tests for `buildCopyLinkUrl` covering all URL shapes and roundtrips through `unpackHmId`


---

Fixes #491