### PR TITLE
fix(nav): never expose private docs in site-header directory fallback

### DIFF
--- a/frontend/apps/desktop/src/models/documents.ts
+++ b/frontend/apps/desktop/src/models/documents.ts
@@ -36,7 +36,6 @@ import {BIG_INT, DEFAULT_GATEWAY_URL} from '@shm/shared/constants'
 import {extractRefs, getAnnotations} from '@shm/shared/content'
 import {prepareHMDocument} from '@shm/shared/document-utils'
 import {EditorBlock} from '@seed-hypermedia/client/editor-types'
-import {useCanSeePrivateDocs} from '@shm/shared/models/capabilities'
 import {prepareHMDocumentInfo, useDirectory, useResource, useResources} from '@shm/shared/models/entity'
 import {invalidateQueries, setQueriesDataByKey} from '@shm/shared/models/query-client'
 import {queryKeys} from '@shm/shared/models/query-keys'
@@ -1455,7 +1454,6 @@ export function useSiteNavigationItems(
     mode: 'Children',
   })
   const drafts = useAccountDraftList(siteHomeEntity?.id?.uid)
-  const canSeePrivate = useCanSeePrivateDocs(siteHomeEntity?.id)
   if (!siteHomeEntity) return null
   const navNode = siteHomeEntity.document?.detachedBlocks?.navigation
   const navItems: DocNavigationItem[] = navNode
@@ -1474,11 +1472,13 @@ export function useSiteNavigationItems(
           } satisfies DocNavigationItem
         })
         .filter((b) => !!b) || []
-    : getSiteNavDirectory({
+    : // Site-header fallback must NEVER include private documents — even for
+      // editors. Editors who want a private doc in the nav must add it
+      // explicitly to the home document's `navigation` detached block.
+      getSiteNavDirectory({
         id: siteHomeEntity.id,
         directory: homeDir.data,
         drafts: drafts.data,
-        includePrivate: canSeePrivate,
       })
   return navItems
 }

--- a/frontend/apps/web/app/__tests__/web-site-header.test.ts
+++ b/frontend/apps/web/app/__tests__/web-site-header.test.ts
@@ -1,15 +1,12 @@
 import {describe, expect, it, vi} from 'vitest'
 import type {DocNavigationItem} from '@shm/ui/navigation'
+import {getSiteNavDirectory} from '@shm/ui/navigation'
+import type {HMDocumentInfo, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 
 vi.mock('@shm/shared', () => ({unpackHmId: vi.fn()}))
-vi.mock('@shm/shared/models/capabilities', () => ({useCanSeePrivateDocs: vi.fn()}))
 vi.mock('@shm/shared/constants', () => ({NOTIFY_SERVICE_HOST: ''}))
 vi.mock('@shm/shared/models/entity', () => ({useDirectory: vi.fn(), useResource: vi.fn()}))
 vi.mock('@shm/ui/hm-host-banner', () => ({HypermediaHostBanner: vi.fn()}))
-vi.mock('@shm/ui/navigation', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@shm/ui/navigation')>()
-  return {...actual, getSiteNavDirectory: vi.fn()}
-})
 vi.mock('@shm/ui/site-header', () => ({SiteHeader: vi.fn()}))
 
 import {resolveNavigationItems} from '../web-site-header'
@@ -69,5 +66,58 @@ describe('resolveNavigationItems', () => {
       directoryItems: [],
     })
     expect(result).toEqual([])
+  })
+})
+
+describe('site-header directory fallback (regression for #418)', () => {
+  function makeId(uid: string, path?: string[]): UnpackedHypermediaId {
+    return {
+      uid,
+      path: path ?? null,
+      version: null,
+      blockRef: null,
+      blockRange: null,
+      hostname: null,
+      scheme: null,
+      latest: null,
+      id: `${uid}/${path?.join('/') ?? ''}`,
+    }
+  }
+
+  function makeDocInfo(uid: string, path: string[], name: string, visibility: 'PUBLIC' | 'PRIVATE'): HMDocumentInfo {
+    const ts = '2024-01-01T00:00:00Z'
+    return {
+      type: 'document',
+      id: makeId(uid, path),
+      path,
+      authors: [uid],
+      createTime: ts,
+      updateTime: ts,
+      sortTime: new Date(ts),
+      genesis: 'genesis',
+      version: 'v1',
+      breadcrumbs: [],
+      activitySummary: {commentCount: 0, latestCommentId: '', latestChangeTime: ts, isUnread: false},
+      generationInfo: {genesis: 'genesis', generation: 1n},
+      metadata: {name},
+      visibility,
+    }
+  }
+
+  // The site header builds its directory fallback by calling
+  // `getSiteNavDirectory({id, directory})` with NO `includePrivate` flag.
+  // This locks in that contract: with no flag, private docs must be excluded —
+  // even when the underlying directory query returned them (which happens for
+  // any viewer with writer+ capability on the site home).
+  it('excludes private docs when called the way WebSiteHeader calls it', () => {
+    const homeId = makeId('alice')
+    const directory: HMDocumentInfo[] = [
+      makeDocInfo('alice', ['public-doc'], 'Public Doc', 'PUBLIC'),
+      makeDocInfo('alice', ['private-doc'], 'Private Doc', 'PRIVATE'),
+    ]
+    const items = getSiteNavDirectory({id: homeId, directory})
+    const names = items.map((i) => i.metadata.name)
+    expect(names).toContain('Public Doc')
+    expect(names).not.toContain('Private Doc')
   })
 })

