### PR TITLE
fix(frontend): refresh draft-backed document metadata

### DIFF
--- a/frontend/apps/desktop/src/components/document-actions-provider.tsx
+++ b/frontend/apps/desktop/src/components/document-actions-provider.tsx
@@ -185,16 +185,17 @@ export function DesktopDocumentActionsProvider({children}: PropsWithChildren) {
     [onCopyReference],
   )
 
-  const getDraftId = useCallback(
+  const getDraft = useCallback(
     (id: UnpackedHypermediaId) => {
-      const draft = drafts.data?.find((d: HMListedDraft) => {
+      return drafts.data?.find((d: HMListedDraft) => {
         if (!d.editUid) return false
         return id.uid === d.editUid && pathMatches(d.editPath || [], id.path)
       })
-      return draft?.id
     },
     [drafts.data],
   )
+
+  const getDraftId = useCallback((id: UnpackedHypermediaId) => getDraft(id)?.id, [getDraft])
 
   const value = useMemo(
     () => ({
@@ -210,6 +211,7 @@ export function DesktopDocumentActionsProvider({children}: PropsWithChildren) {
       onExportDocument,
       onCopyLink,
       getDraftId,
+      getDraft,
     }),
     [
       selectedAccountId,
@@ -224,6 +226,7 @@ export function DesktopDocumentActionsProvider({children}: PropsWithChildren) {
       onExportDocument,
       onCopyLink,
       getDraftId,
+      getDraft,
     ],
   )
 

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -57,6 +57,8 @@ import {
 } from '@shm/shared/models/document-machine'
 import {useDocumentInspector} from '@shm/shared/models/document-machine-inspect'
 import {useResource} from '@shm/shared/models/entity'
+import {invalidateQueries} from '@shm/shared/models/query-client'
+import {queryKeys} from '@shm/shared/models/query-keys'
 import {QueryBlockDraftsProvider} from '@shm/shared/query-block-drafts-context'
 import {isDraftPathSegment} from '@shm/shared/utils/breadcrumbs'
 import {useCommentNavigation} from '@shm/shared/utils/comment-navigation'
@@ -275,6 +277,9 @@ export default function DesktopResourcePage() {
           mineTouchedIds: input.mineTouchedIds.length ? input.mineTouchedIds : undefined,
           baseBlocks: input.baseBlocks ?? undefined,
         })
+        invalidateQueries([queryKeys.DRAFT, result.id])
+        invalidateQueries([queryKeys.DRAFTS_LIST])
+        invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT])
         // console.log('[writeDraft] saved successfully:', {draftId: result.id})
         return result
       }),

