### PR TITLE
Fix CLI document create time

### DIFF
--- a/frontend/apps/cli/src/commands/document.ts
+++ b/frontend/apps/cli/src/commands/document.ts
@@ -410,21 +410,14 @@ export function registerDocumentCommands(program: Command) {
         ops.push(...input.ops)
 
         const signer = createSignerFromKey(key)
-        const genesisBlock = await createGenesisChange(signer)
-
-        const {unsignedBytes, ts} = createChangeOps({
-          ops,
-          genesisCid: genesisBlock.cid,
-          deps: [genesisBlock.cid],
-          depth: 1,
-        })
+        const {unsignedBytes, ts} = createChangeOps({ops})
         const changeBlock = await createChange(unsignedBytes, signer)
         const generation = Number(ts)
         const refInput = await createVersionRef(
           {
             space: account,
             path,
-            genesis: genesisBlock.cid.toString(),
+            genesis: changeBlock.cid.toString(),
             version: changeBlock.cid.toString(),
             generation,
             capability,
@@ -434,7 +427,6 @@ export function registerDocumentCommands(program: Command) {
 
         await client.publish({
           blobs: [
-            {data: new Uint8Array(genesisBlock.bytes), cid: genesisBlock.cid.toString()},
             {data: new Uint8Array(changeBlock.bytes), cid: changeBlock.cid.toString()},
             ...refInput.blobs,
             ...input.fileBlobs.map((b) => ({data: b.data, cid: b.cid})),

--- a/frontend/apps/cli/src/test/cli-fixture.test.ts
+++ b/frontend/apps/cli/src/test/cli-fixture.test.ts
@@ -573,6 +573,12 @@ describe('CLI Full Integration Tests', () => {
         const data = JSON.parse(getResult.stdout)
         expect(data.type).toBe('document')
         expect(data.document.metadata.name).toBe('CLI Test Document')
+        const createTime = data.document.createTime
+        const createTimeMs =
+          typeof createTime === 'string'
+            ? Date.parse(createTime)
+            : Number(createTime?.seconds ?? 0) * 1000 + Number(createTime?.nanos ?? 0) / 1_000_000
+        expect(createTimeMs).toBeGreaterThan(Date.UTC(2020, 0, 1))
       },
       TEST_TIMEOUT,
     )

--- a/frontend/apps/cli/src/test/cli-fixture.test.ts
+++ b/frontend/apps/cli/src/test/cli-fixture.test.ts
@@ -206,6 +206,23 @@ describe('CLI Full Integration Tests', () => {
       }
     }, TEST_TIMEOUT)
 
+    test(
+      'home document keeps a separate deterministic genesis change',
+      async () => {
+        const getResult = await runCli(['document', 'get', writeAccountHmId, '--json'], {server: ctx.webServerUrl})
+        expect(getResult.exitCode).toBe(0)
+
+        const data = JSON.parse(getResult.stdout)
+        expect(data.type).toBe('document')
+        expect(data.document.path).toBe('')
+        expect(data.document.genesis).toBeTruthy()
+        expect(data.document.version).toBeTruthy()
+        expect(data.document.genesis).not.toBe(data.document.version)
+        expect(data.document.generationInfo.genesis).toBe(data.document.genesis)
+      },
+      TEST_TIMEOUT,
+    )
+
     // --- Document Update Tests ---
 
     test(

--- a/frontend/packages/client/src/change.test.ts
+++ b/frontend/packages/client/src/change.test.ts
@@ -2,7 +2,14 @@ import {describe, it, expect} from 'vitest'
 import {decode as cborDecode, encode as cborEncode} from '@ipld/dag-cbor'
 import * as Block from 'multiformats/block'
 import {sha256} from 'multiformats/hashes/sha2'
-import {createChange, createChangeOps, signPreparedChange, signDocumentChange, visibilityToCbor} from './change'
+import {
+  createChange,
+  createChangeOps,
+  createGenesisChange,
+  signPreparedChange,
+  signDocumentChange,
+  visibilityToCbor,
+} from './change'
 import type {HMSigner} from './hm-types'
 
 // A valid base58btc-encoded account UID (multibase 'z' prefix)
@@ -133,7 +140,37 @@ describe('createChange', () => {
   })
 })
 
+describe('createGenesisChange', () => {
+  it('defaults to timestamp zero for deterministic home document genesis changes', async () => {
+    const signer = createMockSigner()
+
+    const result = await createGenesisChange(signer)
+
+    const decoded = cborDecode(result.bytes) as Record<string, unknown>
+    expect(BigInt(decoded['ts'] as number | bigint)).toBe(0n)
+  })
+})
+
 describe('createChangeOps', () => {
+  it('can create the first content change for a non-home document', async () => {
+    const signer = createMockSigner()
+
+    const {unsignedBytes, ts} = createChangeOps({
+      ops: [{type: 'SetAttributes', attrs: [{key: ['title'], value: 'Test'}]}],
+    })
+
+    expect(ts).toBeGreaterThan(0n)
+
+    const decodedUnsigned = cborDecode(unsignedBytes) as Record<string, unknown>
+    expect(decodedUnsigned['genesis']).toBeUndefined()
+    expect(decodedUnsigned['deps']).toBeUndefined()
+    expect(decodedUnsigned['depth']).toBeUndefined()
+
+    const result = await createChange(unsignedBytes, signer)
+    expect(result.genesis).toBeNull()
+    expect(result.cid.toString()).toMatch(/^bafy/)
+  })
+
   it('produces unsigned bytes that createChange can sign', async () => {
     const genesisCID = await makeTestCID({type: 'Change', ts: 0n})
     const signer = createMockSigner()

--- a/frontend/packages/client/src/change.ts
+++ b/frontend/packages/client/src/change.ts
@@ -25,12 +25,12 @@ export type DocumentOperation =
 export type CreateChangeOpsInput = {
   /** Native CBOR ops */
   ops: DocumentOperation[]
-  /** CID of the genesis change blob */
-  genesisCid: CID
-  /** CIDs of dependency changes */
-  deps: CID[]
-  /** Depth of the change (max depth of deps + 1) */
-  depth: number
+  /** CID of the genesis change blob. Omit when creating the first content change for a document. */
+  genesisCid?: CID
+  /** CIDs of dependency changes. Omit when creating the first content change for a document. */
+  deps?: CID[]
+  /** Depth of the change (max depth of deps + 1). Omit when creating the first content change for a document. */
+  depth?: number
   /** Timestamp (defaults to Date.now()) */
   ts?: bigint
 }
@@ -50,9 +50,11 @@ export function createChangeOps(input: CreateChangeOpsInput): {unsignedBytes: Ui
     signer: null,
     ts,
     sig: null,
-    genesis: input.genesisCid,
-    deps: input.deps,
-    depth: input.depth,
+  }
+  if (input.genesisCid) {
+    unsigned.genesis = input.genesisCid
+    unsigned.deps = input.deps ?? []
+    unsigned.depth = input.depth ?? 1
   }
   return {unsignedBytes: cborEncode(unsigned), ts}
 }
@@ -96,7 +98,7 @@ export const signPreparedChange = async (
 
 /**
  * Create a signed genesis Change blob (empty, ts=0).
- * This is the bootstrap blob for a new document, matching the web pattern.
+ * This deterministic sentinel is only intended for home documents.
  */
 export async function createGenesisChange(signer: HMSigner): Promise<{bytes: Uint8Array; cid: CID}> {
   const pubKey = await signer.getPublicKey()


### PR DESCRIPTION
## Summary
- create CLI path documents as a timestamped first content change instead of publishing the zero-timestamp home genesis sentinel
- allow client change creation without an existing genesis CID for first document changes
- add regression coverage that CLI-created docs do not get epoch createTime

Fixes #667.

## Tests
- pnpm --filter @seed-hypermedia/client test -- src/change.test.ts
- cd frontend/apps/cli && bun test src/test/cli-fixture.test.ts -t "document create creates a document"
- pnpm --filter @seed-hypermedia/client typecheck
- pnpm --filter @seed-hypermedia/cli typecheck