### PR TITLE
fix(editor): make button block navigate to its URL on click

### DIFF
--- a/frontend/packages/editor/src/button-view.tsx
+++ b/frontend/packages/editor/src/button-view.tsx
@@ -1,0 +1,90 @@
+import {useOpenUrl} from '@shm/shared'
+import {useEditorGate} from '@shm/shared/models/use-editor-gate'
+import {Button} from '@shm/ui/button'
+import {SizableText} from '@shm/ui/text'
+import {cn} from '@shm/ui/utils'
+import {useEffect, useState} from 'react'
+import type {BlockNoteEditor} from './blocknote/core/BlockNoteEditor'
+import type {Block} from './blocknote/core/extensions/Blocks/api/blockTypes'
+import {useEditorSelectionChange} from './blocknote/react/hooks/useEditorSelectionChange'
+import {updateSelection} from './media-render'
+import type {HMBlockSchema} from './schema'
+
+type ButtonAlignment = 'flex-start' | 'center' | 'flex-end'
+
+/**
+ * Mutable shape passed to `editor.updateBlock` when the button block's props
+ * (url, name, alignment) change.
+ */
+export type ButtonType = {
+  id: string
+  props: {
+    url: string
+    name: string
+    alignment?: string
+  }
+  children: []
+  content: []
+  type: string
+}
+
+/**
+ * React view for the button block. Exported separately from
+ * `createReactBlockSpec` so it can be unit-tested without pulling in the
+ * (circular) full block-schema graph.
+ *
+ * In read-only mode (or when the user has edit permission but isn't currently
+ * editing) clicking the button navigates to `block.props.url` via `useOpenUrl`.
+ * In edit mode the click is a no-op so the block can be selected/focused.
+ */
+export function ButtonBlockView({
+  block,
+  editor,
+}: {
+  block: Block<HMBlockSchema>
+  editor: BlockNoteEditor<HMBlockSchema>
+}) {
+  const [alignment, setAlignment] = useState<ButtonAlignment>(
+    (block.props.alignment as ButtonAlignment) || 'flex-start',
+  )
+  const [, setSelected] = useState(false)
+  const openUrl = useOpenUrl()
+  const {canEdit, isEditing} = useEditorGate()
+
+  // Navigate when the document is being viewed (read-only). In edit mode the
+  // click should select/focus the block instead, mirroring `embed-block.tsx`.
+  const navigateOnClick = !canEdit || !isEditing
+
+  useEditorSelectionChange(editor, () => updateSelection(editor, block, setSelected))
+
+  useEffect(() => {
+    setAlignment(block.props.alignment as ButtonAlignment)
+  }, [block.props.alignment])
+
+  const url = block.props.url
+  const handleClick = navigateOnClick && url ? () => openUrl(url) : undefined
+
+  return (
+    <div
+      className="flex w-full max-w-full flex-col select-none"
+      style={{
+        justifyContent: alignment || 'flex-start',
+      }}
+      contentEditable={false}
+    >
+      <Button
+        variant="brand"
+        size="lg"
+        className={cn(
+          'w-auto max-w-full justify-center border-none border-transparent text-center select-none',
+          alignment == 'center' ? 'self-center' : alignment == 'flex-end' ? 'self-end' : 'self-start',
+        )}
+        onClick={handleClick}
+      >
+        <SizableText size="lg" className="truncate text-center font-sans font-bold text-white">
+          {block.props.name || 'Button Text'}
+        </SizableText>
+      </Button>
+    </div>
+  )
+}

--- a/frontend/packages/editor/src/button.test.tsx
+++ b/frontend/packages/editor/src/button.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import {createRoot, type Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+// Required by react-dom 18 to suppress "not configured to support act(...)" warnings.
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+const openUrl = vi.fn()
+const editorGate = {canEdit: false, isEditing: false}
+
+vi.mock('@shm/shared', () => ({
+  useOpenUrl: () => openUrl,
+}))
+
+vi.mock('@shm/shared/models/use-editor-gate', () => ({
+  useEditorGate: () => editorGate,
+}))
+
+import {ButtonBlockView} from './button-view'
+
+function makeBlock(overrides: {url?: string; name?: string; alignment?: string} = {}) {
+  return {
+    id: 'block-1',
+    type: 'button',
+    props: {
+      url: 'https://example.com/foo',
+      name: 'Click me',
+      alignment: 'flex-start',
+      ...overrides,
+    },
+    content: [],
+    children: [],
+  } as any
+}
+
+function makeEditor() {
+  return {
+    _tiptapEditor: {
+      on: vi.fn(),
+      off: vi.fn(),
+    },
+    updateBlock: vi.fn(),
+    getTextCursorPosition: vi.fn(() => ({block: {id: 'block-1'}})),
+  } as any
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  openUrl.mockReset()
+  editorGate.canEdit = false
+  editorGate.isEditing = false
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+function render(block: ReturnType<typeof makeBlock>, editor: ReturnType<typeof makeEditor> = makeEditor()) {
+  act(() => {
+    root.render(<ButtonBlockView block={block} editor={editor} />)
+  })
+  const el = container.querySelector('button')
+  if (!el) throw new Error('Button element not rendered')
+  return el
+}
+
+describe('ButtonBlockView', () => {
+  it('navigates to the configured URL when clicked in read-only mode (canEdit=false)', () => {
+    editorGate.canEdit = false
+    editorGate.isEditing = false
+    const button = render(makeBlock({url: 'https://example.com/page'}))
+
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))
+    })
+
+    expect(openUrl).toHaveBeenCalledTimes(1)
+    expect(openUrl).toHaveBeenCalledWith('https://example.com/page')
+  })
+
+  it('navigates when the user can edit but is not currently editing', () => {
+    editorGate.canEdit = true
+    editorGate.isEditing = false
+    const button = render(makeBlock({url: 'https://example.com/page'}))
+
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))
+    })
+
+    expect(openUrl).toHaveBeenCalledWith('https://example.com/page')
+  })
+
+  it('does not navigate when the editor is in edit mode', () => {
+    editorGate.canEdit = true
+    editorGate.isEditing = true
+    const button = render(makeBlock({url: 'https://example.com/page'}))
+
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))
+    })
+
+    expect(openUrl).not.toHaveBeenCalled()
+  })
+
+  it('does not attach a click handler when no URL is configured', () => {
+    const button = render(makeBlock({url: ''}))
+
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))
+    })
+
+    expect(openUrl).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/packages/editor/src/button.tsx
+++ b/frontend/packages/editor/src/button.tsx
@@ -1,17 +1,16 @@
-import {useOpenUrl} from '@shm/shared'
-import {Button} from '@shm/ui/button'
-import {SizableText} from '@shm/ui/text'
-import {usePopoverState} from '@shm/ui/use-popover-state'
-import {cn} from '@shm/ui/utils'
-import {useEffect, useState} from 'react'
 import {BlockNoteEditor} from './blocknote/core/BlockNoteEditor'
 import {Block} from './blocknote/core/extensions/Blocks/api/blockTypes'
 import {defaultProps} from './blocknote/core/extensions/Blocks/api/defaultBlocks'