--- a/frontend/packages/editor/src/mentions-plugin.tsx
+++ b/frontend/packages/editor/src/mentions-plugin.tsx
@@ -1,6 +1,7 @@
 import {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {hmId, hypermediaUrlToHref, useUniversalAppContext} from '@shm/shared'
 import {getContactMetadata, getDocumentTitle} from '@shm/shared/content'
+import {useDocumentActions} from '@shm/shared/document-actions-context'
 import {useAccount, useResource} from '@shm/shared/models/entity'
 import {unpackHmId} from '@shm/shared/utils/entity-id-url'
 import {useHighlighter} from '@shm/ui/highlight-context'
@@ -135,10 +136,13 @@ export function MentionToken(props: {value: string; selected?: boolean}) {
 }
 
 function DocumentMention({unpackedRef, selected}: {unpackedRef: UnpackedHypermediaId; selected?: boolean}) {
-  const entity = useResource(unpackedRef)
+  const entity = useResource(unpackedRef, {subscribed: true})
+  const actions = useDocumentActions()
   const highlight = useHighlighter()
-  const resolved =
+  const draft = actions.getDraft?.(unpackedRef)
+  const publishedTitle =
     entity.data && 'document' in entity.data && entity.data.document ? getDocumentTitle(entity.data.document) : null
+  const resolved = draft?.metadata?.name ?? publishedTitle
   return (
     <MentionText selected={selected} {...highlight(unpackedRef)}>
       {resolved || unpackedRef.id}

--- a/frontend/packages/editor/src/query-block.tsx
+++ b/frontend/packages/editor/src/query-block.tsx
@@ -1,6 +1,7 @@
 import {HMAccountsMetadata, HMBlockQuery, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {EditorQueryBlock} from '@seed-hypermedia/client/editor-types'
 import {queryBlockSortedItems} from '@shm/shared/content'
+import {useDocumentActions} from '@shm/shared/document-actions-context'
 import {useDirectory, useResource, useResources} from '@shm/shared/models/entity'
 import {useInteractionSummaries} from '@shm/shared/models/interaction-summary'
 import {useEditorGate} from '@shm/shared/models/use-editor-gate'
@@ -105,22 +106,50 @@ function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
     recursive: mode === 'AllDescendants',
   })
   const directoryItems = useDirectory(queryId, {mode})
+  const directoryData = directoryItems.data ?? []
+  const documents = useResources(
+    directoryData.map((item) => item.id),
+    {
+      enabled: directoryData.length > 0,
+      subscribed: true,
+    },
+  )
+  const actions = useDocumentActions()
+
+  const enrichedItems = useMemo(() => {
+    if (!directoryData.length) return []
+    const freshDocuments = new Map(
+      documents
+        .map((document) => document.data)
+        .filter((data) => data?.type === 'document')
+        .map((data) => [data.id.id, data.document]),
+    )
+    return directoryData.map((item) => {
+      const freshDocument = freshDocuments.get(item.id.id)
+      const draft = actions.getDraft?.(item.id)
+      if (!freshDocument && !draft?.metadata) return item
+      return {
+        ...item,
+        authors: freshDocument?.authors ?? item.authors,
+        metadata: {...item.metadata, ...freshDocument?.metadata, ...draft?.metadata},
+        updateTime: freshDocument?.updateTime ?? item.updateTime,
+        version: freshDocument?.version ?? item.version,
+        visibility: freshDocument?.visibility ?? item.visibility,
+      }
+    })
+  }, [directoryData, documents, actions.getDraft])
 
   const sortedItems = useMemo(() => {
-    if (directoryItems.data && querySort) {
+    if (enrichedItems.length && querySort) {
       const sorted = queryBlockSortedItems({
-        entries: directoryItems.data,
+        entries: enrichedItems,
         sort: querySort,
       })
       const queryLimit = parseInt(block.props.queryLimit || '', 10)
       return sorted.slice(0, queryLimit > 0 ? queryLimit : undefined)
     }
     return []
-  }, [directoryItems, querySort, block.props.queryLimit])
-
-  const docResults = useResources(sortedItems.map((item) => item.id) || [], {
-    enabled: !!directoryItems.data?.length || false,
-  })
+  }, [enrichedItems, querySort, block.props.queryLimit])
 
   const {canEdit, beginEditIfNeeded} = useEditorGate()
 
@@ -173,8 +202,6 @@ function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
       .filter((m) => !!m),
   )
 
-  const documents = useResources(sortedItems.map((item) => item.id))
-
   function getEntity(id: UnpackedHypermediaId) {
     return documents?.find((document) => document.data?.id?.id === id.id)?.data || null
   }
@@ -193,7 +220,9 @@ function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
         accountsMetadata={accountsMetadata}
         itemContributors={itemContributors}
         getEntity={getEntity}
-        isDiscovering={entity.isDiscovering || directoryItems.isLoading}
+        isDiscovering={
+          entity.isDiscovering || directoryItems.isLoading || documents.some((document) => document.isDiscovering)
+        }
         prependItems={prependItems}
         bannerContent={bannerContent}
       />

--- a/frontend/packages/shared/src/document-actions-context.tsx
+++ b/frontend/packages/shared/src/document-actions-context.tsx
@@ -1,5 +1,5 @@
 import {createContext, PropsWithChildren, useContext, useMemo} from 'react'
