### PR TITLE
Remove plus button from image caption

### DIFF
--- a/frontend/packages/editor/src/blocknote/core/__tests__/slash-menu-caption-guards.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/__tests__/slash-menu-caption-guards.test.ts
@@ -97,11 +97,7 @@ describe('slash menu caption guards', () => {
   it('allows slash menu in paragraphs', () => {
     const {view, pluginKey, plugin} = createView(findPos(createDoc(schema), 'paragraph', 1))
 
-    const handled = plugin.props.handleKeyDown!.call(
-      plugin,
-      view,
-      new KeyboardEvent('keydown', {key: '/'}),
-    )
+    const handled = plugin.props.handleKeyDown!.call(plugin, view, new KeyboardEvent('keydown', {key: '/'}))
 
     expect(handled).toBe(true)
     expect(pluginKey.getState(view.state).active).toBe(true)
@@ -111,11 +107,7 @@ describe('slash menu caption guards', () => {
   it('blocks slash menu inside image captions', () => {
     const {view, pluginKey, plugin} = createView(findPos(createDoc(schema), 'image', 1))
 
-    const handled = plugin.props.handleKeyDown!.call(
-      plugin,
-      view,
-      new KeyboardEvent('keydown', {key: '/'}),
-    )
+    const handled = plugin.props.handleKeyDown!.call(plugin, view, new KeyboardEvent('keydown', {key: '/'}))
 
     expect(handled).toBe(false)
     expect(pluginKey.getState(view.state).active).toBe(false)

--- a/frontend/packages/editor/src/blocknote/core/__tests__/slash-menu-caption-guards.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/__tests__/slash-menu-caption-guards.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import {Schema} from 'prosemirror-model'
+import {EditorState, PluginKey, TextSelection} from 'prosemirror-state'
+import {EditorView} from 'prosemirror-view'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {isSlashMenuEnabled} from '../extensions/SlashMenu/SlashMenuPlugin'
+import {setupSuggestionsMenu} from '../shared/plugins/suggestion/SuggestionPlugin'
+
+function createSchema(): Schema {
+  return new Schema({
+    nodes: {
+      doc: {content: 'block+'},
+      paragraph: {
+        group: 'block',
+        content: 'text*',
+        toDOM() {
+          return ['p', 0]
+        },
+      },
+      image: {
+        group: 'block',
+        content: 'text*',
+        toDOM() {
+          return ['figcaption', 0]
+        },
+      },
+      text: {group: 'inline'},
+    },
+  })
+}
+
+function createDoc(schema: Schema) {
+  return schema.nodes.doc.create(null, [
+    schema.nodes.paragraph.create(null, schema.text('hello')),
+    schema.nodes.image.create(null, schema.text('caption')),
+  ])
+}
+
+function findPos(doc: any, nodeType: string, offset = 1): number {
+  let found = -1
+  doc.descendants((node: any, pos: number) => {
+    if (found === -1 && node.type.name === nodeType) {
+      found = pos + offset
+    }
+  })
+  if (found === -1) throw new Error(`Node "${nodeType}" not found`)
+  return found
+}
+
+describe('slash menu caption guards', () => {
+  let schema: Schema
+
+  beforeEach(() => {
+    schema = createSchema()
+  })
+
+  function createView(selectionPos: number) {
+    const doc = createDoc(schema)
+    const pluginKey = new PluginKey('test-slash-menu')
+    const plugin = setupSuggestionsMenu(
+      {
+        isEditable: true,
+        _tiptapEditor: {
+          chain: () => ({
+            focus: () => ({
+              deleteRange: () => ({
+                run: vi.fn(),
+              }),
+            }),
+          }),
+          state: {selection: {from: selectionPos}},
+        },
+      } as any,
+      () => {},
+      pluginKey,
+      '/',
+      () => [{name: 'Paragraph'} as any],
+      () => {},
+      {isEnabled: isSlashMenuEnabled},
+    ).plugin
+
+    const state = EditorState.create({
+      doc,
+      schema,
+      plugins: [plugin],
+      selection: TextSelection.create(doc, selectionPos),
+    })
+    const container = document.createElement('div')
+    const view = new EditorView(container, {
+      state,
+      editable: () => true,
+    })
+
+    return {plugin, pluginKey, view}
+  }
+
+  it('allows slash menu in paragraphs', () => {
+    const {view, pluginKey, plugin} = createView(findPos(createDoc(schema), 'paragraph', 1))
+
+    const handled = plugin.props.handleKeyDown!.call(
+      plugin,
+      view,
+      new KeyboardEvent('keydown', {key: '/'}),
+    )
+
+    expect(handled).toBe(true)
+    expect(pluginKey.getState(view.state).active).toBe(true)
+    view.destroy()
+  })
+
+  it('blocks slash menu inside image captions', () => {
+    const {view, pluginKey, plugin} = createView(findPos(createDoc(schema), 'image', 1))
+
+    const handled = plugin.props.handleKeyDown!.call(
+      plugin,
+      view,
+      new KeyboardEvent('keydown', {key: '/'}),
+    )
+
+    expect(handled).toBe(false)
+    expect(pluginKey.getState(view.state).active).toBe(false)
+    view.destroy()
+  })
+
+  it('closes an active slash menu when selection moves into an image caption', () => {
+    const doc = createDoc(schema)
+    const paragraphPos = findPos(doc, 'paragraph', 1)
+    const captionPos = findPos(doc, 'image', 1)
+    const {view, pluginKey} = createView(paragraphPos)
+
+    view.dispatch(
+      view.state.tr.insertText('/').setMeta(pluginKey, {
+        activate: true,
+        triggerCharacter: '/',
+      }),
+    )
+    expect(pluginKey.getState(view.state).active).toBe(true)
+
+    view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, captionPos)))
+
+    expect(pluginKey.getState(view.state).active).toBe(false)
+    view.destroy()
+  })
+})

--- a/frontend/packages/editor/src/blocknote/core/extensions/SlashMenu/SlashMenuPlugin.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/SlashMenu/SlashMenuPlugin.ts
@@ -1,4 +1,4 @@
-import {Plugin, PluginKey} from 'prosemirror-state'
+import {EditorState, Plugin, PluginKey} from 'prosemirror-state'
 
 import {BlockNoteEditor} from '../../BlockNoteEditor'
 import {EventEmitter} from '../../shared/EventEmitter'
@@ -7,6 +7,13 @@ import {BlockSchema} from '../Blocks/api/blockTypes'
 import {BaseSlashMenuItem} from './BaseSlashMenuItem'
 
 export const slashMenuPluginKey = new PluginKey('SlashMenuPlugin')
+
+/**
+ * Returns whether slash-menu commands are allowed in the current selection context.
+ */
+export function isSlashMenuEnabled(state: EditorState) {
+  return state.selection.$from.parent.type.name !== 'image'
+}
 
 export class SlashMenuProsemirrorPlugin<
   BSchema extends BlockSchema,
@@ -31,6 +38,7 @@ export class SlashMenuProsemirrorPlugin<
             (aliases && aliases.filter((alias) => alias.toLowerCase().startsWith(query.toLowerCase())).length !== 0),
         ),
       ({item, editor}) => item.execute(editor),
+      {isEnabled: isSlashMenuEnabled},
     )
 
     this.plugin = suggestions.plugin

--- a/frontend/packages/editor/src/blocknote/core/shared/plugins/suggestion/SuggestionPlugin.ts
+++ b/frontend/packages/editor/src/blocknote/core/shared/plugins/suggestion/SuggestionPlugin.ts
@@ -142,6 +142,9 @@ export const setupSuggestionsMenu = <T extends SuggestionItem, BSchema extends B
   onSelectItem: (props: {item: T; editor: BlockNoteEditor<BSchema>}) => void = () => {
     // noop
   },
+  options: {
+    isEnabled?: (state: EditorState) => boolean
+  } = {},
 ) => {
   // Assertions
   if (defaultTriggerCharacter.length !== 1) {
@@ -183,6 +186,9 @@ export const setupSuggestionsMenu = <T extends SuggestionItem, BSchema extends B
 
           // Checks if the menu should be shown.
           if (transaction.getMeta(pluginKey)?.activate) {
+            if (options.isEnabled && !options.isEnabled(newState)) {
+              return getDefaultPluginState<T>()
+            }
             return {
               active: true,
               triggerCharacter: transaction.getMeta(pluginKey)?.triggerCharacter || '',
@@ -218,6 +224,7 @@ export const setupSuggestionsMenu = <T extends SuggestionItem, BSchema extends B
           // Hides the menu. This is done after items and notFoundCount are already updated as notFoundCount is needed to
           // check if the menu should be hidden.
           if (
+            (options.isEnabled && !options.isEnabled(newState)) ||
             // Highlighting text should hide the menu.
             newState.selection.from !== newState.selection.to ||
             // Transactions with plugin metadata {deactivate: true} should hide the menu.
@@ -265,6 +272,10 @@ export const setupSuggestionsMenu = <T extends SuggestionItem, BSchema extends B
           if (event.key === defaultTriggerCharacter && !menuIsActive) {
             const {state} = view
             const {selection} = state
+
+            if (options.isEnabled && !options.isEnabled(state)) {
+              return false
+            }
 
             const posBefore = selection.$from.pos - 1
             const charBefore = state.doc.textBetween(posBefore, posBefore + 1, undefined, '\ufffc')

--- a/frontend/packages/editor/src/inline-add-block-button.test.tsx
+++ b/frontend/packages/editor/src/inline-add-block-button.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import {createRoot, type Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+import {InlineAddBlockButton} from './inline-add-block-button'
+
+type SelectionContext = {
+  depth: number
+  parent: {isTextblock: boolean; childCount: number; type: {name: string}}
+  node: (depth: number) => {type: {name: string}; attrs: {listType: string}}
+}
+
+function makeEditor(selectionContext: SelectionContext) {
+  const listeners = new Map<string, Set<() => void>>()
+  return {
+    isEditable: true,
+    _tiptapEditor: {
+      view: {
+        state: {
+          selection: {anchor: 1},
+          doc: {
+            resolve: () => selectionContext,
+          },
+        },
+        coordsAtPos: () => ({top: 20, bottom: 28, left: 64}),
+        focus: vi.fn(),
+        dispatch: vi.fn(),
+      },
+      on: (event: string, cb: () => void) => {
+        if (!listeners.has(event)) listeners.set(event, new Set())
+        listeners.get(event)!.add(cb)
+      },
+      off: (event: string, cb: () => void) => {
+        listeners.get(event)?.delete(cb)
+      },
+    },
+  } as any
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+  document.body.innerHTML = ''
+})
+
+describe('InlineAddBlockButton', () => {
+  it('renders for an empty paragraph block', () => {
+    const editor = makeEditor({
+      depth: 1,
+      parent: {isTextblock: true, childCount: 0, type: {name: 'paragraph'}},
+      node: () => ({type: {name: 'blockChildren'}, attrs: {listType: 'Group'}}),
+    })
+
+    act(() => {
+      root.render(<InlineAddBlockButton editor={editor} />)
+    })
+
+    expect(document.body.querySelector('[aria-label="Insert block"]')).not.toBeNull()
+  })
+
+  it('does not render inside an image caption', () => {
+    const editor = makeEditor({
+      depth: 1,
+      parent: {isTextblock: true, childCount: 0, type: {name: 'image'}},
+      node: () => ({type: {name: 'blockChildren'}, attrs: {listType: 'Group'}}),
+    })
+
+    act(() => {
+      root.render(<InlineAddBlockButton editor={editor} />)
+    })
+
+    expect(document.body.querySelector('[aria-label="Insert block"]')).toBeNull()
+  })
+})

--- a/frontend/packages/editor/src/inline-add-block-button.tsx
+++ b/frontend/packages/editor/src/inline-add-block-button.tsx
@@ -3,7 +3,7 @@ import {cn} from '@shm/ui/utils'
 import {Plus} from 'lucide-react'
 import {useEffect, useRef, useState} from 'react'
 import {createPortal} from 'react-dom'
-import {slashMenuPluginKey} from './blocknote/core/extensions/SlashMenu/SlashMenuPlugin'
+import {isSlashMenuEnabled, slashMenuPluginKey} from './blocknote/core/extensions/SlashMenu/SlashMenuPlugin'
 import type {HyperMediaEditor} from './types'
 
 type Position = {top: number; left: number}
@@ -52,6 +52,7 @@ export function InlineAddBlockButton({editor}: {editor: HyperMediaEditor}) {
       if (!editor.isEditable) return null
       const view = ttEditor.view
       const state = view.state
+      if (!isSlashMenuEnabled(state)) return null
       const {anchor} = state.selection
       const $anchor = state.doc.resolve(anchor)
       const textblock = $anchor.parent


### PR DESCRIPTION
Implemented the image-caption restriction so captions remain inline rich text only and no longer expose block-insertion UI or slash commands.

Notes
- No schema/content-model change was made.
- Existing plain-text caption behavior was preserved.
- Full local validation was blocked in this environment because frontend dependencies were not installed.