### PR TITLE
fix(ui): include draft links when computing unreferenced documents

### DIFF
--- a/frontend/packages/shared/src/__tests__/content-refs.test.ts
+++ b/frontend/packages/shared/src/__tests__/content-refs.test.ts
@@ -1,5 +1,7 @@
 import {describe, expect, it} from 'vitest'
 import {extractAllContentRefs, findSelfQueryBlock, hasQueryBlockTargetingSelf} from '../content'
+import {editorBlocksToHMBlockNodes} from '@seed-hypermedia/client/editorblock-to-hmblock'
+import type {EditorBlock} from '@seed-hypermedia/client/editor-types'
 import {HMBlockNode} from '@seed-hypermedia/client/hm-types'
 
 function makeBlock(block: any, children?: HMBlockNode[]): HMBlockNode {
@@ -325,5 +327,85 @@ describe('findSelfQueryBlock', () => {
     const result = findSelfQueryBlock(blocks, 'uid1', null)
     expect(result).not.toBeNull()
     expect(result!.id).toBe('q1')
+  })
+})
+
+// `UnreferencedDocuments` relies on `editorBlocksToHMBlockNodes` to convert
+// in-memory draft content (BlockNote `EditorBlock[]`) into the published
+// `HMBlockNode[]` shape so the existing ref/query extraction utilities work
+// uniformly. These tests pin that conversion path.
+describe('extractAllContentRefs from editor draft blocks', () => {
+  it('extracts refs from embed blocks, link inlines, and inline-embeds', () => {
+    const draftBlocks: EditorBlock[] = [
+      {
+        id: 'e1',
+        type: 'embed',
+        props: {view: 'Content', url: 'hm://uid1/embedded'},
+        content: [],
+        children: [],
+      },
+      {
+        id: 'p1',
+        type: 'paragraph',
+        props: {},
+        content: [
+          {
+            type: 'link',
+            href: 'hm://uid1/linked',
+            content: [{type: 'text', text: 'click', styles: {}}],
+          },
+        ],
+        children: [],
+      },
+      {
+        id: 'p2',
+        type: 'paragraph',
+        props: {},
+        content: [{type: 'inline-embed', link: 'hm://uid1/mentioned', styles: {}}],
+        children: [],
+      },
+    ]
+    const refs = extractAllContentRefs(editorBlocksToHMBlockNodes(draftBlocks))
+    const links = refs.map((r) => r.link).sort()
+    expect(links).toEqual(['hm://uid1/embedded', 'hm://uid1/linked', 'hm://uid1/mentioned'])
+  })
+
+  it('extracts refs from nested children of editor blocks', () => {
+    const draftBlocks: EditorBlock[] = [
+      {
+        id: 'p1',
+        type: 'paragraph',
+        props: {},
+        content: [{type: 'text', text: 'parent', styles: {}}],
+        children: [
+          {
+            id: 'e1',
+            type: 'embed',
+            props: {view: 'Content', url: 'hm://uid1/nested'},
+            content: [],
+            children: [],
+          },
+        ],
+      },
+    ]
+    const refs = extractAllContentRefs(editorBlocksToHMBlockNodes(draftBlocks))
+    expect(refs).toHaveLength(1)
+    expect(refs[0]!.refId.path).toEqual(['nested'])
+  })
+
+  it('hasQueryBlockTargetingSelf detects a self-targeting Query block in a draft', () => {
+    const draftBlocks: EditorBlock[] = [
+      {
+        id: 'q1',
+        type: 'query',
+        props: {
+          style: 'List',
+          queryIncludes: JSON.stringify([{space: 'uid1', path: '', mode: 'Children'}]),
+        },
+        content: [],
+        children: [],
+      },
+    ]
+    expect(hasQueryBlockTargetingSelf(editorBlocksToHMBlockNodes(draftBlocks), 'uid1', null)).toBe(true)
   })
 })

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -2079,7 +2079,12 @@ function ContentViewWithOutline({
         ) : null}
         {inlineInsert}
         {inlineCards}