-import {HMDocument, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {HMDocument, HMListedDraft, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 
 export type DocumentActionsContextValue = {
   // Account info — card checks ownership/capabilities itself
@@ -21,6 +21,7 @@ export type DocumentActionsContextValue = {
 
   // Draft lookup
   getDraftId?: (id: UnpackedHypermediaId) => string | undefined
+  getDraft?: (id: UnpackedHypermediaId) => HMListedDraft | undefined
 }
 
 const DocumentActionsContext = createContext<DocumentActionsContextValue>({})
@@ -41,6 +42,7 @@ export function DocumentActionsProvider({children, ...value}: PropsWithChildren<
       value.onExportDocument,
       value.onCopyLink,
       value.getDraftId,
+      value.getDraft,
     ],
   )
   return <DocumentActionsContext.Provider value={ctx}>{children}</DocumentActionsContext.Provider>

--- a/frontend/packages/ui/src/__tests__/document-list-item.test.tsx
+++ b/frontend/packages/ui/src/__tests__/document-list-item.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import React from 'react'
+import {createRoot, type Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import type {HMDocumentInfo} from '@seed-hypermedia/client/hm-types'
+import {DocumentActionsProvider} from '@shm/shared/document-actions-context'
+import {UniversalAppProvider} from '@shm/shared/routing'
+import {hmId} from '@shm/shared/utils/entity-id-url'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {DocumentListItem} from '../document-list-item'
+;(globalThis as typeof globalThis & {React?: typeof React; IS_REACT_ACT_ENVIRONMENT?: boolean}).React = React
+;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('@shm/shared/models/interaction-summary', () => ({
+  useInteractionSummary: () => ({data: null}),
+}))
+
+vi.mock('@shm/shared/utils/navigation', () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+function makeItem(name: string): HMDocumentInfo {
+  const id = hmId('uid-1', {path: ['doc']})
+  return {
+    type: 'document',
+    id,
+    path: id.path,
+    authors: ['uid-1'],
+    createTime: '2024-01-01T00:00:00Z',
+    updateTime: '2024-01-01T00:00:00Z',
+    sortTime: new Date('2024-01-01T00:00:00Z'),
+    genesis: 'genesis',
+    version: 'version-1',
+    metadata: {name},
+    visibility: 'PUBLIC',
+  } as HMDocumentInfo
+}
+
+function renderDocumentListItem(getDraft?: (id: ReturnType<typeof hmId>) => any) {
+  const item = makeItem('Published title')
+  act(() => {
+    root.render(
+      <UniversalAppProvider openRoute={vi.fn()} openUrl={vi.fn()} universalClient={{request: vi.fn()} as any}>
+        <DocumentActionsProvider getDraft={getDraft}>
+          <DocumentListItem item={item} />
+        </DocumentActionsProvider>
+      </UniversalAppProvider>,
+    )
+  })
+}
+
+describe('DocumentListItem draft metadata', () => {
+  it('prefers the local draft title and shows draft state', () => {
+    renderDocumentListItem(() => ({
+      id: 'draft-1',
+      metadata: {name: 'Draft list title'},
+    }))
+
+    expect(container.textContent).toContain('Draft list title')
+    expect(container.textContent).not.toContain('Published title')
+    expect(container.textContent).toContain('Draft')
+  })
+})

--- a/frontend/packages/ui/src/__tests__/newspaper.test.tsx
+++ b/frontend/packages/ui/src/__tests__/newspaper.test.tsx
@@ -4,6 +4,7 @@ import {createRoot, type Root} from 'react-dom/client'
 import {act} from 'react-dom/test-utils'
 import {hmId} from '@shm/shared/utils/entity-id-url'
 import {UniversalAppProvider} from '@shm/shared/routing'
+import {DocumentActionsProvider} from '@shm/shared/document-actions-context'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {DocumentCard} from '../newspaper'
 ;(globalThis as typeof globalThis & {React?: typeof React; IS_REACT_ACT_ENVIRONMENT?: boolean}).React = React
@@ -37,10 +38,12 @@ function renderDocumentCard({
   titleLinkOnly = true,
   parentClick = vi.fn(),
   openRoute = vi.fn(),
+  getDraft,
 }: {
   titleLinkOnly?: boolean
   parentClick?: () => void
   openRoute?: ReturnType<typeof vi.fn>
+  getDraft?: (id: ReturnType<typeof hmId>) => any
 } = {}) {
   const docId = hmId('uid-1', {path: ['doc']})
   const entity = {
@@ -62,15 +65,17 @@ function renderDocumentCard({
         openUrl={vi.fn()}
         universalClient={{request: vi.fn(), publish: vi.fn()} as any}
       >
-        <div data-testid="parent" onClick={parentClick}>
-          <DocumentCard
-            data-testid="card"
-            docId={docId}
-            entity={entity}
-            navigate={false}
-            titleLinkOnly={titleLinkOnly}
-          />
-        </div>
+        <DocumentActionsProvider getDraft={getDraft}>
+          <div data-testid="parent" onClick={parentClick}>
+            <DocumentCard
+              data-testid="card"
+              docId={docId}
+              entity={entity}
+              navigate={false}
+              titleLinkOnly={titleLinkOnly}
+            />
+          </div>
+        </DocumentActionsProvider>
       </UniversalAppProvider>,
     )
   })
@@ -101,5 +106,20 @@ describe('DocumentCard title-only navigation', () => {
 
     expect(openRoute).toHaveBeenCalledWith({key: 'document', id: docId}, undefined)
     expect(parentClick).not.toHaveBeenCalled()
+  })
+})
+
+describe('DocumentCard draft metadata', () => {
+  it('prefers the local draft title and shows draft state', () => {
+    renderDocumentCard({
+      getDraft: () => ({
+        id: 'draft-1',
+        metadata: {name: 'Draft document title'},
+      }),
+    })
+
+    expect(container.textContent).toContain('Draft document title')
+    expect(container.textContent).not.toContain('Embedded document')
+    expect(container.textContent).toContain('Draft')
   })
 })

--- a/frontend/packages/ui/src/document-list-item.tsx
+++ b/frontend/packages/ui/src/document-list-item.tsx
@@ -70,9 +70,11 @@ export function DocumentListItem({
   onClick,
 }: DocumentListItemProps) {
   const id = item.id
-  const draftId = draftIdProp
+  const actions = useDocumentActions()
+  const draft = actions.getDraft?.(id)
+  const draftId = draftIdProp ?? draft?.id
 
-  const metadata = item.metadata
+  const metadata = draft?.metadata ? {...item.metadata, ...draft.metadata} : item.metadata
   const visibility = 'visibility' in item ? item.visibility : undefined
   const isPrivate = visibility === 'PRIVATE'
   const headCount = getVersionHeads('version' in item ? item.version : undefined).length
@@ -83,7 +85,7 @@ export function DocumentListItem({
   const itemBreadcrumbs = breadcrumbs !== undefined ? breadcrumbs : 'breadcrumbs' in item ? item.breadcrumbs : null
   const computedIsRead = isRead !== undefined ? isRead : !itemActivitySummary?.isUnread
 
-  const route = draftId ? {key: 'draft' as const, id: draftId} : {key: 'document' as const, id}
+  const route = draftIdProp ? {key: 'draft' as const, id: draftIdProp} : {key: 'document' as const, id}
   const linkProps = useRouteLink(route)
 
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
@@ -98,7 +100,6 @@ export function DocumentListItem({
   }
 
   const highlighter = useHighlighter()
-  const actions = useDocumentActions()
   const {onCopyReference, onPushReference, origin} = useUniversalAppContext()
   const navigate = useNavigate()
 

--- a/frontend/packages/ui/src/inline-descriptor.tsx
+++ b/frontend/packages/ui/src/inline-descriptor.tsx
@@ -1,6 +1,7 @@
 import {HMContactItem, HMMetadata, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {abbreviateUid, AnyTimestamp, formattedDateShort, hmId, NavRoute, normalizeDate, useRouteLink} from '@shm/shared'
-import {useAccount} from '@shm/shared/models/entity'
+import {useDocumentActions} from '@shm/shared/document-actions-context'
+import {useAccount, useResource} from '@shm/shared/models/entity'
 import {useNavRoute} from '@shm/shared/utils/navigation'
 import {Spinner} from './spinner'
 import {Tooltip} from './tooltip'
@@ -108,12 +109,17 @@ export function DocumentNameLink({
   fallback?: string
 }) {
   const linkProps = useRouteLink({key: 'document', id})
+  const actions = useDocumentActions()
+  const draft = actions.getDraft?.(id)
+  const resource = useResource(id, {subscribed: true})
+  const liveMetadata = resource.data?.type === 'document' ? resource.data.document.metadata : undefined
+  const name = draft?.metadata?.name ?? liveMetadata?.name ?? metadata?.name
   return (
     <a
       className="self-inline ring-px ring-border bg-background text-foreground hover:text-foreground dark:hover:bg-muted rounded p-[2px] text-sm ring hover:bg-black/5 active:bg-black/5 dark:active:bg-white/10"
       {...linkProps}
     >
-      {metadata?.name || fallback}
+      {name || fallback}
     </a>
   )
 }

--- a/frontend/packages/ui/src/newspaper.tsx
+++ b/frontend/packages/ui/src/newspaper.tsx
@@ -58,25 +58,29 @@ export function DocumentCard({
   const interactionSummary = useInteractionSummary(summaryId)
   const commentCount = interactionSummary.data?.comments ?? 0
 
+  // Context-driven state
+  const draft = actions.getDraft?.(docId)
+  const draftId = draft?.id ?? actions.getDraftId?.(docId)
+  const bookmarked = actions.isBookmarked?.(docId) ?? false
+  const isOwner = actions.selectedAccountUid === docId.uid
+  const isLoggedIn = !!actions.myAccountIds?.length
+  const hasPath = !!docId.path?.length
+
   const textContent = useMemo(() => {
     if (!showSummary) return null
+    if (draft?.metadata?.summary) {
+      return draft.metadata.summary
+    }
     if (entity?.document?.metadata?.summary) {
       return entity.document.metadata.summary
     }
     return plainTextOfContent(entity?.document?.content)
-  }, [showSummary, entity?.document])
+  }, [showSummary, draft?.metadata?.summary, entity?.document])
 
   const coverImage = entity?.document ? getDocumentImage(entity?.document) : undefined
   const isPrivate = entity?.document?.visibility === 'PRIVATE'
   const doc = entity?.document
   const headCount = getVersionHeads(doc?.version).length
-
-  // Context-driven state
-  const draftId = actions.getDraftId?.(docId)
-  const bookmarked = actions.isBookmarked?.(docId) ?? false
-  const isOwner = actions.selectedAccountUid === docId.uid
-  const isLoggedIn = !!actions.myAccountIds?.length
-  const hasPath = !!docId.path?.length
 
   // Self-assemble menu items from context
   const menuItems = useMemo(() => {
@@ -211,7 +215,7 @@ export function DocumentCard({
   }
 
   const titleClassName = cn('text-foreground block font-sans leading-tight! font-bold', banner ? 'text-2xl' : 'text-lg')
-  const title = entity?.document?.metadata?.name
+  const title = draft?.metadata?.name ?? entity?.document?.metadata?.name
   const content = (
     <>
       <div className={cn('flex max-w-full flex-1 flex-col @md:flex-row', navigateProp && 'cursor-pointer')}>

--- a/frontend/packages/ui/src/resource-token.tsx
+++ b/frontend/packages/ui/src/resource-token.tsx
@@ -1,4 +1,6 @@
 import {HMMetadata, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {useDocumentActions} from '@shm/shared/document-actions-context'
+import {useResource} from '@shm/shared/models/entity'
 import {useRouteLink} from '@shm/shared/routing'
 import {HMIcon} from './hm-icon'
 import {HoverCard, HoverCardContent, HoverCardTrigger} from './hover-card'
@@ -17,8 +19,17 @@ export function ResourceToken({
   }>
 }) {
   const linkProps = useRouteLink({key: 'document', id: id})
+  const actions = useDocumentActions()
+  const draft = actions.getDraft?.(id)
+  const resource = useResource(id, {subscribed: true})
+  const liveMetadata = resource.data?.type === 'document' ? resource.data.document.metadata : undefined
+  const displayMetadata = draft?.metadata
+    ? {...(metadata ?? {}), ...(liveMetadata ?? {}), ...draft.metadata}
+    : liveMetadata ?? metadata
   const icon =
-    !id.path?.length || metadata?.icon ? <HMIcon size={20} id={id} name={metadata?.name} icon={metadata?.icon} /> : null
+    !id.path?.length || displayMetadata?.icon ? (
+      <HMIcon size={20} id={id} name={displayMetadata?.name} icon={displayMetadata?.icon} />
+    ) : null
 
   const baseClassName =
     'inline text-sm whitespace-normal bg-gray-100 border hover:dark:text-white dark:bg-gray-800 hover:bg-gray-200'
@@ -29,11 +40,13 @@ export function ResourceToken({
         <HoverCardTrigger asChild>
           <a {...linkProps} className={cn(baseClassName, previewTriggerClassName)}>
             {icon ? <span className="mr-1 inline-block align-middle">{icon}</span> : null}
-            <span className="text-foreground truncate overflow-hidden">{metadata?.name || 'Untitled Resource'}</span>
+            <span className="text-foreground truncate overflow-hidden">
+              {displayMetadata?.name || 'Untitled Resource'}
+            </span>
           </a>
         </HoverCardTrigger>
         <HoverCardContent className="w-full max-w-100 p-0" align="end">
-          <ResourcePreview metadata={metadata} id={id} />
+          <ResourcePreview metadata={displayMetadata} id={id} />
         </HoverCardContent>
       </HoverCard>
     )
@@ -41,7 +54,7 @@ export function ResourceToken({
   return (
     <a {...linkProps} className={baseClassName}>
       {icon ? <span className="mr-1 inline-block align-middle">{icon}</span> : null}
-      {metadata?.name || 'Untitled Resource'}
+      {displayMetadata?.name || 'Untitled Resource'}
     </a>
   )
 }


### PR DESCRIPTION
## Summary
- Exposes full draft lookup through document actions so UI surfaces can prefer local draft metadata.
- Refreshes draft and draft-list query caches after draft writes.
- Updates query blocks, mentions, inline descriptors, resource tokens, document cards, and list items to use subscribed resource data and draft titles.
- Adds coverage for draft metadata display in document cards and document list items.

---

Fixes #655