### PR TITLE
fix(editor): preserve block-range fragment when pasting Hypermedia links

### DIFF
--- a/frontend/packages/editor/src/tiptap-extension-link/helpers/pasteHandler.test.ts
+++ b/frontend/packages/editor/src/tiptap-extension-link/helpers/pasteHandler.test.ts
@@ -1,0 +1,45 @@
+import {describe, expect, it} from 'vitest'
+import {restoreBlockRangeSuffix} from './pasteHandler'
+
+describe('restoreBlockRangeSuffix', () => {
+  it('reattaches a [start:end] block range linkifyjs truncates', () => {
+    const href = 'https://site.example/doc?v=ver#blockId'
+    const full = 'https://site.example/doc?v=ver#blockId[20:52]'
+    expect(restoreBlockRangeSuffix(href, full)).toBe(full)
+  })
+
+  it('reattaches a + expanded block-range marker', () => {
+    const href = 'https://site.example/doc#blockId'
+    const full = 'https://site.example/doc#blockId+'
+    expect(restoreBlockRangeSuffix(href, full)).toBe(full)
+  })
+
+  it('is a no-op when href already has the full range', () => {
+    const href = 'https://site.example/doc#blockId[20:52]'
+    expect(restoreBlockRangeSuffix(href, href)).toBe(href)
+  })
+
+  it('does not pull trailing brackets into URLs without a fragment', () => {
+    const href = 'https://site.example/doc'
+    const full = 'https://site.example/doc[stuff]'
+    expect(restoreBlockRangeSuffix(href, full)).toBe(href)
+  })
+
+  it('ignores trailing text that is not a block range', () => {
+    const href = 'https://site.example/doc#blockId'
+    const full = 'https://site.example/doc#blockId rest of paste'
+    expect(restoreBlockRangeSuffix(href, full)).toBe(href)
+  })
+
+  it('returns href unchanged when fullText does not start with it', () => {
+    const href = 'https://site.example/doc#blockId'
+    const full = 'see https://site.example/doc#blockId[20:52]'
+    expect(restoreBlockRangeSuffix(href, full)).toBe(href)
+  })
+
+  it('only consumes the block range, leaving following text untouched', () => {
+    const href = 'https://site.example/doc#blockId'
+    const full = 'https://site.example/doc#blockId[20:52] (was great!)'
+    expect(restoreBlockRangeSuffix(href, full)).toBe('https://site.example/doc#blockId[20:52]')
+  })
+})

--- a/frontend/packages/editor/src/tiptap-extension-link/helpers/pasteHandler.ts
+++ b/frontend/packages/editor/src/tiptap-extension-link/helpers/pasteHandler.ts
@@ -170,7 +170,7 @@ export function pasteHandler(options: PasteHandlerOptions): Plugin {
         // )
         const matches = find(textContent)
 
-        const link =
+        const candidate =
           matches.length === 1 &&
           // @ts-ignore
           matches[0].isLink &&
@@ -178,6 +178,13 @@ export function pasteHandler(options: PasteHandlerOptions): Plugin {
           textContent.trim().startsWith(matches[0].href)
             ? matches[0]
             : null
+        const link = candidate
+          ? {
+              ...candidate,
+              // @ts-ignore
+              href: restoreBlockRangeSuffix(candidate.href, textContent.trim()),
+            }
+          : null
 
         const unpackedHmId =
           isHypermediaScheme(textContent) || isPublicGatewayLink(textContent, options.gwUrl)
@@ -642,6 +649,28 @@ function getPastedNodes(parent: any, editor: any): any[] {
   })
 
   return nodes
+}
+
+/**
+ * Recover the trailing block-range fragment (`[start:end]` or `+`) that
+ * linkifyjs drops when it tokenizes a Hypermedia URL.
+ *
+ * Hypermedia encodes a block range as `#blockId[start:end]` or `#blockId+`,
+ * but `[`/`]` are RFC 3986 gen-delims and aren't allowed in a URL fragment
+ * unencoded — linkifyjs ends the URL token at the `[`. Without this, pasting
+ * `https://site.example/path#blockId[20:52]` resolves to a link/embed scoped
+ * to the whole block instead of the highlighted range.
+ *
+ * Only re-attaches when `href` already has a fragment, so unrelated trailing
+ * brackets in plain web URLs (e.g. markdown-style references) aren't pulled
+ * into the URL.
+ */
+export function restoreBlockRangeSuffix(href: string, fullText: string): string {
+  if (!fullText.startsWith(href)) return href
+  if (href.indexOf('#') === -1) return href
+  const remainder = fullText.slice(href.length)
+  const match = remainder.match(/^(\[\d+:\d+\]|\+)/)
+  return match ? href + match[0] : href
 }
 
 async function fetchEntityTitle(hmId: UnpackedHypermediaId, grpcClient: GRPCClient, blockRef?: string | null) {


### PR DESCRIPTION
linkifyjs ends URL tokens at `[`, so pasting a URL like
`…/doc#blockId[20:52]` lost the `[20:52]` part before resolveHypermediaUrl
ran, and the resulting link/embed/mention was scoped to the whole block
instead of the highlighted range. Recover the trailing block-range fragment
(`[start:end]` or `+`) from the original pasted text and re-attach it to the
href before resolution.

https://claude.ai/code/session_01Dsbtzp6eakYfeMZmQYD7ZM