### PR TITLE
fix(editor): handle pasted local media in web editors

### DIFF
--- a/frontend/apps/web/app/commenting.tsx
+++ b/frontend/apps/web/app/commenting.tsx
@@ -682,6 +682,7 @@ export function renderWebInlineEditor({comment, onSave, onCancel, isSaving}: Inl
 
 /** Inline comment editor for the web platform. */
 export function WebInlineEditBox({comment, onSave, onCancel, isSaving}: InlineEditCommentProps) {
+  const client = useUniversalClient()
   const handleSubmit = useCallback(
     async (
       getContent: (
@@ -692,10 +693,13 @@ export function WebInlineEditBox({comment, onSave, onCancel, isSaving}: InlineEd
       ) => Promise<{blockNodes: HMBlockNode[]; blobs: {cid: string; data: Uint8Array}[]}>,
       reset: () => void,
     ) => {
-      const {blockNodes} = await getContent(async (binaries) => ({blobs: [], resultCIDs: []}))
+      const {blockNodes, blobs} = await getContent(prepareAttachments)
+      if (blobs.length) {
+        await client.publish({blobs: blobs.map((blob) => ({cid: blob.cid, data: blob.data}))})
+      }
       onSave(blockNodes)
     },
-    [onSave],
+    [client, onSave],
   )
 
   return (
@@ -705,6 +709,8 @@ export function WebInlineEditBox({comment, onSave, onCancel, isSaving}: InlineEd
         isReplying={false}
         handleSubmit={handleSubmit}
         initialBlocks={comment.content}
+        importWebFile={(url) => importWebFile(url)}
+        handleFileAttachment={(file) => handleFileAttachment(file)}
         hideAvatar
         submitButton={({getContent, reset}) => (
           <>

--- a/frontend/packages/editor/src/document-editor.tsx
+++ b/frontend/packages/editor/src/document-editor.tsx
@@ -76,6 +76,7 @@ export function DocumentEditor({
   perspectiveAccountUid,
   linkExtensionOptions,
   importWebFile,
+  handleFileAttachment,
   isUnpublishedDraft,
   isBlockInPublishedVersion,
 }: DocumentContentProps) {
@@ -152,6 +153,7 @@ export function DocumentEditor({
       renderType: 'document',
       blockSchema: hmBlockSchema,
       importWebFile: importWebFile as any,
+      handleFileAttachment: handleFileAttachment as any,
       getSlashMenuItems: () => getSlashMenuItems({docId: resourceId, onCreateInlineDraft}),
       onEditorContentChange() {
         if (suppressChangeRef.current) return

--- a/frontend/packages/editor/src/handle-local-media-paste-plugin.test.ts
+++ b/frontend/packages/editor/src/handle-local-media-paste-plugin.test.ts
@@ -1,0 +1,86 @@
+import {describe, expect, it, vi, afterEach} from 'vitest'
+import {
+  createNodePropsFromAttachmentResult,
+  extractPastedImageSources,
+  imageSourceToFile,
+} from './handle-local-media-paste-plugin'
+
+describe('local media paste helpers', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('extracts pasted HTML image sources', () => {
+    const html = `
+      <p>before</p>
+      <img src="data:image/png;base64,abc" alt="pasted screenshot">
+      <img src="https://example.com/image.webp">
+    `
+
+    expect(extractPastedImageSources(html)).toEqual(['data:image/png;base64,abc', 'https://example.com/image.webp'])
+  })
+
+  it('skips Seed image block HTML that the schema parser handles', () => {
+    const html = `
+      <div data-content-type="image">
+        <img src="ipfs://already-a-block">
+      </div>
+      <p><img src="https://example.com/external.png"></p>
+    `
+
+    expect(extractPastedImageSources(html)).toEqual(['https://example.com/external.png'])
+  })
+
+  it('converts pasted HTML image sources to Files', async () => {
+    const blob = new Blob(['jpeg data'], {type: 'image/jpeg'})
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      blob: async () => blob,
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const file = await imageSourceToFile('https://example.com/image.jpg', () => 123)
+
+    expect(fetchMock).toHaveBeenCalledWith('https://example.com/image.jpg')
+    expect(file.name).toBe('pasted-image-123.jpg')
+    expect(file.type).toBe('image/jpeg')
+  })
+
+  it('maps desktop/web document upload results to IPFS node props', () => {
+    const file = new File(['image'], 'paste.png', {type: 'image/png'})
+
+    expect(createNodePropsFromAttachmentResult(file, {url: 'ipfs://cid', displaySrc: ''}, 'image')).toEqual({
+      name: 'paste.png',
+      url: 'ipfs://cid',
+      displaySrc: '',
+    })
+  })
+
+  it('maps web comment mediaRef results to draft media node props', () => {
+    const file = new File(['image'], 'paste.png', {type: 'image/png'})
+    const mediaRef = {
+      draftId: 'draft-1',
+      mediaId: 'media-1',
+      name: 'paste.png',
+      mime: 'image/png',
+      size: 5,
+    }
+
+    expect(createNodePropsFromAttachmentResult(file, {mediaRef, displaySrc: 'blob://preview'}, 'image')).toEqual({
+      name: 'paste.png',
+      mediaRef: JSON.stringify(mediaRef),
+      displaySrc: 'blob://preview',
+    })
+  })
+
+  it('maps legacy web binary results to local preview node props', () => {
+    const file = new File(['image'], 'paste.png', {type: 'image/png'})
+    const fileBinary = new Uint8Array([1, 2, 3])
+
+    expect(createNodePropsFromAttachmentResult(file, {fileBinary, displaySrc: 'blob://preview'}, 'image')).toEqual({
+      name: 'paste.png',
+      fileBinary,
+      displaySrc: 'blob://preview',
+    })
+  })
+})

--- a/frontend/packages/editor/src/handle-local-media-paste-plugin.ts
+++ b/frontend/packages/editor/src/handle-local-media-paste-plugin.ts
@@ -2,6 +2,23 @@ import {DAEMON_FILE_UPLOAD_URL, IS_PROD_DESKTOP} from '@shm/shared/constants'
 import {Extension} from '@tiptap/core'
 import {Plugin, PluginKey} from 'prosemirror-state'
 
+type LocalMediaType = 'image' | 'video' | 'file'
+
+type FileAttachmentResult = {
+  displaySrc?: string
+  url?: string
+  fileBinary?: Uint8Array | ArrayBuffer
+  mediaRef?:
+    | string
+    | {
+        draftId: string
+        mediaId: string
+        name: string
+        mime: string
+        size: number
+      }
+}
+
 export const LocalMediaPastePlugin = Extension.create({
   name: 'local-media-paste',
   priority: 100,
@@ -39,6 +56,21 @@ const handleLocalMediaPastePlugin = (blockNoteEditor: any) =>
           }
         }
 
+        for (const file of files) {
+          if (file.type.startsWith('image/')) {
+            processMedia(file, view, insertPos, blockNoteEditor, 'image')
+            return true
+          }
+        }
+
+        const html = event.clipboardData?.getData('text/html') || ''
+        const htmlImageSources = extractPastedImageSources(html)
+        const firstHtmlImageSource = htmlImageSources[0]
+        if (firstHtmlImageSource) {
+          processImageSource(firstHtmlImageSource, view, insertPos, blockNoteEditor)
+          return true
+        }
+
         // Check for video and other file types
         for (const item of items) {
           if (item.type.startsWith('video/')) {
@@ -57,18 +89,78 @@ const handleLocalMediaPastePlugin = (blockNoteEditor: any) =>
           }
         }
 
+        for (const file of files) {
+          if (file.type.startsWith('video/')) {
+            processMedia(file, view, insertPos, blockNoteEditor, 'video')
+            return true
+          }
+
+          processMedia(file, view, insertPos, blockNoteEditor, 'file')
+          return true
+        }
+
         return false
       },
     },
   })
 
-function processMedia(
-  file: File,
-  view: any,
-  insertPos: number,
-  blockNoteEditor: any,
-  mediaType: 'image' | 'video' | 'file',
-) {
+/** Extract image URLs from pasted HTML, skipping Seed image blocks that the schema parser handles. */
+export function extractPastedImageSources(html: string): string[] {
+  if (!html) return []
+
+  const tempEl = document.createElement('div')
+  tempEl.innerHTML = html
+
+  return Array.from(tempEl.querySelectorAll('img[src]'))
+    .filter((imgEl) => !imgEl.closest('[data-content-type="image"]'))
+    .map((imgEl) => imgEl.getAttribute('src') || '')
+    .filter(Boolean)
+}
+
+/** Convert an image URL from pasted HTML into a File that can use the normal media insertion path. */
+export async function imageSourceToFile(src: string, now: () => number = Date.now): Promise<File> {
+  const response = await fetch(src)
+  if (!response.ok) {
+    throw new Error(`Image fetch failed with status ${response.status}`)
+  }
+  const blob = await response.blob()
+  const type = blob.type || 'image/png'
+  return new File([blob], `pasted-image-${now()}.${extensionForImageType(type)}`, {
+    type,
+  })
+}
+
+function extensionForImageType(type: string): string {
+  switch (type) {
+    case 'image/jpeg':
+    case 'image/jpg':
+      return 'jpg'
+    case 'image/gif':
+      return 'gif'
+    case 'image/webp':
+      return 'webp'
+    case 'image/svg+xml':
+      return 'svg'
+    case 'image/bmp':
+      return 'bmp'
+    case 'image/avif':
+      return 'avif'
+    default:
+      return 'png'
+  }
+}
+
+function processImageSource(src: string, view: any, insertPos: number, blockNoteEditor: any) {
+  imageSourceToFile(src)
+    .then((file) => {
+      processMedia(file, view, insertPos, blockNoteEditor, 'image')
+    })
+    .catch((error) => {
+      console.error('Error processing pasted HTML image:', error)
+    })
+}
+
+function processMedia(file: File, view: any, insertPos: number, blockNoteEditor: any, mediaType: LocalMediaType) {
   // Check if we're in a comment editor in the web app
   // Desktop uploads immediately, web stores for later upload
   const isCommentEditor = view.dom.closest('.comment-editor') !== null
@@ -78,73 +170,40 @@ function processMedia(
     typeof (window as any).appInfo !== 'undefined'
   const shouldStoreMedia = isCommentEditor && !isDesktop
 
-  if (shouldStoreMedia) {
-    // Comment editor: Store media blobs in IndexedDB for later upload
-    const editor = blockNoteEditor
+  if (blockNoteEditor?.handleFileAttachment) {
+    processMediaWithAttachmentHandler(file, view, insertPos, blockNoteEditor, mediaType)
+  } else if (shouldStoreMedia) {
+    console.warn('Using legacy binary storage')
+    // Fallback to legacy binary storage if handleFileAttachment not available
+    const binaryReader = new FileReader()
 
-    if (editor?.handleFileAttachment) {
-      // Use the editor's handleFileAttachment which handles IndexedDB storage
-      editor
-        .handleFileAttachment(file)
-        .then((result: any) => {
-          const {name, size} = file
-          const {schema} = view.state
+    binaryReader.onload = (e) => {
+      const fileBinary = new Uint8Array(e.target?.result as ArrayBuffer)
+      const {name, size} = file
+      const {schema} = view.state
 
-          const nodeProps: Record<string, any> = {
-            name: name,
-            // Serialize mediaRef object to JSON string for block attribute
-            mediaRef: result.mediaRef ? JSON.stringify(result.mediaRef) : '',
-          }
-
-          if (mediaType === 'file') {
-            // File blocks don't need displaySrc
-            nodeProps.fileBinary = result.fileBinary
-            nodeProps.size = size
-          } else {
-            nodeProps.displaySrc = result.displaySrc
-            nodeProps.fileBinary = result.fileBinary
-          }
-
-          // @ts-ignore
-          const node = schema.nodes[mediaType].create(nodeProps)
-          view.dispatch(view.state.tr.insert(insertPos, node))
-        })
-        .catch((error: any) => {
-          console.error(`Error processing pasted ${mediaType}:`, error)
-        })
-    } else {
-      console.warn('Using legacy binary storage')
-      // Fallback to legacy binary storage if handleFileAttachment not available
-      const binaryReader = new FileReader()
-
-      binaryReader.onload = (e) => {
-        const fileBinary = new Uint8Array(e.target?.result as ArrayBuffer)
-        const {name, size} = file
-        const {schema} = view.state
-
-        const nodeProps: Record<string, any> = {
-          name: name,
-          fileBinary: fileBinary,
-        }
-
-        if (mediaType === 'file') {
-          nodeProps.size = size
-        } else {
-          // For images and videos, create an object URL for display
-          nodeProps.displaySrc = URL.createObjectURL(file)
-        }
-
-        // @ts-ignore
-        const node = schema.nodes[mediaType].create(nodeProps)
-        view.dispatch(view.state.tr.insert(insertPos, node))
+      const nodeProps: Record<string, any> = {
+        name: name,
+        fileBinary: fileBinary,
       }
 
-      binaryReader.onerror = (error) => {
-        console.error(`Error reading pasted ${mediaType} as binary:`, error)
+      if (mediaType === 'file') {
+        nodeProps.size = size
+      } else {
+        // For images and videos, create an object URL for display
+        nodeProps.displaySrc = URL.createObjectURL(file)
       }
 
-      binaryReader.readAsArrayBuffer(file)
+      // @ts-ignore
+      const node = schema.nodes[mediaType].create(nodeProps)
+      view.dispatch(view.state.tr.insert(insertPos, node))
     }
+
+    binaryReader.onerror = (error) => {
+      console.error(`Error reading pasted ${mediaType} as binary:`, error)
+    }
+
+    binaryReader.readAsArrayBuffer(file)
   } else {
     // Desktop editor: upload immediately to IPFS
     uploadMedia(file)
@@ -168,6 +227,68 @@ function processMedia(
         console.error(`Error uploading pasted ${mediaType}:`, error)
       })
   }
+}
+
+function processMediaWithAttachmentHandler(
+  file: File,
+  view: any,
+  insertPos: number,
+  blockNoteEditor: any,
+  mediaType: LocalMediaType,
+) {
+  blockNoteEditor
+    .handleFileAttachment(file)
+    .then((result: FileAttachmentResult) => {
+      const nodeProps = createNodePropsFromAttachmentResult(file, result, mediaType)
+      const node = view.state.schema.nodes[mediaType].create(nodeProps)
+      view.dispatch(view.state.tr.insert(insertPos, node))
+    })
+    .catch((error: any) => {
+      console.error(`Error processing pasted ${mediaType}:`, error)
+    })
+}
+
+/** Build media node props from a platform-specific file attachment result. */
+export function createNodePropsFromAttachmentResult(
+  file: File,
+  result: FileAttachmentResult,
+  mediaType: LocalMediaType,
+): Record<string, any> {
+  const nodeProps: Record<string, any> = {
+    name: file.name,
+  }
+
+  if (mediaType === 'file') {
+    nodeProps.size = file.size
+  }
+
+  if (result.url) {
+    nodeProps.url = result.url
+    if (mediaType !== 'file') {
+      nodeProps.displaySrc = result.displaySrc || ''
+    }
+    return nodeProps
+  }
+
+  if (result.mediaRef) {
+    nodeProps.mediaRef = typeof result.mediaRef === 'string' ? result.mediaRef : JSON.stringify(result.mediaRef)
+    if (result.fileBinary) {
+      nodeProps.fileBinary = result.fileBinary
+    }
+    if (mediaType !== 'file') {
+      nodeProps.displaySrc = result.displaySrc || ''
+    }
+    return nodeProps
+  }
+
+  if (result.fileBinary) {
+    nodeProps.fileBinary = result.fileBinary
+  }
+  if (mediaType !== 'file') {
+    nodeProps.displaySrc = result.displaySrc || URL.createObjectURL(file)
+  }
+
+  return nodeProps
 }
 
 async function uploadMedia(file: File) {

--- a/frontend/packages/shared/src/document-content-props.ts
+++ b/frontend/packages/shared/src/document-content-props.ts
@@ -68,4 +68,20 @@ export type DocumentContentProps = {
   importWebFile?: (
     url: string,
   ) => Promise<{cid: string; type: string} | {displaySrc: string; fileBinary: Uint8Array | ArrayBuffer; type: string}>
+  /** Handles pasted/dropped local files. Desktop returns IPFS URLs, while web can
+   * return locally-stored draft media or web-published IPFS URLs. */
+  handleFileAttachment?: (file: File) => Promise<{
+    displaySrc?: string
+    url?: string
+    fileBinary?: Uint8Array | ArrayBuffer
+    mediaRef?:
+      | string
+      | {
+          draftId: string
+          mediaId: string
+          name: string
+          mime: string
+          size: number
+        }
+  }>
 }

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -1656,6 +1656,7 @@ function DocumentBody({
           ssrContentHTML={ssrContentHTML}
           perspectiveAccountUid={perspectiveAccountUid}
           linkExtensionOptions={linkExtensionOptions}
+          fileUpload={fileUpload}
         />
       </div>
       {pageFooter ? <div className="mt-auto">{pageFooter}</div> : null}
@@ -2132,6 +2133,7 @@ function MainContent({
   ssrContentHTML,
   perspectiveAccountUid,
   linkExtensionOptions,
+  fileUpload,
 }: {
   docId: UnpackedHypermediaId
   resourceId: UnpackedHypermediaId
@@ -2177,6 +2179,7 @@ function MainContent({
   ssrContentHTML?: string | null
   perspectiveAccountUid?: string | null
   linkExtensionOptions?: LinkExtensionOptions
+  fileUpload?: (file: File) => Promise<string>
 }) {
   switch (activeView) {
     case 'directory':
@@ -2261,6 +2264,7 @@ function MainContent({
           ssrContentHTML={ssrContentHTML}
           perspectiveAccountUid={perspectiveAccountUid}
           linkExtensionOptions={linkExtensionOptions}
+          fileUpload={fileUpload}
         />
       )
   }
@@ -2291,6 +2295,7 @@ function ContentViewWithOutline({
   ssrContentHTML,
   perspectiveAccountUid,
   linkExtensionOptions,
+  fileUpload,
 }: {
   docId: UnpackedHypermediaId
   resourceId: UnpackedHypermediaId
@@ -2320,6 +2325,7 @@ function ContentViewWithOutline({
   ssrContentHTML?: string | null
   perspectiveAccountUid?: string | null
   linkExtensionOptions?: LinkExtensionOptions
+  fileUpload?: (file: File) => Promise<string>
 }) {
   const publishedOutline = useNodesOutline(document, docId)
   const draftOutline = useMemo(
@@ -2327,6 +2333,16 @@ function ContentViewWithOutline({
     [existingDraftContent, docId],
   )
   const outline = draftOutline ?? publishedOutline
+  const handleFileAttachment = useMemo<DocumentContentProps['handleFileAttachment'] | undefined>(() => {
+    if (!fileUpload) return undefined
+    return async (file: File) => {
+      const cid = await fileUpload(file)
+      return {
+        url: cid.startsWith('ipfs://') ? cid : `ipfs://${cid}`,
+        displaySrc: '',
+      }
+    }
+  }, [fileUpload])
 
   return (
     <div {...wrapperProps} className={cn(wrapperProps.className, 'flex')}>
@@ -2369,6 +2385,7 @@ function ContentViewWithOutline({
             linkExtensionOptions={linkExtensionOptions}
             isUnpublishedDraft={isUnpublishedDraft}
             isBlockInPublishedVersion={isBlockInPublishedVersion}
+            handleFileAttachment={handleFileAttachment}
           />
         ) : ssrContentHTML ? (
           <div dangerouslySetInnerHTML={{__html: ssrContentHTML}} />


### PR DESCRIPTION
## Summary
- Restore copy/paste support for local images and other media in web document editors by passing file attachment handling through the document content stack.
- Add handling for clipboard `FileList` entries and pasted HTML image sources, while preserving Seed image block parsing behavior.
- Enable inline comment edits to process and publish pasted media attachments before saving.
- Add focused tests for local media paste helper behavior and attachment result mapping.

---

Fixes #543