### PR TITLE
fix(editor): dismiss selection instead of entering edit mode on click

### DIFF
--- a/frontend/packages/editor/src/click-edit-mode-guard.test.ts
+++ b/frontend/packages/editor/src/click-edit-mode-guard.test.ts
@@ -1,0 +1,131 @@
+import {Schema} from 'prosemirror-model'
+import {EditorState, NodeSelection, TextSelection} from 'prosemirror-state'
+import {EditorView} from 'prosemirror-view'
+import {beforeEach, describe, expect, it} from 'vitest'
+import {applyReadOnlyClickSelectionGuard} from './click-edit-mode-guard'
+
+/**
+ * Regression tests for the "click while selecting" guard wired into the
+ * read-only click handler in `document-editor.tsx`. The guard suppresses
+ * `edit.start` when the user clicks while a non-empty ProseMirror selection
+ * is active and clears the selection instead.
+ */
+
+function createSchema(): Schema {
+  return new Schema({
+    nodes: {
+      doc: {content: 'block+'},
+      paragraph: {
+        content: 'text*',
+        group: 'block',
+        toDOM() {
+          return ['p', 0]
+        },
+      },
+      image: {
+        group: 'block',
+        atom: true,
+        attrs: {src: {default: ''}},
+        toDOM(node) {
+          return ['img', {src: node.attrs.src}]
+        },
+      },
+      text: {group: 'inline'},
+    },
+  })
+}
+
+function createView(schema: Schema, editable: boolean): EditorView {
+  const para = schema.nodes['paragraph']!.create(null, schema.text('hello world'))
+  const img = schema.nodes['image']!.create({src: 'about:blank'})
+  const doc = schema.nodes['doc']!.create(null, [para, img])
+  const state = EditorState.create({doc, schema})
+  const container = document.createElement('div')
+  return new EditorView(container, {
+    state,
+    editable: () => editable,
+  })
+}
+
+describe('applyReadOnlyClickSelectionGuard', () => {
+  let view: EditorView
+
+  beforeEach(() => {
+    view = createView(createSchema(), false)
+  })
+
+  it('returns false and leaves selection alone when nothing was selected at mousedown', () => {
+    const before = view.state.selection
+    expect(before.empty).toBe(true)
+
+    const consumed = applyReadOnlyClickSelectionGuard(view, false)
+
+    expect(consumed).toBe(false)
+    expect(view.state.selection).toBe(before)
+  })
+
+  it('clears a non-empty TextSelection and returns true', () => {
+    const tr = view.state.tr
+    view.dispatch(tr.setSelection(TextSelection.create(tr.doc, 1, 6)))
+    expect(view.state.selection.empty).toBe(false)
+
+    const consumed = applyReadOnlyClickSelectionGuard(view, true)
+
+    expect(consumed).toBe(true)
+    expect(view.state.selection.empty).toBe(true)
+  })
+
+  it('clears a NodeSelection (e.g. on a media block) and returns true', () => {
+    // The image node sits right after the paragraph; its position is the
+    // paragraph's nodeSize.
+    const para = view.state.doc.firstChild!
+    const imagePos = para.nodeSize
+    const tr = view.state.tr
+    view.dispatch(tr.setSelection(NodeSelection.create(tr.doc, imagePos)))
+    expect(view.state.selection.empty).toBe(false)
+    expect(view.state.selection instanceof NodeSelection).toBe(true)
+
+    const consumed = applyReadOnlyClickSelectionGuard(view, true)
+
+    expect(consumed).toBe(true)
+    expect(view.state.selection.empty).toBe(true)
+  })
+
+  it('clears window.getSelection() ranges when invoked', () => {
+    // Stand up a native browser selection over a separate DOM node so we can
+    // observe removeAllRanges() running.
+    const span = document.createElement('span')
+    span.textContent = 'pick me'
+    document.body.appendChild(span)
+    const range = document.createRange()
+    range.selectNodeContents(span)
+    const winSel = window.getSelection()!
+    winSel.removeAllRanges()
+    winSel.addRange(range)
+    expect(winSel.rangeCount).toBe(1)
+
+    // Force a non-empty PM selection so the guard takes its full path.
+    const tr = view.state.tr
+    view.dispatch(tr.setSelection(TextSelection.create(tr.doc, 1, 6)))
+
+    applyReadOnlyClickSelectionGuard(view, true)
+
+    expect(window.getSelection()?.rangeCount ?? 0).toBe(0)
+
+    document.body.removeChild(span)
+  })
+
+  it('is a no-op when hadSelectionAtMousedown is false even if selection is non-empty', () => {
+    // Edge case: the caller didn't capture a selection at mousedown. We trust
+    // the caller — this preserves the "drag-then-click" path where a fresh
+    // selection should not be wiped on the very same click.
+    const tr = view.state.tr
+    view.dispatch(tr.setSelection(TextSelection.create(tr.doc, 1, 6)))
+    const before = view.state.selection
+
+    const consumed = applyReadOnlyClickSelectionGuard(view, false)
+
+    expect(consumed).toBe(false)
+    expect(view.state.selection).toBe(before)
+  })
+})

