### PR TITLE
fix(nav): reflect in-flight nav edits live in site header and fix home-doc publish path

### DIFF
--- a/frontend/apps/desktop/src/components/edit-nav-header-pane.tsx
+++ b/frontend/apps/desktop/src/components/edit-nav-header-pane.tsx
@@ -2,16 +2,12 @@ import {EditNavPopover} from '@/components/edit-navigation-popover'
 import {HMNavigationItem, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {useResource} from '@shm/shared/models/entity'
 import {useEditorGate} from '@shm/shared/models/use-editor-gate'
-import {DocumentMachineSnapshot, useDocumentSelector, useDocumentSend} from '@shm/shared/models/use-document-machine'
-
-function selectMachineNavigation(snapshot: DocumentMachineSnapshot): HMNavigationItem[] | undefined {
-  return snapshot.context.navigation
-}
+import {useDocumentNavigationOptional, useDocumentSend} from '@shm/shared/models/use-document-machine'
 
 export function EditNavHeaderPane({homeId}: {homeId: UnpackedHypermediaId}) {
   const {canEdit, beginEditIfNeeded} = useEditorGate()
   const send = useDocumentSend()
-  const machineNavigation = useDocumentSelector(selectMachineNavigation)
+  const machineNavigation = useDocumentNavigationOptional()
   const homeResource = useResource(homeId, {subscribed: true})
   const homeDocument = homeResource.data?.type === 'document' ? homeResource.data.document : null
 

--- a/frontend/apps/desktop/src/components/editing-toolbar.tsx
+++ b/frontend/apps/desktop/src/components/editing-toolbar.tsx
@@ -10,11 +10,13 @@ import {
   selectDraftId,
   selectEditorBaseline,
   selectMetadata,
+  selectNavigation,
   selectSaveIndicatorStatus,
   selectSaveStatus,
   useDocumentSelector,
   useDocumentSend,
 } from '@shm/shared/models/use-document-machine'
+import {getNavigationChanges} from '@/models/navigation'
 import {type AnyTimestamp, formattedDateMedium, formattedDateShort, normalizeDate} from '@shm/shared/utils/date'
 import {compareBlocksWithMap, createBlocksMap, extractDeletes} from '@shm/shared/utils/document-changes'
 import {createSiteUrl, createWebHMUrl, hmId} from '@shm/shared/utils/entity-id-url'
@@ -74,19 +76,25 @@ function useUnpublishedChangeCount(): number {
   const handlersRef = useEditorHandlersRef()
   const baseline = useDocumentSelector(selectEditorBaseline)
   const metadata = useDocumentSelector(selectMetadata)
+  const navigation = useDocumentSelector(selectNavigation)
+  const publishedDoc = useDocumentSelector(selectDocument)
   const saveStatus = useDocumentSelector(selectSaveStatus)
 
   return useMemo(() => {
     const metadataChangeCount = Object.keys(metadata ?? {}).length
-    if (!baseline) return metadataChangeCount
+    // Site-header nav edits don't touch the editor or metadata, so count
+    // them via the same diff used at publish time. `navigation === undefined`
+    // means no nav edits this session — return 0 ops.
+    const navigationChangeCount = getNavigationChanges(navigation, publishedDoc?.detachedBlocks?.navigation).length
+    if (!baseline) return metadataChangeCount + navigationChangeCount
     const editorBlocks = handlersRef.current?.getCurrentBlocks() ?? []
-    if (editorBlocks.length === 0) return metadataChangeCount
+    if (editorBlocks.length === 0) return metadataChangeCount + navigationChangeCount
     const baselineMap = createBlocksMap(editorBlocksToHMBlockNodes(baseline), '')
     const {changes, touchedBlocks} = compareBlocksWithMap(baselineMap, editorBlocks, '')
     const deletes = extractDeletes(baselineMap, touchedBlocks)
-    return changes.length + deletes.length + metadataChangeCount
+    return changes.length + deletes.length + metadataChangeCount + navigationChangeCount
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [baseline, metadata, saveStatus, handlersRef])
+  }, [baseline, metadata, navigation, publishedDoc, saveStatus, handlersRef])
 }
 
 /** The public URL where this document is or will be available. */

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -260,13 +260,17 @@ export default function DesktopResourcePage() {
         //   1. Legacy location-only drafts (no editUid) — clearly new docs.
         //   2. "Claimed" drafts (editUid+editPath set) where the doc at that
         //      path doesn't exist yet — also new docs (e.g. inline card flow).
+        // Path encoding must match `hmIdPathToEntityQueryPath`: the daemon
+        // expects `''` for the root home doc, not `'/'` — passing `'/'`
+        // resolves to "not found" and would misclassify a home-doc edit as a
+        // first publish, redirecting it to a brand-new child slug.
         let isFirstPublish = !draftData.editUid
         if (!isFirstPublish && draftData.editUid) {
           try {
-            const editPathString = '/' + (draftData.editPath ?? []).join('/')
+            const editPathString = (draftData.editPath ?? []).filter((term) => !!term).join('/')
             const existing = await grpcClient.documents.getDocument({
               account: draftData.editUid,
-              path: editPathString,
+              path: editPathString ? `/${editPathString}` : '',
             })
             if (!existing?.version) isFirstPublish = true
           } catch {
@@ -277,8 +281,11 @@ export default function DesktopResourcePage() {
         // For first publish, compute the destination path from the title slug
         // (the route URL holds the temporary `-${draftId}` slug). For re-publishes,
         // keep the existing route id as the destination so the path doesn't change.
+        // The home doc (editPath = []) is never a first publish — it always exists
+        // at the root once the account is created — so this branch is skipped for it.
         let publishDestinationId = input.documentId
-        if (isFirstPublish && draftData.editUid) {
+        const isHomeDocEdit = (draftData.editPath ?? []).length === 0
+        if (isFirstPublish && draftData.editUid && !isHomeDocEdit) {
           const newPath = computeInlineDraftPublishPath(
             draftData.editPath ?? [],
             draftData.metadata?.name || '',

--- a/frontend/packages/shared/src/models/use-document-machine.ts
+++ b/frontend/packages/shared/src/models/use-document-machine.ts
@@ -1,5 +1,5 @@
 import {EditorBlock} from '@seed-hypermedia/client/editor-types'
-import {HMBlockNode, HMDocument, HMMetadata} from '@seed-hypermedia/client/hm-types'
+import {HMBlockNode, HMDocument, HMMetadata, HMNavigationItem} from '@seed-hypermedia/client/hm-types'
 import {editorBlocksToHMBlockNodes} from '@seed-hypermedia/client/editorblock-to-hmblock'
 import {hmBlocksToEditorContent} from '@seed-hypermedia/client/hmblock-to-editorblock'
 import {useActorRef, useSelector} from '@xstate/react'
@@ -407,6 +407,11 @@ export function selectMetadata(snapshot: DocumentMachineSnapshot): HMMetadata {
   return snapshot.context.metadata
 }
 
+/** Pending site-header navigation changes set during this editing session (home doc only). */
+export function selectNavigation(snapshot: DocumentMachineSnapshot): HMNavigationItem[] | undefined {
+  return snapshot.context.navigation
+}
+
 /** The current error, if any (available in both loading and error states). */
 export function selectError(snapshot: DocumentMachineSnapshot): unknown {
   return snapshot.context.error
@@ -511,6 +516,17 @@ export function useDocumentSend(actorRef?: DocumentMachineActorRef) {
   const contextRef = useDocumentMachineRef()
   const ref = actorRef ?? contextRef
   return ref.send as (event: DocumentMachineEvent) => void
+}
+
+/**
+ * Read the in-flight site-header navigation from the document machine, safely.
+ * Returns `undefined` when outside a `DocumentMachineProvider` or when no
+ * navigation edits are pending — callers should fall back to the published
+ * navigation block in that case.
+ */
+export function useDocumentNavigationOptional(): HMNavigationItem[] | undefined {
+  const actorRef = useDocumentMachineRefOptional()
+  return useSelector(actorRef ?? undefined, (snapshot) => (snapshot ? selectNavigation(snapshot) : undefined))
 }
 
 /**

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -42,6 +42,7 @@ import {
   useAutoRebase,
   useCapabilitySync,
   useDocumentMachineRef,
+  useDocumentNavigationOptional,
   useDocumentSelector,
   useDocumentSend,
   useDocumentSync,
@@ -688,6 +689,30 @@ export function PageWrapper({
   const media = useMedia()
   const isMobile = media.xs && !IS_DESKTOP
 
+  // Live-preview the in-flight nav while the user edits the home doc, so
+  // additions/reorders/deletions in the EditNavPopover show immediately in
+  // the visible site header. Mirrors the legacy draft route at
+  // frontend/apps/desktop/src/pages/draft.tsx:880-893. Returns undefined
+  // outside DocumentMachineProvider (loading/error/discovery branches), in
+  // which case we fall back to the published headerData.items.
+  const machineNav = useDocumentNavigationOptional()
+  const isHomeDoc = !docId.path?.length
+  const liveItems: DocNavigationItem[] | undefined =
+    isHomeDoc && machineNav
+      ? machineNav.map((n) => {
+          const id = unpackHmId(n.link)
+          return {
+            key: n.id,
+            id: id ?? undefined,
+            webUrl: id ? undefined : n.link,
+            draftId: undefined,
+            metadata: {name: n.text || ''},
+            isPublished: true,
+          } satisfies DocNavigationItem
+        })
+      : undefined
+  const itemsForHeader = liveItems ?? headerData.items
+
   return (
     <div
       style={
@@ -705,7 +730,7 @@ export function PageWrapper({
       <SiteHeader
         siteHomeId={siteHomeId}
         docId={docId}
-        items={headerData.items}
+        items={itemsForHeader}
         homeNavigationItems={headerData.homeNavigationItems}
         directoryItems={headerData.directoryItems}
         isCenterLayout={headerData.isCenterLayout}


### PR DESCRIPTION
## Summary

- Closes #524: navigation bar edits now appear immediately in the site header as the user adds/reorders/removes items, without requiring a publish cycle
- Added `useDocumentNavigationOptional` hook to safely read pending nav state from the document machine outside a provider context (returns `undefined` as a fallback)
- Added `selectNavigation` selector to expose `context.navigation` from the document machine
- Wired live nav preview into `PageWrapper` — when editing the home doc, `liveItems` derived from `machineNav` replaces `headerData.items` passed to `SiteHeader`
- Fixed `useUnpublishedChangeCount` to include pending navigation changes via `getNavigationChanges`, so the publish button badge reflects nav-only edits
- Fixed home-doc publish path encoding: the daemon expects `''` for the root document, not `'/'`; passing `'/'` caused the lookup to return "not found" and misclassified a home-doc re-edit as a first publish, redirecting it to a new child slug
- Added `isHomeDocEdit` guard so home-doc edits (empty `editPath`) are never treated as first-publish, preventing accidental slug redirects


---

Fixes #524