### PR TITLE
fix(cli): restore npm-installable published package

### DIFF
--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -174,6 +174,37 @@ jobs:
             exit 1
           fi
 
+      - name: Verify published tarball installs cleanly
+        working-directory: frontend/apps/cli
+        run: |
+          set -euo pipefail
+
+          PACK_DIR=$(mktemp -d)
+          INSTALL_DIR=$(mktemp -d)
+          trap 'rm -rf "$PACK_DIR" "$INSTALL_DIR"' EXIT
+
+          TARBALL=$(npm pack --pack-destination "$PACK_DIR")
+          TARBALL_PATH="$PACK_DIR/$TARBALL"
+
+          PACKAGE_JSON=$(mktemp)
+          trap 'rm -rf "$PACK_DIR" "$INSTALL_DIR" "$PACKAGE_JSON"' EXIT
+          tar -xOf "$TARBALL_PATH" package/package.json > "$PACKAGE_JSON"
+
+          node -e '
+            const fs = require("node:fs")
+            const pkg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"))
+            for (const field of ["dependencies", "optionalDependencies", "peerDependencies"]) {
+              for (const [name, spec] of Object.entries(pkg[field] || {})) {
+                if (typeof spec === "string" && spec.startsWith("workspace:")) {
+                  throw new Error(`Packed CLI contains unsupported workspace protocol in ${field}.${name}: ${spec}`)
+                }
+              }
+            }
+          ' "$PACKAGE_JSON"
+
+          npm install -g "$TARBALL_PATH" --prefix "$INSTALL_DIR"
+          "$INSTALL_DIR/bin/seed-hypermedia" --version >/dev/null
+
       - name: Publish
         run: npm publish --access public
         working-directory: frontend/apps/cli

--- a/frontend/apps/cli/package.json
+++ b/frontend/apps/cli/package.json
@@ -54,7 +54,6 @@
     "@ipld/dag-cbor": "^9.2.2",
     "@noble/ed25519": "^2.2.0",
     "@noble/hashes": "^1.7.0",
-    "@seed-hypermedia/client": "workspace:*",
     "bip39": "^3.1.0",
     "pdfjs-dist": "^4.2.67",
     "chalk": "^5.3.0",
@@ -65,6 +64,7 @@
     "yaml": "^2.6.0"
   },
   "devDependencies": {
+    "@seed-hypermedia/client": "workspace:*",
     "@types/bun": "latest",
     "@types/node": "^20.0.0",
     "typescript": "^5.7.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,9 +172,6 @@ importers:
       '@noble/hashes':
         specifier: ^1.7.0
         version: 1.8.0
-      '@seed-hypermedia/client':
-        specifier: workspace:*
-        version: link:../../packages/client
       bip39:
         specifier: ^3.1.0
         version: 3.1.0
@@ -200,6 +197,9 @@ importers:
         specifier: ^2.6.0
         version: 2.8.2
     devDependencies:
+      '@seed-hypermedia/client':
+        specifier: workspace:*
+        version: link:../../packages/client
       '@types/bun':
         specifier: latest
         version: 1.3.11


### PR DESCRIPTION
## Summary

This fixes fresh npm installs of `@seed-hypermedia/cli`, which currently fail with:

```text
npm ERR! code EUNSUPPORTEDPROTOCOL
npm ERR! Unsupported URL Type "workspace:": workspace:*
```

Tagging @juligasa because the regression was introduced after the CLI dependency layout changed and the publish workflow was switched to `npm publish`.

## Root cause

The CLI currently publishes `@seed-hypermedia/client` as a runtime dependency with:

```json
"@seed-hypermedia/client": "workspace:*"
```

That is valid inside the monorepo, but it is not valid for consumers installing from npm.

The bug became possible when the publish workflow switched from `pnpm publish` to `npm publish`, because `npm publish` preserves the `workspace:*` spec in the packed manifest instead of rewriting it.

The regression after the last good stable version (`0.1.3`) came from:

- `a789831b3a1172ba2ea1dc79a5cfd11248eb5fb9`

That commit moved `@seed-hypermedia/client` back into `dependencies`, which caused `0.1.4` and `0.1.5` to be published with an invalid runtime dependency.

## What this PR changes

### 1) Fix the CLI package manifest

Moves `@seed-hypermedia/client` from `dependencies` back to `devDependencies`.

This is correct because the CLI bundles the client into `dist/index.js` during build, so it is not needed as a runtime dependency for npm consumers.

### 2) Add a publish-time regression guard

Before publishing the CLI, the workflow now:

1. packs the tarball with `npm pack`
2. inspects the packed `package.json`
3. fails if any `dependencies`, `optionalDependencies`, or `peerDependencies` contain a `workspace:` spec
4. smoke-installs the packed tarball into a temp prefix
5. runs `seed-hypermedia --version`

This prevents future releases from silently shipping an un-installable package.

## Validation

I validated the bug locally first.

### Reproduced the broken current release

```bash
npm install -g @seed-hypermedia/cli@0.1.5 --prefix "$(mktemp -d)"
```

Result:

```text
npm ERR! code EUNSUPPORTEDPROTOCOL
npm ERR! Unsupported URL Type "workspace:": workspace:*
```

### Verified historical behavior

Confirmed:

- works: `0.0.1`, `0.0.8`, `0.1.3`, `0.1.0-alpha.7`
- broken: `0.0.2`, `0.1.4`, `0.1.5`

So `0.1.3` was the last working stable release, and `0.1.4` reintroduced the regression.

### Validated this fix locally

Passed:

```bash
pnpm --filter @seed-hypermedia/cli typecheck
pnpm --filter @seed-hypermedia/cli test:unit
pnpm --filter @seed-hypermedia/cli test
pnpm typecheck
pnpm test
```

I also validated the publish artifact directly:

```bash
pnpm --filter @seed-hypermedia/cli build
cd frontend/apps/cli
npm pack --pack-destination <tmpdir>
npm install -g <packed-tarball> --prefix <tmp-prefix>
<tmp-prefix>/bin/seed-hypermedia --version
```

This succeeded, and the packed `package.json` no longer contains any `workspace:` runtime dependency spec.

### Additional notes

- `pnpm audit` still reports existing repo-wide vulnerabilities unrelated to this change.
- `agent-ci` could not be run locally in this environment because `/var/run/docker.sock` is unavailable.

## Why this is the right fix

This addresses both:

- the immediate install failure for npm consumers
- the workflow gap that allowed the regression to ship

So even if someone accidentally reintroduces a workspace dependency later, the publish job should fail before release.