--- a/frontend/packages/editor/src/click-edit-mode-guard.ts
+++ b/frontend/packages/editor/src/click-edit-mode-guard.ts
@@ -1,0 +1,50 @@
+import {Selection, TextSelection} from 'prosemirror-state'
+import type {EditorView} from 'prosemirror-view'
+
+/**
+ * Read-only click guard for the document editor.
+ *
+ * When the editor is in read-only mode and the user has edit permission, a
+ * click on the document body is what flips the unified document machine into
+ * edit mode. If the user already has a selection (highlighted text, a selected
+ * media block, or a multi-block selection) we want that click to dismiss the
+ * selection instead — losing the selection on the way into edit mode is
+ * surprising.
+ *
+ * Call site captures whether a non-empty ProseMirror selection existed at
+ * mousedown (the browser collapses the selection to a cursor at the click
+ * position before the `click` event fires, so we cannot reliably check at
+ * click time). This helper performs the actual dismissal.
+ *
+ * @param view - The ProseMirror view backing the editor.
+ * @param hadSelectionAtMousedown - True if `view.state.selection.empty` was
+ *   false at the most recent mousedown.
+ * @returns `true` if the click was consumed (selection cleared, caller should
+ *   skip `edit.start`); `false` if the caller should fall through to its
+ *   normal click handling.
+ */
+export function applyReadOnlyClickSelectionGuard(view: EditorView, hadSelectionAtMousedown: boolean): boolean {
+  if (!hadSelectionAtMousedown) return false
+
+  const sel = view.state.selection
+  if (!sel.empty) {
+    // Collapse the selection. For a TextSelection, `sel.from` is inside an
+    // inline-content node, so a plain `TextSelection.create(doc, from)` is
+    // valid. For a NodeSelection / MultipleNodeSelection, `sel.from` sits at
+    // a block boundary where a TextSelection would be invalid; in that case
+    // search for the nearest text-only position.
+    const $from = view.state.doc.resolve(sel.from)
+    const collapsed = $from.parent.inlineContent
+      ? TextSelection.create(view.state.doc, sel.from)
+      : Selection.findFrom($from, -1, true) ?? Selection.findFrom($from, 1, true)
+    if (collapsed) {
+      view.dispatch(view.state.tr.setSelection(collapsed))
+    }
+  }
+
+  if (typeof window !== 'undefined') {
+    window.getSelection()?.removeAllRanges()
+  }
+
+  return true
+}

--- a/frontend/packages/editor/src/document-editor.tsx
+++ b/frontend/packages/editor/src/document-editor.tsx
@@ -32,6 +32,7 @@ import {
   useBlockNote,
 } from './blocknote'
 import {blockHighlightPluginKey} from './blocknote/core/extensions/BlockHighlight/BlockHighlightPlugin'
+import {applyReadOnlyClickSelectionGuard} from './click-edit-mode-guard'
 import {FragmentActionsContext, type FragmentActions} from './fragment-actions-context'
 import {HMFormattingToolbar} from './hm-formatting-toolbar'
 import {HypermediaLinkPreview} from './hm-link-preview'
@@ -88,6 +89,10 @@ export function DocumentEditor({
 
   // Track mousedown coords so we can distinguish a click from a drag.
   const mousedownCoordsRef = useRef<{x: number; y: number} | null>(null)
+
+  // Whether ProseMirror had a non-empty selection at the most recent mousedown.
+  // Used to suppress edit.start when a click is intended to dismiss a selection.
+  const mousedownHadSelectionRef = useRef<boolean>(false)
 
   // Set when edit mode is being entered via the "+" button, so the
   // justEnteredEditing effect can call addBlockAtEnd after the editor
@@ -415,6 +420,7 @@ export function DocumentEditor({
 
     const handleMousedown = (e: MouseEvent) => {
       mousedownCoordsRef.current = {x: e.clientX, y: e.clientY}
+      mousedownHadSelectionRef.current = !view.state.selection.empty
     }
 
     const handleClick = (e: MouseEvent) => {
@@ -438,6 +444,16 @@ export function DocumentEditor({
       // If the click landed on a link, let the link plugin handle navigation.
       // Do not enter edit mode and do not preventDefault.
       if (target.closest?.('.link, a[href]')) return
+
+      // If a non-empty ProseMirror selection existed at mousedown, treat the
+      // click as "dismiss my selection" rather than "enter edit mode".
+      const hadSelection = mousedownHadSelectionRef.current
+      mousedownHadSelectionRef.current = false
+      if (hadSelection) {
+        applyReadOnlyClickSelectionGuard(view, true)
+        e.preventDefault()
+        return
+      }
 
       // --- Case 1: click on a known text block ---
       const contentType = getContentTypeFromTarget(target, domRoot)


### PR DESCRIPTION
In read-only mode the document editor's click handler unconditionally sent
edit.start to the unified document machine. When the user had text or a
media block selected, clicking anywhere would lose the selection on its
way into edit mode — surprising and unhelpful. Capture whether a non-empty
ProseMirror selection existed at mousedown and, on the resulting click,
collapse the selection (and the native window selection) and skip
edit.start. If nothing was selected at mousedown, the click still enters
edit mode as before.