--- a/frontend/apps/web/app/web-site-header.tsx
+++ b/frontend/apps/web/app/web-site-header.tsx
@@ -1,6 +1,5 @@
 import {HMDocument, HMMetadata, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {unpackHmId} from '@shm/shared'
-import {useCanSeePrivateDocs} from '@shm/shared/models/capabilities'
 import {NOTIFY_SERVICE_HOST} from '@shm/shared/constants'
 import {useDirectory, useResource} from '@shm/shared/models/entity'
 import {HypermediaHostBanner} from '@shm/ui/hm-host-banner'
@@ -62,13 +61,14 @@ export function WebSiteHeader({origin, ...props}: React.PropsWithChildren<WebSit
         .filter((item) => !!item) || []
     : []
 
-  const canSeePrivate = useCanSeePrivateDocs(props.siteHomeId)
+  // Site-header fallback must NEVER include private documents — even for editors
+  // who can otherwise see them. Editors who want a private doc in the nav must
+  // add it explicitly to the home document's `navigation` detached block.
   const directoryResults = homeDirectoryQuery.data
   const directoryItems = props.siteHomeId
     ? getSiteNavDirectory({
         id: props.siteHomeId,
         directory: directoryResults ?? undefined,
-        includePrivate: canSeePrivate,
       })
     : []
 

--- a/frontend/packages/ui/src/feed-page-common.tsx
+++ b/frontend/packages/ui/src/feed-page-common.tsx
@@ -1,6 +1,5 @@
 import {HMDocument, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {hmId} from '@shm/shared'
-import {useCanSeePrivateDocs} from '@shm/shared/models/capabilities'
 import {IS_DESKTOP} from '@shm/shared/constants'
 import {useDirectory, useResource} from '@shm/shared/models/entity'
 import {useNavRoute} from '@shm/shared/utils/navigation'
@@ -28,12 +27,10 @@ export function FeedPage({docId, extraMenuItems, rightActions}: FeedPageProps) {
   const siteHomeResource = useResource(siteHomeId, {subscribed: true})
   const homeDirectory = useDirectory(siteHomeId)
 
-  const canSeePrivate = useCanSeePrivateDocs(docId)
-
   const siteHomeDocument: HMDocument | null =
     siteHomeResource.data?.type === 'document' ? siteHomeResource.data.document : null
 
-  const headerData = computeHeaderData(siteHomeId, siteHomeDocument, homeDirectory.data, canSeePrivate)
+  const headerData = computeHeaderData(siteHomeId, siteHomeDocument, homeDirectory.data)
 
   const targetDomain = siteHomeDocument?.metadata?.siteUrl || undefined
 

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -20,7 +20,6 @@ import {
 import {useHackyAuthorsSubscriptions} from '@shm/shared/comments-service-provider'
 import {IS_DESKTOP, NOTIFY_SERVICE_HOST} from '@shm/shared/constants'
 import type {BlockRangeSelectOptions, DocumentContentProps} from '@shm/shared/document-content-props'
-import {useCanSeePrivateDocs} from '@shm/shared/models/capabilities'
 import {
   useAccount,
   useAccountsMetadata,
@@ -336,12 +335,11 @@ export function ResourcePage({
   const siteHomeResource = useResource(siteHomeId, {subscribed: true})
   const homeDirectory = useDirectory(siteHomeId)
   const isLatest = useIsLatest(docId, resource)
-  const canSeePrivate = useCanSeePrivateDocs(docId)
 
   const siteHomeDocument = siteHomeResource.data?.type === 'document' ? siteHomeResource.data.document : null
 
   // Compute header data
-  const headerData = computeHeaderData(siteHomeId, siteHomeDocument, homeDirectory.data, canSeePrivate)
+  const headerData = computeHeaderData(siteHomeId, siteHomeDocument, homeDirectory.data)
 
   // Comment handling: when resource is a comment, resolve and load its target document.
   // Hooks must be called unconditionally, so we always call useResource for the target
@@ -620,7 +618,6 @@ export function computeHeaderData(
   siteHomeId: UnpackedHypermediaId,
   siteHomeDocument: HMDocument | null,
   directory: ReturnType<typeof useDirectory>['data'],
-  includePrivate: boolean = false,
 ): HeaderData {
   // Compute navigation items from home document's navigation block
   const navigationBlockNode = siteHomeDocument?.detachedBlocks?.navigation
@@ -642,10 +639,12 @@ export function computeHeaderData(
         .filter((item): item is DocNavigationItem => item !== null) ?? []
     : []
 
+  // Site-header fallback must NEVER include private documents — even for editors
+  // who can otherwise see them. Editors who want a private doc in the nav must
+  // add it explicitly to the home document's `navigation` detached block.
   const directoryItems = getSiteNavDirectory({
     id: siteHomeId,
     directory: directory ?? undefined,
-    includePrivate,
   })
 
   const items = homeNavigationItems.length > 0 ? homeNavigationItems : directoryItems


### PR DESCRIPTION
## Summary

- Removes `includePrivate` flag from `getSiteNavDirectory` calls in the site-header directory fallback path across desktop, web, and shared UI packages
- Removes `useCanSeePrivateDocs` usage from `useSiteNavigationItems`, `WebSiteHeader`, `FeedPage`, and `ResourcePage` — the fallback now unconditionally excludes private documents
- Removes the `includePrivate` parameter from `computeHeaderData` signature (was `false` by default; now hardcoded behavior)
- Adds regression test suite (`web-site-header.test.ts`) that locks in the contract: calling `getSiteNavDirectory` without `includePrivate` must exclude private docs even when the underlying directory query returned them

## Breaking Changes

`computeHeaderData` no longer accepts an `includePrivate` argument. Callers that passed `canSeePrivate` must remove that argument. The directory fallback now always hides private documents; editors who want a private doc in the nav must add it explicitly to the home document's `navigation` detached block.


---

Fixes #418