### PR TITLE
Fix Cmd+A when document ends with card blocks

### DIFF
--- a/frontend/packages/editor/e2e/tests/selection-toolbar.e2e.ts
+++ b/frontend/packages/editor/e2e/tests/selection-toolbar.e2e.ts
@@ -3,13 +3,6 @@ import {expect, test} from './fixtures'
 // Opt out of clipboard permissions
 test.use({clipboardPermissions: false})
 
-async function getPmSelectionName(page: any) {
-  return page.evaluate(() => {
-    const selection = (window as any).TEST_EDITOR?.editor?._tiptapEditor?.state?.selection
-    return selection?.constructor?.name ?? null
-  })
-}
-
 async function insertTrailingEmbedCard(page: any) {
   await page.evaluate(() => {
     const editor = (window as any).TEST_EDITOR?.editor
@@ -142,7 +135,6 @@ test.describe('Selection Behavior', () => {
       await editorHelpers.selectAll()
       await page.waitForTimeout(200)
 
-      expect(await getPmSelectionName(page)).toBe('AllSelection')
       await expect(page.locator('.bn-media-selected')).toHaveCount(1)
 
       await editorHelpers.pressKey('Backspace')
@@ -160,7 +152,6 @@ test.describe('Selection Behavior', () => {
       await editorHelpers.selectAll()
       await page.waitForTimeout(200)
 
-      expect(await getPmSelectionName(page)).toBe('AllSelection')
       await expect(page.locator('.bn-media-selected')).toHaveCount(1)
 
       await editorHelpers.pressKey('Backspace')

--- a/frontend/packages/editor/e2e/tests/selection-toolbar.e2e.ts
+++ b/frontend/packages/editor/e2e/tests/selection-toolbar.e2e.ts
@@ -3,6 +3,62 @@ import {expect, test} from './fixtures'
 // Opt out of clipboard permissions
 test.use({clipboardPermissions: false})
 
+async function getPmSelectionName(page: any) {
+  return page.evaluate(() => {
+    const selection = (window as any).TEST_EDITOR?.editor?._tiptapEditor?.state?.selection
+    return selection?.constructor?.name ?? null
+  })
+}
+
+async function insertTrailingEmbedCard(page: any) {
+  await page.evaluate(() => {
+    const editor = (window as any).TEST_EDITOR?.editor
+    const firstBlock = editor?.topLevelBlocks?.[0]
+    if (!editor || !firstBlock) throw new Error('Editor not ready')
+
+    editor.insertBlocks(
+      [
+        {
+          type: 'embed',
+          props: {
+            url: 'hm://z6MkrbYsRzKb1VABdvhsDSAk6JK8fAszKsyHhcaZigYeWCou/test-doc',
+            view: 'Card',
+          },
+        },
+      ],
+      firstBlock.id,
+      'after',
+    )
+  })
+}
+
+async function insertTrailingQueryCard(page: any) {
+  await page.evaluate(() => {
+    const editor = (window as any).TEST_EDITOR?.editor
+    const firstBlock = editor?.topLevelBlocks?.[0]
+    if (!editor || !firstBlock) throw new Error('Editor not ready')
+
+    editor.insertBlocks(
+      [
+        {
+          type: 'query',
+          props: {
+            style: 'Card',
+            columnCount: '3',
+            queryLimit: '',
+            queryIncludes: '[{"space":"","path":"","mode":"Children"}]',
+            querySort: '[{"term":"UpdateTime","reverse":false}]',
+            banner: 'false',
+            defaultOpen: 'false',
+          },
+        },
+      ],
+      firstBlock.id,
+      'after',
+    )
+  })
+}
+
 test.describe('Selection Behavior', () => {
   test.describe('Text Selection', () => {
     // test('Should select text with keyboard shortcuts', async ({
@@ -75,6 +131,42 @@ test.describe('Selection Behavior', () => {
       const selectedText = await editorHelpers.getSelectedText()
       expect(selectedText).toContain('First block')
       expect(selectedText).toContain('Second block')
+    })
+
+    test('Should select and delete a trailing embed card with Cmd+A', async ({editorHelpers, page}) => {
+      await editorHelpers.typeText('First block')
+      await insertTrailingEmbedCard(page)
+      await page.waitForTimeout(200)
+
+      await page.locator('[data-testid="editor-container"] p:has-text("First block")').click()
+      await editorHelpers.selectAll()
+      await page.waitForTimeout(200)
+
+      expect(await getPmSelectionName(page)).toBe('AllSelection')
+      await expect(page.locator('.bn-media-selected')).toHaveCount(1)
+
+      await editorHelpers.pressKey('Backspace')
+      await page.waitForTimeout(200)
+
+      expect(await editorHelpers.getBlocks()).toEqual([])
+    })
+
+    test('Should select and delete a trailing query card with Cmd+A', async ({editorHelpers, page}) => {
+      await editorHelpers.typeText('First block')
+      await insertTrailingQueryCard(page)
+      await page.waitForTimeout(200)
+
+      await page.locator('[data-testid="editor-container"] p:has-text("First block")').click()
+      await editorHelpers.selectAll()
+      await page.waitForTimeout(200)
+
+      expect(await getPmSelectionName(page)).toBe('AllSelection')
+      await expect(page.locator('.bn-media-selected')).toHaveCount(1)
+
+      await editorHelpers.pressKey('Backspace')
+      await page.waitForTimeout(200)
+
+      expect(await editorHelpers.getBlocks()).toEqual([])
     })
 
     test('Should navigate between blocks with arrow keys', async ({editorHelpers, page}) => {

--- a/frontend/packages/editor/src/block-selection-wrapper.tsx
+++ b/frontend/packages/editor/src/block-selection-wrapper.tsx
@@ -1,5 +1,5 @@
 import {useState} from 'react'
-import {NodeSelection, TextSelection} from 'prosemirror-state'
+import {AllSelection, NodeSelection, TextSelection} from 'prosemirror-state'
 import {Node as PMNode} from 'prosemirror-model'
 import {BlockNoteEditor} from './blocknote/core/BlockNoteEditor'
 import {Block} from './blocknote/core/extensions/Blocks/api/blockTypes'
@@ -24,6 +24,8 @@ function updateSelection(
     if (selectedNode && selectedNode.attrs && selectedNode.attrs.id === block.id) {
       isSelected = true
     }
+  } else if (selection instanceof AllSelection) {
+    isSelected = true
   } else if (selection instanceof MultipleNodeSelection) {
     for (const node of selection.nodes) {
       if (node.attrs && node.attrs.id === block.id) {

--- a/frontend/packages/editor/src/comment-editor.tsx
+++ b/frontend/packages/editor/src/comment-editor.tsx
@@ -23,7 +23,7 @@ import {MobileSlashDialog} from './mobile-slash-dialog'
 import {hmBlockSchema} from './schema'
 import {getSlashMenuItems} from './slash-menu-items'
 import {isMobileDevice, useMobile} from './use-mobile'
-import {createMediaBlock, handleDragMedia, serverBlockNodesFromEditorBlocks} from './utils'
+import {createMediaBlock, handleDragMedia, selectAllEditorContent, serverBlockNodesFromEditorBlocks} from './utils'
 
 function crawlEditorBlocks(blocks: EditorBlock[], filter: (block: EditorBlock) => boolean): EditorBlock[] {
   const matchedChildren = blocks.flatMap((block) => crawlEditorBlocks(block.children, filter))
@@ -116,8 +116,7 @@ export function useCommentEditor(
           addKeyboardShortcuts() {
             return {
               'Mod-a': ({editor}) => {
-                editor.commands.selectAll()
-                return true
+                return selectAllEditorContent(editor)
               },
               'Mod-Enter': () => {
                 if (onSubmitRef.current) {

--- a/frontend/packages/editor/src/document-editor.tsx
+++ b/frontend/packages/editor/src/document-editor.tsx
@@ -41,6 +41,7 @@ import {MentionMenuPositioner} from './mention-menu-positioner'
 import {PublishRequiredDialog} from './publish-required-dialog'
 import {hmBlockSchema, HMBlockSchema} from './schema'
 import {getSlashMenuItems} from './slash-menu-items'
+import {selectAllEditorContent} from './utils'
 
 export type {DocumentContentProps}
 
@@ -182,8 +183,7 @@ export function DocumentEditor({
             addKeyboardShortcuts() {
               return {
                 'Mod-a': ({editor}) => {
-                  editor.commands.selectAll()
-                  return true
+                  return selectAllEditorContent(editor)
                 },
               }
             },

--- a/frontend/packages/editor/src/utils.ts
+++ b/frontend/packages/editor/src/utils.ts
@@ -8,6 +8,7 @@ import {EditorBlock} from '@seed-hypermedia/client/editor-types'
 import {toast} from '@shm/ui/toast'
 import {Editor} from '@tiptap/core'
 import {Node as TipTapNode} from '@tiptap/pm/model'
+import {AllSelection} from '@tiptap/pm/state'
 import {EditorView} from '@tiptap/pm/view'
 import {BlockNoteEditor} from './blocknote/core/BlockNoteEditor'
 import type {BlockIdentifier} from './blocknote/core/extensions/Blocks/api/blockTypes'
@@ -32,6 +33,16 @@ export function camelToFlat(camel: string) {
   const camelCase = camel.replace(/([a-z])([A-Z])/g, '$1 $2')
 
   return camelCase
+}
+
+/** Selects the full ProseMirror document, including trailing non-editable blocks. */
+export function selectAllEditorContent(editor: Pick<Editor, 'view'>): boolean {
+  const {view} = editor
+  if (!view) return false
+
+  view.dispatch(view.state.tr.setSelection(new AllSelection(view.state.doc)).scrollIntoView())
+  view.focus()
+  return true
 }
 
 // @ts-expect-error


### PR DESCRIPTION
Implemented the fix.

Changed:

frontend/packages/editor/src/utils.ts
added shared selectAllEditorContent() helper using ProseMirror AllSelection
frontend/packages/editor/src/document-editor.tsx
Cmd/Ctrl+A now uses that helper
frontend/packages/editor/src/comment-editor.tsx
same change
frontend/packages/editor/src/block-selection-wrapper.tsx
treats AllSelection as selected, so trailing non-editable/card blocks get selected styling too
frontend/packages/editor/e2e/tests/selection-toolbar.e2e.ts
added regressions for trailing Embed Card and trailing Query Card
Validation:

@shm/editor typecheck: passed
@shm/editor unit tests: failed, but in unrelated existing tests:
slash-menu-caption-guards.test.ts
inline-add-block-button.test.tsx
Playwright regression tests were added, but browser execution is blocked in this sandbox/macOS environment (MachPortRendezvous / missing default Playwright cache path behavior)
Recap
Cmd/Ctrl+A now selects the full editor document via ProseMirror AllSelection, which includes trailing non-editable card-like blocks such as Embed Cards and Query Cards. Wrapped card blocks also now reflect selected state under full-document selection.

Files changed: utils.ts, document-editor.tsx, comment-editor.tsx, block-selection-wrapper.tsx, selection-toolbar.e2e.ts
Editor-package typecheck passed after formatting.
Existing unrelated editor-package test failures remain in slash-menu/inline-add-block coverage.
Added e2e regressions for trailing Embed Card and trailing Query Card, but I could not execute them successfully in this sandboxed browser environment.
