### PR TITLE
fix(content): tighten self-query detection to require explicit uid and path

### DIFF
--- a/frontend/apps/desktop/src/components/desktop-query-block-draft-slot.tsx
+++ b/frontend/apps/desktop/src/components/desktop-query-block-draft-slot.tsx
@@ -2,8 +2,8 @@ import {useChildDrafts, useCreateInlineDraft, useDeleteDraft, useUpdateDraftMeta
 import {useNavigate} from '@/utils/useNavigate'
 import {roleCanWrite, useSelectedAccountCapability} from '@shm/shared/models/capabilities'
 import {useResource} from '@shm/shared/models/entity'
-import {QueryBlockDraftSlotProps} from '@shm/shared/query-block-drafts-context'
-import {useMemo, useState} from 'react'
+import {QueryBlockDraftSlotProps, useQueryBlockDrafts} from '@shm/shared/query-block-drafts-context'
+import {useMemo} from 'react'
 
 export function DesktopQueryBlockDraftSlot({targetId, children}: QueryBlockDraftSlotProps) {
   const navigate = useNavigate()
@@ -17,7 +17,7 @@ export function DesktopQueryBlockDraftSlot({targetId, children}: QueryBlockDraft
   const createInlineDraft = useCreateInlineDraft(targetId ?? undefined)
   const deleteDraft = useDeleteDraft()
   const updateDraftMetadata = useUpdateDraftMetadata()
-  const [lastCreatedDraftId, setLastCreatedDraftId] = useState<string | null>(null)
+  const {lastCreatedDraftId, setLastCreatedDraftId} = useQueryBlockDrafts()
 
   const drafts = useMemo(
     () =>
@@ -35,12 +35,12 @@ export function DesktopQueryBlockDraftSlot({targetId, children}: QueryBlockDraft
         {},
         {
           onSuccess: ({draftId}) => {
-            setLastCreatedDraftId(draftId)
+            setLastCreatedDraftId?.(draftId)
           },
         },
       )
     }
-  }, [targetId, canEdit, isPrivate, createInlineDraft])
+  }, [targetId, canEdit, isPrivate, createInlineDraft, setLastCreatedDraftId])
 
   return (
     <>

--- a/frontend/apps/desktop/src/models/__tests__/auto-link-parent.test.ts
+++ b/frontend/apps/desktop/src/models/__tests__/auto-link-parent.test.ts
@@ -202,7 +202,9 @@ describe('documentHasSelfQuery', () => {
     expect(documentHasSelfQuery(doc, documentId)).toBe(false)
   })
 
-  it('returns true when query includes self (empty space)', () => {
+  it('returns false when query includes have empty space (unconfigured)', () => {
+    // Unified semantics: empty space is not a self-match — the editor renders
+    // empty for an unconfigured query block, so it does not auto-include children.
     const doc = createDocument([
       {
         block: {
@@ -219,10 +221,10 @@ describe('documentHasSelfQuery', () => {
         },
       },
     ] as HMBlockNode[])
-    expect(documentHasSelfQuery(doc, documentId)).toBe(true)
+    expect(documentHasSelfQuery(doc, documentId)).toBe(false)
   })
 
-  it('returns true when query includes self (matching space and empty path)', () => {
+  it('returns false when query includes match space but path is empty (and parent path is not root)', () => {
     const doc = createDocument([
       {
         block: {
@@ -239,7 +241,7 @@ describe('documentHasSelfQuery', () => {
         },
       },
     ] as HMBlockNode[])
-    expect(documentHasSelfQuery(doc, documentId)).toBe(true)
+    expect(documentHasSelfQuery(doc, documentId)).toBe(false)
   })
 
   it('returns true when query includes self (matching space and path with leading slash)', () => {
@@ -337,7 +339,7 @@ describe('documentHasSelfQuery', () => {
             query: {
               includes: [
                 {space: 'other-uid', path: 'some/path', mode: 'Children'},
-                {space: 'doc-uid', path: '', mode: 'Children'},
+                {space: 'doc-uid', path: 'my/document', mode: 'Children'},
               ],
             },
           },
@@ -361,7 +363,7 @@ describe('documentHasSelfQuery', () => {
                 banner: false,
                 columnCount: 1,
                 query: {
-                  includes: [{space: '', path: '', mode: 'Children'}],
+                  includes: [{space: 'doc-uid', path: 'my/document', mode: 'Children'}],
                 },
               },
             },

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -39,7 +39,7 @@ import {QuerySearchInputProvider} from '@shm/editor/query-search-context'
 import {hmId, hostnameStripProtocol, unpackHmId, useUniversalAppContext} from '@shm/shared'
 import {CommentsProvider, isRouteEqualToCommentTarget} from '@shm/shared/comments-service-provider'
 import {DEFAULT_GATEWAY_URL} from '@shm/shared/constants'
-import {findSelfQueryBlock} from '@shm/shared/content'
+import {hasQueryBlockTargetingSelf, hasSelfQueryBlockInEditorContent} from '@shm/shared/content'
 import {documentMachine, PublishInput, PushDocumentInput, WriteDraftInput} from '@shm/shared/models/document-machine'
 import {useDocumentInspector} from '@shm/shared/models/document-machine-inspect'
 import {useResource} from '@shm/shared/models/entity'
@@ -410,13 +410,19 @@ export default function DesktopResourcePage() {
   const [lastCreatedDraftId, setLastCreatedDraftId] = useState<string | null>(null)
 
   // Detect self-referential query block — if present, drafts render inside query blocks
-  // and the bottom fallback is suppressed.
-  const selfQueryBlock = useMemo(() => {
-    if (!doc?.content) return null
-    return findSelfQueryBlock(doc.content, docId.uid, docId.path || null)
-  }, [doc?.content, docId.uid, docId.path])
-
-  const hasSelfQuery = !!selfQueryBlock
+  // and the bottom fallback is suppressed. We check both the published doc content
+  // and the parent's draft content so a query block added in an unpublished draft
+  // also suppresses the duplicate.
+  const hasSelfQuery = useMemo(() => {
+    const parentPath = docId.path || null
+    if (existingDraftContent && hasSelfQueryBlockInEditorContent(existingDraftContent, docId.uid, parentPath)) {
+      return true
+    }
+    if (doc?.content && hasQueryBlockTargetingSelf(doc.content, docId.uid, parentPath)) {
+      return true
+    }
+    return false
+  }, [doc?.content, existingDraftContent, docId.uid, docId.path])
 
   // Bottom fallback: drafts of the current doc when no query block on the page targets it
   const inlineCards = useMemo(() => {
@@ -714,7 +720,11 @@ export default function DesktopResourcePage() {
         pushAfterCommentPublish={(targetDocId) => pushAfterAction({id: targetDocId, trigger: 'publish'})}
       >
         <DesktopDocumentActionsProvider>
-          <QueryBlockDraftsProvider DraftSlot={DesktopQueryBlockDraftSlot}>
+          <QueryBlockDraftsProvider
+            DraftSlot={DesktopQueryBlockDraftSlot}
+            lastCreatedDraftId={lastCreatedDraftId}
+            setLastCreatedDraftId={setLastCreatedDraftId}
+          >
             <QuerySearchInputProvider value={SearchInput}>
               <ResourcePage
                 docId={docId}

--- a/frontend/packages/client/src/auto-link.ts
+++ b/frontend/packages/client/src/auto-link.ts
@@ -11,7 +11,7 @@
  */
 
 import type {HMBlockNode, HMDocument, HMSigner, UnpackedHypermediaId} from './hm-types'
-import {hmIdPathToEntityQueryPath, packHmId, unpackHmId} from './hm-types'
+import {entityQueryPathToHmIdPath, packHmId, unpackHmId} from './hm-types'
 import type {SeedClient} from './client'
 import type {DocumentOperation} from './change'
 import {createChangeOps, createChange} from './change'
@@ -59,22 +59,27 @@ export function documentContainsLinkToChild(document: HMDocument, childId: Unpac
 /**
  * Check if a document has a self-referential Query block
  * (a query to itself that would automatically include children).
+ *
+ * A query block is self-referential when one of its `query.includes` entries
+ * has `space === documentId.uid` AND a path that, after normalization, equals
+ * the document's path. Empty `space` or `path` does not count as self — that
+ * represents an unconfigured query block, which the editor renders empty.
  */
 export function documentHasSelfQuery(document: HMDocument, documentId: UnpackedHypermediaId): boolean {
-  const documentPathWithSlash = hmIdPathToEntityQueryPath(documentId.path)
-  const documentPathWithoutSlash = documentId.path?.join('/') || ''
+  const parentPathStr = (documentId.path || []).join('/')
+
+  function isSelfMatch(include: {space?: string; path?: string} | undefined): boolean {
+    if (!include) return false
+    if (include.space !== documentId.uid) return false
+    const includePath = entityQueryPathToHmIdPath(include.path)
+    return (includePath || []).join('/') === parentPathStr
+  }
 
   function searchBlocks(nodes: HMBlockNode[]): boolean {
     for (const node of nodes) {
       if (node.block.type === 'Query') {
-        const query = node.block.attributes?.query
-        if (query?.includes) {
-          for (const inc of query.includes) {
-            const isSpaceMatch = !inc.space || inc.space === documentId.uid
-            const isPathMatch = !inc.path || inc.path === documentPathWithSlash || inc.path === documentPathWithoutSlash
-            if (isSpaceMatch && isPathMatch) return true
-          }
-        }
+        const includes = node.block.attributes?.query?.includes
+        if (includes?.some(isSelfMatch)) return true
       }
       if (node.children && searchBlocks(node.children)) return true
     }

--- a/frontend/packages/shared/src/__tests__/content-refs.test.ts
+++ b/frontend/packages/shared/src/__tests__/content-refs.test.ts
@@ -1,5 +1,10 @@
 import {describe, expect, it} from 'vitest'
-import {extractAllContentRefs, findSelfQueryBlock, hasQueryBlockTargetingSelf} from '../content'
+import {
+  extractAllContentRefs,
+  findSelfQueryBlock,
+  hasQueryBlockTargetingSelf,
+  hasSelfQueryBlockInEditorContent,
+} from '../content'
 import {editorBlocksToHMBlockNodes} from '@seed-hypermedia/client/editorblock-to-hmblock'
 import type {EditorBlock} from '@seed-hypermedia/client/editor-types'
 import {HMBlockNode} from '@seed-hypermedia/client/hm-types'
@@ -327,6 +332,114 @@ describe('findSelfQueryBlock', () => {
     const result = findSelfQueryBlock(blocks, 'uid1', null)
     expect(result).not.toBeNull()
     expect(result!.id).toBe('q1')
+  })
+})
+
+describe('hasSelfQueryBlockInEditorContent', () => {
+  function queryBlock(props: {space: string; path: string; mode?: string}, id = 'q1') {
+    return {
+      id,
+      type: 'query',
+      props: {
+        queryIncludes: JSON.stringify([{space: props.space, path: props.path, mode: props.mode || 'Children'}]),
+      },
+      content: [],
+      children: [],
+    }
+  }
+
+  it('returns false for empty input', () => {
+    expect(hasSelfQueryBlockInEditorContent([], 'uid1', ['p'])).toBe(false)
+    expect(hasSelfQueryBlockInEditorContent(null, 'uid1', ['p'])).toBe(false)
+    expect(hasSelfQueryBlockInEditorContent(undefined, 'uid1', ['p'])).toBe(false)
+  })
+
+  it('returns false when no query blocks exist', () => {
+    expect(
+      hasSelfQueryBlockInEditorContent([{id: 'p1', type: 'paragraph', props: {}, content: [], children: []}], 'uid1', [
+        'p',
+      ]),
+    ).toBe(false)
+  })
+
+  it('returns true when query targets same uid and path with leading slash', () => {
+    const blocks = [queryBlock({space: 'uid1', path: '/my/doc'})]
+    expect(hasSelfQueryBlockInEditorContent(blocks, 'uid1', ['my', 'doc'])).toBe(true)
+  })
+
+  it('returns true when query targets same uid and path without leading slash', () => {
+    const blocks = [queryBlock({space: 'uid1', path: 'my/doc'})]
+    expect(hasSelfQueryBlockInEditorContent(blocks, 'uid1', ['my', 'doc'])).toBe(true)
+  })
+
+  it('returns true for root doc with empty path', () => {
+    const blocks = [queryBlock({space: 'uid1', path: ''})]
+    expect(hasSelfQueryBlockInEditorContent(blocks, 'uid1', null)).toBe(true)
+    expect(hasSelfQueryBlockInEditorContent(blocks, 'uid1', [])).toBe(true)
+  })
+
+  it('returns false when space mismatches', () => {
+    const blocks = [queryBlock({space: 'other', path: 'my/doc'})]
+    expect(hasSelfQueryBlockInEditorContent(blocks, 'uid1', ['my', 'doc'])).toBe(false)
+  })
+
+  it('returns false when path mismatches', () => {
+    const blocks = [queryBlock({space: 'uid1', path: 'other/path'})]
+    expect(hasSelfQueryBlockInEditorContent(blocks, 'uid1', ['my', 'doc'])).toBe(false)
+  })
+
+  it('returns false when query has empty space (unconfigured)', () => {
+    const blocks = [queryBlock({space: '', path: ''})]
+    expect(hasSelfQueryBlockInEditorContent(blocks, 'uid1', ['my', 'doc'])).toBe(false)
+  })
+
+  it('finds query block in nested children', () => {
+    const blocks = [
+      {
+        id: 'g1',
+        type: 'group',
+        props: {},
+        content: [],
+        children: [queryBlock({space: 'uid1', path: 'my/doc'})],
+      },
+    ]
+    expect(hasSelfQueryBlockInEditorContent(blocks, 'uid1', ['my', 'doc'])).toBe(true)
+  })
+
+  it('returns false on malformed queryIncludes JSON', () => {
+    const blocks = [
+      {
+        id: 'q1',
+        type: 'query',
+        props: {queryIncludes: 'not-json'},
+        content: [],
+        children: [],
+      },
+    ]
+    expect(hasSelfQueryBlockInEditorContent(blocks, 'uid1', ['my', 'doc'])).toBe(false)
+  })
+
+  it('uses default queryIncludes when missing (treated as empty space, not self)', () => {
+    const blocks = [{id: 'q1', type: 'query', props: {}, content: [], children: []}]
+    expect(hasSelfQueryBlockInEditorContent(blocks, 'uid1', ['my', 'doc'])).toBe(false)
+  })
+
+  it('matches when one of multiple includes targets self', () => {
+    const blocks = [
+      {
+        id: 'q1',
+        type: 'query',
+        props: {
+          queryIncludes: JSON.stringify([
+            {space: 'other', path: 'foo', mode: 'Children'},
+            {space: 'uid1', path: 'my/doc', mode: 'Children'},
+          ]),
+        },
+        content: [],
+        children: [],
+      },
+    ]
+    expect(hasSelfQueryBlockInEditorContent(blocks, 'uid1', ['my', 'doc'])).toBe(true)
   })
 })
 

--- a/frontend/packages/shared/src/content.ts
+++ b/frontend/packages/shared/src/content.ts
@@ -282,21 +282,28 @@ export function extractAllContentRefs(children: HMBlockNode[]): RefDefinition[] 
   return refs
 }
 
+function isSelfQueryInclude(
+  include: HMBlockQuery['attributes']['query']['includes'][number] | undefined,
+  parentUid: string,
+  parentPath: string[] | null,
+): boolean {
+  if (!include) return false
+  if (include.space !== parentUid) return false
+  const includePath = entityQueryPathToHmIdPath(include.path)
+  const parentPathStr = (parentPath || []).join('/')
+  const includePathStr = (includePath || []).join('/')
+  return includePathStr === parentPathStr
+}
+
 export function hasQueryBlockTargetingSelf(
   children: HMBlockNode[],
   parentUid: string,
   parentPath: string[] | null,
 ): boolean {
   const queryBlocks = extractQueryBlocks(children)
-  return queryBlocks.some((qb) => {
-    const include = qb.attributes.query.includes[0]
-    if (!include) return false
-    if (include.space !== parentUid) return false
-    const includePath = entityQueryPathToHmIdPath(include.path)
-    const parentPathStr = (parentPath || []).join('/')
-    const includePathStr = (includePath || []).join('/')
-    return includePathStr === parentPathStr
-  })
+  return queryBlocks.some((qb) =>
+    qb.attributes.query.includes.some((include) => isSelfQueryInclude(include, parentUid, parentPath)),
+  )
 }
 
 export function findSelfQueryBlock(
@@ -306,15 +313,47 @@ export function findSelfQueryBlock(
 ): HMBlockQuery | null {
   const queryBlocks = extractQueryBlocks(children)
   for (const qb of queryBlocks) {
-    const include = qb.attributes.query.includes[0]
-    if (!include) continue
-    if (include.space !== parentUid) continue
-    const includePath = entityQueryPathToHmIdPath(include.path)
-    const parentPathStr = (parentPath || []).join('/')
-    const includePathStr = (includePath || []).join('/')
-    if (includePathStr === parentPathStr) return qb
+    if (qb.attributes.query.includes.some((include) => isSelfQueryInclude(include, parentUid, parentPath))) {
+      return qb
+    }
   }
   return null
+}
+
+const DEFAULT_QUERY_INCLUDES = '[{"space":"","path":"","mode":"Children"}]'
+
+type EditorBlockLike = {
+  type?: string
+  props?: Record<string, any>
+  children?: any[]
+  [key: string]: any
+}
+
+export function hasSelfQueryBlockInEditorContent(
+  blocks: EditorBlockLike[] | undefined | null,
+  parentUid: string,
+  parentPath: string[] | null,
+): boolean {
+  if (!blocks?.length) return false
+  for (const block of blocks) {
+    if (block?.type === 'query') {
+      const raw = block.props?.queryIncludes ?? DEFAULT_QUERY_INCLUDES
+      let includes: Array<{space?: string; path?: string; mode?: string}> = []
+      try {
+        const parsed = JSON.parse(raw)
+        if (Array.isArray(parsed)) includes = parsed
+      } catch {
+        includes = []
+      }
+      if (includes.some((include) => isSelfQueryInclude(include as any, parentUid, parentPath))) {
+        return true
+      }
+    }
+    if (block?.children?.length && hasSelfQueryBlockInEditorContent(block.children, parentUid, parentPath)) {
+      return true
+    }
+  }
+  return false
 }
 
 export function extractQueryBlocks(children: HMBlockNode[]): HMBlockQuery[] {

--- a/frontend/packages/shared/src/query-block-drafts-context.tsx
+++ b/frontend/packages/shared/src/query-block-drafts-context.tsx
@@ -21,14 +21,24 @@ export type QueryBlockDraftSlotProps = {
 
 export type QueryBlockDraftsContextValue = {
   DraftSlot?: React.ComponentType<QueryBlockDraftSlotProps>
+  lastCreatedDraftId?: string | null
+  setLastCreatedDraftId?: (id: string | null) => void
 }
 
 const defaultValue: QueryBlockDraftsContextValue = {}
 
 const QueryBlockDraftsContext = createContext<QueryBlockDraftsContextValue>(defaultValue)
 
-export function QueryBlockDraftsProvider({children, DraftSlot}: PropsWithChildren<QueryBlockDraftsContextValue>) {
-  const ctx = useMemo(() => ({DraftSlot}), [DraftSlot])
+export function QueryBlockDraftsProvider({
+  children,
+  DraftSlot,
+  lastCreatedDraftId,
+  setLastCreatedDraftId,
+}: PropsWithChildren<QueryBlockDraftsContextValue>) {
+  const ctx = useMemo(
+    () => ({DraftSlot, lastCreatedDraftId, setLastCreatedDraftId}),
+    [DraftSlot, lastCreatedDraftId, setLastCreatedDraftId],
+  )
   return <QueryBlockDraftsContext.Provider value={ctx}>{children}</QueryBlockDraftsContext.Provider>
 }
 


### PR DESCRIPTION
## Summary

- Fixes issue #515 where draft cards were incorrectly created inside documents containing unconfigured/empty query blocks
- Tightens `documentHasSelfQuery` and related helpers to require an explicit `space` (uid) and a normalized path match — empty `space` or `path` no longer counts as a self-match
- Adds `hasSelfQueryBlockInEditorContent` to detect self-referential query blocks directly in editor (draft) content, so the check works before a draft is published
- Lifts `lastCreatedDraftId` state up into `QueryBlockDraftsProvider` context so it is shared correctly across query block draft slots
- Updates `hasQueryBlockTargetingSelf` and `findSelfQueryBlock` to check all `includes` entries (not just the first) via a shared `isSelfQueryInclude` helper
- Updates tests to reflect the new stricter semantics: empty/unconfigured query blocks no longer trigger self-query detection


---

Fixes #515