### PR TITLE
chore: bump Node to 22.22.0 and add react-doctor config

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,7 @@ min_version = "2025.12.12"
 "conda:coreutils" = "9.5"
 go = "1.26.2"
 "go:github.com/thought-machine/please/src" = {"version" = "648d330599c4a96e46ec7aa9bca5839119b04a4c", postinstall = "mv $MISE_TOOL_INSTALL_PATH/bin/src $MISE_TOOL_INSTALL_PATH/bin/plz"}
-node = "22.2.0"
+node = "22.22.0"
 protoc = "24.4"
 pnpm = "10.32.0"
 cmake = "3.31.6"

--- a/react-doctor.config.json
+++ b/react-doctor.config.json
@@ -1,0 +1,19 @@
+{
+  "ignore": {
+    "rules": [
+      "react-doctor/rn-no-raw-text"
+    ],
+    "files": [
+      "**/.tmp/**",
+      "**/__pycache__/**",
+      "backend/util/llama-go/**",
+      "frontend/apps/desktop/forge.config.ts",
+      "frontend/apps/desktop/vite.*.config.*",
+      "frontend/apps/desktop/test/**",
+      "frontend/apps/desktop/e2e/**",
+      "frontend/packages/editor/e2e/**",
+      "frontend/apps/web/playwright-tests/**",
+      "tests/**"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Bump `node` in `mise.toml` from `22.2.0` to `22.22.0` so the engine requirement of recent `oxc-parser` / `knip` / `oxlint` (>=22.12.0) is satisfied.
- Add `react-doctor.config.json` to:
  - silence `react-doctor/rn-no-raw-text` (we target web/Electron, not React Native — every hit is a false positive),
  - skip Playwright test fixtures, where the `use(...)` callback parameter trips the `rules-of-hooks` linter.

This is the foundation for the follow-up PRs that fix the actual diagnostics surfaced by \`npx react-doctor@latest\`.

## Test plan

- [ ] `mise install` (or equivalent) picks up Node 22.22.0; \`node -v\` reports it.
- [ ] \`npx react-doctor@latest\` runs to completion without the \`oxc-parser\` native-binding crash.
- [ ] Re-running react-doctor shows 0 \`rn-no-raw-text\` errors and Playwright fixtures no longer flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)