### PR TITLE
fix(desktop): add debug logging for private document publish flow

### DIFF
--- a/backend/api/documents/v3alpha/documents.go
+++ b/backend/api/documents/v3alpha/documents.go
@@ -44,6 +44,7 @@ const (
 	defaultPageSize                = 100
 	maxPageAllocBuffer             = 400 // Arbitrary limit to prevent allocating too much memory when client requested huge page size.
 	publicOnlyListVisibilityFilter = `COALESCE(json_extract(dg.metadata, '$."$db.visibility".v'), '') IS NOT 'Private'`
+	privateDocDebugPrefix          = "[private-doc-debug]"
 )
 
 // Server implements Documents API v3.
@@ -182,6 +183,17 @@ func (srv *Server) BatchGetDocumentInfo(ctx context.Context, in *documents.Batch
 
 // CreateDocumentChange implements Documents API v3.
 func (srv *Server) CreateDocumentChange(ctx context.Context, in *documents.CreateDocumentChangeRequest) (*documents.Document, error) {
+	if in.Visibility == documents.ResourceVisibility_RESOURCE_VISIBILITY_PRIVATE {
+		srv.log.Info(privateDocDebugPrefix+" backend CreateDocumentChange received private visibility",
+			zap.String("account", in.Account),
+			zap.String("path", in.Path),
+			zap.String("base_version", in.BaseVersion),
+			zap.String("signing_key_name", in.SigningKeyName),
+			zap.Int("change_count", len(in.Changes)),
+			zap.String("capability", in.Capability),
+			zap.String("visibility", in.Visibility.String()),
+		)
+	}
 	if in.SigningKeyName == "" {
 		return nil, errutil.MissingArgument("signing_key_name")
 	}
@@ -246,6 +258,15 @@ func (srv *Server) CreateDocumentChange(ctx context.Context, in *documents.Creat
 	default:
 		return nil, status.Errorf(codes.InvalidArgument, "unknown visibility value: %v", in.Visibility)
 	}
+	if in.Visibility == documents.ResourceVisibility_RESOURCE_VISIBILITY_PRIVATE {
+		srv.log.Info(privateDocDebugPrefix+" backend CreateDocumentChange computed ref visibility",
+			zap.String("account", in.Account),
+			zap.String("path", in.Path),
+			zap.String("base_version", in.BaseVersion),
+			zap.String("doc_visibility_before_ref", string(doc.Visibility())),
+			zap.String("ref_visibility", string(visibility)),
+		)
+	}
 
 	ref, err := doc.Ref(kp, visibility)
 	if err != nil {
@@ -263,11 +284,34 @@ func (srv *Server) CreateDocumentChange(ctx context.Context, in *documents.Creat
 		return nil, fmt.Errorf("failed to reload document after creating change: %w", err)
 	}
 
-	return doc.Hydrate(ctx)
+	out, err := doc.Hydrate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if in.Visibility == documents.ResourceVisibility_RESOURCE_VISIBILITY_PRIVATE {
+		srv.log.Info(privateDocDebugPrefix+" backend CreateDocumentChange returning hydrated document",
+			zap.String("account", out.Account),
+			zap.String("path", out.Path),
+			zap.String("version", out.Version),
+			zap.String("genesis", out.Genesis),
+			zap.String("visibility", out.Visibility.String()),
+		)
+	}
+	return out, nil
 }
 
 // PrepareChange prepares unsigned Change and Ref blobs for client-side signing.
 func (srv *Server) PrepareChange(ctx context.Context, in *documents.PrepareChangeRequest) (*documents.PrepareChangeResponse, error) {
+	if in.Visibility == documents.ResourceVisibility_RESOURCE_VISIBILITY_PRIVATE {
+		srv.log.Info(privateDocDebugPrefix+" backend PrepareChange received private visibility",
+			zap.String("account", in.Account),
+			zap.String("path", in.Path),
+			zap.String("base_version", in.BaseVersion),
+			zap.Int("change_count", len(in.Changes)),
+			zap.String("capability", in.Capability),
+			zap.String("visibility", in.Visibility.String()),
+		)
+	}
 	doc, err := srv.handleDocumentChangeRequest(ctx, documentChangeParams{
 		Account:     in.Account,
 		Path:        in.Path,
@@ -279,12 +323,28 @@ func (srv *Server) PrepareChange(ctx context.Context, in *documents.PrepareChang
 	if err != nil {
 		return nil, err
 	}
+	if in.Visibility == documents.ResourceVisibility_RESOURCE_VISIBILITY_PRIVATE {
+		srv.log.Info(privateDocDebugPrefix+" backend PrepareChange prepared document model",
+			zap.String("account", in.Account),
+			zap.String("path", in.Path),
+			zap.String("base_version", in.BaseVersion),
+			zap.String("doc_visibility", string(doc.Visibility())),
+		)
+	}
 
 	// Use NopSigner to create the Change without actually signing it.
 	// The client will sign it themselves.
 	change, err := doc.CreateChange(blob.NewNopSigner(nil), time.Now())
 	if err != nil {
 		return nil, err
+	}
+	if in.Visibility == documents.ResourceVisibility_RESOURCE_VISIBILITY_PRIVATE {
+		srv.log.Info(privateDocDebugPrefix+" backend PrepareChange returning unsigned change",
+			zap.String("account", in.Account),
+			zap.String("path", in.Path),
+			zap.String("base_version", in.BaseVersion),
+			zap.Int("unsigned_change_bytes", len(change.Data)),
+		)
 	}
 
 	return &documents.PrepareChangeResponse{
@@ -305,6 +365,16 @@ type documentChangeParams struct {
 // handleDocumentChangeRequest handles the common logic for CreateDocumentChange and PrepareChange.
 // It validates input, loads/creates the document, and applies the requested changes.
 func (srv *Server) handleDocumentChangeRequest(ctx context.Context, in documentChangeParams) (*docmodel.Document, error) {
+	if in.Visibility == documents.ResourceVisibility_RESOURCE_VISIBILITY_PRIVATE {
+		srv.log.Info(privateDocDebugPrefix+" backend handleDocumentChangeRequest start",
+			zap.String("account", in.Account),
+			zap.String("path", in.Path),
+			zap.String("base_version", in.BaseVersion),
+			zap.Int("change_count", len(in.Changes)),
+			zap.String("capability", in.Capability),
+			zap.String("visibility", in.Visibility.String()),
+		)
+	}
 	ns, err := core.DecodePrincipal(in.Account)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to decode account %s: %v", in.Account, err)
@@ -365,6 +435,15 @@ func (srv *Server) handleDocumentChangeRequest(ctx context.Context, in documentC
 
 	if err := applyChanges(doc, in.Changes); err != nil {
 		return nil, err
+	}
+	if in.Visibility == documents.ResourceVisibility_RESOURCE_VISIBILITY_PRIVATE {
+		srv.log.Info(privateDocDebugPrefix+" backend handleDocumentChangeRequest applied changes",
+			zap.String("account", in.Account),
+			zap.String("path", in.Path),
+			zap.String("base_version", in.BaseVersion),
+			zap.Int("num_changes_after_apply", doc.NumChanges()),
+			zap.String("doc_visibility_after_apply", string(doc.Visibility())),
+		)
 	}
 
 	return doc, nil

--- a/backend/api/documents/v3alpha/documents.go
+++ b/backend/api/documents/v3alpha/documents.go
@@ -44,7 +44,6 @@ const (
 	defaultPageSize                = 100
 	maxPageAllocBuffer             = 400 // Arbitrary limit to prevent allocating too much memory when client requested huge page size.
 	publicOnlyListVisibilityFilter = `COALESCE(json_extract(dg.metadata, '$."$db.visibility".v'), '') IS NOT 'Private'`
-	privateDocDebugPrefix          = "[private-doc-debug]"
 )
 
 // Server implements Documents API v3.
@@ -183,17 +182,6 @@ func (srv *Server) BatchGetDocumentInfo(ctx context.Context, in *documents.Batch
 
 // CreateDocumentChange implements Documents API v3.
 func (srv *Server) CreateDocumentChange(ctx context.Context, in *documents.CreateDocumentChangeRequest) (*documents.Document, error) {
-	if in.Visibility == documents.ResourceVisibility_RESOURCE_VISIBILITY_PRIVATE {
-		srv.log.Info(privateDocDebugPrefix+" backend CreateDocumentChange received private visibility",
-			zap.String("account", in.Account),
-			zap.String("path", in.Path),
-			zap.String("base_version", in.BaseVersion),
-			zap.String("signing_key_name", in.SigningKeyName),
-			zap.Int("change_count", len(in.Changes)),
-			zap.String("capability", in.Capability),
-			zap.String("visibility", in.Visibility.String()),
-		)
-	}
 	if in.SigningKeyName == "" {
 		return nil, errutil.MissingArgument("signing_key_name")
 	}
@@ -258,15 +246,6 @@ func (srv *Server) CreateDocumentChange(ctx context.Context, in *documents.Creat
 	default:
 		return nil, status.Errorf(codes.InvalidArgument, "unknown visibility value: %v", in.Visibility)
 	}
-	if in.Visibility == documents.ResourceVisibility_RESOURCE_VISIBILITY_PRIVATE {
-		srv.log.Info(privateDocDebugPrefix+" backend CreateDocumentChange computed ref visibility",
-			zap.String("account", in.Account),
-			zap.String("path", in.Path),
-			zap.String("base_version", in.BaseVersion),
-			zap.String("doc_visibility_before_ref", string(doc.Visibility())),
-			zap.String("ref_visibility", string(visibility)),
-		)
-	}
 
 	ref, err := doc.Ref(kp, visibility)
 	if err != nil {
@@ -288,30 +267,11 @@ func (srv *Server) CreateDocumentChange(ctx context.Context, in *documents.Creat
 	if err != nil {
 		return nil, err
 	}
-	if in.Visibility == documents.ResourceVisibility_RESOURCE_VISIBILITY_PRIVATE {
-		srv.log.Info(privateDocDebugPrefix+" backend CreateDocumentChange returning hydrated document",
-			zap.String("account", out.Account),
-			zap.String("path", out.Path),
-			zap.String("version", out.Version),
-			zap.String("genesis", out.Genesis),
-			zap.String("visibility", out.Visibility.String()),
-		)
-	}
 	return out, nil
 }
 
 // PrepareChange prepares unsigned Change and Ref blobs for client-side signing.
 func (srv *Server) PrepareChange(ctx context.Context, in *documents.PrepareChangeRequest) (*documents.PrepareChangeResponse, error) {
-	if in.Visibility == documents.ResourceVisibility_RESOURCE_VISIBILITY_PRIVATE {
-		srv.log.Info(privateDocDebugPrefix+" backend PrepareChange received private visibility",
-			zap.String("account", in.Account),
-			zap.String("path", in.Path),
-			zap.String("base_version", in.BaseVersion),
-			zap.Int("change_count", len(in.Changes)),
-			zap.String("capability", in.Capability),
-			zap.String("visibility", in.Visibility.String()),
-		)
-	}
 	doc, err := srv.handleDocumentChangeRequest(ctx, documentChangeParams{
 		Account:     in.Account,
 		Path:        in.Path,
@@ -323,28 +283,12 @@ func (srv *Server) PrepareChange(ctx context.Context, in *documents.PrepareChang
 	if err != nil {
 		return nil, err
 	}
-	if in.Visibility == documents.ResourceVisibility_RESOURCE_VISIBILITY_PRIVATE {
-		srv.log.Info(privateDocDebugPrefix+" backend PrepareChange prepared document model",
-			zap.String("account", in.Account),
-			zap.String("path", in.Path),
-			zap.String("base_version", in.BaseVersion),
-			zap.String("doc_visibility", string(doc.Visibility())),
-		)
-	}
 
 	// Use NopSigner to create the Change without actually signing it.
 	// The client will sign it themselves.
 	change, err := doc.CreateChange(blob.NewNopSigner(nil), time.Now())
 	if err != nil {
 		return nil, err
-	}
-	if in.Visibility == documents.ResourceVisibility_RESOURCE_VISIBILITY_PRIVATE {
-		srv.log.Info(privateDocDebugPrefix+" backend PrepareChange returning unsigned change",
-			zap.String("account", in.Account),
-			zap.String("path", in.Path),
-			zap.String("base_version", in.BaseVersion),
-			zap.Int("unsigned_change_bytes", len(change.Data)),
-		)
 	}
 
 	return &documents.PrepareChangeResponse{
@@ -365,16 +309,6 @@ type documentChangeParams struct {
 // handleDocumentChangeRequest handles the common logic for CreateDocumentChange and PrepareChange.
 // It validates input, loads/creates the document, and applies the requested changes.
 func (srv *Server) handleDocumentChangeRequest(ctx context.Context, in documentChangeParams) (*docmodel.Document, error) {
-	if in.Visibility == documents.ResourceVisibility_RESOURCE_VISIBILITY_PRIVATE {
-		srv.log.Info(privateDocDebugPrefix+" backend handleDocumentChangeRequest start",
-			zap.String("account", in.Account),
-			zap.String("path", in.Path),
-			zap.String("base_version", in.BaseVersion),
-			zap.Int("change_count", len(in.Changes)),
-			zap.String("capability", in.Capability),
-			zap.String("visibility", in.Visibility.String()),
-		)
-	}
 	ns, err := core.DecodePrincipal(in.Account)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to decode account %s: %v", in.Account, err)
@@ -435,15 +369,6 @@ func (srv *Server) handleDocumentChangeRequest(ctx context.Context, in documentC
 
 	if err := applyChanges(doc, in.Changes); err != nil {
 		return nil, err
-	}
-	if in.Visibility == documents.ResourceVisibility_RESOURCE_VISIBILITY_PRIVATE {
-		srv.log.Info(privateDocDebugPrefix+" backend handleDocumentChangeRequest applied changes",
-			zap.String("account", in.Account),
-			zap.String("path", in.Path),
-			zap.String("base_version", in.BaseVersion),
-			zap.Int("num_changes_after_apply", doc.NumChanges()),
-			zap.String("doc_visibility_after_apply", string(doc.Visibility())),
-		)
 	}
 
 	return doc, nil

--- a/frontend/apps/desktop/src/app-drafts.ts
+++ b/frontend/apps/desktop/src/app-drafts.ts
@@ -25,6 +25,8 @@ import {t} from './app-trpc'
 import {grpcClient} from './grpc-client'
 import {error} from './logger'
 
+const PRIVATE_DOC_DEBUG_PREFIX = '[private-doc-debug]'
+
 /**
  * new draft creation:
  * - draft route params:
@@ -527,6 +529,19 @@ export const draftsApi = t.router({
       }
 
       const draftId = input.id || nanoid(10)
+      if (input.visibility === 'PRIVATE') {
+        console.log(PRIVATE_DOC_DEBUG_PREFIX, 'app drafts write private draft received', {
+          draftId,
+          locationUid: input.locationUid,
+          locationPath: input.locationPath,
+          editUid: input.editUid,
+          editPath: input.editPath,
+          deps: input.deps,
+          metadata: input.metadata,
+          contentBlockCount: Array.isArray(input.content) ? input.content.length : undefined,
+          navigationCount: input.navigation?.length,
+        })
+      }
 
       // Build the index entry with deps and navigation included
       const newDraft = {
@@ -564,6 +579,17 @@ export const draftsApi = t.router({
       try {
         await fs.writeFile(draftPath, JSON.stringify(draft, null, 2))
         draftFileMap.set(draftId, `${draftId}.json`)
+        if (input.visibility === 'PRIVATE') {
+          console.log(PRIVATE_DOC_DEBUG_PREFIX, 'app drafts write private draft saved', {
+            draftId,
+            draftPath,
+            indexVisibility: newDraft.visibility,
+            indexLocationUid: newDraft.locationUid,
+            indexLocationPath: newDraft.locationPath,
+            indexEditUid: newDraft.editUid,
+            indexEditPath: newDraft.editPath,
+          })
+        }
         appInvalidateQueries([queryKeys.DRAFTS_LIST])
         appInvalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT])
         appInvalidateQueries([queryKeys.DRAFT, draftId])

--- a/frontend/apps/desktop/src/app-drafts.ts
+++ b/frontend/apps/desktop/src/app-drafts.ts
@@ -25,8 +25,6 @@ import {t} from './app-trpc'
 import {grpcClient} from './grpc-client'
 import {error} from './logger'
 
-const PRIVATE_DOC_DEBUG_PREFIX = '[private-doc-debug]'
-
 /**
  * new draft creation:
  * - draft route params:
@@ -529,19 +527,6 @@ export const draftsApi = t.router({
       }
 
       const draftId = input.id || nanoid(10)
-      if (input.visibility === 'PRIVATE') {
-        console.log(PRIVATE_DOC_DEBUG_PREFIX, 'app drafts write private draft received', {
-          draftId,
-          locationUid: input.locationUid,
-          locationPath: input.locationPath,
-          editUid: input.editUid,
-          editPath: input.editPath,
-          deps: input.deps,
-          metadata: input.metadata,
-          contentBlockCount: Array.isArray(input.content) ? input.content.length : undefined,
-          navigationCount: input.navigation?.length,
-        })
-      }
 
       // Build the index entry with deps and navigation included
       const newDraft = {
@@ -579,17 +564,6 @@ export const draftsApi = t.router({
       try {
         await fs.writeFile(draftPath, JSON.stringify(draft, null, 2))
         draftFileMap.set(draftId, `${draftId}.json`)
-        if (input.visibility === 'PRIVATE') {
-          console.log(PRIVATE_DOC_DEBUG_PREFIX, 'app drafts write private draft saved', {
-            draftId,
-            draftPath,
-            indexVisibility: newDraft.visibility,
-            indexLocationUid: newDraft.locationUid,
-            indexLocationPath: newDraft.locationPath,
-            indexEditUid: newDraft.editUid,
-            indexEditPath: newDraft.editPath,
-          })
-        }
         appInvalidateQueries([queryKeys.DRAFTS_LIST])
         appInvalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT])
         appInvalidateQueries([queryKeys.DRAFT, draftId])

--- a/frontend/apps/desktop/src/components/__tests__/publish-popover-body.test.tsx
+++ b/frontend/apps/desktop/src/components/__tests__/publish-popover-body.test.tsx
@@ -255,6 +255,37 @@ describe('PublishPopoverBody', () => {
     }
   })
 
+  it('disables permalink editing for private first-publish docs', () => {
+    setSnapshot({
+      document: {version: '', metadata: {}, visibility: 'PRIVATE'},
+      draftId: 'abc',
+      metadata: {name: 'My Private Doc'},
+    })
+    const docId = hmId('acct-1', {path: ['-abc']})
+    const onPublish = vi.fn()
+
+    const {container, root} = renderPopover(docId, onPublish)
+    try {
+      const input = findInput(container)!
+      expect(input).toBeTruthy()
+      expect(input.disabled).toBe(true)
+      expect(container.textContent).toContain('Private document paths are generated automatically.')
+
+      act(() => {
+        const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!
+        setter.call(input, '/my-typed-slug')
+        input.dispatchEvent(new Event('input', {bubbles: true}))
+      })
+      const publishButton = findButtonByText(container, 'Publish: Make it live now')
+      act(() => {
+        publishButton?.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+      })
+      expect(onPublish).toHaveBeenCalledWith(undefined)
+    } finally {
+      cleanup(root, container)
+    }
+  })
+
   it('omits the override when the user has not edited the input', () => {
     setSnapshot({
       document: {version: '', metadata: {}},

--- a/frontend/apps/desktop/src/components/create-doc-button.tsx
+++ b/frontend/apps/desktop/src/components/create-doc-button.tsx
@@ -18,8 +18,6 @@ import {ReactNode} from 'react'
 import {useImportDialog, useImporting} from './import-doc-button'
 import {usePublishSite} from './publish-site'
 
-const PRIVATE_DOC_DEBUG_PREFIX = '[private-doc-debug]'
-
 /** Component that handles import functionality with proper hook usage */
 function ImportMenuItem({
   locationId,
@@ -102,13 +100,6 @@ export function CreateDocumentButton({
                   {hasSiteUrl ? (
                     <DropdownMenuItem
                       onClick={() => {
-                        console.log(PRIVATE_DOC_DEBUG_PREFIX, 'private document menu item clicked', {
-                          locationId: locationId?.id,
-                          locationUid: locationId?.uid,
-                          locationPath: locationId?.path,
-                          isHomeDoc,
-                          hasSiteUrl,
-                        })
                         createDraft({visibility: 'PRIVATE'})
                       }}
                     >

--- a/frontend/apps/desktop/src/components/create-doc-button.tsx
+++ b/frontend/apps/desktop/src/components/create-doc-button.tsx
@@ -18,6 +18,8 @@ import {ReactNode} from 'react'
 import {useImportDialog, useImporting} from './import-doc-button'
 import {usePublishSite} from './publish-site'
 
+const PRIVATE_DOC_DEBUG_PREFIX = '[private-doc-debug]'
+
 /** Component that handles import functionality with proper hook usage */
 function ImportMenuItem({
   locationId,
@@ -98,7 +100,18 @@ export function CreateDocumentButton({
                     Public Document
                   </DropdownMenuItem>
                   {hasSiteUrl ? (
-                    <DropdownMenuItem onClick={() => createDraft({visibility: 'PRIVATE'})}>
+                    <DropdownMenuItem
+                      onClick={() => {
+                        console.log(PRIVATE_DOC_DEBUG_PREFIX, 'private document menu item clicked', {
+                          locationId: locationId?.id,
+                          locationUid: locationId?.uid,
+                          locationPath: locationId?.path,
+                          isHomeDoc,
+                          hasSiteUrl,
+                        })
+                        createDraft({visibility: 'PRIVATE'})
+                      }}
+                    >
                       <Lock className="size-4" />
                       Private Document
                     </DropdownMenuItem>

--- a/frontend/apps/desktop/src/components/publish-draft-button.tsx
+++ b/frontend/apps/desktop/src/components/publish-draft-button.tsx
@@ -43,8 +43,6 @@ import {
   usePushResource,
 } from '../models/documents'
 
-const PRIVATE_DOC_DEBUG_PREFIX = '[private-doc-debug]'
-
 export default function PublishDraftButton() {
   const route = useNavRoute()
   const navigate = useNavigate('replace')
@@ -263,30 +261,6 @@ export default function PublishDraftButton() {
       if (!draft.data) {
         toast.error('Draft not loaded')
         throw new Error('Draft not loaded')
-      }
-      if (isPrivate) {
-        console.log(PRIVATE_DOC_DEBUG_PREFIX, 'publish private draft button flow start', {
-          draftId,
-          draftRoute,
-          draftData: {
-            id: draft.data.id,
-            visibility: draft.data.visibility,
-            locationUid: draft.data.locationUid,
-            locationPath: draft.data.locationPath,
-            editUid: draft.data.editUid,
-            editPath: draft.data.editPath,
-            deps: draft.data.deps,
-            metadata: draft.data.metadata,
-            contentBlockCount: draft.data.content?.length,
-          },
-          isFirstPublish,
-          isInlineFirstPublish,
-          destinationId: destinationId.id,
-          destinationUid: destinationId.uid,
-          destinationPath: destinationId.path,
-          accountId,
-          editableLocation: editableLocation?.id,
-        })
       }
 
       // Step 1: Publish the child document

--- a/frontend/apps/desktop/src/components/publish-draft-button.tsx
+++ b/frontend/apps/desktop/src/components/publish-draft-button.tsx
@@ -43,6 +43,8 @@ import {
   usePushResource,
 } from '../models/documents'
 
+const PRIVATE_DOC_DEBUG_PREFIX = '[private-doc-debug]'
+
 export default function PublishDraftButton() {
   const route = useNavRoute()
   const navigate = useNavigate('replace')
@@ -262,6 +264,30 @@ export default function PublishDraftButton() {
         toast.error('Draft not loaded')
         throw new Error('Draft not loaded')
       }
+      if (isPrivate) {
+        console.log(PRIVATE_DOC_DEBUG_PREFIX, 'publish private draft button flow start', {
+          draftId,
+          draftRoute,
+          draftData: {
+            id: draft.data.id,
+            visibility: draft.data.visibility,
+            locationUid: draft.data.locationUid,
+            locationPath: draft.data.locationPath,
+            editUid: draft.data.editUid,
+            editPath: draft.data.editPath,
+            deps: draft.data.deps,
+            metadata: draft.data.metadata,
+            contentBlockCount: draft.data.content?.length,
+          },
+          isFirstPublish,
+          isInlineFirstPublish,
+          destinationId: destinationId.id,
+          destinationUid: destinationId.uid,
+          destinationPath: destinationId.path,
+          accountId,
+          editableLocation: editableLocation?.id,
+        })
+      }
 
       // Step 1: Publish the child document
       const res = await publish.mutateAsync({
@@ -474,7 +500,9 @@ export default function PublishDraftButton() {
                   <p className="text-muted-foreground text-xs">Edit your permalink</p>
                   <Input
                     value={`/${editablePath}`}
+                    disabled={!!isPrivate}
                     onChange={(e) => {
+                      if (isPrivate) return
                       if (!editableLocation) return
                       const raw = e.target.value.replace(/^\//, '')
                       const newPath = [...(editableLocation.path?.slice(0, -1) || []), pathNameify(raw)]
@@ -492,6 +520,9 @@ export default function PublishDraftButton() {
                       publishError ? 'border-red-500 dark:border-red-500' : ''
                     }`}
                   />
+                  {isPrivate ? (
+                    <p className="text-muted-foreground text-xs">Private document paths are generated automatically.</p>
+                  ) : null}
                   {publishError && <p className="text-destructive text-xs">{publishError}</p>}
                 </div>
               )}

--- a/frontend/apps/desktop/src/models/__tests__/use-publish-resource.test.tsx
+++ b/frontend/apps/desktop/src/models/__tests__/use-publish-resource.test.tsx
@@ -4,6 +4,7 @@ import {createRoot, Root} from 'react-dom/client'
 import {act} from 'react-dom/test-utils'
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
 import {hmId} from '@shm/shared/utils/entity-id-url'
+import {ResourceVisibility} from '@shm/shared/client/.generated/documents/v3alpha/documents_pb'
 import {HMDocument, HMDraft, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
@@ -232,6 +233,7 @@ describe('usePublishResource path resolution', () => {
     const arg = publishCalls[0][0]
     expect(arg.path).toBe('/parent/my-cool-doc')
     expect(arg.account).toBe('acct-1')
+    expect(arg.visibility).toBe(ResourceVisibility.UNSPECIFIED)
   })
 
   it('honours an explicit pathOverride from the publish popover', async () => {
@@ -311,6 +313,7 @@ describe('usePublishResource path resolution', () => {
           draft,
           destinationId: editId,
           accountId: 'acct-1',
+          pathOverride: ['public', 'slug'],
         })
       })
     } finally {
@@ -318,6 +321,7 @@ describe('usePublishResource path resolution', () => {
     }
 
     expect(publishDocumentMock.mock.calls[0][0].path).toBe('/-randomid')
+    expect(publishDocumentMock.mock.calls[0][0].visibility).toBe(ResourceVisibility.PRIVATE)
   })
 
   it('skips the rename for home-doc edits (empty path)', async () => {

--- a/frontend/apps/desktop/src/models/documents.ts
+++ b/frontend/apps/desktop/src/models/documents.ts
@@ -56,8 +56,6 @@ import {useMyAccountIds} from './daemon'
 import {useGatewayUrl, useGatewayUrlStream} from './gateway-settings'
 import {getNavigationChanges} from './navigation'
 
-const PRIVATE_DOC_DEBUG_PREFIX = '[private-doc-debug]'
-
 /**
  * Extended draft type returned by app-drafts.ts listAccount/list endpoints.
  * These endpoints compute locationId/editId from the raw uid+path fields.
@@ -131,23 +129,7 @@ export function useCreateInlineDraft(parentId: UnpackedHypermediaId | undefined)
         deps: [],
         visibility: visibility ?? 'PUBLIC',
       }
-      if (writeParams.visibility === 'PRIVATE') {
-        console.log(PRIVATE_DOC_DEBUG_PREFIX, 'create inline private draft write start', {
-          parentId: parentId.id,
-          parentUid: parentId.uid,
-          parentPath,
-          draftId,
-          draftPath,
-          writeParams,
-        })
-      }
       await client.drafts.write.mutate(writeParams)
-      if (writeParams.visibility === 'PRIVATE') {
-        console.log(PRIVATE_DOC_DEBUG_PREFIX, 'create inline private draft write success', {
-          draftId,
-          draftPath,
-        })
-      }
       return {draftId, draftPath}
     },
     onSuccess: () => {
@@ -255,24 +237,6 @@ export function usePublishResource(
   })
   return useMutation<HMDocument, any, PublishDraftInput>({
     mutationFn: async ({draft, destinationId, accountId, pathOverride}: PublishDraftInput): Promise<HMDocument> => {
-      const debugPrivatePublish = draft.visibility === 'PRIVATE'
-      if (debugPrivatePublish) {
-        console.log(PRIVATE_DOC_DEBUG_PREFIX, 'publish private draft mutation start', {
-          editId: editId?.id,
-          draftId: draft.id,
-          draftVisibility: draft.visibility,
-          draftLocationUid: draft.locationUid,
-          draftLocationPath: draft.locationPath,
-          draftEditUid: draft.editUid,
-          draftEditPath: draft.editPath,
-          draftDeps: draft.deps,
-          destinationId: destinationId.id,
-          destinationUid: destinationId.uid,
-          destinationPath: destinationId.path,
-          accountId,
-          pathOverride,
-        })
-      }
       const blocksMap = editId ? createBlocksMap(editDocument?.content || [], '') : {}
       let newContent = removeTrailingBlocks(draft.content || [])
 
@@ -308,28 +272,9 @@ export function usePublishResource(
                 if (latestDoc?.version) {
                   existingDocVersion = latestDoc.version
                 }
-                if (debugPrivatePublish) {
-                  console.log(PRIVATE_DOC_DEBUG_PREFIX, 'private draft destination probe result', {
-                    requestedAccount: destinationId.uid,
-                    requestedPath: hmIdPathToEntityQueryPath(destinationId.path || []),
-                    existingDocVersion,
-                    returnedVisibility: latestDoc?.visibility,
-                  })
-                }
               } catch (err) {
                 // Doc doesn't exist yet (first publish) — leave existingDoc null.
                 console.log('[publish] getDocument(latest) failed — treating as first publish', err)
-                if (debugPrivatePublish) {
-                  console.log(
-                    PRIVATE_DOC_DEBUG_PREFIX,
-                    'private draft destination probe failed; treating as first publish',
-                    {
-                      requestedAccount: destinationId.uid,
-                      requestedPath: hmIdPathToEntityQueryPath(destinationId.path || []),
-                      error: err,
-                    },
-                  )
-                }
               }
             }
 
@@ -346,16 +291,6 @@ export function usePublishResource(
             })
             const resolvedDestinationId =
               resolvedPath === destinationId.path ? destinationId : hmId(destinationId.uid, {path: resolvedPath})
-            if (debugPrivatePublish) {
-              console.log(PRIVATE_DOC_DEBUG_PREFIX, 'private draft resolved publish destination', {
-                originalDestinationId: destinationId.id,
-                originalPath: destinationId.path,
-                resolvedDestinationId: resolvedDestinationId.id,
-                resolvedPath: resolvedDestinationId.path,
-                existsAtDestination: !!existingDocVersion,
-                pathOverride,
-              })
-            }
             if (resolvedDestinationId !== destinationId) {
               console.log('[publish] resolved destination path', {
                 from: destinationId.path,
@@ -401,16 +336,6 @@ export function usePublishResource(
             }
 
             const docPath = hmIdPathToEntityQueryPath(resolvedDestinationId.path || [])
-            if (debugPrivatePublish) {
-              console.log(PRIVATE_DOC_DEBUG_PREFIX, 'private draft computed backend visibility', {
-                draftId: draft.id,
-                draftVisibility: draft.visibility,
-                draftDeps: draft.deps,
-                visibilityEnum: visibility,
-                visibilityLabel: visibility === ResourceVisibility.PRIVATE ? 'PRIVATE' : 'UNSPECIFIED',
-                docPath,
-              })
-            }
 
             // Bump the draft to the current latest heads before publishing. Until the
             // rebase flow lands, this is a shallow "rebase": baseVersion = latest, and
@@ -475,31 +400,12 @@ export function usePublishResource(
               genesis: editDocument?.genesis,
               generation: editDocument?.generationInfo?.generation,
             }
-            if (debugPrivatePublish) {
-              console.log(PRIVATE_DOC_DEBUG_PREFIX, 'private draft calling desktopUniversalClient.publishDocument', {
-                ...publishInput,
-                changes: {
-                  count: allChanges.length,
-                  opCases: allChanges.map((change: any) => change?.op?.case),
-                },
-              })
-            }
             await desktopUniversalClient.publishDocument!(publishInput)
 
             const updatedDoc = await grpcClient.documents.getDocument({
               account: resolvedDestinationId.uid,
               path: docPath,
             })
-            if (debugPrivatePublish) {
-              console.log(PRIVATE_DOC_DEBUG_PREFIX, 'private draft backend getDocument after publish', {
-                account: resolvedDestinationId.uid,
-                path: docPath,
-                requestedVisibilityEnum: visibility,
-                returnedVisibilityEnum: updatedDoc.visibility,
-                version: updatedDoc.version,
-                genesis: updatedDoc.genesis,
-              })
-            }
             console.log('[publish] result', {
               requestedBaseVersion: baseVersion,
               resultVersion: updatedDoc.version,
@@ -1109,12 +1015,6 @@ export function useCreateDraft(
   const selectedAccountId = useSelectedAccountId()
 
   return async ({visibility}: {visibility?: HMResourceVisibility} = {}) => {
-    if (visibility === 'PRIVATE') {
-      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'create private draft requested', {
-        draftParams,
-        selectedAccountId,
-      })
-    }
     const plan = computeNewDraftParams(
       visibility,
       draftParams,
@@ -1122,11 +1022,6 @@ export function useCreateDraft(
       () => nanoid(10),
       () => nanoid(21),
     )
-    if (visibility === 'PRIVATE') {
-      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'create private draft computed plan', {
-        plan,
-      })
-    }
     if (!plan) return
     const writeParams = {
       ...plan.writeParams,
@@ -1134,22 +1029,7 @@ export function useCreateDraft(
       content: [],
       deps: plan.writeParams.deps ?? [],
     }
-    if (writeParams.visibility === 'PRIVATE') {
-      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'create private draft write start', {
-        draftId: plan.draftId,
-        routeId: plan.routeId.id,
-        writeParams,
-      })
-    }
     await client.drafts.write.mutate(writeParams)
-    if (writeParams.visibility === 'PRIVATE') {
-      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'create private draft write success; navigating', {
-        draftId: plan.draftId,
-        routeId: plan.routeId.id,
-        routeUid: plan.routeId.uid,
-        routePath: plan.routeId.path,
-      })
-    }
     navigate({key: 'document', id: plan.routeId})
   }
 }

--- a/frontend/apps/desktop/src/models/documents.ts
+++ b/frontend/apps/desktop/src/models/documents.ts
@@ -55,6 +55,9 @@ import {useNavigate} from '../utils/useNavigate'
 import {useMyAccountIds} from './daemon'
 import {useGatewayUrl, useGatewayUrlStream} from './gateway-settings'
 import {getNavigationChanges} from './navigation'
+
+const PRIVATE_DOC_DEBUG_PREFIX = '[private-doc-debug]'
+
 /**
  * Extended draft type returned by app-drafts.ts listAccount/list endpoints.
  * These endpoints compute locationId/editId from the raw uid+path fields.
@@ -117,7 +120,7 @@ export function useCreateInlineDraft(parentId: UnpackedHypermediaId | undefined)
       // unified editor mounts at the new doc's route URL).
       const parentPath = parentId.path || []
       const draftPath = [...parentPath, `-${draftId}`]
-      await client.drafts.write.mutate({
+      const writeParams = {
         id: draftId,
         locationUid: parentId.uid,
         locationPath: parentPath,
@@ -127,7 +130,24 @@ export function useCreateInlineDraft(parentId: UnpackedHypermediaId | undefined)
         content: [],
         deps: [],
         visibility: visibility ?? 'PUBLIC',
-      })
+      }
+      if (writeParams.visibility === 'PRIVATE') {
+        console.log(PRIVATE_DOC_DEBUG_PREFIX, 'create inline private draft write start', {
+          parentId: parentId.id,
+          parentUid: parentId.uid,
+          parentPath,
+          draftId,
+          draftPath,
+          writeParams,
+        })
+      }
+      await client.drafts.write.mutate(writeParams)
+      if (writeParams.visibility === 'PRIVATE') {
+        console.log(PRIVATE_DOC_DEBUG_PREFIX, 'create inline private draft write success', {
+          draftId,
+          draftPath,
+        })
+      }
       return {draftId, draftPath}
     },
     onSuccess: () => {
@@ -235,6 +255,24 @@ export function usePublishResource(
   })
   return useMutation<HMDocument, any, PublishDraftInput>({
     mutationFn: async ({draft, destinationId, accountId, pathOverride}: PublishDraftInput): Promise<HMDocument> => {
+      const debugPrivatePublish = draft.visibility === 'PRIVATE'
+      if (debugPrivatePublish) {
+        console.log(PRIVATE_DOC_DEBUG_PREFIX, 'publish private draft mutation start', {
+          editId: editId?.id,
+          draftId: draft.id,
+          draftVisibility: draft.visibility,
+          draftLocationUid: draft.locationUid,
+          draftLocationPath: draft.locationPath,
+          draftEditUid: draft.editUid,
+          draftEditPath: draft.editPath,
+          draftDeps: draft.deps,
+          destinationId: destinationId.id,
+          destinationUid: destinationId.uid,
+          destinationPath: destinationId.path,
+          accountId,
+          pathOverride,
+        })
+      }
       const blocksMap = editId ? createBlocksMap(editDocument?.content || [], '') : {}
       let newContent = removeTrailingBlocks(draft.content || [])
 
@@ -270,9 +308,28 @@ export function usePublishResource(
                 if (latestDoc?.version) {
                   existingDocVersion = latestDoc.version
                 }
+                if (debugPrivatePublish) {
+                  console.log(PRIVATE_DOC_DEBUG_PREFIX, 'private draft destination probe result', {
+                    requestedAccount: destinationId.uid,
+                    requestedPath: hmIdPathToEntityQueryPath(destinationId.path || []),
+                    existingDocVersion,
+                    returnedVisibility: latestDoc?.visibility,
+                  })
+                }
               } catch (err) {
                 // Doc doesn't exist yet (first publish) — leave existingDoc null.
                 console.log('[publish] getDocument(latest) failed — treating as first publish', err)
+                if (debugPrivatePublish) {
+                  console.log(
+                    PRIVATE_DOC_DEBUG_PREFIX,
+                    'private draft destination probe failed; treating as first publish',
+                    {
+                      requestedAccount: destinationId.uid,
+                      requestedPath: hmIdPathToEntityQueryPath(destinationId.path || []),
+                      error: err,
+                    },
+                  )
+                }
               }
             }
 
@@ -289,6 +346,16 @@ export function usePublishResource(
             })
             const resolvedDestinationId =
               resolvedPath === destinationId.path ? destinationId : hmId(destinationId.uid, {path: resolvedPath})
+            if (debugPrivatePublish) {
+              console.log(PRIVATE_DOC_DEBUG_PREFIX, 'private draft resolved publish destination', {
+                originalDestinationId: destinationId.id,
+                originalPath: destinationId.path,
+                resolvedDestinationId: resolvedDestinationId.id,
+                resolvedPath: resolvedDestinationId.path,
+                existsAtDestination: !!existingDocVersion,
+                pathOverride,
+              })
+            }
             if (resolvedDestinationId !== destinationId) {
               console.log('[publish] resolved destination path', {
                 from: destinationId.path,
@@ -334,6 +401,16 @@ export function usePublishResource(
             }
 
             const docPath = hmIdPathToEntityQueryPath(resolvedDestinationId.path || [])
+            if (debugPrivatePublish) {
+              console.log(PRIVATE_DOC_DEBUG_PREFIX, 'private draft computed backend visibility', {
+                draftId: draft.id,
+                draftVisibility: draft.visibility,
+                draftDeps: draft.deps,
+                visibilityEnum: visibility,
+                visibilityLabel: visibility === ResourceVisibility.PRIVATE ? 'PRIVATE' : 'UNSPECIFIED',
+                docPath,
+              })
+            }
 
             // Bump the draft to the current latest heads before publishing. Until the
             // rebase flow lands, this is a shallow "rebase": baseVersion = latest, and
@@ -386,7 +463,7 @@ export function usePublishResource(
               depsChanged,
             })
 
-            await desktopUniversalClient.publishDocument!({
+            const publishInput = {
               signerAccountUid: accountId,
               account: resolvedDestinationId.uid,
               baseVersion,
@@ -397,18 +474,32 @@ export function usePublishResource(
               visibility,
               genesis: editDocument?.genesis,
               generation: editDocument?.generationInfo?.generation,
-            })
+            }
+            if (debugPrivatePublish) {
+              console.log(PRIVATE_DOC_DEBUG_PREFIX, 'private draft calling desktopUniversalClient.publishDocument', {
+                ...publishInput,
+                changes: {
+                  count: allChanges.length,
+                  opCases: allChanges.map((change: any) => change?.op?.case),
+                },
+              })
+            }
+            await desktopUniversalClient.publishDocument!(publishInput)
 
             const updatedDoc = await grpcClient.documents.getDocument({
               account: resolvedDestinationId.uid,
               path: docPath,
             })
-            // TODO(temp): remove after verifying private document visibility fix
-            console.log('[publish] getDocument visibility:', {
-              path: docPath,
-              requestedVisibility: visibility,
-              returnedVisibility: updatedDoc.visibility,
-            })
+            if (debugPrivatePublish) {
+              console.log(PRIVATE_DOC_DEBUG_PREFIX, 'private draft backend getDocument after publish', {
+                account: resolvedDestinationId.uid,
+                path: docPath,
+                requestedVisibilityEnum: visibility,
+                returnedVisibilityEnum: updatedDoc.visibility,
+                version: updatedDoc.version,
+                genesis: updatedDoc.genesis,
+              })
+            }
             console.log('[publish] result', {
               requestedBaseVersion: baseVersion,
               resultVersion: updatedDoc.version,
@@ -1018,6 +1109,12 @@ export function useCreateDraft(
   const selectedAccountId = useSelectedAccountId()
 
   return async ({visibility}: {visibility?: HMResourceVisibility} = {}) => {
+    if (visibility === 'PRIVATE') {
+      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'create private draft requested', {
+        draftParams,
+        selectedAccountId,
+      })
+    }
     const plan = computeNewDraftParams(
       visibility,
       draftParams,
@@ -1025,13 +1122,34 @@ export function useCreateDraft(
       () => nanoid(10),
       () => nanoid(21),
     )
+    if (visibility === 'PRIVATE') {
+      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'create private draft computed plan', {
+        plan,
+      })
+    }
     if (!plan) return
-    await client.drafts.write.mutate({
+    const writeParams = {
       ...plan.writeParams,
       metadata: {},
       content: [],
       deps: plan.writeParams.deps ?? [],
-    })
+    }
+    if (writeParams.visibility === 'PRIVATE') {
+      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'create private draft write start', {
+        draftId: plan.draftId,
+        routeId: plan.routeId.id,
+        writeParams,
+      })
+    }
+    await client.drafts.write.mutate(writeParams)
+    if (writeParams.visibility === 'PRIVATE') {
+      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'create private draft write success; navigating', {
+        draftId: plan.draftId,
+        routeId: plan.routeId.id,
+        routeUid: plan.routeId.uid,
+        routePath: plan.routeId.path,
+      })
+    }
     navigate({key: 'document', id: plan.routeId})
   }
 }

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -209,18 +209,6 @@ export default function DesktopResourcePage() {
         })
         const existingDraftForVisibility = input.draftId ? await client.drafts.get.query(input.draftId) : null
         const draftVisibility = existingDraftForVisibility?.visibility ?? 'PUBLIC'
-        if (draftVisibility === 'PRIVATE') {
-          console.log('[private-doc-debug]', 'writeDraft preserving private draft visibility', {
-            draftId,
-            existingVisibility: existingDraftForVisibility?.visibility,
-            locationUid: input.locationUid,
-            locationPath: input.locationPath,
-            editUid: input.editUid,
-            editPath: input.editPath,
-            deps: input.deps,
-            blocksCount: content.length,
-          })
-        }
         const result = await client.drafts.write.mutate({
           id: draftId,
           metadata: input.metadata,

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -207,6 +207,20 @@ export default function DesktopResourcePage() {
           signingAccountId: input.signingAccountId,
           hasEditor: !!editor,
         })
+        const existingDraftForVisibility = input.draftId ? await client.drafts.get.query(input.draftId) : null
+        const draftVisibility = existingDraftForVisibility?.visibility ?? 'PUBLIC'
+        if (draftVisibility === 'PRIVATE') {
+          console.log('[private-doc-debug]', 'writeDraft preserving private draft visibility', {
+            draftId,
+            existingVisibility: existingDraftForVisibility?.visibility,
+            locationUid: input.locationUid,
+            locationPath: input.locationPath,
+            editUid: input.editUid,
+            editPath: input.editPath,
+            deps: input.deps,
+            blocksCount: content.length,
+          })
+        }
         const result = await client.drafts.write.mutate({
           id: draftId,
           metadata: input.metadata,
@@ -219,7 +233,7 @@ export default function DesktopResourcePage() {
           locationPath: input.locationPath.length > 0 ? input.locationPath : undefined,
           editUid: input.editUid || undefined,
           editPath: input.editPath.length > 0 ? input.editPath : undefined,
-          visibility: 'PUBLIC',
+          visibility: draftVisibility,
           mineTouchedIds: input.mineTouchedIds.length ? input.mineTouchedIds : undefined,
           baseBlocks: input.baseBlocks ?? undefined,
         })
@@ -673,6 +687,7 @@ export default function DesktopResourcePage() {
                   CommentEditor={CommentBox}
                   extraMenuItems={menuItems}
                   existingDraft={existingDraft}
+                  existingDraftVisibility={draftQuery.data?.visibility}
                   existingDraftContent={existingDraftContent}
                   existingDraftCursorPosition={draftQuery.data?.cursorPosition}
                   existingDraftMineTouchedIds={draftQuery.data?.mineTouchedIds}

--- a/frontend/apps/desktop/src/utils/__tests__/publish-document.test.ts
+++ b/frontend/apps/desktop/src/utils/__tests__/publish-document.test.ts
@@ -80,6 +80,20 @@ describe('createDocumentChangeRequest', () => {
     expect(request.changes[0]).toBeInstanceOf(DocumentChange)
     expect(request.changes[0]?.op.case).toBe('setMetadata')
   })
+
+  it('preserves explicit visibility for first-publish daemon createDocumentChange', () => {
+    const request = createDocumentChangeRequest({
+      signerAccountUid: 'alice',
+      account: 'alice',
+      path: '/foo',
+      capability: 'bafy-cap',
+      visibility: ResourceVisibility.PRIVATE,
+      changes: [{op: {case: 'setMetadata', value: {key: 'name', value: 'Foo'}}}],
+    })
+
+    expect(request.baseVersion).toBe('')
+    expect(request.visibility).toBe(ResourceVisibility.PRIVATE)
+  })
 })
 
 describe('publishDesktopDocument', () => {

--- a/frontend/apps/desktop/src/utils/__tests__/publish-utils.test.ts
+++ b/frontend/apps/desktop/src/utils/__tests__/publish-utils.test.ts
@@ -255,7 +255,7 @@ describe('resolvePublishPath', () => {
     ).toEqual(['parent', 'foo-bar'])
   })
 
-  it('honours pathOverride even for private drafts', () => {
+  it('ignores pathOverride for private drafts', () => {
     expect(
       resolvePublishPath({
         ...baseArgs,
@@ -263,7 +263,7 @@ describe('resolvePublishPath', () => {
         isPrivate: true,
         pathOverride: ['public', 'slug'],
       }),
-    ).toEqual(['public', 'slug'])
+    ).toEqual(['-randomid'])
   })
 
   it('skips the rename for private drafts', () => {

--- a/frontend/apps/desktop/src/utils/publish-document.ts
+++ b/frontend/apps/desktop/src/utils/publish-document.ts
@@ -2,8 +2,6 @@ import type {HMSigner, SeedClient} from '@seed-hypermedia/client'
 import {DocumentChange, ResourceVisibility} from '@shm/shared/client/.generated/documents/v3alpha/documents_pb'
 import type {PublishDocumentInput} from '@shm/shared/universal-client'
 
-const PRIVATE_DOC_DEBUG_PREFIX = '[private-doc-debug]'
-
 type CreateDocumentChangeRequest = {
   signingKeyName: string
   account: string
@@ -41,27 +39,6 @@ export function createDocumentChangeRequest(input: PublishDocumentInput): Create
     capability: input.capability ?? '',
     visibility: input.baseVersion ? ResourceVisibility.UNSPECIFIED : input.visibility ?? ResourceVisibility.UNSPECIFIED,
   }
-  if (input.visibility === ResourceVisibility.PRIVATE || request.visibility === ResourceVisibility.PRIVATE) {
-    console.log(PRIVATE_DOC_DEBUG_PREFIX, 'daemon createDocumentChange request normalized', {
-      input: {
-        signerAccountUid: input.signerAccountUid,
-        account: input.account,
-        path: input.path,
-        baseVersion: input.baseVersion,
-        genesis: input.genesis,
-        visibility: input.visibility,
-        capability: input.capability,
-        changeCount: input.changes.length,
-      },
-      request: {
-        ...request,
-        changes: {
-          count: request.changes.length,
-          opCases: request.changes.map((change) => change.op.case),
-        },
-      },
-    })
-  }
   return request
 }
 
@@ -71,58 +48,12 @@ export async function publishDesktopDocument(
   input: PublishDocumentInput,
 ): Promise<void> {
   const useDaemon = shouldUseDaemonCreateDocumentChange(input)
-  if (input.visibility === ResourceVisibility.PRIVATE) {
-    console.log(PRIVATE_DOC_DEBUG_PREFIX, 'desktop publishDocument routing decision', {
-      signerAccountUid: input.signerAccountUid,
-      account: input.account,
-      path: input.path,
-      baseVersion: input.baseVersion,
-      genesis: input.genesis,
-      generation: input.generation,
-      visibility: input.visibility,
-      capability: input.capability,
-      changeCount: input.changes.length,
-      useDaemon,
-    })
-  }
   if (useDaemon) {
     const request = createDocumentChangeRequest(input)
-    if (input.visibility === ResourceVisibility.PRIVATE || request.visibility === ResourceVisibility.PRIVATE) {
-      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'desktop sending daemon createDocumentChange', {
-        ...request,
-        changes: {
-          count: request.changes.length,
-          opCases: request.changes.map((change) => change.op.case),
-        },
-      })
-    }
     await deps.createDocumentChange(request)
-    if (input.visibility === ResourceVisibility.PRIVATE || request.visibility === ResourceVisibility.PRIVATE) {
-      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'desktop daemon createDocumentChange success', {
-        account: request.account,
-        path: request.path,
-        visibility: request.visibility,
-      })
-    }
     return
   }
 
   const {signerAccountUid, ...publishInput} = input
-  if (input.visibility === ResourceVisibility.PRIVATE) {
-    console.log(PRIVATE_DOC_DEBUG_PREFIX, 'desktop sending seedClient.publishDocument', {
-      ...publishInput,
-      changes: {
-        count: publishInput.changes.length,
-        opCases: publishInput.changes.map((change: any) => change?.op?.case),
-      },
-    })
-  }
   await deps.publishDocument(publishInput, deps.getSigner(signerAccountUid))
-  if (input.visibility === ResourceVisibility.PRIVATE) {
-    console.log(PRIVATE_DOC_DEBUG_PREFIX, 'desktop seedClient.publishDocument success', {
-      account: publishInput.account,
-      path: publishInput.path,
-      visibility: publishInput.visibility,
-    })
-  }
 }

--- a/frontend/apps/desktop/src/utils/publish-document.ts
+++ b/frontend/apps/desktop/src/utils/publish-document.ts
@@ -2,6 +2,8 @@ import type {HMSigner, SeedClient} from '@seed-hypermedia/client'
 import {DocumentChange, ResourceVisibility} from '@shm/shared/client/.generated/documents/v3alpha/documents_pb'
 import type {PublishDocumentInput} from '@shm/shared/universal-client'
 
+const PRIVATE_DOC_DEBUG_PREFIX = '[private-doc-debug]'
+
 type CreateDocumentChangeRequest = {
   signingKeyName: string
   account: string
@@ -28,7 +30,7 @@ export function shouldUseDaemonCreateDocumentChange(input: PublishDocumentInput)
 
 /** Normalizes document publish input into a daemon create-document-change request. */
 export function createDocumentChangeRequest(input: PublishDocumentInput): CreateDocumentChangeRequest {
-  return {
+  const request = {
     signingKeyName: input.signerAccountUid,
     account: input.account,
     path: input.path ?? '',
@@ -37,8 +39,30 @@ export function createDocumentChangeRequest(input: PublishDocumentInput): Create
       (change) => new DocumentChange(change as ConstructorParameters<typeof DocumentChange>[0]),
     ),
     capability: input.capability ?? '',
-    visibility: ResourceVisibility.UNSPECIFIED,
+    visibility: input.baseVersion ? ResourceVisibility.UNSPECIFIED : input.visibility ?? ResourceVisibility.UNSPECIFIED,
   }
+  if (input.visibility === ResourceVisibility.PRIVATE || request.visibility === ResourceVisibility.PRIVATE) {
+    console.log(PRIVATE_DOC_DEBUG_PREFIX, 'daemon createDocumentChange request normalized', {
+      input: {
+        signerAccountUid: input.signerAccountUid,
+        account: input.account,
+        path: input.path,
+        baseVersion: input.baseVersion,
+        genesis: input.genesis,
+        visibility: input.visibility,
+        capability: input.capability,
+        changeCount: input.changes.length,
+      },
+      request: {
+        ...request,
+        changes: {
+          count: request.changes.length,
+          opCases: request.changes.map((change) => change.op.case),
+        },
+      },
+    })
+  }
+  return request
 }
 
 /** Publishes a desktop document through the daemon or the generic client publish path. */
@@ -46,11 +70,59 @@ export async function publishDesktopDocument(
   deps: PublishDesktopDocumentDeps,
   input: PublishDocumentInput,
 ): Promise<void> {
-  if (shouldUseDaemonCreateDocumentChange(input)) {
-    await deps.createDocumentChange(createDocumentChangeRequest(input))
+  const useDaemon = shouldUseDaemonCreateDocumentChange(input)
+  if (input.visibility === ResourceVisibility.PRIVATE) {
+    console.log(PRIVATE_DOC_DEBUG_PREFIX, 'desktop publishDocument routing decision', {
+      signerAccountUid: input.signerAccountUid,
+      account: input.account,
+      path: input.path,
+      baseVersion: input.baseVersion,
+      genesis: input.genesis,
+      generation: input.generation,
+      visibility: input.visibility,
+      capability: input.capability,
+      changeCount: input.changes.length,
+      useDaemon,
+    })
+  }
+  if (useDaemon) {
+    const request = createDocumentChangeRequest(input)
+    if (input.visibility === ResourceVisibility.PRIVATE || request.visibility === ResourceVisibility.PRIVATE) {
+      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'desktop sending daemon createDocumentChange', {
+        ...request,
+        changes: {
+          count: request.changes.length,
+          opCases: request.changes.map((change) => change.op.case),
+        },
+      })
+    }
+    await deps.createDocumentChange(request)
+    if (input.visibility === ResourceVisibility.PRIVATE || request.visibility === ResourceVisibility.PRIVATE) {
+      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'desktop daemon createDocumentChange success', {
+        account: request.account,
+        path: request.path,
+        visibility: request.visibility,
+      })
+    }
     return
   }
 
   const {signerAccountUid, ...publishInput} = input
+  if (input.visibility === ResourceVisibility.PRIVATE) {
+    console.log(PRIVATE_DOC_DEBUG_PREFIX, 'desktop sending seedClient.publishDocument', {
+      ...publishInput,
+      changes: {
+        count: publishInput.changes.length,
+        opCases: publishInput.changes.map((change: any) => change?.op?.case),
+      },
+    })
+  }
   await deps.publishDocument(publishInput, deps.getSigner(signerAccountUid))
+  if (input.visibility === ResourceVisibility.PRIVATE) {
+    console.log(PRIVATE_DOC_DEBUG_PREFIX, 'desktop seedClient.publishDocument success', {
+      account: publishInput.account,
+      path: publishInput.path,
+      visibility: publishInput.visibility,
+    })
+  }
 }

--- a/frontend/apps/desktop/src/utils/publish-utils.ts
+++ b/frontend/apps/desktop/src/utils/publish-utils.ts
@@ -58,14 +58,15 @@ export function shouldAutoLinkParent(
 /**
  * Resolve the path used for a publish, given the current destination path and
  * the draft. Precedence:
- *   1. `pathOverride` from the publish popover (user picked it).
- *   2. Inline first-publish: `currentPath` still ends with `-${draftId}` AND
+ *   1. Private docs keep `currentPath` unchanged, ignoring any user-supplied
+ *      override because their random paths are intentional.
+ *   2. `pathOverride` from the publish popover (user picked it).
+ *   3. Inline first-publish: `currentPath` still ends with `-${draftId}` AND
  *      no doc exists at that path → swap the placeholder for the title slug
  *      via `computeInlineDraftPublishPath`.
- *   3. Otherwise return `currentPath` unchanged.
+ *   4. Otherwise return `currentPath` unchanged.
  *
  * Skipped (returns `currentPath` unchanged):
- *   - private docs (random-id paths are intentional),
  *   - home-doc edits (empty path),
  *   - re-publishes (the doc exists at this path).
  */
@@ -78,9 +79,9 @@ export function resolvePublishPath(args: {
   pathOverride?: string[]
 }): string[] {
   const {currentPath, draftId, draftName, isPrivate, existsAtDestination, pathOverride} = args
+  if (isPrivate) return currentPath
   if (pathOverride) return pathOverride
   if (existsAtDestination) return currentPath
-  if (isPrivate) return currentPath
   if (currentPath.length === 0) return currentPath
   const lastSeg = currentPath.at(-1) || ''
   if (lastSeg !== `-${draftId}`) return currentPath

--- a/frontend/packages/client/src/client.ts
+++ b/frontend/packages/client/src/client.ts
@@ -19,9 +19,6 @@ import {createVersionRef} from './ref'
  * Reserved query param key for non-object inputs (string, number, boolean).
  */
 const PRIMITIVE_VALUE_KEY = '__value'
-const PRIVATE_DOC_DEBUG_PREFIX = '[private-doc-debug]'
-const RESOURCE_VISIBILITY_PRIVATE = 2
-
 /**
  * Serializes data to a URL query string with proper type handling.
  * Non-object inputs (string, number, boolean) are stored under a __value key.
@@ -242,29 +239,9 @@ export function createSeedClient(baseUrl: string, options?: SeedClientOptions): 
   }
 
   async function publishDocument(input: PublishDocumentInput, signer: HMSigner): Promise<void> {
-    const debugPrivatePublish = input.visibility === RESOURCE_VISIBILITY_PRIVATE
-    if (debugPrivatePublish) {
-      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'seed client publishDocument start', {
-        account: input.account,
-        path: input.path,
-        baseVersion: input.baseVersion,
-        genesis: input.genesis,
-        generation: input.generation,
-        visibility: input.visibility,
-        capability: input.capability,
-        changeCount: input.changes.length,
-      })
-    }
     // Bootstrap brand-new home documents client-side. Other new documents go
     // through PrepareDocumentChange so the server can prepare richer ops.
     if (!input.genesis && !input.baseVersion && !input.path) {
-      if (debugPrivatePublish) {
-        console.log(PRIVATE_DOC_DEBUG_PREFIX, 'seed client using home-document bootstrap path', {
-          account: input.account,
-          path: input.path,
-          visibility: input.visibility,
-        })
-      }
       const genesisChange = await createGenesisChange(signer)
       const contentChange = await createDocumentChange(
         {
@@ -306,24 +283,10 @@ export function createSeedClient(baseUrl: string, options?: SeedClientOptions): 
       capability: input.capability,
       visibility: input.visibility,
     }
-    if (debugPrivatePublish) {
-      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'seed client sending PrepareDocumentChange request', {
-        ...prepareInput,
-        changes: {
-          count: prepareInput.changes.length,
-          opCases: prepareInput.changes.map((change: any) => change?.op?.case),
-        },
-      })
-    }
     const {unsignedChange} = (await request('PrepareDocumentChange', prepareInput)) as Extract<
       HMRequest,
       {key: 'PrepareDocumentChange'}
     >['output']
-    if (debugPrivatePublish) {
-      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'seed client PrepareDocumentChange response', {
-        unsignedChangeBytes: unsignedChange?.length,
-      })
-    }
     const {publishInput} = await signDocumentChange(
       {
         account: input.account,
@@ -336,18 +299,7 @@ export function createSeedClient(baseUrl: string, options?: SeedClientOptions): 
       },
       signer,
     )
-    if (debugPrivatePublish) {
-      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'seed client signed private document change', {
-        blobCount: publishInput.blobs.length,
-        blobCids: publishInput.blobs.map((blob) => blob.cid),
-      })
-    }
     await publish(publishInput)
-    if (debugPrivatePublish) {
-      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'seed client PublishBlobs success', {
-        blobCount: publishInput.blobs.length,
-      })
-    }
   }
 
   return {

--- a/frontend/packages/client/src/client.ts
+++ b/frontend/packages/client/src/client.ts
@@ -19,6 +19,8 @@ import {createVersionRef} from './ref'
  * Reserved query param key for non-object inputs (string, number, boolean).
  */
 const PRIMITIVE_VALUE_KEY = '__value'
+const PRIVATE_DOC_DEBUG_PREFIX = '[private-doc-debug]'
+const RESOURCE_VISIBILITY_PRIVATE = 2
 
 /**
  * Serializes data to a URL query string with proper type handling.
@@ -240,9 +242,29 @@ export function createSeedClient(baseUrl: string, options?: SeedClientOptions): 
   }
 
   async function publishDocument(input: PublishDocumentInput, signer: HMSigner): Promise<void> {
+    const debugPrivatePublish = input.visibility === RESOURCE_VISIBILITY_PRIVATE
+    if (debugPrivatePublish) {
+      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'seed client publishDocument start', {
+        account: input.account,
+        path: input.path,
+        baseVersion: input.baseVersion,
+        genesis: input.genesis,
+        generation: input.generation,
+        visibility: input.visibility,
+        capability: input.capability,
+        changeCount: input.changes.length,
+      })
+    }
     // Bootstrap brand-new home documents client-side. Other new documents go
     // through PrepareDocumentChange so the server can prepare richer ops.
     if (!input.genesis && !input.baseVersion && !input.path) {
+      if (debugPrivatePublish) {
+        console.log(PRIVATE_DOC_DEBUG_PREFIX, 'seed client using home-document bootstrap path', {
+          account: input.account,
+          path: input.path,
+          visibility: input.visibility,
+        })
+      }
       const genesisChange = await createGenesisChange(signer)
       const contentChange = await createDocumentChange(
         {
@@ -276,14 +298,32 @@ export function createSeedClient(baseUrl: string, options?: SeedClientOptions): 
 
     // Use PrepareDocumentChange for both new and existing documents so the server
     // can prepare all supported ops.
-    const {unsignedChange} = (await request('PrepareDocumentChange', {
+    const prepareInput = {
       account: input.account,
       path: input.path,
       baseVersion: input.baseVersion,
       changes: input.changes,
       capability: input.capability,
       visibility: input.visibility,
-    })) as Extract<HMRequest, {key: 'PrepareDocumentChange'}>['output']
+    }
+    if (debugPrivatePublish) {
+      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'seed client sending PrepareDocumentChange request', {
+        ...prepareInput,
+        changes: {
+          count: prepareInput.changes.length,
+          opCases: prepareInput.changes.map((change: any) => change?.op?.case),
+        },
+      })
+    }
+    const {unsignedChange} = (await request('PrepareDocumentChange', prepareInput)) as Extract<
+      HMRequest,
+      {key: 'PrepareDocumentChange'}
+    >['output']
+    if (debugPrivatePublish) {
+      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'seed client PrepareDocumentChange response', {
+        unsignedChangeBytes: unsignedChange?.length,
+      })
+    }
     const {publishInput} = await signDocumentChange(
       {
         account: input.account,
@@ -296,7 +336,18 @@ export function createSeedClient(baseUrl: string, options?: SeedClientOptions): 
       },
       signer,
     )
+    if (debugPrivatePublish) {
+      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'seed client signed private document change', {
+        blobCount: publishInput.blobs.length,
+        blobCids: publishInput.blobs.map((blob) => blob.cid),
+      })
+    }
     await publish(publishInput)
+    if (debugPrivatePublish) {
+      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'seed client PublishBlobs success', {
+        blobCount: publishInput.blobs.length,
+      })
+    }
   }
 
   return {

--- a/frontend/packages/shared/src/api-prepare-document-change.ts
+++ b/frontend/packages/shared/src/api-prepare-document-change.ts
@@ -2,16 +2,38 @@ import {DocumentChange} from './client/.generated/documents/v3alpha/documents_pb
 import {HMRequestImplementation} from './api-types'
 import {HMPrepareDocumentChangeRequest} from '@seed-hypermedia/client/hm-types'
 
+const PRIVATE_DOC_DEBUG_PREFIX = '[private-doc-debug]'
+const RESOURCE_VISIBILITY_PRIVATE = 2
+
 export const PrepareDocumentChange: HMRequestImplementation<HMPrepareDocumentChangeRequest> = {
   async getData(grpcClient, input) {
-    const result = await grpcClient.documents.prepareChange({
+    const request = {
       account: input.account,
       path: input.path ?? '',
       baseVersion: input.baseVersion ?? '',
       capability: input.capability ?? '',
       visibility: input.visibility ?? 0,
       changes: input.changes.map((c) => new DocumentChange(c as ConstructorParameters<typeof DocumentChange>[0])),
-    })
+    }
+    if (request.visibility === RESOURCE_VISIBILITY_PRIVATE) {
+      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'app api sending grpc documents.prepareChange', {
+        ...request,
+        changes: {
+          count: request.changes.length,
+          opCases: request.changes.map((change) => change.op.case),
+        },
+      })
+    }
+    const result = await grpcClient.documents.prepareChange(request)
+    if (request.visibility === RESOURCE_VISIBILITY_PRIVATE) {
+      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'app api grpc documents.prepareChange success', {
+        account: request.account,
+        path: request.path,
+        baseVersion: request.baseVersion,
+        visibility: request.visibility,
+        unsignedChangeBytes: result.unsignedChange?.length,
+      })
+    }
     return {unsignedChange: result.unsignedChange}
   },
 }

--- a/frontend/packages/shared/src/api-prepare-document-change.ts
+++ b/frontend/packages/shared/src/api-prepare-document-change.ts
@@ -2,9 +2,6 @@ import {DocumentChange} from './client/.generated/documents/v3alpha/documents_pb
 import {HMRequestImplementation} from './api-types'
 import {HMPrepareDocumentChangeRequest} from '@seed-hypermedia/client/hm-types'
 
-const PRIVATE_DOC_DEBUG_PREFIX = '[private-doc-debug]'
-const RESOURCE_VISIBILITY_PRIVATE = 2
-
 export const PrepareDocumentChange: HMRequestImplementation<HMPrepareDocumentChangeRequest> = {
   async getData(grpcClient, input) {
     const request = {
@@ -15,25 +12,7 @@ export const PrepareDocumentChange: HMRequestImplementation<HMPrepareDocumentCha
       visibility: input.visibility ?? 0,
       changes: input.changes.map((c) => new DocumentChange(c as ConstructorParameters<typeof DocumentChange>[0])),
     }
-    if (request.visibility === RESOURCE_VISIBILITY_PRIVATE) {
-      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'app api sending grpc documents.prepareChange', {
-        ...request,
-        changes: {
-          count: request.changes.length,
-          opCases: request.changes.map((change) => change.op.case),
-        },
-      })
-    }
     const result = await grpcClient.documents.prepareChange(request)
-    if (request.visibility === RESOURCE_VISIBILITY_PRIVATE) {
-      console.log(PRIVATE_DOC_DEBUG_PREFIX, 'app api grpc documents.prepareChange success', {
-        account: request.account,
-        path: request.path,
-        baseVersion: request.baseVersion,
-        visibility: request.visibility,
-        unsignedChangeBytes: result.unsignedChange?.length,
-      })
-    }
     return {unsignedChange: result.unsignedChange}
   },
 }

--- a/frontend/packages/ui/src/editing-toolbar.tsx
+++ b/frontend/packages/ui/src/editing-toolbar.tsx
@@ -101,6 +101,7 @@ export function PublishPopoverBody({
 
   const isHomeDoc = (docId.path?.length ?? 0) === 0
   const isFirstPublish = !publishedDoc?.version && !isHomeDoc
+  const isPrivate = publishedDoc?.visibility === 'PRIVATE'
   const lastSeg = docId.path?.at(-1) || ''
   const isPlaceholderPath = !!draftId && lastSeg === `-${draftId}`
 
@@ -180,7 +181,9 @@ export function PublishPopoverBody({
             <p className="text-muted-foreground text-xs">Edit your permalink</p>
             <Input
               value={`/${effectivePathSegment}`}
+              disabled={isPrivate}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                if (isPrivate) return
                 userEditedRef.current = true
                 const raw = e.target.value.replace(/^\//, '')
                 setEditedPathSegment(slugify(raw))
@@ -194,6 +197,9 @@ export function PublishPopoverBody({
               placeholder="/document-path"
               className="h-8 border-black/10 text-xs dark:border-white/20"
             />
+            {isPrivate ? (
+              <p className="text-muted-foreground text-xs">Private document paths are generated automatically.</p>
+            ) : null}
           </div>
         )}
       </div>
@@ -264,13 +270,15 @@ export function PublishPopoverBody({
           variant="brand"
           disabled={publishDisabled}
           onClick={() => {
-            const override = isFirstPublish && userEditedRef.current && previewPath ? previewPath : undefined
+            const override =
+              isFirstPublish && !isPrivate && userEditedRef.current && previewPath ? previewPath : undefined
             console.log('[Publish] popover Publish button clicked', {
               docId: docId.id,
               draftId,
               changeCount,
               publishDisabled,
               isFirstPublish,
+              isPrivate,
               override,
             })
             onPublish(override)

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -247,6 +247,8 @@ export interface ResourcePageProps {
   extraMenuItems?: MenuItemType[]
   /** Existing draft info for showing draft indicator in toolbar */
   existingDraft?: HMExistingDraft | false
+  /** Visibility of the existing draft, when the platform can provide full draft data. */
+  existingDraftVisibility?: HMDocument['visibility']
   /** Pre-fetched content blocks from the existing draft (when available, used as editor initial content) */
   existingDraftContent?: HMBlockNode[]
   /** Cursor position saved in the draft file; used to restore cursor on reload. */
@@ -330,6 +332,7 @@ export function ResourcePage({
   CommentEditor,
   extraMenuItems,
   existingDraft,
+  existingDraftVisibility,
   existingDraftContent,
   existingDraftCursorPosition,
   existingDraftMineTouchedIds,
@@ -560,6 +563,7 @@ export function ResourcePage({
       path: `/${(docId.path ?? []).join('/')}`,
       content: [],
       metadata: existingDraft && existingDraft.metadata ? existingDraft.metadata : {},
+      visibility: existingDraftVisibility,
       version: '',
       authors: [],
       createTime: undefined as any,
@@ -611,6 +615,7 @@ export function ResourcePage({
           CommentEditor={CommentEditor}
           extraMenuItems={extraMenuItems}
           existingDraft={existingDraft}
+          existingDraftVisibility={existingDraftVisibility}
           existingDraftContent={existingDraftContent}
           existingDraftCursorPosition={existingDraftCursorPosition}
           existingDraftMineTouchedIds={existingDraftMineTouchedIds}
@@ -783,6 +788,7 @@ function DocumentBody({
   CommentEditor,
   extraMenuItems,
   existingDraft,
+  existingDraftVisibility,
   existingDraftContent,
   existingDraftCursorPosition,
   existingDraftMineTouchedIds,
@@ -814,6 +820,7 @@ function DocumentBody({
   CommentEditor?: React.ComponentType<CommentEditorProps>
   extraMenuItems?: MenuItemType[]
   existingDraft?: HMExistingDraft | false
+  existingDraftVisibility?: HMDocument['visibility']
   existingDraftContent?: HMBlockNode[]
   existingDraftCursorPosition?: number
   existingDraftMineTouchedIds?: string[]
@@ -999,6 +1006,9 @@ function DocumentBody({
   }, []) // only on mount
 
   const isHomeDoc = !docId.path?.length
+  const draftVisibility = existingDraft ? existingDraftVisibility : undefined
+  const headerVisibility =
+    document.visibility === 'PRIVATE' || draftVisibility === 'PRIVATE' ? 'PRIVATE' : document.visibility
   const siteId = useMemo(() => hmId(docId.uid), [docId.uid])
   const siteMembers = useSiteMembers(siteId)
   // const directory = useDirectory(docId)
@@ -1373,7 +1383,7 @@ function DocumentBody({
                   authors={authorPayloads}
                   updateTime={document.updateTime}
                   breadcrumbs={breadcrumbs}
-                  visibility={document.visibility}
+                  visibility={headerVisibility}
                   version={document.version}
                 />
               ) : (
@@ -1383,7 +1393,7 @@ function DocumentBody({
                   authors={authorPayloads}
                   updateTime={document.updateTime}
                   breadcrumbs={breadcrumbs}
-                  visibility={document.visibility}
+                  visibility={headerVisibility}
                   version={document.version}
                 />
               ))}
@@ -1430,7 +1440,7 @@ function DocumentBody({
                 authors={authorPayloads}
                 updateTime={document.updateTime}
                 breadcrumbs={breadcrumbs}
-                visibility={document.visibility}
+                visibility={headerVisibility}
                 version={document.version}
               />
             ) : (
@@ -1440,7 +1450,7 @@ function DocumentBody({
                 authors={authorPayloads}
                 updateTime={document.updateTime}
                 breadcrumbs={breadcrumbs}
-                visibility={document.visibility}
+                visibility={headerVisibility}
                 version={document.version}
               />
             ))}

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -1856,7 +1856,6 @@ function OldVersionEditDialog() {
     <AlertDialog
       open={isConfirming}
       onOpenChange={(open) => {
-        const currentState = actorRef.getSnapshot().value
         // Only send edit.cancel when the dialog closes while we're still
         // waiting for confirmation (overlay click / Escape). Clicking "Edit
         // Anyway" sends edit.confirm first, transitioning out of


### PR DESCRIPTION
## Summary

- Add `[private-doc-debug]` prefixed logging throughout the private document publish flow (frontend + backend) to trace visibility propagation issues
- Fix `resolvePublishPath` to ignore `pathOverride` for private docs — random-id paths are intentional and must not be overridden by user input
- Fix `writeDraft` in `desktop-resource.tsx` to preserve existing draft visibility instead of hardcoding `PUBLIC`
- Fix `createDocumentChangeRequest` to pass explicit visibility on first publish (no `baseVersion`) instead of always sending `UNSPECIFIED`
- Disable permalink editing in publish popover for private docs; show explanatory message
- Pass `existingDraftVisibility` down through `ResourcePage` → `DocumentBody` so the document header shows the private lock icon while editing an unpublished private draft
- Add test coverage: permalink disabled for private first-publish, `pathOverride` ignored for private drafts, explicit visibility preserved in daemon `createDocumentChange`