-import {useEditorSelectionChange} from './blocknote/react/hooks/useEditorSelectionChange'
 import {createReactBlockSpec} from './blocknote/react/ReactBlockSpec'
-import {updateSelection} from './media-render'
-import {HMBlockSchema} from './schema'
+import {ButtonBlockView} from './button-view'
+import type {HMBlockSchema} from './schema'
 
+export {ButtonBlockView, type ButtonType} from './button-view'
+
+/**
+ * BlockNote block spec for the URL button. Renders `ButtonBlockView` which
+ * navigates to `block.props.url` on click in read-only mode.
+ */
 export const ButtonBlock = createReactBlockSpec({
   type: 'button',
   propSchema: {
@@ -33,75 +32,7 @@ export const ButtonBlock = createReactBlockSpec({
   },
   containsInlineContent: true,
   // @ts-ignore
-  render: ({block, editor}: {block: Block<HMBlockSchema>; editor: BlockNoteEditor<HMBlockSchema>}) =>
-    Render(block, editor),
+  render: ({block, editor}: {block: Block<HMBlockSchema>; editor: BlockNoteEditor<HMBlockSchema>}) => (
+    <ButtonBlockView block={block} editor={editor} />
+  ),
 })
-
-type ButtonAlignment = 'flex-start' | 'center' | 'flex-end'
-
-export type ButtonType = {
-  id: string
-  props: {
-    url: string
-    name: string
-    alignment?: string
-  }
-  children: []
-  content: []
-  type: string
-}
-
-const Render = (block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSchema>) => {
-  const popoverState = usePopoverState()
-  // const [focused, setFocused] = useState(false)
-  // const [sizing, setSizing] = useState('hug-content')
-  const [alignment, setAlignment] = useState<ButtonAlignment>(
-    (block.props.alignment as ButtonAlignment) || 'flex-start',
-  )
-  const [selected, setSelected] = useState(false)
-  const [forceEdit, setForceEdit] = useState(false)
-  // const [buttonText, setButtonText] = useState(
-  //   block.props.name || 'Button Label',
-  // )
-  // const sizingOptions = [
-  //   {value: 'hug-content', label: 'Hug content'},
-  //   {value: 'fill-width', label: 'Fill width'},
-  // ]
-  // const [link, setLink] = useState(block.props.url)
-  const openUrl = useOpenUrl()
-
-  const assign = (newProps: ButtonType) => {
-    editor.updateBlock(block.id, {
-      props: {...block.props, ...newProps.props},
-    })
-  }
-
-  useEditorSelectionChange(editor, () => updateSelection(editor, block, setSelected))
-
-  useEffect(() => {
-    setAlignment(block.props.alignment as ButtonAlignment)
-  }, [block.props.alignment])
-
-  return (
-    <div
-      className="flex w-full max-w-full flex-col select-none"
-      style={{
-        justifyContent: alignment || 'flex-start',
-      }}
-      contentEditable={false}
-    >
-      <Button
-        variant="brand"
-        size="lg"
-        className={cn(
-          'w-auto max-w-full justify-center border-none border-transparent text-center select-none',
-          alignment == 'center' ? 'self-center' : alignment == 'flex-end' ? 'self-end' : 'self-start',
-        )}
-      >
-        <SizableText size="lg" className="truncate text-center font-sans font-bold text-white">
-          {block.props.name || 'Button Text'}
-        </SizableText>
-      </Button>
-    </div>
-  )
-}


### PR DESCRIPTION
The button block rendered a `<Button>` with no `onClick`, so clicking a
URL button on web (read-only) did nothing. Wire it through `useOpenUrl`
and gate on `useEditorGate` so navigation only fires when the document
isn't actively being edited (mirroring `embed-block.tsx`).

Splits the React view into `button-view.tsx` so it can be unit-tested
without pulling in the full block-schema graph (createReactBlockSpec
triggers a circular import chain otherwise).