### PR TITLE
Fix moved document comment search

### DIFF
--- a/backend/api/documents/v3alpha/comments.go
+++ b/backend/api/documents/v3alpha/comments.go
@@ -176,6 +176,8 @@ func (srv *Server) ListComments(ctx context.Context, in *documents.ListCommentsR
 			if err != nil {
 				return nil, err
 			}
+			pb.TargetAccount = acc.String()
+			pb.TargetPath = in.TargetPath
 
 			resp.Comments = append(resp.Comments, pb)
 		}
@@ -282,6 +284,48 @@ func (srv *Server) commentDBMapper() sqlitex.MapperFunc[indexedComment] {
 }
 
 var qIterComments = dqb.Str(`
+	WITH RECURSIVE
+	latest_document_generations AS (
+		SELECT dg.*
+		FROM document_generations dg
+		GROUP BY dg.resource
+		HAVING dg.generation = MAX(dg.generation)
+	),
+	comment_resource_chain(origin_resource, resource, iri, depth) AS (
+		SELECT DISTINCT
+			sb.resource,
+			sb.resource,
+			r.iri,
+			0
+		FROM structural_blobs sb
+		JOIN resources r ON r.id = sb.resource
+		WHERE sb.type = 'Comment'
+		AND sb.resource IS NOT NULL
+
+		UNION ALL
+
+		SELECT
+			cr.origin_resource,
+			target.id,
+			target.iri,
+			cr.depth + 1
+		FROM comment_resource_chain cr
+		JOIN latest_document_generations dg ON dg.resource = cr.resource
+		JOIN resources target ON target.iri = dg.metadata->>'$."$db.redirect".v'
+		WHERE dg.metadata->>'$."$db.redirect".v' IS NOT NULL
+		AND target.id != cr.resource
+		AND cr.depth < 16
+	),
+	effective_comment_resources AS (
+		SELECT origin_resource, resource, iri
+		FROM (
+			SELECT
+				cr.*,
+				ROW_NUMBER() OVER (PARTITION BY cr.origin_resource ORDER BY cr.depth DESC) rn
+			FROM comment_resource_chain cr
+		)
+		WHERE rn = 1
+	)
 	SELECT
 		sb.id,
         b.codec,
@@ -293,8 +337,9 @@ var qIterComments = dqb.Str(`
         	sb.*,
          	ROW_NUMBER() OVER (PARTITION BY sb.extra_attrs->>'tsid' ORDER BY sb.ts DESC) rn
         FROM structural_blobs sb
+		JOIN effective_comment_resources ecr ON ecr.origin_resource = sb.resource
   		WHERE sb.type = 'Comment'
-    	AND sb.resource = (SELECT id FROM resources WHERE iri = :iri)
+		AND ecr.iri = :iri
 	) sb
 	JOIN blobs b ON b.id = sb.id
 	WHERE sb.rn = 1
@@ -303,6 +348,48 @@ var qIterComments = dqb.Str(`
 `)
 
 var qIterCommentsPublicOnly = dqb.Str(`
+	WITH RECURSIVE
+	latest_document_generations AS (
+		SELECT dg.*
+		FROM document_generations dg
+		GROUP BY dg.resource
+		HAVING dg.generation = MAX(dg.generation)
+	),
+	comment_resource_chain(origin_resource, resource, iri, depth) AS (
+		SELECT DISTINCT
+			sb.resource,
+			sb.resource,
+			r.iri,
+			0
+		FROM structural_blobs sb
+		JOIN resources r ON r.id = sb.resource
+		WHERE sb.type = 'Comment'
+		AND sb.resource IS NOT NULL
+
+		UNION ALL
+
+		SELECT
+			cr.origin_resource,
+			target.id,
+			target.iri,
+			cr.depth + 1
+		FROM comment_resource_chain cr
+		JOIN latest_document_generations dg ON dg.resource = cr.resource
+		JOIN resources target ON target.iri = dg.metadata->>'$."$db.redirect".v'
+		WHERE dg.metadata->>'$."$db.redirect".v' IS NOT NULL
+		AND target.id != cr.resource
+		AND cr.depth < 16
+	),
+	effective_comment_resources AS (
+		SELECT origin_resource, resource, iri
+		FROM (
+			SELECT
+				cr.*,
+				ROW_NUMBER() OVER (PARTITION BY cr.origin_resource ORDER BY cr.depth DESC) rn
+			FROM comment_resource_chain cr
+		)
+		WHERE rn = 1
+	)
 	SELECT
 		sb.id,
         b.codec,
@@ -314,8 +401,9 @@ var qIterCommentsPublicOnly = dqb.Str(`
         	sb.*,
          	ROW_NUMBER() OVER (PARTITION BY sb.extra_attrs->>'tsid' ORDER BY sb.ts DESC) rn
         FROM structural_blobs sb
+		JOIN effective_comment_resources ecr ON ecr.origin_resource = sb.resource
   		WHERE sb.type = 'Comment'
-    	AND sb.resource = (SELECT id FROM resources WHERE iri = :iri)
+		AND ecr.iri = :iri
 	) sb
 	JOIN blobs b ON b.id = sb.id
 	WHERE sb.rn = 1

