### PR TITLE
fix(frontend): support local web draft placeholder publishes

### DIFF
--- a/frontend/apps/web/app/document-edit/use-web-can-edit.test.ts
+++ b/frontend/apps/web/app/document-edit/use-web-can-edit.test.ts
@@ -81,6 +81,20 @@ describe('resolveWebCanEdit', () => {
     expect(result.signingAccountId).toBe(null)
   })
 
+  it('owner can edit before capabilities finish loading', () => {
+    const result = resolveWebCanEdit({
+      docId: makeDocId(OWNER_UID),
+      delegatedAccountUid: OWNER_UID,
+      origin: null,
+      originHomeId: null,
+      capabilities: undefined,
+      isBrowser: true,
+    })
+    expect(result.canEdit).toBe(true)
+    expect(result.signingAccountId).toBe(OWNER_UID)
+    expect(result.capability?.id).toBe('_owner')
+  })
+
   it('owner on gateway can edit', () => {
     const result = resolveWebCanEdit({
       docId: makeDocId(OWNER_UID),

--- a/frontend/apps/web/app/document-edit/use-web-can-edit.ts
+++ b/frontend/apps/web/app/document-edit/use-web-can-edit.ts
@@ -39,7 +39,16 @@ export function resolveWebCanEdit(args: {
   const caps = args.capabilities ?? []
 
   if (isOwner) {
-    capability = caps.find((c) => c.id === '_owner') ?? null
+    capability =
+      caps.find((c) => c.id === '_owner') ??
+      ({
+        id: '_owner',
+        accountUid: signingAccountId,
+        role: 'owner',
+        grantId: args.docId,
+        label: 'Owner',
+        createTime: {seconds: 0, nanos: 0},
+      } as HMCapability)
   } else {
     capability = caps.find((c) => c.accountUid === signingAccountId && roleCanWrite(c.role)) ?? null
   }

--- a/frontend/apps/web/app/document-edit/web-create-draft.test.ts
+++ b/frontend/apps/web/app/document-edit/web-create-draft.test.ts
@@ -47,6 +47,7 @@ describe('createWebDocumentDraft', () => {
       locationId: makeDocId('site', ['parent']),
       signingAccountId: 'author',
       visibility: 'PUBLIC',
+      capabilityCid: 'cap-1',
       navigate,
       generateDraftId: () => 'draft-1',
     })
@@ -59,6 +60,7 @@ describe('createWebDocumentDraft', () => {
       draftId: 'draft-1',
       docId: routeId.id,
       signingAccountId: 'author',
+      capabilityCid: 'cap-1',
       locationUid: 'site',
       locationPath: ['parent'],
       editUid: 'site',

--- a/frontend/apps/web/app/document-edit/web-create-draft.ts
+++ b/frontend/apps/web/app/document-edit/web-create-draft.ts
@@ -26,12 +26,14 @@ export async function createWebDocumentDraft({
   navigate,
   generateDraftId = () => nanoid(10),
   generatePath = () => nanoid(21),
+  capabilityCid,
 }: {
   locationId: UnpackedHypermediaId
   signingAccountId: string
   visibility?: HMResourceVisibility
   content?: HMBlockNode[]
   metadata?: HMMetadata
+  capabilityCid?: string
   navigate: (route: WebDocumentDraftRoute) => void
   generateDraftId?: () => string
   generatePath?: () => string
@@ -46,6 +48,7 @@ export async function createWebDocumentDraft({
     draftId,
     docId: routeId.id,
     signingAccountId,
+    ...(capabilityCid ? {capabilityCid} : {}),
     content,
     metadata,
     deps: [],
@@ -91,10 +94,12 @@ export async function createWebDocumentDraftFromMarkdownFile({
   locationId,
   signingAccountId,
   navigate,
+  capabilityCid,
 }: {
   file: File
   locationId: UnpackedHypermediaId
   signingAccountId: string
+  capabilityCid?: string
   navigate: (route: WebDocumentDraftRoute) => void
 }): Promise<UnpackedHypermediaId> {
   const text = await file.text()
@@ -103,6 +108,7 @@ export async function createWebDocumentDraftFromMarkdownFile({
   return createWebDocumentDraft({
     locationId,
     signingAccountId,
+    capabilityCid,
     metadata,
     content: markdownToHMBlockNodes(markdown),
     navigate,

--- a/frontend/apps/web/app/document-edit/web-document-actors.test.ts
+++ b/frontend/apps/web/app/document-edit/web-document-actors.test.ts
@@ -437,6 +437,42 @@ describe('publishWebDocument', () => {
     expect(args.capability).toBe(capCid)
   })
 
+  it('non-owner publish falls back to draft capability CID', async () => {
+    const capCid = (await makeTestCID({v: 'draft-cap'})).toString()
+
+    await putWebDocDraft({
+      draftId,
+      docId: makeDocId(OWNER).id,
+      signingAccountId: ALICE,
+      capabilityCid: capCid,
+      content: [paragraph('b1', 'hi')],
+      metadata: {},
+      deps: ['old-head'],
+      navigation: null,
+      locationUid: null,
+      locationPath: null,
+      editUid: null,
+      editPath: null,
+      cursorPosition: null,
+    })
+
+    const deps = makeDeps({
+      editorBlocks: [
+        {
+          id: 'b1',
+          type: 'paragraph',
+          props: {childrenType: 'Group'},
+          content: [{type: 'text', text: 'hi'}],
+          children: [],
+        },
+      ],
+    })
+
+    await publishWebDocument({...baseInput, publishAccountUid: ALICE}, deps)
+    const prepareCall = deps.requestMock.mock.calls.find((c: any) => c[0] === 'PrepareDocumentChange')!
+    expect(prepareCall[1].capability).toBe(capCid)
+  })
+
   it('metadata-only change emits setAttribute', async () => {
     await putWebDocDraft({
       draftId,

--- a/frontend/apps/web/app/document-edit/web-document-actors.ts
+++ b/frontend/apps/web/app/document-edit/web-document-actors.ts
@@ -41,6 +41,7 @@ import {nanoid} from 'nanoid'
 import {fromPromise} from 'xstate'
 
 import {deleteWebDocDraft, getWebDocDraft, putWebDocDraft, type WebDocDraft} from './web-draft-db'
+import {isWebDraftPlaceholderPath} from './web-draft-path'
 
 /** @deprecated Use `EditorAccessor` from `@shm/shared/models/document-machine` instead. */
 export type WebEditorAccessor = EditorAccessor
@@ -90,6 +91,7 @@ function makeWriteDraftActor(deps: CreateWebDocumentMachineDeps) {
       draftId,
       docId: deps.docId.id,
       signingAccountId: input.signingAccountId ?? '',
+      capabilityCid: existingDraft?.capabilityCid ?? deps.getCapabilityCid(),
       content,
       metadata: input.metadata ?? {},
       deps: input.deps,
@@ -168,7 +170,7 @@ export async function publishWebDocument(input: PublishInput, deps: CreateWebDoc
   const baseVersion = latestVersion || (draft.deps.length ? draft.deps.join('.') : '')
   const isPrivate = draft.visibility === 'PRIVATE' || editDocument?.visibility === 'PRIVATE'
   const currentPath = deps.docId.path ?? []
-  const isPlaceholderPath = currentPath.at(-1) === `-${draft.draftId}`
+  const isPlaceholderPath = isWebDraftPlaceholderPath(currentPath, draft.draftId)
   const publishPath = isPrivate
     ? currentPath
     : input.pathOverride
@@ -187,7 +189,7 @@ export async function publishWebDocument(input: PublishInput, deps: CreateWebDoc
     throw new Error('No signing account available for publish')
   }
 
-  const capabilityCid = deps.getCapabilityCid() ?? ''
+  const capabilityCid = deps.getCapabilityCid() ?? draft.capabilityCid ?? ''
   const visibility = isPrivate ? ResourceVisibility.PRIVATE : ResourceVisibility.UNSPECIFIED
   // Web signs client-side via `signDocumentChange`. Generation must be strictly
   // greater than existing HEAD's — a tie keeps the old HEAD. Desktop avoids this

--- a/frontend/apps/web/app/document-edit/web-draft-db.ts
+++ b/frontend/apps/web/app/document-edit/web-draft-db.ts
@@ -15,6 +15,8 @@ export interface WebDocDraft {
   docId: string
   /** Vault-delegated account UID that will sign the publish. */
   signingAccountId: string
+  /** Capability CID used by non-owner publishes. */
+  capabilityCid?: string
   /** Editor blocks at the time of last save. */
   content: HMBlockNode[]
   /** Pending metadata changes for this draft (subset of HMMetadata). */

--- a/frontend/apps/web/app/document-edit/web-draft-path.test.ts
+++ b/frontend/apps/web/app/document-edit/web-draft-path.test.ts
@@ -1,0 +1,31 @@
+import {describe, expect, it} from 'vitest'
+
+import {
+  getWebDraftPlaceholderId,
+  isWebDraftPlaceholderPath,
+  shouldBypassServerDocumentFetchForWebDraftPath,
+} from './web-draft-path'
+
+describe('web draft placeholder paths', () => {
+  it('extracts a draft id from the final placeholder segment', () => {
+    expect(getWebDraftPlaceholderId(['parent', '-draft-1'])).toBe('draft-1')
+    expect(getWebDraftPlaceholderId(['parent', 'child'])).toBeNull()
+  })
+
+  it('matches a specific placeholder draft id', () => {
+    expect(isWebDraftPlaceholderPath(['parent', '-draft-1'], 'draft-1')).toBe(true)
+    expect(isWebDraftPlaceholderPath(['parent', '-draft-1'], 'draft-2')).toBe(false)
+  })
+
+  it('bypasses server fetch only for unversioned non-inspect placeholder URLs', () => {
+    expect(
+      shouldBypassServerDocumentFetchForWebDraftPath({path: ['parent', '-draft-1'], isInspect: false, version: null}),
+    ).toBe(true)
+    expect(
+      shouldBypassServerDocumentFetchForWebDraftPath({path: ['parent', '-draft-1'], isInspect: true, version: null}),
+    ).toBe(false)
+    expect(
+      shouldBypassServerDocumentFetchForWebDraftPath({path: ['parent', '-draft-1'], isInspect: false, version: 'v1'}),
+    ).toBe(false)
+  })
+})

--- a/frontend/apps/web/app/document-edit/web-draft-path.ts
+++ b/frontend/apps/web/app/document-edit/web-draft-path.ts
@@ -1,0 +1,33 @@
+/** Utilities for web-only document draft placeholder paths. */
+
+/** Return the local draft id encoded by a placeholder segment like `-abc123`. */
+export function getWebDraftPlaceholderIdFromSegment(segment: string | null | undefined): string | null {
+  if (!segment?.startsWith('-')) return null
+  const draftId = segment.slice(1)
+  return draftId.length > 0 ? draftId : null
+}
+
+/** Return the local draft id encoded by a placeholder path's final segment. */
+export function getWebDraftPlaceholderId(path: string[] | null | undefined): string | null {
+  return getWebDraftPlaceholderIdFromSegment(path?.at(-1))
+}
+
+/** Return true when the path points at a web local draft placeholder. */
+export function isWebDraftPlaceholderPath(path: string[] | null | undefined, draftId?: string | null): boolean {
+  const placeholderDraftId = getWebDraftPlaceholderId(path)
+  if (!placeholderDraftId) return false
+  return draftId ? placeholderDraftId === draftId : true
+}
+
+/** Return true when the route should avoid fetching a placeholder draft from the backend. */
+export function shouldBypassServerDocumentFetchForWebDraftPath({
+  path,
+  isInspect,
+  version,
+}: {
+  path: string[] | null | undefined
+  isInspect: boolean
+  version: string | null | undefined
+}): boolean {
+  return !isInspect && !version && isWebDraftPlaceholderPath(path)
+}

--- a/frontend/apps/web/app/loaders.ts
+++ b/frontend/apps/web/app/loaders.ts
@@ -576,6 +576,65 @@ export type GRPCError = {
   code: Code
 }
 
+/** Load the shell data for a local web draft placeholder URL without backend document fetch. */
+export async function loadWebDraftPlaceholderResource<T extends Record<string, unknown> = Record<string, never>>(
+  parsedRequest: ParsedRequest,
+  id: UnpackedHypermediaId,
+  extraData?: T & {instrumentationCtx?: InstrumentationContext},
+): Promise<WrappedResponse<SiteDocumentPayload & Omit<T, 'instrumentationCtx'>>> {
+  const {hostname, origin} = parsedRequest
+  const ctx = extraData?.instrumentationCtx
+  const noopCtx = {
+    enabled: false,
+    requestPath: '',
+    requestMethod: '',
+    root: {name: '', start: 0, children: []},
+    current: {name: '', start: 0, children: []},
+  } as InstrumentationContext
+
+  const config = await getConfig(hostname)
+  if (!config) {
+    throw new Error('No config found for hostname ' + hostname)
+  }
+  let homeMetadata = null
+  let originHomeId: undefined | UnpackedHypermediaId = undefined
+  if (config.registeredAccountUid) {
+    const homeId = hmId(config.registeredAccountUid)
+    try {
+      const result = await instrument(ctx || noopCtx, `getHomeMetadata(${packHmId(homeId)})`, () => getMetadata(homeId))
+      homeMetadata = result.metadata
+      originHomeId = result.id
+    } catch (e) {}
+  }
+
+  const document = {
+    account: id.uid,
+    path: `/${(id.path ?? []).join('/')}`,
+    content: [],
+    metadata: {},
+    visibility: undefined,
+    version: '',
+    authors: [],
+    createTime: undefined,
+    updateTime: undefined,
+    genesis: '',
+  } as unknown as HMDocument
+
+  const loadedSiteDocument = {
+    ...(extraData || {}),
+    id,
+    document,
+    siteHost: origin,
+    isLatest: false,
+    ssrContentHTML: null,
+    homeMetadata,
+    origin,
+    originHomeId,
+  }
+  const {instrumentationCtx: _, ...cleanDocument} = loadedSiteDocument as any
+  return wrapJSON(cleanDocument)
+}
+
 export async function loadSiteResource<T extends Record<string, unknown> = Record<string, never>>(
   parsedRequest: ParsedRequest,
   id: UnpackedHypermediaId,

--- a/frontend/apps/web/app/routes/$.tsx
+++ b/frontend/apps/web/app/routes/$.tsx
@@ -6,7 +6,7 @@ import {
   setRequestInstrumentationContext,
 } from '@/instrumentation.server'
 import {createResourceMetadata, metadataToPageMeta} from '@/hypermedia-metadata'
-import {GRPCError, loadSiteResource, SiteDocumentPayload} from '@/loaders'
+import {GRPCError, loadSiteResource, loadWebDraftPlaceholderResource, SiteDocumentPayload} from '@/loaders'
 import {defaultPageMeta} from '@/meta'
 import {NoSitePage, NotRegisteredPage} from '@/not-registered'
 import {WebSiteProvider} from '@/providers'
@@ -15,6 +15,7 @@ import {getConfig} from '@/site-config.server'
 import {unwrap, type Wrapped} from '@/wrapping'
 import {getDaemonAuthToken, withDaemonAuthToken} from '@/daemon-auth.server'
 import {WebFeedPage} from '@/web-feed-page'
+import {shouldBypassServerDocumentFetchForWebDraftPath} from '@/document-edit/web-draft-path'
 import {WebInspectorPage, WebResourcePage} from '@/web-resource-page'
 import {wrapJSON} from '@/wrapping.server'
 import {Code} from '@connectrpc/connect'
@@ -340,17 +341,30 @@ async function loadRoute({params, request}: {params: Params; request: Request}) 
     })
   }
 
-  const result = await instrument(ctx, 'loadSiteResource', () =>
-    loadSiteResource(parsedRequest, documentId, {
-      prefersLanguages: parsedRequest.prefersLanguages,
-      viewTerm,
-      panelParam: effectivePanelParam,
-      openComment,
-      accountUid,
-      isInspect,
-      inspectTab: isInspect && inspectTab ? (inspectTab as ExtendedSitePayload['inspectTab']) : null,
-      instrumentationCtx: ctx,
-    }),
+  const siteResourceData = {
+    prefersLanguages: parsedRequest.prefersLanguages,
+    viewTerm,
+    panelParam: effectivePanelParam,
+    openComment,
+    accountUid,
+    isInspect,
+    inspectTab: isInspect && inspectTab ? (inspectTab as ExtendedSitePayload['inspectTab']) : null,
+    instrumentationCtx: ctx,
+  }
+
+  const shouldLoadLocalDraftShell = shouldBypassServerDocumentFetchForWebDraftPath({
+    path: documentId.path,
+    isInspect,
+    version,
+  })
+
+  const result = await instrument(
+    ctx,
+    shouldLoadLocalDraftShell ? 'loadWebDraftPlaceholderResource' : 'loadSiteResource',
+    () =>
+      shouldLoadLocalDraftShell
+        ? loadWebDraftPlaceholderResource(parsedRequest, documentId, siteResourceData)
+        : loadSiteResource(parsedRequest, documentId, siteResourceData),
   )
 
   // For data requests (client-side nav), print summary here since there's no SSR phase

--- a/frontend/apps/web/app/web-resource-page.tsx
+++ b/frontend/apps/web/app/web-resource-page.tsx
@@ -35,8 +35,14 @@ import {processPendingIntent} from './pending-intent'
 import {WebHeaderActions, WebSitePageShell, useWebCreateDocumentMenuItem} from './web-utils'
 import {useWebCanEdit} from './document-edit/use-web-can-edit'
 import {createWebDocumentMachine} from './document-edit/web-document-actors'
-import {cleanupOldWebDocDrafts, deleteWebDocDraft, getLatestWebDocDraftForDoc} from './document-edit/web-draft-db'
+import {
+  cleanupOldWebDocDrafts,
+  deleteWebDocDraft,
+  getLatestWebDocDraftForDoc,
+  getWebDocDraft,
+} from './document-edit/web-draft-db'
 import {makeWebFileUpload} from './document-edit/web-image-upload'
+import {getWebDraftPlaceholderId} from './document-edit/web-draft-path'
 
 /** Lazy-loaded inline comment editor — avoids pulling the full editor bundle eagerly. */
 const LazyWebInlineEditor = lazy(() => import('./commenting').then((mod) => ({default: mod.WebInlineEditBox})))
@@ -136,31 +142,24 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
     }
   }, [])
 
-  // Build a documentMachine wired to web actors. Stable per (docId, signing identity, capability).
-  const machine = useMemo(() => {
-    return createWebDocumentMachine({
-      docId,
-      getEditor: () => editorAccessor,
-      client: universalClient,
-      getSigner: (accountUid: string) => {
-        if (!universalClient.getSigner) {
-          throw new Error('Universal client does not provide a signer; cannot publish from web')
-        }
-        return universalClient.getSigner(accountUid)
-      },
-      getCapabilityCid: () => (capability && capability.id !== '_owner' ? capability.id : undefined),
-      onPublishSuccess,
-    })
-  }, [docId.id, universalClient, editorAccessor, capability?.id, onPublishSuccess])
+  const placeholderDraftId = useMemo(() => getWebDraftPlaceholderId(docId.path), [docId.path])
 
-  // Load any local IDB draft for this doc. Used to seed the machine's draft.resolved event.
+  // Load any local IDB draft for this doc. Placeholder draft URLs must load by
+  // exact draft id instead of asking the backend for the nonexistent document.
   const draftQuery = useQuery({
-    queryKey: ['web-doc-draft', docId.id, signingAccountId ?? null] as const,
+    queryKey: ['web-doc-draft', docId.id, signingAccountId ?? null, placeholderDraftId ?? null] as const,
     queryFn: async () => {
       if (!signingAccountId) return null
+      if (placeholderDraftId) {
+        const draft = await getWebDocDraft(placeholderDraftId)
+        if (draft?.docId !== docId.id) return null
+        if (draft.signingAccountId !== signingAccountId) return null
+        return draft
+      }
+      if (!canEdit) return null
       return getLatestWebDocDraftForDoc(docId.id)
     },
-    enabled: typeof window !== 'undefined' && canEdit,
+    enabled: typeof window !== 'undefined' && !!signingAccountId && (canEdit || !!placeholderDraftId),
     staleTime: 60_000,
   })
   // Detect and auto-delete stale IDB drafts whose base version doesn't match
@@ -177,13 +176,35 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
     }
   }, [isDraftStale, draftData])
 
+  const canEditLocalPlaceholderDraft =
+    !!placeholderDraftId && !!draftData && !!signingAccountId && draftData.signingAccountId === signingAccountId
+  const effectiveCanEdit = canEdit || canEditLocalPlaceholderDraft
+  const effectiveCapabilityCid = capability && capability.id !== '_owner' ? capability.id : draftData?.capabilityCid
+
+  // Build a documentMachine wired to web actors. Stable per (docId, signing identity, capability).
+  const machine = useMemo(() => {
+    return createWebDocumentMachine({
+      docId,
+      getEditor: () => editorAccessor,
+      client: universalClient,
+      getSigner: (accountUid: string) => {
+        if (!universalClient.getSigner) {
+          throw new Error('Universal client does not provide a signer; cannot publish from web')
+        }
+        return universalClient.getSigner(accountUid)
+      },
+      getCapabilityCid: () => effectiveCapabilityCid,
+      onPublishSuccess,
+    })
+  }, [docId.id, universalClient, editorAccessor, effectiveCapabilityCid, onPublishSuccess])
+
   const existingDraft: HMExistingDraft | false | undefined = useMemo(() => {
-    if (!canEdit) return false
+    if (!effectiveCanEdit) return false
     if (draftQuery.isLoading) return undefined
     const d = draftData
     if (!d || isDraftStale) return false
     return {id: d.draftId, metadata: d.metadata as HMExistingDraft['metadata']}
-  }, [canEdit, draftQuery.isLoading, draftData, isDraftStale])
+  }, [effectiveCanEdit, draftQuery.isLoading, draftData, isDraftStale])
   const existingDraftContent = isDraftStale ? undefined : draftData?.content ?? undefined
   const existingDraftCursorPosition = isDraftStale ? undefined : draftData?.cursorPosition ?? undefined
 
@@ -272,7 +293,7 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
   const showPublishToolbar = route.key === 'document'
 
   const editingFloatingActions =
-    canEdit && showPublishToolbar
+    effectiveCanEdit && showPublishToolbar
       ? ({menuItems}: {menuItems: any[]}) => (
           <EditingDocToolsRight docId={docId} existingMenuItems={menuItems} {...webToolbarCallbacks} />
         )
@@ -282,7 +303,8 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
   const {menuItem: newMenuItem, content: newMenuContent} = useWebCreateDocumentMenuItem({
     locationId: docId,
     signingAccountId: signingAccountId ?? undefined,
-    canCreate: canEdit && !!signingAccountId,
+    canCreate: effectiveCanEdit && !!signingAccountId,
+    capabilityCid: effectiveCapabilityCid,
   })
   const extraMenuItems = useMemo(() => (newMenuItem ? [newMenuItem] : []), [newMenuItem])
 
@@ -331,7 +353,7 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
             ssrContentHTML={ssrContentHTML}
             perspectiveAccountUid={ownAccountUid}
             linkExtensionOptions={linkExtensionOptions}
-            canEdit={canEdit}
+            canEdit={effectiveCanEdit}
             machine={machine}
             signingAccountId={signingAccountId ?? undefined}
             publishAccountUid={signingAccountId ?? undefined}

--- a/frontend/apps/web/app/web-utils.tsx
+++ b/frontend/apps/web/app/web-utils.tsx
@@ -59,10 +59,12 @@ export function useWebCreateDocumentMenuItem({
   locationId,
   signingAccountId,
   canCreate,
+  capabilityCid,
 }: {
   locationId: UnpackedHypermediaId
   signingAccountId?: string
   canCreate: boolean
+  capabilityCid?: string
 }): {
   menuItem: MenuItemType | null
   content: ReactNode
@@ -77,10 +79,11 @@ export function useWebCreateDocumentMenuItem({
         locationId,
         signingAccountId,
         visibility,
+        capabilityCid,
         navigate: (route) => navigate(route),
       })
     },
-    [locationId, navigate, signingAccountId],
+    [capabilityCid, locationId, navigate, signingAccountId],
   )
 
   const menuItem = useMemo<MenuItemType | null>(() => {
@@ -130,6 +133,7 @@ export function useWebCreateDocumentMenuItem({
                 file,
                 locationId,
                 signingAccountId,
+                capabilityCid,
                 navigate: (route) => navigate(route),
               }),
               {


### PR DESCRIPTION
## Summary
- Bypass backend document fetches for unversioned local web draft placeholder URLs and load a shell document instead.
- Preserve capability CIDs on local web drafts so non-owner publishes can sign with the draft capability.
- Allow owners to edit while capability loading is still pending by synthesizing the owner capability.
- Load placeholder drafts by exact draft id and treat matching local drafts as editable.
- Add tests for placeholder path handling, draft capability persistence, and publish fallback behavior.