### PR TITLE
fix(shared): repair duplicate draft block ids before publish

### DIFF
--- a/frontend/packages/shared/src/utils/document-changes-rebase.test.ts
+++ b/frontend/packages/shared/src/utils/document-changes-rebase.test.ts
@@ -1,6 +1,14 @@
+import type {EditorBlock} from '@seed-hypermedia/client/editor-types'
 import type {HMBlockNode} from '@seed-hypermedia/client/hm-types'
 import {describe, expect, it} from 'vitest'
-import {applyRebasePlan, classifyRebase, computeTheirsTouches} from './document-changes'
+import {
+  applyRebasePlan,
+  classifyRebase,
+  compareBlocksWithMap,
+  computeTheirsTouches,
+  createBlocksMap,
+  ensureUniqueEditorBlockIds,
+} from './document-changes'
 
 type BlockOverrides = {
   id: string
@@ -22,6 +30,10 @@ function para({id, text = '', revision, attributes}: BlockOverrides): HMBlockNod
 
 function node(over: BlockOverrides, children: HMBlockNode[] = []): HMBlockNode {
   return {block: para(over) as HMBlockNode['block'], children}
+}
+
+function editorPara(id: string, text = '', children: EditorBlock[] = []): EditorBlock {
+  return {id, type: 'paragraph', props: {}, content: [{type: 'text', text, styles: {}}], children}
 }
 
 describe('computeTheirsTouches', () => {
@@ -236,5 +248,25 @@ describe('applyRebasePlan', () => {
       conflictedBlockIds: [],
     })
     expect((merged[0]?.children?.[0]?.block as any)?.text).toBe('mine child')
+  })
+})
+
+describe('ensureUniqueEditorBlockIds', () => {
+  it('renames duplicate editor block ids before publish diffing', () => {
+    const base: HMBlockNode[] = [node({id: 'parent'}, [node({id: 'dup', text: 'base child'})])]
+    const mine: EditorBlock[] = [
+      editorPara('parent', '', [editorPara('dup', 'first copy'), editorPara('dup', 'second copy')]),
+    ]
+
+    const repaired = ensureUniqueEditorBlockIds(mine, () => 'fresh-dup')
+    expect(repaired[0]?.children.map((child) => child.id)).toEqual(['dup', 'fresh-dup'])
+
+    const {changes} = compareBlocksWithMap(createBlocksMap(base, ''), mine, '')
+    const selfMoves = changes.filter((change: any) => {
+      if (change.op?.case !== 'moveBlock') return false
+      const move = change.op.value
+      return move.blockId === move.leftSibling
+    })
+    expect(selfMoves).toEqual([])
   })
 })

--- a/frontend/packages/shared/src/utils/document-changes.ts
+++ b/frontend/packages/shared/src/utils/document-changes.ts
@@ -2,6 +2,7 @@ import {EditorBlock} from '@seed-hypermedia/client/editor-types'
 import {editorBlockToHMBlock} from '@seed-hypermedia/client/editorblock-to-hmblock'
 import {HMBlock, HMBlockNode, HMMetadata, HMQuery} from '@seed-hypermedia/client/hm-types'
 import isEqual from 'lodash/isEqual'
+import {nanoid} from 'nanoid'
 import {DocumentChange_SetAttribute} from '../client'
 import {Block, DocumentChange} from '../client/.generated/documents/v3alpha/documents_pb'
 
@@ -129,7 +130,46 @@ export function createBlocksMap(blockNodes: Array<HMBlockNode> = [], parentId: s
   return result
 }
 
