### PR TITLE
fix(activity): use source document for comment mention notifications

### DIFF
--- a/backend/api/activity/v1alpha/activity.go
+++ b/backend/api/activity/v1alpha/activity.go
@@ -437,9 +437,10 @@ func (srv *Server) ListEvents(ctx context.Context, req *activity.ListEventsReque
 				blobID      = stmt.ColumnInt64(11)
 				observeTime = timestamppb.New(time.Unix(stmt.ColumnInt64(12), 0))
 				tsid        = blob.TSID(stmt.ColumnText(13))
-				//extraAttrs  = stmt.ColumnText(14)
-				isDeleted = stmt.ColumnText(16) == "1"
-				source    = stmt.ColumnText(18)
+				//extraAttrs        = stmt.ColumnText(14)
+				isDeleted         = stmt.ColumnText(16) == "1"
+				source            = stmt.ColumnText(18)
+				sourceResourceIRI = stmt.ColumnText(19)
 			)
 			genesisBlobIDs = append(genesisBlobIDs, strconv.FormatInt(stmt.ColumnInt64(17), 10))
 			if target == "" && blobType != "Comment" {
@@ -447,7 +448,7 @@ func (srv *Server) ListEvents(ctx context.Context, req *activity.ListEventsReque
 			}
 
 			if blobType == "Comment" {
-				sourceDoc = target
+				sourceDoc = sourceResourceIRI
 				source = "hm://" + author + "/" + tsid.String()
 				eventTime = timestamppb.New(tsid.Timestamp())
 
@@ -867,12 +868,14 @@ SELECT distinct
         WHEN structural_blobs.type != 'Change' THEN structural_blobs.genesis_blob
         ELSE coalesce(structural_blobs.genesis_blob, structural_blobs.id)
     END AS effective_genesis,
-	r2.iri AS source_iri
+	r2.iri AS source_iri,
+	source_resources.iri AS source_resource_iri
 FROM resource_links
 JOIN structural_blobs ON structural_blobs.id = resource_links.source
 JOIN blobs INDEXED BY blobs_metadata ON blobs.id = structural_blobs.id
 JOIN public_keys ON public_keys.id = structural_blobs.author
 JOIN resources ON resources.id = resource_links.target
+LEFT JOIN resources source_resources ON source_resources.id = structural_blobs.resource
 LEFT JOIN resources r2
   ON r2.genesis_blob = CASE
         WHEN structural_blobs.type != 'Change' THEN structural_blobs.genesis_blob

--- a/backend/api/activity/v1alpha/activity_test.go
+++ b/backend/api/activity/v1alpha/activity_test.go
@@ -3,6 +3,7 @@ package activity
 import (
 	context "context"
 	"fmt"
+	"seed/backend/blob"
 	"seed/backend/core"
 	activity "seed/backend/genproto/activity/v1alpha"
 	"seed/backend/logging"
@@ -11,6 +12,7 @@ import (
 	"seed/backend/util/sqlite"
 	"seed/backend/util/sqlite/sqlitex"
 	"testing"
+	"time"
 
 	"github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/require"
@@ -135,6 +137,59 @@ func TestListEventsEmitsNextTokenWhenDedupShortensPage(t *testing.T) {
 	}
 	require.Contains(t, page2IDs, int64(1),
 		"id=1 must be reachable via pagination after dedup shortens page 1")
+}
+
+func TestListEventsCommentMentionSourceDocumentUsesCommentTarget(t *testing.T) {
+	alice := newTestServer(t, "alice")
+	ctx := context.Background()
+
+	author, err := core.DecodePrincipal("z6Mkv1LjkRosErBhmqrkmb5sDxXNs6EzBDSD8ktywpYLLGuC")
+	require.NoError(t, err)
+	mentioned, err := core.DecodePrincipal("z6MkrJVnaZkeF1cWQrJ7g4LtpZvZQJtnYFWCKq66P2pyGcGP")
+	require.NoError(t, err)
+	commentTime := time.UnixMilli(1_000).UTC()
+	commentTSID := blob.NewTSID(commentTime, []byte("comment"))
+
+	require.NoError(t, alice.db.WithSave(ctx, func(conn *sqlite.Conn) error {
+		if err := sqlitex.Exec(conn, `INSERT INTO public_keys (id, principal) VALUES (1, ?), (2, ?);`, nil, []byte(author), []byte(mentioned)); err != nil {
+			return err
+		}
+
+		hash, err := multihash.Sum([]byte("comment-blob"), multihash.SHA2_256, -1)
+		if err != nil {
+			return err
+		}
+		profileHash, err := multihash.Sum([]byte("profile-resource"), multihash.SHA2_256, -1)
+		if err != nil {
+			return err
+		}
+		if err := sqlitex.Exec(conn, `INSERT INTO blobs (id, multihash, codec, data, size, insert_time) VALUES (100, ?, ?, ?, 1, 1), (101, ?, ?, ?, 1, 1);`, nil, []byte(hash), int64(0x55), []byte{1}, []byte(profileHash), int64(0x55), []byte{1}); err != nil {
+			return err
+		}
+
+		docIRI := "hm://" + author.String() + "/doc"
+		mentionedProfileIRI := "hm://" + mentioned.String() + "/:profile"
+		if err := sqlitex.Exec(conn, `INSERT INTO resources (id, iri, owner, genesis_blob, create_time) VALUES (10, ?, 1, 100, 0), (20, ?, 2, 101, 0);`, nil, docIRI, mentionedProfileIRI); err != nil {
+			return err
+		}
+
+		if err := sqlitex.Exec(conn, `INSERT INTO structural_blobs (id, type, ts, author, genesis_blob, resource, extra_attrs) VALUES (100, 'Comment', ?, 1, 100, 10, json_object('tsid', ?));`, nil, commentTime.UnixMilli(), commentTSID.String()); err != nil {
+			return err
+		}
+		return sqlitex.Exec(conn, `INSERT INTO resource_links (source, target, type, is_pinned, extra_attrs) VALUES (100, 20, 'comment/Embed', 0, '{}');`, nil)
+	}))
+
+	events, err := alice.ListEvents(ctx, &activity.ListEventsRequest{
+		PageSize:        10,
+		FilterEventType: []string{"comment/Embed"},
+	})
+	require.NoError(t, err)
+	require.Len(t, events.Events, 1)
+
+	mention := events.Events[0].GetNewMention()
+	require.NotNil(t, mention)
+	require.Equal(t, "hm://"+author.String()+"/doc", mention.SourceDocument)
+	require.Equal(t, "hm://"+mentioned.String()+"/:profile", mention.Target)
 }
 
 // TODO: update profile idempotent no change


### PR DESCRIPTION
## Summary

Fixes #693.

In `ActivityFeed.ListEvents`, comment mention events were incorrectly setting `newMention.sourceDocument` to the mention target. For account/profile mentions, that meant the source document became `hm://<mentioned-account>/:profile`, causing notification titles like `mentioned you in :profile` and causing web site-scoped inbox filtering to hide the notification.

This PR keeps `newMention.target` as the mentioned entity, but sets `newMention.sourceDocument` from the comment blob's resource IRI.

## Changes

- Include the comment/source structural blob resource IRI in the mentions feed query.
- Use that source resource IRI for `SourceDocument` when the mention source blob is a `Comment`.
- Add a regression test covering a comment mention of `hm://<account>/:profile` inside `hm://<author>/doc`.

## Validation

```bash
go test ./backend/api/activity/v1alpha
```
