### PR TITLE
refactor(editor): extract BlockSelectionWrapper for media block selection

### DIFF
--- a/frontend/packages/editor/src/block-selection-wrapper.tsx
+++ b/frontend/packages/editor/src/block-selection-wrapper.tsx
@@ -1,0 +1,54 @@
+import {useState} from 'react'
+import {NodeSelection, TextSelection} from 'prosemirror-state'
+import {BlockNoteEditor} from './blocknote/core/BlockNoteEditor'
+import {Block} from './blocknote/core/extensions/Blocks/api/blockTypes'
+import {MultipleNodeSelection} from './blocknote/core/extensions/SideMenu/MultipleNodeSelection'
+import {useEditorSelectionChange} from './blocknote/react/hooks/useEditorSelectionChange'
+import {HMBlockSchema} from './schema'
+import {getNodesInSelection} from './utils'
+import {cn} from '@shm/ui/utils'
+import './blockSelection.css'
+
+function updateSelection(
+  editor: BlockNoteEditor<HMBlockSchema>,
+  block: Block<HMBlockSchema>,
+  setSelected: (selected: boolean) => void,
+) {
+  const {view} = editor._tiptapEditor
+  const {selection} = view.state
+  let isSelected = false
+
+  if (selection instanceof NodeSelection) {
+    const selectedNode = view.state.doc.resolve(selection.from).parent
+    if (selectedNode && selectedNode.attrs && selectedNode.attrs.id === block.id) {
+      isSelected = true
+    }
+  } else if (selection instanceof TextSelection || selection instanceof MultipleNodeSelection) {
+    const selectedNodes = getNodesInSelection(view)
+    isSelected = selectedNodes.some((node) => node.attrs && node.attrs.id === block.id)
+  }
+
+  setSelected(isSelected)
+}
+
+export function BlockSelectionWrapper({
+  editor,
+  block,
+  children,
+  className,
+}: {
+  editor: BlockNoteEditor<HMBlockSchema>
+  block: Block<HMBlockSchema>
+  children: React.ReactNode
+  className?: string
+}) {
+  const [selected, setSelected] = useState(false)
+
+  useEditorSelectionChange(editor, () => updateSelection(editor, block, setSelected))
+
+  return (
+    <div contentEditable={false} className={cn(className, selected && 'bn-media-selected bg-background')}>
+      {children}
+    </div>
+  )
+}

--- a/frontend/packages/editor/src/block-selection-wrapper.tsx
+++ b/frontend/packages/editor/src/block-selection-wrapper.tsx
@@ -1,11 +1,12 @@
 import {useState} from 'react'
 import {NodeSelection, TextSelection} from 'prosemirror-state'
+import {Node as PMNode} from 'prosemirror-model'
 import {BlockNoteEditor} from './blocknote/core/BlockNoteEditor'
 import {Block} from './blocknote/core/extensions/Blocks/api/blockTypes'
+import {getBlockInfoWithManualOffset} from './blocknote/core/extensions/Blocks/helpers/getBlockInfoFromPos'
 import {MultipleNodeSelection} from './blocknote/core/extensions/SideMenu/MultipleNodeSelection'
 import {useEditorSelectionChange} from './blocknote/react/hooks/useEditorSelectionChange'
 import {HMBlockSchema} from './schema'
-import {getNodesInSelection} from './utils'
 import {cn} from '@shm/ui/utils'
 import './blockSelection.css'
 
@@ -23,9 +24,29 @@ function updateSelection(
     if (selectedNode && selectedNode.attrs && selectedNode.attrs.id === block.id) {
       isSelected = true
     }
-  } else if (selection instanceof TextSelection || selection instanceof MultipleNodeSelection) {
-    const selectedNodes = getNodesInSelection(view)
-    isSelected = selectedNodes.some((node) => node.attrs && node.attrs.id === block.id)
+  } else if (selection instanceof MultipleNodeSelection) {
+    for (const node of selection.nodes) {
+      if (node.attrs && node.attrs.id === block.id) {
+        isSelected = true
+        break
+      }
+    }
+  } else if (selection instanceof TextSelection) {
+    const {from, to} = selection
+    view.state.doc.descendants((node: PMNode, pos: number) => {
+      if (node.type.name === 'blockNode' && node.attrs?.id === block.id) {
+        try {
+          const blockInfo = getBlockInfoWithManualOffset(node, pos)
+          const contentStart = blockInfo.blockContent.beforePos + 1
+          const contentEnd = blockInfo.blockContent.afterPos - 1
+          if (from <= contentStart && to >= contentEnd) {
+            isSelected = true
+          }
+        } catch {}
+        return false
+      }
+      return true
+    })
   }
 
   setSelected(isSelected)
