### PR TITLE
Navigate to content tab after inline document creation from non-content tabs

### DIFF
--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -619,6 +619,9 @@ export default function DesktopResourcePage() {
             {
               onSuccess: ({draftId}) => {
                 setLastCreatedDraftId(draftId)
+                if (route.key !== 'document') {
+                  navigate({key: 'document', id: docId})
+                }
               },
             },
           )


### PR DESCRIPTION
When the user clicks "New Document" / "Public Document" while on the
Comments or Collaborators tab, the created draft card was only rendered
in the content view and nothing visible happened. On success, we now
navigate back to the document content route so the user can immediately
see and interact with the new draft card.

Fixes: https://github.com/seed-hypermedia/seed/issues/346