### PR TITLE
perf(hmnet): tame autonomous P2P CPU burn

### DIFF
--- a/backend/hmnet/client.go
+++ b/backend/hmnet/client.go
@@ -12,7 +12,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
-	"github.com/libp2p/go-libp2p/p2p/net/swarm"
 	"go.uber.org/multierr"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
@@ -136,11 +135,6 @@ func (c *Client) dialPeer(ctx context.Context, pid peer.ID) (*grpc.ClientConn, e
 
 	if c.me == pid {
 		return nil, errDialSelf
-	}
-
-	sw, ok := c.host.Network().(*swarm.Swarm)
-	if ok {
-		sw.Backoff().Clear(pid)
 	}
 
 	// We do lock sharding here. We don't want to hold the main lock for too long,

--- a/backend/hmnet/connect.go
+++ b/backend/hmnet/connect.go
@@ -30,6 +30,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sethvargo/go-retry"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -47,6 +48,19 @@ const (
 	// response above which we log the sharer as suspicious. A healthy peer will
 	// have mostly fresh data; a misconfigured/malicious one dumps its whole table.
 	suspiciousStaleShare = 0.5
+
+	// targetConnectedPeers is the steady-state goal for active Seed-protocol
+	// peers. Once we're at or above this, the periodic peer-exchange
+	// scheduler is a no-op — we still react to disconnect events to top up.
+	targetConnectedPeers = 20
+
+	// peerExchangeTick is the period between scheduler waits. Was 15 s; with
+	// a per-peer dial budget driven by the connection gap, more frequent
+	// ticks just create churn.
+	peerExchangeTick = 60 * time.Second
+
+	// peerExchangeDialFanout caps concurrent storeRemotePeers calls per tick.
+	peerExchangeDialFanout = 8
 )
 
 var (
@@ -206,6 +220,106 @@ func (n *Node) peerWriteIsRedundant(ctx context.Context, pid, incomingAddrs stri
 // whole table in one round-trip; the loop is a correctness belt for the
 // degenerate case where a remote genuinely has more.
 const maxSharedPeersPerPage = 2000
+
+// runPeerExchangeTick keeps us at targetConnectedPeers Seed-protocol peers.
+// It is a no-op when we're already at the target; otherwise it dials
+// freshness-ranked candidates from the peers table with bounded concurrency.
+// Unlike the previous unconditional fan-out, it does NOT clear libp2p's
+// per-peer backoff (see client.dialPeer) so unreachable peers naturally fade
+// from the dial schedule until they come back online.
+func (n *Node) runPeerExchangeTick(ctx context.Context) error {
+	connected := n.connectedSeedPeers()
+	if len(connected) >= targetConnectedPeers {
+		return nil
+	}
+	need := targetConnectedPeers - len(connected)
+
+	candidates, err := n.peerExchangeCandidates(ctx, connected, need*4)
+	if err != nil {
+		return err
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(peerExchangeDialFanout)
+	for _, pid := range candidates[:min(need, len(candidates))] {
+		pid := pid
+		g.Go(func() error {
+			// storeRemotePeers handles its own per-call timeout.
+			if err := n.storeRemotePeers(pid); err != nil {
+				n.log.Debug("PeerExchangeDialFailed",
+					zap.String("PID", pid.String()), zap.Error(err))
+			}
+			_ = gctx
+			return nil
+		})
+	}
+	return g.Wait()
+}
+
+// connectedSeedPeers returns the subset of currently-connected libp2p peers
+// that have advertised our Seed protocol ID via Identify, excluding any
+// configured bootstrap peers. Bootstrap peers are infrastructure — the
+// ConnectionManager pins them and PeriodicBootstrap reconnects them — so
+// counting them as part of the "useful peers" budget would mask the case
+// where we have no organic peers and PEX-driven discovery has stalled.
+// Symmetric with peerExchangeCandidates, which also excludes bootstrap.
+func (n *Node) connectedSeedPeers() []peer.ID {
+	conns := n.p2p.Host.Network().Conns()
+	out := make([]peer.ID, 0, len(conns))
+	seen := make(map[peer.ID]struct{}, len(conns))
+	ps := n.p2p.Peerstore()
+	for _, c := range conns {
+		pid := c.RemotePeer()
+		if _, ok := seen[pid]; ok {
+			continue
+		}
+		seen[pid] = struct{}{}
+		if n.cfg.IsBootstrap(pid) {
+			continue
+		}
+		proto, err := ps.FirstSupportedProtocol(pid, n.protocol.ID)
+		if err != nil || proto != n.protocol.ID {
+			continue
+		}
+		out = append(out, pid)
+	}
+	return out
+}
+
+// peerExchangeCandidates returns up to limit peer IDs from the peers table,
+// ordered by updated_at DESC (most recently confirmed alive first), excluding
+// peers we are already connected to and any configured bootstrap peers.
+// Bootstrap peers are excluded because the libp2p host's connection manager
+// already keeps a live link to them.
+func (n *Node) peerExchangeCandidates(ctx context.Context, connected []peer.ID, limit int) ([]peer.ID, error) {
+	skip := make(map[peer.ID]struct{}, len(connected))
+	for _, pid := range connected {
+		skip[pid] = struct{}{}
+	}
+	var out []peer.ID
+	err := n.db.WithSave(ctx, func(conn *sqlite.Conn) error {
+		return sqlitex.Exec(conn,
+			"SELECT pid FROM peers WHERE updated_at > (strftime('%s', 'now') - 30*86400) ORDER BY updated_at DESC LIMIT ?;",
+			func(stmt *sqlite.Stmt) error {
+				pid, err := peer.Decode(stmt.ColumnText(0))
+				if err != nil {
+					return nil // tolerate; bad rows aren't fatal
+				}
+				if _, dup := skip[pid]; dup {
+					return nil
+				}
+				if n.cfg.IsBootstrap(pid) {
+					return nil
+				}
+				out = append(out, pid)
+				return nil
+			}, limit*2) // overfetch to absorb skip filtering
+	})
+	return out, err
+}
 
 func (n *Node) storeRemotePeers(id peer.ID) (err error) {
 	n.log.Debug("storeRemotePeers Called", zap.String("PID", id.String()))

--- a/backend/hmnet/hmnet.go
+++ b/backend/hmnet/hmnet.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
-	"math/rand/v2"
 	"regexp"
 	"runtime"
 	"seed/backend/blob"
@@ -20,7 +18,6 @@ import (
 	"seed/backend/util/grpcprom"
 	"seed/backend/util/libp2px"
 	"seed/backend/util/must"
-	"seed/backend/util/sqlite"
 	"seed/backend/util/sqlite/sqlitex"
 	"strings"
 	"sync/atomic"
@@ -61,6 +58,21 @@ const (
 )
 
 var userAgent = "seed/<dev>"
+
+// bitswapWorkerCount caps the boxo bitswap server's blockstore worker pool.
+// boxo defaults to 128 (BitswapEngineBlockstoreWorkerCount in
+// boxo/bitswap/internal/defaults/defaults.go), tuned for big public IPFS
+// gateways. With our SQLite pool size, 128 workers serialize on
+// sqlitex.Pool.Get and produce hundreds of thousands of mutex contention
+// events per minute. Scale with cores instead, with a small floor so a
+// single-core VPS still has enough parallelism to overlap I/O.
+func bitswapWorkerCount() int {
+	n := runtime.NumCPU() * 4
+	if n < 16 {
+		n = 16
+	}
+	return n
+}
 
 // DefaultRelays bootstrap seed-owned relays so they can reserve slots to do holepunch.
 func DefaultRelays() []peer.AddrInfo {
@@ -137,9 +149,7 @@ func New(cfg config.P2P, device *core.KeyPair, ks core.KeyStore, db *sqlitex.Poo
 
 	bsOpts := []bitswap.Option{
 		bitswap.WithPeerBlockRequestFilter(index.CanPeerAccessCID),
-	}
-	if runtime.NumCPU() < 2 {
-		bsOpts = append(bsOpts, bitswap.EngineBlockstoreWorkerCount(64))
+		bitswap.EngineBlockstoreWorkerCount(bitswapWorkerCount()),
 	}
 	bitswap, err := ipfs.NewBitswap(
 		host,
@@ -324,45 +334,18 @@ func (n *Node) Start(ctx context.Context) (err error) {
 			return nil
 		})
 		g.Go(func() error {
-			t := time.NewTimer(15 * time.Second)
-			localPeers := make(map[peer.ID]time.Time)
+			t := time.NewTimer(peerExchangeTick)
 			defer t.Stop()
 			for {
-				if err = n.db.WithSave(ctx, func(conn *sqlite.Conn) error {
-					return sqlitex.Exec(conn, qListPeers(), func(stmt *sqlite.Stmt) error {
-						pidStr := stmt.ColumnText(2)
-						pid, err := peer.Decode(pidStr)
-						if err != nil {
-							if ctx.Err() == nil {
-								return err
-							}
-						}
-
-						_, ok := localPeers[pid]
-						if ok && time.Now().Before(localPeers[pid]) {
-							return nil
-						}
-
-						localPeers[pid] = time.Now().Add(time.Duration(rand.IntN(60*5)) * time.Second).Add(60 * time.Second) //nolint:gosec // We don't need a secure random generator here.
-						return nil
-					}, math.MaxInt64, math.MaxInt64)
-				}); err != nil {
-					if ctx.Err() == nil {
-						return err
-					}
-					return nil
-				}
 				select {
 				case <-ctx.Done():
 					return nil
 				case <-t.C:
-					for pid, next := range localPeers {
-						if time.Now().After(next) {
-							go func(pid peer.ID) { _ = n.storeRemotePeers(pid) }(pid)
-						}
-					}
-					t.Reset(15 * time.Second)
 				}
+				if err := n.runPeerExchangeTick(ctx); err != nil && ctx.Err() == nil {
+					n.log.Debug("PeerExchangeTickFailed", zap.Error(err))
+				}
+				t.Reset(peerExchangeTick)
 			}
 		})
 	}

--- a/backend/hmnet/peer_exchange_tick_test.go
+++ b/backend/hmnet/peer_exchange_tick_test.go
@@ -1,0 +1,226 @@
+package hmnet
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"seed/backend/blob"
+	"seed/backend/config"
+	"seed/backend/core/coretest"
+	"seed/backend/core/keystore"
+	"seed/backend/logging"
+	"seed/backend/storage"
+	"seed/backend/util/must"
+	"seed/backend/util/sqlite"
+	"seed/backend/util/sqlite/sqlitex"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+)
+
+// fakePeerIDs returns n distinct, deterministic PIDs derived from the
+// known fakeUsers identities so candidate ordering is reproducible.
+func fakePeerIDs(t *testing.T, n int) []peer.ID {
+	t.Helper()
+	names := []string{"alice", "alice-2", "bob", "carol", "david"}
+	out := make([]peer.ID, 0, n)
+	for i := 0; i < n; i++ {
+		name := names[i%len(names)]
+		// Skew the second half to avoid duplicates by appending a synthetic
+		// suffix index — but coretest only knows the canonical names, so we
+		// stop once we've exhausted the table.
+		if i >= len(names) {
+			t.Fatalf("only %d distinct test PIDs available, asked for %d", len(names), n)
+		}
+		t2 := coretest.NewTester(name)
+		out = append(out, t2.Device.PeerID())
+	}
+	return out
+}
+
+// makeTestNode constructs a real *Node backed by a real test SQLite pool and
+// libp2p host. It mirrors networking_test.go's setup but skips Start() so we
+// retain control of the peer-exchange goroutine inside individual tests.
+func makeTestNode(t *testing.T) *Node {
+	t.Helper()
+
+	u := coretest.NewTester("alice")
+
+	db := storage.MakeTestDB(t)
+	idx := must.Do2(blob.OpenIndex(context.Background(), db, logging.New("seed/hyper", "debug")))
+
+	cfg := config.Default().P2P
+	cfg.Port = 0
+	cfg.NoRelay = true
+	cfg.BootstrapPeers = nil
+	cfg.NoMetrics = true
+
+	ks := keystore.NewMemory()
+	must.Do(ks.StoreKey(context.Background(), "main", u.Account))
+
+	n, err := New(cfg, u.Device, ks, db, idx, zap.NewNop())
+	require.NoError(t, err)
+
+	errc := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		errc <- n.Start(ctx)
+	}()
+
+	t.Cleanup(func() {
+		err := <-errc
+		if err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			t.Fatal(err)
+		}
+	})
+
+	select {
+	case <-n.Ready():
+	case err := <-errc:
+		require.NoError(t, err)
+	}
+
+	t.Cleanup(cancel)
+
+	return n
+}
+
+// insertPeers inserts the given peers directly into the peers table with the
+// supplied updated_at offsets relative to now (negative seconds = older). The
+// addresses column is forced unique because of the table's UNIQUE constraint.
+func insertPeers(t *testing.T, db *sqlitex.Pool, pids []peer.ID, updatedAtOffsetSec []int64) {
+	t.Helper()
+	require.Equal(t, len(pids), len(updatedAtOffsetSec))
+	now := time.Now().Unix()
+	require.NoError(t, db.WithTx(context.Background(), func(conn *sqlite.Conn) error {
+		for i, pid := range pids {
+			addr := fmt.Sprintf("/ip4/127.0.0.1/tcp/%d/p2p/%s", 30000+i, pid.String())
+			ts := now + updatedAtOffsetSec[i]
+			if err := sqlitex.Exec(conn,
+				"INSERT INTO peers (pid, addresses, explicitly_connected, created_at, updated_at) VALUES (?, ?, ?, ?, ?);",
+				nil, pid.String(), addr, false, ts, ts); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+}
+
+func TestPeerExchangeCandidates_OrdersByUpdatedAtDesc(t *testing.T) {
+	n := makeTestNode(t)
+
+	pids := fakePeerIDs(t, 4)
+	// Index 0: oldest (-3600s), 1: -1800, 2: -60, 3: -10 — so newest first should be 3,2,1,0.
+	insertPeers(t, n.db, pids, []int64{-3600, -1800, -60, -10})
+
+	got, err := n.peerExchangeCandidates(context.Background(), nil, 10)
+	require.NoError(t, err)
+	require.Equal(t, []peer.ID{pids[3], pids[2], pids[1], pids[0]}, got)
+}
+
+func TestPeerExchangeCandidates_FreshnessWindowExcludesAncient(t *testing.T) {
+	n := makeTestNode(t)
+
+	pids := fakePeerIDs(t, 3)
+	// One row beyond 30 days old; must be filtered out by the SQL freshness clause.
+	older := -int64((PeerFreshnessWindow + time.Hour).Seconds())
+	insertPeers(t, n.db, pids, []int64{-60, older, -120})
+
+	got, err := n.peerExchangeCandidates(context.Background(), nil, 10)
+	require.NoError(t, err)
+	require.NotContains(t, got, pids[1])
+	require.Equal(t, []peer.ID{pids[0], pids[2]}, got)
+}
+
+func TestPeerExchangeCandidates_SkipsConnectedAndBootstrap(t *testing.T) {
+	u := coretest.NewTester("alice")
+
+	db := storage.MakeTestDB(t)
+	idx := must.Do2(blob.OpenIndex(context.Background(), db, logging.New("seed/hyper", "debug")))
+
+	cfg := config.Default().P2P
+	cfg.Port = 0
+	cfg.NoRelay = true
+	cfg.NoMetrics = true
+
+	pids := fakePeerIDs(t, 4)
+	// Make pids[0] a bootstrap peer.
+	bootstrapMA := must.Do2(multiaddr.NewMultiaddr(
+		fmt.Sprintf("/ip4/127.0.0.1/tcp/40001/p2p/%s", pids[0].String())))
+	cfg.BootstrapPeers = []peer.AddrInfo{
+		{ID: pids[0], Addrs: []multiaddr.Multiaddr{bootstrapMA}},
+	}
+
+	ks := keystore.NewMemory()
+	must.Do(ks.StoreKey(context.Background(), "main", u.Account))
+
+	n, err := New(cfg, u.Device, ks, db, idx, zap.NewNop())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = n.clean.Close() })
+
+	insertPeers(t, db, pids, []int64{-10, -20, -30, -40})
+
+	// Pretend pids[1] is currently connected; combined with the bootstrap
+	// exclusion, the only valid candidates are pids[2] and pids[3].
+	got, err := n.peerExchangeCandidates(context.Background(), []peer.ID{pids[1]}, 10)
+	require.NoError(t, err)
+	require.Equal(t, []peer.ID{pids[2], pids[3]}, got)
+}
+
+func TestPeerExchangeCandidates_LimitOverfetchAbsorbsSkips(t *testing.T) {
+	n := makeTestNode(t)
+
+	pids := fakePeerIDs(t, 5)
+	insertPeers(t, n.db, pids, []int64{-10, -20, -30, -40, -50})
+
+	// Skip pids[0] and pids[1]; ask for 3 — implementation should overfetch
+	// (limit*2 = 6) so the surviving 3 still come back.
+	got, err := n.peerExchangeCandidates(context.Background(), []peer.ID{pids[0], pids[1]}, 3)
+	require.NoError(t, err)
+	require.Equal(t, []peer.ID{pids[2], pids[3], pids[4]}, got)
+}
+
+func TestConnectedSeedPeers_EmptyWhenNoConns(t *testing.T) {
+	n := makeTestNode(t)
+	require.Empty(t, n.connectedSeedPeers(),
+		"a freshly-started node with no peers must report 0 connected Seed peers")
+}
+
+func TestRunPeerExchangeTick_NoopWhenNoCandidates(t *testing.T) {
+	n := makeTestNode(t)
+	// Empty peers table → tick must return promptly with no error and no
+	// goroutine fan-out (we have no live peer to actually dial against, so
+	// any attempt to dial would expose itself as a hang or test timeout).
+	done := make(chan error, 1)
+	go func() { done <- n.runPeerExchangeTick(context.Background()) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("runPeerExchangeTick blocked despite empty candidate set")
+	}
+}
+
+func TestPeerExchangeTickConstants(t *testing.T) {
+	// Document the contract the live verification steps in the plan rely on.
+	require.Equal(t, 20, targetConnectedPeers)
+	require.Equal(t, 60*time.Second, peerExchangeTick)
+	require.Equal(t, 8, peerExchangeDialFanout)
+}
+
+// Sanity: bitswapWorkerCount honors its 16-worker floor and scales with cores.
+func TestBitswapWorkerCountFloor(t *testing.T) {
+	got := bitswapWorkerCount()
+	require.GreaterOrEqual(t, got, 16, "worker count must respect the 16 floor")
+	// Smell-check the upper bound — we never want to exceed boxo's old default
+	// dramatically. NumCPU*4 on a typical CI runner (8) = 32, on a 32-core box
+	// = 128; this assertion just enforces "sensible".
+	require.LessOrEqual(t, got, 4096)
+}
+


### PR DESCRIPTION
## What's going on

Idle daemon (no frontend attached) was sitting at ~4,000 goroutines and chewing CPU. Live diagnosis from `/debug/pprof` and `/debug/network` pinned three culprits:

- ~1,640 goroutines in `pion/ice` UDP recv loops, ~78 active WebRTC ICE agents
- 60 in-flight `storeRemotePeers → grpc.DialContext` from a peer-exchange tick that fanned out to every due peer with no concurrency cap
- 128 boxo bitswap workers all serializing on `sqlitex.Pool.Get` (mutex profile showed 441k contention events)
- `hmnet.(*Client).dialPeer` was wiping libp2p's per-peer dial backoff on every call, so unreachable peers kept getting redialed at full speed forever

## What changed

**Peer-exchange scheduler is now target-driven.** Instead of firing one detached goroutine per due peer every 15s, the tick runs every 60s and is a no-op when we already have ≥20 connected non-bootstrap Seed peers. When the target isn't met, it picks freshness-ranked candidates from the peers table, excludes already-connected and bootstrap peers, and dials them with concurrency capped at 8 via `errgroup.SetLimit`. Bootstrap peers are excluded *symmetrically* — they're plumbing pinned by ConnectionManager, not part of the organic-discovery target.

**Stopped clearing libp2p's dial backoff.** This is the single highest-leverage line in the patch: deleted the `swarm.Backoff().Clear(pid)` block in `client.dialPeer`. Libp2p already exponentially backs off failed peers; we were defeating it on every call.

**Bitswap worker pool scaled to cores.** `max(16, NumCPU*4)` instead of inheriting boxo's gateway-tuned 128. The SQLite pool can't feed 128 workers in parallel, so they all queued on `Pool.Get`.

## Files

- `backend/hmnet/hmnet.go` — `bitswapWorkerCount`, replaced 15s tick with 60s target-driven loop
- `backend/hmnet/connect.go` — new `runPeerExchangeTick`, `connectedSeedPeers`, `peerExchangeCandidates` (bootstrap excluded symmetrically)
- `backend/hmnet/client.go` — removed the backoff-clear and the now-unused `swarm` import
- `backend/hmnet/peer_exchange_tick_test.go` — 8 new unit tests covering ranking, freshness, exclusion, overfetch, and the constants

## Test plan

- [x] `go test -count=1 ./backend/hmnet/...` — green locally (8 new tests + existing pass)
- [x] `go vet ./backend/...` — clean
- [x] Rebuild + restart daemon with no frontend, leave running ≥5 min, then verify:
  - `curl -s http://localhost:58001/debug/pprof/goroutine?debug=1 | head -1` — total drops from ~4,000 to <800
  - `cat /proc/<pid>/status | grep -E '^(VmRSS|Threads)'` — both noticeably lower
  - `curl -s 'http://localhost:58001/debug/pprof/profile?seconds=30' -o /tmp/cpu.pprof && go tool pprof -top /tmp/cpu.pprof | head -30` — `pion/ice`, `bitswap.blockstoreManager.worker`, and `dialPeer` no longer dominate
  - `curl -s http://localhost:58001/debug/pprof/mutex?debug=1 | head -40` — `sqlitex.Pool.Get` and `dialPeer.Unlock` drop ~10×
  - `curl -s http://localhost:58001/debug/network` — connected non-bootstrap Seed peer count converges to ~20
- [x] Edge case: stop daemon, prune `peers` table to bootstrap rows only, restart — `runPeerExchangeTick` should fire (target unmet) instead of being suppressed by bootstrap-only conns. This validates the symmetric bootstrap exclusion.

## Out of scope (separate follow-ups)

1. Disable libp2p WebRTC transport for non-browser nodes — even after this patch we'll still try webrtc-direct for any peer that advertises it; opting out shaves ~25 goroutines per dial attempt.
2. Bitswap blob-index drift — `blobs` rows with `size>=0` but no matching `structural_blobs` row are invisible to RBSR, causing the 5.2 GiB / 99.9% duplicate-block waste. Deeper change in `indexBlob` rollback paths.
3. Wire up the dormant `lastSeenTracker` so `runPeerExchangeTick` doesn't have to walk `host.Network().Conns()` each tick.