### PR TITLE
desktop: restrict publish UI to edit context and grey disabled states

### DIFF
--- a/frontend/apps/desktop/src/components/__tests__/publish-popover-body.test.tsx
+++ b/frontend/apps/desktop/src/components/__tests__/publish-popover-body.test.tsx
@@ -202,6 +202,27 @@ describe('PublishPopoverBody', () => {
     }
   })
 
+  it('shows a non-clickable not-yet-published status for first publish docs', () => {
+    setSnapshot({
+      document: {version: '', metadata: {}},
+      draftId: 'abc',
+      metadata: {name: 'My Cool Doc'},
+    })
+    const docId = hmId('acct-1', {path: ['parent', '-abc']})
+    const onPublish = vi.fn()
+
+    const {container, root} = renderPopover(docId, onPublish)
+    try {
+      expect(container.textContent).toContain('Not yet published')
+      const matchingButton = Array.from(container.querySelectorAll('button')).find((button) =>
+        button.textContent?.includes('Not yet published'),
+      )
+      expect(matchingButton).toBeUndefined()
+    } finally {
+      cleanup(root, container)
+    }
+  })
+
   it('forwards the user-typed override to onPublish when Publish is clicked', () => {
     setSnapshot({
       document: {version: '', metadata: {}},

--- a/frontend/apps/desktop/src/components/__tests__/publish-popover-body.test.tsx
+++ b/frontend/apps/desktop/src/components/__tests__/publish-popover-body.test.tsx
@@ -214,8 +214,8 @@ describe('PublishPopoverBody', () => {
     const {container, root} = renderPopover(docId, onPublish)
     try {
       expect(container.textContent).toContain('Not yet published')
-      const matchingButton = Array.from(container.querySelectorAll('button')).find((button) =>
-        button.textContent?.includes('Not yet published'),
+      const matchingButton = Array.from(container.querySelectorAll('button')).find(
+        (button) => button.textContent?.includes('Not yet published'),
       )
       expect(matchingButton).toBeUndefined()
     } finally {

--- a/frontend/apps/desktop/src/components/editing-toolbar.tsx
+++ b/frontend/apps/desktop/src/components/editing-toolbar.tsx
@@ -31,6 +31,7 @@ import {Separator} from '@shm/ui/separator'
 import {Spinner} from '@shm/ui/spinner'
 import {toast} from '@shm/ui/toast'
 import {Tooltip} from '@shm/ui/tooltip'
+import {cn} from '@shm/ui/utils'
 import {usePopoverState} from '@shm/ui/use-popover-state'
 import {Check, ChevronRight, Clock, Copy, FileDiff, Trash} from 'lucide-react'
 import {forwardRef, ReactNode, useMemo, useRef, useState} from 'react'
@@ -273,7 +274,7 @@ export function PublishPopoverBody({
       <Separator className="bg-black/10 dark:bg-white/10" />
 
       {/* Last published row that opens versions panel on click */}
-      {publishedDoc && relativeTime ? (
+      {!!publishedDoc?.version ? (
         <button
           type="button"
           onClick={goToVersions}
@@ -282,12 +283,17 @@ export function PublishPopoverBody({
         >
           <Clock className="text-muted-foreground size-3.5" />
           <span className="flex-1">
-            <span className="text-foreground">{relativeTime}</span>
+            <span className="text-foreground">{relativeTime ?? 'Published'}</span>
             {authorName ? <span className="text-muted-foreground"> by {authorName}</span> : null}
           </span>
           <ChevronRight className="text-muted-foreground size-3.5" />
         </button>
-      ) : null}
+      ) : (
+        <div className="-mx-2 flex items-center gap-2 rounded px-2 py-1 text-xs">
+          <Clock className="text-muted-foreground size-3.5" />
+          <span className="text-muted-foreground flex-1">Not yet published</span>
+        </div>
+      )}
 
       {/* Changes count row */}
       <div className="-mx-2 flex items-center gap-2 rounded px-2 py-1 text-xs">
@@ -302,7 +308,11 @@ export function PublishPopoverBody({
       <div className="flex flex-col gap-1">
         <Button
           size="sm"
-          variant="brand"
+          variant={publishDisabled ? 'ghost' : 'brand'}
+          className={cn(
+            publishDisabled &&
+              'bg-neutral-100 text-neutral-500 hover:bg-neutral-100 disabled:opacity-100 dark:bg-neutral-800 dark:text-neutral-400',
+          )}
           disabled={publishDisabled}
           onClick={() => {
             // Only forward an explicit override when the user typed something
@@ -331,18 +341,32 @@ export function PublishPopoverBody({
   )
 }
 
-/** Trigger button for the Publish popover. Shows a pulsing white dot when there are unsaved changes. */
+function canPublishDocument({
+  draftId,
+  changeCount,
+}: {
+  draftId: string | null
+  changeCount: number
+}) {
+  return !!draftId && changeCount > 0
+}
+
+/** Trigger button for the Publish popover. */
 const PublishTrigger = forwardRef<
   HTMLButtonElement,
-  {hasUnsavedChanges: boolean; onClick: (e: React.MouseEvent) => void}
->(({hasUnsavedChanges, onClick}, ref) => {
+  {canPublish: boolean; onClick: (e: React.MouseEvent) => void}
+>(({canPublish, onClick}, ref) => {
   return (
-    <Button ref={ref} size="sm" variant="brand" className="gap-1.5" onClick={onClick}>
-      {hasUnsavedChanges ? (
-        <span className="relative flex size-2 shrink-0 rounded-full bg-white">
-          <span className="absolute inset-0 animate-ping rounded-full bg-white opacity-75" />
-        </span>
-      ) : null}
+    <Button
+      ref={ref}
+      size="sm"
+      variant={canPublish ? 'green' : 'ghost'}
+      className={cn(
+        'gap-1.5',
+        !canPublish && 'bg-neutral-100 text-neutral-500 hover:bg-neutral-100 dark:bg-neutral-800 dark:text-neutral-400',
+      )}
+      onClick={onClick}
+    >
       Publish
     </Button>
   )
@@ -364,7 +388,10 @@ export function PublishButtonWithPopover({
 }) {
   const draftId = useDocumentSelector(selectDraftId)
   const changeCount = useUnpublishedChangeCount()
-  const hasUnpublishedChanges = changeCount > 0
+  const canPublish = canPublishDocument({
+    draftId,
+    changeCount,
+  })
   const send = useDocumentSend()
   const deleteDraftDialog = useDeleteDraftDialog()
 
@@ -395,6 +422,7 @@ export function PublishButtonWithPopover({
   const allItems = [...existingMenuItems, ...editingTrailingItems]
 
   const publishNow = (pathOverride?: string[]) => {
+    if (!canPublish) return
     popoverState.onOpenChange(false)
     setHasTriggeredPublish()
     // From non-editing state (e.g. DraftActionsToolbar), enter editing before
@@ -406,7 +434,7 @@ export function PublishButtonWithPopover({
 
   const handlePublishTriggerClick = (e: React.MouseEvent) => {
     e.preventDefault()
-    if (hasTriggeredPublish) {
+    if (hasTriggeredPublish && canPublish) {
       publishNow()
     } else {
       popoverState.onOpenChange(!popoverState.open)
@@ -417,7 +445,7 @@ export function PublishButtonWithPopover({
     <>
       <Popover open={popoverState.open} onOpenChange={popoverState.onOpenChange}>
         <PopoverAnchor asChild>
-          <PublishTrigger hasUnsavedChanges={hasUnpublishedChanges} onClick={handlePublishTriggerClick} />
+          <PublishTrigger canPublish={canPublish} onClick={handlePublishTriggerClick} />
         </PopoverAnchor>
         <PopoverContent align="end" className="w-80">
           <PublishPopoverBody
@@ -425,7 +453,7 @@ export function PublishButtonWithPopover({
             changeCount={changeCount}
             onPublish={publishNow}
             onClose={() => popoverState.onOpenChange(false)}
-            publishDisabled={!draftId || changeCount === 0}
+            publishDisabled={!canPublish}
           />
         </PopoverContent>
       </Popover>

--- a/frontend/apps/desktop/src/components/editing-toolbar.tsx
+++ b/frontend/apps/desktop/src/components/editing-toolbar.tsx
@@ -341,36 +341,30 @@ export function PublishPopoverBody({
   )
 }
 
-function canPublishDocument({
-  draftId,
-  changeCount,
-}: {
-  draftId: string | null
-  changeCount: number
-}) {
+function canPublishDocument({draftId, changeCount}: {draftId: string | null; changeCount: number}) {
   return !!draftId && changeCount > 0
 }
 
 /** Trigger button for the Publish popover. */
-const PublishTrigger = forwardRef<
-  HTMLButtonElement,
-  {canPublish: boolean; onClick: (e: React.MouseEvent) => void}
->(({canPublish, onClick}, ref) => {
-  return (
-    <Button
-      ref={ref}
-      size="sm"
-      variant={canPublish ? 'green' : 'ghost'}
-      className={cn(
-        'gap-1.5',
-        !canPublish && 'bg-neutral-100 text-neutral-500 hover:bg-neutral-100 dark:bg-neutral-800 dark:text-neutral-400',
-      )}
-      onClick={onClick}
-    >
-      Publish
-    </Button>
-  )
-})
+const PublishTrigger = forwardRef<HTMLButtonElement, {canPublish: boolean; onClick: (e: React.MouseEvent) => void}>(
+  ({canPublish, onClick}, ref) => {
+    return (
+      <Button
+        ref={ref}
+        size="sm"
+        variant={canPublish ? 'green' : 'ghost'}
+        className={cn(
+          'gap-1.5',
+          !canPublish &&
+            'bg-neutral-100 text-neutral-500 hover:bg-neutral-100 dark:bg-neutral-800 dark:text-neutral-400',
+        )}
+        onClick={onClick}
+      >
+        Publish
+      </Button>
+    )
+  },
+)
 PublishTrigger.displayName = 'PublishTrigger'
 
 /**

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -632,11 +632,12 @@ export default function DesktopResourcePage() {
 
   const showPublishToolbar = route.key === 'document'
 
-  const editingFloatingActions = canEdit && showPublishToolbar
-    ? ({menuItems}: {menuItems: any[]}) => (
-        <EditingDocToolsRight docId={docId} existingMenuItems={menuItems} newButton={newButton} />
-      )
-    : undefined
+  const editingFloatingActions =
+    canEdit && showPublishToolbar
+      ? ({menuItems}: {menuItems: any[]}) => (
+          <EditingDocToolsRight docId={docId} existingMenuItems={menuItems} newButton={newButton} />
+        )
+      : undefined
 
   const onReplyClick = useCallback(
     (replyComment: HMComment) => {

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -7,7 +7,7 @@ import {DesktopQueryBlockDraftSlot} from '@/components/desktop-query-block-draft
 import {DesktopDocumentActionsProvider} from '@/components/document-actions-provider'
 import {EditNavHeaderPane} from '@/components/edit-nav-header-pane'
 import {useEditProfileDialog} from '@/components/edit-profile-dialog'
-import {DraftActionsToolbar, EditingDocToolsRight} from '@/components/editing-toolbar'
+import {EditingDocToolsRight} from '@/components/editing-toolbar'
 import {InlineNewDocumentCard} from '@/components/inline-new-document-card'
 import {JoinButton} from '@/components/join-button'
 import {MoveDialog} from '@/components/move-dialog'
@@ -630,14 +630,12 @@ export default function DesktopResourcePage() {
       />
     ) : null
 
-  const editingFloatingActions = canEdit
+  const showPublishToolbar = route.key === 'document'
+
+  const editingFloatingActions = canEdit && showPublishToolbar
     ? ({menuItems}: {menuItems: any[]}) => (
         <EditingDocToolsRight docId={docId} existingMenuItems={menuItems} newButton={newButton} />
       )
-    : undefined
-
-  const draftActions = canEdit
-    ? ({menuItems}: {menuItems: any[]}) => <DraftActionsToolbar docId={docId} existingMenuItems={menuItems} />
     : undefined
 
   const onReplyClick = useCallback(
@@ -757,7 +755,6 @@ export default function DesktopResourcePage() {
                 onEditorReady={handleEditorReady}
                 machineExtras={null}
                 editingFloatingActions={editingFloatingActions}
-                draftActions={draftActions}
                 newButton={newButton}
                 signingAccountId={selectedAccountId || undefined}
                 publishAccountUid={selectedAccount?.id?.uid || undefined}


### PR DESCRIPTION
### New publish-toolbar behavior
The desktop publish experience was updated so the Publish UI behaves more like an explicit edit action.

### What changed
  ### Publish is only visible in Edit Context

- Hidden in Reading Context
- Hidden when a draft exists but the user is not actively editing
- Hidden on non-content/main non-edit views
- Publish button state is clearer

### Green when there are changes that can be published
Grey when there are no changes to publish
This applies both to:
the top-right Publish trigger
the main “Publish: Make it live now” button inside the popover
Publish popover stays as the main interaction

Still shows the publish dialog/details
Still allows access to status/info even when publish is unavailable
Publish status messaging improved

If the document has never been published, the popover shows:
“Not yet published”
This status is non-clickable
What was intentionally not added
No “highlight changes to publish” behavior
No change to the current outside-click / Esc editing behavior
No new publish confirmation flow; existing confirmation behavior remains