### PR TITLE
fix(documents): deduplicate block IDs before publish to prevent block==left CRDT errors

### DIFF
--- a/frontend/apps/desktop/src/models/documents.ts
+++ b/frontend/apps/desktop/src/models/documents.ts
@@ -36,6 +36,7 @@ import {queryKeys} from '@shm/shared/models/query-keys'
 import {
   compareBlocksWithMap,
   createBlocksMap,
+  deduplicateBlockIds,
   extractDeletes,
   getDocAttributeChanges,
 } from '@shm/shared/utils/document-changes'
@@ -236,6 +237,7 @@ export function usePublishResource(
     mutationFn: async ({draft, destinationId, accountId, pathOverride}: PublishDraftInput): Promise<HMDocument> => {
       const blocksMap = editId ? createBlocksMap(editDocument?.content || [], '') : {}
       let newContent = removeTrailingBlocks(draft.content || [])
+      newContent = deduplicateBlockIds(newContent, new Set(Object.keys(blocksMap)))
 
       // Fill query blocks for new documents
       if (!editId) {

--- a/frontend/packages/shared/src/utils/document-changes.test.ts
+++ b/frontend/packages/shared/src/utils/document-changes.test.ts
@@ -1,0 +1,94 @@
+import type {EditorBlock} from '@seed-hypermedia/client/editor-types'
+import {describe, expect, it} from 'vitest'
+import {deduplicateBlockIds} from './document-changes'
+
+function para(id: string, children: EditorBlock[] = []): EditorBlock {
+  return {
+    type: 'paragraph',
+    id,
+    props: {},
+    content: [],
+    children,
+  } as EditorBlock
+}
+
+describe('deduplicateBlockIds', () => {
+  it('returns blocks unchanged when no duplicates', () => {
+    const blocks = [para('a'), para('b'), para('c')]
+    const result = deduplicateBlockIds(blocks)
+    expect(result.map((b) => b.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('assigns new ID to duplicate sibling', () => {
+    const blocks = [para('a'), para('a')]
+    const result = deduplicateBlockIds(blocks)
+    expect(result[0]!.id).toBe('a')
+    expect(result[1]!.id).not.toBe('a')
+    expect(result[1]!.id.length).toBe(8)
+  })
+
+  it('assigns new ID to duplicate in nested children', () => {
+    const blocks = [para('a', [para('b')]), para('b')]
+    const result = deduplicateBlockIds(blocks)
+    expect(result[0]!.id).toBe('a')
+    expect(result[0]!.children[0]!.id).toBe('b')
+    expect(result[1]!.id).not.toBe('b')
+  })
+
+  it('handles triple duplicates', () => {
+    const blocks = [para('x'), para('x'), para('x')]
+    const result = deduplicateBlockIds(blocks)
+    const ids = result.map((b) => b.id)
+    expect(ids[0]).toBe('x')
+    expect(new Set(ids).size).toBe(3)
+  })
+
+  it('deduplicates deeply nested blocks', () => {
+    const blocks = [para('a', [para('b', [para('c')])]), para('c')]
+    const result = deduplicateBlockIds(blocks)
+    expect(result[0]!.children[0]!.children[0]!.id).toBe('c')
+    expect(result[1]!.id).not.toBe('c')
+  })
+
+  it('never produces block==left scenario', () => {
+    const blocks = [para('a'), para('a'), para('b'), para('b')]
+    const result = deduplicateBlockIds(blocks)
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i]!.id).not.toBe(result[i - 1]!.id)
+    }
+  })
+
+  describe('published ID protection', () => {
+    it('never renames a published block on first encounter', () => {
+      const published = new Set(['a', 'b'])
+      const blocks = [para('a'), para('b'), para('a')]
+      const result = deduplicateBlockIds(blocks, published)
+      expect(result[0]!.id).toBe('a')
+      expect(result[1]!.id).toBe('b')
+      expect(result[2]!.id).not.toBe('a')
+    })
+
+    it('renames non-published block that collides with published ID', () => {
+      const published = new Set(['x'])
+      const blocks = [para('x'), para('x')]
+      const result = deduplicateBlockIds(blocks, published)
+      expect(result[0]!.id).toBe('x')
+      expect(result[1]!.id).not.toBe('x')
+    })
+
+    it('keeps published IDs even without duplicates', () => {
+      const published = new Set(['a', 'b'])
+      const blocks = [para('a'), para('b'), para('c')]
+      const result = deduplicateBlockIds(blocks, published)
+      expect(result.map((b) => b.id)).toEqual(['a', 'b', 'c'])
+    })
+
+    it('renames new block whose ID matches published ID in nested children', () => {
+      const published = new Set(['x'])
+      const blocks = [para('a', [para('x')]), para('x')]
+      const result = deduplicateBlockIds(blocks, published)
+      expect(result[0]!.children[0]!.id).toBe('x')
+      expect(result[1]!.id).not.toBe('x')
+    })
+  })
+})

--- a/frontend/packages/shared/src/utils/document-changes.ts
+++ b/frontend/packages/shared/src/utils/document-changes.ts
@@ -2,6 +2,7 @@ import {EditorBlock} from '@seed-hypermedia/client/editor-types'
 import {editorBlockToHMBlock} from '@seed-hypermedia/client/editorblock-to-hmblock'
 import {HMBlock, HMBlockNode, HMMetadata, HMQuery} from '@seed-hypermedia/client/hm-types'
 import isEqual from 'lodash/isEqual'
+import {nanoid} from 'nanoid'
 import {DocumentChange_SetAttribute} from '../client'
 import {Block, DocumentChange} from '../client/.generated/documents/v3alpha/documents_pb'
 
@@ -600,6 +601,39 @@ function buildChildrenMap(nodes: HMBlockNode[]): Map<string, HMBlockNode[]> {
   }
   walk(nodes, '')
   return map
+}
+
+/**
+ * Walk editor blocks and assign fresh IDs to duplicates so the CRDT
+ * move-block operations never send block==left to the backend.
+ *
+ * Published IDs (from blocksMap) are "reserved": the first encounter
+ * of a published ID always keeps it; only subsequent occurrences are
+ * renamed. Non-published duplicate IDs follow the same first-wins rule.
+ */
+export function deduplicateBlockIds(blocks: EditorBlock[], publishedIds = new Set<string>()): EditorBlock[] {
+  const usedIds = new Set<string>(publishedIds)
+  const claimedPublished = new Set<string>()
+
+  function walk(block: EditorBlock): EditorBlock {
+    let id = block.id
+    const isFirstPublishedEncounter = publishedIds.has(id) && !claimedPublished.has(id)
+
+    if (usedIds.has(id) && !isFirstPublishedEncounter) {
+      id = nanoid(8)
+    }
+
+    if (publishedIds.has(block.id)) claimedPublished.add(block.id)
+    usedIds.add(id)
+
+    const children = block.children.map(walk)
+    if (id !== block.id || children !== block.children) {
+      return {...block, id, children}
+    }
+    return block
+  }
+
+  return blocks.map(walk)
 }
 
 function isQueryEqual(q1?: HMQuery, q2?: HMQuery): boolean {


### PR DESCRIPTION
## Summary

- Fixes `ConnectError: [unknown] block and left must not be the same` on publish (issue #608)
- Adds `deduplicateBlockIds` utility in `document-changes.ts` — walks editor blocks pre-publish and reassigns fresh 8-char `nanoid` IDs to any duplicates
- Published block IDs (from existing `blocksMap`) are "reserved": first encounter keeps original ID, subsequent duplicates get renamed
- Calls `deduplicateBlockIds` in `usePublishResource` mutation before CRDT change diffing
- Adds 13 unit tests covering: no-op case, sibling duplicates, nested duplicates, triple duplicates, deep nesting, published ID protection, and the original `block==left` scenario


---

Fixes #608