### PR TITLE
fix(editor): preserve responsive image widths

### DIFF
--- a/frontend/apps/web/app/styles.css
+++ b/frontend/apps/web/app/styles.css
@@ -178,6 +178,8 @@ body {
 .ssr-content-placeholder [data-content-type='image'] img {
   max-width: 100%;
   height: auto;
+  max-height: 600px;
+  object-fit: contain;
   border-radius: 4px;
 }
 .ssr-content-placeholder [data-content-type='image'] .inlineContent {

--- a/frontend/packages/client/src/editorblock-to-hmblock.ts
+++ b/frontend/packages/client/src/editorblock-to-hmblock.ts
@@ -25,6 +25,14 @@ function toHMBlockType(editorBlockType: EditorBlock['type']): HMBlockType | unde
   return undefined
 }
 
+function toImageWidthNumber(width: string | undefined): number | null {
+  if (width?.trim().endsWith('%')) {
+    const percentage = Number(width.trim().slice(0, -1))
+    return Number.isFinite(percentage) && percentage > 0 ? percentage : null
+  }
+  return toNumber(width)
+}
+
 // Mutable block type for building HMBlock before validation
 type MutableBlock = {
   id: string
@@ -164,7 +172,7 @@ export function editorBlockToHMBlock(editorBlock: EditorBlock): HMBlock {
     } else {
       blockImage.link = ''
     }
-    const width = toNumber(editorBlock.props.width)
+    const width = toImageWidthNumber(editorBlock.props.width)
     if (width) {
       blockImage.attributes.width = width
     }

--- a/frontend/packages/client/src/hmblock-to-editorblock.ts
+++ b/frontend/packages/client/src/hmblock-to-editorblock.ts
@@ -137,7 +137,8 @@ export function hmBlockToEditorBlock(block: HMBlock): EditorBlock {
         if (value !== undefined) {
           if (key == 'width' || key == 'size') {
             if (typeof value == 'number') {
-              ;(out.props as any)[key] = String(value)
+              ;(out.props as any)[key] =
+                blockType === 'image' && key === 'width' && value > 0 && value <= 100 ? `${value}%` : String(value)
             }
           } else if (typeof value == 'boolean') {
             ;(out.props as any)[key] = String(value)

--- a/frontend/packages/editor/src/image.test.tsx
+++ b/frontend/packages/editor/src/image.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import {createRoot, type Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+const editorGate = {canEdit: true, isEditing: true, beginEditIfNeeded: vi.fn()}
+
+vi.mock('@shm/shared/models/use-editor-gate', () => ({
+  useEditorGate: () => editorGate,
+}))
+
+vi.mock('@shm/ui/get-file-url', () => ({
+  useImageUrl: () => (url: string) => `resolved:${url}`,
+}))
+
+vi.mock('@shm/ui/resize-handle', () => ({
+  ResizeHandle: ({onMouseDown, style}: any) => (
+    <div
+      data-testid={style?.left !== undefined ? 'left-resize-handle' : 'right-resize-handle'}
+      onMouseDown={onMouseDown}
+    />
+  ),
+}))
+
+vi.mock('@shm/ui/toast', () => ({
+  toast: {error: vi.fn()},
+}))
+
+vi.mock('./blocknote/react', () => ({
+  createReactBlockSpec: (config: any) => config,
+}))
+
+vi.mock('./media-render', () => ({
+  MediaRender: () => null,
+}))
+
+vi.mock('./media-container', () => ({
+  MediaContainer: ({children, width, onHoverIn}: any) => (
+    <div data-testid="media-container" data-width={width}>
+      <button data-testid="show-resize-handles" onClick={onHoverIn} />
+      {children}
+    </div>
+  ),
+}))
+
+import {ImageDisplay} from './image'
+
+function makeEditor(editorWidth = 390) {
+  return {
+    domElement: {firstElementChild: {clientWidth: editorWidth}},
+    importWebFile: undefined,
+    isEditable: true,
+    renderType: 'editor',
+    setTextCursorPosition: vi.fn(),
+  } as any
+}
+
+function makeBlock(width = '') {
+  return {
+    id: 'block-1',
+    type: 'image',
+    props: {
+      url: 'https://example.com/tall-mobile-screenshot.png',
+      width,
+      name: '',
+      alt: '',
+      displaySrc: '',
+      mediaRef: '',
+    },
+    content: [],
+    children: [],
+  } as any
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  editorGate.canEdit = true
+  editorGate.isEditing = true
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+describe('ImageDisplay responsive sizing', () => {
+  it('keeps default images full-width and uses the 600px height cap as a CSS hint only', () => {
+    const assign = vi.fn()
+
+    act(() => {
+      root.render(<ImageDisplay editor={makeEditor()} block={makeBlock()} assign={assign} />)
+    })
+
+    const mediaContainer = container.querySelector('[data-testid="media-container"]') as HTMLElement
+    const image = container.querySelector('img') as HTMLImageElement
+
+    expect(mediaContainer.dataset.width).toBe('100%')
+    expect(image.style.width).toBe('100%')
+    expect(image.style.height).toBe('auto')
+    expect(image.style.maxHeight).toBe('600px')
+    expect(image.style.objectFit).toBe('contain')
+
+    act(() => {
+      image.dispatchEvent(new Event('load'))
+    })
+
+    expect(assign).not.toHaveBeenCalled()
+  })
+
+  it('persists explicit resize as a percentage of the editor width', () => {
+    const assign = vi.fn()
+    const editor = makeEditor(390)
+
+    act(() => {
+      root.render(<ImageDisplay editor={editor} block={makeBlock()} assign={assign} />)
+    })
+
+    const showHandles = container.querySelector('[data-testid="show-resize-handles"]') as HTMLElement
+    act(() => {
+      showHandles.click()
+    })
+
+    const rightHandle = container.querySelector('[data-testid="right-resize-handle"]') as HTMLElement
+    act(() => {
+      rightHandle.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, clientX: 0}))
+    })
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', {clientX: -45}))
+    })
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mouseup', {bubbles: true}))
+    })
+
+    expect(assign).toHaveBeenCalledWith({
+      props: {
+        width: '76.92%',
+      },
+    })
+  })
+})

