### PR TITLE
fix(frontend): keep right panel action inside active tab

### DIFF
--- a/frontend/packages/ui/src/document-tools.tsx
+++ b/frontend/packages/ui/src/document-tools.tsx
@@ -21,7 +21,7 @@ import {
   Shield,
   Users,
 } from 'lucide-react'
-import {useRef, useState} from 'react'
+import {cloneElement, isValidElement, useRef, useState} from 'react'
 import {PageTab} from './page-tabs'
 import {cn} from './utils'
 
@@ -31,7 +31,7 @@ export function DocumentTools({
   commentsCount = 0,
   citationsCount = 0,
   collabsCount = 0,
-  rightActions,
+  activeTabAction,
   existingDraft,
   currentPanel,
   mode = 'document',
@@ -44,7 +44,8 @@ export function DocumentTools({
   commentsCount?: number
   citationsCount?: number
   collabsCount?: number
-  rightActions?: React.ReactNode
+  /** Rendered immediately to the right of the active tab pill. When no tab is active, rendered as last sibling. */
+  activeTabAction?: React.ReactNode
   existingDraft?: HMExistingDraft | false
   /** Current panel route — tabs preserve this when navigating */
   currentPanel?: DocumentPanelRoute | null
@@ -238,6 +239,13 @@ export function DocumentTools({
             },
           },
         ]
+  const hasActive = buttons.some((b) => b.active)
+  const standaloneAction =
+    !hasActive && activeTabAction
+      ? isValidElement(activeTabAction)
+        ? cloneElement(activeTabAction as React.ReactElement<{accent?: boolean}>, {accent: true})
+        : activeTabAction
+      : null
   const tabButtons = (
     <>
       {/* Hidden measurement container with labels always visible */}
@@ -257,8 +265,10 @@ export function DocumentTools({
             count={button.count}
             bg={button.bg}
             showLabel
+            trailingAction={button.active ? activeTabAction : undefined}
           />
         ))}
+        {standaloneAction}
       </div>
       {buttons.map((button) => (
         <PageTab
@@ -271,8 +281,10 @@ export function DocumentTools({
           count={button.count}
           bg={button.bg}
           showLabel={showLabels}
+          trailingAction={button.active ? activeTabAction : undefined}
         />
       ))}
+      {standaloneAction}
     </>
   )
 
@@ -295,9 +307,7 @@ export function DocumentTools({
             >
               {tabButtons}
             </div>
-            <div {...sidebarProps} className={cn(sidebarProps.className, 'flex !h-auto items-center !p-0')}>
-              {rightActions ? <div className="flex shrink-0 items-center">{rightActions}</div> : null}
-            </div>
+            <div {...sidebarProps} className={cn(sidebarProps.className, '!h-auto !p-0')} />
           </div>
         </div>
       )
@@ -306,7 +316,7 @@ export function DocumentTools({
     // No sidebars: center with mx-auto, no flex-1 (matching header pattern)
     return (
       <div className="flex w-full shrink-0">
-        <div style={wrapperProps.style} className="mx-auto flex w-full items-center justify-between">
+        <div style={wrapperProps.style} className="mx-auto flex w-full items-center">
           <div
             {...mainContentProps}
             ref={containerRef}
@@ -314,7 +324,6 @@ export function DocumentTools({
           >
             {tabButtons}
           </div>
-          {rightActions && <div className="flex shrink-0 items-center">{rightActions}</div>}
         </div>
       </div>
     )
@@ -325,7 +334,6 @@ export function DocumentTools({
       <div ref={containerRef} className="flex flex-1 items-center gap-2 p-1 md:gap-4 md:p-2">
         {tabButtons}
       </div>
-      {rightActions ? <div className="flex shrink-0 items-center px-0 md:px-2 lg:px-4">{rightActions}</div> : null}
     </div>
   )
 }

--- a/frontend/packages/ui/src/inspector-page.tsx
+++ b/frontend/packages/ui/src/inspector-page.tsx
@@ -80,7 +80,7 @@ export function InspectorPage({docId, pageFooter}: {docId: UnpackedHypermediaId;
       mode="inspect"
       inspectRoute={route}
       inspectTabs={inspectTabs}
-      rightActions={openTarget ? <InspectorOpenButton label={openTarget.label} route={openTarget.route} /> : null}
+      activeTabAction={openTarget ? <InspectorOpenButton label={openTarget.label} route={openTarget.route} /> : null}
     />
   )
 
@@ -208,14 +208,31 @@ function InspectorContent({
 function InspectorOpenButton({
   label,
   route,
+  nested = false,
+  accent = false,
 }: {
   label: string
   route: ReturnType<typeof createRouteFromInspectNavRoute>
+  /** When true, button is rendered inside an active tab pill — drop outline, inherit text color, square the left edge. */
+  nested?: boolean
+  /** When true (and not nested), render as a full accent pill matching the active tab styling. */
+  accent?: boolean
 }) {
   const linkProps = useRouteLink(route)
 
   return (
-    <Button asChild size="sm" variant="outline">
+    <Button
+      asChild
+      size="sm"
+      variant={nested ? 'ghost' : accent ? 'accent' : 'outline'}
+      className={
+        nested
+          ? 'h-9 rounded-l-none rounded-r-full px-3 hover:bg-black/5 dark:hover:bg-white/10'
+          : accent
+          ? 'rounded-full'
+          : undefined
+      }
+    >
       <a {...linkProps}>{label}</a>
     </Button>
   )

--- a/frontend/packages/ui/src/open-in-panel.tsx
+++ b/frontend/packages/ui/src/open-in-panel.tsx
@@ -4,14 +4,30 @@ import {useNavigate} from '@shm/shared/utils/navigation'
 import {SquareChevronRight} from 'lucide-react'
 import {Button} from './button'
 import {Tooltip} from './tooltip'
+import {cn} from './utils'
 
-export function OpenInPanelButton({id, panelRoute}: {id: UnpackedHypermediaId; panelRoute: DocumentPanelRoute}) {
+export function OpenInPanelButton({
+  id,
+  panelRoute,
+  nested = false,
+  accent = false,
+}: {
+  id: UnpackedHypermediaId
+  panelRoute: DocumentPanelRoute
+  /** When true, button is rendered inside an active tab pill — drop own bg, inherit text color, square the left edge. */
+  nested?: boolean
+  /** When true (and not nested), render as a full accent pill so the standalone button reads as the active tab. */
+  accent?: boolean
+}) {
   const replace = useNavigate('replace')
 
   return (
     <Tooltip content="Open in right panel">
       <Button
-        className="mx-2 shadow-sm"
+        variant={nested ? 'ghost' : accent ? 'accent' : 'ghost'}
+        className={cn(
+          nested ? 'h-9 rounded-l-none rounded-r-full px-3 hover:bg-black/5 dark:hover:bg-white/10' : 'rounded-full',
+        )}
         onClick={() => {
           replace({
             key: 'document',
@@ -20,7 +36,7 @@ export function OpenInPanelButton({id, panelRoute}: {id: UnpackedHypermediaId; p
           })
         }}
       >
-        <SquareChevronRight />
+        <SquareChevronRight className="size-4" />
       </Button>
     </Tooltip>
   )

--- a/frontend/packages/ui/src/page-tabs.tsx
+++ b/frontend/packages/ui/src/page-tabs.tsx
@@ -1,5 +1,6 @@
 import {NavRoute, useRouteLink} from '@shm/shared'
 import {LucideIcon} from 'lucide-react'
+import {cloneElement, isValidElement, ReactNode} from 'react'
 import {Button, ButtonProps} from './button'
 import {Tooltip} from './tooltip'
 import {cn} from './utils'
@@ -45,6 +46,12 @@ export interface PageTabProps extends Omit<ButtonProps, 'variant' | 'asChild'> {
   showLabel?: boolean
   /** Optional background color class override */
   bg?: string
+  /**
+   * Optional node rendered inside the active tab pill, to the right of label/count.
+   * Only rendered when `active` is true. Receives `nested` prop via cloneElement so
+   * the action can adapt its styling to sit inside the accent pill.
+   */
+  trailingAction?: ReactNode
 }
 
 /**
@@ -60,10 +67,46 @@ export function PageTab({
   active = false,
   showLabel = true,
   bg,
+  trailingAction,
   className,
   ...props
 }: PageTabProps) {
   const linkProps = useRouteLink(route)
+
+  const linkContent = (
+    <>
+      {Icon && <Icon className="size-4" />}
+      {label && showLabel ? <span className="hidden truncate text-sm md:block">{label}</span> : null}
+      {count ? <span className="text-sm">{count}</span> : null}
+    </>
+  )
+
+  if (active && trailingAction) {
+    const nestedAction = isValidElement(trailingAction)
+      ? cloneElement(trailingAction as React.ReactElement<{nested?: boolean}>, {nested: true})
+      : trailingAction
+    return (
+      <Tooltip content="">
+        <div
+          className={cn(
+            'bg-accent text-accent-foreground inline-flex items-center rounded-full shadow-xs',
+            bg,
+            className,
+          )}
+        >
+          <a
+            {...linkProps}
+            data-tab={route.key}
+            className="inline-flex h-9 items-center gap-2 rounded-l-full pr-2 pl-4 transition-colors hover:bg-black/5 dark:hover:bg-white/10"
+          >
+            {linkContent}
+          </a>
+          {nestedAction}
+        </div>
+      </Tooltip>
+    )
+  }
+
   const btn = (
     <Button
       className={cn('flex-1 rounded-full', bg, className)}
@@ -72,9 +115,7 @@ export function PageTab({
       {...props}
     >
       <a {...linkProps} data-tab={route.key}>
-        {Icon && <Icon className="size-4" />}
-        {label && showLabel ? <span className="hidden truncate text-sm md:block">{label}</span> : null}
-        {count ? <span className="text-sm">{count}</span> : null}
+        {linkContent}
       </a>
     </Button>
   )

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -1506,17 +1506,7 @@ function DocumentBody({
   }, [extraMenuItems, commonMenuItems, inspectMenuItem, documentOptionsMenuItem, isUnpublishedDraft])
 
   const hasOptions = allMenuItems.length > 0
-  const actionButtons = hasOptions ? (
-    <>
-      {/* Only show in the floating overlay on md+ screens — on mobile the same
-          button is rendered inside DocumentTools rightActions (md:hidden), so
-          hiding it here prevents both from showing simultaneously around the
-          md breakpoint (issue #321). */}
-      <div className="hidden md:block">
-        <OptionsDropdown menuItems={allMenuItems} align="end" side="bottom" />
-      </div>
-    </>
-  ) : null
+  const actionButtons = hasOptions ? <OptionsDropdown menuItems={allMenuItems} align="end" side="bottom" /> : null
 
   // Main page content (used in both mobile and desktop layouts)
   const mainPageContent = (
@@ -1683,34 +1673,17 @@ function DocumentBody({
                     showSidebars,
                   }
             }
-            rightActions={
-              <div className="flex items-center gap-1">
-                {/* Mobile: show editing/draft actions inline (desktop uses floating overlay).
-                    These include their own OptionsDropdown, so hide the standalone one. */}
-                {isMobile && isEditing && editingFloatingActions ? (
-                  editingFloatingActions({menuItems: allMenuItems})
-                ) : isMobile && !isEditing && ctx.draftId !== null && draftActions ? (
-                  draftActions({menuItems: allMenuItems})
-                ) : (
-                  <>
-                    {hasOptions && (
-                      <div className="md:hidden">
-                        <OptionsDropdown menuItems={allMenuItems} align="end" side="bottom" />
-                      </div>
-                    )}
-                  </>
-                )}
-                {activeView !== 'content' && activeView !== 'site-profile' && !isMobile && (
-                  <OpenInPanelButton
-                    id={docId}
-                    panelRoute={
-                      route.key === activeView
-                        ? extractPanelRoute(route)
-                        : {key: activeView as Exclude<ActiveView, 'content' | 'site-profile'>, id: docId}
-                    }
-                  />
-                )}
-              </div>
+            activeTabAction={
+              activeView !== 'content' && activeView !== 'site-profile' ? (
+                <OpenInPanelButton
+                  id={docId}
+                  panelRoute={
+                    route.key === activeView
+                      ? extractPanelRoute(route)
+                      : {key: activeView as Exclude<ActiveView, 'content' | 'site-profile'>, id: docId}
+                  }
+                />
+              ) : null
             }
           />
         </div>


### PR DESCRIPTION
## Summary
- Moves the right-panel open action from the toolbar edge into the active tab pill so it cannot overlap neighboring toolbar buttons.
- Adds nested/accent styling support for tab-adjacent actions in document and inspector toolbars.
- Simplifies document toolbar action placement by removing the separate `rightActions` area and rendering active-tab actions consistently across layouts.

---

Fixes #424