### PR TITLE
[codex] Add draft breadcrumb context

### DIFF
--- a/docs/draft-context-unification.md
+++ b/docs/draft-context-unification.md
@@ -1,0 +1,104 @@
+# Draft context unification (Phase 2)
+
+## Why
+
+After "Phase 1 — desktop draft-aware breadcrumbs" shipped, the codebase has
+three overlapping draft-related React contexts:
+
+- `DraftActionsContext` (`frontend/packages/editor/src/draft-actions-context.tsx`)
+  — editor surface: create / lookup / delete / open inline drafts.
+- `DraftBreadcrumbContext` (`frontend/packages/shared/src/draft-breadcrumb-context.tsx`)
+  — breadcrumb data lookup; added in Phase 1.
+- `QueryBlockDraftsContext` (`frontend/packages/shared/src/query-block-drafts-context.tsx`)
+  — UI-slot context for query blocks; a separate concern from the data
+  contexts.
+
+Two of these (Actions, Breadcrumb) overlap conceptually: both are
+platform-specific draft data lookups consumed by shared UI. They should
+collapse into a single provider per app, and the web app needs parity with
+desktop so renamed drafts also win in the breadcrumb on web.
+
+## Goal
+
+- One unified `DraftContext` in `@shm/shared` covering both editor and
+  breadcrumb use cases.
+- Web provider with parity: IndexedDB-backed drafts; breadcrumbs and inline
+  drafts both work; no daemon `Resource` fetches for draft segments.
+- Keep `QueryBlockDraftsContext` separate for now (it is a UI-slot, not a
+  data context). Flag as a possible later cleanup.
+
+## Plan
+
+1. Move `frontend/packages/editor/src/draft-actions-context.tsx` →
+   `frontend/packages/shared/src/draft-context.tsx`. Leave a one-line
+   re-export shim in the old path so existing editor imports keep
+   compiling; migrate call-sites opportunistically.
+
+2. Extend the moved type with `useDraftsForAccount` from Phase 1:
+
+   ```ts
+   export type DraftContextValue = {
+     onCreateInlineDraft: (
+       parentId: UnpackedHypermediaId,
+     ) => Promise<{draftId: string; draftPath: string[]}>
+     useInlineDraft: (id: string | undefined) => {data?: HMListedDraft | null}
+     onDeleteDraft: (id: string) => Promise<void>
+     onOpenDraft: (draftId: string, draftPath: string[]) => void
+     useDraftsForAccount: (uid: string | undefined) => {
+       data: HMListedDraftWithLocation[] | undefined
+       isLoading: boolean
+     }
+   }
+   ```
+
+3. Delete `frontend/packages/shared/src/draft-breadcrumb-context.tsx`. Move
+   `useDraftsForAccountSafe`, `findDraftForPath`, and the
+   `HMListedDraftWithLocation` re-export next to the unified context.
+   Update `frontend/packages/ui/src/resource-page-common.tsx` to consume the
+   unified context instead of the Phase 1 breadcrumb-only one.
+
+4. Desktop: fold `DesktopDraftBreadcrumbProvider` into
+   `DesktopDraftActionsProvider` (rename to `DesktopDraftProvider`). The
+   merged provider supplies the full `DraftContextValue`.
+
+5. Web:
+   - Add `listWebDocDraftsForAccount(uid)` and a
+     `webDraftToListedDraft(d) → HMListedDraftWithLocation` mapper to
+     `frontend/apps/web/app/document-edit/web-draft-db.ts`. Scan by
+     `editUid === uid || locationUid === uid`. Cheap given web draft volume.
+   - New `frontend/apps/web/app/web-draft-provider.tsx` fulfils the full
+     `DraftContextValue`. React-query wrappers around the IndexedDB helpers;
+     invalidate `['web-drafts-account', uid]` from every save site in
+     `frontend/apps/web/app/document-edit/web-document-actors.ts`. If
+     `onCreateInlineDraft` / `onDeleteDraft` / `onOpenDraft` are out of
+     scope for web product yet, ship them as `console.warn` stubs. The
+     breadcrumb features keep working since they only need
+     `useDraftsForAccount` + `useInlineDraft`.
+
+6. Mount `<WebDraftProvider>` around `<ResourcePage>` in
+   `frontend/apps/web/app/web-resource-page.tsx`.
+
+7. Keep `QueryBlockDraftsContext` separate. Note as a possible later
+   cleanup.
+
+## Verification
+
+- All Phase 1 desktop verification steps still pass — see Phase 1 plan.
+- Web: create a new child draft and rename a published doc in the draft
+  editor. The breadcrumb renders the draft title in both cases without a
+  `/Resource` request hitting the gateway.
+- SSR HTML matches today's output (provider returns empty server-side, no
+  draft override).
+- Tests: `pnpm --filter @shm/web test` covers
+  `listWebDocDraftsForAccount`; existing `findDraftForPath` tests in
+  `@shm/shared` still pass after the move.
+- Gates per `frontend/AGENTS.md`: `pnpm typecheck`, `pnpm test`,
+  `pnpm audit`, `pnpm format:write`.
+
+## Out of scope
+
+- Folding `QueryBlockDraftsContext` into the unified data context.
+- Server-side draft storage on web (the IndexedDB store stays
+  per-browser).
+- Cross-account draft breadcrumbs (current model assumes the entire
+  breadcrumb chain is anchored to one root account).

