### PR TITLE
ci: migrate windows runners to windows-2025-vs2026

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -92,7 +92,7 @@ runs:
           backend/util/llama-go/libcommon.a
           backend/util/llama-go/libvulkan-1.a
           backend/util/llama-go/build
-        key: llama-windows-2025-vs2026-${{ steps.llama-sha.outputs.sha }}
+        key: llama-windows-2025-${{ steps.llama-sha.outputs.sha }}
 
     - name: "Build llama.cpp (Linux)"
       if: inputs.matrix-os == 'ubuntu-latest' && steps.llama-cache-unix.outputs.cache-hit != 'true'

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -47,7 +47,7 @@ runs:
       shell: bash
 
     - name: 'Install Vulkan SDK (Windows)'
-      if: inputs.matrix-os == 'windows-2025'
+      if: inputs.matrix-os == 'windows-2025-vs2026'
       shell: powershell
       run: |
         $vulkanVersion = "1.4.313.2"
@@ -67,7 +67,7 @@ runs:
 
     - name: Cache llama.cpp build (Linux / macOS)
       id: llama-cache-unix
-      if: inputs.matrix-os != 'windows-2025'
+      if: inputs.matrix-os != 'windows-2025-vs2026'
       uses: actions/cache@v4
       with:
         path: |
@@ -80,7 +80,7 @@ runs:
 
     - name: Cache llama.cpp build (Windows)
       id: llama-cache-windows
-      if: inputs.matrix-os == 'windows-2025'
+      if: inputs.matrix-os == 'windows-2025-vs2026'
       uses: actions/cache@v4
       with:
         path: |
@@ -92,7 +92,7 @@ runs:
           backend/util/llama-go/libcommon.a
           backend/util/llama-go/libvulkan-1.a
           backend/util/llama-go/build
-        key: llama-windows-2025-${{ steps.llama-sha.outputs.sha }}
+        key: llama-windows-2025-vs2026-${{ steps.llama-sha.outputs.sha }}
 
     - name: "Build llama.cpp (Linux)"
       if: inputs.matrix-os == 'ubuntu-latest' && steps.llama-cache-unix.outputs.cache-hit != 'true'
@@ -111,7 +111,7 @@ runs:
         MACOSX_DEPLOYMENT_TARGET: '13.0'
 
     - name: "Build llama.cpp (Windows)"
-      if: inputs.matrix-os == 'windows-2025' && steps.llama-cache-windows.outputs.cache-hit != 'true'
+      if: inputs.matrix-os == 'windows-2025-vs2026' && steps.llama-cache-windows.outputs.cache-hit != 'true'
       shell: bash
       run: |
         set -euo pipefail
@@ -189,7 +189,7 @@ runs:
 
     - name: Setup cache Windows
       uses: actions/cache@v4
-      if: inputs.matrix-os == 'windows-2025'
+      if: inputs.matrix-os == 'windows-2025-vs2026'
       with:
         path: |
           ~\AppData\Local\go-build

--- a/.github/workflows/desktop-smoke-test.yml
+++ b/.github/workflows/desktop-smoke-test.yml
@@ -58,7 +58,7 @@ jobs:
           # matrix-arch: ${{ matrix.config.arch }}
 
       - name: Build Backend (Unix)
-        if: matrix.config.os != 'windows-2025'
+        if: matrix.config.os != 'windows-2025-vs2026'
         run: |
           mkdir -p plz-out/bin/backend
           # GPU is enabled by default (no -tags needed)
@@ -70,7 +70,7 @@ jobs:
           C_INCLUDE_PATH: ${{ github.workspace }}/backend/util/llama-go
 
       - name: Build Backend (Windows)
-        if: matrix.config.os == 'windows-2025'
+        if: matrix.config.os == 'windows-2025-vs2026'
         run: |
           mkdir -p plz-out/bin/backend
           # GPU is enabled by default (no -tags needed)
@@ -89,7 +89,7 @@ jobs:
           VITE_VERSION: "100.10.1"
 
       - name: Build, package & make (Unix)