-        <UnreferencedDocuments docId={docId} content={document.content} directory={directory} />
+        <UnreferencedDocuments
+          docId={docId}
+          content={document.content}
+          draftContent={existingDraftContent}
+          directory={directory}
+        />
       </div>
 
       {showSidebars && <div {...sidebarProps} />}

--- a/frontend/packages/ui/src/unreferenced-documents.tsx
+++ b/frontend/packages/ui/src/unreferenced-documents.tsx
@@ -1,18 +1,39 @@
+import {EditorBlock} from '@seed-hypermedia/client/editor-types'
 import {HMBlockNode, HMDocumentInfo, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
-import {extractAllContentRefs, hasQueryBlockTargetingSelf} from '@shm/shared'
+import {editorBlocksToHMBlockNodes, extractAllContentRefs, hasQueryBlockTargetingSelf} from '@shm/shared'
 import {useCanSeePrivateDocs} from '@shm/shared/models/capabilities'
 import {ChevronDown, ChevronRight} from 'lucide-react'
 import {useMemo, useState} from 'react'
 import {DocumentListItem} from './document-list-item'
 import {cn} from './utils'
 
+function toHMBlockNodes(blocks: EditorBlock[] | HMBlockNode[]): HMBlockNode[] {
+  // EditorBlock has `type` at top level; HMBlockNode wraps a `block` field.
+  const first = blocks[0]
+  const isEditorFormat = first != null && 'type' in first && !('block' in first)
+  return isEditorFormat ? editorBlocksToHMBlockNodes(blocks as EditorBlock[]) : (blocks as HMBlockNode[])
+}
+
+/**
+ * Renders the collapsible "Unreferenced Documents" section listing child
+ * documents that are not linked or embedded from the current document. When a
+ * draft of the document exists, its content takes precedence over the
+ * published content so links added/removed in the draft are reflected
+ * immediately, matching what the editor displays.
+ *
+ * `draftContent` accepts either editor format (`EditorBlock[]`, used at
+ * runtime by the desktop draft store) or the published `HMBlockNode[]` format,
+ * mirroring the auto-detection in `document-editor.tsx`.
+ */
 export function UnreferencedDocuments({
   docId,
   content,
+  draftContent,
   directory,
 }: {
   docId: UnpackedHypermediaId
   content: HMBlockNode[]
+  draftContent?: EditorBlock[] | HMBlockNode[]
   directory: HMDocumentInfo[] | undefined
 }) {
   const [isExpanded, setIsExpanded] = useState(false)
@@ -21,11 +42,13 @@ export function UnreferencedDocuments({
   const unreferencedDocs = useMemo(() => {
     if (!directory || directory.length === 0) return []
 
-    if (hasQueryBlockTargetingSelf(content, docId.uid, docId.path)) {
+    const sourceContent = draftContent && draftContent.length > 0 ? toHMBlockNodes(draftContent) : content
+
+    if (hasQueryBlockTargetingSelf(sourceContent, docId.uid, docId.path)) {
       return []
     }
 
-    const allRefs = extractAllContentRefs(content)
+    const allRefs = extractAllContentRefs(sourceContent)
     const referencedIds = new Set<string>()
     allRefs.forEach((ref) => {
       if (ref.refId) {
@@ -36,7 +59,7 @@ export function UnreferencedDocuments({
     return directory
       .filter((child) => canSeePrivate || child.visibility !== 'PRIVATE')
       .filter((child) => !referencedIds.has(child.id.id))
-  }, [content, directory, docId.uid, docId.path, canSeePrivate])
+  }, [content, draftContent, directory, docId.uid, docId.path, canSeePrivate])
 
   if (unreferencedDocs.length === 0) return null
 


### PR DESCRIPTION
The "Unreferenced Documents" section only inspected the published
document's content, so adding a link or embed to a child doc inside the
in-progress draft did not remove that child from the list. Pass the
existing draft content through to the component and use it (when
present) as the source for ref extraction, mirroring the
"draft overrides published" pattern already used by the editor.

Drafts are stored as BlockNote EditorBlock[]; the component auto-detects
the format and converts via editorBlocksToHMBlockNodes so the existing
extractAllContentRefs / hasQueryBlockTargetingSelf utilities work
uniformly.