--- a/frontend/apps/desktop/src/components/desktop-draft-breadcrumb-provider.tsx
+++ b/frontend/apps/desktop/src/components/desktop-draft-breadcrumb-provider.tsx
@@ -1,0 +1,23 @@
+import {useAccountDraftList} from '@/models/documents'
+import {DraftBreadcrumbContext, DraftBreadcrumbContextValue} from '@shm/shared/draft-breadcrumb-context'
+import {PropsWithChildren, useMemo} from 'react'
+
+/**
+ * Provides the draft list needed by the document-header breadcrumb so we can
+ * substitute draft metadata (and skip the daemon `Resource` fetch) for
+ * segments backed by a local draft. Mounted at the resource-page level so it
+ * covers every breadcrumb rendered in the document view.
+ */
+export function DesktopDraftBreadcrumbProvider({children}: PropsWithChildren) {
+  const value = useMemo<DraftBreadcrumbContextValue>(
+    () => ({
+      useDraftsForAccount: (uid: string | undefined) => {
+        const query = useAccountDraftList(uid)
+        return {data: query.data, isLoading: query.isLoading}
+      },
+    }),
+    [],
+  )
+
+  return <DraftBreadcrumbContext.Provider value={value}>{children}</DraftBreadcrumbContext.Provider>
+}

--- a/frontend/apps/desktop/src/models/documents.ts
+++ b/frontend/apps/desktop/src/models/documents.ts
@@ -59,11 +59,12 @@ import {getNavigationChanges} from './navigation'
 /**
  * Extended draft type returned by app-drafts.ts listAccount/list endpoints.
  * These endpoints compute locationId/editId from the raw uid+path fields.
+ *
+ * Re-exported from `@shm/shared/draft-breadcrumb-context` so platform
+ * providers and shared UI agree on the shape.
  */