+function nextUniqueBlockId(createId: () => string, seen: Set<string>): string {
+  let id = createId()
+  while (!id || seen.has(id)) id = createId()
+  seen.add(id)
+  return id
+}
+
+/**
+ * Repair corrupted editor content before building publish changes.
+ *
+ * The document CRDT requires every block id to appear at most once. A stale
+ * draft/rebase can duplicate a subtree with the original ids, which later makes
+ * the publish diff emit invalid moves such as `blockId === leftSibling`. Keep
+ * the first occurrence stable and assign fresh ids to later duplicates so the
+ * copied blocks publish as new blocks instead of colliding with the originals.
+ */
+export function ensureUniqueEditorBlockIds(blocks: Array<EditorBlock>, createId: () => string): Array<EditorBlock> {
+  const seen = new Set<string>()
+
+  const visit = (block: EditorBlock): EditorBlock => {
+    const id = !block.id || seen.has(block.id) ? nextUniqueBlockId(createId, seen) : block.id
+    if (id === block.id) seen.add(id)
+
+    const children = block.children?.map(visit) ?? []
+    if (id === block.id && children === block.children) return block
+    return {...block, id, children} as EditorBlock
+  }
+
+  return blocks.map(visit)
+}
+
 export function compareBlocksWithMap(blocksMap: BlocksMap, blocks: Array<EditorBlock>, parentId: string) {
+  return compareUniqueBlocksWithMap(
+    blocksMap,
+    ensureUniqueEditorBlockIds(blocks, () => nanoid(10)),
+    parentId,
+  )
+}
+
+function compareUniqueBlocksWithMap(blocksMap: BlocksMap, blocks: Array<EditorBlock>, parentId: string) {
   let changes: Array<DocumentChange> = []
   let touchedBlocks: Array<string> = []
 
@@ -201,7 +241,7 @@ export function compareBlocksWithMap(blocksMap: BlocksMap, blocks: Array<EditorB
     }
 
     if (block.children.length) {
-      let nestedResults = compareBlocksWithMap(blocksMap, block.children, block.id)
+      let nestedResults = compareUniqueBlocksWithMap(blocksMap, block.children, block.id)
       changes = [...changes, ...nestedResults.changes]
       touchedBlocks = [...touchedBlocks, ...nestedResults.touchedBlocks]
     }


### PR DESCRIPTION
## Summary
- repairs duplicate editor block IDs before generating publish changes
- keeps the first occurrence stable and gives later duplicate draft blocks fresh IDs so duplicated/corrupted draft subtrees publish as new blocks
- adds a regression test that exercises the real `compareBlocksWithMap` publish-diff path and asserts it no longer emits `moveBlock.blockId === moveBlock.leftSibling`

Fixes #608.

## Before-fix reproduction
Reproduced on current `origin/main` (`b0e0cf664`) using the draft JSON attached to #608.

Command:
```bash
corepack pnpm exec tsx /home/e.guest/.openclaw/workspace/tmp/issue-608/repro.ts
```

Before the fix, `compareBlocksWithMap(createBlocksMap(baseBlocks, ''), draft.content, '')` produced one invalid move:

```json
{"blockId":"-X8B2_qS","parent":"X456eDA0","leftSibling":"-X8B2_qS"}
```

That matches the backend validation error from `backend/api/documents/v3alpha/docmodel/crdt_block_tree.go`: `block and left must not be the same`.

## Fix summary
The intended path is the shared publish-diff generation in `frontend/packages/shared/src/utils/document-changes.ts`.

This PR adds `ensureUniqueEditorBlockIds()` and runs it at the start of `compareBlocksWithMap()`:
- the first occurrence of each editor block ID is preserved;
- later duplicate occurrences get fresh `nanoid(10)` IDs;
- the existing diff logic then treats those duplicate copies as new blocks and emits valid `moveBlock`/`replaceBlock` changes.

## After-fix verification
Re-ran the same reproduction script against the patched branch:

```text
changes 295 touched 175
selfMoves 0
```

Also ran:
```bash
corepack pnpm --filter @shm/shared exec vitest --run src/utils/document-changes-rebase.test.ts
corepack pnpm --filter @shm/shared run typecheck
corepack pnpm --filter @shm/desktop run typecheck
git diff --check
```

## Self-review notes
- Patch is small and localized to the shared publish-diff layer.
- It does not relax or duplicate backend CRDT validation.
- It does not reimplement publishing; it repairs corrupt editor input before the existing diff builder runs.
- Normal non-corrupt drafts keep stable IDs because only repeated/missing IDs are regenerated.
- The regression test exercises the real diff helper, not a mocked publish result.