-        if: matrix.config.os != 'windows-2025'
+        if: matrix.config.os != 'windows-2025-vs2026'
         run: |
           pnpm desktop:make --arch=${{ matrix.config.arch }}
         env:
@@ -109,7 +109,7 @@ jobs:
           VITE_DESKTOP_SENTRY_DSN: "${{ secrets.DESKTOP_SENTRY_DSN }}"
 
       - name: Build, package and make (Win32)
-        if: matrix.config.os == 'windows-2025'
+        if: matrix.config.os == 'windows-2025-vs2026'
         run: |
           pnpm desktop:make --arch=${{ matrix.config.arch }}
         env:

--- a/.github/workflows/dev-desktop.yml
+++ b/.github/workflows/dev-desktop.yml
@@ -72,7 +72,7 @@ jobs:
             arch: x64
             goarch: amd64
             daemon_name: x86_64-unknown-linux-gnu
-          - os: windows-2025
+          - os: windows-2025-vs2026
             arch: x64
             goarch: amd64
             daemon_name: x86_64-pc-windows-gnu
@@ -90,7 +90,7 @@ jobs:
           enableCrossOsArchive: true
 
       - name: Download GGUF model (Unix)
-        if: matrix.config.os != 'windows-2025'
+        if: matrix.config.os != 'windows-2025-vs2026'
         run: |
           if [ ! -f backend/llm/backends/llamacpp/models/granite-embedding-107m-multilingual-Q8_0.gguf ]; then
             mkdir -p backend/llm/backends/llamacpp/models
@@ -115,7 +115,7 @@ jobs:
           # matrix-arch: ${{ matrix.config.arch }}
 
       - name: Build Backend (Unix)
-        if: matrix.config.os != 'windows-2025'
+        if: matrix.config.os != 'windows-2025-vs2026'
         run: |
           mkdir -p plz-out/bin/backend
           # GPU is enabled by default (no -tags needed)
@@ -128,7 +128,7 @@ jobs:
           C_INCLUDE_PATH: ${{ github.workspace }}/backend/util/llama-go
 
       - name: Build Backend (Windows)
-        if: matrix.config.os == 'windows-2025'
+        if: matrix.config.os == 'windows-2025-vs2026'
         shell: bash
         run: |
           mkdir -p plz-out/bin/backend
@@ -143,7 +143,7 @@ jobs:
           C_INCLUDE_PATH: ${{ github.workspace }}/backend/util/llama-go
 
       - name: Stage Windows runtime DLL
-        if: matrix.config.os == 'windows-2025'
+        if: matrix.config.os == 'windows-2025-vs2026'
         shell: bash
         run: |
           set -euo pipefail
@@ -158,7 +158,7 @@ jobs:
           ls -la plz-out/bin/backend/libwinpthread-1.dll
 
       - name: Verify Windows daemon runtime deps
-        if: matrix.config.os == 'windows-2025'
+        if: matrix.config.os == 'windows-2025-vs2026'
         shell: bash
         run: |
           set -euo pipefail
@@ -209,7 +209,7 @@ jobs:
         env:
           VITE_VERSION: '${{ needs.build-info.outputs.version }}'
       - name: Build, package & make (Unix)
-        if: matrix.config.os != 'windows-2025'
+        if: matrix.config.os != 'windows-2025-vs2026'
         run: |
           pnpm desktop:publish --arch=${{ matrix.config.arch }}
         env:
@@ -384,7 +384,7 @@ jobs:
           }
 
       - name: Upload daemon debug info to Sentry (Unix)
-        if: matrix.config.os != 'windows-2025' && env.SENTRY_AUTH_TOKEN != ''
+        if: matrix.config.os != 'windows-2025-vs2026' && env.SENTRY_AUTH_TOKEN != ''
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: mintter

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -67,7 +67,7 @@ jobs:
             arch: x64
             goarch: amd64
             daemon_name: x86_64-unknown-linux-gnu
-          - os: windows-2025
+          - os: windows-2025-vs2026
             arch: x64
             goarch: amd64
             daemon_name: x86_64-pc-windows-gnu