-export type HMListedDraftWithLocation = HMListedDraft & {
-  locationId?: UnpackedHypermediaId
-  editId?: UnpackedHypermediaId
-}
+import type {HMListedDraftWithLocation} from '@shm/shared/draft-breadcrumb-context'
+export type {HMListedDraftWithLocation}
 
 export function useDraftList() {
   return useQuery({

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -4,6 +4,7 @@ import {CommentBox, renderDesktopInlineEditor, triggerCommentDraftFocus} from '@
 import {CreateDocumentButton} from '@/components/create-doc-button'
 import {useDeleteDialog} from '@/components/delete-dialog'
 import {DesktopDraftActionsProvider} from '@/components/desktop-draft-actions-provider'
+import {DesktopDraftBreadcrumbProvider} from '@/components/desktop-draft-breadcrumb-provider'
 import {DesktopQueryBlockDraftSlot} from '@/components/desktop-query-block-draft-slot'
 import {DesktopDocumentActionsProvider} from '@/components/document-actions-provider'
 import {EditNavHeaderPane} from '@/components/edit-nav-header-pane'
@@ -663,46 +664,48 @@ export default function DesktopResourcePage() {
       >
         <DesktopDocumentActionsProvider>
           <DesktopDraftActionsProvider>
-            <QueryBlockDraftsProvider
-              DraftSlot={DesktopQueryBlockDraftSlot}
-              lastCreatedDraftId={lastCreatedDraftId}
-              setLastCreatedDraftId={setLastCreatedDraftId}
-            >
-              <QuerySearchInputProvider value={SearchInput}>
-                <ResourcePage
-                  docId={docId}
-                  canEdit={canEdit}
-                  CommentEditor={CommentBox}
-                  extraMenuItems={menuItems}
-                  existingDraft={existingDraft}
-                  existingDraftVisibility={draftQuery.data?.visibility}
-                  existingDraftContent={existingDraftContent}
-                  existingDraftCursorPosition={draftQuery.data?.cursorPosition}
-                  existingDraftMineTouchedIds={draftQuery.data?.mineTouchedIds}
-                  existingDraftBaseBlocks={draftQuery.data?.baseBlocks}
-                  inlineCards={inlineCards}
-                  rightActions={<JoinButton siteUid={docId.uid} />}
-                  onEditProfile={onEditProfile}
-                  inspect={inspect}
-                  inspectStore={inspectStore}
-                  DocumentContentComponent={DocumentEditor}
-                  machine={machine}
-                  onEditorReady={handleEditorReady}
-                  machineExtras={null}
-                  editingFloatingActions={editingFloatingActions}
-                  draftActions={draftActions}
-                  newButton={newButton}
-                  signingAccountId={selectedAccountId || undefined}
-                  publishAccountUid={selectedAccount?.id?.uid || undefined}
-                  perspectiveAccountUid={selectedAccountId}
-                  linkExtensionOptions={linkExtensionOptions}
-                  fileUpload={fileUpload}
-                  editNavPane={
-                    canEdit && !docId.path?.length ? <EditNavHeaderPane homeId={hmId(docId.uid)} /> : undefined
-                  }
-                />
-              </QuerySearchInputProvider>
-            </QueryBlockDraftsProvider>
+            <DesktopDraftBreadcrumbProvider>
+              <QueryBlockDraftsProvider
+                DraftSlot={DesktopQueryBlockDraftSlot}
+                lastCreatedDraftId={lastCreatedDraftId}
+                setLastCreatedDraftId={setLastCreatedDraftId}
+              >
+                <QuerySearchInputProvider value={SearchInput}>
+                  <ResourcePage
+                    docId={docId}
+                    canEdit={canEdit}
+                    CommentEditor={CommentBox}
+                    extraMenuItems={menuItems}
+                    existingDraft={existingDraft}
+                    existingDraftVisibility={draftQuery.data?.visibility}
+                    existingDraftContent={existingDraftContent}
+                    existingDraftCursorPosition={draftQuery.data?.cursorPosition}
+                    existingDraftMineTouchedIds={draftQuery.data?.mineTouchedIds}
+                    existingDraftBaseBlocks={draftQuery.data?.baseBlocks}
+                    inlineCards={inlineCards}
+                    rightActions={<JoinButton siteUid={docId.uid} />}
+                    onEditProfile={onEditProfile}
+                    inspect={inspect}
+                    inspectStore={inspectStore}
+                    DocumentContentComponent={DocumentEditor}
+                    machine={machine}
+                    onEditorReady={handleEditorReady}
+                    machineExtras={null}
+                    editingFloatingActions={editingFloatingActions}
+                    draftActions={draftActions}
+                    newButton={newButton}
+                    signingAccountId={selectedAccountId || undefined}
+                    publishAccountUid={selectedAccount?.id?.uid || undefined}
+                    perspectiveAccountUid={selectedAccountId}
+                    linkExtensionOptions={linkExtensionOptions}
+                    fileUpload={fileUpload}
+                    editNavPane={
+                      canEdit && !docId.path?.length ? <EditNavHeaderPane homeId={hmId(docId.uid)} /> : undefined
+                    }
+                  />
+                </QuerySearchInputProvider>
+              </QueryBlockDraftsProvider>
+            </DesktopDraftBreadcrumbProvider>
           </DesktopDraftActionsProvider>
         </DesktopDocumentActionsProvider>
       </CommentsProvider>

--- a/frontend/packages/shared/src/__tests__/draft-breadcrumb-context.test.ts
+++ b/frontend/packages/shared/src/__tests__/draft-breadcrumb-context.test.ts
@@ -1,0 +1,99 @@
+import type {HMMetadata} from '@seed-hypermedia/client/hm-types'
+import {describe, expect, it} from 'vitest'
+import {findDraftForPath, type HMListedDraftWithLocation} from '../draft-breadcrumb-context'
+import {hmId} from '../utils/entity-id-url'
+
+function makeDraft(overrides: Partial<HMListedDraftWithLocation>): HMListedDraftWithLocation {
+  return {
+    id: overrides.id ?? 'draft-1',
+    metadata: (overrides.metadata as HMMetadata) ?? ({name: 'unnamed'} as HMMetadata),
+    visibility: overrides.visibility ?? 'PUBLIC',
+    deps: overrides.deps ?? [],
+    lastUpdateTime: overrides.lastUpdateTime ?? 0,
+    ...overrides,
+  }
+}
+
+describe('findDraftForPath', () => {
+  it('returns null when no drafts are loaded', () => {
+    expect(findDraftForPath(undefined, 'acc', ['x'])).toBeNull()
+    expect(findDraftForPath([], 'acc', ['x'])).toBeNull()
+  })
+
+  it('matches a draft whose editId points at the exact published path', () => {
+    const draft = makeDraft({
+      editUid: 'acc',
+      editPath: ['guides', 'install'],
+      editId: hmId('acc', {path: ['guides', 'install']}),
+    })
+
+    const match = findDraftForPath([draft], 'acc', ['guides', 'install'])
+
+    expect(match).toBe(draft)
+  })
+
+  it('does not match when uid differs', () => {
+    const draft = makeDraft({
+      editUid: 'acc',
+      editPath: ['guides'],
+      editId: hmId('acc', {path: ['guides']}),
+    })
+
+    expect(findDraftForPath([draft], 'other', ['guides'])).toBeNull()
+  })
+
+  it('does not match when path differs', () => {
+    const draft = makeDraft({
+      editUid: 'acc',
+      editPath: ['guides'],
+      editId: hmId('acc', {path: ['guides']}),
+    })
+
+    expect(findDraftForPath([draft], 'acc', ['guides', 'install'])).toBeNull()
+  })
+
+  it('falls back to locationId for new-child drafts with -draftId placeholder segment', () => {
+    const draft = makeDraft({
+      id: 'draft-xyz',
+      locationUid: 'acc',
+      locationPath: ['parent'],
+      editUid: 'acc',
+      editPath: ['parent', '-draft-xyz'],
+      locationId: hmId('acc', {path: ['parent']}),
+      editId: hmId('acc', {path: ['parent', '-draft-xyz']}),
+    })
+
+    const match = findDraftForPath([draft], 'acc', ['parent', '-draft-xyz'])
+
+    expect(match).toBe(draft)
+  })
+
+  it('does not use locationId fallback when last segment is not a placeholder', () => {
+    const draft = makeDraft({
+      locationUid: 'acc',
+      locationPath: ['parent'],
+      locationId: hmId('acc', {path: ['parent']}),
+    })
+
+    expect(findDraftForPath([draft], 'acc', ['parent', 'real-doc'])).toBeNull()
+  })
+
+  it('prefers editId over locationId when both could match', () => {
+    const wrongLocationDraft = makeDraft({
+      id: 'loc-draft',
+      locationUid: 'acc',
+      locationPath: ['parent'],
+      locationId: hmId('acc', {path: ['parent']}),
+    })
+    const editDraft = makeDraft({
+      id: 'edit-draft',
+      editUid: 'acc',
+      editPath: ['parent', '-x'],
+      editId: hmId('acc', {path: ['parent', '-x']}),
+    })
+
+    const match = findDraftForPath([wrongLocationDraft, editDraft], 'acc', ['parent', '-x'])
+
+    expect(match).toBe(editDraft)
+  })
+})

--- a/frontend/packages/shared/src/draft-breadcrumb-context.tsx
+++ b/frontend/packages/shared/src/draft-breadcrumb-context.tsx
@@ -1,0 +1,85 @@
+import type {HMListedDraft, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {createContext, useContext} from 'react'
+import {pathMatches} from './utils/entity-id-url'
+
+/**
+ * `HMListedDraft` plus the resolved `locationId` / `editId` that the desktop
+ * draft endpoints (see `app-drafts.ts`) compute from the raw uid + path
+ * fields. Lifted into shared so providers on every platform can return the
+ * same shape.
+ */
+export type HMListedDraftWithLocation = HMListedDraft & {
+  locationId?: UnpackedHypermediaId
+  editId?: UnpackedHypermediaId
+}
+
+/**
+ * Cross-platform draft data lookup needed by the document-header breadcrumb.
+ * Desktop and web each ship a provider; environments without a provider
+ * (SSR, tests) read through {@link useDraftsForAccountSafe} and behave as if
+ * there are no drafts.
+ */
+export type DraftBreadcrumbContextValue = {
+  useDraftsForAccount: (uid: string | undefined) => {
+    data: HMListedDraftWithLocation[] | undefined
+    isLoading: boolean
+  }
+}
+
+export const DraftBreadcrumbContext = createContext<DraftBreadcrumbContextValue | null>(null)
+
+const EMPTY_RESULT = {data: [] as HMListedDraftWithLocation[], isLoading: false}
+
+/**
+ * Read the draft list for an account through the context, falling back to an
+ * empty result when no provider is mounted. Call from React render only —
+ * the underlying hook is invoked each call.
+ */
+export function useDraftsForAccountSafe(uid: string | undefined): {
+  data: HMListedDraftWithLocation[] | undefined
+  isLoading: boolean
+} {
+  const ctx = useContext(DraftBreadcrumbContext)
+  if (!ctx) return EMPTY_RESULT
+  return ctx.useDraftsForAccount(uid)
+}
+
+/**
+ * Find the draft that targets the given path under the given account.
+ *
+ * Two match strategies, in order:
+ * 1. Exact `editId` match — draft is editing the published doc at that path
+ *    (covers renamed-but-unpublished titles overriding the published doc).
+ * 2. `locationId` parent match when the requested path ends with a
+ *    `-${draftId}` placeholder segment — covers new-child drafts that don't
+ *    yet have a published path. We match `locationId` against
+ *    `path.slice(0, -1)` since `editPath = [...locationPath, '-draftId']`.
+ *
+ * Returns `null` when nothing matches.
+ */
+export function findDraftForPath(
+  drafts: HMListedDraftWithLocation[] | undefined,
+  uid: string,
+  path: string[] | undefined,
+): HMListedDraftWithLocation | null {
+  if (!drafts || drafts.length === 0) return null
+  const normalizedPath = path ?? []
+
+  for (const draft of drafts) {
+    if (draft.editId && draft.editId.uid === uid && pathMatches(draft.editId.path, normalizedPath)) {
+      return draft
+    }
+  }
+
+  const lastSegment = normalizedPath[normalizedPath.length - 1]
+  if (lastSegment && lastSegment.startsWith('-')) {
+    const parentPath = normalizedPath.slice(0, -1)
+    for (const draft of drafts) {
+      if (draft.locationId && draft.locationId.uid === uid && pathMatches(draft.locationId.path, parentPath)) {
+        return draft
+      }
+    }
+  }
+
+  return null
+}

--- a/frontend/packages/shared/src/utils/breadcrumbs.ts
+++ b/frontend/packages/shared/src/utils/breadcrumbs.ts
@@ -1,6 +1,15 @@
 import type {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {hmId} from './entity-id-url'
 
+/**
+ * A breadcrumb path segment that starts with `-` is the placeholder slug we
+ * assign to a new child draft before it is published. Use this as a fast
+ * pre-check before the full draft-list lookup.
+ */
+export function isDraftPathSegment(segment: string | undefined | null): boolean {
+  return !!segment && segment.startsWith('-')
+}
+
 export function getParentPaths(path?: string[] | null): string[][] {
   if (!path) return [[]]
   let walkParentPaths: string[] = []

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -20,6 +20,7 @@ import {
 import {useHackyAuthorsSubscriptions} from '@shm/shared/comments-service-provider'
 import {DEFAULT_GATEWAY_URL, IS_DESKTOP, NOTIFY_SERVICE_HOST} from '@shm/shared/constants'
 import type {BlockRangeSelectOptions, DocumentContentProps} from '@shm/shared/document-content-props'
+import {findDraftForPath, useDraftsForAccountSafe} from '@shm/shared/draft-breadcrumb-context'
 import {
   useAccount,
   useAccountsMetadata,
@@ -51,7 +52,7 @@ import {
 } from '@shm/shared/models/use-document-machine'
 import {useEditorGate} from '@shm/shared/models/use-editor-gate'
 import {getRoutePanel} from '@shm/shared/routes'
-import {getBreadcrumbDocumentIds} from '@shm/shared/utils/breadcrumbs'
+import {getBreadcrumbDocumentIds, isDraftPathSegment} from '@shm/shared/utils/breadcrumbs'
 import {
   activityFilterToSlug,
   createWebHMUrl,
@@ -1020,20 +1021,78 @@ function DocumentBody({
     return getBreadcrumbDocumentIds(docId)
   }, [docId, isHomeDoc])
 
-  const breadcrumbResults = useResources(breadcrumbIds, {subscribed: true})
+  // Local drafts override published metadata for breadcrumb segments. The
+  // provider returns an empty list on platforms without local drafts (e.g.
+  // current web), so the daemon-fetch path stays unchanged there.
+  const accountDrafts = useDraftsForAccountSafe(docId.uid)
+
+  // Resolve each breadcrumb segment to a local draft when possible. A draft
+  // match short-circuits the daemon fetch and the discovery subscription —
+  // we pass `null` at draft positions to `useResources` (see below) which
+  // honours `enabled: !!id` and skips both.
+  const draftsForBreadcrumbs = useMemo(
+    () => breadcrumbIds.map((id) => findDraftForPath(accountDrafts.data, id.uid, id.path ?? [])),
+    [breadcrumbIds, accountDrafts.data],
+  )
+
+  // Positions where the draft list is still loading but the path *looks*
+  // like a draft (placeholder `-` segment). We treat them as loading rather
+  // than firing a daemon fetch we'll discard once the local list resolves.
+  const pendingDraftLookup = useMemo(
+    () => breadcrumbIds.map((id) => accountDrafts.isLoading && isDraftPathSegment(id.path?.at(-1))),
+    [breadcrumbIds, accountDrafts.isLoading],
+  )
+
+  // Mask draft positions so `useResources` skips the daemon `Resource`
+  // request and the discovery subscription for them. Array length is
+  // preserved so downstream index-based access stays aligned.
+  const resourceFetchIds = useMemo(
+    () => breadcrumbIds.map((id, i) => (draftsForBreadcrumbs[i] || pendingDraftLookup[i] ? null : id)),
+    [breadcrumbIds, draftsForBreadcrumbs, pendingDraftLookup],
+  )
+
+  const breadcrumbResults = useResources(resourceFetchIds, {subscribed: true})
 
   const breadcrumbs = useMemo((): BreadcrumbEntry[] | undefined => {
     if (isHomeDoc) return undefined
     const lastIdx = breadcrumbIds.length - 1
     const items: BreadcrumbEntry[] = breadcrumbIds.map((id, i) => {
+      const draft = draftsForBreadcrumbs[i]
+      const fallbackName = id.path?.at(-1) || id.uid.slice(0, 8)
+
+      if (draft) {
+        return {
+          id,
+          metadata: draft.metadata ?? {},
+          fallbackName: draft.metadata?.name || fallbackName,
+          isLoading: false,
+          isTombstone: false,
+          isNotFound: false,
+          isError: false,
+          isUnpublishedDraft: true,
+        }
+      }
+
+      if (pendingDraftLookup[i]) {
+        return {
+          id,
+          metadata: {},
+          fallbackName,
+          isLoading: true,
+          isTombstone: false,
+          isNotFound: false,
+          isError: false,
+          isUnpublishedDraft: true,
+        }
+      }
+
       const result = breadcrumbResults[i]
       const data = result?.data
       const metadata = data?.type === 'document' ? data.document?.metadata || {} : {}
-      const fallbackName = id.path?.at(-1) || id.uid.slice(0, 8)
       const isCurrent = i === lastIdx
-      // The current doc may be a local-only draft (no published version on
-      // disk yet). Surface a friendlier "draft" tooltip on this crumb instead
-      // of the generic "Document not found on the network".
+      // Fallback: the document machine knows the current doc is an
+      // unpublished draft even before the account draft list resolves.
+      // Avoids flashing "not found" on the active draft on first paint.
       const showAsUnpublishedDraft = isCurrent && isUnpublishedDraft
       return {
         id,
@@ -1074,7 +1133,18 @@ function DocumentBody({
     }
 
     return items
-  }, [isHomeDoc, breadcrumbIds, breadcrumbResults, activeView, routeBlockRef, document.content, route])
+  }, [
+    isHomeDoc,
+    breadcrumbIds,
+    breadcrumbResults,
+    draftsForBreadcrumbs,
+    pendingDraftLookup,
+    isUnpublishedDraft,
+    activeView,
+    routeBlockRef,
+    document.content,
+    route,
+  ])
 
   // Track when DocumentTools becomes sticky
   const [isToolsSticky, setIsToolsSticky] = useState(false)


### PR DESCRIPTION
## Summary

- Add a shared draft breadcrumb context/provider so draft-aware breadcrumb state can be passed through desktop resource rendering.
- Wire desktop resource pages and resource page common UI to consume draft breadcrumb state.
- Add breadcrumb utilities coverage plus a design note documenting the draft context unification.

## Why

Draft breadcrumb handling was split across desktop/resource layers. Centralizing the draft context keeps breadcrumb rendering consistent while preserving desktop-specific draft data fetching at the boundary.

## Validation

- `pnpm --filter @shm/shared test -- draft-breadcrumb-context`
- `pnpm --filter @shm/shared typecheck`
- `pnpm --filter @shm/ui typecheck`
- `pnpm --filter @shm/desktop typecheck`
