### PR TITLE
improve some navigation issues

### DIFF
--- a/frontend/apps/desktop/src/components/__tests__/edit-navigation-popover.test.tsx
+++ b/frontend/apps/desktop/src/components/__tests__/edit-navigation-popover.test.tsx
@@ -1,8 +1,15 @@
-import React from 'react'
+import React, {useState} from 'react'
 import {createRoot, Root} from 'react-dom/client'
 import {act} from 'react-dom/test-utils'
-import {describe, expect, it, vi} from 'vitest'
 import type {HMNavigationItem} from '@seed-hypermedia/client/hm-types'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+const {packHmIdMock, resolveHypermediaUrlMock, useDirectoryMock, useSearchMock} = vi.hoisted(() => ({
+  packHmIdMock: vi.fn((id: {uid: string; path?: string[]}) => `hm://${id.uid}/${id.path?.join('/') || ''}`),
+  resolveHypermediaUrlMock: vi.fn(),
+  useDirectoryMock: vi.fn(() => ({data: []})),
+  useSearchMock: vi.fn(() => ({data: {entities: []}})),
+}))
 
 vi.mock('@atlaskit/pragmatic-drag-and-drop/combine', () => ({
   combine:
@@ -18,7 +25,7 @@ vi.mock('@atlaskit/pragmatic-drag-and-drop/element/adapter', () => ({
 }))
 
 vi.mock('@shm/shared', () => ({
-  packHmId: vi.fn(),
+  packHmId: packHmIdMock,
   unpackHmId: vi.fn((value: string) => {
     if (!value.startsWith('hm://')) return null
     const [, rest] = value.split('hm://')
@@ -27,16 +34,16 @@ vi.mock('@shm/shared', () => ({
       path: segments.slice(1),
     }
   }),
-  useSearch: vi.fn(() => ({data: {entities: []}})),
+  useSearch: useSearchMock,
 }))
 
 vi.mock('@shm/shared/models/entity', () => ({
-  useDirectory: vi.fn(() => ({data: []})),
+  useDirectory: useDirectoryMock,
   useResource: vi.fn(() => ({data: null})),
 }))
 
 vi.mock('@seed-hypermedia/client', () => ({
-  resolveHypermediaUrl: vi.fn(),
+  resolveHypermediaUrl: resolveHypermediaUrlMock,
 }))
 
 vi.mock('@shm/ui/button', () => ({
@@ -63,7 +70,11 @@ vi.mock('@shm/ui/forms', () => ({
 }))
 
 vi.mock('@shm/ui/search', () => ({
-  SearchResultItem: ({item}: any) => <div>{item.title}</div>,
+  SearchResultItem: ({item}: any) => (
+    <button type="button" data-search-result={item.title} onClick={() => item.onSelect?.()}>
+      {item.title}
+    </button>
+  ),
 }))
 
 vi.mock('@shm/ui/spinner', () => ({
@@ -87,13 +98,18 @@ vi.mock('lucide-react', () => ({
 import {EditNavPopover} from '../edit-navigation-popover'
 ;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
 
+function TestHarness({initialDocNav}: {initialDocNav: HMNavigationItem[]}) {
+  const [docNav, setDocNav] = useState(initialDocNav)
+  return <EditNavPopover docNav={docNav} editDocNav={setDocNav} />
+}
+
 function renderPopover(docNav: HMNavigationItem[]) {
   const container = document.createElement('div')
   document.body.appendChild(container)
   const root = createRoot(container)
 
   act(() => {
-    root.render(<EditNavPopover docNav={docNav} editDocNav={vi.fn()} />)
+    root.render(<TestHarness initialDocNav={docNav} />)
   })
 
   return {container, root}
@@ -105,6 +121,21 @@ function cleanup(root: Root, container: HTMLDivElement) {
   })
   container.remove()
 }
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  act(() => {
+    input.value = value
+    input.dispatchEvent(new Event('input', {bubbles: true}))
+  })
+}
+
+afterEach(() => {
+  useSearchMock.mockReset()
+  useSearchMock.mockReturnValue({data: {entities: []}})
+  useDirectoryMock.mockReset()
+  useDirectoryMock.mockReturnValue({data: []})
+  resolveHypermediaUrlMock.mockReset()
+})
 
 describe('EditNavPopover trigger', () => {
   it('shows the empty-state CTA when navigation has no items', () => {
@@ -129,7 +160,7 @@ describe('EditNavPopover trigger', () => {
     }
   })
 
-  it('shows inline item fields inside the same popover surface for a new item', () => {
+  it('shows editable link and label inputs for a new item', () => {
     const {container, root} = renderPopover([{id: 'nav-1', type: 'Link', text: '', link: ''}])
 
     try {
@@ -138,27 +169,90 @@ describe('EditNavPopover trigger', () => {
       expect(container.textContent).toContain('Incomplete')
       expect(container.textContent).toContain('Link')
       expect(container.textContent).toContain('Label')
-      expect(container.textContent).toContain('Select document or paste URL')
+      expect(container.querySelector('input[placeholder="Search documents or paste URL"]')).not.toBeNull()
       expect(container.textContent!.indexOf('Link')).toBeLessThan(container.textContent!.indexOf('Label'))
     } finally {
       cleanup(root, container)
     }
   })
 
-  it('shows only the document path in the link field for hm links', () => {
+  it('shows only the document path in the link input for hm links', () => {
     const {container, root} = renderPopover([{id: 'nav-1', type: 'Link', text: 'Docs', link: 'hm://alice/docs'}])
 
     try {
-      const trigger = Array.from(container.querySelectorAll('button')).find(
-        (button) => button.textContent?.includes('Docs'),
-      )
+      const linkInput = container.querySelector('input[aria-label="Link"]') as HTMLInputElement | null
+      expect(linkInput?.value).toBe('/docs')
+      expect(container.textContent).not.toContain('hm://alice/docs')
+    } finally {
+      cleanup(root, container)
+    }
+  })
 
-      act(() => {
-        trigger?.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+  it('updates link and label when a document search result is selected', async () => {
+    useSearchMock.mockImplementation((query: string) => ({
+      data: {
+        entities:
+          query === 'Shared'
+            ? [
+                {
+                  id: {uid: 'alice', path: ['shared-meaning']},
+                  title: 'Shared Meaning',
+                  parentNames: ['Notes'],
+                  icon: null,
+                  searchQuery: query,
+                  versionTime: '',
+                },
+              ]
+            : [],
+      },
+    }))
+
+    const {container, root} = renderPopover([{id: 'nav-1', type: 'Link', text: '', link: ''}])
+
+    try {
+      const linkInput = container.querySelector('input[aria-label="Link"]') as HTMLInputElement
+      const labelInput = container.querySelector('input[placeholder="My Link..."]') as HTMLInputElement
+
+      await act(async () => {
+        linkInput.focus()
+      })
+      setInputValue(linkInput, 'Shared')
+
+      const resultButton = container.querySelector('[data-search-result="Shared Meaning"]') as HTMLButtonElement | null
+      expect(resultButton).not.toBeNull()
+
+      await act(async () => {
+        resultButton?.click()
       })
 
-      expect(container.textContent).toContain('/docs')
-      expect(container.textContent).not.toContain('hm://alice/docs')
+      expect(linkInput.value).toBe('/shared-meaning')
+      expect(labelInput.value).toBe('Shared Meaning')
+    } finally {
+      cleanup(root, container)
+    }
+  })
+
+  it('commits pasted web URLs from the link input and updates the label', async () => {
+    resolveHypermediaUrlMock.mockResolvedValue(null)
+
+    const {container, root} = renderPopover([{id: 'nav-1', type: 'Link', text: '', link: ''}])
+
+    try {
+      const linkInput = container.querySelector('input[aria-label="Link"]') as HTMLInputElement
+      const labelInput = container.querySelector('input[placeholder="My Link..."]') as HTMLInputElement
+
+      await act(async () => {
+        linkInput.focus()
+      })
+      setInputValue(linkInput, 'https://seed.example/docs')
+
+      await act(async () => {
+        linkInput.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter', bubbles: true}))
+      })
+
+      expect(resolveHypermediaUrlMock).toHaveBeenCalledWith('https://seed.example/docs')
+      expect(linkInput.value).toBe('https://seed.example/docs')
+      expect(labelInput.value).toBe('https://seed.example/docs')
     } finally {
       cleanup(root, container)
     }

--- a/frontend/apps/desktop/src/components/__tests__/edit-navigation-popover.test.tsx
+++ b/frontend/apps/desktop/src/components/__tests__/edit-navigation-popover.test.tsx
@@ -189,7 +189,7 @@ describe('EditNavPopover trigger', () => {
   })
 
   it('updates link and label when a document search result is selected', async () => {
-    useSearchMock.mockImplementation((query: string) => ({
+    useSearchMock.mockImplementation(((query: string) => ({
       data: {
         entities:
           query === 'Shared'
@@ -205,7 +205,7 @@ describe('EditNavPopover trigger', () => {
               ]
             : [],
       },
-    }))
+    })) as any)
 
     const {container, root} = renderPopover([{id: 'nav-1', type: 'Link', text: '', link: ''}])
 

--- a/frontend/apps/desktop/src/components/edit-navigation-popover.tsx
+++ b/frontend/apps/desktop/src/components/edit-navigation-popover.tsx
@@ -581,12 +581,7 @@ function SearchUI({
           const isSelected = normalizedFocusedIndex === itemIndex
 
           return (
-            <div
-              key={item.key}
-              data-nav-link-result="true"
-              tabIndex={-1}
-              onMouseDown={(e) => e.preventDefault()}
-            >
+            <div key={item.key} data-nav-link-result="true" tabIndex={-1} onMouseDown={(e) => e.preventDefault()}>
               <SearchResultItem
                 item={{
                   ...item,

--- a/frontend/apps/desktop/src/components/edit-navigation-popover.tsx
+++ b/frontend/apps/desktop/src/components/edit-navigation-popover.tsx
@@ -27,6 +27,12 @@ function createEmptyNavigationItem(): HMNavigationItem {
   }
 }
 
+function getDisplayValueForLink(link: string) {
+  if (!link) return ''
+  const unpackedLink = unpackHmId(link)
+  return unpackedLink ? `/${unpackedLink.path?.join('/') || ''}` : link
+}
+
 export function EditNavPopover({
   docNav,
   editDocNav,
@@ -349,180 +355,253 @@ function HMDocURLInput({
   homeId?: UnpackedHypermediaId
   filterPresets: (item: {link: string}) => boolean
 }) {
-  const unpackedLink = unpackHmId(link)
-  let label = link || 'Select document or paste URL'
-  let fontClass = 'text-muted-foreground'
-  const TriggerIcon = link?.match(/^https?:\/\//) ? Globe : Search
-  if (link) {
-    label = unpackedLink ? `/${unpackedLink.path?.join('/') || ''}` : link
-    fontClass = 'text-primary'
-  }
-  const popoverState = usePopoverState()
-  return (
-    <>
-      <Popover {...popoverState}>
-        <PopoverTrigger asChild>
-          <button
-            type="button"
-            className={cn(
-              'hover:bg-muted/40 flex w-full items-center gap-2 rounded-md border border-black/8 bg-transparent px-3 py-2 text-left text-sm transition-colors dark:border-white/10',
-              fontClass,
-            )}
-          >
-            <TriggerIcon className="text-muted-foreground size-4 shrink-0" />
-            <span className="min-w-0 flex-1 truncate">{label}</span>
-            <span className="text-muted-foreground text-xs">Choose</span>
-          </button>
-        </PopoverTrigger>
-        <PopoverContent className="p-0">
-          <SearchUI
-            onValue={onUpdate}
-            homeId={homeId}
-            onClose={() => popoverState.onOpenChange(false)}
-            filterPresets={filterPresets}
-          />
-        </PopoverContent>
-      </Popover>
-    </>
-  )
-}
-
-function SearchUI({
-  onValue,
-  onClose,
-  homeId,
-  filterPresets,
-}: {
-  onValue: (link: string, title: string) => void
-  onClose: () => void
-  homeId?: UnpackedHypermediaId
-  filterPresets: (item: {link: string}) => boolean
-}) {
-  const [query, setQuery] = useState('')
-  const [isLoading, setIsLoading] = useState(false)
-  const isWebUrl = query.match(/^https?:\/\//)
-  const search = useSearch(query, {enabled: !!query})
+  const [query, setQuery] = useState(getDisplayValueForLink(link))
+  const [isOpen, setIsOpen] = useState(false)
   const [focusedIndex, setFocusedIndex] = useState(0)
-  const dirList = useDirectory(homeId, {mode: 'Children'})
-  const isSearching = !!query.length
+  const [activeSelection, setActiveSelection] = useState<{
+    link: string
+    title: string
+  } | null>(null)
+  const [isResolvingUrl, setIsResolvingUrl] = useState(false)
+  const displayValue = getDisplayValueForLink(link)
+  const isWebUrl = /^https?:\/\//.test(query.trim())
   const Icon = isWebUrl ? Globe : Search
-  const results: SearchResult[] = isSearching
-    ? search?.data?.entities
-        ?.sort((a, b) => Number(!!b.id.latest) - Number(!!a.id.latest))
-        ?.map((item, index) => {
-          const title = item.title || item.id.uid
-          return {
-            key: packHmId(item.id),
-            title,
-            path: item.parentNames,
-            icon: item.icon,
-            onFocus: () => {
-              setFocusedIndex(index)
-            },
-            onMouseEnter: () => {
-              setFocusedIndex(index)
-            },
-            onSelect: () => onValue(packHmId(item.id), item.title || ''),
-            subtitle: 'Document',
-            searchQuery: item.searchQuery,
-            versionTime: item.versionTime || '',
-          }
-        })
-        .filter(Boolean) ?? []
-    : dirList.data?.map((d, index) => {
-        const id = d.id.id
-        return {
-          key: id,
-          title: d.metadata.name || '',
-          path: d.path,
-          icon: d.metadata.icon,
-          onSelect: () => onValue(id, d.metadata.name || ''),
-          subtitle: 'Document',
-          searchQuery: query,
-          onFocus: () => {
-            setFocusedIndex(index)
-          },
-          onMouseEnter: () => {
-            setFocusedIndex(index)
-          },
-        }
-      }) ?? []
+
+  useEffect(() => {
+    setQuery(displayValue)
+  }, [displayValue])
+
+  function closeAndReset() {
+    setIsOpen(false)
+    setFocusedIndex(0)
+    setActiveSelection(null)
+    setQuery(displayValue)
+    setIsResolvingUrl(false)
+  }
 
   return (
-    <div className="z-50 max-h-[50vh] overflow-y-auto">
-      <div className="border-color8 relative border-b-1 p-1">
+    <div className="flex flex-col gap-2">
+      <div className="relative">
+        <Icon className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
         <Input
-          autoFocus
-          className="w-full rounded-sm p-2 pl-10"
+          aria-label="Link"
+          className={cn('pl-9', link ? 'text-primary' : 'text-muted-foreground')}
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          onKeyDown={(e) => {
+          placeholder="Search documents or paste URL"
+          onFocus={() => {
+            setIsOpen(true)
+            setFocusedIndex(0)
+          }}
+          onBlur={() => {
+            window.setTimeout(() => {
+              if (
+                document.activeElement instanceof HTMLElement &&
+                document.activeElement.dataset.navLinkResult === 'true'
+              ) {
+                return
+              }
+              closeAndReset()
+            }, 0)
+          }}
+          onChange={(e) => {
+            setQuery(e.target.value)
+            setIsOpen(true)
+            setFocusedIndex(0)
+          }}
+          onKeyDown={async (e) => {
             if (e.key === 'Escape') {
               e.preventDefault()
-              onClose()
-            }
-
-            if (e.key === 'Enter') {
-              if (query.match(/^https?:\/\//)) {
-                onValue(query, '')
-                setIsLoading(true)
-                resolveHypermediaUrl(query)
-                  .then((resolved) => {
-                    if (resolved) {
-                      onValue(resolved.id, resolved.title || '')
-                    }
-                    setIsLoading(false)
-                    onClose()
-                  })
-                  .catch((e) => {
-                    console.error(e)
-                    onClose()
-                  })
-              } else {
-                const selectedEntity = results[focusedIndex]
-                if (selectedEntity) {
-                  onValue(selectedEntity.key, selectedEntity.title || '')
-                  onClose()
-                }
-              }
+              closeAndReset()
+              return
             }
 
             if (e.key === 'ArrowUp') {
               e.preventDefault()
-              setFocusedIndex((prev) => (prev - 1 + results.length) % results.length)
+              setFocusedIndex((prev) => prev - 1)
+              return
             }
 
             if (e.key === 'ArrowDown') {
               e.preventDefault()
-              setFocusedIndex((prev) => (prev + 1) % results.length)
+              setFocusedIndex((prev) => prev + 1)
+              return
+            }
+
+            if (e.key !== 'Enter') return
+
+            const trimmedQuery = query.trim()
+            if (!trimmedQuery) return
+
+            e.preventDefault()
+
+            if (/^https?:\/\//.test(trimmedQuery)) {
+              onUpdate(trimmedQuery, trimmedQuery)
+              setIsResolvingUrl(true)
+              try {
+                const resolved = await resolveHypermediaUrl(trimmedQuery)
+                if (resolved) {
+                  onUpdate(resolved.id, resolved.title || trimmedQuery)
+                }
+              } catch (error) {
+                console.error(error)
+              } finally {
+                setIsResolvingUrl(false)
+                setIsOpen(false)
+                setActiveSelection(null)
+              }
+              return
+            }
+
+            if (activeSelection) {
+              onUpdate(activeSelection.link, activeSelection.title)
+              setQuery(getDisplayValueForLink(activeSelection.link))
+              setIsOpen(false)
+              setFocusedIndex(0)
+              setActiveSelection(null)
             }
           }}
         />
-        <Icon className="absolute top-1/2 left-3 -translate-y-1/2" size={20} />
       </div>
-      {isLoading && (
-        <div className="flex justify-center p-2">
+      {isOpen ? (
+        <SearchUI
+          query={query}
+          focusedIndex={focusedIndex}
+          isResolvingUrl={isResolvingUrl}
+          onActiveResultChange={setActiveSelection}
+          onFocusedIndexChange={setFocusedIndex}
+          onValue={(nextLink, title) => {
+            onUpdate(nextLink, title)
+            setQuery(getDisplayValueForLink(nextLink))
+            setIsOpen(false)
+            setFocusedIndex(0)
+            setActiveSelection(null)
+            setIsResolvingUrl(false)
+          }}
+          homeId={homeId}
+          filterPresets={filterPresets}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+function SearchUI({
+  query,
+  focusedIndex,
+  isResolvingUrl,
+  onActiveResultChange,
+  onFocusedIndexChange,
+  onValue,
+  homeId,
+  filterPresets,
+}: {
+  query: string
+  focusedIndex: number
+  isResolvingUrl: boolean
+  onActiveResultChange: (result: {link: string; title: string} | null) => void
+  onFocusedIndexChange: (index: number | ((prev: number) => number)) => void
+  onValue: (link: string, title: string) => void
+  homeId?: UnpackedHypermediaId
+  filterPresets: (item: {link: string}) => boolean
+}) {
+  const trimmedQuery = query.trim()
+  const isWebUrl = /^https?:\/\//.test(trimmedQuery)
+  const isSearching = !!trimmedQuery.length
+  const search = useSearch(query, {enabled: isSearching && !isWebUrl})
+  const dirList = useDirectory(homeId, {mode: 'Children'})
+  const results: SearchResult[] = (
+    isSearching
+      ? search?.data?.entities
+          ?.sort((a, b) => Number(!!b.id.latest) - Number(!!a.id.latest))
+          ?.map((item, index) => {
+            const title = item.title || item.id.uid
+            return {
+              key: packHmId(item.id),
+              title,
+              path: item.parentNames,
+              icon: item.icon,
+              onFocus: () => {
+                onFocusedIndexChange(index)
+              },
+              onMouseEnter: () => {
+                onFocusedIndexChange(index)
+              },
+              onSelect: () => onValue(packHmId(item.id), item.title || ''),
+              subtitle: 'Document',
+              searchQuery: item.searchQuery,
+              versionTime: item.versionTime || '',
+            }
+          })
+          .filter(Boolean) ?? []
+      : dirList.data?.map((d, index) => {
+          const id = d.id.id
+          return {
+            key: id,
+            title: d.metadata.name || '',
+            path: d.path,
+            icon: d.metadata.icon,
+            onSelect: () => onValue(id, d.metadata.name || ''),
+            subtitle: 'Document',
+            searchQuery: query,
+            onFocus: () => {
+              onFocusedIndexChange(index)
+            },
+            onMouseEnter: () => {
+              onFocusedIndexChange(index)
+            },
+          }
+        }) ?? []
+  ).filter((item) => filterPresets({link: item.key}))
+
+  const normalizedFocusedIndex =
+    results.length > 0 ? ((focusedIndex % results.length) + results.length) % results.length : 0
+
+  useEffect(() => {
+    const activeItem = results[normalizedFocusedIndex]
+    onActiveResultChange(activeItem ? {link: activeItem.key, title: activeItem.title || ''} : null)
+  }, [normalizedFocusedIndex, onActiveResultChange, results])
+
+  return (
+    <div className="z-50 max-h-[50vh] overflow-y-auto rounded-md border border-black/8 bg-white shadow-sm dark:border-white/10 dark:bg-black">
+      {isResolvingUrl ? (
+        <div className="flex justify-center p-3">
           <Spinner />
         </div>
-      )}
-      {results.map((item, itemIndex) => {
-        const isSelected = focusedIndex === itemIndex
+      ) : null}
+      {!isResolvingUrl && isWebUrl ? (
+        <div className="text-muted-foreground px-3 py-2 text-sm">Press Enter to use this URL.</div>
+      ) : null}
+      {!isResolvingUrl && !results.length && !isWebUrl ? (
+        <div className="text-muted-foreground px-3 py-2 text-sm">
+          {isSearching ? 'No documents found.' : 'No documents available.'}
+        </div>
+      ) : null}
+      {!isResolvingUrl &&
+        results.map((item, itemIndex) => {
+          const isSelected = normalizedFocusedIndex === itemIndex
 
-        return (
-          <SearchResultItem
-            item={{
-              ...item,
-              path: item.path || [],
-              onSelect: () => {
-                onValue(item.key, item.title || '')
-              },
-              onFocus: () => setFocusedIndex(itemIndex),
-              onMouseEnter: () => setFocusedIndex(itemIndex),
-            }}
-            selected={isSelected}
-          />
-        )
-      })}
+          return (
+            <div
+              key={item.key}
+              data-nav-link-result="true"
+              tabIndex={-1}
+              onMouseDown={(e) => e.preventDefault()}
+            >
+              <SearchResultItem
+                item={{
+                  ...item,
+                  path: item.path || [],
+                  onSelect: () => {
+                    onValue(item.key, item.title || '')
+                  },
+                  onFocus: () => onFocusedIndexChange(itemIndex),
+                  onMouseEnter: () => onFocusedIndexChange(itemIndex),
+                }}
+                selected={isSelected}
+              />
+            </div>
+          )
+        })}
     </div>
   )
 }

--- a/frontend/packages/editor/e2e/tests/selection-toolbar.e2e.ts
+++ b/frontend/packages/editor/e2e/tests/selection-toolbar.e2e.ts
@@ -377,8 +377,44 @@ test.describe('Slash Menu', () => {
 test.describe('Link Toolbar', () => {
   // Select the text with a link mark and wait for the link preview to be visible
   async function selectLinkAndExpectPreview(editorHelpers: any, page: any) {
-    const contentArea = editorHelpers.getContentArea()
-    await contentArea.locator(`span:has-text("Link")`).first().click()
+    await editorHelpers.focusEditor()
+    await page.evaluate(() => {
+      const bnEditor = (window as any).TEST_EDITOR?.editor
+      if (!bnEditor) throw new Error('window.TEST_EDITOR.editor not found')
+
+      const tiptap = (bnEditor as any)._tiptapEditor
+      if (!tiptap?.state || !tiptap?.view) throw new Error('tiptap editor/view not found')
+
+      const {doc, schema} = tiptap.state
+      const linkMarkType = schema.marks.link
+      let selection: {from: number; to: number} | null = null
+
+      doc.descendants((node: any, pos: number) => {
+        if (node.isText) {
+          const linkMark = node.marks?.find((mark: any) => mark.type === linkMarkType)
+          if (linkMark) {
+            selection = {
+              from: pos,
+              to: pos + (node.text?.length || 1),
+            }
+            return false
+          }
+        }
+
+        if (node.type?.name === 'inline-embed') {
+          selection = {
+            from: pos,
+            to: pos + node.nodeSize,
+          }
+          return false
+        }
+      })
+
+      if (!selection) throw new Error('No link selection found in test fixture')
+
+      tiptap.commands.setTextSelection(selection)
+      tiptap.view.focus()
+    })
     await page.waitForTimeout(50)
     await expect(page.getByTestId('hm-link-preview')).toBeVisible()
     await expect(page.getByTestId('hm-link-preview-edit-button')).toBeVisible()

--- a/frontend/packages/editor/e2e/tests/selection-toolbar.e2e.ts
+++ b/frontend/packages/editor/e2e/tests/selection-toolbar.e2e.ts
@@ -387,32 +387,28 @@ test.describe('Link Toolbar', () => {
 
       const {doc, schema} = tiptap.state
       const linkMarkType = schema.marks.link
-      let selection: {from: number; to: number} | null = null
+      let selectionPos: number | null = null
 
       doc.descendants((node: any, pos: number) => {
         if (node.isText) {
           const linkMark = node.marks?.find((mark: any) => mark.type === linkMarkType)
           if (linkMark) {
-            selection = {
-              from: pos,
-              to: pos + (node.text?.length || 1),
-            }
+            selectionPos = pos + Math.min(1, node.text?.length || 1)
             return false
           }
         }
 
         if (node.type?.name === 'inline-embed') {
-          selection = {
-            from: pos,
-            to: pos + node.nodeSize,
-          }
+          selectionPos = pos + 1
           return false
         }
+
+        return undefined
       })
 
-      if (!selection) throw new Error('No link selection found in test fixture')
+      if (selectionPos === null) throw new Error('No link selection found in test fixture')
 
-      tiptap.commands.setTextSelection(selection)
+      tiptap.commands.setTextSelection(selectionPos)
       tiptap.view.focus()
     })
     await page.waitForTimeout(50)


### PR DESCRIPTION
### Summary
This PR improves the Navigation Settings popup so the Link field behaves like a real input instead of a static “Choose” control.

### What changed
Replaced the Link picker button with an editable combobox-style input
Users can now:
type to search internal documents
select search results directly from the dropdown
paste full external URLs and press Enter
The Link field now shows:
/path for internal hm links
the raw URL for external links
Selecting or entering a link now always updates the Label field
Preserved keyboard interactions:
↑ / ↓ to move through results
Enter to confirm
Esc to close/reset
Updated unit tests to cover:
editable Link input rendering
hm path display behavior
internal doc selection
pasted external URL handling
### Why
This makes the popup match user expectations: Label and Link both remain separate fields, but the Link field now feels like an actual input while still safely supporting internal document selection.

### How to test
Open the Navigation Settings popup and confirm Link is editable.
Type a document name in Link, select a result, and verify:
Link becomes /doc-path
Label updates to the selected doc title
Paste a full https://... URL into Link, press Enter, and verify Label updates too.
Open an existing internal nav item and confirm the Link field shows only the path, not the full hm://... value.
Check keyboard behavior: ArrowUp, ArrowDown, Enter, and Escape.
