### PR TITLE
fix(web): wrap feed and resource pages with DocumentActionsProvider

### DIFF
--- a/frontend/apps/web/app/web-feed-page.tsx
+++ b/frontend/apps/web/app/web-feed-page.tsx
@@ -1,5 +1,6 @@
 import {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {CommentsProvider, InlineEditCommentProps} from '@shm/shared/comments-service-provider'
+import {DocumentActionsProvider} from '@shm/shared/document-actions-context'
 import {Spinner} from '@shm/ui/spinner'
 import {FeedPage} from '@shm/ui/feed-page-common'
 import {lazy, Suspense} from 'react'
@@ -22,7 +23,9 @@ export function WebFeedPage({docId}: {docId: UnpackedHypermediaId}) {
   return (
     <WebSitePageShell siteUid={docId.uid}>
       <CommentsProvider renderInlineEditor={renderWebInlineEditor}>
-        <FeedPage docId={docId} extraMenuItems={menuItems} rightActions={<WebHeaderActions siteUid={docId.uid} />} />
+        <DocumentActionsProvider onCopyLink={() => {}}>
+          <FeedPage docId={docId} extraMenuItems={menuItems} rightActions={<WebHeaderActions siteUid={docId.uid} />} />
+        </DocumentActionsProvider>
       </CommentsProvider>
     </WebSitePageShell>
   )

--- a/frontend/apps/web/app/web-resource-page.tsx
+++ b/frontend/apps/web/app/web-resource-page.tsx
@@ -13,6 +13,7 @@ import {computeInlineDraftPublishPath} from '@shm/shared/utils/publish-paths'
 import {useQuery} from '@tanstack/react-query'
 import {InlineSubscribeBox} from '@shm/ui/inline-subscribe-box'
 import {InspectorPage} from '@shm/ui/inspector-page'
+import {DocumentActionsProvider} from '@shm/shared/document-actions-context'
 import {CommentEditorProps, ResourcePage} from '@shm/ui/resource-page-common'
 import {Spinner} from '@shm/ui/spinner'
 import {useAppDialog} from '@shm/ui/universal-dialog'
@@ -294,30 +295,32 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
         onReplyCountClick={onReplyCountClick}
         renderInlineEditor={renderWebInlineEditor}
       >
-        <ResourcePage
-          docId={docId}
-          CommentEditor={CommentEditor}
-          pageFooter={<PageFooter id={docId} hideDeviceLinkToast={true} />}
-          onEditProfile={onEditProfile}
-          profileHeaderButtons={profileHeaderButtons}
-          onFollowClick={onFollowClick}
-          rightActions={<WebHeaderActions siteUid={docId.uid} />}
-          inlineInsert={inlineInsert}
-          DocumentContentComponent={DocumentContentComponent}
-          ssrContentHTML={ssrContentHTML}
-          perspectiveAccountUid={ownAccountUid}
-          canEdit={canEdit}
-          machine={machine}
-          signingAccountId={signingAccountId ?? undefined}
-          publishAccountUid={signingAccountId ?? undefined}
-          onEditorReady={onEditorReady}
-          existingDraft={existingDraft}
-          existingDraftContent={existingDraftContent}
-          existingDraftCursorPosition={existingDraftCursorPosition}
-          editingFloatingActions={editingFloatingActions}
-          draftActions={draftActions}
-          fileUpload={fileUpload}
-        />
+        <DocumentActionsProvider onCopyLink={() => {}}>
+          <ResourcePage
+            docId={docId}
+            CommentEditor={CommentEditor}
+            pageFooter={<PageFooter id={docId} hideDeviceLinkToast={true} />}
+            onEditProfile={onEditProfile}
+            profileHeaderButtons={profileHeaderButtons}
+            onFollowClick={onFollowClick}
+            rightActions={<WebHeaderActions siteUid={docId.uid} />}
+            inlineInsert={inlineInsert}
+            DocumentContentComponent={DocumentContentComponent}
+            ssrContentHTML={ssrContentHTML}
+            perspectiveAccountUid={ownAccountUid}
+            canEdit={canEdit}
+            machine={machine}
+            signingAccountId={signingAccountId ?? undefined}
+            publishAccountUid={signingAccountId ?? undefined}
+            onEditorReady={onEditorReady}
+            existingDraft={existingDraft}
+            existingDraftContent={existingDraftContent}
+            existingDraftCursorPosition={existingDraftCursorPosition}
+            editingFloatingActions={editingFloatingActions}
+            draftActions={draftActions}
+            fileUpload={fileUpload}
+          />
+        </DocumentActionsProvider>
       </CommentsProvider>
       {editProfileDialog.content}
       {followAccountContent}

--- a/frontend/packages/ui/src/document-list-item.tsx
+++ b/frontend/packages/ui/src/document-list-item.tsx
@@ -247,6 +247,9 @@ export function DocumentListItem({
     isOwner,
     isLoggedIn,
     hasPath,
+    onCopyReference,
+    onPushReference,
+    origin,
   ])
 
   const hasActions = !!actions.onBookmarkToggle || commentCount > 0 || menuItems.length > 0

--- a/frontend/packages/ui/src/newspaper.tsx
+++ b/frontend/packages/ui/src/newspaper.tsx
@@ -197,7 +197,7 @@ export function DocumentCard({
       })
     }
     return items
-  }, [actions, docId, doc, isOwner, isLoggedIn, hasPath])
+  }, [actions, docId, doc, isOwner, isLoggedIn, hasPath, onCopyReference, onPushReference, origin])
 
   const sharedProps = {
     ...highlighter(docId),


### PR DESCRIPTION
## Summary

- Fixes #615: "Copy link" on document cards failed with `universalClient not found in UniversalAppContext` error
- Wraps `WebFeedPage` and `WebResourcePage` with `DocumentActionsProvider` so card context menus have the required context
- Adds missing deps (`onCopyReference`, `onPushReference`, `origin`) to `useMemo` in `DocumentCard` and `DocumentListItem` to prevent stale closures

## Breaking Changes

None.


---

Fixes #615