### PR TITLE
fix(frontend): preserve comment drafts when opening side panel

### DIFF
--- a/frontend/apps/desktop/src/components/__tests__/commenting.test.tsx
+++ b/frontend/apps/desktop/src/components/__tests__/commenting.test.tsx
@@ -1,0 +1,195 @@
+import React, {useEffect} from 'react'
+import {createRoot, Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {hmId} from '@shm/shared/utils/entity-id-url'
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+import {CommentBox} from '../commenting'
+
+const {writeCommentDraftMock, invalidateQueriesMock} = vi.hoisted(() => ({
+  writeCommentDraftMock: vi.fn(),
+  invalidateQueriesMock: vi.fn(),
+}))
+
+vi.mock('@/grpc-client', () => ({
+  domainResolver: vi.fn(),
+}))
+
+vi.mock('@/models/comments', () => ({
+  useCommentDraft: () => ({
+    data: undefined,
+    isInitialLoading: false,
+  }),
+}))
+
+vi.mock('@/models/push-after-action', () => ({
+  usePushAfterAction: () => vi.fn(),
+}))
+
+vi.mock('@/selected-account', () => ({
+  useSelectedAccount: () => ({
+    id: {uid: 'alice'},
+    metadata: {name: 'Alice'},
+  }),
+  useSelectedAccountId: () => 'alice',
+}))
+
+vi.mock('@/trpc', () => ({
+  client: {
+    comments: {
+      writeCommentDraft: {
+        mutate: writeCommentDraftMock,
+      },
+      removeCommentDraft: {
+        mutate: vi.fn(),
+      },
+    },
+    recentSigners: {
+      writeRecentSigner: {
+        mutate: vi.fn(),
+      },
+    },
+  },
+}))
+
+vi.mock('@/utils/media-drag', () => ({
+  handleDragMedia: vi.fn(),
+}))
+
+vi.mock('@/utils/useNavigate', () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+vi.mock('@seed-hypermedia/client', () => ({
+  createComment: vi.fn(),
+}))
+
+vi.mock('@shm/editor/comment-editor', () => ({
+  CommentEditor: ({onContentChange}: {onContentChange?: (blocks: any[]) => void}) => {
+    useEffect(() => {
+      onContentChange?.([
+        {
+          block: {
+            id: 'block-1',
+            type: 'Paragraph',
+            text: 'unsaved draft',
+          },
+          children: [],
+        },
+      ])
+    }, [onContentChange])
+
+    return <div data-testid="comment-editor" />
+  },
+}))
+
+vi.mock('@shm/shared/client/.generated/documents/v3alpha/documents_pb', async () => {
+  const actual = await vi.importActual<typeof import('@shm/shared/client/.generated/documents/v3alpha/documents_pb')>(
+    '@shm/shared/client/.generated/documents/v3alpha/documents_pb',
+  )
+  return {
+    ...actual,
+    BlockNode: {
+      ...actual.BlockNode,
+      fromJson: (value: unknown) => value,
+    },
+  }
+})
+
+vi.mock('@shm/shared/models/comments', () => ({
+  useDocumentComments: () => ({data: {comments: []}}),
+}))
+
+vi.mock('@shm/shared/models/contacts', () => ({
+  useContacts: () => [],
+}))
+
+vi.mock('@shm/shared/models/entity', () => ({
+  useResource: () => ({data: {type: 'document', document: {visibility: 'PUBLIC'}}}),
+}))
+
+vi.mock('@shm/shared/models/query-client', () => ({
+  invalidateQueries: invalidateQueriesMock,
+}))
+
+vi.mock('@shm/shared/optimistic-comment', () => ({
+  applyOptimisticComment: vi.fn(),
+  buildOptimisticComment: vi.fn(),
+  navigateToComment: vi.fn(),
+}))
+
+vi.mock('@shm/shared/routing', () => ({
+  useUniversalClient: () => ({
+    getSigner: vi.fn(),
+    publish: vi.fn(),
+  }),
+}))
+
+vi.mock('@shm/shared/utils/navigation', () => ({
+  useNavRoute: () => ({key: 'document', panel: null}),
+}))
+;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+
+function renderCommentBox() {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {retry: false},
+      mutations: {retry: false},
+    },
+  })
+
+  act(() => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <CommentBox docId={hmId('alice', {path: ['doc']})} />
+      </QueryClientProvider>,
+    )
+  })
+
+  return {container, root}
+}
+
+function cleanupRendered(root: Root, container: HTMLDivElement) {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('CommentBox draft persistence', () => {
+  it('flushes a pending comment draft when unmounted before the debounce fires', async () => {
+    writeCommentDraftMock.mockResolvedValue('draft-1')
+
+    const {container, root} = renderCommentBox()
+
+    cleanupRendered(root, container)
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(writeCommentDraftMock).toHaveBeenCalledWith({
+      blocks: [
+        {
+          block: {
+            id: 'block-1',
+            type: 'Paragraph',
+            text: 'unsaved draft',
+          },
+          children: [],
+        },
+      ],
+      targetDocId: 'hm://alice/doc',
+      replyCommentId: undefined,
+      quotingBlockId: undefined,
+      context: undefined,
+    })
+  })
+})

--- a/frontend/apps/desktop/src/components/commenting.tsx
+++ b/frontend/apps/desktop/src/components/commenting.tsx
@@ -18,6 +18,7 @@ import {CommentEditor} from '@shm/editor/comment-editor'
 import {queryClient, queryKeys} from '@shm/shared'
 import {BlockNode} from '@shm/shared/client/.generated/documents/v3alpha/documents_pb'
 import type {InlineEditCommentProps} from '@shm/shared/comments-service-provider'
+import {hasBlockContent} from '@shm/shared/content'
 import {useDocumentComments} from '@shm/shared/models/comments'
 import {useContacts} from '@shm/shared/models/contacts'
 import {useResource} from '@shm/shared/models/entity'
@@ -29,7 +30,7 @@ import {Button} from '@shm/ui/button'
 import {Tooltip} from '@shm/ui/tooltip'
 import {useMutation} from '@tanstack/react-query'
 import {Check, SendHorizonal, X} from 'lucide-react'
-import {memo, ReactNode, useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import React, {memo, ReactNode, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 
 export function useCommentGroupAuthors(commentGroups: HMCommentGroup[]): HMListDiscussionsOutput['authors'] {
   const commentGroupAuthors = new Set<string>()
@@ -99,15 +100,8 @@ function CommentBoxImpl(props: {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const isDeletingDraft = useRef(false)
   const saveTimeoutRef = useRef<NodeJS.Timeout>()
-
-  // Clean up save timeout on unmount to prevent memory leak
-  useEffect(() => {
-    return () => {
-      if (saveTimeoutRef.current) {
-        clearTimeout(saveTimeoutRef.current)
-      }
-    }
-  }, [])
+  const pendingBlocksRef = useRef<HMBlockNode[] | null>(null)
+  const flushPendingDraftSaveRef = useRef<() => void>(() => {})
 
   const commentDraftQueryKey = [queryKeys.COMMENT_DRAFT, docId.id, commentId, quotingBlockId, context]
 
@@ -123,6 +117,7 @@ function CommentBoxImpl(props: {
       }),
     onSuccess: () => {
       invalidateQueries([queryKeys.COMMENT_DRAFTS_LIST])
+      invalidateQueries(commentDraftQueryKey)
     },
   })
 
@@ -233,29 +228,53 @@ function CommentBoxImpl(props: {
   }, [focusOnMount])
 
   // Handle content changes - save draft
+  const saveDraftBlocks = useCallback(
+    (blocks: HMBlockNode[]) => {
+      if (isDeletingDraft.current) return
+
+      const hasContent = blocks.some(hasBlockContent)
+
+      if (!hasContent) {
+        if (draft.data) {
+          removeDraft.mutate()
+        }
+        return
+      }
+
+      writeDraft.mutate(blocks)
+    },
+    [draft.data, writeDraft, removeDraft],
+  )
+
+  const flushPendingDraftSave = useCallback(() => {
+    if (!pendingBlocksRef.current) return
+
+    const blocks = pendingBlocksRef.current
+    pendingBlocksRef.current = null
+    clearTimeout(saveTimeoutRef.current)
+    saveDraftBlocks(blocks)
+  }, [saveDraftBlocks])
+
+  flushPendingDraftSaveRef.current = flushPendingDraftSave
+
+  // Clean up save timeout on unmount, but persist the pending draft first.
+  useEffect(() => {
+    return () => {
+      flushPendingDraftSaveRef.current()
+    }
+  }, [])
+
   const handleContentChange = useCallback(
     (blocks: HMBlockNode[]) => {
       if (isDeletingDraft.current) return
 
+      pendingBlocksRef.current = blocks
       clearTimeout(saveTimeoutRef.current)
       saveTimeoutRef.current = setTimeout(() => {
-        const hasContent = blocks.some(
-          (block) =>
-            // @ts-expect-error - text exists on paragraph/heading blocks
-            (block.block?.text && block.block.text.trim()) || (block.children && block.children.length > 0),
-        )
-
-        if (!hasContent) {
-          if (draft.data) {
-            removeDraft.mutate()
-          }
-          return
-        }
-
-        writeDraft.mutate(blocks)
+        flushPendingDraftSave()
       }, 500)
     },
-    [draft.data, writeDraft, removeDraft],
+    [flushPendingDraftSave],
   )
 
   // Handle submit

--- a/frontend/packages/editor/src/comment-editor.tsx
+++ b/frontend/packages/editor/src/comment-editor.tsx
@@ -326,7 +326,7 @@ export function CommentEditor({
   const [isDraggingOver, setIsDraggingOver] = useState(false)
   const tx = useTx()
   const isInitializedRef = useRef(false)
-  const contentChangeTimeoutRef = useRef<NodeJS.Timeout>()
+  const hasPendingContentChangeRef = useRef(false)
   const shouldFocusOnActivateRef = useRef(false)
   const shouldMoveCursorToEndOnFocusRef = useRef(false)
   const dragDepthRef = useRef(0)
@@ -570,26 +570,9 @@ export function CommentEditor({
     if (!onContentChange) return
 
     const handleChange = () => {
-      // Clear previous timeout
-      if (contentChangeTimeoutRef.current) {
-        clearTimeout(contentChangeTimeoutRef.current)
-      }
-
-      // Debounce content change notifications
-      contentChangeTimeoutRef.current = setTimeout(() => {
-        try {
-          // @ts-expect-error
-          const editorBlocks: EditorBlock[] = editor.topLevelBlocks
-          const mediaRefs = collectSerializedMediaRefs(editorBlocks)
-          const blocks = serverBlockNodesFromEditorBlocks(editor, editorBlocks)
-          onContentChange(
-            blocks.map((b) => b.toJson()) as HMBlockNode[],
-            Object.keys(mediaRefs).length > 0 ? mediaRefs : undefined,
-          )
-        } catch (error) {
-          console.error('Failed to notify content change:', error)
-        }
-      }, 500)
+      hasPendingContentChangeRef.current = true
+      emitContentChangeNow()
+      hasPendingContentChangeRef.current = false
     }
 
     // Listen to editor changes
@@ -597,8 +580,9 @@ export function CommentEditor({
 
     return () => {
       editor._tiptapEditor.off('update', handleChange)
-      if (contentChangeTimeoutRef.current) {
-        clearTimeout(contentChangeTimeoutRef.current)
+      if (hasPendingContentChangeRef.current) {
+        emitContentChangeNow()
+        hasPendingContentChangeRef.current = false
       }
     }
   }, [editor, onContentChange])

--- a/frontend/packages/ui/src/__tests__/resource-page-common.test.ts
+++ b/frontend/packages/ui/src/__tests__/resource-page-common.test.ts
@@ -1,0 +1,108 @@
+import {hmId} from '@shm/shared'
+import {describe, expect, it} from 'vitest'
+import {getCommentReplyPanelRoute, shouldSuppressMainCommentEditor} from '../resource-page-common'
+
+describe('shouldSuppressMainCommentEditor', () => {
+  const docId = hmId('alice', {path: ['doc']})
+
+  it('suppresses the main editor when the right panel has the same top-level comment target', () => {
+    expect(
+      shouldSuppressMainCommentEditor({
+        docId,
+        activeView: 'comments',
+        panelRoute: {
+          key: 'comments',
+          id: docId,
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('does not suppress the main editor for different focused reply comments', () => {
+    expect(
+      shouldSuppressMainCommentEditor({
+        docId,
+        activeView: 'comments',
+        discussionsParams: {openComment: 'comment-a'},
+        panelRoute: {
+          key: 'comments',
+          id: docId,
+          openComment: 'comment-b',
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('does not suppress the main editor for different block comment targets', () => {
+    expect(
+      shouldSuppressMainCommentEditor({
+        docId,
+        activeView: 'comments',
+        discussionsParams: {targetBlockId: 'block-a'},
+        panelRoute: {
+          key: 'comments',
+          id: docId,
+          targetBlockId: 'block-b',
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('does not suppress the main editor when a non-comments panel is open', () => {
+    expect(
+      shouldSuppressMainCommentEditor({
+        docId,
+        activeView: 'comments',
+        panelRoute: {
+          key: 'activity',
+          id: docId,
+        },
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('getCommentReplyPanelRoute', () => {
+  const docId = hmId('alice', {path: ['doc']})
+
+  it('creates a panel comments route focused on the replied comment', () => {
+    expect(
+      getCommentReplyPanelRoute({
+        docId,
+        isReplying: true,
+        comment: {
+          id: 'alice/comment-tsid',
+          version: 'comment-version',
+          threadRootVersion: 'thread-root-version',
+          targetAccount: 'alice',
+          targetPath: '/doc',
+        } as any,
+      }),
+    ).toMatchObject({
+      key: 'comments',
+      id: docId,
+      openComment: 'alice/comment-tsid',
+      isReplying: true,
+      replyCommentVersion: 'comment-version',
+      rootReplyCommentVersion: 'thread-root-version',
+    })
+  })
+
+  it('switches the panel target document when the replied comment belongs to another document', () => {
+    const panelRoute = getCommentReplyPanelRoute({
+      docId,
+      comment: {
+        id: 'alice/other-comment-tsid',
+        version: 'comment-version',
+        targetAccount: 'alice',
+        targetPath: '/other-doc',
+      } as any,
+    })
+
+    expect(panelRoute).toMatchObject({
+      key: 'comments',
+      openComment: 'alice/other-comment-tsid',
+    })
+    expect(panelRoute.id.path).toEqual(['other-doc'])
+  })
+})

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -1,6 +1,7 @@
 import {
   BlockRange,
   HMBlockNode,
+  HMComment,
   HMDocument,
   HMExistingDraft,
   UnpackedHypermediaId,
@@ -17,7 +18,12 @@ import {
   unpackHmId,
   useUniversalAppContext,
 } from '@shm/shared'
-import {useHackyAuthorsSubscriptions} from '@shm/shared/comments-service-provider'
+import {
+  CommentsProvider,
+  isRouteEqualToCommentTarget,
+  useCommentsServiceContext,
+  useHackyAuthorsSubscriptions,
+} from '@shm/shared/comments-service-provider'
 import {DEFAULT_GATEWAY_URL, IS_DESKTOP, NOTIFY_SERVICE_HOST} from '@shm/shared/constants'
 import type {
   BlockRangeSelectOptions,
@@ -214,6 +220,78 @@ function extractPanelRoute(route: NavRoute): DocumentPanelRoute {
 }
 
 export type ActiveView = 'content' | 'activity' | 'comments' | 'directory' | 'collaborators' | 'site-profile'
+
+type CommentDraftTarget = {
+  docId: string
+  commentId?: string
+  quotingBlockId?: string
+}
+
+function getCommentDraftTarget(
+  docId: UnpackedHypermediaId,
+  params?: {openComment?: string; targetBlockId?: string},
+): CommentDraftTarget {
+  return {
+    docId: docId.id,
+    commentId: params?.openComment,
+    quotingBlockId: params?.targetBlockId,
+  }
+}
+
+function areSameCommentDraftTarget(a: CommentDraftTarget, b: CommentDraftTarget) {
+  return a.docId === b.docId && a.commentId === b.commentId && a.quotingBlockId === b.quotingBlockId
+}
+
+export function shouldSuppressMainCommentEditor({
+  docId,
+  activeView,
+  discussionsParams,
+  panelRoute,
+}: {
+  docId: UnpackedHypermediaId
+  activeView: ActiveView
+  discussionsParams?: {openComment?: string; targetBlockId?: string}
+  panelRoute: DocumentPanelRoute | null
+}) {
+  if (activeView !== 'comments' || panelRoute?.key !== 'comments') return false
+
+  return areSameCommentDraftTarget(
+    getCommentDraftTarget(docId, discussionsParams),
+    getCommentDraftTarget(panelRoute.id, {
+      openComment: panelRoute.openComment,
+      targetBlockId: panelRoute.targetBlockId,
+    }),
+  )
+}
+
+export function getCommentReplyPanelRoute({
+  docId,
+  comment,
+  isReplying = false,
+}: {
+  docId: UnpackedHypermediaId
+  comment: HMComment
+  isReplying?: boolean
+}): Extract<DocumentPanelRoute, {key: 'comments'}> {
+  const targetRoute = isRouteEqualToCommentTarget({
+    id: docId,
+    comment,
+  })
+  const replyVersionData = isReplying
+    ? {
+        isReplying: true,
+        replyCommentVersion: comment.version,
+        rootReplyCommentVersion: comment.threadRootVersion || comment.version,
+      }
+    : {}
+
+  return {
+    key: 'comments',
+    id: targetRoute || docId,
+    openComment: comment.id,
+    ...replyVersionData,
+  }
+}
 
 function getActiveView(routeKey: string): ActiveView {
   switch (routeKey) {
@@ -977,6 +1055,12 @@ function DocumentBody({
       : openComment
       ? {openComment}
       : undefined
+  const suppressMainCommentEditor = shouldSuppressMainCommentEditor({
+    docId,
+    activeView,
+    discussionsParams,
+    panelRoute,
+  })
 
   // Respect the showActivity metadata toggle to hide the document tools bar.
   const showActivity = document.metadata?.showActivity !== false
@@ -1636,6 +1720,7 @@ function DocumentBody({
           showSidebars={showSidebars}
           showCollapsed={showCollapsed}
           discussionsParams={discussionsParams}
+          suppressCommentEditor={suppressMainCommentEditor}
           activityFilterEventType={route.key === 'activity' ? route.filterEventType : undefined}
           onActivityFilterChange={handleMainActivityFilterChange}
           blockCitations={blockCitations}
@@ -2028,30 +2113,12 @@ function PanelContentRenderer({
       )
     case 'comments':
       return (
-        <DiscussionsPageContent
+        <CommentsPanelContent
           docId={docId}
-          showTitle={false}
-          showOpenInPanel={false}
+          panelRoute={panelRoute}
           contentMaxWidth={contentMaxWidth}
           targetDomain={siteUrl}
-          openComment={panelRoute.openComment}
-          targetBlockId={panelRoute.targetBlockId}
-          blockId={panelRoute.blockId}
-          blockRange={panelRoute.blockRange}
-          commentEditor={
-            CommentEditor ? (
-              <CommentEditor
-                key={panelRoute.openComment}
-                docId={docId}
-                quotingBlockId={panelRoute.targetBlockId}
-                commentId={panelRoute.openComment}
-                isReplying={panelRoute.isReplying ?? !!panelRoute.openComment}
-                replyCommentVersion={panelRoute.replyCommentVersion}
-                rootReplyCommentVersion={panelRoute.rootReplyCommentVersion}
-                focusOnMount
-              />
-            ) : undefined
-          }
+          CommentEditor={CommentEditor}
         />
       )
     case 'directory':
@@ -2066,6 +2133,83 @@ function PanelContentRenderer({
     default:
       return null
   }
+}
+
+function CommentsPanelContent({
+  docId,
+  panelRoute,
+  contentMaxWidth,
+  targetDomain,
+  CommentEditor,
+}: {
+  docId: UnpackedHypermediaId
+  panelRoute: Extract<DocumentPanelRoute, {key: 'comments'}>
+  contentMaxWidth: number
+  targetDomain?: string
+  CommentEditor?: React.ComponentType<CommentEditorProps>
+}) {
+  const commentsContext = useCommentsServiceContext()
+  const route = useNavRoute()
+  const replaceRoute = useNavigate('replace')
+
+  const onReplyClick = useCallback(
+    (comment: HMComment) => {
+      if (!('panel' in route)) return
+      replaceRoute({
+        ...route,
+        panel: getCommentReplyPanelRoute({
+          docId,
+          comment,
+          isReplying: true,
+        }),
+      } as NavRoute)
+    },
+    [docId, replaceRoute, route],
+  )
+
+  const onReplyCountClick = useCallback(
+    (comment: HMComment) => {
+      if (!('panel' in route)) return
+      replaceRoute({
+        ...route,
+        panel: getCommentReplyPanelRoute({
+          docId,
+          comment,
+        }),
+      } as NavRoute)
+    },
+    [docId, replaceRoute, route],
+  )
+
+  return (
+    <CommentsProvider {...commentsContext} onReplyClick={onReplyClick} onReplyCountClick={onReplyCountClick}>
+      <DiscussionsPageContent
+        docId={docId}
+        showTitle={false}
+        showOpenInPanel={false}
+        contentMaxWidth={contentMaxWidth}
+        targetDomain={targetDomain}
+        openComment={panelRoute.openComment}
+        targetBlockId={panelRoute.targetBlockId}
+        blockId={panelRoute.blockId}
+        blockRange={panelRoute.blockRange}
+        commentEditor={
+          CommentEditor ? (
+            <CommentEditor
+              key={panelRoute.openComment}
+              docId={docId}
+              quotingBlockId={panelRoute.targetBlockId}
+              commentId={panelRoute.openComment}
+              isReplying={panelRoute.isReplying ?? !!panelRoute.openComment}
+              replyCommentVersion={panelRoute.replyCommentVersion}
+              rootReplyCommentVersion={panelRoute.rootReplyCommentVersion}
+              focusOnMount
+            />
+          ) : undefined
+        }
+      />
+    </CommentsProvider>
+  )
 }
 
 function DocumentOptionsPanel({
@@ -2112,6 +2256,7 @@ function MainContent({
   showSidebars,
   showCollapsed,
   discussionsParams,
+  suppressCommentEditor,
   activityFilterEventType,
   onActivityFilterChange,
   blockCitations,
@@ -2153,6 +2298,7 @@ function MainContent({
     replyCommentVersion?: string
     rootReplyCommentVersion?: string
   }
+  suppressCommentEditor?: boolean
   activityFilterEventType?: string[]
   onActivityFilterChange?: (filter: {filterEventType?: string[]}) => void
   blockCitations?: Record<string, {citations: number; comments: number}> | null
@@ -2217,7 +2363,7 @@ function MainContent({
           blockId={discussionsParams?.blockId}
           blockRange={discussionsParams?.blockRange}
           commentEditor={
-            CommentEditor ? (
+            CommentEditor && !suppressCommentEditor ? (
               <CommentEditor
                 key={discussionsParams?.openComment}
                 docId={docId}


### PR DESCRIPTION
## Summary
- Prevent duplicate main and side-panel comment editors from mounting for the same draft target.
- Flush pending comment draft saves on editor unmount so opening the side panel does not drop unsaved content.
- Route side-panel reply actions through panel-specific comment handling.
- Add regression coverage for draft persistence and duplicate editor suppression.

Fixes #557

---

Fixes #557