--- a/frontend/packages/editor/src/image.tsx
+++ b/frontend/packages/editor/src/image.tsx
@@ -157,7 +157,8 @@ const Render = (block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
   )
 }
 
-const ImageDisplay = ({editor, block, assign}: DisplayComponentProps) => {
+/** Renders an image block with responsive sizing and editor resize handles. */
+export const ImageDisplay = ({editor, block, assign}: DisplayComponentProps) => {
   const getImageUrl = useImageUrl()
   const {canEdit} = useEditorGate()
 
@@ -286,13 +287,14 @@ const ImageDisplay = ({editor, block, assign}: DisplayComponentProps) => {
   // Max image height in px.
   const maxHeight = 600
 
+  const getEditorWidth = () => editor.domElement.firstElementChild!.clientWidth
+  const widthProp = block.props.width?.trim()
   let width: number =
-    // @ts-ignore
-    parseFloat(block.props.width) || editor.domElement.firstElementChild!.clientWidth
+    widthProp && widthProp.endsWith('%')
+      ? (parseFloat(widthProp) / 100) * getEditorWidth()
+      : parseFloat(widthProp || '') || getEditorWidth()
   const [currentWidth, setCurrentWidth] = useState(width)
   const [showHandle, setShowHandle] = useState(false)
-  // Track image natural dimensions for aspect ratio calculation
-  const [imageAspectRatio, setImageAspectRatio] = useState<number | null>(null)
 
   const resizeParamsRef = useRef<{
     handleUsed: 'left' | 'right'
@@ -301,34 +303,18 @@ const ImageDisplay = ({editor, block, assign}: DisplayComponentProps) => {
   } | null>(null)
 
   useEffect(() => {
-    if (block.props.width) {
-      width = parseFloat(block.props.width)
-      setCurrentWidth(parseFloat(block.props.width))
+    const editorWidth = getEditorWidth()
+    const nextWidthProp = block.props.width?.trim()
+    if (nextWidthProp) {
+      const parsedWidth = parseFloat(nextWidthProp)
+      const nextWidth = nextWidthProp.endsWith('%') ? (parsedWidth / 100) * editorWidth : parsedWidth
+      width = Math.min(nextWidth || editorWidth, editorWidth)
+      setCurrentWidth(width)
     } else {
-      width = editor.domElement.firstElementChild!.clientWidth
+      width = editorWidth
       setCurrentWidth(width)
     }
   }, [block.props.width])
-
-  // Handle image load to get aspect ratio
-  const handleImageLoad = (event: React.SyntheticEvent<HTMLImageElement>) => {
-    const img = event.currentTarget
-    if (img.naturalWidth && img.naturalHeight) {
-      const aspectRatio = img.naturalWidth / img.naturalHeight
-      setImageAspectRatio(aspectRatio)
-
-      // If current width would make height exceed maxHeight, adjust width
-      if (aspectRatio && currentWidth / aspectRatio > maxHeight) {
-        const newWidth = maxHeight * aspectRatio
-        setCurrentWidth(newWidth)
-        assign({
-          props: {
-            width: newWidth.toString(),
-          },
-        })
-      }
-    }
-  }
 
   const windowMouseMoveHandler = (event: MouseEvent) => {
     if (!resizeParamsRef.current) {
@@ -349,19 +335,10 @@ const ImageDisplay = ({editor, block, assign}: DisplayComponentProps) => {
     if (newWidth < minWidth) {
       width = minWidth
       setCurrentWidth(minWidth)
-    } else if (newWidth > editor.domElement.firstElementChild!.clientWidth) {
-      width = editor.domElement.firstElementChild!.clientWidth
-      setCurrentWidth(editor.domElement.firstElementChild!.clientWidth)
+    } else if (newWidth > getEditorWidth()) {
+      width = getEditorWidth()
+      setCurrentWidth(getEditorWidth())
     } else {
-      // Check if new width would make height exceed maxHeight (if we know aspect ratio)
-      if (imageAspectRatio) {
-        const projectedHeight = newWidth / imageAspectRatio
-        if (projectedHeight > maxHeight) {
-          // Limit width based on maxHeight and aspect ratio
-          newWidth = maxHeight * imageAspectRatio
-        }
-      }
-
       width = newWidth
       setCurrentWidth(newWidth)
     }
@@ -379,7 +356,7 @@ const ImageDisplay = ({editor, block, assign}: DisplayComponentProps) => {
 
     assign({
       props: {
-        width: width.toString(),
+        width: `${Math.round((width / getEditorWidth()) * 10000) / 100}%`,
       },
     })
   }
@@ -414,7 +391,7 @@ const ImageDisplay = ({editor, block, assign}: DisplayComponentProps) => {
     resizeParamsRef.current = {
       handleUsed: 'left',
       // @ts-ignore
-      initialWidth: width || parseFloat(block.props.width),
+      initialWidth: currentWidth || width || parseFloat(block.props.width),
       initialClientX: event.clientX,
     }
     editor.setTextCursorPosition(block.id, 'start')
@@ -427,7 +404,7 @@ const ImageDisplay = ({editor, block, assign}: DisplayComponentProps) => {
     resizeParamsRef.current = {
       handleUsed: 'right',
       // @ts-ignore
-      initialWidth: width || parseFloat(block.props.width),
+      initialWidth: currentWidth || width || parseFloat(block.props.width),
       initialClientX: event.clientX,
     }
     editor.setTextCursorPosition(block.id, 'start')
@@ -446,7 +423,7 @@ const ImageDisplay = ({editor, block, assign}: DisplayComponentProps) => {
         }
       }}
       onHoverOut={imageMouseLeaveHandler}
-      width={currentWidth}
+      width={`${Math.round((currentWidth / getEditorWidth()) * 10000) / 100}%`}
       onSubmitUrl={handleMenuUrl}
       urlMenuLabel="Insert from URL"
       urlInputPlaceholder="Paste an image URL"
@@ -462,13 +439,13 @@ const ImageDisplay = ({editor, block, assign}: DisplayComponentProps) => {
         <img
           style={{
             width: `100%`,
+            height: 'auto',
             maxHeight: `${maxHeight}px`,
             objectFit: 'contain',
           }}
           src={imageSrc}
           alt={block.props.name || block.props.alt}
           contentEditable={false}
-          onLoad={handleImageLoad}
         />
       )}
     </MediaContainer>

--- a/frontend/packages/editor/src/ssr-render.ts
+++ b/frontend/packages/editor/src/ssr-render.ts
@@ -153,9 +153,10 @@ function renderBlockContent(
     case 'Image': {
       const link = block.link || ''
       const width = block.attributes?.width
-      const widthAttr = width ? ` width="${width}"` : ''
+      const widthAttr = width && width > 100 ? ` width="${width}"` : ''
+      const widthStyle = width && width > 0 && width <= 100 ? ` style="width:${width}%"` : ''
       const imgHtml = link
-        ? `<img src="/hm/api/image/${esc(link)}" alt="${esc(text)}" loading="lazy"${widthAttr} />`
+        ? `<img src="/hm/api/image/${esc(link)}" alt="${esc(text)}" loading="lazy"${widthAttr}${widthStyle} />`
         : ''
       const captionHtml = text
         ? `<span class="inlineContent">${renderAnnotatedText(text, annotations, renderHref)}</span>`

--- a/frontend/packages/shared/src/client/__tests__/editorblock-to-hmblock.test.ts
+++ b/frontend/packages/shared/src/client/__tests__/editorblock-to-hmblock.test.ts
@@ -535,7 +535,7 @@ describe('EditorBlock to HMBlock', () => {
       expect(val).toEqual(result)
     })
 
-    test('image wrong width value should be removed (percentage)', () => {
+    test('image percentage width is preserved as a responsive width value', () => {
       const editorBlock: EditorImageBlock = {
         id: 'foo',
         type: 'image',
@@ -559,7 +559,9 @@ describe('EditorBlock to HMBlock', () => {
         text: ``,
         link: 'ipfs://foobarcid_IMAGE',
         annotations: [],
-        attributes: {},
+        attributes: {
+          width: 80,
+        },
       }
       const val = editorBlockToHMBlock(editorBlock)
 

--- a/frontend/packages/shared/src/client/__tests__/hmblock-to-editorblock.test.ts
+++ b/frontend/packages/shared/src/client/__tests__/hmblock-to-editorblock.test.ts
@@ -519,6 +519,41 @@ describe('HMBlock to EditorBlock', () => {
       expect(val).toEqual(result)
     })
 
+    test('image responsive percentage width', () => {
+      const hmBlock: HMBlockImage = {
+        id: 'foo',
+        type: 'Image',
+        text: ``,
+        link: 'ipfs://foobarcid_IMAGE',
+        annotations: [],
+        attributes: {
+          width: 80,
+        },
+        revision: 'revision123',
+      }
+
+      const result: EditorImageBlock = {
+        id: 'foo',
+        type: 'image',
+        children: [],
+        props: {
+          url: 'ipfs://foobarcid_IMAGE',
+          revision: 'revision123',
+          width: '80%',
+        },
+        content: [
+          {
+            type: 'text',
+            text: '',
+            styles: {},
+          },
+        ],
+      }
+      const val = hmBlockToEditorBlock(hmBlock)
+
+      expect(val).toEqual(result)
+    })
+
     test('image with wrong width value should be removed', () => {
       const hmBlock: HMBlockImage = {
         id: 'foo',

--- a/frontend/packages/ui/src/hm-prose.css
+++ b/frontend/packages/ui/src/hm-prose.css
@@ -350,6 +350,8 @@
 .hm-prose [data-content-type='image'] img {
   max-width: 100%;
   height: auto;
+  max-height: 600px;
+  object-fit: contain;
 }
 
 .hm-prose figure {


### PR DESCRIPTION
## Summary
- Preserve image widths stored as percentages when converting between editor blocks and HM blocks.
- Render percentage image widths responsively in the editor and SSR output instead of treating them as fixed pixels.
- Add image sizing safeguards with a 600px max height and contained object fit for editor, SSR, and prose rendering.
- Add tests covering responsive image width conversion and resize persistence.

---

Fixes #542