### PR TITLE
fix(frontend): report caught push and workflow errors

### DIFF
--- a/frontend/apps/desktop/src/__tests__/report-error.test.ts
+++ b/frontend/apps/desktop/src/__tests__/report-error.test.ts
@@ -1,0 +1,67 @@
+import {Code, ConnectError} from '@connectrpc/connect'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+const captureExceptionMock = vi.fn()
+const setTagMock = vi.fn()
+const setExtrasMock = vi.fn()
+const toastErrorMock = vi.fn()
+
+vi.mock('@sentry/electron/renderer', () => ({
+  withScope: (cb: (scope: {setTag: typeof setTagMock; setExtras: typeof setExtrasMock}) => void) => {
+    cb({setTag: setTagMock, setExtras: setExtrasMock})
+  },
+  captureException: (...args: unknown[]) => captureExceptionMock(...args),
+}))
+
+vi.mock('@shm/ui/toast', () => ({
+  toast: {error: (...args: unknown[]) => toastErrorMock(...args)},
+}))
+
+beforeEach(() => {
+  captureExceptionMock.mockClear()
+  setTagMock.mockClear()
+  setExtrasMock.mockClear()
+  toastErrorMock.mockClear()
+})
+
+describe('reportError', () => {
+  it('captures plain Error with feature/operation tags and extras, no toast', async () => {
+    const {reportError} = await import('../errors')
+    const err = new Error('boom')
+    reportError(err, {feature: 'push-resource', operation: 'push-to-peer', host: 'site.example'})
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1)
+    expect(captureExceptionMock).toHaveBeenCalledWith(err)
+    expect(setTagMock).toHaveBeenCalledWith('feature', 'push-resource')
+    expect(setTagMock).toHaveBeenCalledWith('operation', 'push-to-peer')
+    expect(setExtrasMock).toHaveBeenCalledWith({host: 'site.example'})
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('extracts ConnectError code into a connect_code tag', async () => {
+    const {reportError} = await import('../errors')
+    const err = new ConnectError('unavailable', Code.Unavailable)
+    reportError(err, {feature: 'push-resource', operation: 'resolve-peer'})
+    expect(setTagMock).toHaveBeenCalledWith('connect_code', String(Code.Unavailable))
+    expect(captureExceptionMock).toHaveBeenCalledWith(err)
+  })
+
+  it('wraps non-Error inputs into an Error', async () => {
+    const {reportError} = await import('../errors')
+    reportError('plain string failure', {feature: 'misc', operation: 'noop'})
+    const captured = captureExceptionMock.mock.calls[0]?.[0]
+    expect(captured).toBeInstanceOf(Error)
+    expect((captured as Error).message).toBe('plain string failure')
+  })
+})
+
+describe('appError', () => {
+  it('shows toast and delegates to reportError', async () => {
+    const errors = await import('../errors')
+    const original = new Error('original')
+    errors.default('Failed to publish', {error: original, feature: 'publish', operation: 'commit'})
+    expect(toastErrorMock).toHaveBeenCalledWith('Failed to publish')
+    expect(captureExceptionMock).toHaveBeenCalledWith(original)
+    expect(setTagMock).toHaveBeenCalledWith('feature', 'publish')
+    expect(setTagMock).toHaveBeenCalledWith('operation', 'commit')
+  })
+})

--- a/frontend/apps/desktop/src/components/commenting.tsx
+++ b/frontend/apps/desktop/src/components/commenting.tsx
@@ -1,3 +1,4 @@
+import {reportError} from '@/errors'
 import {domainResolver} from '@/grpc-client'
 import {useCommentDraft} from '@/models/comments'
 import {usePushAfterAction} from '@/models/push-after-action'
@@ -189,6 +190,11 @@ function CommentBoxImpl(props: {
       // Do NOT roll back cache or navigation; do NOT invalidate queries (would fail offline).
       setIsSubmitting(false)
       console.warn('Comment publish failed, keeping optimistic comment:', err.message)
+      reportError(err, {
+        feature: 'comment',
+        operation: 'publish',
+        docId: docId.id,
+      })
     },
     onSuccess: () => {
       setIsSubmitting(false)
@@ -333,6 +339,11 @@ function CommentBoxImpl(props: {
       } catch (err) {
         setIsSubmitting(false)
         console.error('Failed to submit comment:', err)
+        reportError(err, {
+          feature: 'comment',
+          operation: 'submit',
+          docId: docId.id,
+        })
       }
     },
     [

--- a/frontend/apps/desktop/src/components/payment-settings.tsx
+++ b/frontend/apps/desktop/src/components/payment-settings.tsx
@@ -1,3 +1,4 @@
+import {reportError} from '@/errors'
 import {useCurrencyComparisons} from '@/models/compare-currencies'
 import {
   useCreateLocalInvoice,
@@ -81,6 +82,7 @@ export function AccountWallet({
           createWallet.mutateAsync({accountUid}).catch((e) => {
             console.error(e)
             toast.error(`Failed to create wallet: ${e.message}`)
+            reportError(e, {feature: 'payments', operation: 'create-wallet', accountUid})
           })
         }}
       >

--- a/frontend/apps/desktop/src/components/publish-draft-button.tsx
+++ b/frontend/apps/desktop/src/components/publish-draft-button.tsx
@@ -1,4 +1,5 @@
 import {DraftStatus, draftStatus} from '@/draft-status'
+import {reportError} from '@/errors'
 import {draftEditId, draftLocationId} from '@/models/drafts'
 import {useGatewayUrl, usePushOnPublish} from '@/models/gateway-settings'
 import {useSelectedAccount} from '@/selected-account'
@@ -362,6 +363,12 @@ export default function PublishDraftButton() {
           })
           pushResource(parentResultId).catch((err) => {
             console.error('Failed to push parent document:', err)
+            reportError(err, {
+              feature: 'publish-draft',
+              operation: 'push-parent',
+              parentResourceId: parentResultId.id,
+              childResourceId: childResultId.id,
+            })
           })
         }
 
@@ -380,6 +387,12 @@ export default function PublishDraftButton() {
       await handlePublish(editId, signingAccountId).catch((err) => {
         console.error('Publish failed:', err)
         toast.error(err.message || 'Publish failed')
+        reportError(err, {
+          feature: 'publish-draft',
+          operation: 'publish-existing',
+          editId: editId.id,
+          signingAccountId,
+        })
       })
     } else if (editableLocation && signingAccountId) {
       // First publish with editable location from popover
@@ -395,6 +408,12 @@ export default function PublishDraftButton() {
       await handlePublish(editableLocation, signingAccountId).catch((err) => {
         console.error('Publish failed:', err)
         setPublishError(err.message || 'Failed to publish. Try a different path name.')
+        reportError(err, {
+          feature: 'publish-draft',
+          operation: 'publish-first',
+          editableLocation,
+          signingAccountId,
+        })
       })
     } else {
       toast.error('Cannot publish: missing location or account')

--- a/frontend/apps/desktop/src/components/wxr-import-dialog.tsx
+++ b/frontend/apps/desktop/src/components/wxr-import-dialog.tsx
@@ -2,6 +2,7 @@
  * WordPress WXR Import Dialog Component.
  * Provides a multi-step UI for importing WordPress exports.
  */
+import {reportError} from '@/errors'
 import {useMyAccountsWithWriteAccess} from '@/models/access-control'
 import {client} from '@/trpc'
 import {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
@@ -71,6 +72,7 @@ function WXRImportDialog({input, onClose}: {input: WXRImportDialogInput; onClose
     },
     onError: (error: Error) => {
       toast.error(`Failed to parse WXR file: ${error.message}`)
+      reportError(error, {feature: 'wxr-import', operation: 'parse'})
     },
   })
 
@@ -89,6 +91,11 @@ function WXRImportDialog({input, onClose}: {input: WXRImportDialogInput; onClose
     },
     onError: (error: Error) => {
       toast.error(`Failed to start import: ${error.message}`)
+      reportError(error, {
+        feature: 'wxr-import',
+        operation: 'start',
+        destinationId: input.destinationId.id,
+      })
     },
   })
 
@@ -533,6 +540,7 @@ function CompleteStep({onClose, results}: {onClose: () => void; results: ImportR
     },
     onError: (error) => {
       toast.error(`Failed to export author keys file: ${error instanceof Error ? error.message : 'Unknown error'}`)
+      reportError(error, {feature: 'wxr-import', operation: 'export-author-keys'})
     },
   })
 

--- a/frontend/apps/desktop/src/models/ai-config.ts
+++ b/frontend/apps/desktop/src/models/ai-config.ts
@@ -1,3 +1,4 @@
+import {reportError} from '@/errors'
 import {client} from '@/trpc'
 import {invalidateQueries} from '@shm/shared/models/query-client'
 import {queryKeys} from '@shm/shared/models/query-keys'
@@ -16,8 +17,9 @@ export function useAIConfig() {
 export function useSetAIConfigValue() {
   return useMutation({
     mutationFn: (input: {path: string; value: any}) => client.aiConfig.setValue.mutate(input),
-    onError() {
+    onError(err) {
       toast.error('Could not save AI config')
+      reportError(err, {feature: 'ai-config', operation: 'set-value'})
     },
     onSuccess() {
       invalidateQueries([queryKeys.AI_CONFIG])
@@ -65,8 +67,9 @@ export function useAddProvider() {
       baseUrl?: string
       authMode?: 'apiKey' | 'login'
     }) => client.aiConfig.addProvider.mutate(input),
-    onError() {
+    onError(err) {
       toast.error('Could not add provider')
+      reportError(err, {feature: 'ai-config', operation: 'add-provider'})
     },
     onSuccess() {
       invalidateProviderQueries()
@@ -85,8 +88,9 @@ export function useUpdateProvider() {
       baseUrl?: string
       authMode?: 'apiKey' | 'login'
     }) => client.aiConfig.updateProvider.mutate(input),
-    onError() {
+    onError(err) {
       toast.error('Could not update provider')
+      reportError(err, {feature: 'ai-config', operation: 'update-provider'})
     },
     onSuccess() {
       invalidateProviderQueries()
@@ -97,8 +101,9 @@ export function useUpdateProvider() {
 export function useDuplicateProvider() {
   return useMutation({
     mutationFn: (id: string) => client.aiConfig.duplicateProvider.mutate(id),
-    onError() {
+    onError(err) {
       toast.error('Could not duplicate provider')
+      reportError(err, {feature: 'ai-config', operation: 'duplicate-provider'})
     },
     onSuccess() {
       invalidateProviderQueries()
@@ -109,8 +114,9 @@ export function useDuplicateProvider() {
 export function useDeleteProvider() {
   return useMutation({
     mutationFn: (id: string) => client.aiConfig.deleteProvider.mutate(id),
-    onError() {
+    onError(err) {
       toast.error('Could not delete provider')
+      reportError(err, {feature: 'ai-config', operation: 'delete-provider'})
     },
     onSuccess() {
       invalidateProviderQueries()
@@ -121,8 +127,9 @@ export function useDeleteProvider() {
 export function useSetSelectedProvider() {
   return useMutation({
     mutationFn: (id: string) => client.aiConfig.setSelectedProvider.mutate(id),
-    onError() {
+    onError(err) {
       toast.error('Could not set selected provider')
+      reportError(err, {feature: 'ai-config', operation: 'set-selected-provider'})
     },
     onSuccess() {
       invalidateProviderQueries()

--- a/frontend/apps/desktop/src/models/documents.ts
+++ b/frontend/apps/desktop/src/models/documents.ts
@@ -1,5 +1,6 @@
 import {dispatchOnboardingDialog} from '@/components/onboarding'
 import {desktopUniversalClient} from '@/desktop-universal-client'
+import {reportError} from '@/errors'
 import {grpcClient} from '@/grpc-client'
 import {useSelectedAccountId} from '@/selected-account'
 import {client} from '@/trpc'
@@ -741,6 +742,13 @@ export async function pushResource(
         }
       } catch (error) {
         console.error('Error loading site resource for pushing to the siteUrl', uid, error)
+        reportError(error, {
+          feature: 'push-resource',
+          operation: 'resolve-site-host',
+          uid,
+          resourceId: id.id,
+          onlyPushToHost,
+        })
       }
     }),
   )
@@ -817,6 +825,13 @@ export async function pushResource(
       } catch (error) {
         console.error('Error getting peerId for host', host, error)
         updateHostStatus(host, 'error', (error as Error).message)
+        reportError(error, {
+          feature: 'push-resource',
+          operation: 'resolve-peer',
+          host,
+          resourceId: id.id,
+          onlyPushToHost,
+        })
       }
     }),
   )
@@ -839,6 +854,15 @@ export async function pushResource(
     console.error('No peers found to push to', {
       resource,
       destinationHosts,
+    })
+    const hostStatuses = status.hosts.map(({host, status, message}) => ({host, status, message}))
+    reportError(new Error('Failed to connect to any sites.'), {
+      feature: 'push-resource',
+      operation: 'no-peers',
+      resourceId: id.id,
+      onlyPushToHost,
+      destinationHosts: Array.from(destinationHosts),
+      hostStatuses,
     })
     throw new Error('Failed to connect to any sites.')
   }
@@ -873,6 +897,16 @@ export async function pushResource(
       } catch (error) {
         console.error(`== publish ${syncDebugId} == Error pushing to peer`, peerId, error)
         updatePeerStatus(peerId, 'error', (error as Error).message)
+        const hostEntry = status.hosts.find((h) => h.peerId === peerId)
+        reportError(error, {
+          feature: 'push-resource',
+          operation: 'push-to-peer',
+          host: hostEntry?.host,
+          peerId,
+          resourceId: id.id,
+          pushResourceUrl,
+          onlyPushToHost,
+        })
       }
       // console.log(`== publish ${syncDebugId} == lastProgress`, lastProgress)
       // if (lastProgress?.peersFailed ?? 0 > 0) {

--- a/frontend/apps/desktop/src/models/export-documents.tsx
+++ b/frontend/apps/desktop/src/models/export-documents.tsx
@@ -1,4 +1,5 @@
 import {useAppContext} from '@/app-context'
+import {reportError} from '@/errors'
 import {grpcClient} from '@/grpc-client'
 import {convertBlocksToMarkdown} from '@/utils/blocks-to-markdown'
 import {hmBlocksToEditorContent} from '@seed-hypermedia/client/hmblock-to-editorblock'
@@ -63,6 +64,11 @@ export function useExportDocuments() {
       })
       .catch((err) => {
         toast.error(err)
+        reportError(err, {
+          feature: 'export-documents',
+          operation: 'export',
+          docIds,
+        })
       })
   }
 }

--- a/frontend/apps/desktop/src/models/push-after-action.tsx
+++ b/frontend/apps/desktop/src/models/push-after-action.tsx
@@ -1,3 +1,4 @@
+import {reportError} from '@/errors'
 import {usePushResource} from '@/models/documents'
 import {usePushOnCopy, usePushOnPublish} from '@/models/gateway-settings'
 import {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
@@ -31,6 +32,13 @@ export function usePushAfterAction() {
       })
       promise.catch((err) => {
         console.error('[push-after-action]', params.trigger, err)
+        reportError(err, {
+          feature: 'push-after-action',
+          operation: 'top-level',
+          trigger: params.trigger,
+          resourceId: params.id.id,
+          onlyPushToHost: params.onlyPushToHost,
+        })
       })
     },
     [pushResource, pushOnPublish.data, pushOnCopy.data],

--- a/frontend/apps/desktop/src/models/site.ts
+++ b/frontend/apps/desktop/src/models/site.ts
@@ -1,3 +1,4 @@
+import {reportError} from '@/errors'
 import {grpcClient} from '@/grpc-client'
 import {client} from '@/trpc'
 import {toPlainMessage} from '@bufbuild/protobuf'
@@ -64,6 +65,12 @@ export function useSiteRegistration(accountUid: string) {
           // error is not a dealbreaker for this workflow, we still want to move to the next step
           console.error('Failed pushing resources to site', error)
           toast.error('Failed to push resources to the new site. Sync can be attempted again later.')
+          reportError(error, {
+            feature: 'site-registration',
+            operation: 'push-resources',
+            siteUrl,
+            accountUid,
+          })
         }
       }
 

--- a/frontend/apps/desktop/src/pages/settings.tsx
+++ b/frontend/apps/desktop/src/pages/settings.tsx
@@ -1,6 +1,7 @@
 import {useAppContext, useIPC} from '@/app-context'
 import {LinkDeviceDialog} from '@/components/link-device-dialog'
 import {AccountWallet, WalletPage} from '@/components/payment-settings'
+import {reportError} from '@/errors'
 import {
   useAddProvider,
   useAIProviders,
@@ -614,6 +615,11 @@ export function DeveloperSettings() {
     },
     onError: (error: unknown) => {
       toast.error('Failed to restart daemon: ' + String(error))
+      reportError(error, {
+        feature: 'settings',
+        operation: 'restart-daemon',
+        pendingEmbeddingState,
+      })
     },
   })
   const openDraftLogs = useMutation({
@@ -1246,7 +1252,15 @@ function PushSettingRow({
           onValueChange={(value) => {
             const validValue: 'always' | 'never' = value === 'never' ? 'never' : 'always'
             setMutation.mutate(validValue, {
-              onError: () => toast.error('Failed to update setting.'),
+              onError: (error: unknown) => {
+                toast.error('Failed to update setting.')
+                reportError(error, {
+                  feature: 'settings',
+                  operation: 'update-push-setting',
+                  setting: label,
+                  value: validValue,
+                })
+              },
             })
           }}
           className="flex items-center gap-4"

--- a/frontend/apps/web/app/auth.tsx
+++ b/frontend/apps/web/app/auth.tsx
@@ -24,6 +24,7 @@ import {createSecretTapUnlock} from './secret-tap-unlock'
 import * as authSession from './auth-session'
 import {preparePublicKey, signWithKeyPair} from './auth-utils'
 import {createDefaultAccountName} from './default-account-name'
+import {reportError} from './report-error'
 import {getVaultAccountSettingsUrl} from './vault-links'
 import {
   AUTH_STATE_DELEGATION_RETURN_URL,
@@ -115,7 +116,12 @@ function syncKeyPair(newKeyPair: LocalWebIdentity | null) {
 }
 
 function updateKeyPair() {
-  loadLocalWebIdentity().then(syncKeyPair).catch(console.error)
+  loadLocalWebIdentity()
+    .then(syncKeyPair)
+    .catch((err) => {
+      console.error(err)
+      reportError(err, {feature: 'auth', operation: 'load-local-identity'})
+    })
 }
 
 export function logout() {
@@ -128,6 +134,7 @@ export function logout() {
     clearAllAuthState(),
     fetch('/hm/api/auth', {method: 'DELETE', credentials: 'include'}).catch((e) => {
       console.error('Failed to clear daemon auth cookie', e)
+      reportError(e, {feature: 'auth', operation: 'logout-clear-daemon-cookie'})
     }),
   ])
     .then(() => {
@@ -135,6 +142,7 @@ export function logout() {
     })
     .catch((e) => {
       console.error('Failed to log out', e)
+      reportError(e, {feature: 'auth', operation: 'logout'})
     })
 }
 
@@ -166,6 +174,11 @@ export async function createAccount({
   if (existingStored?.vaultUrl) {
     await authSession.clearSession(existingStored.vaultUrl).catch((err) => {
       console.error('Failed to clear delegated session while creating local account', err)
+      reportError(err, {
+        feature: 'auth',
+        operation: 'create-account-clear-delegated',
+        vaultUrl: existingStored.vaultUrl,
+      })
     })
   }
 
@@ -187,6 +200,7 @@ export async function createAccount({
       }
     } catch (err) {
       console.warn('Failed to verify existing local account, proceeding with account creation', err)
+      reportError(err, {feature: 'auth', operation: 'verify-existing-account', uid})
     }
   } else {
     keyPair = await generateAndStoreKeyPair()

--- a/frontend/apps/web/app/commenting.tsx
+++ b/frontend/apps/web/app/commenting.tsx
@@ -1,4 +1,5 @@
 import {useCreateAccount} from '@/auth'
+import {reportError} from '@/report-error'
 import {useNavigate as useRemixNavigate} from '@remix-run/react'
 import {createComment, filesToIpfsBlobs} from '@seed-hypermedia/client'
 import {
@@ -171,6 +172,7 @@ export default function WebCommenting({
       // Keep the optimistic comment visible — the publish can be retried later.
       // Do NOT roll back cache or navigation; do NOT invalidate queries (would crash offline).
       console.warn('Comment publish failed, keeping optimistic comment:', _err)
+      reportError(_err, {feature: 'web-comment', operation: 'publish', docId: docId.id})
     },
     onSuccess: ({response, commentId, commentPayload}) => {
       if (isPerfEnabled()) markCommentSubmitEnd()
@@ -209,6 +211,7 @@ export default function WebCommenting({
         })
         .catch((e) => {
           console.error('Failed to process pending intent after account creation:', e)
+          reportError(e, {feature: 'web-comment', operation: 'process-pending-intent'})
         })
     },
   })

--- a/frontend/apps/web/app/report-error.test.ts
+++ b/frontend/apps/web/app/report-error.test.ts
@@ -1,0 +1,45 @@
+import {Code, ConnectError} from '@connectrpc/connect'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+const captureExceptionMock = vi.fn()
+const setTagMock = vi.fn()
+const setExtrasMock = vi.fn()
+
+vi.mock('@sentry/remix', () => ({
+  withScope: (cb: (scope: {setTag: typeof setTagMock; setExtras: typeof setExtrasMock}) => void) => {
+    cb({setTag: setTagMock, setExtras: setExtrasMock})
+  },
+  captureException: (...args: unknown[]) => captureExceptionMock(...args),
+}))
+
+beforeEach(() => {
+  captureExceptionMock.mockClear()
+  setTagMock.mockClear()
+  setExtrasMock.mockClear()
+})
+
+describe('reportError (web)', () => {
+  it('captures plain Error with feature/operation tags and extras', async () => {
+    const {reportError} = await import('./report-error')
+    const err = new Error('boom')
+    reportError(err, {feature: 'web-comment', operation: 'publish', docId: 'hm://doc'})
+    expect(captureExceptionMock).toHaveBeenCalledWith(err)
+    expect(setTagMock).toHaveBeenCalledWith('feature', 'web-comment')
+    expect(setTagMock).toHaveBeenCalledWith('operation', 'publish')
+    expect(setExtrasMock).toHaveBeenCalledWith({docId: 'hm://doc'})
+  })
+
+  it('extracts ConnectError code', async () => {
+    const {reportError} = await import('./report-error')
+    const err = new ConnectError('nope', Code.NotFound)
+    reportError(err, {feature: 'api', operation: 'load'})
+    expect(setTagMock).toHaveBeenCalledWith('connect_code', String(Code.NotFound))
+  })
+
+  it('wraps non-Error inputs', async () => {
+    const {reportError} = await import('./report-error')
+    reportError({weird: 'object'}, {feature: 'misc', operation: 'noop'})
+    const captured = captureExceptionMock.mock.calls[0]?.[0]
+    expect(captured).toBeInstanceOf(Error)
+  })
+})

--- a/frontend/apps/web/app/report-error.ts
+++ b/frontend/apps/web/app/report-error.ts
@@ -1,6 +1,5 @@
 import {ConnectError} from '@connectrpc/connect'
-import * as Sentry from '@sentry/electron/renderer'
-import {toast} from '@shm/ui/toast'
+import * as Sentry from '@sentry/remix'
 
 export type ReportErrorContext = {
   feature?: string
@@ -9,9 +8,9 @@ export type ReportErrorContext = {
 }
 
 /**
- * Report an error to Sentry without surfacing it to the user.
- * Use for caught errors where the user already saw a generic toast (or where
- * the failure is invisible by design) but engineering still needs the details.
+ * Report an error to Sentry without showing it to the user.
+ * Mirrors the desktop `reportError` so call sites stay symmetric across apps.
+ * No-ops when Sentry isn't initialized (its own captureException already does).
  */
 export function reportError(input: unknown, ctx?: ReportErrorContext): void {
   const error = toError(input)
@@ -31,13 +30,9 @@ export function reportError(input: unknown, ctx?: ReportErrorContext): void {
     }
     Sentry.captureException(error)
   })
-  console.error('📣 🚨', error.message, ctx)
-}
-
-export default function appError(message: string, metadata?: Record<string, unknown>): void {
-  toast.error(message)
-  const errorSource = metadata?.error ?? new Error(message)
-  reportError(errorSource, {...metadata, _toastMessage: message})
+  if (typeof console !== 'undefined' && typeof console.error === 'function') {
+    console.error('📣 🚨', error.message, ctx)
+  }
 }
 
 function toError(input: unknown): Error {
@@ -53,7 +48,7 @@ function toError(input: unknown): Error {
 function serializeMetadata(metadata: Headers | undefined): Record<string, string> | undefined {
   if (!metadata) return undefined
   const out: Record<string, string> = {}
-  metadata.forEach((value: string, key: string) => {
+  metadata.forEach((value, key) => {
     out[key] = value
   })
   return out

--- a/frontend/apps/web/app/routes/hm.device-link.$.tsx
+++ b/frontend/apps/web/app/routes/hm.device-link.$.tsx
@@ -5,6 +5,7 @@ import {defaultSiteIcon} from '@/meta'
 import {PageFooter} from '@/page-footer'
 import {getOptimizedImageUrl, NavigationLoadingContent, WebSiteProvider} from '@/providers'
 import {parseRequest} from '@/request'
+import {reportError} from '@/report-error'
 import {WebSiteHeader} from '@/web-site-header'
 import {unwrap} from '@/wrapping'
 import {wrapJSON} from '@/wrapping.server'
@@ -672,6 +673,7 @@ function useLinkDevice(localIdentity: LocalWebIdentity) {
           state: 'error',
           error: (error as Error).message,
         })
+        reportError(error, {feature: 'device-link', operation: 'link-device'})
       },
       onSuccess: (data) => {
         invalidateQueries([queryKeys.ACCOUNT])


### PR DESCRIPTION
## Summary

- Add shared Sentry `reportError` helpers for desktop and web that tag feature/operation context, include extra metadata, and extract Connect RPC error codes.
- Report caught push failures with destination host, peer, resource, and status context so server push errors are diagnosable when shown only as generic UI failures.
- Add error reporting to related caught frontend workflows including publish, comments, imports, auth, settings, payments, exports, and AI config mutations.
- Add Vitest coverage for desktop and web error reporting behavior, including non-`Error` inputs and `ConnectError` handling.

---

Fixes #671