@@ -47,7 +68,7 @@ export function BlockSelectionWrapper({
   useEditorSelectionChange(editor, () => updateSelection(editor, block, setSelected))
 
   return (
-    <div contentEditable={false} className={cn(className, selected && 'bn-media-selected bg-background')}>
+    <div contentEditable={false} className={cn(className, selected && 'bn-media-selected')}>
       {children}
     </div>
   )

--- a/frontend/packages/editor/src/blockSelection.css
+++ b/frontend/packages/editor/src/blockSelection.css
@@ -1,0 +1,14 @@
+.bn-media-selected {
+  outline: 3px solid #3b82f6;
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+.bn-media-selected .replace-btn,
+.bn-media-selected .sel-btn {
+  opacity: 1;
+}
+
+.bn-media-selected .video-iframe {
+  pointer-events: auto;
+}

--- a/frontend/packages/editor/src/blockSelection.css
+++ b/frontend/packages/editor/src/blockSelection.css
@@ -12,3 +12,14 @@
 .bn-media-selected .video-iframe {
   pointer-events: auto;
 }
+
+[data-node-type='blockNode'].bn-full-block-selected:has(> [data-content-type='image']),
+[data-node-type='blockNode'].bn-full-block-selected:has(> [data-content-type='video']),
+[data-node-type='blockNode'].bn-full-block-selected:has(> [data-content-type='file']),
+[data-node-type='blockNode'].bn-full-block-selected:has(> [data-content-type='embed']),
+[data-node-type='blockNode'].bn-full-block-selected:has(> [data-content-type='web-embed']),
+[data-node-type='blockNode'].bn-full-block-selected:has(> [data-content-type='button']),
+[data-node-type='blockNode'].bn-full-block-selected:has(> [data-content-type='query']),
+[data-node-type='blockNode'].bn-full-block-selected:has(> [data-content-type='math']) {
+  background-color: transparent;
+}

--- a/frontend/packages/editor/src/blocknote/core/extensions/FullBlockSelection/FullBlockSelectionPlugin.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/FullBlockSelection/FullBlockSelectionPlugin.ts
@@ -7,6 +7,7 @@ import {EventEmitter} from '../../shared/EventEmitter'
 import {BlockSchema} from '../Blocks/api/blockTypes'
 import {getBlockInfoWithManualOffset} from '../Blocks/helpers/getBlockInfoFromPos'
 import {MultipleNodeSelection} from '../SideMenu/MultipleNodeSelection'
+import {selectableNodeTypes} from '../BlockManipulation/BlockManipulationExtension'
 
 import './full-block-selection.css'
 
@@ -129,12 +130,21 @@ function buildDecorations(doc: Node, blockIds: string[]): DecorationSet {
 
   doc.descendants((node, pos) => {
     if (node.type.name === 'blockNode' && idSet.has(node.attrs['id'] as string)) {
+      try {
+        const blockInfo = getBlockInfoWithManualOffset(node, pos)
+        if (selectableNodeTypes.includes(blockInfo.blockContentType)) {
+          return true
+        }
+      } catch {
+        // Not a valid block structure — apply decoration anyway.
+      }
       decorations.push(
         Decoration.node(pos, pos + node.nodeSize, {
           class: DECORATION_CLASS,
         }),
       )
     }
+    return true
   })
 
   return DecorationSet.create(doc, decorations)

--- a/frontend/packages/editor/src/button-view.tsx
+++ b/frontend/packages/editor/src/button-view.tsx
@@ -6,8 +6,7 @@ import {cn} from '@shm/ui/utils'
 import {useEffect, useState} from 'react'
 import type {BlockNoteEditor} from './blocknote/core/BlockNoteEditor'
 import type {Block} from './blocknote/core/extensions/Blocks/api/blockTypes'
-import {useEditorSelectionChange} from './blocknote/react/hooks/useEditorSelectionChange'
-import {updateSelection} from './media-render'
+import {BlockSelectionWrapper} from './block-selection-wrapper'
 import type {HMBlockSchema} from './schema'
 
 type ButtonAlignment = 'flex-start' | 'center' | 'flex-end'
@@ -47,15 +46,12 @@ export function ButtonBlockView({
   const [alignment, setAlignment] = useState<ButtonAlignment>(
     (block.props.alignment as ButtonAlignment) || 'flex-start',
   )
-  const [, setSelected] = useState(false)
   const openUrl = useOpenUrl()
   const {canEdit, isEditing} = useEditorGate()
 
   // Navigate when the document is being viewed (read-only). In edit mode the
   // click should select/focus the block instead, mirroring `embed-block.tsx`.
   const navigateOnClick = !canEdit || !isEditing
-
-  useEditorSelectionChange(editor, () => updateSelection(editor, block, setSelected))
 
   useEffect(() => {
     setAlignment(block.props.alignment as ButtonAlignment)
@@ -65,26 +61,27 @@ export function ButtonBlockView({
   const handleClick = navigateOnClick && url ? () => openUrl(url) : undefined
 
   return (
-    <div
-      className="flex w-full max-w-full flex-col select-none"
-      style={{
-        justifyContent: alignment || 'flex-start',
-      }}
-      contentEditable={false}
-    >
-      <Button
-        variant="brand"
-        size="lg"
-        className={cn(
-          'w-auto max-w-full justify-center border-none border-transparent text-center select-none',
-          alignment == 'center' ? 'self-center' : alignment == 'flex-end' ? 'self-end' : 'self-start',
-        )}
-        onClick={handleClick}
+    <BlockSelectionWrapper editor={editor} block={block}>
+      <div
+        className="flex w-full max-w-full flex-col select-none"
+        style={{
+          justifyContent: alignment || 'flex-start',
+        }}
       >
-        <SizableText size="lg" className="truncate text-center font-sans font-bold text-white">
-          {block.props.name || 'Button Text'}
-        </SizableText>
-      </Button>
-    </div>
+        <Button
+          variant="brand"
+          size="lg"
+          className={cn(
+            'w-auto max-w-full justify-center border-none border-transparent text-center select-none',
+            alignment == 'center' ? 'self-center' : alignment == 'flex-end' ? 'self-end' : 'self-start',
+          )}
+          onClick={handleClick}
+        >
+          <SizableText size="lg" className="truncate text-center font-sans font-bold text-white">
+            {block.props.name || 'Button Text'}
+          </SizableText>
+        </Button>
+      </div>
+    </BlockSelectionWrapper>
   )
 }

--- a/frontend/packages/editor/src/embed-block.tsx
+++ b/frontend/packages/editor/src/embed-block.tsx
@@ -31,6 +31,7 @@ import {useDraftActions} from './draft-actions-context'
 import {EmbedEditorView} from './embed-editor'
 import {MediaContainer} from './media-container'
 import {DisplayComponentProps, MediaRender, MediaType} from './media-render'
+import {BlockSelectionWrapper} from './block-selection-wrapper'
 import {HMBlockSchema} from './schema'
 
 export const EmbedBlock = createReactBlockSpec({
@@ -214,7 +215,11 @@ const Render = (block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
   // When the embed points at an unpublished child draft,
   // render a placeholder card instead of the URL input form.
   if (block.props.draftId) {
-    return <DraftEmbedPlaceholder draftId={block.props.draftId} editor={editor} blockId={block.id} />
+    return (
+      <BlockSelectionWrapper editor={editor} block={block}>
+        <DraftEmbedPlaceholder draftId={block.props.draftId} editor={editor} blockId={block.id} />
+      </BlockSelectionWrapper>
+    )
   }
   const gwUrl = useGatewayUrlStream()
   const submitEmbed = async (url: string, assign: any, setFileName: any, setLoading: any) => {
@@ -277,15 +282,13 @@ const Render = (block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
   )
 }
 
-const EmbedDisplay = ({editor, block, assign, selected, setSelected}: DisplayComponentProps) => {
+const EmbedDisplay = ({editor, block, assign}: DisplayComponentProps) => {
   const {canEdit, isEditing} = useEditorGate()
   return (
     <MediaContainer
       editor={editor}
       block={block}
       mediaType="embed"
-      selected={selected}
-      setSelected={setSelected}
       assign={assign}
       // styleProps={{
       //   pointerEvents: activeId && activeId !== block.id ? 'none' : '',
@@ -528,7 +531,7 @@ export const EmbedLauncherInput = ({
             setFocusedIndex((prev) => (prev - 1 + activeItems.length) % activeItems.length)
           }
         }}
-        className="border-muted-foreground/30 focus-visible:border-ring text-foreground w-full"
+        className="border-muted-foreground/30 focus-visible:border-ring text-foreground placeholder:text-foreground/50 w-full"
       />
 
       {content}

--- a/frontend/packages/editor/src/file.tsx
+++ b/frontend/packages/editor/src/file.tsx
@@ -59,7 +59,7 @@ const Render = (block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
   )
 }
 
-const FileDisplay = ({editor, block, selected, setSelected, assign}: DisplayComponentProps) => {
+const FileDisplay = ({editor, block, assign}: DisplayComponentProps) => {
   const {saveCidAsFile} = useUniversalAppContext()
   const {isEditing} = useEditorGate()
   const url: string = block.props.url || ''
@@ -68,14 +68,7 @@ const FileDisplay = ({editor, block, selected, setSelected, assign}: DisplayComp
   const showDownload = !!fileCid && !isEditing
 
   return (
-    <MediaContainer
-      editor={editor}
-      block={block}
-      mediaType="file"
-      selected={selected}
-      setSelected={setSelected}
-      assign={assign}
-    >
+    <MediaContainer editor={editor} block={block} mediaType="file" assign={assign}>
       <div className="group relative w-full">
         <Button className="w-full justify-start px-4 py-3 select-none" disabled>
           <File className="size-4 shrink-0" />
@@ -92,8 +85,7 @@ const FileDisplay = ({editor, block, selected, setSelected, assign}: DisplayComp
             variant="accent"
             size="xs"
             className={cn(
-              'absolute top-2 right-2 z-10 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100',
-              selected && 'opacity-100',
+              'sel-btn absolute top-2 right-2 z-10 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100',
             )}
             asChild
           >

--- a/frontend/packages/editor/src/image.tsx
+++ b/frontend/packages/editor/src/image.tsx
@@ -156,7 +156,7 @@ const Render = (block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
   )
 }
 
-const ImageDisplay = ({editor, block, selected, setSelected, assign}: DisplayComponentProps) => {
+const ImageDisplay = ({editor, block, assign}: DisplayComponentProps) => {
   const getImageUrl = useImageUrl()
   const {canEdit} = useEditorGate()
 
@@ -401,8 +401,6 @@ const ImageDisplay = ({editor, block, selected, setSelected, assign}: DisplayCom
       editor={editor}
       block={block}
       mediaType="image"
-      selected={selected}
-      setSelected={setSelected}
       assign={assign}
       onHoverIn={() => {
         // Suppress resize handles in viewer render type (discussion panel)

--- a/frontend/packages/editor/src/media-container.test.tsx
+++ b/frontend/packages/editor/src/media-container.test.tsx
@@ -50,14 +50,7 @@ afterEach(() => {
 function renderImageContainer(editor: ReturnType<typeof makeEditor>) {
   act(() => {
     root.render(
-      <MediaContainer
-        editor={editor}
-        block={makeBlock()}
-        mediaType="image"
-        selected={false}
-        setSelected={() => {}}
-        assign={() => {}}
-      >
+      <MediaContainer editor={editor} block={makeBlock()} mediaType="image" assign={() => {}}>
         <div data-testid="media-child" />
       </MediaContainer>,
     )

--- a/frontend/packages/editor/src/media-container.tsx
+++ b/frontend/packages/editor/src/media-container.tsx
@@ -16,8 +16,6 @@ interface ContainerProps {
   block: Block<HMBlockSchema>
   mediaType: string
   styleProps?: Object
-  selected: boolean
-  setSelected: any
   assign: any
   children: any
   onHoverIn?: () => void
@@ -33,8 +31,6 @@ export const MediaContainer = ({
   block,
   mediaType,
   styleProps,
-  selected,
-  setSelected,
   assign,
   children,
   onHoverIn,
@@ -121,7 +117,6 @@ export const MediaContainer = ({
       e.preventDefault()
       e.stopPropagation()
       setDrag(false)
-      if (selected) setSelected(false)
       if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
         const file = Array.from(e.dataTransfer.files)[0]
         // @ts-ignore
@@ -147,23 +142,15 @@ export const MediaContainer = ({
     },
     onDragEnter: (e: React.DragEvent<HTMLDivElement>) => {
       if (e.dataTransfer && e.dataTransfer.types && Array.from(e.dataTransfer.types).includes('Files')) {
-        const relatedTarget = e.relatedTarget as HTMLElement
         e.preventDefault()
         e.stopPropagation()
         setDrag(true)
-        if ((!relatedTarget || !e.currentTarget.contains(relatedTarget)) && e.dataTransfer.effectAllowed !== 'move') {
-          setSelected(true)
-        }
       }
     },
     onDragLeave: (e: React.DragEvent<HTMLDivElement>) => {
-      const relatedTarget = e.relatedTarget as HTMLElement
       e.preventDefault()
       e.stopPropagation()
       setDrag(false)
-      if ((!relatedTarget || !e.currentTarget.contains(relatedTarget)) && e.dataTransfer.effectAllowed !== 'move') {
-        setSelected(false)
-      }
     },
   }
 
@@ -226,9 +213,9 @@ export const MediaContainer = ({
         className={cn(
           'group relative flex max-w-full flex-col rounded-md border-2 transition-colors',
           mediaType === 'file' ? 'w-full' : 'w-full',
-          drag || selected ? 'border-foreground/20 dark:border-foreground/30' : 'border-border',
+          drag ? 'border-foreground/20 dark:border-foreground/30' : 'border-border',
           drag && 'border-dashed',
-          editor.commentEditor && !drag && !selected ? 'bg-black/5 dark:bg-white/10' : 'bg-muted',
+          editor.commentEditor && !drag ? 'bg-black/5 dark:bg-white/10' : 'bg-muted',
           className ?? block.type,
         )}
         style={{width}}
@@ -254,8 +241,7 @@ export const MediaContainer = ({
               variant="accent"
               size="xs"
               className={cn(
-                'absolute top-2 right-2 z-10 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100',
-                selected && 'opacity-100',
+                'replace-btn absolute top-2 right-2 z-10 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100',
               )}
               onClick={() => fileInputRef.current?.click()}
             >

--- a/frontend/packages/editor/src/media-render.tsx
+++ b/frontend/packages/editor/src/media-render.tsx
@@ -10,14 +10,11 @@ import {SizableText} from '@shm/ui/text'
 import {Tooltip} from '@shm/ui/tooltip'
 import {cn} from '@shm/ui/utils'
 import {AlertCircle} from 'lucide-react'
-import {NodeSelection, TextSelection} from 'prosemirror-state'
 import {ChangeEvent, FunctionComponent, useEffect, useState} from 'react'
 import {BlockNoteEditor} from './blocknote/core/BlockNoteEditor'
 import {Block} from './blocknote/core/extensions/Blocks/api/blockTypes'
-import {MultipleNodeSelection} from './blocknote/core/extensions/SideMenu/MultipleNodeSelection'
-import {useEditorSelectionChange} from './blocknote/react/hooks/useEditorSelectionChange'
 import {HMBlockSchema} from './schema'
-import {getNodesInSelection} from './utils'
+import {BlockSelectionWrapper} from './block-selection-wrapper'
 
 export type MediaType = {
   id: string
@@ -38,8 +35,6 @@ export type MediaType = {
 export interface DisplayComponentProps {
   editor: BlockNoteEditor<HMBlockSchema>
   block: Block<HMBlockSchema>
-  selected: boolean
-  setSelected: any
   assign?: any
 }
 
@@ -77,30 +72,6 @@ interface RenderProps {
   validateFile?: (file: File) => boolean
 }
 
-export function updateSelection(
-  editor: BlockNoteEditor<HMBlockSchema>,
-  block: Block<HMBlockSchema>,
-  setSelected: (selected: boolean) => void,
-) {
-  const {view} = editor._tiptapEditor
-  const {selection} = view.state
-  let isSelected = false
-
-  if (selection instanceof NodeSelection) {
-    // If the selection is a NodeSelection, check if this block is the selected node
-    const selectedNode = view.state.doc.resolve(selection.from).parent
-    if (selectedNode && selectedNode.attrs && selectedNode.attrs.id === block.id) {
-      isSelected = true
-    }
-  } else if (selection instanceof TextSelection || selection instanceof MultipleNodeSelection) {
-    // If it's a TextSelection or MultipleNodeSelection (TODO Fix for drag), check if this block's node is within the selection range
-    const selectedNodes = getNodesInSelection(view)
-    isSelected = selectedNodes.some((node) => node.attrs && node.attrs.id === block.id)
-  }
-
-  setSelected(isSelected)
-}
-
 export const MediaRender: React.FC<RenderProps> = ({
   block,
   editor,
@@ -112,12 +83,9 @@ export const MediaRender: React.FC<RenderProps> = ({
   hideForm,
   validateFile,
 }) => {
-  const [selected, setSelected] = useState(false)
   const [uploading, setUploading] = useState(false)
   const hasSrc = !!block.props?.src
   const {canEdit, beginEditIfNeeded} = useEditorGate()
-
-  useEditorSelectionChange(editor, () => updateSelection(editor, block, setSelected))
 
   useEffect(() => {
     if (!uploading && hasSrc && editor.importWebFile && block.props.src) {
@@ -171,10 +139,6 @@ export const MediaRender: React.FC<RenderProps> = ({
     editor.updateBlock(block.id, props)
   }
 
-  const setSelection = (isSelected: boolean) => {
-    setSelected(isSelected)
-  }
-
   if (hasSrc || uploading) {
     // this means we have a URL in the props.url that is not starting with `ipfs://`, which means we are uploading the image to IPFS
     return (
@@ -185,34 +149,28 @@ export const MediaRender: React.FC<RenderProps> = ({
   }
 
   return (
-    <div className="flex w-full flex-col">
-      {hideForm ? (
-        <MediaComponent
-          block={block}
-          editor={editor}
-          assign={assignMedia}
-          selected={selected}
-          setSelected={setSelection}
-          DisplayComponent={DisplayComponent}
-        />
-      ) : editor.renderType !== 'viewer' && (canEdit || editor.isEditable) ? (
-        // The editor accepts authoring when the user has edit permission
-        // or when the editor instance itself is editable
-        <MediaForm
-          block={block}
-          assign={assignMedia}
-          editor={editor}
-          selected={selected}
-          mediaType={mediaType}
-          CustomInput={CustomInput}
-          submit={submit}
-          icon={icon}
-          validateFile={validateFile}
-        />
-      ) : (
-        <></>
-      )}
-    </div>
+    <BlockSelectionWrapper editor={editor} block={block}>
+      <div className="flex w-full flex-col">
+        {hideForm ? (
+          <MediaComponent block={block} editor={editor} assign={assignMedia} DisplayComponent={DisplayComponent} />
+        ) : editor.renderType !== 'viewer' && (canEdit || editor.isEditable) ? (
+          // The editor accepts authoring when the user has edit permission
+          // or when the editor instance itself is editable
+          <MediaForm
+            block={block}
+            assign={assignMedia}
+            editor={editor}
+            mediaType={mediaType}
+            CustomInput={CustomInput}
+            submit={submit}
+            icon={icon}
+            validateFile={validateFile}
+          />
+        ) : (
+          <></>
+        )}
+      </div>
+    </BlockSelectionWrapper>
   )
 }
 
@@ -220,27 +178,20 @@ function MediaComponent({
   block,
   editor,
   assign,
-  selected,
-  setSelected,
   DisplayComponent,
 }: {
   block: Block<HMBlockSchema>
   editor: BlockNoteEditor<HMBlockSchema>
   assign: any
-  selected: boolean
-  setSelected: any
   DisplayComponent: React.ComponentType<DisplayComponentProps>
 }) {
-  return (
-    <DisplayComponent editor={editor} block={block} selected={selected} setSelected={setSelected} assign={assign} />
-  )
+  return <DisplayComponent editor={editor} block={block} assign={assign} />
 }
 
 function MediaForm({
   block,
   assign,
   editor,
-  selected = false,
   mediaType,
   submit,
   icon,
@@ -250,7 +201,6 @@ function MediaForm({
   block: Block<HMBlockSchema>
   assign: any
   editor: BlockNoteEditor<HMBlockSchema>
-  selected: boolean
   mediaType: string
   submit?: (url: string, assign: any, setFileName: any, setLoading: any) => Promise<void> | void | undefined
   icon: JSX.Element | FunctionComponent<{color?: string; size?: number}> | null
@@ -427,9 +377,9 @@ function MediaForm({
     <div
       className={cn(
         'bg-muted relative flex flex-col rounded-md border-2 transition-colors outline-none',
-        drag || selected ? 'border-foreground/20 dark:border-foreground/30' : 'border-border',
+        drag ? 'border-foreground/20 dark:border-foreground/30' : 'border-border',
         drag && 'border-dashed',
-        editor.commentEditor && !drag && !selected && 'border-border bg-black/5 dark:bg-white/10',
+        editor.commentEditor && !drag && 'border-border bg-black/5 dark:bg-white/10',
         isActiveUpload && mediaType !== 'file' && 'aspect-video',
         isActiveUpload && mediaType === 'file' && 'min-h-[240px]',
       )}
@@ -484,7 +434,7 @@ function MediaForm({
                 />
               ) : (
                 <Input
-                  className="border-muted-foreground/30 focus-visible:border-ring text-foreground max-w-full pl-3"
+                  className="border-muted-foreground/30 focus-visible:border-ring text-foreground placeholder:text-foreground/50 max-w-full pl-3"
                   placeholder={`Input ${mediaType === 'web-embed' ? 'X.com or Instagram' : mediaType} URL here…`}
                   onChangeText={(text) => {
                     setUrl(text)

--- a/frontend/packages/editor/src/query-block.tsx
+++ b/frontend/packages/editor/src/query-block.tsx
@@ -22,6 +22,7 @@ import {Fragment} from '@tiptap/pm/model'
 import {ReactNode, useCallback, useEffect, useMemo, useState} from 'react'
 import {Block, BlockNoteEditor} from './blocknote'
 import {createReactBlockSpec} from './blocknote/react'
+import {BlockSelectionWrapper} from './block-selection-wrapper'
 import {useQuerySearchInput} from './query-search-context'
 import {HMBlockSchema} from './schema'
 
@@ -200,36 +201,34 @@ function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
   }
 
   return (
-    <div
-      // @ts-ignore
-      contentEditable={false}
-      className="group relative -mx-4 flex flex-col px-4 select-none"
-    >
-      {canEdit && (
-        <QuerySettings
-          // @ts-expect-error
-          queryDocName={entity.data?.document?.metadata.name || ''}
-          queryIncludes={queryIncludes}
-          querySort={querySort}
-          style={style}
-          banner={banner}
-          // @ts-expect-error
-          block={block}
-          editor={editor}
-          beginEditIfNeeded={beginEditIfNeeded}
-          onValuesChange={({id, props}) => {
-            if (id) {
-              setQueryId(id)
-            }
-            assign(props)
-          }}
-        />
-      )}
-      {/* Stop mousedown propagation so ProseMirror doesn't intercept clicks on item links */}
-      <div onMouseDown={(e) => e.stopPropagation()} onClick={(e) => e.stopPropagation()}>
-        {DraftSlot ? <DraftSlot targetId={queryId}>{(data) => renderContent(data)}</DraftSlot> : renderContent(null)}
+    <BlockSelectionWrapper editor={editor} block={block}>
+      <div className="group relative -mx-4 flex flex-col px-4 select-none">
+        {canEdit && (
+          <QuerySettings
+            // @ts-expect-error
+            queryDocName={entity.data?.document?.metadata.name || ''}
+            queryIncludes={queryIncludes}
+            querySort={querySort}
+            style={style}
+            banner={banner}
+            // @ts-expect-error
+            block={block}
+            editor={editor}
+            beginEditIfNeeded={beginEditIfNeeded}
+            onValuesChange={({id, props}) => {
+              if (id) {
+                setQueryId(id)
+              }
+              assign(props)
+            }}
+          />
+        )}
+        {/* Stop mousedown propagation so ProseMirror doesn't intercept clicks on item links */}
+        <div onMouseDown={(e) => e.stopPropagation()} onClick={(e) => e.stopPropagation()}>
+          {DraftSlot ? <DraftSlot targetId={queryId}>{(data) => renderContent(data)}</DraftSlot> : renderContent(null)}
+        </div>
       </div>
-    </div>
+    </BlockSelectionWrapper>
   )
 }
 

--- a/frontend/packages/editor/src/slash-menu-items.tsx
+++ b/frontend/packages/editor/src/slash-menu-items.tsx
@@ -13,9 +13,32 @@ import {
   Video,
 } from 'lucide-react'
 import {RiGridFill, RiHeading, RiText, RiWindow2Fill} from 'react-icons/ri'
+import {NodeSelection} from 'prosemirror-state'
+import {Node} from 'prosemirror-model'
 import {BlockNoteEditor, BlockSpec, insertOrUpdateBlock, PartialBlock, PropSchema} from './blocknote/core'
 import {getBlockInfoFromPos} from './blocknote/core/extensions/Blocks/helpers/getBlockInfoFromPos'
 import {HMBlockSchema} from './schema'
+
+function selectInsertedBlock(editor: BlockNoteEditor<Record<string, BlockSpec<string, PropSchema>>>) {
+  setTimeout(() => {
+    const {view} = editor._tiptapEditor
+    const prevBlock = editor.getTextCursorPosition().prevBlock
+    if (!prevBlock) return
+    let found = false
+    view.state.doc.descendants((node: Node, pos: number) => {
+      if (!found && node.type.name === 'blockNode' && node.attrs.id === prevBlock.id) {
+        const blockContentPos = pos + 1
+        view.dispatch(
+          view.state.tr.setSelection(NodeSelection.create(view.state.doc, blockContentPos)).scrollIntoView(),
+        )
+        view.focus()
+        found = true
+        return false
+      }
+      return true
+    })
+  }, 50)
+}
 
 export function getSlashMenuItems({
   showQuery = true,
@@ -49,8 +72,7 @@ export function getSlashMenuItems({
             } as PartialBlock<HMBlockSchema>,
             true,
           )
-          const {state, view} = editor._tiptapEditor
-          view.dispatch(state.tr.scrollIntoView())
+          selectInsertedBlock(editor)
         } catch (err) {
           console.error('Failed to create inline draft:', err)
         }
@@ -74,8 +96,7 @@ export function getSlashMenuItems({
         } as PartialBlock<HMBlockSchema>,
         true,
       )
-      const {state, view} = editor._tiptapEditor
-      view.dispatch(state.tr.scrollIntoView())
+      selectInsertedBlock(editor)
     },
   })
   slashMenuItems.push({
@@ -96,8 +117,7 @@ export function getSlashMenuItems({
         } as PartialBlock<HMBlockSchema>,
         true,
       )
-      const {state, view} = editor._tiptapEditor
-      view.dispatch(state.tr.scrollIntoView())
+      selectInsertedBlock(editor)
     },
   })
 
@@ -189,8 +209,7 @@ export function getSlashMenuItems({
         } as PartialBlock<HMBlockSchema>,
         true,
       )
-      const {state, view} = editor._tiptapEditor
-      view.dispatch(state.tr.scrollIntoView())
+      selectInsertedBlock(editor)
     },
   })
   slashMenuItems.push({
@@ -211,8 +230,7 @@ export function getSlashMenuItems({
         } as PartialBlock<HMBlockSchema>,
         true,
       )
-      const {state, view} = editor._tiptapEditor
-      view.dispatch(state.tr.scrollIntoView())
+      selectInsertedBlock(editor)
     },
   })
   slashMenuItems.push({
@@ -233,8 +251,7 @@ export function getSlashMenuItems({
         } as PartialBlock<HMBlockSchema>,
         true,
       )
-      const {state, view} = editor._tiptapEditor
-      view.dispatch(state.tr.scrollIntoView())
+      selectInsertedBlock(editor)
     },
   })
   slashMenuItems.push({
@@ -255,8 +272,7 @@ export function getSlashMenuItems({
         } as PartialBlock<HMBlockSchema>,
         true,
       )
-      const {state, view} = editor._tiptapEditor
-      view.dispatch(state.tr.scrollIntoView())
+      selectInsertedBlock(editor)
     },
   })
 
@@ -360,8 +376,7 @@ export function getSlashMenuItems({
         } as PartialBlock<HMBlockSchema>,
         true,
       )
-      const {state, view} = editor._tiptapEditor
-      view.dispatch(state.tr.scrollIntoView())
+      selectInsertedBlock(editor)
     },
   })
   if (showQuery) {
@@ -397,8 +412,7 @@ export function getSlashMenuItems({
           } as PartialBlock<HMBlockSchema>,
           true,
         )
-        const {state, view} = editor._tiptapEditor
-        view.dispatch(state.tr.scrollIntoView())
+        selectInsertedBlock(editor)
       },
     })
   }

--- a/frontend/packages/editor/src/video.tsx
+++ b/frontend/packages/editor/src/video.tsx
@@ -258,7 +258,7 @@ function VideoOptions({
   )
 }
 
-const VideoDisplay = ({editor, block, selected, setSelected, assign}: DisplayComponentProps) => {
+const VideoDisplay = ({editor, block, assign}: DisplayComponentProps) => {
   const getFileUrl = useFileProxyUrl()
   const {canEdit} = useEditorGate()
   const autoplay = block.props.autoplay === 'true'
@@ -429,8 +429,6 @@ const VideoDisplay = ({editor, block, selected, setSelected, assign}: DisplayCom
       editor={editor}
       block={block}
       mediaType="video"
-      selected={selected}
-      setSelected={setSelected}
       assign={assign}
       onHoverIn={() => {
         // Suppress resize handles in viewer render type (discussion panel)
@@ -473,11 +471,8 @@ const VideoDisplay = ({editor, block, selected, setSelected, assign}: DisplayCom
             contentEditable={false}
             className={cn(
               'video-iframe absolute top-0 right-0 bottom-0 left-0',
-              // In a non-editable context the iframe should be clickable.
-              !editor.isEditable && 'pointer-events-auto',
-              editor.isEditable && !canEdit && 'pointer-events-auto',
-              editor.isEditable && canEdit && !selected && 'pointer-events-none',
-              editor.isEditable && canEdit && selected && 'pointer-events-auto',
+              (!editor.isEditable || !canEdit) && 'pointer-events-auto',
+              editor.isEditable && canEdit && 'pointer-events-none',
             )}
             src={getVideoIframeSrc(block.props.url)}
             allowFullScreen

--- a/frontend/packages/editor/src/web-embed.tsx
+++ b/frontend/packages/editor/src/web-embed.tsx
@@ -82,7 +82,7 @@ const Render = (block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
   )
 }
 
-const WebEmbedDisplay = ({editor, block, selected, setSelected, assign}: DisplayComponentProps) => {
+const WebEmbedDisplay = ({editor, block, assign}: DisplayComponentProps) => {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(false)
   const openUrl = useOpenUrl()
@@ -155,8 +155,6 @@ const WebEmbedDisplay = ({editor, block, selected, setSelected, assign}: Display
       editor={editor}
       block={block}
       mediaType="web-embed"
-      selected={selected}
-      setSelected={setSelected}
       assign={assign}
       onPress={() => {
         if (block.props.link) {


### PR DESCRIPTION
https://github.com/user-attachments/assets/2ad3a293-237a-4575-bbf6-e27a28c4b051

## Summary

- Extract `BlockSelectionWrapper` component from `media-render.tsx` into `block-selection-wrapper.tsx` — centralizes selection logic previously duplicated across media blocks
- Remove `selected`/`setSelected` props from `DisplayComponentProps`, `MediaContainer`, `MediaForm`, and all display components (`ImageDisplay`, `VideoDisplay`, `FileDisplay`, `WebEmbedDisplay`, `EmbedDisplay`)
- Add `blockSelection.css` with `.bn-media-selected` outline styles and CSS-class-based visibility for `.replace-btn` and `.sel-btn` buttons — replaces inline `selected && 'opacity-100'` conditionals
- Wrap `MediaRender`, `ButtonBlockView`, `QueryBlock`, and embed render paths in `BlockSelectionWrapper`
- Extract `selectInsertedBlock` helper in `slash-menu-items.tsx` — deduplicates repeated `view.dispatch(state.tr.scrollIntoView())` calls after slash-menu insertions, now uses `NodeSelection` to auto-select the inserted block
- Video iframe pointer-events logic simplified: CSS-class toggle replaces four-way `selected`-dependent conditional
- Add `placeholder:text-foreground/50` to URL inputs in embed and media form for better placeholder contrast

