### PR TITLE
feat(frontend): keep documents visible during transient errors

### DIFF
--- a/frontend/apps/cli/cli-doc.md
+++ b/frontend/apps/cli/cli-doc.md
@@ -1,0 +1,3 @@
+## Hello new CLI doc
+
+first block here.

--- a/frontend/apps/desktop/src/root.tsx
+++ b/frontend/apps/desktop/src/root.tsx
@@ -175,6 +175,12 @@ function useDarkMode(): boolean {
 // Register the desktop QueryClient so shared invalidateQueries() works
 registerQueryClient(queryClient)
 
+// Dev-only: expose the QueryClient on window so we can poke the React Query cache from
+// DevTools (e.g. forcing transient resource errors to verify the document banner).
+if (process.env.NODE_ENV !== 'production' && typeof window !== 'undefined') {
+  ;(window as any).__qc = queryClient
+}
+
 // Broadcast invalidations to all windows via IPC (local invalidation handled by invalidateQueries itself)
 onQueryInvalidation((queryKey: QueryKey) => {
   ipc.send?.('invalidate_queries', queryKey)

--- a/frontend/apps/web/app/providers.tsx
+++ b/frontend/apps/web/app/providers.tsx
@@ -73,6 +73,10 @@ function getQueryClient() {
   if (!browserQueryClient) {
     browserQueryClient = createQueryClient()
     registerQueryClient(browserQueryClient)
+    // Dev-only: expose for DevTools console (e.g. forcing transient resource errors).
+    if (import.meta.env?.DEV) {
+      ;(window as any).__qc = browserQueryClient
+    }
   }
   return browserQueryClient
 }

--- a/frontend/packages/shared/src/models/__tests__/document-machine.test.ts
+++ b/frontend/packages/shared/src/models/__tests__/document-machine.test.ts
@@ -1301,4 +1301,71 @@ describe('DocumentLifecycle machine', () => {
       actor.stop()
     })
   })
+
+  describe('transient resource error', () => {
+    it('resource.transientError on loaded keeps state in loaded and stores the error', () => {
+      const actor = createTestActor()
+      actor.start()
+      loadDocument(actor)
+      expect(actor.getSnapshot().value).toBe('loaded')
+
+      actor.send({
+        type: 'resource.transientError',
+        error: {kind: 'refetch-error', message: 'peer unreachable'},
+      })
+      expect(actor.getSnapshot().value).toBe('loaded')
+      expect(actor.getSnapshot().context.transientResourceError).toEqual({
+        kind: 'refetch-error',
+        message: 'peer unreachable',
+      })
+      actor.stop()
+    })
+
+    it('resource.recovered clears the transient error without touching state', () => {
+      const actor = createTestActor()
+      actor.start()
+      loadDocument(actor)
+      actor.send({type: 'resource.transientError', error: {kind: 'discovering'}})
+      expect(actor.getSnapshot().context.transientResourceError).toEqual({kind: 'discovering'})
+
+      actor.send({type: 'resource.recovered'})
+      expect(actor.getSnapshot().value).toBe('loaded')
+      expect(actor.getSnapshot().context.transientResourceError).toBeNull()
+      actor.stop()
+    })
+
+    it('document.loaded populates lastGoodDocument and lastGoodVersion', () => {
+      const actor = createTestActor()
+      actor.start()
+      loadDocument(actor)
+      const snap = actor.getSnapshot()
+      expect(snap.context.lastGoodDocument).toBe(mockDocument)
+      expect(snap.context.lastGoodVersion).toBe('bafyabc.bafydef')
+      actor.stop()
+    })
+
+    it('document.remoteUpdate refreshes lastGoodDocument and lastGoodVersion', () => {
+      const actor = createTestActor()
+      actor.start()
+      loadDocument(actor)
+      const updated = {...mockDocument, version: 'bafyabc.bafyupdated'} as HMDocument
+      actor.send({type: 'document.remoteUpdate', document: updated})
+      const snap = actor.getSnapshot()
+      expect(snap.context.lastGoodDocument).toBe(updated)
+      expect(snap.context.lastGoodVersion).toBe('bafyabc.bafyupdated')
+      actor.stop()
+    })
+
+    it('transient error fires during editing without changing the parallel state', () => {
+      const actor = createTestActor()
+      actor.start()
+      loadDocument(actor)
+      actor.send({type: 'edit.start'})
+      const before = actor.getSnapshot().value
+      actor.send({type: 'resource.transientError', error: {kind: 'not-found-transient'}})
+      expect(actor.getSnapshot().value).toEqual(before)
+      expect(actor.getSnapshot().context.transientResourceError).toEqual({kind: 'not-found-transient'})
+      actor.stop()
+    })
+  })
 })

