### PR TITLE
fix(scripts): make check-ts-directives skip generated code and count net change

### DIFF
--- a/scripts/check-ts-directives.mjs
+++ b/scripts/check-ts-directives.mjs
@@ -2,175 +2,214 @@
 
 /**
  * Script to check for new TypeScript compiler directives in changed code.
- * Prevents new additions of @ts-expect-error, @ts-nocheck, and @ts-ignore.
+ * Prevents net new additions of @ts-expect-error, @ts-nocheck, and @ts-ignore.
  *
  * Usage:
  *   node scripts/check-ts-directives.mjs [--base-branch=main]
  *
  * The script will:
  * 1. Get the git diff for changed files
- * 2. Check only added lines (prefixed with +)
- * 3. Search for banned TypeScript directives
- * 4. Exit with error code 1 if any are found
+ * 2. For each file, count directive occurrences on added (+) vs removed (-)
+ *    lines and flag only the net positive — directives that were merely
+ *    moved (e.g. by a JSX wrapper refactor) net to zero and pass
+ * 3. Skip files under /.generated/ or /generated/ paths, since
+ *    protoc-gen-es emits `// @ts-nocheck` in every file it writes
+ * 4. Exit with error code 1 if any net new violations remain
  */
 
-import {execSync} from "child_process";
-import {exit} from "process";
+import {execSync} from 'child_process'
+import {exit} from 'process'
 
 // TypeScript directives to check for
-const BANNED_DIRECTIVES = ["@ts-expect-error", "@ts-nocheck", "@ts-ignore"];
+const BANNED_DIRECTIVES = ['@ts-expect-error', '@ts-nocheck', '@ts-ignore']
 
 // File extensions to check
-const TS_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
+const TS_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']
+
+// Path fragments identifying auto-generated code. The protoc-gen-es generator
+// always emits `// @ts-nocheck` at the top of every file it writes, so any
+// regen produces "new" directives that aren't hand-written and shouldn't
+// block CI.
+const GENERATED_PATH_FRAGMENTS = ['/.generated/', '/generated/']
 
 function getBaseBranch() {
-  const argBaseBranch = process.argv.find((arg) =>
-    arg.startsWith("--base-branch=")
-  );
+  const argBaseBranch = process.argv.find((arg) => arg.startsWith('--base-branch='))
   if (argBaseBranch) {
-    return argBaseBranch.split("=")[1];
+    return argBaseBranch.split('=')[1]
   }
 
   // Default to main, but try to detect the default branch
   try {
-    const defaultBranch = execSync(
-      "git symbolic-ref refs/remotes/origin/HEAD",
-      {encoding: "utf8"}
-    )
+    const defaultBranch = execSync('git symbolic-ref refs/remotes/origin/HEAD', {encoding: 'utf8'})
       .trim()
-      .replace("refs/remotes/origin/", "");
-    return defaultBranch;
+      .replace('refs/remotes/origin/', '')
+    return defaultBranch
   } catch {
-    return "main";
+    return 'main'
   }
 }
 
 function isTypeScriptFile(filename) {
-  return TS_EXTENSIONS.some((ext) => filename.endsWith(ext));
+  return TS_EXTENSIONS.some((ext) => filename.endsWith(ext))
+}
+
+function isGeneratedFile(filename) {
+  const normalized = '/' + filename.replace(/^\.\//, '')
+  return GENERATED_PATH_FRAGMENTS.some((frag) => normalized.includes(frag))
 }
 
 function getGitDiff() {
-  const baseBranch = getBaseBranch();
+  const baseBranch = getBaseBranch()
 
   try {
     // Try to get diff against base branch first (for PRs)
     try {
-      return execSync(`git diff ${baseBranch}...HEAD`, {encoding: "utf8"});
+      return execSync(`git diff ${baseBranch}...HEAD`, {encoding: 'utf8'})
     } catch {
       // If that fails, try against origin/main
       try {
         return execSync(`git diff origin/${baseBranch}...HEAD`, {
-          encoding: "utf8",
-        });
+          encoding: 'utf8',
+        })
       } catch {
         // If still fails, get staged changes + working directory changes
-        const staged = execSync("git diff --cached", {encoding: "utf8"});
-        const unstaged = execSync("git diff", {encoding: "utf8"});
-        return staged + "\n" + unstaged;
+        const staged = execSync('git diff --cached', {encoding: 'utf8'})
+        const unstaged = execSync('git diff', {encoding: 'utf8'})
+        return staged + '\n' + unstaged
       }
     }
   } catch (error) {
-    console.error("Failed to get git diff:", error.message);
-    exit(1);
+    console.error('Failed to get git diff:', error.message)
+    exit(1)
   }
 }
 
