### PR TITLE
fix(react): resolve rules-of-hooks violations across workspaces

### DIFF
--- a/frontend/apps/desktop/src/components/commenting.tsx
+++ b/frontend/apps/desktop/src/components/commenting.tsx
@@ -47,8 +47,8 @@ export function useCommentGroupAuthors(commentGroups: HMCommentGroup[]): HMListD
   )
 }
 
-export const CommentBox = memo(_CommentBox)
-function _CommentBox(props: {
+export const CommentBox = memo(CommentBoxImpl)
+function CommentBoxImpl(props: {
   docId: UnpackedHypermediaId
   backgroundColor?: string
   quotingBlockId?: string

--- a/frontend/apps/desktop/src/components/copy-reference-button.tsx
+++ b/frontend/apps/desktop/src/components/copy-reference-button.tsx
@@ -27,8 +27,7 @@ export function useDocumentUrl({
 } | null {
   const docEntity = useResource(docId)
   const route = useNavRoute()
-  if (!docId?.uid) return null
-  const accountId = hmId(docId.uid)
+  const accountId = docId?.uid ? hmId(docId.uid) : undefined
   const accountEntity = useResource(accountId)
   const gwUrl = useGatewayUrl().data || DEFAULT_GATEWAY_URL
   // @ts-expect-error
@@ -37,7 +36,7 @@ export function useDocumentUrl({
     siteHostname || gwUrl,
     siteHostname ? accountId : undefined,
   )
-  if (!docId) return null
+  if (!docId?.uid || !accountId) return null
   const url = routeToUrl(route, {
     hostname: siteHostname || gwUrl,
     originHomeId: siteHostname ? accountId : undefined,

--- a/frontend/apps/desktop/src/components/discussions-panel.tsx
+++ b/frontend/apps/desktop/src/components/discussions-panel.tsx
@@ -7,9 +7,9 @@ import {BlockDiscussions, CommentDiscussions, Discussions} from '@shm/ui/comment
 import {memo} from 'react'
 import {CommentBox} from './commenting'
 
-export const DiscussionsPanel = memo(_DiscussionsPanel)
+export const DiscussionsPanel = memo(DiscussionsPanelImpl)
 
-function _DiscussionsPanel(props: {docId: UnpackedHypermediaId; selection: CommentsRoute}) {
+function DiscussionsPanelImpl(props: {docId: UnpackedHypermediaId; selection: CommentsRoute}) {
   const {docId, selection} = props
   // Use selection.id if available (panel's own target), otherwise fall back to docId
   const targetDocId = selection.id ?? docId

--- a/frontend/apps/desktop/src/components/move-dialog.tsx
+++ b/frontend/apps/desktop/src/components/move-dialog.tsx
@@ -26,15 +26,15 @@ export function MoveDialog({
   const moveDoc = useMoveDocument()
   const navigate = useNavigate()
   const selectedAccount = useSelectedAccount()
-  if (!selectedAccount) {
-    return <div>No account selected</div>
-  }
   const [location, setLocation] = useState<UnpackedHypermediaId | null>(input.id)
   const isAvailable = useRef(true)
   const pathInvalid = useMemo(
     () => location && validatePath(hmIdPathToEntityQueryPath(location.path)),
     [location?.path],
   )
+  if (!selectedAccount) {
+    return <div>No account selected</div>
+  }
   if (!document)
     return (
       <div className="flex items-center justify-center">

--- a/frontend/apps/desktop/src/components/publish-site.tsx
+++ b/frontend/apps/desktop/src/components/publish-site.tsx
@@ -651,6 +651,9 @@ function SeedHostRegisterSubdomain({
       subdomain: '',
     },
   })
+  useEffect(() => {
+    setFocus('subdomain')
+  }, [setFocus])
   if (!loggedIn) return null
   function onSubmit({subdomain}: RegisterSubdomainFields) {
     createSite
@@ -665,9 +668,6 @@ function SeedHostRegisterSubdomain({
         onPublished(host)
       })
   }
-  useEffect(() => {
-    setFocus('subdomain')
-  }, [])
   const isSubmitting = register.isLoading || createSite.isLoading
 
   // @ts-expect-error

--- a/frontend/apps/desktop/src/models/access-control.ts
+++ b/frontend/apps/desktop/src/models/access-control.ts
@@ -130,9 +130,9 @@ export function useMyAccountsCapabilities() {
 }
 
 export function useMyCapability(id?: UnpackedHypermediaId, minimumRole: HMRole = 'writer'): HMCapability | null {
-  if (!id) return null
   const myAccounts = useMyAccountIds()
   const capabilities = useCapabilities(id)
+  if (!id) return null
   if (myAccounts.data?.indexOf(id.uid) !== -1) {
     return {
       id: '_owner',

--- a/frontend/apps/desktop/src/pages/preview.tsx
+++ b/frontend/apps/desktop/src/pages/preview.tsx
@@ -58,8 +58,11 @@ export default function PreviewPage() {
     return <PublishedPreview docId={route.docId} />
   }
 
-  // Draft preview mode (original behavior)
-  const {data: draft, isLoading} = useDraft(route.draftId)
+  return <DraftPreview draftId={route.draftId} />
+}
+
+function DraftPreview({draftId}: {draftId: string | undefined}) {
+  const {data: draft, isLoading} = useDraft(draftId)
 
   if (isLoading) {
     return (

--- a/frontend/apps/web/app/cache-policy.ts
+++ b/frontend/apps/web/app/cache-policy.ts
@@ -2,7 +2,7 @@ import {ParsedRequest} from './request'
 
 export const ENABLE_HTML_CACHE = false
 
-export function useFullRender(parsedRequest: ParsedRequest) {
+export function shouldFullRender(parsedRequest: ParsedRequest) {
   if (!ENABLE_HTML_CACHE) return true
   const {url, headers} = parsedRequest
   return (

--- a/frontend/apps/web/app/entry.server.tsx
+++ b/frontend/apps/web/app/entry.server.tsx
@@ -20,7 +20,7 @@ import {mkdir, readFile, stat, writeFile} from 'fs/promises'
 import * as isbotModule from 'isbot'
 import {dirname, join, resolve} from 'path'
 import {renderToPipeableStream} from 'react-dom/server'
-import {ENABLE_HTML_CACHE, useFullRender} from './cache-policy'
+import {ENABLE_HTML_CACHE, shouldFullRender} from './cache-policy'
 import {grpcClient} from './client.server'
 import {
   clearRequestInstrumentationContext,
@@ -383,7 +383,7 @@ export default async function handleRequest(
   const serviceConfig = await getConfig(hostname)
   const originAccountId = serviceConfig?.registeredAccountUid
 
-  if (!ENABLE_HTML_CACHE || useFullRender(parsedRequest)) {
+  if (!ENABLE_HTML_CACHE || shouldFullRender(parsedRequest)) {
     sendPerfLog('requested full')
     return handleFullRequest(request, responseStatusCode, responseHeaders, remixContext, loadContext, sendPerfLog)
   }

--- a/frontend/apps/web/app/routes/$.tsx
+++ b/frontend/apps/web/app/routes/$.tsx
@@ -1,4 +1,4 @@
-import {useFullRender} from '@/cache-policy'
+import {shouldFullRender} from '@/cache-policy'
 import {WebCommenting} from '@/client-lazy'
 import {
   createInstrumentationContext,
@@ -249,7 +249,7 @@ export const loader = async ({params, request}: {params: Params; request: Reques
     setRequestInstrumentationContext(request.url, ctx)
   }
 
-  if (!useFullRender(parsedRequest)) {
+  if (!shouldFullRender(parsedRequest)) {
     if (isDataRequest && ctx.enabled) {
       printInstrumentationSummary(ctx)
     }

--- a/frontend/apps/web/app/routes/hm.download.tsx
+++ b/frontend/apps/web/app/routes/hm.download.tsx
@@ -1,5 +1,5 @@
 import downloadBg from '@/assets/download-bg.png'
-import {useFullRender} from '@/cache-policy'
+import {shouldFullRender} from '@/cache-policy'
 import {loadSiteResource, SiteDocumentPayload} from '@/loaders'
 import {defaultPageMeta} from '@/meta'
 import {PageFooter} from '@/page-footer'
@@ -81,7 +81,7 @@ async function loadUpstreamRelease() {
 
 export const loader = async ({request}: {request: Request}) => {
   const parsedRequest = parseRequest(request)
-  if (!useFullRender(parsedRequest)) return null
+  if (!shouldFullRender(parsedRequest)) return null
   const {hostname} = parsedRequest
   const serviceConfig = await getConfig(hostname)
   if (!serviceConfig) throw new Error(`No config defined for ${hostname}`)

--- a/frontend/packages/editor/src/embed-block.tsx
+++ b/frontend/packages/editor/src/embed-block.tsx
@@ -109,13 +109,13 @@ const Render = (block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
       mediaType="embed"
       submit={submitEmbed}
       CustomInput={EmbedLauncherInput}
-      DisplayComponent={display}
+      DisplayComponent={Display}
       icon={<ExternalLink />}
     />
   )
 }
 
-const display = ({editor, block, assign, selected, setSelected}: DisplayComponentProps) => {
+const Display = ({editor, block, assign, selected, setSelected}: DisplayComponentProps) => {
   const {canEdit, isEditing} = useEditorGate()
   return (
     <MediaContainer

--- a/frontend/packages/editor/src/file.tsx
+++ b/frontend/packages/editor/src/file.tsx
@@ -53,13 +53,13 @@ const Render = (block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
       hideForm={!!block.props.url || !!block.props.fileBinary || !!block.props.mediaRef}
       editor={editor}
       mediaType="file"
-      DisplayComponent={display}
+      DisplayComponent={Display}
       icon={<File />}
     />
   )
 }
 
-const display = ({editor, block, selected, setSelected, assign}: DisplayComponentProps) => {
+const Display = ({editor, block, selected, setSelected, assign}: DisplayComponentProps) => {
   const {saveCidAsFile} = useUniversalAppContext()
   const {isEditing} = useEditorGate()
   const url: string = block.props.url || ''

--- a/frontend/packages/editor/src/image.tsx
+++ b/frontend/packages/editor/src/image.tsx
@@ -150,13 +150,13 @@ const Render = (block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
       editor={editor}
       mediaType="image"
       submit={submitImage}
-      DisplayComponent={display}
+      DisplayComponent={Display}
       icon={<RiImage2Line className="text-black dark:text-white" />}
     />
   )
 }
 
-const display = ({editor, block, selected, setSelected, assign}: DisplayComponentProps) => {
+const Display = ({editor, block, selected, setSelected, assign}: DisplayComponentProps) => {
   const getImageUrl = useImageUrl()
   const {canEdit} = useEditorGate()
 

--- a/frontend/packages/editor/src/video.tsx
+++ b/frontend/packages/editor/src/video.tsx
@@ -139,7 +139,7 @@ const Render = (block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
       editor={editor}
       mediaType="video"
       submit={submitVideo}
-      DisplayComponent={display}
+      DisplayComponent={Display}
       icon={<RiVideoAddLine className="text-black dark:text-white" />}
       validateFile={validateFile}
     />
@@ -258,7 +258,7 @@ function VideoOptions({
   )
 }
 
-const display = ({editor, block, selected, setSelected, assign}: DisplayComponentProps) => {
+const Display = ({editor, block, selected, setSelected, assign}: DisplayComponentProps) => {
   const getFileUrl = useFileProxyUrl()
   const {canEdit} = useEditorGate()
   const autoplay = block.props.autoplay === 'true'

--- a/frontend/packages/editor/src/web-embed.tsx
+++ b/frontend/packages/editor/src/web-embed.tsx
@@ -76,13 +76,13 @@ const Render = (block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
       editor={editor}
       mediaType="web-embed"
       submit={submitWebEmbedLink}
-      DisplayComponent={display}
+      DisplayComponent={Display}
       icon={<TwitterXIcon fill="currentColor" />}
     />
   )
 }
 
-const display = ({editor, block, selected, setSelected, assign}: DisplayComponentProps) => {
+const Display = ({editor, block, selected, setSelected, assign}: DisplayComponentProps) => {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(false)
   const openUrl = useOpenUrl()

--- a/frontend/packages/ui/src/comments.tsx
+++ b/frontend/packages/ui/src/comments.tsx
@@ -79,12 +79,10 @@ export function CommentDiscussions({
   const [showParents, setShowParents] = useState(false)
   const parentsRef = useRef<HTMLDivElement>(null)
 
-  if (!commentId) return null
-
   // Fetch all comments for the document
   const commentsService = useCommentsService({targetId} as any)
 
-  const parentThread = useCommentParents(commentsService.data?.comments, commentId)
+  const parentThread = useCommentParents(commentsService.data?.comments, commentId ?? '')
   const commentGroupReplies = useCommentGroups(commentsService.data?.comments, commentId)
 
   // Subscribe to all authors in this discussion
@@ -133,6 +131,8 @@ export function CommentDiscussions({
 
     return () => clearTimeout(timer)
   }, [parentThread?.thread, showParents, commentId]) // Added commentId as dependency
+
+  if (!commentId) return null
 
   if (commentsService.error) {
     return (

--- a/frontend/packages/ui/src/components/scroll-area.tsx
+++ b/frontend/packages/ui/src/components/scroll-area.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import {forwardRef} from 'react'
 import {cn} from '../utils'
 
-function _ScrollArea(
+function ScrollAreaImpl(
   {
     className,
     viewportClassName,
@@ -84,7 +84,7 @@ function _ScrollArea(
   )
 }
 
-const ScrollArea = forwardRef(_ScrollArea)
+const ScrollArea = forwardRef(ScrollAreaImpl)
 
 function ScrollBar({
   className,

--- a/frontend/packages/ui/src/hm-icon.tsx
+++ b/frontend/packages/ui/src/hm-icon.tsx
@@ -8,7 +8,7 @@ import {useImageUrl} from './get-file-url'
 import {Tooltip} from './tooltip'
 import {cn} from './utils'
 
-export const HMIcon = memo(_HMIcon, (prevProps, nextProps) => {
+export const HMIcon = memo(HMIconImpl, (prevProps, nextProps) => {
   // Custom comparison function for memo
   // Deep comparison for id object
   if (prevProps.id?.id !== nextProps.id?.id) return false
@@ -25,7 +25,7 @@ export const HMIcon = memo(_HMIcon, (prevProps, nextProps) => {
   return true
 })
 
-function _HMIcon({
+function HMIconImpl({
   id,
   name,
   icon,

--- a/frontend/packages/ui/src/inline-descriptor.tsx
+++ b/frontend/packages/ui/src/inline-descriptor.tsx
@@ -18,12 +18,10 @@ function formatUTC(date: Date) {
 }
 
 export function Timestamp({time, route}: {time: AnyTimestamp; route?: NavRoute | null}) {
-  if (!time) return null
+  const linkProps = useRouteLink(route ?? null)
+  const date = time ? normalizeDate(time) : null
 
-  const linkProps = route ? useRouteLink(route ?? null) : {}
-  const date = normalizeDate(time)
-
-  if (!date) return null
+  if (!time || !date) return null
 
   return (
     <Tooltip side="top" delay={400} content={formatUTC(date)}>

--- a/frontend/packages/ui/src/inspector-page.tsx
+++ b/frontend/packages/ui/src/inspector-page.tsx
@@ -139,6 +139,19 @@ function InspectorContent({
 }) {
   const inspectTab = route.inspectTab || 'document'
 
+  const getRouteForUrl = useCallback((url: string) => {
+    if (url.startsWith('ipfs://')) {
+      return createInspectIpfsNavRoute(url.slice('ipfs://'.length))
+    }
+
+    const targetRoute = hypermediaUrlToRoute(url)
+    return targetRoute ? createInspectNavRouteFromRoute(targetRoute) : null
+  }, [])
+
+  const inspectPayload = useMemo(() => {
+    return getInspectPayload(docId, route, resource, inspectData)
+  }, [docId, inspectData, resource, route])
+
   if (!resource) {
     return <PageNotFound />
   }
@@ -169,19 +182,6 @@ function InspectorContent({
       route.targetView === 'comments' &&
       !!route.targetOpenComment &&
       inspectData.commentsQuery.isLoading)
-
-  const getRouteForUrl = useCallback((url: string) => {
-    if (url.startsWith('ipfs://')) {
-      return createInspectIpfsNavRoute(url.slice('ipfs://'.length))
-    }
-
-    const targetRoute = hypermediaUrlToRoute(url)
-    return targetRoute ? createInspectNavRouteFromRoute(targetRoute) : null
-  }, [])
-
-  const inspectPayload = useMemo(() => {
-    return getInspectPayload(docId, route, resource, inspectData)
-  }, [docId, inspectData, resource, route])
 
   const emptyMessage = getInspectEmptyMessage(resource, inspectTab, !!route.targetOpenComment)
 
@@ -380,9 +380,10 @@ function getInspectToolTabs(
 function getInspectPayload(
   docId: UnpackedHypermediaId,
   route: InspectRouteType,
-  resource: InspectorResourceData,
+  resource: InspectorResourceData | undefined,
   inspectData: ReturnType<typeof useInspectDatasets>,
 ) {
+  if (!resource) return null
   const inspectTab = route.inspectTab || 'document'
 
   if (resource.type === 'comment') {

--- a/frontend/packages/ui/src/members-facepile.tsx
+++ b/frontend/packages/ui/src/members-facepile.tsx
@@ -17,8 +17,6 @@ interface MembersFacepileProps {
 export function MembersFacepile({members, siteId, description, className}: MembersFacepileProps) {
   const totalCount = members.length
 
-  if (totalCount === 0) return null
-
   const displayUids = useMemo(() => members.slice(0, MAX_AVATARS).map((m) => m.account.uid), [members])
 
   const accountsMeta = useAccountsMetadata(displayUids)
@@ -27,6 +25,8 @@ export function MembersFacepile({members, siteId, description, className}: Membe
     key: 'collaborators',
     id: {...siteId, latest: true, version: null},
   })
+
+  if (totalCount === 0) return null
 
   return (
     <a

--- a/frontend/packages/ui/src/navigation.tsx
+++ b/frontend/packages/ui/src/navigation.tsx
@@ -172,34 +172,18 @@ export function DocumentOutline({
   activeBlockId: string | null
   onCloseNav?: () => void
 }) {
-  return outline.map((node) => {
-    const outlineProps = useRouteLink(
-      {
-        key: 'document',
-        id: {
-          ...id,
-          blockRef: node.id,
-          blockRange: {expanded: true},
-        },
-      },
-      {
-        replace: true,
-      },
-    )
-    return (
-      <OutlineNode
-        node={node}
-        key={node.id}
-        indented={indented}
-        onActivateBlock={onActivateBlock}
-        onClick={onClick}
-        activeBlockId={activeBlockId}
-        onCloseNav={onCloseNav}
-        outlineProps={outlineProps}
-        docId={id}
-      />
-    )
-  })
+  return outline.map((node) => (
+    <OutlineNode
+      node={node}
+      key={node.id}
+      indented={indented}
+      onActivateBlock={onActivateBlock}
+      onClick={onClick}
+      activeBlockId={activeBlockId}
+      onCloseNav={onCloseNav}
+      docId={id}
+    />
+  ))
 }
 
 export function DraftOutline({
@@ -235,7 +219,6 @@ function OutlineNode({
   onActivateBlock,
   onClick,
   onCloseNav,
-  outlineProps,
   docId,
 }: {
   node: NodeOutline
@@ -244,9 +227,23 @@ function OutlineNode({
   onActivateBlock: (blockId: string) => void
   onClick?: ButtonProps['onClick']
   onCloseNav?: () => void
-  outlineProps?: any
   docId?: UnpackedHypermediaId
 }) {
+  const outlineProps = useRouteLink(
+    docId
+      ? {
+          key: 'document',
+          id: {
+            ...docId,
+            blockRef: node.id,
+            blockRange: {expanded: true},
+          },
+        }
+      : null,
+    {
+      replace: true,
+    },
+  )
   return (
     <>
       <SmallListItem
@@ -267,38 +264,18 @@ function OutlineNode({
         }}
       />
       {node.children?.length
-        ? node.children.map((child) => {
-            let childOutlineProps
-            if (outlineProps && docId) {
-              childOutlineProps = useRouteLink(
-                {
-                  key: 'document',
-                  id: {
-                    ...docId,
-                    blockRef: child.id,
-                    blockRange: {expanded: true},
-                  },
-                },
-                {
-                  replace: true,
-                },
-              )
-            }
-
-            return (
-              <OutlineNode
-                node={child}
-                key={child.id}
-                indented={indented + 1}
-                activeBlockId={activeBlockId}
-                onActivateBlock={onActivateBlock}
-                onClick={onClick}
-                onCloseNav={onCloseNav}
-                outlineProps={childOutlineProps}
-                docId={docId}
-              />
-            )
-          })
+        ? node.children.map((child) => (
+            <OutlineNode
+              node={child}
+              key={child.id}
+              indented={indented + 1}
+              activeBlockId={activeBlockId}
+              onActivateBlock={onActivateBlock}
+              onClick={onClick}
+              onCloseNav={onCloseNav}
+              docId={docId}
+            />
+          ))
         : null}
     </>
   )

--- a/frontend/packages/ui/src/search.tsx
+++ b/frontend/packages/ui/src/search.tsx
@@ -158,27 +158,26 @@ export function HeaderSearch({siteHomeId}: {siteHomeId: UnpackedHypermediaId | n
   }, [popoverState.open])
 
   // Listen for Command+K / Ctrl+K keyboard shortcut
-  if (IS_WEB) {
-    useEffect(() => {
-      const handleKeyDown = (e: KeyboardEvent) => {
-        // Don't trigger if user is typing in an input, textarea, or contenteditable
-        const target = e.target as HTMLElement
-        if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
-          return
-        }
-
-        if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-          e.preventDefault()
-          popoverState.onOpenChange(true)
-        }
+  useEffect(() => {
+    if (!IS_WEB) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Don't trigger if user is typing in an input, textarea, or contenteditable
+      const target = e.target as HTMLElement
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+        return
       }
 
-      window.addEventListener('keydown', handleKeyDown)
-      return () => {
-        window.removeEventListener('keydown', handleKeyDown)
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault()
+        popoverState.onOpenChange(true)
       }
-    }, [])
-  }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [popoverState])
 
   const searchItems: SearchResult[] = toSearchResults(searchResults.entities)
 
@@ -427,10 +426,9 @@ export function RecentSearchResultItem({
   siteHomeId?: UnpackedHypermediaId | null
 }) {
   let path = normalizePath(item.path.slice(0, -1))
+  const homeUnpacked = item.id ? unpackHmId(`hm://${item.id.uid}`) : null
+  const homeEntity = useResource(homeUnpacked)
   if (item.id) {
-    const homeId = `hm://${item.id.uid}`
-    const unpacked = unpackHmId(homeId)
-    const homeEntity = useResource(unpacked!)
     const doc = homeEntity.data?.type === 'document' ? homeEntity.data.document : undefined
     const homeTitle = getDocumentTitle(doc)
 

--- a/frontend/packages/ui/src/toast.tsx
+++ b/frontend/packages/ui/src/toast.tsx
@@ -4,46 +4,27 @@ import 'sonner/dist/styles.css'
 
 export {toast} from 'sonner'
 
-// Universal theme hook that works in both Next.js and non-Next.js environments
+// Universal theme hook: observe `dark` class on <html> (works for both next-themes
+// in desktop and the manual class toggle in web).
 const useUniversalTheme = () => {
   const [theme, setTheme] = useState<'light' | 'dark' | 'system'>('system')
 
-  // @ts-ignore
   useEffect(() => {
-    // Check if we're in a Next.js environment with next-themes
-    if (typeof window !== 'undefined' && (window as any).__NEXT_DATA__) {
-      // Next.js environment (desktop app)
-      try {
-        const {useTheme} = require('next-themes')
-        const nextTheme = useTheme()
-        setTheme(nextTheme.theme || 'system')
-      } catch (e) {
-        // Fallback if next-themes is not available
-        setTheme('system')
+    if (typeof document === 'undefined') return
+    const readTheme = () => (document.documentElement.classList.contains('dark') ? 'dark' : 'light')
+    setTheme(readTheme())
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+          setTheme(readTheme())
+        }
       }
-    } else {
-      // Non-Next.js environment (web app)
-      // Check for dark class on document element
-      const isDark = document.documentElement.classList.contains('dark')
-      setTheme(isDark ? 'dark' : 'light')
-
-      // Watch for theme changes
-      const observer = new MutationObserver((mutations) => {
-        mutations.forEach((mutation) => {
-          if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
-            const isDark = document.documentElement.classList.contains('dark')
-            setTheme(isDark ? 'dark' : 'light')
-          }
-        })
-      })
-
-      observer.observe(document.documentElement, {
-        attributes: true,
-        attributeFilter: ['class'],
-      })
-
-      return () => observer.disconnect()
-    }
+    })
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class'],
+    })
+    return () => observer.disconnect()
   }, [])
 
   return {theme}


### PR DESCRIPTION
## Summary

react-doctor surfaced ~100 \`react-hooks/rules-of-hooks\` errors. This PR handles them in three buckets.

### 1. Misnamed identifiers (linter false positives)

- \`useFullRender\` → \`shouldFullRender\` in \`web/app/cache-policy.ts\` + 3 call sites (\`entry.server.tsx\`, \`routes/\$.tsx\`, \`routes/hm.download.tsx\`). It's a plain predicate, not a hook.
- \`_CommentBox\` → \`CommentBoxImpl\` (desktop), \`_DiscussionsPanel\` → \`DiscussionsPanelImpl\` (desktop), \`_HMIcon\` → \`HMIconImpl\` (ui), \`_ScrollArea\` → \`ScrollAreaImpl\` (ui). All are \`memo\`/\`forwardRef\` payloads — uppercase-first satisfies the rule.
- editor \`display\` → \`Display\` in \`image.tsx\`, \`video.tsx\`, \`file.tsx\`, \`web-embed.tsx\`, \`embed-block.tsx\`. Passed as \`DisplayComponent={Display}\` JSX prop; PascalCase aligns with convention.

### 2. Real conditional-hook bugs

Hooks now run unconditionally above the early-returns that previously short-circuited them:

- desktop \`access-control.ts\` \`useMyCapability\`
- desktop \`copy-reference-button.tsx\` \`useDocumentUrl\`
- desktop \`move-dialog.tsx\` \`MoveDialog\`
- desktop \`pages/preview.tsx\` \`PreviewPage\` — split off \`DraftPreview\` subcomponent so \`useDraft\` only runs in its branch.
- desktop \`publish-site.tsx\` \`SeedHostRegisterSubdomain\` — \`useEffect\` moved above \`if (!loggedIn) return null\`.
- ui \`comments.tsx\` \`FocusedComment\` — \`if (!commentId) return null\` moved after hooks; \`useCommentParents\` gets \`commentId ?? ''\`.
- ui \`inspector-page.tsx\` \`InspectorContent\` — \`useCallback\` / \`useMemo\` moved above resource-type guards; \`getInspectPayload\` accepts \`resource | undefined\`.
- ui \`inline-descriptor.tsx\` \`Timestamp\`
- ui \`members-facepile.tsx\`
- ui \`search.tsx\` — \`useEffect\` no longer wrapped in \`if (IS_WEB) { … }\` (\`IS_WEB\` check now inside the effect); \`RecentSearchResultItem\` always calls \`useResource(null)\` when no \`item.id\`.

### 3. Hooks-in-callback

- ui \`navigation.tsx\` — \`DocumentOutline\` and \`OutlineNode\` no longer call \`useRouteLink\` inside \`.map()\` callbacks. Each \`OutlineNode\` calls the hook once at its top, and children render via plain recursion.
- ui \`toast.tsx\` — \`useUniversalTheme\` previously did \`require('next-themes').useTheme()\` inside a \`useEffect\` callback. Replaced with a single \`MutationObserver\` on \`<html class>\`, which works for both desktop (next-themes also sets the \`dark\` class) and web.

## Test plan

- [ ] \`pnpm typecheck\` clean (web, ui, editor, desktop, shared).
- [ ] \`pnpm --filter @shm/desktop dev\` — open editor; embed media (image, video, file, web-embed) still renders; comment box opens; reply works; access-control gating still works; move-dialog and draft preview flows ok.
- [ ] \`pnpm --filter @shm/web dev\` — toast theme reacts to light/dark toggle on \`<html class>\`; Cmd+K opens search; recent search result item shows parent home title; document outline navigates with \`replace: true\` on click.
- [ ] \`SeedHostRegisterSubdomain\` subdomain input auto-focuses on mount.
- [ ] Re-run \`npx react-doctor@latest\` from root — \`rules-of-hooks\` error count drops to ~0.

Depends on / pairs with #591 (config + Node bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)