### PR TITLE
Add text placeholder only to the first block

### DIFF
--- a/frontend/packages/editor/src/blocknote/core/BlockNoteExtensions.ts
+++ b/frontend/packages/editor/src/blocknote/core/BlockNoteExtensions.ts
@@ -125,6 +125,7 @@ export const getBlockNoteExtensions = <BSchema extends HMBlockSchema>(opts: {
       Gapcursor,
       Placeholder.configure({
         emptyNodeClass: blockStyles.isEmpty,
+        firstEmptyBlockClass: blockStyles.isFirstEmptyBlock,
         hasAnchorClass: blockStyles.hasAnchor,
         isFilterClass: blockStyles.isFilter,
         includeChildren: true,

--- a/frontend/packages/editor/src/blocknote/core/__tests__/placeholder-extension.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/__tests__/placeholder-extension.test.ts
@@ -1,0 +1,141 @@
+import {TextSelection} from 'prosemirror-state'
+import {describe, expect, it} from 'vitest'
+import {BlockNoteEditor} from '../BlockNoteEditor'
+import type {PartialBlock} from '../extensions/Blocks/api/blockTypes'
+import blockStyles from '../extensions/Blocks/nodes/Block.module.css'
+
+type PartialAnyBlock = PartialBlock<any>
+
+function createEditor(initialContent: PartialAnyBlock[], renderType: 'document' | 'comment' = 'document') {
+  return new BlockNoteEditor({
+    initialContent,
+    renderType,
+  })
+}
+
+function getBlockContentStartPos(editor: BlockNoteEditor<any>, blockId: string) {
+  let target: number | null = null
+
+  editor._tiptapEditor.state.doc.descendants((node, pos) => {
+    if (target !== null) {
+      return false
+    }
+
+    if (node.type.name === 'blockNode' && node.attrs.id === blockId) {
+      target = pos + 1 /* enter blockNode */ + 1 /* enter blockContent */
+      return false
+    }
+
+    return true
+  })
+
+  if (target === null) {
+    throw new Error(`Block "${blockId}" not found`)
+  }
+
+  return target
+}
+
+function placeCursorInBlock(editor: BlockNoteEditor<any>, blockId: string, offset = 0) {
+  const start = getBlockContentStartPos(editor, blockId)
+  const tr = editor._tiptapEditor.state.tr.setSelection(TextSelection.create(editor._tiptapEditor.state.doc, start + offset))
+  editor._tiptapEditor.view.dispatch(tr)
+}
+
+function getBlockContentElement(editor: BlockNoteEditor<any>, blockId: string) {
+  const element = editor._tiptapEditor.view.dom.querySelector(`[data-id="${blockId}"] > [data-content-type]`)
+
+  if (!(element instanceof HTMLElement)) {
+    throw new Error(`Block content for "${blockId}" not found`)
+  }
+
+  return element
+}
+
+function hasFirstBlockPlaceholder(editor: BlockNoteEditor<any>, blockId: string) {
+  return getBlockContentElement(editor, blockId).classList.contains(blockStyles.isFirstEmptyBlock)
+}
+
+function insertText(editor: BlockNoteEditor<any>, text: string) {
+  const {from, to} = editor._tiptapEditor.state.selection
+  editor._tiptapEditor.view.dispatch(editor._tiptapEditor.state.tr.insertText(text, from, to))
+}
+
+function deleteTextFromBlock(editor: BlockNoteEditor<any>, blockId: string, length: number) {
+  const start = getBlockContentStartPos(editor, blockId)
+  const tr = editor._tiptapEditor.state.tr
+    .setSelection(TextSelection.create(editor._tiptapEditor.state.doc, start, start + length))
+    .deleteSelection()
+  editor._tiptapEditor.view.dispatch(tr)
+}
+
+describe('first-block placeholder behavior', () => {
+  it('shows the placeholder only on the first empty block when the second block is focused', () => {
+    const editor = createEditor([
+      {id: 'b1', type: 'paragraph'},
+      {id: 'b2', type: 'paragraph'},
+    ])
+    placeCursorInBlock(editor, 'b2')
+
+    expect(hasFirstBlockPlaceholder(editor, 'b1')).toBe(true)
+    expect(hasFirstBlockPlaceholder(editor, 'b2')).toBe(false)
+
+    editor._tiptapEditor.destroy()
+  })
+
+  it('keeps the placeholder on the first block when later blocks have content', () => {
+    const editor = createEditor([
+      {id: 'b1', type: 'paragraph'},
+      {id: 'b2', type: 'paragraph', content: 'second block'},
+    ])
+    placeCursorInBlock(editor, 'b2', 'second block'.length)
+
+    expect(hasFirstBlockPlaceholder(editor, 'b1')).toBe(true)
+    expect(hasFirstBlockPlaceholder(editor, 'b2')).toBe(false)
+
+    editor._tiptapEditor.destroy()
+  })
+
+  it('shows no placeholder when the first block has content and a later block is empty', () => {
+    const editor = createEditor([
+      {id: 'b1', type: 'paragraph', content: 'first block'},
+      {id: 'b2', type: 'paragraph'},
+    ])
+    placeCursorInBlock(editor, 'b2')
+
+    expect(hasFirstBlockPlaceholder(editor, 'b1')).toBe(false)
+    expect(hasFirstBlockPlaceholder(editor, 'b2')).toBe(false)
+
+    editor._tiptapEditor.destroy()
+  })
+
+  it('reapplies the placeholder when the first block is cleared back to empty', () => {
+    const editor = createEditor([{id: 'b1', type: 'paragraph'}])
+    placeCursorInBlock(editor, 'b1')
+    insertText(editor, 'hello')
+
+    expect(hasFirstBlockPlaceholder(editor, 'b1')).toBe(false)
+
+    deleteTextFromBlock(editor, 'b1', 'hello'.length)
+
+    expect(hasFirstBlockPlaceholder(editor, 'b1')).toBe(true)
+
+    editor._tiptapEditor.destroy()
+  })
+
+  it('keeps the same first-block-only behavior in comment editors', () => {
+    const editor = createEditor(
+      [
+        {id: 'b1', type: 'paragraph'},
+        {id: 'b2', type: 'paragraph'},
+      ],
+      'comment',
+    )
+    placeCursorInBlock(editor, 'b2')
+
+    expect(hasFirstBlockPlaceholder(editor, 'b1')).toBe(true)
+    expect(hasFirstBlockPlaceholder(editor, 'b2')).toBe(false)
+
+    editor._tiptapEditor.destroy()
+  })
+})

--- a/frontend/packages/editor/src/blocknote/core/__tests__/placeholder-extension.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/__tests__/placeholder-extension.test.ts
@@ -38,7 +38,9 @@ function getBlockContentStartPos(editor: BlockNoteEditor<any>, blockId: string) 
 
 function placeCursorInBlock(editor: BlockNoteEditor<any>, blockId: string, offset = 0) {
   const start = getBlockContentStartPos(editor, blockId)
-  const tr = editor._tiptapEditor.state.tr.setSelection(TextSelection.create(editor._tiptapEditor.state.doc, start + offset))
+  const tr = editor._tiptapEditor.state.tr.setSelection(
+    TextSelection.create(editor._tiptapEditor.state.doc, start + offset),
+  )
   editor._tiptapEditor.view.dispatch(tr)
 }
 

--- a/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/Block.module.css
+++ b/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/Block.module.css
@@ -444,7 +444,8 @@ NESTED BLOCKS
 /* PLACEHOLDERS*/
 
 .isEmpty:before,
-.isFilter:before {
+.isFilter:before,
+.isFirstEmptyBlock:before {
   /*float: left; */
   content: '';
   pointer-events: none;
@@ -455,7 +456,8 @@ NESTED BLOCKS
 }
 
 .isEmpty:before,
-.isFilter:before {
+.isFilter:before,
+.isFirstEmptyBlock:before {
   opacity: 0.5;
 }
 
@@ -466,7 +468,7 @@ NESTED BLOCKS
 
 /* TODO: would be nicer if defined from code */
 
-.blockContent.isEmpty.hasAnchor:before {
+.blockContent.isFirstEmptyBlock:before {
   font-size: 0.9em;
   font-family:
     'Inter',
@@ -505,7 +507,7 @@ NESTED BLOCKS
   content: 'Type to filter';
 }
 
-.blockContent[data-content-type='heading'].isEmpty.hasAnchor:before {
+.blockContent[data-content-type='heading'].isFirstEmptyBlock:before {
   font-family:
     'Inter',
     'SF Pro Display',
@@ -524,7 +526,7 @@ NESTED BLOCKS
   content: 'Heading';
 }
 
-.blockContent[data-content-type='code-block'].isEmpty.hasAnchor:before {
+.blockContent[data-content-type='code-block'].isFirstEmptyBlock:before {
   font-family:
     'Inter',
     'SF Pro Display',

--- a/frontend/packages/editor/src/blocknote/core/extensions/Placeholder/PlaceholderExtension.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/Placeholder/PlaceholderExtension.ts
@@ -85,7 +85,8 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
               const hasAnchor = anchor >= pos && anchor <= pos + node.nodeSize
               const isEmpty = !node.isLeaf && !node.childCount
               const isFirstTopLevelBlockContent = pos === firstTopLevelBlockContentPos
-              const showsFilterPlaceholder = hasAnchor && isEmpty && menuState?.triggerCharacter === '' && menuState?.active
+              const showsFilterPlaceholder =
+                hasAnchor && isEmpty && menuState?.triggerCharacter === '' && menuState?.active
               const showsFirstBlockPlaceholder = isEmpty && isFirstTopLevelBlockContent
 
               if (showsFirstBlockPlaceholder || showsFilterPlaceholder) {

--- a/frontend/packages/editor/src/blocknote/core/extensions/Placeholder/PlaceholderExtension.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/Placeholder/PlaceholderExtension.ts
@@ -16,6 +16,7 @@ const PLUGIN_KEY = new PluginKey(`blocknote-placeholder`)
 export interface PlaceholderOptions {
   emptyEditorClass: string
   emptyNodeClass: string
+  firstEmptyBlockClass: string
   isFilterClass: string
   hasAnchorClass: string
   placeholder:
@@ -33,6 +34,7 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
     return {
       emptyEditorClass: 'is-editor-empty',
       emptyNodeClass: 'is-empty',
+      firstEmptyBlockClass: 'is-first-empty-block',
       isFilterClass: 'is-filter',
       hasAnchorClass: 'has-anchor',
       placeholder: 'Write something …',
@@ -54,21 +56,48 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
             const active = this.editor.isEditable || !this.options.showOnlyWhenEditable
             const {anchor} = selection
             const decorations: Decoration[] = []
+            const topLevelBlockChildren = doc.firstChild
+            let firstTopLevelBlockNodePos: number | null = null
 
             if (!active) {
               return
             }
 
+            if (topLevelBlockChildren) {
+              doc.descendants((node, pos, parent) => {
+                if (firstTopLevelBlockNodePos !== null) {
+                  return false
+                }
+
+                if (node.type.name === 'blockNode' && parent === topLevelBlockChildren) {
+                  firstTopLevelBlockNodePos = pos
+                  return false
+                }
+
+                return true
+              })
+            }
+
+            const firstTopLevelBlockContentPos =
+              firstTopLevelBlockNodePos === null ? null : firstTopLevelBlockNodePos + 1
+
             doc.descendants((node, pos) => {
               const hasAnchor = anchor >= pos && anchor <= pos + node.nodeSize
               const isEmpty = !node.isLeaf && !node.childCount
+              const isFirstTopLevelBlockContent = pos === firstTopLevelBlockContentPos
+              const showsFilterPlaceholder = hasAnchor && isEmpty && menuState?.triggerCharacter === '' && menuState?.active
+              const showsFirstBlockPlaceholder = isEmpty && isFirstTopLevelBlockContent
 
-              if ((hasAnchor || !this.options.showOnlyCurrent) && isEmpty) {
-                const classes = [this.options.emptyNodeClass]
+              if (showsFirstBlockPlaceholder || showsFilterPlaceholder) {
+                const classes: string[] = []
 
-                // TODO: Doesn't work?
-                if (this.editor.isEmpty) {
-                  classes.push(this.options.emptyEditorClass)
+                if (showsFirstBlockPlaceholder) {
+                  classes.push(this.options.emptyNodeClass, this.options.firstEmptyBlockClass)
+
+                  // TODO: Doesn't work?
+                  if (this.editor.isEmpty) {
+                    classes.push(this.options.emptyEditorClass)
+                  }
                 }
 
                 if (hasAnchor) {
@@ -76,7 +105,7 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
                 }
 
                 // If slash menu is of drag type and active, show the filter placeholder
-                if (menuState?.triggerCharacter === '' && menuState?.active) {
+                if (showsFilterPlaceholder) {
                   classes.push(this.options.isFilterClass)
                 }
                 // using widget, didn't work (caret position bug)

--- a/frontend/packages/editor/src/blocknote/core/extensions/Placeholder/PlaceholderExtension.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/Placeholder/PlaceholderExtension.ts
@@ -56,20 +56,20 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
             const active = this.editor.isEditable || !this.options.showOnlyWhenEditable
             const {anchor} = selection
             const decorations: Decoration[] = []
-            const topLevelBlockChildren = doc.firstChild
+            const firstDocChild = doc.firstChild
             let firstTopLevelBlockNodePos: number | null = null
 
             if (!active) {
               return
             }
 
-            if (topLevelBlockChildren) {
+            if (firstDocChild) {
               doc.descendants((node, pos, parent) => {
                 if (firstTopLevelBlockNodePos !== null) {
                   return false
                 }
 
-                if (node.type.name === 'blockNode' && parent === topLevelBlockChildren) {
+                if (node.type.name === 'blockNode' && parent === firstDocChild) {
                   firstTopLevelBlockNodePos = pos
                   return false
                 }


### PR DESCRIPTION
- Restricts the empty-editor placeholder so it appears only on the first top-level empty text block.
- Prevents the placeholder from appearing in the second or later empty blocks, even when those blocks are focused.
- Preserves the rule that the placeholder disappears once the first block has content and returns if that first block is cleared again.
- Keeps the behavior shared across document and comment editors, instead of introducing a document-only special case.
- Adds regression tests covering first-block-only placeholder behavior and the reappearance/absence cases.