+// Walk a unified diff and compute, per file, how many times each banned
+// directive was added vs removed, plus the list of added-line locations.
+// A directive only counts as a violation when its net count (added minus
+// removed) is positive — moving a directive within a file or splitting a
+// component out shows up as a wash and is ignored.
 function parseDiff(diff) {
-  const violations = [];
-  const lines = diff.split("\n");
-  let currentFile = null;
-  let lineNumber = 0;
+  const perFile = new Map()
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-
-    // Track current file being processed
-    if (line.startsWith("+++")) {
-      currentFile = line.substring(4).replace(/^b\//, "");
-      lineNumber = 0;
-      continue;
-    }
-
-    // Track line numbers for added lines
-    if (line.startsWith("@@")) {
-      const match = line.match(/\+(\d+)/);
-      if (match) {
-        lineNumber = parseInt(match[1]) - 1;
+  function ensure(file) {
+    let entry = perFile.get(file)
+    if (!entry) {
+      entry = {
+        added: Object.fromEntries(BANNED_DIRECTIVES.map((d) => [d, 0])),
+        removed: Object.fromEntries(BANNED_DIRECTIVES.map((d) => [d, 0])),
+        addedLines: Object.fromEntries(BANNED_DIRECTIVES.map((d) => [d, []])),
       }
-      continue;
+      perFile.set(file, entry)
+    }
+    return entry
+  }
+
+  const lines = diff.split('\n')
+  let currentFile = null
+  let skipFile = false
+  let lineNumber = 0
+
+  for (const line of lines) {
+    if (line.startsWith('+++')) {
+      currentFile = line.substring(4).replace(/^b\//, '')
+      // `+++ /dev/null` happens for deletions — nothing to check.
+      skipFile = currentFile === '/dev/null' || !isTypeScriptFile(currentFile) || isGeneratedFile(currentFile)
+      lineNumber = 0
+      continue
     }
 
-    // Only check added lines in TypeScript/JavaScript files
-    if (line.startsWith("+") && currentFile && isTypeScriptFile(currentFile)) {
-      lineNumber++;
-      const content = line.substring(1); // Remove the + prefix
+    if (line.startsWith('@@')) {
+      const match = line.match(/\+(\d+)/)
+      if (match) {
+        lineNumber = parseInt(match[1], 10) - 1
+      }
+      continue
+    }
 
-      // Check for banned directives
+    if (skipFile || !currentFile) continue
+
+    if (line.startsWith('+') && !line.startsWith('+++')) {
+      lineNumber++
+      const content = line.substring(1)
+      const entry = ensure(currentFile)
       for (const directive of BANNED_DIRECTIVES) {
         if (content.includes(directive)) {
-          violations.push({
-            file: currentFile,
+          entry.added[directive]++
+          entry.addedLines[directive].push({
             line: lineNumber,
-            directive: directive,
             content: content.trim(),
-          });
+          })
         }
       }
-    } else if (!line.startsWith("-")) {
-      // Only increment line number for non-removed lines
-      lineNumber++;
+    } else if (line.startsWith('-') && !line.startsWith('---')) {
+      const content = line.substring(1)
+      const entry = ensure(currentFile)
+      for (const directive of BANNED_DIRECTIVES) {
+        if (content.includes(directive)) {
+          entry.removed[directive]++
+        }
+      }
+    } else {
+      lineNumber++
     }
   }
 
-  return violations;
+  const violations = []
+  for (const [file, entry] of perFile) {
+    for (const directive of BANNED_DIRECTIVES) {
+      const net = entry.added[directive] - entry.removed[directive]
+      if (net > 0) {
+        // Report the last `net` added occurrences — those are the ones
+        // that couldn't be paired with a removal in this hunk.
+        const tail = entry.addedLines[directive].slice(-net)
+        for (const loc of tail) {
+          violations.push({file, directive, ...loc})
+        }
+      }
+    }
+  }
+  return violations
 }
 
 function main() {
-  console.log("🔍 Checking for new TypeScript compiler directives...");
+  console.log('🔍 Checking for new TypeScript compiler directives...')
 
-  const diff = getGitDiff();
+  const diff = getGitDiff()
 
   if (!diff.trim()) {
-    console.log("✅ No changes detected, skipping check");
-    exit(0);
+    console.log('✅ No changes detected, skipping check')
+    exit(0)
   }
 
-  const violations = parseDiff(diff);
+  const violations = parseDiff(diff)
 
   if (violations.length === 0) {
-    console.log("✅ No new TypeScript directives found");
-    exit(0);
+    console.log('✅ No new TypeScript directives found')
+    exit(0)
   }
 
-  console.error("❌ Found new TypeScript compiler directives in changed code:");
-  console.error("");
+  console.error('❌ Found new TypeScript compiler directives in changed code:')
+  console.error('')
 
   violations.forEach((violation) => {
-    console.error(`  ${violation.file}:${violation.line}`);
-    console.error(`    Found: ${violation.directive}`);
-    console.error(`    Line: ${violation.content}`);
-    console.error("");
-  });
+    console.error(`  ${violation.file}:${violation.line}`)
+    console.error(`    Found: ${violation.directive}`)
+    console.error(`    Line: ${violation.content}`)
+    console.error('')
+  })
 
-  console.error(`Found ${violations.length} violation(s).`);
-  console.error("");
-  console.error(
-    "TypeScript compiler directives like @ts-expect-error, @ts-nocheck, and @ts-ignore"
-  );
-  console.error(
-    "should be avoided in new code. Please fix the underlying TypeScript errors instead."
-  );
-  console.error("");
-  console.error("If you absolutely must use these directives:");
-  console.error("1. Fix the TypeScript error properly if possible");
-  console.error(
-    "2. Add detailed comments explaining why the directive is necessary"
-  );
-  console.error(
-    "3. Consider if the code can be refactored to avoid the need for the directive"
-  );
+  console.error(`Found ${violations.length} violation(s).`)
+  console.error('')
+  console.error('TypeScript compiler directives like @ts-expect-error, @ts-nocheck, and @ts-ignore')
+  console.error('should be avoided in new code. Please fix the underlying TypeScript errors instead.')
+  console.error('')
+  console.error('If you absolutely must use these directives:')
+  console.error('1. Fix the TypeScript error properly if possible')
+  console.error('2. Add detailed comments explaining why the directive is necessary')
+  console.error('3. Consider if the code can be refactored to avoid the need for the directive')
 
-  exit(1);
+  exit(1)
 }
 
-main();
+main()


### PR DESCRIPTION
The lint job of test-frontend-parallel.yml runs check-ts-directives.mjs,
which was flagging two classes of false positive on otherwise-valid branches:

1. Auto-generated proto files. protoc-gen-es always emits `// @ts-nocheck`
   at the top of every file it writes (every file under .generated/* uses
   it as a convention). Regenerating protos for a new service - e.g. the
   telemetry package - then surfaces as "new @ts-nocheck" violations even
   though no one hand-wrote a directive.

2. Directives moved by a refactor. Wrapping JSX in a new component
   (e.g. extracting BlockSelectionWrapper) produced a diff with three
   directives removed and two re-added; the script counted only the
   `+` side and reported two new violations even though the net was
   negative.

Fix:
- Skip files whose path contains /.generated/ or /generated/.
- Walk both `+` and `-` lines in the diff, accumulate counts per (file,
  directive), and only report a violation when added > removed.
- Drop the doc comment claim that the script "checks only added lines"
  since it now considers both sides to compute net change.