### PR TITLE
fix(editor): fix link pasting in embed/comment inputs (issue #613)

### DIFF
--- a/frontend/apps/desktop/src/components/commenting.tsx
+++ b/frontend/apps/desktop/src/components/commenting.tsx
@@ -1,3 +1,4 @@
+import {domainResolver} from '@/grpc-client'
 import {useCommentDraft} from '@/models/comments'
 import {usePushAfterAction} from '@/models/push-after-action'
 import {useSelectedAccount, useSelectedAccountId} from '@/selected-account'
@@ -359,6 +360,7 @@ function CommentBoxImpl(props: {
       initialBlocks={draft.data?.blocks}
       onContentChange={handleContentChange}
       handleFileAttachment={handleFileAttachment}
+      domainResolver={domainResolver}
       account={{
         id: account.id,
         metadata: account.metadata,
@@ -434,6 +436,7 @@ function InlineEditBox({comment, onSave, onCancel, isSaving}: InlineEditCommentP
         handleSubmit={handleSubmit}
         initialBlocks={comment.content}
         handleFileAttachment={handleFileAttachment}
+        domainResolver={domainResolver}
         account={account ? {id: account.id, metadata: account.metadata} : undefined}
         perspectiveAccountUid={selectedAccountId}
         submitButton={({getContent, reset}) => (

--- a/frontend/packages/editor/src/comment-editor.tsx
+++ b/frontend/packages/editor/src/comment-editor.tsx
@@ -66,6 +66,10 @@ export function useCommentEditor(
       size: number
     }
   }>,
+  // Resolver that maps a hostname (e.g. eric.vicenti.net) to its Seed account UID.
+  // Required so URLs pasted into embed/link inputs inside a comment can be
+  // resolved to hm:// references instead of erroring as "not a hypermedia link".
+  domainResolver?: (hostname: string) => Promise<string | null>,
 ) {
   // Use refs so extensions created once by useBlockNote can access the latest callbacks.
   // useBlockNote only creates the editor on the first render, but these callbacks may
@@ -89,6 +93,7 @@ export function useCommentEditor(
       // grpcClient,
       // openUrl,
       gwUrl,
+      domainResolver,
       // checkWebUrl: checkWebUrl.mutateAsync,
     },
 
@@ -233,6 +238,7 @@ export function CommentEditor({
   handleFileAttachment,
   getDraftMediaBlob,
   hideAvatar,
+  domainResolver,
 }: {
   submitButton: (opts: {
     reset: () => void
@@ -286,6 +292,9 @@ export function CommentEditor({
   getDraftMediaBlob?: (draftId: string, mediaId: string) => Promise<Blob | null>
   /** Hide the leading avatar */
   hideAvatar?: boolean
+  /** Optional resolver that maps a hostname to a Seed account UID, used when
+   * pasting Hypermedia URLs in embed/link inputs nested inside this comment. */
+  domainResolver?: (hostname: string) => Promise<string | null>
 }) {
   const [submitTrigger, setSubmitTrigger] = useState(0)
   const submitCallbackRef = useRef<(() => void) | null>(null)
@@ -301,6 +310,7 @@ export function CommentEditor({
     isMobile ? () => setIsSlashDialogOpen(true) : undefined,
     importWebFile,
     handleFileAttachment,
+    domainResolver,
   )
   // Check if we have non-empty draft content
   const hasDraftContent =

--- a/frontend/packages/editor/src/embed-block.test.tsx
+++ b/frontend/packages/editor/src/embed-block.test.tsx
@@ -1,0 +1,239 @@
+// @vitest-environment jsdom
+import {createRoot, type Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('@shm/shared/models/recents', () => ({
+  useRecents: () => ({data: []}),
+}))
+
+vi.mock('@shm/shared/models/search', () => ({
+  useSearch: () => ({data: {entities: []}}),
+}))
+
+vi.mock('@shm/shared/gateway-url', () => ({
+  useGatewayUrlStream: () => ({get: () => ''}),
+}))
+
+vi.mock('@shm/shared/models/use-editor-gate', () => ({
+  useEditorGate: () => ({canEdit: false, isEditing: false}),
+}))
+
+vi.mock('./blocknote/react', () => ({
+  createReactBlockSpec: (spec: any) => spec,
+}))
+
+vi.mock('./draft-actions-context', () => ({
+  useDraftActions: () => null,
+}))
+
+vi.mock('./embed-editor', () => ({
+  EmbedEditorView: () => null,
+}))
+
+vi.mock('./media-container', () => ({
+  MediaContainer: ({children}: any) => <div>{children}</div>,
+}))
+
+vi.mock('./media-render', () => ({
+  MediaRender: () => null,
+}))
+
+const resolveHypermediaUrlMock = vi.fn()
+vi.mock('@seed-hypermedia/client', () => ({
+  resolveHypermediaUrl: (...args: any[]) => resolveHypermediaUrlMock(...args),
+}))
+
+vi.mock('@shm/shared/utils/entity-id-url', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@shm/shared/utils/entity-id-url')>()
+  return {
+    ...actual,
+    isHypermediaScheme: (url: string) => url.startsWith('hm://'),
+    isPublicGatewayLink: (url: string, gwUrl: any) => {
+      const gw = typeof gwUrl?.get === 'function' ? gwUrl.get() : gwUrl
+      return typeof gw === 'string' && !!gw && url.startsWith(gw)
+    },
+    normalizeHmId: (url: string) => (url.startsWith('hm://') ? url : null),
+    packHmId: (hmId: any) => hmId?.id ?? `hm://${hmId?.uid ?? 'unknown'}`,
+  }
+})
+
+import {EmbedLauncherInput, resolveEmbedUrl} from './embed-block'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+function renderLauncher(overrides: Partial<Parameters<typeof EmbedLauncherInput>[0]> = {}) {
+  const props = {
+    editor: {} as any,
+    assign: vi.fn(),
+    setUrl: vi.fn(),
+    fileName: {name: 'Upload File', color: undefined as string | undefined},
+    setFileName: vi.fn(),
+    submit: vi.fn(),
+    setLoading: vi.fn(),
+    ...overrides,
+  }
+  act(() => {
+    root.render(<EmbedLauncherInput {...props} />)
+  })
+  const input = container.querySelector('input') as HTMLInputElement | null
+  if (!input) throw new Error('Input not rendered')
+  return {input, props}
+}
+
+describe('EmbedLauncherInput paste handling', () => {
+  it('stops paste event propagation so ProseMirror handlers do not intercept', () => {
+    const {input} = renderLauncher()
+
+    const stopPropagation = vi.fn()
+    const pasteEvent = new Event('paste', {bubbles: true}) as any
+    pasteEvent.stopPropagation = stopPropagation
+    pasteEvent.clipboardData = {
+      getData: (type: string) => (type === 'text/plain' ? 'https://example.com' : ''),
+    }
+
+    act(() => {
+      input.dispatchEvent(pasteEvent)
+    })
+
+    expect(stopPropagation).toHaveBeenCalled()
+  })
+
+  it('updates URL state when text is typed/changed', () => {
+    const {input, props} = renderLauncher()
+
+    act(() => {
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!
+      nativeInputValueSetter.call(input, 'https://pasted.example')
+      input.dispatchEvent(new Event('input', {bubbles: true}))
+    })
+
+    expect(props.setUrl).toHaveBeenCalledWith('https://pasted.example')
+  })
+
+  it('calls submit when Enter is pressed on a URL value', () => {
+    const submit = vi.fn()
+    const {input, props} = renderLauncher({submit})
+
+    act(() => {
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!
+      nativeInputValueSetter.call(input, 'https://example.com')
+      input.dispatchEvent(new Event('input', {bubbles: true}))
+    })
+
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter', bubbles: true}))
+    })
+
+    expect(submit).toHaveBeenCalledWith('https://example.com', props.assign, props.setFileName, props.setLoading)
+  })
+
+  it('calls submit when Enter is pressed on a hm:// URL', () => {
+    const submit = vi.fn()
+    const {input} = renderLauncher({submit})
+
+    act(() => {
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!
+      nativeInputValueSetter.call(input, 'hm://z6Mk...')
+      input.dispatchEvent(new Event('input', {bubbles: true}))
+    })
+
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter', bubbles: true}))
+    })
+
+    expect(submit).toHaveBeenCalled()
+  })
+
+  it('does not call submit when Enter is pressed on non-URL text', () => {
+    const submit = vi.fn()
+    const {input} = renderLauncher({submit})
+
+    act(() => {
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!
+      nativeInputValueSetter.call(input, 'just a search query')
+      input.dispatchEvent(new Event('input', {bubbles: true}))
+    })
+
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter', bubbles: true}))
+    })
+
+    expect(submit).not.toHaveBeenCalled()
+  })
+})
+
+describe('resolveEmbedUrl', () => {
+  beforeEach(() => {
+    resolveHypermediaUrlMock.mockReset()
+  })
+
+  it('returns direct kind for hm:// URLs without calling resolver', async () => {
+    const result = await resolveEmbedUrl('hm://abc/path')
+    expect(result).toEqual({kind: 'direct', url: 'hm://abc/path'})
+    expect(resolveHypermediaUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('returns direct kind for public gateway links without calling resolver', async () => {
+    const gwUrl = {get: () => 'https://hyper.media'}
+    const result = await resolveEmbedUrl('https://hyper.media/abc/path', {gwUrl})
+    // normalizeHmId mock only normalizes hm://, so falls back to raw url
+    expect(result).toEqual({kind: 'direct', url: 'https://hyper.media/abc/path'})
+    expect(resolveHypermediaUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('returns resolved kind when resolveHypermediaUrl yields an hmId', async () => {
+    resolveHypermediaUrlMock.mockResolvedValueOnce({hmId: {id: 'hm://xyz/posts/foo', uid: 'xyz'}})
+    const domainResolver = vi.fn().mockResolvedValue('xyz')
+    const result = await resolveEmbedUrl('https://eric.vicenti.net/posts/foo', {domainResolver})
+    expect(result).toEqual({kind: 'resolved', url: 'hm://xyz/posts/foo'})
+    expect(resolveHypermediaUrlMock).toHaveBeenCalledWith(
+      'https://eric.vicenti.net/posts/foo',
+      expect.objectContaining({domainResolver}),
+    )
+  })
+
+  it('returns no-match kind when resolveHypermediaUrl returns null', async () => {
+    resolveHypermediaUrlMock.mockResolvedValueOnce(null)
+    const result = await resolveEmbedUrl('https://example.com/whatever')
+    expect(result).toEqual({kind: 'no-match'})
+  })
+
+  it('returns no-match kind when resolveHypermediaUrl returns an object without hmId', async () => {
+    resolveHypermediaUrlMock.mockResolvedValueOnce({hmId: null})
+    const result = await resolveEmbedUrl('https://example.com/whatever')
+    expect(result).toEqual({kind: 'no-match'})
+  })
+
+  it('returns error kind when resolveHypermediaUrl throws', async () => {
+    const fetchError = new Error('CORS preflight failed')
+    resolveHypermediaUrlMock.mockRejectedValueOnce(fetchError)
+    const result = await resolveEmbedUrl('https://offline.example')
+    expect(result).toEqual({kind: 'error', error: fetchError})
+  })
+
+  it('passes the provided domainResolver through to resolveHypermediaUrl', async () => {
+    resolveHypermediaUrlMock.mockResolvedValueOnce({hmId: {id: 'hm://x', uid: 'x'}})
+    const domainResolver = vi.fn()
+    await resolveEmbedUrl('https://site.example/p', {domainResolver})
+    expect(resolveHypermediaUrlMock).toHaveBeenCalledWith(
+      'https://site.example/p',
+      expect.objectContaining({domainResolver}),
+    )
+  })
+})

--- a/frontend/packages/editor/src/embed-block.tsx
+++ b/frontend/packages/editor/src/embed-block.tsx
@@ -174,6 +174,42 @@ function DraftEmbedPlaceholder({
   )
 }
 
+// Result of attempting to resolve a URL for embedding. Pure to keep it testable.
+export type EmbedResolveResult =
+  | {kind: 'direct'; url: string}
+  | {kind: 'resolved'; url: string}
+  | {kind: 'no-match'}
+  | {kind: 'error'; error: unknown}
+
+/**
+ * Resolve an arbitrary URL into something usable as an embed reference.
+ * - Direct: input was already `hm://` or a public gateway link — normalize and return.
+ * - Resolved: arbitrary web URL successfully resolved to a Hypermedia document via the domain resolver / OPTIONS fallback.
+ * - No-match: resolver ran without throwing but did not find a Hypermedia hmId.
+ * - Error: resolver threw (network failure, CORS, etc).
+ */
+export async function resolveEmbedUrl(
+  url: string,
+  opts: {
+    gwUrl?: any
+    domainResolver?: (hostname: string) => Promise<string | null>
+  } = {},
+): Promise<EmbedResolveResult> {
+  if (isPublicGatewayLink(url, opts.gwUrl) || isHypermediaScheme(url)) {
+    const hmLink = normalizeHmId(url, opts.gwUrl)
+    return {kind: 'direct', url: hmLink ?? url}
+  }
+  try {
+    const res = await resolveHypermediaUrl(url, {domainResolver: opts.domainResolver})
+    if (res?.hmId) {
+      return {kind: 'resolved', url: packHmId(res.hmId)}
+    }
+    return {kind: 'no-match'}
+  } catch (error) {
+    return {kind: 'error', error}
+  }
+}
+
 const Render = (block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSchema>) => {
   // When the embed points at an unpublished child draft,
   // render a placeholder card instead of the URL input form.
@@ -182,10 +218,7 @@ const Render = (block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
   }
   const gwUrl = useGatewayUrlStream()
   const submitEmbed = async (url: string, assign: any, setFileName: any, setLoading: any) => {
-    if (isPublicGatewayLink(url, gwUrl) || isHypermediaScheme(url)) {
-      const hmLink = normalizeHmId(url, gwUrl)
-      const newUrl = hmLink ? hmLink : url
-      assign({props: {url: newUrl}} as MediaType)
+    const advanceCursor = () => {
       const cursorPosition = editor.getTextCursorPosition()
       editor.focus()
       if (cursorPosition.block.id === block.id) {
@@ -195,36 +228,39 @@ const Render = (block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
           editor.setTextCursorPosition(editor.getTextCursorPosition().nextBlock!, 'start')
         }
       }
-    } else {
-      setLoading(true)
-      resolveHypermediaUrl(url, {domainResolver: editor.domainResolver})
-        .then((res) => {
-          if (res?.hmId) {
-            assign({props: {url: packHmId(res.hmId)}} as MediaType)
-            const cursorPosition = editor.getTextCursorPosition()
-            editor.focus()
-            if (cursorPosition.block.id === block.id) {
-              if (cursorPosition.nextBlock) editor.setTextCursorPosition(cursorPosition.nextBlock, 'start')
-              else {
-                editor.insertBlocks([{type: 'paragraph', content: ''}], block.id, 'after')
-                editor.setTextCursorPosition(editor.getTextCursorPosition().nextBlock!, 'start')
-              }
-            }
-          } else {
-            setFileName({
-              name: 'The provided url is not a hypermedia link',
-              color: 'red',
-            })
-          }
-          setLoading(false)
+    }
+
+    setLoading(true)
+    const result = await resolveEmbedUrl(url, {gwUrl, domainResolver: editor.domainResolver})
+    setLoading(false)
+
+    switch (result.kind) {
+      case 'direct':
+      case 'resolved':
+        assign({props: {url: result.url}} as MediaType)
+        advanceCursor()
+        return
+      case 'no-match':
+        console.warn('[embed-block] resolveHypermediaUrl returned no hmId', {
+          url,
+          hasDomainResolver: !!editor.domainResolver,
         })
-        .catch((e) => {
-          setFileName({
-            name: 'The provided url is not a hypermedia link',
-            color: 'red',
-          })
-          setLoading(false)
+        setFileName({
+          name: 'Could not resolve URL to a Hypermedia document',
+          color: 'red',
         })
+        return
+      case 'error':
+        console.error('[embed-block] resolveHypermediaUrl failed', {
+          url,
+          hasDomainResolver: !!editor.domainResolver,
+          error: result.error,
+        })
+        setFileName({
+          name: 'Failed to reach URL — site may be offline or block requests',
+          color: 'red',
+        })
+        return
     }
   }
   return (
@@ -312,18 +348,22 @@ function EditorEmbedContent({
   )
 }
 
-const EmbedLauncherInput = ({
+export const EmbedLauncherInput = ({
   editor,
   assign,
   setUrl,
   fileName,
   setFileName,
+  submit,
+  setLoading,
 }: {
   editor: BlockNoteEditor
   assign: any
   setUrl: any
   fileName: any
   setFileName: any
+  submit?: (url: string, assign: any, setFileName: any, setLoading: any) => Promise<void> | void | undefined
+  setLoading?: any
 }) => {
   const [search, setSearch] = useState('')
   const [focused, setFocused] = useState(false)
@@ -443,6 +483,13 @@ const EmbedLauncherInput = ({
         placeholder="Query or input Embed URL…"
         onFocus={() => setFocused(true)}
         onBlur={() => setTimeout(() => setFocused(false), 150)}
+        onPaste={(e) => {
+          // Prevent ProseMirror's editor-level paste handlers (link, markdown,
+          // local-media) from intercepting paste events inside this nested
+          // <input>. Without this, those handlers call preventDefault and the
+          // native input never receives the pasted text.
+          e.stopPropagation()
+        }}
         onKeyDown={(e) => {
           if (e.key === 'Escape') {
             setFocused(false)
@@ -450,14 +497,17 @@ const EmbedLauncherInput = ({
           }
 
           // If Enter is pressed and the input looks like a URL or hypermedia link,
-          // blur the input to trigger form submission instead of selecting a search result
+          // submit directly so the embed is created instead of selecting a search result.
           if (e.key === 'Enter') {
             const isUrl = search.startsWith('http://') || search.startsWith('https://') || search.startsWith('hm://')
 
             if (isUrl) {
-              // Blur to trigger form submission with the typed URL
-              e.currentTarget.blur()
               setFocused(false)
+              if (submit) {
+                submit(search, assign, setFileName, setLoading ?? (() => {}))
+              } else {
+                e.currentTarget.blur()
+              }
               return
             }
 

--- a/frontend/packages/editor/src/media-render.tsx
+++ b/frontend/packages/editor/src/media-render.tsx
@@ -70,6 +70,8 @@ interface RenderProps {
     setUrl: any
     fileName: any
     setFileName: any
+    submit?: (url: string, assign: any, setFileName: any, setLoading: any) => Promise<void> | void | undefined
+    setLoading?: any
   }>
   hideForm?: boolean
   validateFile?: (file: File) => boolean
@@ -258,6 +260,8 @@ function MediaForm({
     setUrl: any
     fileName: any
     setFileName: any
+    submit?: (url: string, assign: any, setFileName: any, setLoading: any) => Promise<void> | void | undefined
+    setLoading?: any
   }>
   validateFile?: (file: File) => boolean
 }) {
@@ -475,6 +479,8 @@ function MediaForm({
                   setUrl={setUrl}
                   fileName={fileName}
                   setFileName={setFileName}
+                  submit={submit}
+                  setLoading={setLoading}
                 />
               ) : (
                 <Input
@@ -487,6 +493,13 @@ function MediaForm({
                         name: 'Upload File',
                         color: undefined,
                       })
+                  }}
+                  onPaste={(e) => {
+                    // Prevent ProseMirror's editor-level paste handlers (link, markdown,
+                    // local-media) from intercepting paste events inside this nested
+                    // <input>. Without this, those handlers call preventDefault and the
+                    // native input never receives the pasted text.
+                    e.stopPropagation()
                   }}
                   autoFocus
                 />


### PR DESCRIPTION
## Summary

- Stop ProseMirror editor-level paste handlers from intercepting paste events inside embed/comment `<input>` fields by calling `e.stopPropagation()` on `onPaste`
- Extract `resolveEmbedUrl` as a pure, testable function that normalizes direct HM/gateway links and resolves arbitrary web URLs via domain resolver
- Thread `domainResolver` from `commenting.tsx` → `CommentEditor` → `useCommentEditor` → `linkExtensionOptions` so pasted URLs inside comment embed inputs resolve correctly
- Pass `submit` and `setLoading` through `MediaForm` → `CustomInput` props so `EmbedLauncherInput` can submit directly on Enter without requiring blur
- Export `EmbedLauncherInput` and `resolveEmbedUrl` for unit testing
- Add `embed-block.test.tsx` with 10 tests covering paste propagation, Enter-key submit, and all `resolveEmbedUrl` result kinds


---

Fixes #613