### PR TITLE
feat(ui): surface concurrent-head merged state and trigger push on copy

### DIFF
--- a/backend/api/documents/v3alpha/documents_test.go
+++ b/backend/api/documents/v3alpha/documents_test.go
@@ -485,6 +485,20 @@ func TestConcurrentChanges(t *testing.T) {
 		must.Do2(cid.Decode(doc22.Version)),
 	)
 	require.Equal(t, wantVersion.String(), concurrent.Version, "concurrent version must match")
+	require.Contains(t, concurrent.Version, ".", "concurrent version must be a dot-joined compound of multiple heads")
+
+	// Asking for the document at the dot-joined compound version must return the
+	// same CRDT-merged state as asking for the latest. This is the silent-merge
+	// case the UI must surface: callers see one "version" string but it represents
+	// multiple concurrent heads merged on read.
+	concurrentExplicit, err := alice.GetDocument(ctx, &documents.GetDocumentRequest{
+		Account: doc1.Account,
+		Path:    doc1.Path,
+		Version: concurrent.Version,
+	})
+	require.NoError(t, err)
+	require.Equal(t, concurrent.Version, concurrentExplicit.Version, "explicit compound version must round-trip")
+	testutil.StructsEqual(concurrent, concurrentExplicit).Compare(t, "compound-version fetch must match latest fetch")
 
 	merged, err := alice.CreateDocumentChange(ctx, &documents.CreateDocumentChangeRequest{
 		SigningKeyName: "main",

--- a/frontend/apps/desktop/src/pages/library.tsx
+++ b/frontend/apps/desktop/src/pages/library.tsx
@@ -15,7 +15,7 @@ import {
 } from '@seed-hypermedia/client/hm-types'
 import {getMetadataName} from '@shm/shared/content'
 import {DocumentRoute} from '@shm/shared/routes'
-import {hmId} from '@shm/shared/utils/entity-id-url'
+import {getVersionHeads, hmId} from '@shm/shared/utils/entity-id-url'
 import {useNavRoute} from '@shm/shared/utils/navigation'
 import {entityQueryPathToHmIdPath} from '@shm/shared/utils/path-api'
 import {LibraryEntryUpdateSummary} from '@shm/ui/activity'
@@ -25,6 +25,7 @@ import {Popover, PopoverContent, PopoverTrigger} from '@shm/ui/components/popove
 import {Container, PanelContainer} from '@shm/ui/container'
 import {FacePile} from '@shm/ui/face-pile'
 import {HMIcon} from '@shm/ui/hm-icon'
+import {MergedBadge} from '@shm/ui/merged-badge'
 import {OptionsDropdown} from '@shm/ui/options-dropdown'
 import {PrivateBadge} from '@shm/ui/private-badge'
 import {SizableText} from '@shm/ui/text'
@@ -400,6 +401,7 @@ export function LibraryDocumentItem({
   const {isSelecting, selectedDocIds, onSelect} = useContext(librarySelectionContext)
   const isSelected = selectedDocIds.includes(id.id)
   const isRead = !item.activitySummary?.isUnread
+  const headCount = getVersionHeads(item.version).length
   return (
     <Button
       // this data attribute is used by the hypermedia highlight component
@@ -434,6 +436,7 @@ export function LibraryDocumentItem({
               {getMetadataName(metadata)}
             </SizableText>
             {item.visibility === 'PRIVATE' && <PrivateBadge />}
+            {headCount > 1 && <MergedBadge count={headCount} />}
           </div>
           {item.activitySummary && <LibraryEntryCommentCount activitySummary={item.activitySummary} />}
           <LibraryEntryAuthors item={item} accountsMetadata={accountsMetadata} />

--- a/frontend/apps/desktop/src/utils/navigation-container.tsx
+++ b/frontend/apps/desktop/src/utils/navigation-container.tsx
@@ -136,6 +136,9 @@ export function NavigationContainer({children}: {children: ReactNode}) {
         await copyTextToClipboard(url)
         pushAfterAction({id, trigger: 'copy', onlyPushToHost: gwUrl})
       }}
+      onPushReference={(id: UnpackedHypermediaId) => {
+        pushAfterAction({id, trigger: 'copy', onlyPushToHost: gwUrl})
+      }}
     >
       <NavContextProvider value={navigation}>
         {children}

--- a/frontend/apps/explore/src/components/tabs/ChangesTab.tsx
+++ b/frontend/apps/explore/src/components/tabs/ChangesTab.tsx
@@ -25,6 +25,9 @@ const ChangesTab: React.FC<{changes: any[] | undefined; docId: UnpackedHypermedi
       }
       if (deps) {
         out.deps = deps.map((dep: string) => `ipfs://${dep}`)
+        if (deps.length > 1) {
+          out.mergedFrom = deps.length
+        }
       }
       return out
     })

--- a/frontend/packages/shared/src/routing.tsx
+++ b/frontend/packages/shared/src/routing.tsx
@@ -48,6 +48,11 @@ type UniversalAppContextValue = {
 
   openUrl: (url: string, newWindow?: boolean) => void
   onCopyReference?: (hmId: UnpackedHypermediaId) => Promise<void>
+  /** Optional platform-specific push trigger fired AFTER a link has already
+   * been copied by the caller. On desktop this delegates to the
+   * pushOnCopy-gated push flow with toast feedback. Web/mobile may leave it
+   * undefined. */
+  onPushReference?: (hmId: UnpackedHypermediaId) => void
 
   // set this to true if you want all <a href="" values to be full hm:// hypermedia urls. otherwise, web URLs will be prepared
   // you must be confused at this point, because I wrote this and I got confused! Here's why we do it:
@@ -109,6 +114,7 @@ export function UniversalAppProvider(props: {
   openRoute: null | ((route: NavRoute, replace?: boolean) => void)
   openRouteNewWindow?: null | ((route: NavRoute) => void)
   onCopyReference?: (hmId: UnpackedHypermediaId) => Promise<void>
+  onPushReference?: (hmId: UnpackedHypermediaId) => void
   hmUrlHref?: boolean
   languagePack?: LanguagePack
   selectedIdentity?: StateStream<string | null>
@@ -131,6 +137,7 @@ export function UniversalAppProvider(props: {
         openRoute: props.openRoute,
         openRouteNewWindow: props.openRouteNewWindow,
         onCopyReference: props.onCopyReference,
+        onPushReference: props.onPushReference,
         hmUrlHref: props.hmUrlHref,
         languagePack: props.languagePack,
         selectedIdentity: props.selectedIdentity,

--- a/frontend/packages/shared/src/utils/entity-id-url.ts
+++ b/frontend/packages/shared/src/utils/entity-id-url.ts
@@ -901,6 +901,19 @@ export function displayHostname(fullHost: string): string {
   return fullHost.replace(/https?:\/\//, '')
 }
 
+/**
+ * Splits a version string into its constituent head CIDs.
+ *
+ * A version is a dot-separated list of CIDs (one per concurrent head). When the document
+ * has more than one head, the version becomes `cid1.cid2[.cid3...]`. This helper is the
+ * single source of truth for "how many heads is this version" so UI code can detect the
+ * merged/concurrent state without re-implementing the split.
+ */
+export function getVersionHeads(version: string | null | undefined): string[] {
+  if (!version) return []
+  return version.split('.').filter(Boolean)
+}
+
 export function hmIdMatches(a: UnpackedHypermediaId, b: UnpackedHypermediaId) {
   return (
     // @ts-expect-error

--- a/frontend/packages/shared/src/utils/version-heads.test.ts
+++ b/frontend/packages/shared/src/utils/version-heads.test.ts
@@ -1,0 +1,24 @@
+import {describe, expect, it} from 'vitest'
+import {getVersionHeads} from './entity-id-url'
+
+describe('getVersionHeads', () => {
+  it('returns an empty array for null/undefined/empty input', () => {
+    expect(getVersionHeads(null)).toEqual([])
+    expect(getVersionHeads(undefined)).toEqual([])
+    expect(getVersionHeads('')).toEqual([])
+  })
+
+  it('returns a single CID when the version has no concurrent heads', () => {
+    expect(getVersionHeads('bafyOnlyHead')).toEqual(['bafyOnlyHead'])
+  })
+
+  it('splits a dot-joined version into multiple heads', () => {
+    expect(getVersionHeads('bafyA.bafyB')).toEqual(['bafyA', 'bafyB'])
+    expect(getVersionHeads('bafyA.bafyB.bafyC')).toEqual(['bafyA', 'bafyB', 'bafyC'])
+  })
+
+  it('filters out empty segments produced by stray dots', () => {
+    expect(getVersionHeads('.bafyA.')).toEqual(['bafyA'])
+    expect(getVersionHeads('bafyA..bafyB')).toEqual(['bafyA', 'bafyB'])
+  })
+})

--- a/frontend/packages/ui/src/document-header.tsx
+++ b/frontend/packages/ui/src/document-header.tsx
@@ -7,6 +7,7 @@ import {
 } from '@seed-hypermedia/client/hm-types'
 import {abbreviateUid, useRouteLink} from '@shm/shared'
 import {useAccount} from '@shm/shared/models/entity'
+import {getVersionHeads} from '@shm/shared/utils/entity-id-url'
 import {useNavRoute} from '@shm/shared/utils/navigation'
 import {useMemo} from 'react'
 import {Container} from './container'
@@ -15,6 +16,7 @@ import {useHighlighter} from './highlight-context'
 import {HMIcon} from './hm-icon'
 import {Home} from './icons'
 import {getContextualProfileRoute} from './inline-descriptor'
+import {MergedBadge} from './merged-badge'
 import {PrivateBadge} from './private-badge'
 import {Spinner} from './spinner'
 import {SizableText} from './text'
@@ -45,6 +47,7 @@ export function DocumentHeader({
   siteUrl,
   documentTools,
   visibility,
+  version,
   showTitle = true,
   children,
 }: {
@@ -56,6 +59,7 @@ export function DocumentHeader({
   siteUrl?: string
   documentTools?: React.ReactNode
   visibility?: HMResourceVisibility
+  version?: HMDocument['version'] | null
   showTitle?: boolean
   children?: React.ReactNode
 }) {
@@ -64,6 +68,7 @@ export function DocumentHeader({
   const isHomeDoc = !docId?.path?.length
   const highlighter = useHighlighter()
   const isPrivate = visibility === 'PRIVATE'
+  const headCount = getVersionHeads(version).length
 
   return (
     <Container
@@ -85,7 +90,12 @@ export function DocumentHeader({
           </div>
         ) : null}
         {breadcrumbs && breadcrumbs.length > 0 ? <Breadcrumbs breadcrumbs={breadcrumbs} /> : null}
-        {isPrivate && <PrivateBadge />}
+        {(isPrivate || headCount > 1) && (
+          <div className="flex flex-wrap items-center gap-2">
+            {isPrivate && <PrivateBadge />}
+            {headCount > 1 && <MergedBadge count={headCount} />}
+          </div>
+        )}
         {children ? (
           children
         ) : (

--- a/frontend/packages/ui/src/document-list-item.tsx
+++ b/frontend/packages/ui/src/document-list-item.tsx
@@ -10,6 +10,7 @@ import {
 import {formattedDate, getMetadataName, hmId, InteractionSummaryPayload, useRouteLink} from '@shm/shared'
 import {useDocumentActions} from '@shm/shared/document-actions-context'
 import {useInteractionSummary} from '@shm/shared/models/interaction-summary'
+import {getVersionHeads} from '@shm/shared/utils/entity-id-url'
 import {useNavigate} from '@shm/shared/utils/navigation'
 import {Bookmark, Copy, Forward, GitFork, Link, MessageSquare, Pencil} from 'lucide-react'
 import {useMemo} from 'react'
@@ -20,6 +21,7 @@ import {DraftBadge} from './draft-badge'
 import {useHighlighter} from './highlight-context'
 import {HMIcon} from './hm-icon'
 import {Download, Trash} from './icons'
+import {MergedBadge} from './merged-badge'
 import {MenuItemType, OptionsDropdown} from './options-dropdown'
 import {PrivateBadge} from './private-badge'
 import {SizableText} from './text'
@@ -64,6 +66,7 @@ export function DocumentListItem({
   const metadata = item.metadata
   const visibility = 'visibility' in item ? item.visibility : undefined
   const isPrivate = visibility === 'PRIVATE'
+  const headCount = getVersionHeads('version' in item ? item.version : undefined).length
   const itemActivitySummary =
     activitySummary !== undefined ? activitySummary : 'activitySummary' in item ? item.activitySummary : null
   const itemLatestComment =
@@ -222,6 +225,7 @@ export function DocumentListItem({
               </SizableText>
               {!!draftId && <DraftBadge />}
               {isPrivate && <PrivateBadge size="sm" />}
+              {headCount > 1 && <MergedBadge count={headCount} size="sm" />}
             </div>
             {commentCount > 0 && !hasActions && <DocumentListItemCommentCount count={commentCount} />}
             {!itemActivitySummary && 'updateTime' in item && (

--- a/frontend/packages/ui/src/feed.tsx
+++ b/frontend/packages/ui/src/feed.tsx
@@ -198,7 +198,7 @@ function EventHeaderContent({
   const deleteCommentMutation = useDeleteComment()
   const deleteCommentDialog = useDeleteCommentDialog()
   const copyHmLink = useCopyHmLink()
-  const {origin: appOrigin} = useUniversalAppContext()
+  const {origin: appOrigin, onPushReference} = useUniversalAppContext()
   if (event.type == 'comment') {
     const options: MenuItemType[] = []
     if (event.comment && currentAccount && currentAccount == event.comment.author) {
@@ -353,15 +353,17 @@ function EventHeaderContent({
                 currentRoute.key === 'document' || currentRoute.key === 'comments' || currentRoute.key === 'activity'
                   ? currentRoute.id.latest
                   : undefined
+              const versionedId = hmId(event.docId.uid, {
+                path: event.docId.path,
+                version: event.document.version,
+                latest: routeLatest ?? false,
+                hostname: targetDomain ?? null,
+              })
               copyHmLink({
-                id: hmId(event.docId.uid, {
-                  path: event.docId.path,
-                  version: event.document.version,
-                  latest: routeLatest ?? false,
-                  hostname: targetDomain ?? null,
-                }),
+                id: versionedId,
                 gatewayUrl: appOrigin ?? undefined,
               })
+              onPushReference?.(versionedId)
             }}
           >
             <Link className="size-3" />

--- a/frontend/packages/ui/src/feed.tsx
+++ b/frontend/packages/ui/src/feed.tsx
@@ -7,10 +7,10 @@ import {useRouteLink, useUniversalAppContext} from '@shm/shared/routing'
 import {useTx, useTxString} from '@shm/shared/translation'
 import {useActivityFeed} from '@shm/shared/use-activity-feed'
 import {AnyTimestamp, formattedDateShort, normalizeDate} from '@shm/shared/utils/date'
-import {commentIdToHmId, getCommentTargetId, hmId} from '@shm/shared/utils/entity-id-url'
+import {commentIdToHmId, getCommentTargetId, getVersionHeads, hmId} from '@shm/shared/utils/entity-id-url'
 import {useNavRoute} from '@shm/shared/utils/navigation'
 import _ from 'lodash'
-import {CircleAlert, Link, Trash2} from 'lucide-react'
+import {CircleAlert, Link, Merge, Trash2} from 'lucide-react'
 import {memo, useEffect, useMemo, useRef} from 'react'
 import {SelectionContent} from './accessories'
 import {useReadOnlyViewer} from '@shm/shared/readonly-viewer-context'
@@ -309,27 +309,65 @@ function EventHeaderContent({
   }
 
   if (event.type == 'doc-update') {
+    const docUpdateHeadCount = getVersionHeads(event.document.version).length
     return (
-      <InlineDescriptor>
-        <AuthorNameLink author={event.author} />{' '}
-        {!isSingleResource ? (
-          <>
-            <span>
-              {/* TODO: check if this is the correct way of getting the first ref update of a document */}
-              {event.document.version == event.document.genesis ? 'created' : 'updated'}
-            </span>{' '}
-            <DocumentNameLink metadata={event.document.metadata} id={event.docId} />{' '}
-          </>
-        ) : (
-          <>
-            <span>
-              {/* TODO: check if this is the correct way of getting the first ref update of a document */}
-              {event.document.version == event.document.genesis ? 'created the document' : 'updated the document'}
-            </span>{' '}
-          </>
-        )}
-        <Timestamp time={event.time} route={route} />
-      </InlineDescriptor>
+      <div className="flex w-full items-start justify-between gap-2">
+        <InlineDescriptor>
+          <AuthorNameLink author={event.author} />{' '}
+          {!isSingleResource ? (
+            <>
+              <span>
+                {/* TODO: check if this is the correct way of getting the first ref update of a document */}
+                {event.document.version == event.document.genesis ? 'created' : 'updated'}
+              </span>{' '}
+              <DocumentNameLink metadata={event.document.metadata} id={event.docId} />{' '}
+            </>
+          ) : (
+            <>
+              <span>
+                {/* TODO: check if this is the correct way of getting the first ref update of a document */}
+                {event.document.version == event.document.genesis ? 'created the document' : 'updated the document'}
+              </span>{' '}
+            </>
+          )}
+          <Timestamp time={event.time} route={route} />
+          {docUpdateHeadCount > 1 ? (
+            <Tooltip content={`Merged ${docUpdateHeadCount} concurrent versions`}>
+              <span className="text-muted-foreground ml-1 inline-flex items-center gap-0.5 align-middle">
+                <Merge size={12} strokeWidth={2} />
+                <span className="text-xs">{docUpdateHeadCount}</span>
+              </span>
+            </Tooltip>
+          ) : null}
+        </InlineDescriptor>
+        <Tooltip content={tx('Copy Link to Version')}>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="text-muted-foreground hover-hover:opacity-0 hover-hover:group-hover:opacity-100 transition-opacity duration-200 ease-in-out"
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              if (!event.docId?.uid) return
+              const routeLatest =
+                currentRoute.key === 'document' || currentRoute.key === 'comments' || currentRoute.key === 'activity'
+                  ? currentRoute.id.latest
+                  : undefined
+              copyHmLink({
+                id: hmId(event.docId.uid, {
+                  path: event.docId.path,
+                  version: event.document.version,
+                  latest: routeLatest ?? false,
+                  hostname: targetDomain ?? null,
+                }),
+                gatewayUrl: appOrigin ?? undefined,
+              })
+            }}
+          >
+            <Link className="size-3" />
+          </Button>
+        </Tooltip>
+      </div>
     )
   }
 

--- a/frontend/packages/ui/src/merged-badge.tsx
+++ b/frontend/packages/ui/src/merged-badge.tsx
@@ -1,0 +1,16 @@
+import {Merge} from 'lucide-react'
+import {Badge} from './components/badge'
+import {cn} from './utils'
+
+export function MergedBadge({count, size = 'md', className}: {count: number; size?: 'sm' | 'md'; className?: string}) {
+  if (count <= 1) return null
+  return (
+    <Badge
+      variant="outline"
+      className={cn('text-muted-foreground gap-0.5', size === 'sm' ? 'text-[10px]' : 'text-xs', className)}
+    >
+      <Merge size={size === 'sm' ? 10 : 12} strokeWidth={2} />
+      Merged · {count} versions
+    </Badge>
+  )
+}

--- a/frontend/packages/ui/src/navigation.tsx
+++ b/frontend/packages/ui/src/navigation.tsx
@@ -8,6 +8,7 @@ import {
   UnpackedHypermediaId,
 } from '@seed-hypermedia/client/hm-types'
 import {getMetadataName, getNodesOutline, NavRoute, NodeOutline, useRouteLink} from '@shm/shared'
+import {getVersionHeads} from '@shm/shared/utils/entity-id-url'
 import {useIsomorphicLayoutEffect} from '@shm/shared/utils/use-isomorphic-layout-effect'
 import {ReactNode, useMemo} from 'react'
 import {HoverCard, HoverCardContent, HoverCardTrigger} from './/hover-card'
@@ -15,6 +16,7 @@ import {ButtonProps} from './button'
 import {useHighlighter} from './highlight-context'
 import {HMIcon} from './hm-icon'
 import {SmallListItem} from './list-item'
+import {MergedBadge} from './merged-badge'
 import {PrivateBadge} from './private-badge'
 import {useMedia} from './use-media'
 import {usePopoverState} from './use-popover-state'
@@ -47,7 +49,14 @@ export function DocumentSmallListItem({
   const isPrivate = visibility === 'PRIVATE'
   const icon = id ? <HMIcon id={id} name={metadata?.name} icon={metadata?.icon} size={20} /> : null
 
-  const privateBadge = isPrivate ? <PrivateBadge size="sm" /> : null
+  const headCount = getVersionHeads(id?.version).length
+  const accessory =
+    isPrivate || headCount > 1 ? (
+      <div className="flex items-center gap-1">
+        {isPrivate && <PrivateBadge size="sm" />}
+        {headCount > 1 && <MergedBadge count={headCount} size="sm" />}
+      </div>
+    ) : null
 
   return (
     <SmallListItem
@@ -60,7 +69,7 @@ export function DocumentSmallListItem({
       icon={icon}
       active={active}
       isDraft={!!draftId}
-      accessory={privateBadge}
+      accessory={accessory}
       {...linkProps}
     />
   )

--- a/frontend/packages/ui/src/newspaper.tsx
+++ b/frontend/packages/ui/src/newspaper.tsx
@@ -2,6 +2,7 @@ import {HMAccountsMetadata, HMResourceFetchResult, UnpackedHypermediaId} from '@
 import {getDocumentImage, hmId, plainTextOfContent, useRouteLink} from '@shm/shared'
 import {useDocumentActions} from '@shm/shared/document-actions-context'
 import {useInteractionSummary} from '@shm/shared/models/interaction-summary'
+import {getVersionHeads} from '@shm/shared/utils/entity-id-url'
 import {useNavigate} from '@shm/shared/utils/navigation'
 import {Bookmark, Copy, Forward, GitFork, Link, MessageSquare, Pencil} from 'lucide-react'
 import {HTMLAttributes, useMemo} from 'react'
@@ -11,6 +12,7 @@ import {FacePile} from './face-pile'
 import {useImageUrl} from './get-file-url'
 import {useHighlighter} from './highlight-context'
 import {Download, Trash} from './icons'
+import {MergedBadge} from './merged-badge'
 import {MenuItemType, OptionsDropdown} from './options-dropdown'
 import {PrivateBadge} from './private-badge'
 import {SizableText} from './text'
@@ -61,6 +63,7 @@ export function DocumentCard({
   const coverImage = entity?.document ? getDocumentImage(entity?.document) : undefined
   const isPrivate = entity?.document?.visibility === 'PRIVATE'
   const doc = entity?.document
+  const headCount = getVersionHeads(doc?.version).length
 
   // Context-driven state
   const draftId = actions.getDraftId?.(docId)
@@ -192,6 +195,7 @@ export function DocumentCard({
               )}
               {!!draftId && <DraftBadge />}
               {!draftId && isPrivate && <PrivateBadge size="sm" />}
+              {!draftId && headCount > 1 && <MergedBadge count={headCount} size="sm" />}
             </div>
             <div className="flex items-center gap-1">
               {actions.onBookmarkToggle && (

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -1326,6 +1326,7 @@ function DocumentBody({
                   updateTime={document.updateTime}
                   breadcrumbs={breadcrumbs}
                   visibility={document.visibility}
+                  version={document.version}
                 />
               ) : (
                 <DocumentHeader
@@ -1335,6 +1336,7 @@ function DocumentBody({
                   updateTime={document.updateTime}
                   breadcrumbs={breadcrumbs}
                   visibility={document.visibility}
+                  version={document.version}
                 />
               ))}
           </div>
@@ -1381,6 +1383,7 @@ function DocumentBody({
                 updateTime={document.updateTime}
                 breadcrumbs={breadcrumbs}
                 visibility={document.visibility}
+                version={document.version}
               />
             ) : (
               <DocumentHeader
@@ -1390,6 +1393,7 @@ function DocumentBody({
                 updateTime={document.updateTime}
                 breadcrumbs={breadcrumbs}
                 visibility={document.visibility}
+                version={document.version}
               />
             ))}
         </div>
@@ -1630,6 +1634,7 @@ function EditableDocumentHeader({
   updateTime,
   breadcrumbs,
   visibility,
+  version,
 }: {
   docId: UnpackedHypermediaId
   docMetadata: HMDocument['metadata']
@@ -1637,6 +1642,7 @@ function EditableDocumentHeader({
   updateTime: HMDocument['updateTime']
   breadcrumbs?: BreadcrumbEntry[]
   visibility?: string
+  version?: HMDocument['version'] | null
 }) {
   const ctx = useDocumentSelector(selectContext)
   const isEditing = useDocumentSelector(selectIsEditing)
@@ -1717,6 +1723,7 @@ function EditableDocumentHeader({
       updateTime={updateTime}
       breadcrumbs={breadcrumbs}
       visibility={visibility as any}
+      version={version}
       showTitle={false}
     >
       <textarea


### PR DESCRIPTION
## Summary

- Add `getVersionHeads()` utility to `entity-id-url.ts` — single source of truth for splitting a dot-joined compound version string into its constituent CIDs
- Add `MergedBadge` component (`@shm/ui/merged-badge`) that renders a merge icon + head count when a document has more than one concurrent head
- Surface `MergedBadge` across all document-listing surfaces: library page, document list items, newspaper cards, navigation sidebar items, and the document header (both read-only and editable variants)
- Show an inline merge indicator in the activity feed for `doc-update` events that carry a compound version
- Add a "Copy Link to Version" button in the feed's `doc-update` event header row
- Introduce `onPushReference` callback to `UniversalAppContext` / `UniversalAppProvider` so platform-specific push logic can be triggered after a link is copied; wire it up in `navigation-container.tsx` to call `pushAfterAction` on the desktop
- Extend backend `TestConcurrentChanges` to assert that the compound version round-trips through an explicit `GetDocument` call and that the CRDT-merged state matches the implicit latest fetch
- Add unit tests for `getVersionHeads` covering null/undefined/empty, single-head, multi-head, and stray-dot cases
