### PR TITLE
fix(comments): dedupe edits and tombstones in comment count

### DIFF
--- a/backend/api/documents/v3alpha/comments_test.go
+++ b/backend/api/documents/v3alpha/comments_test.go
@@ -1175,3 +1175,112 @@ func TestListComments_AfterDocumentMove(t *testing.T) {
 	require.Len(t, newPathResult.Comments, 1, "comment must be found via the canonical new path")
 	require.Equal(t, cmt.Id, newPathResult.Comments[0].Id)
 }
+
+// TestCommentCount_DedupesEditsAndDeletions ensures that editing or deleting a
+// comment does not inflate ActivitySummary.CommentCount. Each comment TSID
+// counts at most once while at least one non-tombstone version exists.
+func TestCommentCount_DedupesEditsAndDeletions(t *testing.T) {
+	t.Parallel()
+
+	alice := newTestDocsAPI(t, "alice")
+	bob := coretest.NewTester("bob")
+	ctx := context.Background()
+	require.NoError(t, alice.keys.StoreKey(ctx, "bob", bob.Account))
+
+	homeDoc, err := alice.CreateDocumentChange(ctx, &pb.CreateDocumentChangeRequest{
+		SigningKeyName: "main",
+		Account:        alice.me.Account.PublicKey.String(),
+		Path:           "",
+		Changes: []*pb.DocumentChange{
+			{Op: &pb.DocumentChange_SetMetadata_{SetMetadata: &pb.DocumentChange_SetMetadata{Key: "title", Value: "Doc"}}},
+		},
+	})
+	require.NoError(t, err)
+
+	getHomeCount := func(t *testing.T) int32 {
+		t.Helper()
+		list, err := alice.ListDocuments(ctx, &pb.ListDocumentsRequest{Account: alice.me.Account.PublicKey.String()})
+		require.NoError(t, err)
+		for _, d := range list.Documents {
+			if d.Path == "" {
+				require.NotNil(t, d.ActivitySummary)
+				return d.ActivitySummary.CommentCount
+			}
+		}
+		t.Fatal("home doc not found in ListDocuments response")
+		return 0
+	}
+
+	require.Equal(t, int32(0), getHomeCount(t), "no comments yet")
+
+	root, err := alice.CreateComment(ctx, &pb.CreateCommentRequest{
+		SigningKeyName: "bob",
+		TargetAccount:  alice.me.Account.PublicKey.String(),
+		TargetPath:     "",
+		TargetVersion:  homeDoc.Version,
+		Content: []*pb.BlockNode{
+			{Block: &pb.Block{Id: "b1", Type: "paragraph", Text: "root"}},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(1), getHomeCount(t), "one comment = count 1")
+
+	reply, err := alice.CreateComment(ctx, &pb.CreateCommentRequest{
+		SigningKeyName: "main",
+		TargetAccount:  alice.me.Account.PublicKey.String(),
+		TargetPath:     "",
+		TargetVersion:  homeDoc.Version,
+		ReplyParent:    root.Id,
+		Content: []*pb.BlockNode{
+			{Block: &pb.Block{Id: "b1", Type: "paragraph", Text: "reply"}},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(2), getHomeCount(t), "root + reply = count 2")
+
+	_, err = alice.UpdateComment(ctx, &pb.UpdateCommentRequest{
+		SigningKeyName: "main",
+		Comment: &pb.Comment{
+			Id:            reply.Id,
+			TargetAccount: alice.me.Account.PublicKey.String(),
+			TargetPath:    "",
+			TargetVersion: homeDoc.Version,
+			Author:        alice.me.Account.PublicKey.String(),
+			Content: []*pb.BlockNode{
+				{Block: &pb.Block{Id: "b1", Type: "paragraph", Text: "reply edited"}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(2), getHomeCount(t), "editing reply must not change count")
+
+	_, err = alice.UpdateComment(ctx, &pb.UpdateCommentRequest{
+		SigningKeyName: "main",
+		Comment: &pb.Comment{
+			Id:            reply.Id,
+			TargetAccount: alice.me.Account.PublicKey.String(),
+			TargetPath:    "",
+			TargetVersion: homeDoc.Version,
+			Author:        alice.me.Account.PublicKey.String(),
+			Content: []*pb.BlockNode{
+				{Block: &pb.Block{Id: "b1", Type: "paragraph", Text: "reply edited again"}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(2), getHomeCount(t), "second edit must not change count")
+
+	_, err = alice.DeleteComment(ctx, &pb.DeleteCommentRequest{
+		Id:             reply.Id,
+		SigningKeyName: "main",
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(1), getHomeCount(t), "deleting reply removes it from count")
+
+	_, err = alice.DeleteComment(ctx, &pb.DeleteCommentRequest{
+		Id:             root.Id,
+		SigningKeyName: "bob",
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(0), getHomeCount(t), "deleting last comment makes count 0")
+}

--- a/backend/blob/blob_comment.go
+++ b/backend/blob/blob_comment.go
@@ -360,6 +360,15 @@ func indexComment(ictx *indexingCtx, id int64, eb Encoded[*Comment]) error {
 			panic("BUG: missing resource for comment target")
 		}
 
+		// commentCountDelta computes how this blob changes the count of distinct,
+		// non-deleted comment TSIDs for the target. Edits with the same TSID don't
+		// change the count; tombstones decrement only when a previously-live version
+		// existed; out-of-order arrivals (non-tombstone after tombstone) re-activate.
+		delta, err := commentCountDelta(ictx.conn, id, eb.TSID(), isTombstone)
+		if err != nil {
+			return fmt.Errorf("failed to compute comment count delta for %s: %w", c, err)
+		}
+
 		generations, err := documentGeneration{}.loadAllByResource(ictx.conn, resourceID)
 		if err != nil {
 			return fmt.Errorf("failed to load generations for comment %s: %w", c, err)
@@ -370,12 +379,18 @@ func indexComment(ictx *indexingCtx, id int64, eb Encoded[*Comment]) error {
 				continue
 			}
 
-			commentTime := v.Ts.UnixMilli()
-			if commentTime > dg.LastCommentTime {
-				dg.LastComment = id
-				dg.LastCommentTime = commentTime
+			// Only let live (non-tombstone) versions advance the latest comment pointer.
+			if !isTombstone {
+				commentTime := v.Ts.UnixMilli()
+				if commentTime > dg.LastCommentTime {
+					dg.LastComment = id
+					dg.LastCommentTime = commentTime
+				}
 			}
-			dg.CommentCount++
+			dg.CommentCount += delta
+			if dg.CommentCount < 0 {
+				dg.CommentCount = 0
+			}
 
 			if err := dg.save(ictx.conn); err != nil {
 				return err
@@ -387,12 +402,17 @@ func indexComment(ictx *indexingCtx, id int64, eb Encoded[*Comment]) error {
 			return err
 		}
 
-		if commentTime := v.Ts.UnixMilli(); commentTime > sm.LastCommentTime {
-			sm.LastCommentTime = commentTime
-			sm.LastComment = id
+		if !isTombstone {
+			if commentTime := v.Ts.UnixMilli(); commentTime > sm.LastCommentTime {
+				sm.LastCommentTime = commentTime
+				sm.LastComment = id
+			}
 		}
 
-		sm.CommentCount++
+		sm.CommentCount += delta
+		if sm.CommentCount < 0 {
+			sm.CommentCount = 0
+		}
 
 		if err := sm.save(ictx.conn); err != nil {
 			return err
@@ -407,6 +427,46 @@ func indexComment(ictx *indexingCtx, id int64, eb Encoded[*Comment]) error {
 
 	return nil
 }
+
+// commentCountDelta returns the change to apply to comment counts when indexing
+// a Comment blob. A new TSID contributes +1, edits contribute 0, the first
+// tombstone for a previously-live TSID contributes -1, and a live blob arriving
+// after a tombstone (out-of-order P2P sync) re-activates the TSID for +1.
+func commentCountDelta(conn *sqlite.Conn, currentID int64, tsid TSID, isTombstone bool) (delta int64, err error) {
+	var priorAny, priorLive int64
+	rows, discard, check := sqlitex.Query(conn, qCommentTSIDPriorVersions(), string(tsid), currentID).All()
+	defer discard(&err)
+	for row := range rows {
+		row.Scan(&priorAny, &priorLive)
+	}
+	if cerr := check(); cerr != nil {
+		return 0, cerr
+	}
+
+	switch {
+	case isTombstone && priorLive > 0:
+		return -1, nil
+	case isTombstone:
+		return 0, nil
+	case priorAny == 0:
+		return 1, nil
+	case priorLive == 0:
+		// A tombstone existed before this live version arrived (out-of-order sync).
+		return 1, nil
+	default:
+		return 0, nil
+	}
+}
+
+var qCommentTSIDPriorVersions = dqb.Str(`
+	SELECT
+		COUNT(*) AS prior_any,
+		COALESCE(SUM(CASE WHEN extra_attrs->>'deleted' IS NULL THEN 1 ELSE 0 END), 0) AS prior_live
+	FROM structural_blobs
+	WHERE type = 'Comment'
+	  AND extra_attrs->>'tsid' = ?1
+	  AND id != ?2;
+`)
 
 type spaceCommentStats struct {
 	shouldUpdate bool

--- a/backend/storage/storage_migrations.go
+++ b/backend/storage/storage_migrations.go
@@ -63,6 +63,10 @@ type migration struct {
 //
 // In case of even the most minor doubts, consult with the team before adding a new migration, and submit the code to review if needed.
 var migrations = []migration{
+	// Reindex to recompute comment counts after deduping edited/deleted comment blobs.
+	{Version: "2026-05-11.010000", Run: func(_ *Store, conn *sqlite.Conn) error {
+		return scheduleReindex(conn)
+	}},
 	// Marker migration for the vault production data-dir version bump.
 	{Version: "2026-04-19.010000", Run: func(_ *Store, _ *sqlite.Conn) error {
 		return nil


### PR DESCRIPTION
## Summary
- Editing or deleting a comment no longer inflates `ActivitySummary.CommentCount`. Counter now tracks distinct comment TSIDs that have at least one live (non-tombstone) version.
- `indexComment` computes a delta via the new `commentCountDelta` helper and `qCommentTSIDPriorVersions`; `LastComment` / `LastCommentTime` only advance on non-tombstone blobs.
- Migration `2026-05-11.010000` triggers a full reindex so existing data dirs recompute `document_generations.comment_count` and `spaces.comment_count`.

## Test plan
- [x] `go build ./backend/blob/... ./backend/storage/... ./backend/api/documents/...`
- [x] `go test ./backend/blob/...`
- [x] `go test ./backend/api/documents/... ./backend/storage/...`
- [x] `go vet ./backend/blob/... ./backend/storage/... ./backend/api/documents/v3alpha/...`
- [ ] Manual: post comment + reply, edit reply twice → `CommentCount = 2`. Delete reply → 1. Delete root → 0.
- [ ] Manual: run daemon against existing DB and confirm reindex migration applies cleanly and existing counters converge to the new definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)