@@ -85,7 +85,7 @@ jobs:
           enableCrossOsArchive: true
 
       - name: Download GGUF model (Unix)
-        if: matrix.config.os != 'windows-2025'
+        if: matrix.config.os != 'windows-2025-vs2026'
         run: |
           if [ ! -f backend/llm/backends/llamacpp/models/granite-embedding-107m-multilingual-Q8_0.gguf ]; then
             mkdir -p backend/llm/backends/llamacpp/models
@@ -216,7 +216,7 @@ jobs:
         env:
           VITE_VERSION: '${{ needs.build-info.outputs.version }}'
       - name: Build, package & make (Unix)
-        if: matrix.config.os != 'windows-2025'
+        if: matrix.config.os != 'windows-2025-vs2026'
         run: |
           pnpm desktop:make --arch=${{ matrix.config.arch }}
         env:
@@ -285,7 +285,7 @@ jobs:
           SENTRY_AUTH_TOKEN: '${{ secrets.SENTRY_AUTH_TOKEN }}'
 
       - name: Upload daemon debug info to Sentry (Unix)
-        if: matrix.config.os != 'windows-2025' && env.SENTRY_AUTH_TOKEN != ''
+        if: matrix.config.os != 'windows-2025-vs2026' && env.SENTRY_AUTH_TOKEN != ''
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: mintter

--- a/.github/workflows/test-desktop.yml
+++ b/.github/workflows/test-desktop.yml
@@ -46,7 +46,7 @@ jobs:
             arch: x64
             goarch: amd64
             daemon_name: x86_64-unknown-linux-gnu
-          - os: windows-2025
+          - os: windows-2025-vs2026
             arch: x64
             goarch: amd64
             daemon_name: x86_64-pc-windows-gnu
@@ -64,7 +64,7 @@ jobs:
           enableCrossOsArchive: true
 
       - name: Download GGUF model (Unix)
-        if: matrix.config.os != 'windows-2025'
+        if: matrix.config.os != 'windows-2025-vs2026'
         run: |
           if [ ! -f backend/llm/backends/llamacpp/models/granite-embedding-107m-multilingual-Q8_0.gguf ]; then
             mkdir -p backend/llm/backends/llamacpp/models
@@ -89,7 +89,7 @@ jobs:
           # matrix-arch: ${{ matrix.config.arch }}
 
       - name: Build Backend (Unix)
-        if: matrix.config.os != 'windows-2025'
+        if: matrix.config.os != 'windows-2025-vs2026'
         run: |
           mkdir -p plz-out/bin/backend
           # GPU is enabled by default (no -tags needed)
@@ -101,7 +101,7 @@ jobs:
           C_INCLUDE_PATH: ${{ github.workspace }}/backend/util/llama-go
 
       - name: Build Backend (Windows)
-        if: matrix.config.os == 'windows-2025'
+        if: matrix.config.os == 'windows-2025-vs2026'
         run: |
           mkdir -p plz-out/bin/backend
           # GPU is enabled by default (no -tags needed)
@@ -120,7 +120,7 @@ jobs:
           VITE_VERSION: "100.0.0"
 
       - name: Build, package & make (Unix)
-        if: matrix.config.os != 'windows-2025'
+        if: matrix.config.os != 'windows-2025-vs2026'
         run: |
           pnpm desktop:package --arch=${{ matrix.config.arch }}
         env:
@@ -136,7 +136,7 @@ jobs:
           VITE_DESKTOP_HOSTNAME: "http://localhost"
 
       - name: Build, package and make (Win32)
-        if: matrix.config.os == 'windows-2025'
+        if: matrix.config.os == 'windows-2025-vs2026'
         run: |
           $env:DEBUG='electron-osx-sign*,electron-notarize*'
           pnpm desktop:package --arch=${{ matrix.config.arch }}


### PR DESCRIPTION
Move all GitHub Actions matrix entries and `matrix-os`/`matrix.config.os`
conditionals (plus the llama.cpp Windows cache key) from `windows-2025`
to the new `windows-2025-vs2026` runner image so the Windows desktop and
backend builds run on the VS 2026 toolchain.