--- a/frontend/packages/shared/src/models/document-machine.ts
+++ b/frontend/packages/shared/src/models/document-machine.ts
@@ -107,7 +107,32 @@ export type DocumentMachineContext = {
    */
   pendingPublish: boolean
   error: unknown
+  /**
+   * Last document payload seen via `document.loaded` or `document.remoteUpdate`. Survives
+   * subsequent transient resource failures so UI can keep rendering the document while a
+   * background refetch is errored / discovering / not-found.
+   */
+  lastGoodDocument: HMDocument | null
+  /** Version string for {@link lastGoodDocument}; mirrors `publishedVersion` at the time of capture. */
+  lastGoodVersion: string | null
+  /**
+   * Non-fatal resource fetch state surfaced by the consumer (`useResource`). Drives a banner
+   * in the page header without changing the machine's top-level state. `null` when the
+   * resource fetch is in a healthy state.
+   */
+  transientResourceError: TransientResourceError
 }
+
+/**
+ * Non-fatal resource fetch state derived by the consumer of {@link useResource}.
+ * Stored in {@link DocumentMachineContext} so banners and debug tooling read from
+ * a single source of truth.
+ */
+export type TransientResourceError =
+  | {kind: 'refetch-error'; message: string}
+  | {kind: 'discovering'}
+  | {kind: 'not-found-transient'}
+  | null
 
 /** All events the machine can receive. */
 export type DocumentMachineEvent =
@@ -154,6 +179,8 @@ export type DocumentMachineEvent =
   | {type: 'rebase.apply'; mergedBlocks: HMBlockNode[]; newDocument: HMDocument}
   | {type: 'rebase.detectConflict'; conflictedBlockIds: string[]; author: string | null}
   | {type: 'rebase.dismiss'}