--- a/backend/api/entities/v1alpha/entities.go
+++ b/backend/api/entities/v1alpha/entities.go
@@ -208,7 +208,8 @@ SELECT
 `)
 
 var qGetFTSByIDs = dqb.Str(`
-WITH fts_data AS (
+WITH RECURSIVE
+fts_data AS (
   SELECT
     fts.raw_content,
     fts.type,
@@ -216,8 +217,9 @@ WITH fts_data AS (
     fts.version,
     fts.blob_id,
     structural_blobs.genesis_blob,
-	structural_blobs.extra_attrs->>'tsid' AS tsid,
-	fts.rowid
+    structural_blobs.resource,
+    structural_blobs.extra_attrs->>'tsid' AS tsid,
+    fts.rowid
   FROM fts
     JOIN structural_blobs
       ON structural_blobs.id = fts.blob_id
@@ -229,6 +231,47 @@ WITH fts_data AS (
       ON resources.id = structural_blobs.resource
   WHERE fts.rowid IN (SELECT value FROM json_each(?))
 	AND blobs.size > 0
+),
+latest_document_generations AS (
+  SELECT dg.*
+  FROM document_generations dg
+  GROUP BY dg.resource
+  HAVING dg.generation = MAX(dg.generation)
+),
+comment_resource_chain(origin_resource, resource, iri, depth) AS (
+  SELECT DISTINCT
+    f.resource,
+    f.resource,
+    resources.iri,
+    0
+  FROM fts_data f
+  JOIN resources ON resources.id = f.resource
+  WHERE f.type = 'comment'
+  AND f.resource IS NOT NULL
+
+  UNION ALL
+
+  SELECT
+    cr.origin_resource,
+    target.id,
+    target.iri,
+    cr.depth + 1
+  FROM comment_resource_chain cr
+  JOIN latest_document_generations dg ON dg.resource = cr.resource
+  JOIN resources target ON target.iri = dg.metadata->>'$."$db.redirect".v'
+  WHERE dg.metadata->>'$."$db.redirect".v' IS NOT NULL
+  AND target.id != cr.resource
+  AND cr.depth < 16
+),
+effective_comment_resources AS (
+  SELECT origin_resource, resource, iri
+  FROM (
+    SELECT
+      cr.*,
+      ROW_NUMBER() OVER (PARTITION BY cr.origin_resource ORDER BY cr.depth DESC) rn
+    FROM comment_resource_chain cr
+  )
+  WHERE rn = 1
 )
 
 SELECT
@@ -243,7 +286,7 @@ SELECT
   pk_subject.principal AS contact_subject,
   blobs.codec,
   blobs.multihash,
-  COALESCE(document_generations.metadata, structural_blobs.extra_attrs, '{}'),
+  COALESCE(current_document_generation.metadata, document_generations.metadata, structural_blobs.extra_attrs, '{}'),
   dg_subject.metadata AS subject_metadata,
   COALESCE((
     SELECT json_group_array(
@@ -252,7 +295,7 @@ SELECT
                'multihash', hex(b2.multihash)
              )
            )
-    FROM json_each(COALESCE(document_generations.heads, '[]')) AS a
+    FROM json_each(COALESCE(current_document_generation.heads, document_generations.heads, '[]')) AS a
       JOIN blobs AS b2
         ON b2.id = a.value
   ), '[]') AS heads,
@@ -271,8 +314,13 @@ FROM fts_data AS f
   JOIN public_keys
     ON public_keys.id = structural_blobs.author
 
+  LEFT JOIN effective_comment_resources ecr
+    ON ecr.origin_resource = f.resource
+
   LEFT JOIN resources
-    ON resources.id = (SELECT resource from structural_blobs WHERE
+    ON resources.id = COALESCE(
+      CASE WHEN f.type = 'comment' THEN ecr.resource END,
+      (SELECT resource from structural_blobs WHERE
 	     (f.blob_id       = structural_blobs.genesis_blob
            AND structural_blobs.type = 'Ref')
       OR (f.genesis_blob = structural_blobs.genesis_blob
@@ -284,10 +332,15 @@ FROM fts_data AS f
            AND structural_blobs.author = ?)
       OR (f.blob_id       = structural_blobs.id
            AND structural_blobs.type = 'Profile')
-     limit 1)
+     limit 1))
 
   LEFT JOIN document_generations
     ON document_generations.resource = resources.id
+    AND f.type != 'comment'
+
+  LEFT JOIN latest_document_generations AS current_document_generation
+    ON current_document_generation.resource = resources.id
+    AND f.type = 'comment'
 
   LEFT JOIN document_generations dg_subject
 	ON dg_subject.resource = (select id from resources where owner in (select extra_attrs->>'subject' from structural_blobs where id = f.blob_id) order by id limit 1)
@@ -295,31 +348,83 @@ FROM fts_data AS f
   LEFT JOIN public_keys pk_subject
     ON pk_subject.id = structural_blobs.extra_attrs->>'subject'
 
-WHERE (f.type = 'profile' OR document_generations.is_deleted = False)
+WHERE (f.type = 'profile' OR COALESCE(current_document_generation.is_deleted, document_generations.is_deleted) = False)
 `)
 
 var qKeywordSearch = dqb.Str(`
-SELECT
+WITH RECURSIVE
+matched_fts AS (
+  SELECT
     fts.rowid,
-    fts.rank
-FROM fts
-JOIN fts_index fi ON fi.rowid = fts.rowid
-JOIN structural_blobs sb ON sb.id = fts.blob_id
-JOIN blobs ON blobs.id = fts.blob_id
-LEFT JOIN public_blobs pb ON pb.id = fts.blob_id
+    fts.rank,
+    fts.blob_id,
+    fts.type
+  FROM fts
+  WHERE fts.raw_content MATCH ?
+  AND fts.type IN (?, ?, ?, ?, ?)
+),
+latest_document_generations AS (
+  SELECT dg.*
+  FROM document_generations dg
+  GROUP BY dg.resource
+  HAVING dg.generation = MAX(dg.generation)
+),
+comment_resource_chain(origin_resource, resource, iri, depth) AS (
+  SELECT DISTINCT
+    sb.resource,
+    sb.resource,
+    resources.iri,
+    0
+  FROM matched_fts mf
+  JOIN structural_blobs sb ON sb.id = mf.blob_id
+  JOIN resources ON resources.id = sb.resource
+  WHERE mf.type = 'comment'
+  AND sb.resource IS NOT NULL
+
+  UNION ALL
+
+  SELECT
+    cr.origin_resource,
+    target.id,
+    target.iri,
+    cr.depth + 1
+  FROM comment_resource_chain cr
+  JOIN latest_document_generations dg ON dg.resource = cr.resource
+  JOIN resources target ON target.iri = dg.metadata->>'$."$db.redirect".v'
+  WHERE dg.metadata->>'$."$db.redirect".v' IS NOT NULL
+  AND target.id != cr.resource
+  AND cr.depth < 16
+),
+effective_comment_resources AS (
+  SELECT origin_resource, resource, iri
+  FROM (
+    SELECT
+      cr.*,
+      ROW_NUMBER() OVER (PARTITION BY cr.origin_resource ORDER BY cr.depth DESC) rn
+    FROM comment_resource_chain cr
+  )
+  WHERE rn = 1
+)
+SELECT
+    mf.rowid,
+    mf.rank
+FROM matched_fts mf
+JOIN fts_index fi ON fi.rowid = mf.rowid
+JOIN structural_blobs sb ON sb.id = mf.blob_id
+JOIN blobs ON blobs.id = mf.blob_id
+LEFT JOIN public_blobs pb ON pb.id = mf.blob_id
 LEFT JOIN resources r1 ON r1.id = sb.resource
-LEFT JOIN blob_links bl ON bl.target = fts.blob_id AND bl.type = 'ref/head'
+LEFT JOIN blob_links bl ON bl.target = mf.blob_id AND bl.type = 'ref/head'
 LEFT JOIN structural_blobs sb_ref ON sb_ref.id = bl.source
 LEFT JOIN resources r2 ON r2.id = sb_ref.resource
-WHERE fts.raw_content MATCH ?
-  AND fts.type IN (?, ?, ?, ?, ?)
-  AND blobs.size > 0
-  AND COALESCE(r1.iri, r2.iri) IS NOT NULL
-  AND COALESCE(r1.iri, r2.iri) GLOB ?
+LEFT JOIN effective_comment_resources ecr ON ecr.origin_resource = sb.resource
+WHERE blobs.size > 0
+  AND COALESCE(CASE WHEN mf.type = 'comment' THEN ecr.iri END, r1.iri, r2.iri) IS NOT NULL
+  AND COALESCE(CASE WHEN mf.type = 'comment' THEN ecr.iri END, r1.iri, r2.iri) GLOB ?
   AND (? = 0 OR pb.id IS NOT NULL)
 ORDER BY
-  (fts.type = 'contact' OR fts.type = 'title' OR fts.type = 'profile') DESC,
-  fts.rank ASC
+  (mf.type = 'contact' OR mf.type = 'title' OR mf.type = 'profile') DESC,
+  mf.rank ASC
 LIMIT ?
 `)
 
@@ -1743,7 +1848,61 @@ var qEntitiesLookupID = dqb.Str(`
 `)
 
 const qListMentionsTpl = `
-WITH changes AS (
+WITH RECURSIVE
+latest_document_generations AS (
+  SELECT dg.*
+  FROM document_generations dg
+  GROUP BY dg.resource
+  HAVING dg.generation = MAX(dg.generation)
+),
+comment_resource_origins AS (
+  SELECT DISTINCT resource_links.target AS resource
+  FROM resource_links
+  JOIN structural_blobs ON structural_blobs.id = resource_links.source
+  WHERE structural_blobs.type = 'Comment'
+
+  UNION
+
+  SELECT DISTINCT structural_blobs.resource AS resource
+  FROM resource_links
+  JOIN structural_blobs ON structural_blobs.id = resource_links.source
+  WHERE structural_blobs.type = 'Comment'
+  AND structural_blobs.resource IS NOT NULL
+),
+comment_resource_chain(origin_resource, resource, iri, depth) AS (
+  SELECT
+    comment_resource_origins.resource,
+    comment_resource_origins.resource,
+    resources.iri,
+    0
+  FROM comment_resource_origins
+  JOIN resources ON resources.id = comment_resource_origins.resource
+
+  UNION ALL
+
+  SELECT
+    cr.origin_resource,
+    target.id,
+    target.iri,
+    cr.depth + 1
+  FROM comment_resource_chain cr
+  JOIN latest_document_generations dg ON dg.resource = cr.resource
+  JOIN resources target ON target.iri = dg.metadata->>'$."$db.redirect".v'
+  WHERE dg.metadata->>'$."$db.redirect".v' IS NOT NULL
+  AND target.id != cr.resource
+  AND cr.depth < 16
+),
+effective_comment_resources AS (
+  SELECT origin_resource, resource, iri
+  FROM (
+    SELECT
+      cr.*,
+      ROW_NUMBER() OVER (PARTITION BY cr.origin_resource ORDER BY cr.depth DESC) rn
+    FROM comment_resource_chain cr
+  )
+  WHERE rn = 1
+),
+changes AS (
 SELECT
     structural_blobs.genesis_blob,
 	structural_blobs.ts,
@@ -1769,7 +1928,7 @@ AND structural_blobs.type IN ('Change')
 AND (:publicOnly = 0 OR pb3.id IS NOT NULL)
 )
 SELECT
-    resources.iri,
+    source_resource.iri,
     blobs.codec,
     blobs.multihash,
 	public_keys.principal AS author,
@@ -1789,13 +1948,14 @@ FROM resource_links
 JOIN structural_blobs ON structural_blobs.id = resource_links.source
 JOIN blobs INDEXED BY blobs_metadata ON blobs.id = structural_blobs.id
 JOIN public_keys ON public_keys.id = structural_blobs.author
-LEFT JOIN resources ON resources.id = structural_blobs.resource
+LEFT JOIN effective_comment_resources target_resource ON target_resource.origin_resource = resource_links.target
+LEFT JOIN effective_comment_resources source_resource ON source_resource.origin_resource = structural_blobs.resource
 LEFT JOIN public_blobs pb ON pb.id = blobs.id
-WHERE resource_links.target = :target
+WHERE target_resource.resource = :target
 AND blobs.id %s :blob_id
 AND structural_blobs.type IN ('Comment')
 AND (:publicOnly = 0 OR pb.id IS NOT NULL)
-GROUP BY resources.iri, link_id, target_version, target_fragment
+GROUP BY source_resource.iri, link_id, target_version, target_fragment
 
 UNION ALL
 SELECT

--- a/backend/daemon/daemon_e2e_test.go
+++ b/backend/daemon/daemon_e2e_test.go
@@ -4619,6 +4619,163 @@ func TestSearchVersionConsistency(t *testing.T) {
 	})
 }
 
+func TestMovedDocumentCommentsFollowRedirects(t *testing.T) {
+	t.Parallel()
+
+	setup := func(t *testing.T, name string) (ctx context.Context, app *App, account string, comment *documents.Comment) {
+		t.Helper()
+
+		ctx = context.Background()
+		app = makeTestApp(t, name, makeTestConfig(t), true)
+		account = coretest.NewTester(name).Account.PublicKey.String()
+
+		doc, err := app.RPC.DocumentsV3.CreateDocumentChange(ctx, &documents.CreateDocumentChangeRequest{
+			Account:        account,
+			Path:           "/comments-move-src",
+			SigningKeyName: "main",
+			Changes: []*documents.DocumentChange{
+				{Op: &documents.DocumentChange_SetMetadata_{
+					SetMetadata: &documents.DocumentChange_SetMetadata{Key: "title", Value: "Comment Move Source"},
+				}},
+				{Op: &documents.DocumentChange_MoveBlock_{
+					MoveBlock: &documents.DocumentChange_MoveBlock{BlockId: "body", Parent: "", LeftSibling: ""},
+				}},
+				{Op: &documents.DocumentChange_ReplaceBlock{
+					ReplaceBlock: &documents.Block{Id: "body", Type: "paragraph", Text: "document body"},
+				}},
+			},
+		})
+		require.NoError(t, err)
+
+		comment, err = app.RPC.DocumentsV3.CreateComment(ctx, &documents.CreateCommentRequest{
+			SigningKeyName: "main",
+			TargetAccount:  account,
+			TargetPath:     "/comments-move-src",
+			TargetVersion:  doc.Version,
+			Content: []*documents.BlockNode{
+				{Block: &documents.Block{Id: "c1", Type: "paragraph", Text: "helloPearMovedUnique"}},
+			},
+		})
+		require.NoError(t, err)
+
+		moveDocument := func(from, to string) {
+			t.Helper()
+			info, err := app.RPC.DocumentsV3.GetDocumentInfo(ctx, &documents.GetDocumentInfoRequest{
+				Account: account,
+				Path:    from,
+			})
+			require.NoError(t, err)
+
+			_, err = app.RPC.DocumentsV3.CreateRef(ctx, &documents.CreateRefRequest{
+				Account:        account,
+				Path:           to,
+				SigningKeyName: "main",
+				Target: &documents.RefTarget{
+					Target: &documents.RefTarget_Version_{
+						Version: &documents.RefTarget_Version{
+							Genesis: info.Genesis,
+							Version: info.Version,
+						},
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			_, err = app.RPC.DocumentsV3.CreateRef(ctx, &documents.CreateRefRequest{
+				Account:        account,
+				Path:           from,
+				SigningKeyName: "main",
+				Target: &documents.RefTarget{
+					Target: &documents.RefTarget_Redirect_{
+						Redirect: &documents.RefTarget_Redirect{
+							Account: account,
+							Path:    to,
+						},
+					},
+				},
+			})
+			require.NoError(t, err)
+		}
+
+		moveDocument("/comments-move-src", "/comments-move-mid")
+		moveDocument("/comments-move-mid", "/comments-move-dst")
+
+		return ctx, app, account, comment
+	}
+
+	t.Run("ListComments", func(t *testing.T) {
+		ctx, app, account, comment := setup(t, "alice")
+
+		srcComments, err := app.RPC.DocumentsV3.ListComments(ctx, &documents.ListCommentsRequest{
+			TargetAccount: account,
+			TargetPath:    "/comments-move-src",
+		})
+		require.NoError(t, err)
+		require.Empty(t, srcComments.Comments, "comments must not remain listed on the original moved path")
+
+		midComments, err := app.RPC.DocumentsV3.ListComments(ctx, &documents.ListCommentsRequest{
+			TargetAccount: account,
+			TargetPath:    "/comments-move-mid",
+		})
+		require.NoError(t, err)
+		require.Empty(t, midComments.Comments, "comments must not remain listed on an intermediate moved path")
+
+		dstComments, err := app.RPC.DocumentsV3.ListComments(ctx, &documents.ListCommentsRequest{
+			TargetAccount: account,
+			TargetPath:    "/comments-move-dst",
+		})
+		require.NoError(t, err)
+		require.Len(t, dstComments.Comments, 1, "comments must follow multi-hop document redirects")
+		require.Equal(t, comment.Id, dstComments.Comments[0].Id)
+		require.Equal(t, account, dstComments.Comments[0].TargetAccount)
+		require.Equal(t, "/comments-move-dst", dstComments.Comments[0].TargetPath)
+	})
+
+	t.Run("SearchEntities", func(t *testing.T) {
+		ctx, app, account, comment := setup(t, "alice")
+
+		search, err := app.RPC.Entities.SearchEntities(ctx, &entities.SearchEntitiesRequest{
+			Query:       "helloPearMovedUnique",
+			IncludeBody: true,
+			PageSize:    10,
+		})
+		require.NoError(t, err)
+		require.Len(t, search.Entities, 1, "comment search result must survive document moves")
+		require.Equal(t, "comment", search.Entities[0].Type)
+		require.Equal(t, "hm://"+comment.Id, search.Entities[0].Id)
+		require.Equal(t, "hm://"+account+"/comments-move-dst", search.Entities[0].DocId)
+		require.Contains(t, search.Entities[0].Content, "helloPearMovedUnique")
+	})
+
+	t.Run("ListEntityMentions", func(t *testing.T) {
+		ctx, app, account, comment := setup(t, "alice")
+
+		srcMentions, err := app.RPC.Entities.ListEntityMentions(ctx, &entities.ListEntityMentionsRequest{
+			Id:       "hm://" + account + "/comments-move-src",
+			PageSize: 10,
+		})
+		require.NoError(t, err)
+		require.Empty(t, srcMentions.Mentions, "comment mentions must not remain on the original moved path")
+
+		midMentions, err := app.RPC.Entities.ListEntityMentions(ctx, &entities.ListEntityMentionsRequest{
+			Id:       "hm://" + account + "/comments-move-mid",
+			PageSize: 10,
+		})
+		require.NoError(t, err)
+		require.Empty(t, midMentions.Mentions, "comment mentions must not remain on an intermediate moved path")
+
+		dstMentions, err := app.RPC.Entities.ListEntityMentions(ctx, &entities.ListEntityMentionsRequest{
+			Id:       "hm://" + account + "/comments-move-dst",
+			PageSize: 10,
+		})
+		require.NoError(t, err)
+		require.Len(t, dstMentions.Mentions, 1, "interaction summary must count comments after document moves")
+		require.Equal(t, "Comment", dstMentions.Mentions[0].SourceType)
+		require.Equal(t, "hm://"+comment.Id, dstMentions.Mentions[0].Source)
+		require.Equal(t, "hm://"+account+"/comments-move-dst", dstMentions.Mentions[0].SourceDocument)
+	})
+}
+
 func TestPublicOnlyGetPrivateDocument(t *testing.T) {
 	t.Parallel()
 

--- a/frontend/apps/desktop/src/components/commenting.tsx
+++ b/frontend/apps/desktop/src/components/commenting.tsx
@@ -204,6 +204,7 @@ function _CommentBox(props: {
       invalidateQueries([queryKeys.SITE_LIBRARY, docId.uid])
       invalidateQueries([queryKeys.LIST_ACCOUNTS])
       invalidateQueries([queryKeys.DOC_CITATIONS])
+      invalidateQueries([queryKeys.SEARCH])
 
       invalidateQueries([queryKeys.DOCUMENT_ACTIVITY])
       invalidateQueries([queryKeys.DOCUMENT_DISCUSSION])

--- a/frontend/apps/desktop/src/components/search-input.tsx
+++ b/frontend/apps/desktop/src/components/search-input.tsx
@@ -178,9 +178,15 @@ export const SearchInput = forwardRef<
       ?.slice(0, 50)
       ?.map((item, index) => {
         const title = item.title || item.id.uid
-        const route = item.type === 'contact' ? ({key: 'profile', id: item.id} as NavRoute) : appRouteOfId(item.id)
+        const route =
+          item.type === 'contact'
+            ? ({key: 'profile', id: item.id} as NavRoute)
+            : item.type === 'comment' && item.commentId
+            ? ({key: 'comments', id: item.id, openComment: item.commentId} as NavRoute)
+            : appRouteOfId(item.id)
+        const subtitle = item.type === 'contact' ? 'Contact' : item.type === 'comment' ? 'Comment' : 'Document'
         return {
-          key: packHmId(item.id),
+          key: item.commentId ? `${packHmId(item.id)}:comments/${item.commentId}` : packHmId(item.id),
           title,
           path: item.parentNames,
           icon: item.icon,
@@ -191,7 +197,7 @@ export const SearchInput = forwardRef<
             setFocusedIndex(index)
           },
           onSelect: () => onSelect({id: item.id, route}),
-          subtitle: item.type === 'contact' ? 'Contact' : 'Document',
+          subtitle,
           searchQuery: item.searchQuery,
           versionTime: item.versionTime || '',
         }

--- a/frontend/apps/desktop/src/models/documents.ts
+++ b/frontend/apps/desktop/src/models/documents.ts
@@ -1452,14 +1452,24 @@ export function useMoveDocument() {
       push(to)
     },
     onSuccess: (_, {from, to}) => {
+      invalidateQueries([queryKeys.ENTITY, from.id])
+      invalidateQueries([queryKeys.ENTITY, to.id])
+      invalidateQueries([queryKeys.RESOLVED_ENTITY, from.id])
+      invalidateQueries([queryKeys.RESOLVED_ENTITY, to.id])
+      invalidateQueries([queryKeys.SEARCH])
+      invalidateQueries([queryKeys.LIST_ROOT_DOCUMENTS])
+      invalidateQueries([queryKeys.SITE_LIBRARY, from.uid])
+      invalidateQueries([queryKeys.SITE_LIBRARY, to.uid])
       invalidateQueries([queryKeys.DOCUMENT_INTERACTION_SUMMARY, from.id])
       invalidateQueries([queryKeys.DOCUMENT_INTERACTION_SUMMARY, to.id])
       getParentPaths(from.path).forEach((path) => {
         const parentId = hmId(from.uid, {path})
+        invalidateQueries([queryKeys.DOC_LIST_DIRECTORY, parentId.id])
         invalidateQueries([queryKeys.DOCUMENT_INTERACTION_SUMMARY, parentId.id])
       })
       getParentPaths(to.path).forEach((path) => {
         const parentId = hmId(to.uid, {path})
+        invalidateQueries([queryKeys.DOC_LIST_DIRECTORY, parentId.id])
         invalidateQueries([queryKeys.DOCUMENT_INTERACTION_SUMMARY, parentId.id])
       })
     },

--- a/frontend/packages/client/src/hm-types.ts
+++ b/frontend/packages/client/src/hm-types.ts
@@ -1226,13 +1226,14 @@ export type HMSearchInput = z.infer<typeof HMSearchInputSchema>
 
 export const HMSearchResultItemSchema = z.object({
   id: unpackedHmIdSchema,
+  commentId: z.string().optional(),
   metadata: HMDocumentMetadataSchema.optional(),
   title: z.string(),
   icon: z.string(),
   parentNames: z.array(z.string()),
   versionTime: z.string().optional(),
   searchQuery: z.string(),
-  type: z.enum(['document', 'contact']),
+  type: z.enum(['document', 'contact', 'comment']),
 })
 
 export const HMSearchPayloadSchema = z.object({

--- a/frontend/packages/shared/src/__tests__/api-search.test.ts
+++ b/frontend/packages/shared/src/__tests__/api-search.test.ts
@@ -1,0 +1,46 @@
+import {describe, expect, it, vi} from 'vitest'
+import {Search} from '../api-search'
+
+const account = 'z6Mkq9emq1yUBq4KSeiSH5yzgNBJSnidPVqFnTpzjCdLxB3R'
+
+describe('Search.getData', () => {
+  it('maps comment hits to their containing document and keeps the comment id for focus', async () => {
+    const grpcClient = {
+      entities: {
+        searchEntities: vi.fn().mockResolvedValue({
+          entities: [
+            {
+              id: `hm://${account}/z6GXZLPYtXaHn4`,
+              docId: `hm://${account}/tests-moved`,
+              content: 'helloPear',
+              type: 'comment',
+              icon: '',
+              parentNames: ['Julio'],
+            },
+          ],
+        }),
+      },
+    } as any
+
+    const result = await Search.getData(
+      grpcClient,
+      {
+        query: 'hellopear',
+        includeBody: true,
+      },
+      (() => Promise.resolve(null)) as any,
+    )
+
+    expect(result.entities).toHaveLength(1)
+    expect(result.entities[0]).toMatchObject({
+      id: {
+        id: `hm://${account}/tests-moved`,
+        uid: account,
+        path: ['tests-moved'],
+      },
+      commentId: `${account}/z6GXZLPYtXaHn4`,
+      title: 'helloPear',
+      type: 'comment',
+    })
+  })
+})

--- a/frontend/packages/shared/src/__tests__/search-schema.test.ts
+++ b/frontend/packages/shared/src/__tests__/search-schema.test.ts
@@ -32,6 +32,15 @@ describe('HMSearchResultItemSchema', () => {
     expect(result.success).toBe(true)
   })
 
+  it('accepts comment search results with focused comment id', () => {
+    const result = HMSearchResultItemSchema.safeParse({
+      ...validItem,
+      commentId: 'z6MkhUgmuFYwEDED4P5EdPKqh35ybJprcGxaVpK9u3H8vpGh/z6GXComment',
+      type: 'comment',
+    })
+    expect(result.success).toBe(true)
+  })
+
   it('rejects versionTime as a Timestamp-like object (regression for #305)', () => {
     const item = {
       ...validItem,

--- a/frontend/packages/shared/src/api-search.ts
+++ b/frontend/packages/shared/src/api-search.ts
@@ -43,6 +43,21 @@ export const Search: HMRequestImplementation<HMSearchRequest> = {
               type: 'contact' as const,
             }
           }
+          if (entity.type === 'comment') {
+            const docId = unpackHmId(entity.docId)
+            return docId
+              ? {
+                  id: docId,
+                  commentId: entity.id.replace(/^hm:\/\//, ''),
+                  title: entity.content,
+                  parentNames: entity.parentNames,
+                  icon: entity.icon,
+                  versionTime: entity.versionTime ? entity.versionTime.toDate().toLocaleString() : undefined,
+                  searchQuery: query,
+                  type: 'comment' as const,
+                }
+              : undefined
+          }
           return id
             ? {
                 id,

--- a/frontend/packages/shared/src/comments-service-provider.tsx
+++ b/frontend/packages/shared/src/comments-service-provider.tsx
@@ -218,6 +218,7 @@ export function useDeleteComment() {
       invalidateQueries([queryKeys.DOCUMENT_COMMENTS])
       invalidateQueries([queryKeys.BLOCK_DISCUSSIONS])
       invalidateQueries([queryKeys.ACTIVITY_FEED])
+      invalidateQueries([queryKeys.SEARCH])
       pushAfterCommentPublish?.(
         hmId(params.comment.targetAccount, {path: entityQueryPathToHmIdPath(params.comment.targetPath || '')}),
       )
@@ -257,6 +258,7 @@ export function useUpdateComment() {
       invalidateQueries([queryKeys.BLOCK_DISCUSSIONS])
       invalidateQueries([queryKeys.ACTIVITY_FEED])
       invalidateQueries([queryKeys.COMMENT_VERSIONS])
+      invalidateQueries([queryKeys.SEARCH])
       pushAfterCommentPublish?.(
         hmId(params.comment.targetAccount, {path: entityQueryPathToHmIdPath(params.comment.targetPath || '')}),
       )

--- a/frontend/packages/shared/src/models/search.ts
+++ b/frontend/packages/shared/src/models/search.ts
@@ -7,13 +7,14 @@ import {useUniversalClient} from '../routing'
 
 export type SearchResultItem = {
   id: UnpackedHypermediaId
+  commentId?: string
   metadata?: HMDocument['metadata']
   title: string
   icon: string
   parentNames: string[]
   versionTime?: string
   searchQuery: string
-  type: 'document' | 'contact'
+  type: 'document' | 'contact' | 'comment'
 }
 
 export type SearchPayload = {
@@ -77,7 +78,7 @@ export function useSearch(
       for (const result of out.entities) {
         if (entities.length >= limit) break
 
-        const key = packHmId(result.id)
+        const key = result.commentId ? `${packHmId(result.id)}:comments/${result.commentId}` : packHmId(result.id)
         if (!alreadySeenIds.has(key)) {
           alreadySeenIds.add(key)
           entities.push(result)
@@ -86,5 +87,9 @@ export function useSearch(
       return {out, entities}
     },
     enabled,
+    staleTime: 0,
+    cacheTime: 0,
+    keepPreviousData: false,
+    refetchOnMount: 'always',
   })
 }

--- a/frontend/packages/ui/src/search.tsx
+++ b/frontend/packages/ui/src/search.tsx
@@ -319,7 +319,8 @@ export function SearchResultItem({
 }) {
   const elm = useRef<HTMLDivElement>(null)
   const collapsedPath = useCollapsedPath(item.path ?? [], elm)
-  const unpackedId = unpackHmId(item.key)
+  const routeKey = item.key.split(':comments/')[0] || item.key
+  const unpackedId = unpackHmId(routeKey)
 
   useIsomorphicLayoutEffect(() => {
     if (selected) {
@@ -327,7 +328,7 @@ export function SearchResultItem({
     }
   }, [selected])
 
-  const navigateProps = useRouteLinkHref(item.key)
+  const navigateProps = useRouteLinkHref(routeKey)
 
   const selectProps = item.onSelect
     ? {


### PR DESCRIPTION
Fix comments/search results after documents move.\n\n- Follow redirect chains for document comments\n- Route comment search hits through their containing document\n- Refresh search after local moves/comment changes