### PR TITLE
fix(frontend): align editor prose and code block behavior

### DIFF
--- a/frontend/apps/web/app/styles.css
+++ b/frontend/apps/web/app/styles.css
@@ -162,15 +162,14 @@ body {
   }
 }
 
-/* === CODE BLOCK chrome (prose owns font + size inside) === */
+/* === CODE BLOCK chrome ===
+ * Surface (background, border, radius, padding) is owned by `.hm-prose pre`
+ * in packages/ui/src/hm-prose.css. Only structural layout lives here. */
 .ssr-content-placeholder .blockContent[data-content-type='code-block'] {
-  background-color: rgba(0, 0, 0, 0.05);
-  border-radius: 6px;
   display: block;
   box-sizing: border-box;
   width: 100%;
   max-width: 100%;
-  overflow: hidden;
   position: relative;
 }
 
@@ -190,63 +189,10 @@ body {
   text-align: center;
 }
 
-/* === TEXT COLORS (from Block.module.css) === */
-.ssr-content-placeholder [data-text-color='gray'] {
-  color: #9b9a97;
-}
-.ssr-content-placeholder [data-text-color='brown'] {
-  color: #64473a;
-}
-.ssr-content-placeholder [data-text-color='red'] {
-  color: #e03e3e;
-}
-.ssr-content-placeholder [data-text-color='orange'] {
-  color: #d9730d;
-}
-.ssr-content-placeholder [data-text-color='yellow'] {
-  color: #dfab01;
-}
-.ssr-content-placeholder [data-text-color='green'] {
-  color: #4d6461;
-}
-.ssr-content-placeholder [data-text-color='blue'] {
-  color: #0b6e99;
-}
-.ssr-content-placeholder [data-text-color='purple'] {
-  color: #6940a5;
-}
-.ssr-content-placeholder [data-text-color='pink'] {
-  color: #ad1a72;
-}
-
-/* === BACKGROUND COLORS (from Block.module.css) === */
-.ssr-content-placeholder [data-background-color='gray'] {
-  background-color: #ebeced;
-}
-.ssr-content-placeholder [data-background-color='brown'] {
-  background-color: #e9e5e3;
-}
-.ssr-content-placeholder [data-background-color='red'] {
-  background-color: #fbe4e4;
-}
-.ssr-content-placeholder [data-background-color='orange'] {
-  background-color: #faebdd;
-}
-.ssr-content-placeholder [data-background-color='yellow'] {
-  background-color: #fbf3db;
-}
-.ssr-content-placeholder [data-background-color='green'] {
-  background-color: #ddedea;
-}
-.ssr-content-placeholder [data-background-color='blue'] {
-  background-color: #ddebf1;
-}
-.ssr-content-placeholder [data-background-color='purple'] {
-  background-color: #eae4f2;
-}
-.ssr-content-placeholder [data-background-color='pink'] {
-  background-color: #f4dfeb;
-}
+/* Inline text / background colors are owned by `.hm-prose [data-text-color]`
+ * / `[data-background-color]` in packages/ui/src/hm-prose.css. The SSR
+ * placeholder carries the `hm-prose` class, so those rules (light + dark)
+ * apply directly — no SSR-specific copy needed. */
 
 /* === TEXT ALIGNMENT === */
 .ssr-content-placeholder [data-text-alignment='left'] {

--- a/frontend/apps/web/vite.config.mts
+++ b/frontend/apps/web/vite.config.mts
@@ -78,6 +78,10 @@ export default defineConfig(({isSsrBuild}) => {
     },
     plugins: [
       remix({
+        // Keep colocated test files out of the route table — otherwise Remix
+        // turns e.g. `app/routes/hm.api.auth.test.ts` into a route, bundles it
+        // into the server build, and its `vitest` import crashes every page.
+        ignoredRouteFiles: ['**/*.test.*', '**/*.spec.*'],
         future: {
           v3_fetcherPersist: true,
           v3_relativeSplatPath: true,

--- a/frontend/packages/editor/e2e/tests/block-manipulation.e2e.ts
+++ b/frontend/packages/editor/e2e/tests/block-manipulation.e2e.ts
@@ -36,13 +36,24 @@ test.describe('Block Manipulation', () => {
       expect(blocks[0].type).toBe('heading')
     })
 
-    test('Should insert code block with slash menu', async ({editorHelpers, page}) => {
+    test('Should insert code block with slash menu', async ({editorHelpers}) => {
       await editorHelpers.openSlashMenu()
       await editorHelpers.clickSlashMenuItem('Code Block')
-      // await page.waitForTimeout(200)
+      await editorHelpers.typeText('const answer = 42')
 
       const blocks = await editorHelpers.getBlocks()
       expect(blocks[0].type).toBe('code-block')
+      expect(blocks[0].content[0].text).toBe('const answer = 42')
+    })
+
+    test('Should remove empty code block formatting on Backspace', async ({editorHelpers}) => {
+      await editorHelpers.openSlashMenu()
+      await editorHelpers.clickSlashMenuItem('Code Block')
+      await editorHelpers.pressKey('Backspace')
+
+      const blocks = await editorHelpers.getAllBlocks()
+      expect(blocks[0].type).toBe('paragraph')
+      expect(blocks[0].content).toEqual([])
     })
 
     test('Should filter slash menu items when typing after slash', async ({editorHelpers, page}) => {

--- a/frontend/packages/editor/src/blocknote/core/extensions/SlashMenu/defaultSlashMenuItems.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/SlashMenu/defaultSlashMenuItems.ts
@@ -9,6 +9,7 @@ export function insertOrUpdateBlock<BSchema extends BlockSchema>(
   editor: BlockNoteEditor<BSchema>,
   block: PartialBlock<BSchema>,
   isNode?: boolean,
+  keepSelection?: boolean,
 ) {
   const currentBlock = editor.getTextCursorPosition().block
 
@@ -20,7 +21,11 @@ export function insertOrUpdateBlock<BSchema extends BlockSchema>(
       currentBlock.content[0].text === '/') ||
     currentBlock.content.length === 0
   ) {
-    editor.updateBlock(currentBlock, block)
+    if (keepSelection === undefined) {
+      editor.updateBlock(currentBlock, block)
+    } else {
+      editor.updateBlock(currentBlock, block, keepSelection)
+    }
     if (isNode) {
       const cursorPosition = editor.getTextCursorPosition()
       editor.focus()

--- a/frontend/packages/editor/src/blocknote/react/SideMenu/components/DragHandleMenu/DefaultDragHandleMenu.tsx
+++ b/frontend/packages/editor/src/blocknote/react/SideMenu/components/DragHandleMenu/DefaultDragHandleMenu.tsx
@@ -129,11 +129,15 @@ var turnIntoItems = [
     Icon: RiCodeBoxLine,
     onClick: ({block, editor}: {block: Block<HMBlockSchema>; editor: BlockNoteEditor<HMBlockSchema>}) => {
       editor.focus()
-      editor.updateBlock(block, {
-        type: 'code-block',
-        props: {},
-        content: block.content,
-      })
+      editor.updateBlock(
+        block,
+        {
+          type: 'code-block',
+          props: {},
+          content: block.content,
+        },
+        true,
+      )
     },
   },
   // {

--- a/frontend/packages/editor/src/editor.css
+++ b/frontend/packages/editor/src/editor.css
@@ -110,6 +110,16 @@
   box-shadow: none !important;
 }
 
+/* The image caption is a nested contentEditable region. The browser
+ * draws a focus outline on it — tinted by the global `* { outline-ring }`
+ * base rule — which reads as a stray bordered box under the image. The
+ * block already shows its own selection chrome, so suppress it. */
+.image-caption:focus,
+.image-caption:focus-visible,
+.image-caption:focus-within {
+  outline: none;
+}
+
 .hm-file-drop-indicator {
   background: rgba(59, 130, 246, 0.9);
   border-radius: 999px;

--- a/frontend/packages/editor/src/heading-component-plugin.tsx
+++ b/frontend/packages/editor/src/heading-component-plugin.tsx
@@ -3,6 +3,53 @@ import {updateBlockCommand} from './blocknote/core/api/blockManipulation/command
 import {getBlockInfoFromPos} from './blocknote/core/extensions/Blocks/helpers/getBlockInfoFromPos'
 import styles from './blocknote/core/extensions/Blocks/nodes/Block.module.css'
 import {InputRule, mergeAttributes} from '@tiptap/core'
+import {Plugin, PluginKey} from 'prosemirror-state'
+
+/**
+ * Compute the visual heading level for a heading node at the given doc
+ * position. Top-level document headings are h2 — h1 is reserved for the
+ * document title rendered above the editor body — and each level of
+ * nesting demotes one step further, clamped to h6.
+ */
+function computeHeadingDepth(doc: any, pos: number): number {
+  const $pos = doc.resolve(pos)
+  let ancestors = 0
+  for (let d = 0; d <= $pos.depth; d++) {
+    if ($pos.node(d).type.name === 'blockNode') ancestors++
+  }
+  // `ancestors` is 1 for a top-level heading; +1 shifts the scale so the
+  // first level is h2 rather than h1.
+  return Math.min(Math.max(ancestors + 1, 2), 6)
+}
+
+const headingDepthNormalizerKey = new PluginKey('headingDepthNormalizer')
+
+/**
+ * Keeps each heading node's `level` attribute in sync with its actual
+ * nesting depth in the doc tree. Runs once per dispatched transaction
+ * that changes the doc, and is a no-op when every heading is already
+ * at the right level — so it converges in one pass and does not loop.
+ */
+const headingDepthNormalizer = new Plugin({
+  key: headingDepthNormalizerKey,
+  appendTransaction(transactions, _oldState, newState) {
+    if (!transactions.some((tr) => tr.docChanged)) return null
+
+    let tr = newState.tr
+    let modified = false
+
+    newState.doc.descendants((node, pos) => {
+      if (node.type.name !== 'heading') return
+      const target = String(computeHeadingDepth(newState.doc, pos))
+      if (node.attrs.level !== target) {
+        tr = tr.setNodeMarkup(pos, undefined, {...node.attrs, level: target})
+        modified = true
+      }
+    })
+
+    return modified ? tr : null
+  },
+})
 
 export const HMHeadingBlockContent = createTipTapBlock<'heading'>({
   name: 'heading',
@@ -103,6 +150,10 @@ export const HMHeadingBlockContent = createTipTapBlock<'heading'>({
       }),
       0,
     ]
+  },
+
+  addProseMirrorPlugins() {
+    return [headingDepthNormalizer]
   },
 })
 

--- a/frontend/packages/editor/src/hm-formatting-toolbar.tsx
+++ b/frontend/packages/editor/src/hm-formatting-toolbar.tsx
@@ -301,10 +301,14 @@ export function HMFormattingToolbar<Schema extends Record<string, BlockSpec<stri
     const tiptap = props.editor._tiptapEditor
     const {state} = tiptap
     const blockInfo = getBlockInfoFromSelection(state)
-    props.editor.updateBlock(blockInfo.block.node.attrs.id, {
-      type: blockType,
-      props: {},
-    })
+    props.editor.updateBlock(
+      blockInfo.block.node.attrs.id,
+      {
+        type: blockType,
+        props: {},
+      },
+      blockType === 'code-block',
+    )
     setCurrentBlockType(blockType)
   }
 

--- a/frontend/packages/editor/src/inline-add-block-button.tsx
+++ b/frontend/packages/editor/src/inline-add-block-button.tsx
@@ -57,6 +57,9 @@ export function InlineAddBlockButton({editor}: {editor: HyperMediaEditor}) {
       const $anchor = state.doc.resolve(anchor)
       const textblock = $anchor.parent
       if (!textblock.isTextblock || textblock.childCount > 0) return null
+      // Code blocks are textblocks too, but inserting a block from an empty
+      // line inside them makes no sense — suppress the button there.
+      if (textblock.type.name === 'code-block' || textblock.type.spec.code) return null
       // Check if the cursor's block is a list item.
       let inList = false
       for (let d = $anchor.depth; d > 0; d--) {

--- a/frontend/packages/editor/src/math.tsx
+++ b/frontend/packages/editor/src/math.tsx
@@ -90,12 +90,19 @@ const Render = (block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
   }, [block.content])
 
   useEffect(() => {
-    if (opened && inputRef.current) {
-      // @ts-ignore
-      inputRef.current.focus()
-      const length = inputRef.current.value.length
-      inputRef.current.setSelectionRange(length, length)
-    }
+    if (!opened) return
+    // Defer the focus to the next macrotask: when the block is opened right
+    // after insertion, `selectInsertedBlock` calls `view.focus()` on the
+    // ProseMirror view synchronously, which would otherwise steal focus
+    // back from the textarea. Running after that lets the textarea win.
+    const timer = setTimeout(() => {
+      const el = inputRef.current
+      if (!el) return
+      el.focus()
+      const length = el.value.length
+      el.setSelectionRange(length, length)
+    }, 0)
+    return () => clearTimeout(timer)
   }, [opened])
 
   // Function to measure content and container widths

--- a/frontend/packages/editor/src/media-container.tsx
+++ b/frontend/packages/editor/src/media-container.tsx
@@ -222,10 +222,15 @@ export const MediaContainer = ({
       )}
       <div
         className={cn(
-          'group relative flex max-w-full flex-col rounded-md border-2 transition-colors',
-          mediaType === 'file' ? 'w-full' : 'w-full',
-          drag ? 'border-foreground/20 dark:border-foreground/30' : 'border-border',
-          drag && 'border-dashed',
+          'group relative flex w-full max-w-full flex-col rounded-md transition-colors',
+          // Image/video carry their own rounding + shadow (see hm-prose.css),
+          // so they get no chrome border; other media keep the framed box.
+          // The dashed border still appears while dragging as a drop target.
+          drag
+            ? 'border-foreground/20 dark:border-foreground/30 border-2 border-dashed'
+            : mediaType === 'image' || mediaType === 'video'
+            ? ''
+            : 'border-border border-2',
           editor.commentEditor && !drag ? 'bg-black/5 dark:bg-white/10' : 'bg-muted',
           className ?? block.type,
         )}

--- a/frontend/packages/editor/src/slash-menu-items.test.tsx
+++ b/frontend/packages/editor/src/slash-menu-items.test.tsx
@@ -2,6 +2,33 @@ import {describe, expect, it, vi} from 'vitest'
 import {getSlashMenuItems} from './slash-menu-items'
 
 describe('getSlashMenuItems', () => {
+  it('keeps the cursor in a newly inserted code block', () => {
+    const currentBlock = {id: 'block-1', content: []}
+    const tr = {scrollIntoView: vi.fn(() => 'scroll-tr')}
+    const editor = {
+      getTextCursorPosition: vi.fn(() => ({block: currentBlock})),
+      updateBlock: vi.fn(),
+      _tiptapEditor: {
+        state: {tr},
+        view: {dispatch: vi.fn()},
+      },
+    }
+
+    const item = getSlashMenuItems().find((item) => item.name === 'Code Block')
+
+    item!.execute(editor as any)
+
+    expect(editor.updateBlock).toHaveBeenCalledWith(
+      currentBlock,
+      {
+        type: 'code-block',
+        props: {language: ''},
+      },
+      true,
+    )
+    expect(editor._tiptapEditor.view.dispatch).toHaveBeenCalledWith('scroll-tr')
+  })
+
   it('inserts New document draft embed without focusing/selecting the editor block', async () => {
     const currentBlock = {id: 'block-1', content: [{type: 'text', text: '/'}]}
     const editor = {

--- a/frontend/packages/editor/src/slash-menu-items.tsx
+++ b/frontend/packages/editor/src/slash-menu-items.tsx
@@ -183,8 +183,10 @@ export function getSlashMenuItems({
         } as PartialBlock<HMBlockSchema>,
         true,
       )
-      const {state, view} = editor._tiptapEditor
-      view.dispatch(state.tr.scrollIntoView())
+      // Select the inserted math block so its render effect opens and
+      // focuses the LaTeX textarea, instead of leaving the cursor in
+      // the following block.
+      selectInsertedBlock(editor)
     },
   })
 

--- a/frontend/packages/editor/src/slash-menu-items.tsx
+++ b/frontend/packages/editor/src/slash-menu-items.tsx
@@ -154,17 +154,17 @@ export function getSlashMenuItems({
     icon: <Code size={18} />,
     hint: 'Insert a Code Block',
     execute: (editor: BlockNoteEditor) => {
-      insertOrUpdateBlock(editor, {
-        type: 'code-block',
-        props: {
-          language: '',
-        },
-      } as PartialBlock<HMBlockSchema>)
-      // Move cursor to the code-block after converting from paragraph
-      const codeBlock = editor.getTextCursorPosition().prevBlock
-      if (codeBlock && codeBlock.type === 'code-block') {
-        editor.setTextCursorPosition(codeBlock, 'start')
-      }
+      insertOrUpdateBlock(
+        editor,
+        {
+          type: 'code-block',
+          props: {
+            language: '',
+          },
+        } as PartialBlock<HMBlockSchema>,
+        false,
+        true,
+      )
       const {state, view} = editor._tiptapEditor
       view.dispatch(state.tr.scrollIntoView())
     },

--- a/frontend/packages/editor/src/ssr-render.ts
+++ b/frontend/packages/editor/src/ssr-render.ts
@@ -40,8 +40,10 @@ export function renderDocumentToHTML(blocks: HMBlockNode[], opts?: SSRRenderOpts
   try {
     const embeds = opts?.embeds ?? {}
     const renderHref = opts?.renderHref
-    // Wrap in a blockChildren container at depth 1 (matching editor's root group)
-    const inner = renderBlockChildren(blocks, 'Group', 1, null, embeds, renderHref)
+    // Wrap in a blockChildren container at depth 1 (matching editor's root group).
+    // `nestingDepth` tracks blockNode-ancestor count so headings can render
+    // the right h-tag without trusting the stored level prop.
+    const inner = renderBlockChildren(blocks, 'Group', 1, null, embeds, renderHref, 0)
     if (!inner) return null
     const result = `<div class="ssr-content-placeholder hm-prose">${inner}</div>`
 
@@ -66,6 +68,7 @@ function renderBlockChildren(
   columnCount: number | null,
   embeds: Record<string, SSREmbedData>,
   renderHref: SSRRenderOpts['renderHref'],
+  nestingDepth: number,
 ): string {
   const tag = listTag(listType)
   const isGrid = listType === 'Grid'
@@ -76,7 +79,7 @@ function renderBlockChildren(
   const isListContainer = listType === 'Ordered' || listType === 'Unordered'
 
   const childrenHtml = blocks
-    .map((node) => renderBlockNode(node, isListContainer, listLevel, embeds, renderHref))
+    .map((node) => renderBlockNode(node, isListContainer, listLevel, embeds, renderHref, nestingDepth))
     .join('')
 
   return `<${tag} class="blockChildren" data-node-type="blockChildren" data-list-type="${esc(
@@ -94,12 +97,15 @@ function renderBlockNode(
   listLevel: number,
   embeds: Record<string, SSREmbedData>,
   renderHref: SSRRenderOpts['renderHref'],
+  nestingDepth: number,
 ): string {
   const block = node.block
   const tag = insideList ? 'li' : 'div'
   const idAttr = block.id ? ` data-id="${esc(block.id)}" id="${esc(block.id)}"` : ''
 
-  const contentHtml = renderBlockContent(block, embeds, renderHref)
+  // This blockNode itself contributes one ancestor to nested children. The
+  // current heading (if this block is a heading) renders at h{nestingDepth+1}.
+  const contentHtml = renderBlockContent(block, embeds, renderHref, nestingDepth + 1)
 
   // Render children if present
   let childrenHtml = ''
@@ -110,7 +116,15 @@ function renderBlockNode(
 
     const nextLevel = childrenType === 'Ordered' || childrenType === 'Unordered' ? listLevel + 1 : listLevel
 
-    childrenHtml = renderBlockChildren(node.children, childrenType, nextLevel, colCount, embeds, renderHref)
+    childrenHtml = renderBlockChildren(
+      node.children,
+      childrenType,
+      nextLevel,
+      colCount,
+      embeds,
+      renderHref,
+      nestingDepth + 1,
+    )
   }
 
   return `<${tag} class="blockNode" data-node-type="blockNode"${idAttr}>${contentHtml}${childrenHtml}</${tag}>`
@@ -124,6 +138,7 @@ function renderBlockContent(
   block: any,
   embeds: Record<string, SSREmbedData>,
   renderHref: SSRRenderOpts['renderHref'],
+  headingLevel: number,
 ): string {
   const text: string = block.text || ''
   const annotations: HMAnnotation[] = block.annotations || []
@@ -135,8 +150,12 @@ function renderBlockContent(
     }
 
     case 'Heading': {
-      const level = block.attributes?.level || '2'
-      const h = Math.min(Math.max(Number(level) || 2, 1), 5)
+      // Visual level is driven by nesting depth (see `headingLevel` arg),
+      // not the stored `level` attribute, so legacy/imported docs render
+      // consistently and the h-tag always reflects document hierarchy.
+      // `+ 1` shifts the scale so a top-level heading is h2 — h1 is
+      // reserved for the document title.
+      const h = Math.min(Math.max(headingLevel + 1, 2), 6)
       const inlineHtml = renderAnnotatedText(text, annotations, renderHref)
       return `<div class="blockContent" data-content-type="heading" data-level="${h}"><h${h} class="inlineContent">${inlineHtml}</h${h}></div>`
     }

--- a/frontend/packages/editor/src/tiptap-extension-code-block/code-block.ts
+++ b/frontend/packages/editor/src/tiptap-extension-code-block/code-block.ts
@@ -189,7 +189,7 @@ export const CodeBlock = Node.create<CodeBlockOptions>({
         }
 
         if (isAtStart || !$anchor.parent.textContent.length) {
-          return this.editor.commands.clearNodes()
+          return this.editor.commands.setNode('paragraph')
         }
 
         return false

--- a/frontend/packages/ui/src/components/textarea.tsx
+++ b/frontend/packages/ui/src/components/textarea.tsx
@@ -2,9 +2,13 @@ import * as React from 'react'
 
 import {cn} from '../utils'
 
-function Textarea({className, ...props}: React.ComponentProps<'textarea'>) {
+const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<'textarea'>>(function Textarea(
+  {className, ...props},
+  ref,
+) {
   return (
     <textarea
+      ref={ref}
       data-slot="textarea"
       className={cn(
         'border-border placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
@@ -13,6 +17,6 @@ function Textarea({className, ...props}: React.ComponentProps<'textarea'>) {
       {...props}
     />
   )
-}
+})
 
 export {Textarea}

--- a/frontend/packages/ui/src/document-header.tsx
+++ b/frontend/packages/ui/src/document-header.tsx
@@ -104,7 +104,7 @@ export function DocumentHeader({
         ) : (
           <>
             {showTitle && (
-              <SizableText size="4xl" weight="bold" {...highlighter(docId)}>
+              <SizableText size="5xl" weight="bold" {...highlighter(docId)}>
                 {isHomeDoc ? 'Home' : docMetadata?.name}
               </SizableText>
             )}

--- a/frontend/packages/ui/src/hm-prose.css
+++ b/frontend/packages/ui/src/hm-prose.css
@@ -43,9 +43,13 @@
 .hm-prose {
   font-family: ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
   font-size: var(--hm-prose-size, 1.125rem);
-  line-height: 1.6;
+  line-height: 1.7;
   color: var(--foreground, inherit);
   max-width: none;
+  /* Extra width code/image blocks may "break out" past the text column
+   * (split evenly — half each side). Inherited by descendants; zeroed in
+   * comments and embeds below so the breakout rule is a no-op there. */
+  --hm-breakout: 120px;
 }
 
 .hm-prose.is-comment,
@@ -61,6 +65,15 @@
     Arial,
     sans-serif;
   font-size: 1rem;
+}
+
+/* No breakout in comments or embedded documents — those render in tight
+ * columns where a wider block would overflow. The custom property is
+ * inherited, so setting it on the subtree root covers all descendants. */
+.hm-prose.is-comment,
+.hm-prose .is-comment,
+.block-embed {
+  --hm-breakout: 0px;
 }
 
 /* Headings ride the UI sans stack so they read as structure, not prose. */
@@ -81,7 +94,8 @@
     Arial,
     sans-serif;
   font-weight: 600;
-  line-height: 1.25;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
   color: var(--foreground, inherit);
   /* margin-top is owned by the wrapper (.blockNode) so the first-child
    * reset works cleanly in both editor and SSR DOM trees. See below. */
@@ -89,19 +103,23 @@
 }
 
 .hm-prose h1 {
-  font-size: 1.9em;
-  margin-bottom: 0.4em;
+  font-size: 2em;
+  line-height: 1.25;
+  margin-bottom: 0.6em;
 }
 .hm-prose h2 {
-  font-size: 1.5em;
+  font-size: 1.55em;
+  line-height: 1.3;
   margin-bottom: 0.4em;
 }
 .hm-prose h3 {
-  font-size: 1.25em;
+  font-size: 1.3em;
+  line-height: 1.35;
   margin-bottom: 0.35em;
 }
 .hm-prose h4 {
-  font-size: 1.1em;
+  font-size: 1.15em;
+  line-height: 1.4;
   margin-bottom: 0.3em;
 }
 .hm-prose h5,
@@ -121,7 +139,7 @@
  * wrappers override with a bigger section-marker gap, and the
  * `:first-child` rule zeroes it for the first block. */
 .hm-prose [data-node-type='blockNode'] + [data-node-type='blockNode'] {
-  margin-top: 0.75rem; /* ~12px at 16px base — visible "paragraph" gap */
+  margin-top: 0.75rem; /* ~12px — relaxed paragraph rhythm */
 }
 
 /* Section-marker rhythm lives on the heading's WRAPPER, not the
@@ -132,15 +150,15 @@
   margin-top: 2.5rem;
 }
 .hm-prose [data-node-type='blockNode']:has(> [data-content-type='heading'][data-level='2']) {
-  margin-top: 2rem;
+  margin-top: 2.25rem;
 }
 .hm-prose [data-node-type='blockNode']:has(> [data-content-type='heading'][data-level='3']) {
-  margin-top: 1.5rem;
+  margin-top: 1.75rem;
 }
 .hm-prose [data-node-type='blockNode']:has(> [data-content-type='heading'][data-level='4']),
 .hm-prose [data-node-type='blockNode']:has(> [data-content-type='heading'][data-level='5']),
 .hm-prose [data-node-type='blockNode']:has(> [data-content-type='heading'][data-level='6']) {
-  margin-top: 1.25rem;
+  margin-top: 1.5rem;
 }
 
 /* Media / code / quote / embed get a bit more breathing room than
@@ -157,10 +175,42 @@
   margin-top: 1.25rem;
 }
 
-/* Top-of-document first block: no margin. Covers both the editor's
- * root ProseMirror child and the SSR outer container. */
-.hm-prose [data-node-type='blockNode']:first-child,
-.hm-prose [data-node-type='blockChildren'] > [data-node-type='blockNode']:first-child {
+/* ---------- Code / media breakout ----------
+ * Code blocks, images, and videos render wider than the prose text
+ * column when the layout has room — a centered "breakout". The block
+ * keeps its normal flow position (margins, rhythm) but is widened and
+ * re-centered on the column's axis via `left: 50%` + a -50% shift.
+ *
+ *   width = the text column (100%) + `--hm-breakout`, but never more
+ *   than the viewport (`100vw - 3rem`) — so on narrow screens it
+ *   collapses cleanly back to the column width with no overflow.
+ *
+ * `--hm-breakout` is 0 in comments/embeds (see Base), making this a
+ * no-op there: width resolves to 100%, and the 50%/-50% pair cancels.
+ *
+ * Both `> child` and `> wrapper > child` are matched: code blocks are
+ * a direct `<pre>` child of the blockNode, while React-rendered image
+ * and video blocks sit one wrapper element deeper. */
+.hm-prose [data-node-type='blockNode']:has(> [data-content-type='code-block']),
+.hm-prose [data-node-type='blockNode']:has(> [data-content-type='image']),
+.hm-prose [data-node-type='blockNode']:has(> [data-content-type='video']),
+.hm-prose [data-node-type='blockNode']:has(> * > [data-content-type='code-block']),
+.hm-prose [data-node-type='blockNode']:has(> * > [data-content-type='image']),
+.hm-prose [data-node-type='blockNode']:has(> * > [data-content-type='video']) {
+  position: relative;
+  left: 50%;
+  width: min(calc(100% + var(--hm-breakout, 0px)), 100vw - 3rem);
+  max-width: none;
+  transform: translateX(-50%);
+}
+
+/* Top-of-document first block: no margin — UNLESS it is a heading.
+ * A leading heading keeps its section-gap so it sits clear of the
+ * document title above the editor body. */
+.hm-prose [data-node-type='blockNode']:first-child:not(:has(> [data-content-type='heading'])),
+.hm-prose
+  [data-node-type='blockChildren']
+  > [data-node-type='blockNode']:first-child:not(:has(> [data-content-type='heading'])) {
   margin-top: 0;
 }
 
@@ -169,14 +219,6 @@
  * its parent. Specificity (0,3,0) beats the reset above (0,2,0). */
 .hm-prose [data-node-type='blockChildren'] [data-node-type='blockChildren'] > [data-node-type='blockNode']:first-child {
   margin-top: 0.25em;
-}
-
-/* Consecutive headings collapse to body rhythm so stacked H1→H2
- * doesn't open a double section break. */
-.hm-prose
-  [data-node-type='blockNode']:has(> [data-content-type='heading'])
-  + [data-node-type='blockNode']:has(> [data-content-type='heading']) {
-  margin-top: 1rem;
 }
 
 /* List items tighten: items inside a list belong to one visual unit. */
@@ -236,7 +278,7 @@
 /* ---------- Inline marks ---------- */
 .hm-prose strong,
 .hm-prose b {
-  font-weight: 600;
+  font-weight: 500;
   color: inherit;
 }
 .hm-prose em,
@@ -274,40 +316,64 @@
 
 /* ---------- Inline code ----------
  * Pill treatment: visible background, softer foreground, monospace.
- * Light-mode uses a subtle tinted gray; dark-mode flips to a higher-
- * contrast chip that reads clearly against the panel background.
- * Colors are written as fallbacks so the pill works even in contexts
- * that don't register the design tokens (e.g. naked SSR). */
+ * Colors come from Tailwind's sky palette CSS variables so the chip
+ * tracks the design system; dark mode flips to lighter sky steps for
+ * contrast against the panel background. */
 .hm-prose code {
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace);
   font-size: 0.875em;
-  background-color: rgba(0, 0, 0, 0.07);
-  color: #b91c1c; /* slate-red, WCAG AA on light muted bg */
-  padding: 0.15em 0.4em;
-  border-radius: 0.3em;
+  background-color: var(--color-sky-50);
+  color: var(--color-sky-700);
+  border: 1px solid var(--color-sky-200);
+  padding: 0.1em 0.4em;
+  border-radius: 0.35em;
   line-height: 1.4;
   font-weight: 500;
 }
 
 .dark .hm-prose code,
 [data-theme='dark'] .hm-prose code {
-  background-color: rgba(255, 255, 255, 0.08);
-  color: #fca5a5; /* soft red-pink, WCAG AA on dark muted bg */
+  background-color: var(--color-sky-950);
+  color: var(--color-sky-300);
+  border-color: var(--color-sky-800);
 }
 
-/* ---------- Code blocks ---------- */
+/* ---------- Code blocks ----------
+ * Premium-object treatment: pale surface, soft border, squircle radius,
+ * generous vertical padding. Surface uses the semantic `--muted` /
+ * `--border` theme tokens, which are already redefined under `.dark`
+ * — so no separate dark-mode rule is needed. */
 .hm-prose pre {
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace);
   font-size: 0.9em;
-  line-height: 1.5;
+  line-height: 1.6;
   margin: 0;
+  background-color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  /* Horizontal padding absorbs the breakout: when the block is widened
+   * by `--hm-breakout`, half of it on each side pads the code back so
+   * the code text lines up with the regular paragraph column. Falls
+   * back to a normal inset when there is no breakout (comments/embeds). */
+  padding: 1.1em max(1.25em, calc(var(--hm-breakout, 0px) / 2));
+  overflow-x: auto;
 }
 
-.hm-prose pre code {
+/* Code INSIDE a <pre> is plain text, not an inline-code pill — strip the
+ * pill chrome. The dark-mode selector is repeated with `.dark` /
+ * `[data-theme='dark']` so it out-specifies `.dark .hm-prose code`
+ * (0,2,1), which would otherwise paint the inline-code blue background
+ * across the whole code block. */
+.hm-prose pre code,
+.dark .hm-prose pre code,
+[data-theme='dark'] .hm-prose pre code {
   background: transparent;
+  border: 0;
+  color: inherit;
   padding: 0;
   border-radius: 0;
   font-size: inherit;
+  font-weight: inherit;
 }
 
 /* ---------- Blockquotes ---------- */
@@ -335,23 +401,57 @@
 /* ---------- Horizontal rule ---------- */
 .hm-prose hr {
   border: 0;
-  border-top: 1px solid var(--border, currentColor);
-  opacity: 0.4;
-  margin: 1.5em 0;
+  border-top: 1px solid var(--border);
+  margin: 2em 0;
 }
 
-/* ---------- Images / figures ----------
+/* ---------- Images ----------
  * Safety-cap is scoped to the image BLOCK specifically, not every <img>
  * under `.hm-prose`. Broad `.hm-prose img` defaults conflict with
  * Tailwind utility classes (`h-full`, `object-cover`, `w-full`) that
  * sibling components like document-card covers and query-block thumbs
  * apply to their own imagery — those shouldn't inherit prose sizing
- * just because they happen to be inside a prose container. */
+ * just because they happen to be inside a prose container.
+ *
+ * Rounded corners + a soft shadow give the image a "premium object"
+ * feel; no border (the shadow alone separates it from the page). */
 .hm-prose [data-content-type='image'] img {
   max-width: 100%;
   height: auto;
   max-height: 600px;
   object-fit: contain;
+  border-radius: 0.75rem;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 12px 28px rgba(0, 0, 0, 0.08);
+}
+
+.dark .hm-prose [data-content-type='image'] img,
+[data-theme='dark'] .hm-prose [data-content-type='image'] img {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    0 16px 32px rgba(0, 0, 0, 0.45);
+}
+
+/* ---------- Videos ----------
+ * The <video>/<iframe> player fills an absolutely-positioned 16:9 box,
+ * so its own width/height are owned by the block component — applying
+ * image-style `height: auto` here breaks that and overflows the frame.
+ * The corner radius, clip, and shadow ride on the block element so the
+ * square-cornered player is masked to the rounded frame. */
+.hm-prose [data-content-type='video'] {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 12px 28px rgba(0, 0, 0, 0.08);
+}
+
+.dark .hm-prose [data-content-type='video'],
+[data-theme='dark'] .hm-prose [data-content-type='video'] {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    0 16px 32px rgba(0, 0, 0, 0.45);
 }
 
 .hm-prose figure {
@@ -365,99 +465,156 @@
   margin-top: 0.5em;
 }
 
-/* ---------- Comment variant ---------- */
-.hm-prose.is-comment .blockNode:has(> [data-content-type='heading'][data-level='1']),
-.hm-prose.is-comment .blockNode:has(> [data-content-type='heading'][data-level='2']),
-.hm-prose.is-comment .blockNode:has(> [data-content-type='heading'][data-level='3']) {
-  /* Comments tighten section rhythm. */
-  margin-top: 1rem;
+/* ---------- Comment variant ----------
+ * Comments revert to compact rhythm and tighter line-height; editorial
+ * doc spacing is overkill in a threaded comment context. */
+.hm-prose.is-comment {
+  line-height: 1.55;
 }
-.hm-prose.is-comment .blockNode:has(> [data-content-type='heading'][data-level='4']),
-.hm-prose.is-comment .blockNode:has(> [data-content-type='heading'][data-level='5']),
-.hm-prose.is-comment .blockNode:has(> [data-content-type='heading'][data-level='6']) {
+
+.hm-prose.is-comment [data-node-type='blockNode'] + [data-node-type='blockNode'] {
+  margin-top: 0.5rem;
+}
+
+.hm-prose.is-comment [data-node-type='blockNode']:has(> [data-content-type='image']),
+.hm-prose.is-comment [data-node-type='blockNode']:has(> [data-content-type='video']),
+.hm-prose.is-comment [data-node-type='blockNode']:has(> [data-content-type='file']),
+.hm-prose.is-comment [data-node-type='blockNode']:has(> [data-content-type='embed']),
+.hm-prose.is-comment [data-node-type='blockNode']:has(> [data-content-type='web-embed']),
+.hm-prose.is-comment [data-node-type='blockNode']:has(> [data-content-type='button']),
+.hm-prose.is-comment [data-node-type='blockNode']:has(> [data-content-type='math']),
+.hm-prose.is-comment [data-node-type='blockNode']:has(> [data-content-type='query']),
+.hm-prose.is-comment [data-node-type='blockNode']:has(> [data-content-type='code-block']) {
   margin-top: 0.75rem;
 }
 
+.hm-prose.is-comment [data-node-type='blockNode']:has(> [data-content-type='heading'][data-level='1']),
+.hm-prose.is-comment [data-node-type='blockNode']:has(> [data-content-type='heading'][data-level='2']),
+.hm-prose.is-comment [data-node-type='blockNode']:has(> [data-content-type='heading'][data-level='3']) {
+  /* Comments tighten section rhythm. */
+  margin-top: 1rem;
+}
+.hm-prose.is-comment [data-node-type='blockNode']:has(> [data-content-type='heading'][data-level='4']),
+.hm-prose.is-comment [data-node-type='blockNode']:has(> [data-content-type='heading'][data-level='5']),
+.hm-prose.is-comment [data-node-type='blockNode']:has(> [data-content-type='heading'][data-level='6']) {
+  margin-top: 0.75rem;
+}
+
+/* ---------- Inline text / background colors ----------
+ * The editor's color picker writes `data-text-color` / `data-background-color`
+ * attributes; the palette below maps each name onto Tailwind's built-in
+ * color scales. Text uses the `-600` step in light mode and `-400` in dark
+ * for contrast; backgrounds use the pale `-100` step in light mode and the
+ * deep `-950` step in dark. Tailwind has no "brown" — `stone` (its warm
+ * neutral) stands in. */
 .hm-prose [data-text-color='gray'] {
-  color: #9b9a97;
+  color: var(--color-gray-500);
 }
 .hm-prose [data-text-color='brown'] {
-  color: #64473a;
+  color: var(--color-stone-500);
 }
 .hm-prose [data-text-color='red'] {
-  color: #e03e3e;
+  color: var(--color-red-600);
 }
 .hm-prose [data-text-color='orange'] {
-  color: #d9730d;
+  color: var(--color-orange-600);
 }
 .hm-prose [data-text-color='yellow'] {
-  color: #dfab01;
+  color: var(--color-yellow-600);
 }
 .hm-prose [data-text-color='green'] {
-  color: #4d6461;
+  color: var(--color-emerald-600);
 }
 .hm-prose [data-text-color='blue'] {
-  color: #0b6e99;
+  color: var(--color-sky-600);
 }
 .hm-prose [data-text-color='purple'] {
-  color: #6940a5;
+  color: var(--color-violet-600);
 }
 .hm-prose [data-text-color='pink'] {
-  color: #ad1a72;
+  color: var(--color-pink-600);
+}
+
+.dark .hm-prose [data-text-color='gray'] {
+  color: var(--color-gray-400);
+}
+.dark .hm-prose [data-text-color='brown'] {
+  color: var(--color-stone-400);
+}
+.dark .hm-prose [data-text-color='red'] {
+  color: var(--color-red-400);
+}
+.dark .hm-prose [data-text-color='orange'] {
+  color: var(--color-orange-400);
+}
+.dark .hm-prose [data-text-color='yellow'] {
+  color: var(--color-yellow-400);
+}
+.dark .hm-prose [data-text-color='green'] {
+  color: var(--color-emerald-400);
+}
+.dark .hm-prose [data-text-color='blue'] {
+  color: var(--color-sky-400);
+}
+.dark .hm-prose [data-text-color='purple'] {
+  color: var(--color-violet-400);
+}
+.dark .hm-prose [data-text-color='pink'] {
+  color: var(--color-pink-400);
 }
 
 .hm-prose [data-background-color='gray'] {
-  background-color: #ebeced;
+  background-color: var(--color-gray-100);
 }
 .hm-prose [data-background-color='brown'] {
-  background-color: #e9e5e3;
+  background-color: var(--color-stone-100);
 }
 .hm-prose [data-background-color='red'] {
-  background-color: #fbe4e4;
+  background-color: var(--color-red-100);
 }
 .hm-prose [data-background-color='orange'] {
-  background-color: #faebdd;
+  background-color: var(--color-orange-100);
 }
 .hm-prose [data-background-color='yellow'] {
-  background-color: #fbf3db;
+  background-color: var(--color-yellow-100);
 }
 .hm-prose [data-background-color='green'] {
-  background-color: #ddedea;
+  background-color: var(--color-emerald-100);
 }
 .hm-prose [data-background-color='blue'] {
-  background-color: #ddebf1;
+  background-color: var(--color-sky-100);
 }
 .hm-prose [data-background-color='purple'] {
-  background-color: #eae4f2;
+  background-color: var(--color-violet-100);
 }
 .hm-prose [data-background-color='pink'] {
-  background-color: #f4dfeb;
+  background-color: var(--color-pink-100);
 }
 
 .dark .hm-prose [data-background-color='gray'] {
-  background-color: rgba(155, 154, 151, 0.3);
+  background-color: var(--color-gray-900);
 }
 .dark .hm-prose [data-background-color='brown'] {
-  background-color: rgba(100, 71, 58, 0.4);
+  background-color: var(--color-stone-900);
 }
 .dark .hm-prose [data-background-color='red'] {
-  background-color: rgba(224, 62, 62, 0.35);
+  background-color: var(--color-red-950);
 }
 .dark .hm-prose [data-background-color='orange'] {
-  background-color: rgba(217, 115, 13, 0.35);
+  background-color: var(--color-orange-950);
 }
 .dark .hm-prose [data-background-color='yellow'] {
-  background-color: rgba(223, 171, 1, 0.35);
+  background-color: var(--color-yellow-950);
 }
 .dark .hm-prose [data-background-color='green'] {
-  background-color: rgba(77, 100, 97, 0.5);
+  background-color: var(--color-emerald-950);
 }
 .dark .hm-prose [data-background-color='blue'] {
-  background-color: rgba(11, 110, 153, 0.4);
+  background-color: var(--color-sky-950);
 }
 .dark .hm-prose [data-background-color='purple'] {
-  background-color: rgba(105, 64, 165, 0.4);
+  background-color: var(--color-violet-950);
 }
 .dark .hm-prose [data-background-color='pink'] {
-  background-color: rgba(173, 26, 114, 0.35);
+  background-color: var(--color-pink-950);
 }


### PR DESCRIPTION
## Summary
- Centralize editor/SSR prose styling in `hm-prose`, including heading rhythm, inline colors, code blocks, and media presentation.
- Keep cursor selection inside code blocks when inserted or converted, and make Backspace in an empty code block return to a paragraph.
- Sync heading levels with nesting depth in both editor and SSR rendering.
- Ignore colocated route test/spec files in Remix builds and add coverage for code block slash-menu behavior.