+  | {type: 'resource.transientError'; error: NonNullable<TransientResourceError>}
+  | {type: 'resource.recovered'}
 
 /** Input for the writeDraft actor. */
 export type WriteDraftInput = {
@@ -233,6 +260,27 @@ export const documentMachine = setup({
         }
         return null
       },
+      lastGoodDocument: ({context, event}) => {
+        if (event.type === 'document.loaded' || event.type === 'document.remoteUpdate') {
+          return event.document
+        }
+        return context.lastGoodDocument
+      },
+      lastGoodVersion: ({context, event}) => {
+        if (event.type === 'document.loaded' || event.type === 'document.remoteUpdate') {
+          return event.document.version
+        }
+        return context.lastGoodVersion
+      },
+    }),
+    setTransientResourceError: assign({
+      transientResourceError: ({context, event}) => {
+        if (event.type !== 'resource.transientError') return context.transientResourceError
+        return event.error
+      },
+    }),
+    clearTransientResourceError: assign({
+      transientResourceError: null,
     }),
     setMetadata: assign({
       metadata: ({context, event}) => {
@@ -406,6 +454,14 @@ export const documentMachine = setup({
         if (event.type !== 'rebase.apply') return context.baseBlocks
         return event.mergedBlocks
       },
+      lastGoodDocument: ({context, event}) => {
+        if (event.type !== 'rebase.apply') return context.lastGoodDocument
+        return event.newDocument
+      },
+      lastGoodVersion: ({context, event}) => {
+        if (event.type !== 'rebase.apply') return context.lastGoodVersion
+        return event.newDocument.version ?? context.lastGoodVersion
+      },
       mineTouchedIds: [],
       pendingRemoteDocument: null,
       pendingRemoteVersion: null,
@@ -559,6 +615,14 @@ export const documentMachine = setup({
         if (!doc) return null
         return hmBlocksToEditorContent(doc.content ?? [], {childrenType: 'Group'})
       },
+      lastGoodDocument: ({context, event}) => {
+        const doc = (event as any).output as HMDocument
+        return doc ?? context.lastGoodDocument
+      },
+      lastGoodVersion: ({context, event}) => {
+        const doc = (event as any).output as HMDocument
+        return doc?.version ?? context.lastGoodVersion
+      },
     }),
     setEditorBaselineFromSnapshot: assign({
       editorBaseline: ({event, context}) => {
@@ -629,6 +693,12 @@ export const documentMachine = setup({
     'childDraftRefs.changed': {
       actions: ['updateChildDraftRefs'],
     },
+    'resource.transientError': {
+      actions: ['setTransientResourceError'],
+    },
+    'resource.recovered': {
+      actions: ['clearTransientResourceError'],
+    },
   },
   context: ({input}) => ({
     documentId: input.documentId,
@@ -664,6 +734,9 @@ export const documentMachine = setup({
     referencedChildDraftIds: [],
     pendingDeletedChildDraftIds: [],
     error: null,
+    lastGoodDocument: null,
+    lastGoodVersion: null,
+    transientResourceError: null,
   }),
   initial: 'loading',
   states: {

--- a/frontend/packages/shared/src/models/use-document-machine.ts
+++ b/frontend/packages/shared/src/models/use-document-machine.ts
@@ -14,6 +14,7 @@ import {
   DiscardDraftInput,
   PendingRebase,
   PublishInput,
+  TransientResourceError,
   WriteDraftInput,
 } from './document-machine'
 import {EditorHandlers, EditorHandlersContext} from './editor-handlers-context'
@@ -307,6 +308,40 @@ export function useExistingDraftSync(existingDraft: {id: string} | false | undef
   }, [actorRef, existingDraft])
 }
 
+/**
+ * Sync transient resource fetch state (refetch errors, discovery flapping, transient
+ * not-found) into the machine. Dispatches `resource.transientError` when a non-null
+ * error appears or changes, and `resource.recovered` once the resource fetch is healthy
+ * again. The machine stores the error in context without changing its top-level state,
+ * so the document keeps rendering while the consumer surfaces a banner.
+ */
+export function useResourceTransientSync(transientError: TransientResourceError) {
+  const actorRef = useDocumentMachineRef()
+  const prevRef = useRef<TransientResourceError>(null)
+
+  useEffect(() => {
+    const prev = prevRef.current
+    if (!sameTransientError(prev, transientError)) {
+      prevRef.current = transientError
+      if (transientError) {
+        actorRef.send({type: 'resource.transientError', error: transientError})
+      } else {
+        actorRef.send({type: 'resource.recovered'})
+      }
+    }
+  }, [actorRef, transientError])
+}
+
+function sameTransientError(a: TransientResourceError, b: TransientResourceError): boolean {
+  if (a === b) return true
+  if (!a || !b) return false
+  if (a.kind !== b.kind) return false
+  if (a.kind === 'refetch-error' && b.kind === 'refetch-error') {
+    return a.message === b.message
+  }
+  return true
+}
+
 // -- Selectors --
 
 /** Whether the machine is in the `loading` state. */
@@ -394,6 +429,21 @@ export function selectNavigation(snapshot: DocumentMachineSnapshot): HMNavigatio
 }
 
 /** The current error, if any (available in both loading and error states). */
+/** Last document payload the machine accepted; survives transient resource refetch failures. */
+export function selectLastGoodDocument(snapshot: DocumentMachineSnapshot): HMDocument | null {
+  return snapshot.context.lastGoodDocument
+}
+
+/** Version of {@link selectLastGoodDocument}. */
+export function selectLastGoodVersion(snapshot: DocumentMachineSnapshot): string | null {
+  return snapshot.context.lastGoodVersion
+}
+
+/** Non-fatal resource fetch state surfaced by the consumer; `null` when the resource is healthy. */
+export function selectTransientResourceError(snapshot: DocumentMachineSnapshot): TransientResourceError {
+  return snapshot.context.transientResourceError
+}
+
 export function selectError(snapshot: DocumentMachineSnapshot): unknown {
   return snapshot.context.error
 }

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -58,9 +58,11 @@ import {
   useDocumentSend,
   useDocumentSync,
   useDraftResolutionSync,
+  useResourceTransientSync,
   useScrollSync,
   useVersionLatestSync,
 } from '@shm/shared/models/use-document-machine'
+import type {TransientResourceError} from '@shm/shared/models/document-machine'
 import {useEditorGate} from '@shm/shared/models/use-editor-gate'
 import {getRoutePanel} from '@shm/shared/routes'
 import {getBreadcrumbDocumentIds, isDraftPathSegment} from '@shm/shared/utils/breadcrumbs'
@@ -452,6 +454,17 @@ export function ResourcePage({
     recursive: true,
   })
 
+  // Once a real document has been seen, keep DocumentMachineProvider mounted across any
+  // subsequent transient resource failures (refetch errors, discovery flapping, transient
+  // not-found from a stale daemon `latest` pointer). Without this sticky gate, the early
+  // returns below would unmount DocumentBody and destroy the XState actor on each blip.
+  const hasEverLoadedRef = useRef(false)
+  const lastGoodDocumentRef = useRef<HMDocument | null>(null)
+  if (resource.data?.type === 'document') {
+    hasEverLoadedRef.current = true
+    lastGoodDocumentRef.current = resource.data.document
+  }
+
   // docId.uid determines the site header — for site-profile, docId IS the site context
   const siteHomeId = hmId(docId.uid, {latest: true})
   const siteHomeResource = useResource(siteHomeId, {subscribed: true})
@@ -471,6 +484,22 @@ export function ResourcePage({
     subscribed: true,
     recursive: true,
   })
+
+  // Transient (non-fatal) resource state surfaced as a banner under the site header
+  // while the document keeps rendering. Only meaningful after the doc has loaded at
+  // least once; before that, the regular loading/error branches still take over.
+  const transientResourceError: TransientResourceError = (() => {
+    if (!hasEverLoadedRef.current) return null
+    if (resource.data?.type === 'error') {
+      const msg = resource.data.message ?? 'Refresh failed'
+      // Permission errors are persistent, not transient — leave to the regular branch.
+      if (msg.toLowerCase().includes('permission')) return null
+      return {kind: 'refetch-error', message: msg}
+    }
+    if (resource.isDiscovering) return {kind: 'discovering'}
+    if (resource.data?.type === 'not-found') return {kind: 'not-found-transient'}
+    return null
+  })()
 
   // Site profile view: subscribe to and discover the profile account, then render profile content
   if (isSiteProfile) {
@@ -498,7 +527,7 @@ export function ResourcePage({
   }
 
   // Loading state - should not show during SSR if data was prefetched
-  if (resource.isInitialLoading) {
+  if (resource.isInitialLoading && !hasEverLoadedRef.current) {
     return (
       <PageWrapper siteHomeId={siteHomeId} docId={docId} headerData={headerData} rightActions={rightActions}>
         <div className="flex flex-1 items-center justify-center">
@@ -522,7 +551,7 @@ export function ResourcePage({
       (resource.data.type === 'error' && !resource.data.message?.toLowerCase?.().includes('permission')))
 
   // Handle discovery state
-  if (resource.isDiscovering && !hasUnpublishedDraft) {
+  if (resource.isDiscovering && !hasUnpublishedDraft && !hasEverLoadedRef.current) {
     return (
       <PageWrapper siteHomeId={siteHomeId} docId={docId} headerData={headerData} rightActions={rightActions}>
         <PageDiscovery />
@@ -532,7 +561,7 @@ export function ResourcePage({
   }
 
   // Handle not-found
-  if ((!resource.data || resource.data.type === 'not-found') && !hasUnpublishedDraft) {
+  if ((!resource.data || resource.data.type === 'not-found') && !hasUnpublishedDraft && !hasEverLoadedRef.current) {
     return (
       <PageWrapper siteHomeId={siteHomeId} docId={docId} headerData={headerData} rightActions={rightActions}>
         <PageNotFound />
@@ -541,7 +570,7 @@ export function ResourcePage({
     )
   }
 
-  // Handle tombstone (deleted)
+  // Handle tombstone (deleted) — real deletion, not transient. Always unmount.
   if (!hasUnpublishedDraft && (resource.isTombstone || resource.data?.type === 'tombstone')) {
     const isCommentRoute = route.key === 'comments'
     return (
@@ -552,7 +581,7 @@ export function ResourcePage({
     )
   }
 
-  // Handle private document (permission denied)
+  // Handle private document (permission denied) — persistent state, always unmount.
   if (resource.data?.type === 'error' && resource.data.message.toLowerCase().includes('permission')) {
     return (
       <PageWrapper siteHomeId={siteHomeId} docId={docId} headerData={headerData} rightActions={rightActions}>
@@ -562,8 +591,9 @@ export function ResourcePage({
     )
   }
 
-  // Handle error
-  if (!hasUnpublishedDraft && resource.data?.type === 'error') {
+  // Handle error — only if we never loaded successfully. Otherwise fall through to the
+  // success render path with a banner so the user keeps the document in view.
+  if (!hasUnpublishedDraft && resource.data?.type === 'error' && !hasEverLoadedRef.current) {
     return (
       <PageWrapper siteHomeId={siteHomeId} docId={docId} headerData={headerData} rightActions={rightActions}>
         <div className="flex flex-1 items-center justify-center p-8">
@@ -638,6 +668,10 @@ export function ResourcePage({
   let document: HMDocument
   if (resource.data?.type === 'document') {
     document = resource.data.document
+  } else if (lastGoodDocumentRef.current) {
+    // Transient refetch failure / not-found / discovery flap — keep showing the last
+    // good document. The banner in PageWrapper informs the user.
+    document = lastGoodDocumentRef.current
   } else if (hasUnpublishedDraft) {
     document = {
       account: docId.uid,
@@ -686,6 +720,7 @@ export function ResourcePage({
         document={document}
         rightActions={rightActions}
         editNavPane={editNavPane}
+        transientResourceError={transientResourceError}
       >
         <DocumentBody
           docId={docId}
@@ -716,6 +751,7 @@ export function ResourcePage({
           ssrContentHTML={ssrContentHTML}
           perspectiveAccountUid={perspectiveAccountUid}
           linkExtensionOptions={linkExtensionOptions}
+          transientResourceError={transientResourceError}
         />
       </PageWrapper>
       {machineExtras}
@@ -783,6 +819,7 @@ export function PageWrapper({
   isMainFeedVisible = false,
   rightActions,
   editNavPane,
+  transientResourceError,
 }: {
   siteHomeId: UnpackedHypermediaId
   docId: UnpackedHypermediaId
@@ -792,6 +829,8 @@ export function PageWrapper({
   isMainFeedVisible?: boolean
   rightActions?: React.ReactNode
   editNavPane?: React.ReactNode
+  /** Non-fatal resource fetch state rendered as a banner below the header. */
+  transientResourceError?: TransientResourceError
 }) {
   // Mobile: let content flow naturally (document scroll)
   // Desktop: fixed height container (element scroll via ScrollArea in children)
@@ -853,7 +892,33 @@ export function PageWrapper({
         rightActions={rightActions}
         editNavPane={editNavPane}
       />
+      <TransientResourceBanner error={transientResourceError ?? null} />
       {children}
+    </div>
+  )
+}
+
+function TransientResourceBanner({error}: {error: TransientResourceError}) {
+  if (!error) return null
+  const tone =
+    error.kind === 'refetch-error'
+      ? 'bg-amber-100 text-amber-900 dark:bg-amber-900/40 dark:text-amber-100'
+      : 'bg-muted text-muted-foreground'
+  let message: string
+  switch (error.kind) {
+    case 'refetch-error':
+      message = `Couldn't refresh from peers. Showing last loaded version. (${error.message})`
+      break
+    case 'discovering':
+      message = 'Looking for newer version…'
+      break
+    case 'not-found-transient':
+      message = 'Document temporarily unreachable. Retrying…'
+      break
+  }
+  return (
+    <div role="status" className={cn('px-4 py-2 text-xs', tone)} data-testid="transient-resource-banner">
+      {message}
     </div>
   )
 }
@@ -889,6 +954,7 @@ function DocumentBody({
   ssrContentHTML,
   perspectiveAccountUid,
   linkExtensionOptions,
+  transientResourceError,
 }: {
   docId: UnpackedHypermediaId
   document: HMDocument
@@ -932,6 +998,8 @@ function DocumentBody({
   perspectiveAccountUid?: string | null
   /** Options passed to the link extension. */
   linkExtensionOptions?: LinkExtensionOptions
+  /** Non-fatal resource fetch state synced into the machine context. */
+  transientResourceError?: TransientResourceError
 }) {
   // Sync document into state machine
   useDocumentSync(document)
@@ -943,6 +1011,8 @@ function DocumentBody({
   useAccountSync(signingAccountId, publishAccountUid)
   // Forward scroll events from the scroll container to the machine
   useScrollSync()
+  // Surface transient resource fetch state inside the machine for debug / inner consumers.
+  useResourceTransientSync(transientResourceError ?? null)
   // Sync draft resolution — machine stays in loading until this settles.
   // undefined = still loading, {draftId: null} = no draft, {draftId: string} = draft + content ready
   const draftResolution = useMemo(() => {


### PR DESCRIPTION
## Summary
- Keep the document machine mounted after a document has loaded so transient resource errors, discovery flaps, or temporary not-found states do not blank the page.
- Store the last good document/version and transient resource status in machine context, with sync hooks and selectors for UI/debug consumers.
- Add a non-fatal header banner that explains refresh/discovery issues while continuing to render the last loaded document.
- Expose the React Query client in dev builds for web/desktop debugging and add document machine coverage for transient resource events.