### PR TITLE
feat(editing): keep publish button visible after leaving edit mode

### DIFF
--- a/frontend/apps/desktop/src/components/delete-draft-dialog.tsx
+++ b/frontend/apps/desktop/src/components/delete-draft-dialog.tsx
@@ -19,10 +19,10 @@ function DeleteDraftDialog({onClose, input}: {onClose: () => void; input: {draft
 
   return (
     <>
-      <AlertDialogTitle>{editId ? 'Discard Changes in this Document?' : 'Discard this Draft?'}</AlertDialogTitle>
+      <AlertDialogTitle>{editId ? 'Discard unpublished changes?' : 'Discard this Draft?'}</AlertDialogTitle>
       <Text className="text-muted-foreground text-sm">
         {editId
-          ? 'All changes made to the current version of this document will be permanently deleted. This action cannot be undone.'
+          ? 'Your unpublished changes will be discarded and the document will revert to its last published version.'
           : 'This draft document and all its content will be permanently deleted. This action cannot be undone.'}
       </Text>
 

--- a/frontend/apps/desktop/src/components/editing-toolbar.tsx
+++ b/frontend/apps/desktop/src/components/editing-toolbar.tsx
@@ -350,18 +350,17 @@ const PublishTrigger = forwardRef<
 PublishTrigger.displayName = 'PublishTrigger'
 
 /**
- * Combined right-actions for DocumentTools when editing.
- * Renders: save indicator, publish (with popover), new button, three-dots (merged menu).
+ * Shared publish button + popover + options dropdown, used in both editing and
+ * non-editing toolbars. Manages the first-click-popover / second-click-publish
+ * flow internally.
  * Must be rendered inside DocumentMachineProvider.
  */
-export function EditingDocToolsRight({
+export function PublishButtonWithPopover({
   docId,
   existingMenuItems,
-  newButton,
 }: {
   docId: UnpackedHypermediaId
   existingMenuItems: MenuItemType[]
-  newButton?: ReactNode
 }) {
   const draftId = useDocumentSelector(selectDraftId)
   const changeCount = useUnpublishedChangeCount()
@@ -369,9 +368,6 @@ export function EditingDocToolsRight({
   const send = useDocumentSend()
   const deleteDraftDialog = useDeleteDraftDialog()
 
-  // Track first-time popover behavior. Flipped when the user actually triggers a
-  // publish from inside the popover. Persisted at module scope keyed by docId so
-  // the flag survives the remount that happens after a successful publish.
   const [hasTriggeredPublish, setHasTriggeredPublishState] = useState(() => publishTriggeredForDoc.has(docId.id))
   const setHasTriggeredPublish = () => {
     publishTriggeredForDoc.add(docId.id)
@@ -379,8 +375,6 @@ export function EditingDocToolsRight({
   }
   const popoverState = usePopoverState()
 
-  // Destructive "Discard Changes" is appended so it sits with other destructive
-  // actions at the bottom.
   const editingTrailingItems: MenuItemType[] = []
 
   if (draftId) {
@@ -403,6 +397,10 @@ export function EditingDocToolsRight({
   const publishNow = (pathOverride?: string[]) => {
     popoverState.onOpenChange(false)
     setHasTriggeredPublish()
+    // From non-editing state (e.g. DraftActionsToolbar), enter editing before
+    // publishing so the machine can process publish.start from editing.draft.idle.
+    // When already editing, edit.start is a no-op (unhandled in editing state).
+    send({type: 'edit.start'})
     send({type: 'publish.start', pathOverride})
   }
 
@@ -416,9 +414,7 @@ export function EditingDocToolsRight({
   }
 
   return (
-    <div className="flex items-center gap-1">
-      <SaveIndicator />
-
+    <>
       <Popover open={popoverState.open} onOpenChange={popoverState.onOpenChange}>
         <PopoverAnchor asChild>
           <PublishTrigger hasUnsavedChanges={hasUnpublishedChanges} onClick={handlePublishTriggerClick} />
@@ -433,11 +429,52 @@ export function EditingDocToolsRight({
           />
         </PopoverContent>
       </Popover>
-
-      {newButton}
-
       <OptionsDropdown menuItems={allItems} align="end" side="bottom" />
       {deleteDraftDialog.content}
+    </>
+  )
+}
+
+/**
+ * Combined right-actions for DocumentTools when editing.
+ * Renders: save indicator, publish (with popover), new button, three-dots (merged menu).
+ * Must be rendered inside DocumentMachineProvider.
+ */
+export function EditingDocToolsRight({
+  docId,
+  existingMenuItems,
+  newButton,
+}: {
+  docId: UnpackedHypermediaId
+  existingMenuItems: MenuItemType[]
+  newButton?: ReactNode
+}) {
+  return (
+    <div className="flex items-center gap-1">
+      <SaveIndicator />
+      <PublishButtonWithPopover docId={docId} existingMenuItems={existingMenuItems} />
+      {newButton}
+    </div>
+  )
+}
+
+/**
+ * Slim toolbar shown when a draft exists but the user is not actively editing.
+ * Shows the publish button (with pulsing dot for unsaved changes) and the
+ * options dropdown (with "Discard Changes" when a draft is present).
+ * No SaveIndicator — autosave only runs during editing.
+ * Must be rendered inside DocumentMachineProvider.
+ */
+export function DraftActionsToolbar({
+  docId,
+  existingMenuItems,
+}: {
+  docId: UnpackedHypermediaId
+  existingMenuItems: MenuItemType[]
+}) {
+  return (
+    <div className="flex items-center gap-1">
+      <PublishButtonWithPopover docId={docId} existingMenuItems={existingMenuItems} />
     </div>
   )
 }

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -7,7 +7,7 @@ import {DesktopDocumentActionsProvider} from '@/components/document-actions-prov
 import {DesktopQueryBlockDraftSlot} from '@/components/desktop-query-block-draft-slot'
 import {EditNavHeaderPane} from '@/components/edit-nav-header-pane'
 import {useEditProfileDialog} from '@/components/edit-profile-dialog'
-import {EditingDocToolsRight} from '@/components/editing-toolbar'
+import {DraftActionsToolbar, EditingDocToolsRight} from '@/components/editing-toolbar'
 import {InlineNewDocumentCard} from '@/components/inline-new-document-card'
 import {JoinButton} from '@/components/join-button'
 import {MoveDialog} from '@/components/move-dialog'
@@ -625,6 +625,12 @@ export default function DesktopResourcePage() {
       )
     : undefined
 
+  const draftActions = canEdit
+    ? ({menuItems}: {menuItems: any[]}) => (
+        <DraftActionsToolbar docId={docId} existingMenuItems={menuItems} />
+      )
+    : undefined
+
   const onReplyClick = useCallback(
     (replyComment: HMComment) => {
       const replyVersionData = {
@@ -742,6 +748,7 @@ export default function DesktopResourcePage() {
                 onEditorReady={handleEditorReady}
                 machineExtras={null}
                 editingFloatingActions={editingFloatingActions}
+                draftActions={draftActions}
                 newButton={newButton}
                 signingAccountId={selectedAccountId || undefined}
                 publishAccountUid={selectedAccount?.id?.uid || undefined}

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -626,9 +626,7 @@ export default function DesktopResourcePage() {
     : undefined
 
   const draftActions = canEdit
-    ? ({menuItems}: {menuItems: any[]}) => (
-        <DraftActionsToolbar docId={docId} existingMenuItems={menuItems} />
-      )
+    ? ({menuItems}: {menuItems: any[]}) => <DraftActionsToolbar docId={docId} existingMenuItems={menuItems} />
     : undefined
 
   const onReplyClick = useCallback(

--- a/frontend/packages/shared/src/models/document-machine.ts
+++ b/frontend/packages/shared/src/models/document-machine.ts
@@ -637,6 +637,9 @@ export const documentMachine = setup({
             actions: ['setDepsFromPublished', 'snapshotBaseBlocks'],
           },
         ],
+        'edit.discard': {
+          actions: ['clearDraftState'],
+        },
         'document.remoteUpdate': {
           target: 'loaded',
           actions: ['setDocumentData'],

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -249,6 +249,8 @@ export interface ResourcePageProps {
   machineExtras?: ReactNode
   /** Render prop for floating overlay when editing. Receives existing menu items so they can be merged. */
   editingFloatingActions?: (props: {menuItems: MenuItemType[]}) => ReactNode
+  /** Render prop for floating overlay when a draft exists but not actively editing. Shown when a draft exists and isEditing is false. */
+  draftActions?: (props: {menuItems: MenuItemType[]}) => ReactNode
   /** Button for creating a new document. Rendered in the top-right floating overlay in both editing and non-editing states. */
   newButton?: ReactNode
   /** Signing account ID for draft saving (desktop only). Flows into machine context. */
@@ -308,6 +310,7 @@ export function ResourcePage({
   onEditorReady,
   machineExtras,
   editingFloatingActions,
+  draftActions,
   newButton,
   signingAccountId,
   publishAccountUid,
@@ -587,6 +590,7 @@ export function ResourcePage({
           onEditorReady={onEditorReady}
           canEdit={canEdit}
           editingFloatingActions={editingFloatingActions}
+          draftActions={draftActions}
           newButton={newButton}
           signingAccountId={signingAccountId}
           publishAccountUid={publishAccountUid}
@@ -769,6 +773,7 @@ function DocumentBody({
   onEditorReady,
   canEdit = false,
   editingFloatingActions,
+  draftActions,
   newButton,
   signingAccountId,
   publishAccountUid,
@@ -805,6 +810,8 @@ function DocumentBody({
   canEdit?: boolean
   /** Render prop for floating overlay when editing */
   editingFloatingActions?: (props: {menuItems: MenuItemType[]}) => ReactNode
+  /** Render prop for floating overlay when a draft exists but not actively editing */
+  draftActions?: (props: {menuItems: MenuItemType[]}) => ReactNode
   /** Button for creating a new document. Rendered in the top-right floating overlay in both editing and non-editing states. */
   newButton?: ReactNode
   /** Signing account ID for draft saving (desktop only) */
@@ -1613,7 +1620,9 @@ function DocumentBody({
         onFilterChange={handleFilterChange}
       >
         <GotoLatestBanner isLatest={isLatest} id={docId} document={document} />
-        {/* Floating action buttons — when editing, show editing toolbar; otherwise show new button + options menu */}
+        {/* Floating action buttons — when editing, show editing toolbar;
+            when a draft exists but not editing, show draft toolbar (publish + menu);
+            otherwise show new button + options menu */}
         {isEditing && editingFloatingActions ? (
           <div
             className={cn(
@@ -1621,6 +1630,14 @@ function DocumentBody({
             )}
           >
             {editingFloatingActions({menuItems: allMenuItems})}
+          </div>
+        ) : !isEditing && ctx.draftId !== null && draftActions ? (
+          <div
+            className={cn(
+              'absolute top-2 right-2 z-40 flex items-center gap-1 rounded-sm transition-opacity md:top-4 md:right-4',
+            )}
+          >
+            {draftActions({menuItems: allMenuItems})}
           </div>
         ) : newButton || actionButtons ? (
           <div


### PR DESCRIPTION
## Summary

- **Keep publish button visible after leaving editing mode**: Extracted `PublishButtonWithPopover` from `EditingDocToolsRight` so the publish button (with popover/options dropdown) remains visible even when the user exits editing mode. Added new `DraftActionsToolbar` component shown when a draft exists but editing is inactive.
- **Frame discard as revert to last published version**: Updated dialog copy for editing-mode discard to say "Discard unpublished changes?" with a clearer description that the document reverts to its last published version. Added `edit.discard` handler in the document machine to clear draft state.
- **Prop plumbing**: Passed new `draftActions` render prop through `ResourcePage` → `DocumentBody` → rendered when `isEditing` is false but `ctx.draftId` is present.