### PR TITLE
fix(editor): sync formatting toolbar hides with style popover

### DIFF
--- a/frontend/packages/editor/src/blocknote/core/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -157,6 +157,20 @@ export class FormattingToolbarView<BSchema extends BlockSchema> {
     }
   }
 
+  /**
+   * Force the toolbar to its hidden state and notify subscribers. Used by
+   * external triggers (e.g. document scroll) so the close goes through the
+   * plugin's event channel instead of the React positioner's local state —
+   * otherwise consumers subscribed to `onUpdate` (such as the Style Options
+   * popover) never learn that the toolbar is going away.
+   */
+  hide() {
+    if (this.formattingToolbarState?.show) {
+      this.formattingToolbarState.show = false
+      this.updateFormattingToolbar()
+    }
+  }
+
   destroy() {
     this.pmView.dom.removeEventListener('mousedown', this.viewMousedownHandler)
     this.pmView.dom.removeEventListener('mouseup', this.viewMouseupHandler)
@@ -208,5 +222,10 @@ export class FormattingToolbarProsemirrorPlugin<BSchema extends BlockSchema> ext
 
   public onUpdate(callback: (state: FormattingToolbarState) => void) {
     return this.on('update', callback)
+  }
+
+  /** Hide the toolbar and notify subscribers via the `update` event. */
+  public hide() {
+    this.view?.hide()
   }
 }

--- a/frontend/packages/editor/src/blocknote/react/FormattingToolbar/components/FormattingToolbarPositioner.tsx
+++ b/frontend/packages/editor/src/blocknote/react/FormattingToolbar/components/FormattingToolbarPositioner.tsx
@@ -26,7 +26,16 @@ export const FormattingToolbarPositioner = <BSchema extends BlockSchema = Defaul
     })
   }, [props.editor])
 
-  useHideOnDocumentScroll(() => setShow(false))
+  // Route scroll-driven hides through the plugin so subscribers (e.g. the
+  // Style Options popover) get notified and can close themselves. Falls back
+  // to local state if the plugin isn't ready yet.
+  useHideOnDocumentScroll(() => {
+    if (props.editor.formattingToolbar) {
+      props.editor.formattingToolbar.hide()
+    } else {
+      setShow(false)
+    }
+  })
 
   const getReferenceClientRect = useMemo(() => {
     if (!referencePos) {

--- a/frontend/packages/editor/src/hm-formatting-toolbar.tsx
+++ b/frontend/packages/editor/src/hm-formatting-toolbar.tsx
@@ -487,7 +487,7 @@ export function HMFormattingToolbar<Schema extends Record<string, BlockSpec<stri
                     type="button"
                     variant="ghost"
                     data-testid="style-options-trigger"
-                    className="h-9 gap-1.5 rounded-md border border-black/10 px-3 text-sm font-normal hover:bg-black/10 dark:border-white/10 dark:hover:bg-white/10"
+                    className="format-toolbar-item h-9 gap-1.5 rounded-md border border-black/10 px-3 text-sm font-normal hover:bg-black/10 dark:border-white/10 dark:hover:bg-white/10"
                   >
                     <ListChecks className="size-4" />
                     <span>Style options</span>
@@ -501,9 +501,21 @@ export function HMFormattingToolbar<Schema extends Record<string, BlockSpec<stri
                   collisionPadding={8}
                   onOpenAutoFocus={(e) => e.preventDefault()}
                   onCloseAutoFocus={(e) => e.preventDefault()}
-                  // Keep focus on the editor when a click lands on a
-                  // non-focusable area of the panel.
-                  onPointerDown={(e) => e.preventDefault()}
+                  // Keep focus on the editor when a pointer lands on
+                  // non-focusable areas of the panel (padding, gaps, section
+                  // headings). Focusable controls (buttons, inputs) keep
+                  // their native behavior so text selection and keyboard
+                  // focus still work if the panel ever gains an input.
+                  onPointerDown={(e) => {
+                    const target = e.target as HTMLElement | null
+                    if (
+                      !target?.closest(
+                        'button, input, textarea, select, a, [contenteditable=""], [contenteditable="true"]',
+                      )
+                    ) {
+                      e.preventDefault()
+                    }
+                  }}
                   className="format-toolbar-item bg-background z-[10000] w-[22rem] max-w-[92vw] p-3"
                 >
                   <StyleOptionsPanel


### PR DESCRIPTION
## Summary

The primary fix for #673 (stable component reference so the formatting toolbar stops remounting on every parent render) landed via the text-color/highlight/size/font commit on `main`. This PR builds on top of that with three follow-ups so the Style Options popover lifecycle stays consistent under all hide paths.

- **Route scroll-driven hides through the plugin.** `FormattingToolbarPositioner` previously called `setShow(false)` directly on `useHideOnDocumentScroll`, bypassing the `onUpdate` event channel — so the Style Options popover never learned the toolbar was hiding and stayed open above an invisible reference. Added `FormattingToolbarView.hide()` + `FormattingToolbarProsemirrorPlugin.hide()`, and the positioner now calls `editor.formattingToolbar.hide()`. The plugin emits `update({show: false})`, which the popover's subscription picks up to close itself.
- **Scope `onPointerDown preventDefault` to non-focusable areas.** Previously every pointerdown inside `PopoverContent` was prevented, which kept editor focus but would block native focus / text selection on any future input or textarea inside the panel. Now only pointerdowns on non-focusable targets (panel padding, section headings, gaps) preventDefault; clicks on `button`, `input`, `textarea`, `select`, `a`, `[contenteditable]` keep their native behavior.
- **Tag the Style Options trigger with `format-toolbar-item`.** Matches the existing pattern on `HMLinkToolbarButton` so the editor's `blurHandler` recognizes focus moving onto the trigger as still in-toolbar. Belt-and-suspenders for keyboard-driven open.

---

Fixes #673