### PR TITLE
feat(comments): support fragment quote ranges

### DIFF
--- a/frontend/apps/desktop/src/app-comments.ts
+++ b/frontend/apps/desktop/src/app-comments.ts
@@ -110,13 +110,28 @@ function getCommentStoreId(
   targetDocId: string,
   replyCommentId?: string,
   quotingBlockId?: string,
+  quotingRange?: {start: number; end: number},
   context?: 'accessory' | 'feed' | 'document-content',
 ) {
   const parts = ['Comment', targetDocId]
   if (replyCommentId) parts.push(replyCommentId)
   if (quotingBlockId) parts.push(quotingBlockId)
+  if (quotingRange) parts.push(`${quotingRange.start}-${quotingRange.end}`)
   if (context) parts.push(context)
   return parts.join('-')
+}
+
+const quotingRangeInputSchema = z
+  .object({
+    start: z.number(),
+    end: z.number(),
+  })
+  .optional()
+
+function quotingRangeEquals(a?: {start: number; end: number}, b?: {start: number; end: number}): boolean {
+  if (!a && !b) return true
+  if (!a || !b) return false
+  return a.start === b.start && a.end === b.end
 }
 
 export const commentsApi = t.router({
@@ -129,11 +144,12 @@ export const commentsApi = t.router({
         targetDocId: z.string().or(z.undefined()).optional(),
         replyCommentId: z.string().optional(),
         quotingBlockId: z.string().optional(),
+        quotingRange: quotingRangeInputSchema,
         context: z.enum(['accessory', 'feed', 'document-content']).optional(),
       }),
     )
     .query(async ({input}) => {
-      const {targetDocId, replyCommentId, quotingBlockId, context} = input
+      const {targetDocId, replyCommentId, quotingBlockId, quotingRange, context} = input
       if (!targetDocId) return null
 
       // Find existing draft matching these parameters
@@ -143,6 +159,7 @@ export const commentsApi = t.router({
           d.targetDocId === targetDocId &&
           d.replyCommentId === replyCommentId &&
           d.quotingBlockId === quotingBlockId &&
+          quotingRangeEquals(d.quotingRange, quotingRange) &&
           (context === undefined ? true : d.context === context),
       )
 
@@ -157,6 +174,7 @@ export const commentsApi = t.router({
           targetDocId,
           replyCommentId,
           quotingBlockId,
+          quotingRange,
           context,
           lastUpdateTime: existingDraft.lastUpdateTime,
         } as HMCommentDraft
@@ -174,12 +192,13 @@ export const commentsApi = t.router({
         targetDocId: z.string(),
         replyCommentId: z.string().optional(),
         quotingBlockId: z.string().optional(),
+        quotingRange: quotingRangeInputSchema,
         context: z.enum(['accessory', 'feed', 'document-content']).optional(),
         blocks: z.array(z.any()),
       }),
     )
     .mutation(async ({input}) => {
-      const {targetDocId, replyCommentId, quotingBlockId, context, blocks} = input
+      const {targetDocId, replyCommentId, quotingBlockId, quotingRange, context, blocks} = input
 
       if (!commentDraftIndex) {
         throw Error('[COMMENT DRAFT]: Comment Draft Index not initialized')
@@ -192,6 +211,7 @@ export const commentsApi = t.router({
           d.targetDocId === targetDocId &&
           d.replyCommentId === replyCommentId &&
           d.quotingBlockId === quotingBlockId &&
+          quotingRangeEquals(d.quotingRange, quotingRange) &&
           (context === undefined ? true : d.context === context),
       )
 
@@ -206,6 +226,7 @@ export const commentsApi = t.router({
           targetDocId,
           replyCommentId,
           quotingBlockId,
+          quotingRange,
           context,
           lastUpdateTime: Date.now(),
         },
@@ -225,11 +246,12 @@ export const commentsApi = t.router({
         targetDocId: z.string(),
         replyCommentId: z.string().optional(),
         quotingBlockId: z.string().optional(),
+        quotingRange: quotingRangeInputSchema,
         context: z.enum(['accessory', 'feed', 'document-content']).optional(),
       }),
     )
     .mutation(async ({input}) => {
-      const {targetDocId, replyCommentId, quotingBlockId, context} = input
+      const {targetDocId, replyCommentId, quotingBlockId, quotingRange, context} = input
 
       // When context is undefined, match any draft regardless of stored context
       const existingDraft = commentDraftIndex?.find(
@@ -237,6 +259,7 @@ export const commentsApi = t.router({
           d.targetDocId === targetDocId &&
           d.replyCommentId === replyCommentId &&
           d.quotingBlockId === quotingBlockId &&
+          quotingRangeEquals(d.quotingRange, quotingRange) &&
           (context === undefined ? true : d.context === context),
       )
 

--- a/frontend/apps/desktop/src/components/commenting.tsx
+++ b/frontend/apps/desktop/src/components/commenting.tsx
@@ -55,6 +55,8 @@ function CommentBoxImpl(props: {
   docId: UnpackedHypermediaId
   backgroundColor?: string
   quotingBlockId?: string
+  /** Codepoint range within the quoted block; absent ⇒ whole-block quote. */
+  quotingRange?: {start: number; end: number}
   commentId?: string
   isReplying?: boolean
   /** Focus the editor on mount (renamed from `autoFocus` to satisfy a11y rules). */
@@ -65,7 +67,11 @@ function CommentBoxImpl(props: {
   /** CID version of the thread root comment, passed from the route. */
   rootReplyCommentVersion?: string
 }) {
-  const {docId, quotingBlockId, commentId, isReplying, focusOnMount, context} = props
+  const {docId, quotingBlockId, quotingRange, commentId, isReplying, focusOnMount, context} = props
+  const quoting = useMemo(
+    () => (quotingBlockId ? {blockId: quotingBlockId, range: quotingRange} : undefined),
+    [quotingBlockId, quotingRange?.start, quotingRange?.end],
+  )
 
   const account = useSelectedAccount()
   const selectedAccountId = useSelectedAccountId()
@@ -93,9 +99,10 @@ function CommentBoxImpl(props: {
   const finalRootVersion = props.rootReplyCommentVersion || resolvedReply?.rootReplyCommentVersion
 
   const draft = useCommentDraft(
-    quotingBlockId ? {...docId, blockRef: quotingBlockId} : docId,
+    quotingBlockId ? {...docId, blockRef: quotingBlockId, blockRange: quotingRange ?? null} : docId,
     commentId,
     quotingBlockId,
+    quotingRange,
     context,
   )
 
@@ -105,7 +112,15 @@ function CommentBoxImpl(props: {
   const pendingBlocksRef = useRef<HMBlockNode[] | null>(null)
   const flushPendingDraftSaveRef = useRef<() => void>(() => {})
 
-  const commentDraftQueryKey = [queryKeys.COMMENT_DRAFT, docId.id, commentId, quotingBlockId, context]
+  const commentDraftQueryKey = [
+    queryKeys.COMMENT_DRAFT,
+    docId.id,
+    commentId,
+    quotingBlockId,
+    quotingRange?.start,
+    quotingRange?.end,
+    context,
+  ]
 
   // Draft write mutation
   const writeDraft = useMutation({
@@ -115,6 +130,7 @@ function CommentBoxImpl(props: {
         targetDocId: docId.id,
         replyCommentId: commentId,
         quotingBlockId: quotingBlockId,
+        quotingRange: quotingRange,
         context: context,
       }),
     onSuccess: () => {
@@ -130,6 +146,7 @@ function CommentBoxImpl(props: {
         targetDocId: docId.id,
         replyCommentId: commentId,
         quotingBlockId: quotingBlockId,
+        quotingRange: quotingRange,
         context: context,
       }),
     onMutate: async () => {
@@ -178,11 +195,11 @@ function CommentBoxImpl(props: {
         contentBlocks,
         replyParentId: commentId || undefined,
         threadRootVersion: finalRootVersion,
-        quotingBlockId,
+        quoting,
         visibility: targetDoc?.visibility === 'PRIVATE' ? 'PRIVATE' : 'PUBLIC',
       })
 
-      applyOptimisticComment(queryClient, docId, optimisticComment, authorMetadata, quotingBlockId)
+      applyOptimisticComment(queryClient, docId, optimisticComment, authorMetadata, quoting)
       navigateToComment(navigate, route, optimisticComment.id)
     },
     onError: (err: {message: string}) => {
@@ -323,7 +340,7 @@ function CommentBoxImpl(props: {
             docVersion: targetVersion || docId.version || '',
             replyCommentVersion: finalReplyVersion,
             rootReplyCommentVersion: finalRootVersion,
-            quotingBlockId,
+            quoting,
             visibility: targetDoc?.visibility === 'PRIVATE' ? 'Private' : '',
           },
           signer,
@@ -356,6 +373,9 @@ function CommentBoxImpl(props: {
       finalReplyVersion,
       finalRootVersion,
       quotingBlockId,
+      quotingRange?.start,
+      quotingRange?.end,
+      quoting,
       writeRecentSigner,
     ],
   )

--- a/frontend/apps/desktop/src/components/discussions-panel.tsx
+++ b/frontend/apps/desktop/src/components/discussions-panel.tsx
@@ -16,11 +16,20 @@ function DiscussionsPanelImpl(props: {docId: UnpackedHypermediaId; selection: Co
   const homeDoc = useResource(hmId(targetDocId.uid))
   const targetDomain = homeDoc.data?.type === 'document' ? homeDoc.data.document.metadata.siteUrl : undefined
 
+  const quotingRange =
+    selection.blockRange &&
+    'start' in selection.blockRange &&
+    typeof selection.blockRange.start === 'number' &&
+    typeof selection.blockRange.end === 'number'
+      ? {start: selection.blockRange.start, end: selection.blockRange.end}
+      : undefined
+
   const commentEditor = (
     <CommentBox
       docId={targetDocId}
       commentId={selection.openComment}
       quotingBlockId={selection.targetBlockId}
+      quotingRange={quotingRange}
       context="accessory"
       focusOnMount={selection.autoFocus}
       replyCommentVersion={selection.replyCommentVersion}

--- a/frontend/apps/desktop/src/models/comments.ts
+++ b/frontend/apps/desktop/src/models/comments.ts
@@ -14,16 +14,26 @@ export function useCommentDraft(
   targetDocId: UnpackedHypermediaId,
   commentId: string | undefined,
   quotingBlockId: string | undefined,
+  quotingRange: {start: number; end: number} | undefined,
   context: 'accessory' | 'feed' | 'document-content' | undefined,
   opts?: {enabled?: boolean},
 ) {
   const comment = useQuery({
-    queryKey: [queryKeys.COMMENT_DRAFT, targetDocId.id, commentId, quotingBlockId, context],
+    queryKey: [
+      queryKeys.COMMENT_DRAFT,
+      targetDocId.id,
+      commentId,
+      quotingBlockId,
+      quotingRange?.start,
+      quotingRange?.end,
+      context,
+    ],
     queryFn: () =>
       client.comments.getCommentDraft.query({
         targetDocId: targetDocId.id,
         replyCommentId: commentId,
         quotingBlockId: quotingBlockId,
+        quotingRange: quotingRange,
         context: context,
       }),
     enabled: opts?.enabled,

--- a/frontend/apps/desktop/src/pages/drafts.tsx
+++ b/frontend/apps/desktop/src/pages/drafts.tsx
@@ -238,6 +238,7 @@ function CommentDraftItem({item}: {item: HMListedCommentDraft}) {
       targetDocId: string
       replyCommentId?: string
       quotingBlockId?: string
+      quotingRange?: {start: number; end: number}
       context?: 'accessory' | 'feed' | 'document-content'
     }) => client.comments.removeCommentDraft.mutate(input),
     onSuccess: () => {

--- a/frontend/apps/desktop/src/tailwind.css
+++ b/frontend/apps/desktop/src/tailwind.css
@@ -28,7 +28,7 @@
   --brand-11: #d0f1d1;
   --brand-12: #e4f6e5;
   --brand: var(--brand-5);
-  --highlight: lch(95.19% 10.86 145.56);
+  --highlight: hsl(123, 56%, 86%);
   --link: lch(44.196 70 286.91);
   --link-hover: lch(38 70 286.91);
   --background: oklch(0.98 0 0);
@@ -102,7 +102,7 @@
   --brand-11: hsl(180, 36%, 22%);
   --brand-12: hsl(180, 29%, 17%);
   --brand: var(--brand-8);
-  --highlight: hsl(180, 41%, 8%);
+  --highlight: hsl(180, 48%, 18%);
   --link: lch(59.472 70 288.421);
   --link-hover: lch(65 70 288.421);
   --background: oklch(0.2046 0 0);

--- a/frontend/apps/web/app/auth.tsx
+++ b/frontend/apps/web/app/auth.tsx
@@ -416,15 +416,15 @@ function CreateAccountDialog({input, onClose}: {input: {}; onClose: () => void})
 
   return (
     <>
-      <DialogTitle className="flex gap-2 items-center max-sm:text-base" onClick={secretTap.tap}>
+      <DialogTitle className="flex items-center gap-2 max-sm:text-base" onClick={secretTap.tap}>
         {localAccountUnlocked ? (
           tx('create_account_title', ({siteName}: {siteName: string}) => `Create Account on ${siteName}`, {
             siteName: siteName || 'this site',
           })
         ) : (
           <>
-            <div className="flex justify-center items-center bg-emerald-600 rounded-full size-8">
-              <SeedLogo className="text-white size-4" />
+            <div className="flex size-8 items-center justify-center rounded-full bg-emerald-600">
+              <SeedLogo className="size-4 text-white" />
             </div>
             {tx('your_hypermedia_identity', 'Your Hypermedia Identity')}
           </>
@@ -472,21 +472,21 @@ function CreateAccountDialog({input, onClose}: {input: {}; onClose: () => void})
           </Button>
 
           {/* Divider */}
-          <div className="flex gap-2 items-center">
-            <div className="flex-1 h-px bg-neutral-200 dark:bg-neutral-700" />
+          <div className="flex items-center gap-2">
+            <div className="h-px flex-1 bg-neutral-200 dark:bg-neutral-700" />
             <span className="text-xs text-neutral-400 dark:text-neutral-500">Or,</span>
-            <div className="flex-1 h-px bg-neutral-200 dark:bg-neutral-700" />
+            <div className="h-px flex-1 bg-neutral-200 dark:bg-neutral-700" />
           </div>
 
           <Button variant="outline" size="lg" className="w-full" onClick={() => handleVaultSignIn()}>
             Already have a Hypermedia Identity?
           </Button>
 
-          <div className="text-sm text-center text-neutral-500 dark:text-neutral-400">
+          <div className="text-center text-sm text-neutral-500 dark:text-neutral-400">
             Do you have another identity domain?{' '}
             <button
               type="button"
-              className="font-medium text-emerald-600 underline cursor-pointer underline-offset-2 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300"
+              className="cursor-pointer font-medium text-emerald-600 underline underline-offset-2 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300"
               onClick={() => setShowCustomVaultInput(true)}
             >
               Sign in with it
@@ -494,7 +494,7 @@ function CreateAccountDialog({input, onClose}: {input: {}; onClose: () => void})
           </div>
 
           {showCustomVaultInput && (
-            <div className="flex flex-col gap-2 p-3 rounded-md border border-neutral-200 dark:border-neutral-700">
+            <div className="flex flex-col gap-2 rounded-md border border-neutral-200 p-3 dark:border-neutral-700">
               <SizableText size="sm" className="font-medium">
                 Hypermedia Vault URL
               </SizableText>
@@ -511,7 +511,7 @@ function CreateAccountDialog({input, onClose}: {input: {}; onClose: () => void})
                   }
                 }}
               />
-              <div className="flex gap-2 justify-end">
+              <div className="flex justify-end gap-2">
                 <Button variant="ghost" size="sm" onClick={() => setShowCustomVaultInput(false)}>
                   Cancel
                 </Button>
@@ -544,7 +544,7 @@ function VaultSuccessDialog({input, onClose}: {input: {variant: 'comment' | 'joi
 
   return (
     <>
-      <DialogTitle className="flex gap-2 items-center">
+      <DialogTitle className="flex items-center gap-2">
         You are in <span aria-hidden>🎉</span>
       </DialogTitle>
       {input.variant === 'comment' ? (
@@ -619,7 +619,7 @@ export function LogoutDialog({onClose}: {onClose: () => void}) {
   if (!keyPair) return <DialogTitle>No session found</DialogTitle>
   if (account.isLoading)
     return (
-      <div className="flex justify-center items-center">
+      <div className="flex items-center justify-center">
         <Spinner />
       </div>
     )
@@ -832,7 +832,7 @@ export function AccountFooterActions(props: {hideDeviceLinkToast?: boolean}) {
 
   if (!userKeyPair) return null
   return (
-    <div className="flex flex-wrap gap-2 justify-end max-w-full">
+    <div className="flex max-w-full flex-wrap justify-end gap-2">
       {logoutDialog.content}
       {editProfileDialog.content}
       {linkKeysDialog.content}

--- a/frontend/apps/web/app/comment-draft-utils.ts
+++ b/frontend/apps/web/app/comment-draft-utils.ts
@@ -8,11 +8,20 @@ interface CommentDraft {
   timestamp: number
 }
 
+/** Range of a quoted fragment within a block, in codepoint offsets. */
+export type QuotingRange = {start: number; end: number}
+
 // Generate a unique key for storing drafts
-function getDraftKey(docId: string, replyCommentId?: string | null, quotingBlockId?: string): string {
+function getDraftKey(
+  docId: string,
+  replyCommentId?: string | null,
+  quotingBlockId?: string,
+  quotingRange?: QuotingRange,
+): string {
   const parts = ['comment-draft', docId]
   if (replyCommentId) parts.push(`reply-${replyCommentId}`)
   if (quotingBlockId) parts.push(`quote-${quotingBlockId}`)
+  if (quotingRange) parts.push(`range-${quotingRange.start}-${quotingRange.end}`)
   return parts.join('-')
 }
 
@@ -47,8 +56,13 @@ function cleanupOldDrafts() {
   keysToRemove.forEach((key) => localStorage.removeItem(key))
 }
 
-export function useCommentDraftPersistence(docId: string, replyCommentId?: string | null, quotingBlockId?: string) {
-  const draftKey = getDraftKey(docId, replyCommentId, quotingBlockId)
+export function useCommentDraftPersistence(
+  docId: string,
+  replyCommentId?: string | null,
+  quotingBlockId?: string,
+  quotingRange?: QuotingRange,
+) {
+  const draftKey = getDraftKey(docId, replyCommentId, quotingBlockId, quotingRange)
   const [draft, setDraftState] = useState<CommentDraft | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const saveTimeoutRef = useRef<NodeJS.Timeout>()

--- a/frontend/apps/web/app/commenting.tsx
+++ b/frontend/apps/web/app/commenting.tsx
@@ -58,7 +58,12 @@ export type WebCommentingProps = {
   replyCommentId?: string | null
   rootReplyCommentVersion?: string | null
   quotingBlockId?: string
+  /** Codepoint range within the quoted block when commenting on a text fragment. */
+  quotingRange?: {start: number; end: number}
   onSuccess?: (successData: {id: string; response: HMPublishBlobsOutput; commentPayload: PublishCommentInput}) => void
+  /** Focus the editor on mount. */
+  focusOnMount?: boolean
+  /** @deprecated Use focusOnMount. Kept for older callers. */
   autoFocus?: boolean
 }
 
@@ -70,9 +75,15 @@ export default function WebCommenting({
   rootReplyCommentVersion: rootReplyCommentVersionProp,
   replyCommentId: replyCommentIdProp,
   quotingBlockId,
+  quotingRange,
   onSuccess,
+  focusOnMount,
   autoFocus,
 }: WebCommentingProps) {
+  const quoting = useMemo(
+    () => (quotingBlockId ? {blockId: quotingBlockId, range: quotingRange} : undefined),
+    [quotingBlockId, quotingRange?.start, quotingRange?.end],
+  )
   const tx = useTxString()
   const universalClient = useUniversalClient()
   const {getSigner, publish} = universalClient
@@ -104,7 +115,7 @@ export default function WebCommenting({
     isLoading: isDraftLoading,
     saveDraft,
     removeDraft,
-  } = useCommentDraftPersistence(docId.id, replyCommentId, quotingBlockId)
+  } = useCommentDraftPersistence(docId.id, replyCommentId, quotingBlockId, quotingRange)
 
   // Track latest editor content for non-destructive reads (e.g. persisting intent to IDB)
   const latestBlocksRef = useRef<HMBlockNode[] | null>(null)
@@ -121,8 +132,9 @@ export default function WebCommenting({
     const parts = ['comment-draft', docId.id]
     if (replyCommentId) parts.push(`reply-${replyCommentId}`)
     if (quotingBlockId) parts.push(`quote-${quotingBlockId}`)
+    if (quotingRange) parts.push(`range-${quotingRange.start}-${quotingRange.end}`)
     return parts.join('-')
-  }, [docId.id, replyCommentId, quotingBlockId])
+  }, [docId.id, replyCommentId, quotingBlockId, quotingRange?.start, quotingRange?.end])
 
   // Cleanup old draft media on mount
   useEffect(() => {
@@ -161,11 +173,11 @@ export default function WebCommenting({
         contentBlocks,
         replyParentId: replyCommentId || undefined,
         threadRootVersion: rootReplyCommentVersion || undefined,
-        quotingBlockId,
+        quoting,
         visibility: 'PUBLIC',
       })
 
-      applyOptimisticComment(queryClient, docId, optimisticComment, authorMetadata, quotingBlockId)
+      applyOptimisticComment(queryClient, docId, optimisticComment, authorMetadata, quoting)
       navigateToComment(navNavigate, route, optimisticComment.id)
     },
     onError: (_err) => {
@@ -275,6 +287,7 @@ export default function WebCommenting({
               replyCommentVersion: replyCommentVersion || undefined,
               rootReplyCommentVersion: rootReplyCommentVersion || undefined,
               quotingBlockId,
+              quotingRange,
             })
             console.log('[commenting] intent saved to IDB')
           }
@@ -304,7 +317,7 @@ export default function WebCommenting({
             docVersion,
             replyCommentVersion,
             rootReplyCommentVersion,
-            quotingBlockId,
+            quoting,
             prepareAttachments,
           },
           signer,
@@ -336,6 +349,9 @@ export default function WebCommenting({
       replyCommentVersion,
       rootReplyCommentVersion,
       quotingBlockId,
+      quotingRange?.start,
+      quotingRange?.end,
+      quoting,
       createAccount,
       postComment,
       clearDraft,
@@ -392,7 +408,7 @@ export default function WebCommenting({
     <div className="w-full">
       <CommentEditor
         key={`${draftId}-${editorGeneration}`}
-        focusOnMount={autoFocus}
+        focusOnMount={focusOnMount ?? autoFocus}
         isReplying={isReplyEditor}
         handleSubmit={handleSubmit}
         initialBlocks={initialBlocks}

--- a/frontend/apps/web/app/local-db.ts
+++ b/frontend/apps/web/app/local-db.ts
@@ -265,6 +265,8 @@ export interface PendingCommentIntent {
   replyCommentVersion?: string
   rootReplyCommentVersion?: string
   quotingBlockId?: string
+  /** Codepoint offsets within the quoted block. Absent ⇒ whole-block quote. */
+  quotingRange?: {start: number; end: number}
 }
 
 export interface PendingJoinIntent {
@@ -289,6 +291,12 @@ const PendingCommentIntentSchema = z.object({
   replyCommentVersion: z.string().optional(),
   rootReplyCommentVersion: z.string().optional(),
   quotingBlockId: z.string().optional(),
+  quotingRange: z
+    .object({
+      start: z.number(),
+      end: z.number(),
+    })
+    .optional(),
 })
 
 const PendingJoinIntentSchema = z.object({

--- a/frontend/apps/web/app/pending-intent.ts
+++ b/frontend/apps/web/app/pending-intent.ts
@@ -170,7 +170,7 @@ async function runProcessPendingIntent(originHomeId?: UnpackedHypermediaId): Pro
           content,
           replyCommentVersion: intent.replyCommentVersion,
           rootReplyCommentVersion: intent.rootReplyCommentVersion,
-          quotingBlockId: intent.quotingBlockId,
+          quoting: intent.quotingBlockId ? {blockId: intent.quotingBlockId, range: intent.quotingRange} : undefined,
         },
         signer,
       )
@@ -191,7 +191,7 @@ async function runProcessPendingIntent(originHomeId?: UnpackedHypermediaId): Pro
       invalidateQueries([queryKeys.ACTIVITY_FEED])
 
       // Clear the comment draft from localStorage
-      clearCommentDraft(docId.id, intent.replyCommentId, intent.quotingBlockId)
+      clearCommentDraft(docId.id, intent.replyCommentId, intent.quotingBlockId, intent.quotingRange)
 
       await clearPendingIntent()
 
@@ -213,10 +213,16 @@ async function runProcessPendingIntent(originHomeId?: UnpackedHypermediaId): Pro
   return null
 }
 
-function clearCommentDraft(docId: string, replyCommentId?: string | null, quotingBlockId?: string) {
+function clearCommentDraft(
+  docId: string,
+  replyCommentId?: string | null,
+  quotingBlockId?: string,
+  quotingRange?: {start: number; end: number},
+) {
   const parts = ['comment-draft', docId]
   if (replyCommentId) parts.push(`reply-${replyCommentId}`)
   if (quotingBlockId) parts.push(`quote-${quotingBlockId}`)
+  if (quotingRange) parts.push(`range-${quotingRange.start}-${quotingRange.end}`)
   const key = parts.join('-')
   try {
     localStorage.removeItem(key)

--- a/frontend/apps/web/app/tailwind.css
+++ b/frontend/apps/web/app/tailwind.css
@@ -28,7 +28,7 @@
   --brand-11: #d0f1d1;
   --brand-12: #e4f6e5;
   --brand: var(--brand-5);
-  --highlight: hsl(123, 50%, 93%);
+  --highlight: hsl(123, 56%, 86%);
   --link: lch(44.196 70 286.91);
   --link-hover: lch(38 70 286.91);
   --background: oklch(0.98 0 0);
@@ -102,7 +102,7 @@
   --brand-11: hsl(180, 36%, 22%);
   --brand-12: hsl(180, 29%, 17%);
   --brand: var(--brand-8);
-  --highlight: hsl(180, 41%, 8%);
+  --highlight: hsl(180, 48%, 18%);
   --link: lch(59.472 70 288.421);
   --link-hover: lch(65 70 288.421);
   --background: oklch(0.2046 0 0);

--- a/frontend/apps/web/app/web-utils.tsx
+++ b/frontend/apps/web/app/web-utils.tsx
@@ -152,9 +152,9 @@ function PlaceholderAvatar({onClick}: {onClick: () => void}) {
   return (
     <button
       onClick={onClick}
-      className="flex justify-center items-center rounded-full border border-gray-400 border-dashed cursor-pointer size-8"
+      className="flex size-8 cursor-pointer items-center justify-center rounded-full border border-dashed border-gray-400"
     >
-      <User className="text-gray-400 size-4" />
+      <User className="size-4 text-gray-400" />
     </button>
   )
 }
@@ -196,7 +196,7 @@ export function WebHeaderActions({siteUid}: {siteUid: string}) {
   if (!keyPair) {
     return (
       <>
-        <div className="flex gap-2 items-center">
+        <div className="flex items-center gap-2">
           <PlaceholderAvatar onClick={() => createAccount()} />
           <JoinButton onClick={() => createAccount()} />
         </div>
@@ -227,7 +227,7 @@ export function WebHeaderActions({siteUid}: {siteUid: string}) {
   const menuItems = (
     <>
       <button
-        className="flex gap-3 items-center px-4 py-3 w-full text-left hover:bg-accent"
+        className="hover:bg-accent flex w-full items-center gap-3 px-4 py-3 text-left"
         onClick={() => {
           if (accountId) {
             navigate({key: 'profile', id: hmId(accountId, {latest: true})})
@@ -238,9 +238,9 @@ export function WebHeaderActions({siteUid}: {siteUid: string}) {
         <User className="size-5" />
         <span className="text-sm">My Profile</span>
       </button>
-      <div className="mx-4 h-px bg-border" />
+      <div className="bg-border mx-4 h-px" />
       <button
-        className="flex gap-3 items-center px-4 py-3 w-full text-left hover:bg-accent disabled:opacity-50"
+        className="hover:bg-accent flex w-full items-center gap-3 px-4 py-3 text-left disabled:opacity-50"
         onClick={() => {
           if (vaultAccountSettingsUrl) {
             window.open(vaultAccountSettingsUrl, '_blank')
@@ -252,9 +252,9 @@ export function WebHeaderActions({siteUid}: {siteUid: string}) {
         <UserCog className="size-5" />
         <span className="text-sm">Manage account</span>
       </button>
-      <div className="mx-4 h-px bg-border" />
+      <div className="bg-border mx-4 h-px" />
       <button
-        className="flex gap-3 items-center px-4 py-3 w-full text-left text-destructive hover:bg-accent"
+        className="text-destructive hover:bg-accent flex w-full items-center gap-3 px-4 py-3 text-left"
         onClick={() => {
           setMobileMenuOpen(false)
           logoutDialog.open({})
@@ -269,33 +269,33 @@ export function WebHeaderActions({siteUid}: {siteUid: string}) {
   return (
     <>
       {isMobile ? (
-        <div className="flex gap-2 items-center">
-          <button className="flex rounded-full shadow-lg cursor-pointer" onClick={() => setMobileMenuOpen(true)}>
+        <div className="flex items-center gap-2">
+          <button className="flex cursor-pointer rounded-full shadow-lg" onClick={() => setMobileMenuOpen(true)}>
             {avatarIcon}
           </button>
           {keyPair.notifyServerUrl ? <NotifsButton /> : null}
           <MobilePanelSheet isOpen={mobileMenuOpen} title="" onClose={() => setMobileMenuOpen(false)}>
-            <div className="flex gap-3 items-center px-4 py-4">
+            <div className="flex items-center gap-3 px-4 py-4">
               {avatarIcon}
               <div className="min-w-0">
-                <p className="text-sm font-medium truncate">{account?.metadata?.name || 'Account'}</p>
+                <p className="truncate text-sm font-medium">{account?.metadata?.name || 'Account'}</p>
               </div>
             </div>
-            <div className="h-px bg-border" />
+            <div className="bg-border h-px" />
             {menuItems}
           </MobilePanelSheet>
         </div>
       ) : (
-        <div className="flex gap-2 items-center">
+        <div className="flex items-center gap-2">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <button className="flex rounded-full shadow-lg cursor-pointer">{avatarIcon}</button>
+              <button className="flex cursor-pointer rounded-full shadow-lg">{avatarIcon}</button>
             </DropdownMenuTrigger>
             <DropdownMenuContent side="bottom" align="end" className="min-w-[200px]">
-              <div className="flex gap-3 items-center px-2 py-2">
+              <div className="flex items-center gap-3 px-2 py-2">
                 {avatarIcon}
                 <div className="min-w-0">
-                  <p className="text-sm font-medium truncate">{account?.metadata?.name || 'Account'}</p>
+                  <p className="truncate text-sm font-medium">{account?.metadata?.name || 'Account'}</p>
                 </div>
               </div>
               <DropdownMenuSeparator className="bg-black/10 dark:bg-white/10" />
@@ -374,7 +374,7 @@ function NotifsButton() {
 
   return (
     <ButtonLink
-      className="relative p-0 h-8 rounded-full border-transparent border-1"
+      className="relative h-8 rounded-full border-1 border-transparent p-0"
       variant="ghost"
       size="icon"
       {...linkProps}

--- a/frontend/packages/client/__tests__/comment.test.ts
+++ b/frontend/packages/client/__tests__/comment.test.ts
@@ -146,6 +146,60 @@ describe('createComment', () => {
       data: new Uint8Array([8, 9]),
     })
   })
+
+  it('wraps content with an Embed whose link includes the codepoint range fragment', async () => {
+    const signer = makeSigner()
+    const publishInput = await createComment(
+      {
+        content: makeBlocks('quoting reply'),
+        docId: TEST_DOC_ID,
+        docVersion: 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi',
+        quoting: {blockId: 'quoted-block', range: {start: 3, end: 17}},
+      },
+      signer,
+    )
+
+    const decodedComment = cborDecode(publishInput.blobs[0]!.data) as any
+    expect(decodedComment.body).toHaveLength(1)
+    expect(decodedComment.body[0].type).toBe('Embed')
+    expect(decodedComment.body[0].link).toContain('#quoted-block[3:17]')
+    expect(decodedComment.body[0].children[0].text).toBe('quoting reply')
+  })
+
+  it('drops the range fragment when start === end (empty selection collapses to whole block)', async () => {
+    const signer = makeSigner()
+    const publishInput = await createComment(
+      {
+        content: makeBlocks('hello'),
+        docId: TEST_DOC_ID,
+        docVersion: 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi',
+        quoting: {blockId: 'quoted-block', range: {start: 5, end: 5}},
+      },
+      signer,
+    )
+
+    const decodedComment = cborDecode(publishInput.blobs[0]!.data) as any
+    expect(decodedComment.body[0].link).toContain('#quoted-block')
+    expect(decodedComment.body[0].link).not.toContain('[')
+  })
+
+  it('accepts the legacy quotingBlockId field for back-compat (no range encoded)', async () => {
+    const signer = makeSigner()
+    const publishInput = await createComment(
+      {
+        content: makeBlocks('legacy quote'),
+        docId: TEST_DOC_ID,
+        docVersion: 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi',
+        quotingBlockId: 'quoted-block',
+      },
+      signer,
+    )
+
+    const decodedComment = cborDecode(publishInput.blobs[0]!.data) as any
+    expect(decodedComment.body[0].type).toBe('Embed')
+    expect(decodedComment.body[0].link).toContain('#quoted-block')
+    expect(decodedComment.body[0].link).not.toContain('[')
+  })
 })
 
 describe('updateComment', () => {

--- a/frontend/packages/client/src/comment.ts
+++ b/frontend/packages/client/src/comment.ts
@@ -48,13 +48,41 @@ type PrepareAttachments = (binaries: Uint8Array[]) => Promise<{
   resultCIDs: string[]
 }>
 
+/**
+ * Target of a quoted block fragment in a comment. The optional `range`
+ * holds zero-based Unicode codepoint offsets within the block's text.
+ * When `range` is omitted, the comment quotes the whole block.
+ */
+export type QuotingTarget = {
+  blockId: string
+  range?: {start: number; end: number}
+}
+
 type CreateCommentBaseInput = {
   docId: UnpackedHypermediaId
   docVersion: string
   replyCommentVersion?: string | null
   rootReplyCommentVersion?: string | null
+  /** Structured quote target (preferred). */
+  quoting?: QuotingTarget
+  /** Deprecated: pass `quoting: {blockId}` instead. Still honored for back-compat. */
   quotingBlockId?: string
   visibility?: 'Private' | ''
+}
+
+/**
+ * Normalizes legacy `quotingBlockId` and the new `quoting` field into a
+ * single QuotingTarget shape (or undefined when no quote target is set).
+ */
+function resolveQuotingTarget(input: {quoting?: QuotingTarget; quotingBlockId?: string}): QuotingTarget | undefined {
+  if (input.quoting) {
+    if (input.quoting.range && input.quoting.range.start === input.quoting.range.end) {
+      return {blockId: input.quoting.blockId}
+    }
+    return input.quoting
+  }
+  if (input.quotingBlockId) return {blockId: input.quotingBlockId}
+  return undefined
 }
 
 export type CreateCommentInput =
@@ -367,7 +395,19 @@ function generateBlockId(length: number = 8): string {
 }
 
 function wrapQuotedContent(content: HMBlockNode[], input: CreateCommentBaseInput): HMBlockNode[] {
-  if (!input.quotingBlockId) return content
+  const quoting = resolveQuotingTarget(input)
+  if (!quoting) return content
+  // Pin to the exact captured version (no `latest` flag) so the embed always
+  // renders the document state the user actually selected from — otherwise
+  // later edits to the source doc would shift the codepoint range and the
+  // highlight would land on different text.
+  const link = packHmId({
+    ...input.docId,
+    blockRef: quoting.blockId,
+    blockRange: quoting.range ?? null,
+    version: input.docVersion,
+    latest: false,
+  })
   return [
     {
       block: {
@@ -379,11 +419,7 @@ function wrapQuotedContent(content: HMBlockNode[], input: CreateCommentBaseInput
           view: 'Content',
         },
         annotations: [],
-        link: packHmId({
-          ...input.docId,
-          blockRef: input.quotingBlockId,
-          version: input.docVersion,
-        }),
+        link,
       },
       children: content,
     } as HMBlockNode,

--- a/frontend/packages/client/src/editorblock-to-hmblock.ts
+++ b/frontend/packages/client/src/editorblock-to-hmblock.ts
@@ -49,7 +49,7 @@ export function editorBlockToHMBlock(editorBlock: EditorBlock): HMBlock {
   if (!blockType) throw new Error('Unsupported block type ' + editorBlock.type)
 
   let block: MutableBlock = {
-    id: editorBlock.id,
+    id: normalizeEditorBlockId(editorBlock.id),
     type: blockType,
     attributes: {},
     text: '',
@@ -335,5 +335,18 @@ function flattenLeaves(content: Array<HMInlineContent>): Array<HMInlineContent> 
     }
   }
 
+  return result
+}
+
+function normalizeEditorBlockId(id: string | undefined): string {
+  return id && id !== 'empty' ? id : generateBlockId()
+}
+
+function generateBlockId(length: number = 8): string {
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  let result = ''
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * characters.length))
+  }
   return result
 }

--- a/frontend/packages/client/src/hm-types.ts
+++ b/frontend/packages/client/src/hm-types.ts
@@ -932,12 +932,19 @@ export type HMExistingDraft = {
   metadata?: HMMetadata
 }
 
+/** Codepoint offsets within a quoted block. */
+export const QuotingRangeSchema = z.object({
+  start: z.number(),
+  end: z.number(),
+})
+
 // Comment draft schemas
 export const HMCommentDraftSchema = z.object({
   blocks: z.array(HMBlockNodeSchema),
   targetDocId: z.string().optional(),
   replyCommentId: z.string().optional(),
   quotingBlockId: z.string().optional(),
+  quotingRange: QuotingRangeSchema.optional(),
   context: z.enum(['accessory', 'feed', 'document-content']).optional(),
   lastUpdateTime: z.number().optional(),
 })
@@ -949,6 +956,7 @@ export const HMListedCommentDraftSchema = z.object({
   targetDocId: z.string(),
   replyCommentId: z.string().optional(),
   quotingBlockId: z.string().optional(),
+  quotingRange: QuotingRangeSchema.optional(),
   context: z.enum(['accessory', 'feed', 'document-content']).optional(),
   lastUpdateTime: z.number(),
 })

--- a/frontend/packages/client/src/hmblock-to-editorblock.ts
+++ b/frontend/packages/client/src/hmblock-to-editorblock.ts
@@ -191,6 +191,28 @@ export function hmBlockToEditorBlock(block: HMBlock): EditorBlock {
   }
 
   while (i < blockText.length) {
+    const inlineEmbed = findInlineEmbedStartingAt(pos)
+    if (inlineEmbed) {
+      if (leaf) {
+        finishLeaf(textStart, i)
+        leaf = null
+      }
+      if (inlineBlockContent) {
+        leaves.push(inlineBlockContent)
+        inlineBlockContent = null
+      }
+      leaves.push({
+        type: 'inline-embed',
+        styles: {},
+        link: inlineEmbed.link,
+      } as EditorInlineEmbed)
+      skipToCodepoint(inlineEmbed.end)
+      textStart = i
+      leafAnnotations.clear()
+      if (i >= blockText.length) return out
+      continue
+    }
+
     let ul = 1
 
     let annotationsChanged = trackPosAnnotations(pos)
@@ -474,6 +496,38 @@ export function hmBlockToEditorBlock(block: HMBlock): EditorBlock {
     })
 
     return annotationsChanged
+  }
+
+  function findInlineEmbedStartingAt(pos: number): {link: string; end: number} | null {
+    const blockAnnotations = (block as any).annotations as unknown[] | undefined
+    if (!blockAnnotations) return null
+
+    for (const annotation of blockAnnotations) {
+      const annotationData = annotation as unknown as {
+        type?: string
+        link?: string
+        starts?: number[]
+        ends?: number[]
+      }
+      if (annotationData.type !== 'Embed') continue
+
+      const spanIndex = annotationData.starts?.findIndex((start) => start === pos) ?? -1
+      if (spanIndex === -1) continue
+
+      const end = annotationData.ends?.[spanIndex]
+      if (typeof end !== 'number' || end <= pos) continue
+
+      return {link: annotationData.link || '', end}
+    }
+
+    return null
+  }
+
+  function skipToCodepoint(end: number) {
+    while (pos < end && i < blockText.length) {
+      i += isSurrogate(blockText, i) ? 2 : 1
+      pos++
+    }
   }
 }
 

--- a/frontend/packages/client/src/index.ts
+++ b/frontend/packages/client/src/index.ts
@@ -19,7 +19,13 @@ export type {
 export {createSeedClient} from './client'
 export type {PublishDocumentInput, SeedClient, SeedClientOptions} from './client'
 export {commentRecordIdFromBlob, createComment, deleteComment, updateComment} from './comment'
-export type {CommentAttachmentBlob, CreateCommentInput, DeleteCommentInput, UpdateCommentInput} from './comment'
+export type {
+  CommentAttachmentBlob,
+  CreateCommentInput,
+  DeleteCommentInput,
+  QuotingTarget,
+  UpdateCommentInput,
+} from './comment'
 export {contactRecordIdFromBlob, createContact, deleteContact, updateContact} from './contact'
 export type {CreateContactInput, CreateContactResult, DeleteContactInput, UpdateContactInput} from './contact'
 export {SeedClientError, SeedNetworkError, SeedValidationError} from './errors'

--- a/frontend/packages/editor/src/blocknote/core/BlockNoteExtensions.ts
+++ b/frontend/packages/editor/src/blocknote/core/BlockNoteExtensions.ts
@@ -112,13 +112,19 @@ export const getBlockNoteExtensions = <BSchema extends HMBlockSchema>(opts: {
 
   const isViewer = opts.editor.renderType === 'viewer'
 
-  // Viewer + Document: read-only UI plugins (BlockHighlight, ImageGallery, Supernumbers)
+  // BlockHighlight is needed in all render types so embedded fragment
+  // previews can highlight the referenced codepoint range via the
+  // `rangeFocus` plugin meta. ImageGallery and Supernumbers stay scoped
+  // to viewer/document/comment surfaces.
+  ret.push(
+    Extension.create({
+      name: 'BlockHighlightExtension',
+      addProseMirrorPlugins: () => [createBlockHighlightPlugin()],
+    }),
+  )
+
   if (!isEmbed) {
     ret.push(
-      Extension.create({
-        name: 'BlockHighlightExtension',
-        addProseMirrorPlugins: () => [createBlockHighlightPlugin()],
-      }),
       Extension.create({
         name: 'ImageGalleryExtension',
         addProseMirrorPlugins: () => [ImageGalleryPlugin],

--- a/frontend/packages/editor/src/blocknote/core/extensions/BlockHighlight/BlockHighlightPlugin.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/BlockHighlight/BlockHighlightPlugin.test.ts
@@ -1,0 +1,104 @@
+import {Schema} from 'prosemirror-model'
+import {EditorState, TextSelection} from 'prosemirror-state'
+import {describe, expect, test} from 'vitest'
+import {prosemirrorPosToBlockTextOffset} from '../RangeSelection/RangeSelectionPlugin'
+import {blockHighlightPluginKey, codepointOffsetToPos, createBlockHighlightPlugin} from './BlockHighlightPlugin'
+
+const schema = new Schema({
+  nodes: {
+    doc: {content: 'blockContent'},
+    blockContent: {content: 'inline*', group: 'block'},
+    text: {group: 'inline'},
+    inlineEmbed: {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      attrs: {link: {default: ''}},
+      toDOM: (node) => ['span', {'data-inline-embed': node.attrs.link}, 0],
+    },
+  },
+})
+
+const blockSchema = new Schema({
+  nodes: {
+    doc: {content: 'blockNode'},
+    blockNode: {
+      content: 'blockContent',
+      attrs: {id: {default: ''}},
+      toDOM: (node) => ['div', {'data-id': node.attrs.id}, 0],
+    },
+    blockContent: {content: 'inline*', group: 'block'},
+    text: {group: 'inline'},
+  },
+})
+
+describe('codepointOffsetToPos', () => {
+  test('maps inline embed atom boundaries as one codepoint', () => {
+    const content = schema.nodes.blockContent.create(null, [
+      schema.text('Hi '),
+      schema.nodes.inlineEmbed.create({link: 'hm://doc'}),
+      schema.text('there'),
+    ])
+    const contentBeforePos = 10
+    const contentStart = contentBeforePos + 1
+
+    expect(codepointOffsetToPos(content, contentBeforePos, 0)).toBe(contentStart)
+    expect(codepointOffsetToPos(content, contentBeforePos, 3)).toBe(contentStart + 3)
+    expect(codepointOffsetToPos(content, contentBeforePos, 4)).toBe(contentStart + 4)
+    expect(codepointOffsetToPos(content, contentBeforePos, 5)).toBe(contentStart + 5)
+  })
+
+  test('maps unicode text offsets by codepoint, not UTF-16 unit', () => {
+    const content = schema.nodes.blockContent.create(null, [schema.text('A😊B')])
+    const contentBeforePos = 20
+    const contentStart = contentBeforePos + 1
+
+    expect(codepointOffsetToPos(content, contentBeforePos, 1)).toBe(contentStart + 1)
+    expect(codepointOffsetToPos(content, contentBeforePos, 2)).toBe(contentStart + 3)
+    expect(codepointOffsetToPos(content, contentBeforePos, 3)).toBe(contentStart + 4)
+  })
+})
+
+describe('prosemirrorPosToBlockTextOffset', () => {
+  test('maps split text and inline embed atoms the same way as fragment highlighting', () => {
+    const content = schema.nodes.blockContent.create(null, [
+      schema.text('Hi '),
+      schema.nodes.inlineEmbed.create({link: 'hm://doc'}),
+      schema.text('there'),
+    ])
+    const doc = schema.nodes.doc.create(null, content)
+    const contentBeforePos = 0
+    const contentStart = contentBeforePos + 1
+
+    expect(prosemirrorPosToBlockTextOffset(doc, contentStart, contentBeforePos)).toBe(0)
+    expect(prosemirrorPosToBlockTextOffset(doc, contentStart + 3, contentBeforePos)).toBe(3)
+    expect(prosemirrorPosToBlockTextOffset(doc, contentStart + 4, contentBeforePos)).toBe(4)
+    expect(prosemirrorPosToBlockTextOffset(doc, contentStart + 5, contentBeforePos)).toBe(5)
+  })
+})
+
+describe('createBlockHighlightPlugin', () => {
+  test('clears fragment highlight when the user selects other text', () => {
+    const doc = blockSchema.nodes.doc.create(
+      null,
+      blockSchema.nodes.blockNode.create(
+        {id: 'block-1'},
+        blockSchema.nodes.blockContent.create(null, [blockSchema.text('hello world')]),
+      ),
+    )
+    let state = EditorState.create({doc, plugins: [createBlockHighlightPlugin()]})
+
+    state = state.apply(
+      state.tr.setMeta(blockHighlightPluginKey, {
+        type: 'rangeFocus',
+        blockId: 'block-1',
+        start: 0,
+        end: 5,
+      }),
+    )
+    expect(blockHighlightPluginKey.getState(state)?.find()).toHaveLength(1)
+
+    state = state.apply(state.tr.setSelection(TextSelection.create(state.doc, 3, 8)))
+    expect(blockHighlightPluginKey.getState(state)?.find()).toHaveLength(0)
+  })
+})

--- a/frontend/packages/editor/src/blocknote/core/extensions/BlockHighlight/BlockHighlightPlugin.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/BlockHighlight/BlockHighlightPlugin.ts
@@ -1,5 +1,5 @@
 import {Node as ProseMirrorNode} from 'prosemirror-model'
-import {Plugin, PluginKey} from 'prosemirror-state'
+import {Plugin, PluginKey, TextSelection} from 'prosemirror-state'
 import {Decoration, DecorationSet} from 'prosemirror-view'
 
 import './block-highlight.css'
@@ -73,32 +73,56 @@ function findBlockContent(
 
 /**
  * Convert a codepoint offset within a `blockContent` node into a ProseMirror
- * document position. Inverse of `posToBlockTextOffset` used in the range
- * selection / formatting toolbar code paths.
+ * document position. The walker uses each inline child's absolute parent
+ * offset (`nodeOffset`) rather than a running counter, so it stays correct
+ * when paragraphs split into multiple text children (e.g. when a Bold /
+ * Range / Link mark splits the run).
  */
-function codepointOffsetToPos(content: ProseMirrorNode, contentBeforePos: number, codepointOffset: number): number {
+export function codepointOffsetToPos(
+  content: ProseMirrorNode,
+  contentBeforePos: number,
+  codepointOffset: number,
+): number {
   const contentStart = contentBeforePos + 1
   if (codepointOffset <= 0) return contentStart
 
-  let remaining = codepointOffset
+  let codepointsSeen = 0
   let pos = contentStart
+  let done = false
 
-  content.forEach((node) => {
-    if (remaining <= 0) return
+  content.forEach((node, nodeOffset) => {
+    if (done) return
+    // Absolute ProseMirror position of the start of this inline child.
+    const nodeAbsStart = contentStart + nodeOffset
+
     if (node.isText && node.text) {
       const codepoints = Array.from(node.text)
-      if (remaining >= codepoints.length) {
-        pos += node.nodeSize
-        remaining -= codepoints.length
-      } else {
-        // Convert codepoints back to UTF-16 length for ProseMirror's text offset.
+      const remaining = codepointOffset - codepointsSeen
+      if (remaining <= codepoints.length) {
+        // Target codepoint lands inside this text node — walk codepoints
+        // and translate back into a UTF-16 offset.
         const slice = codepoints.slice(0, remaining).join('')
-        pos += slice.length
-        remaining = 0
+        pos = nodeAbsStart + slice.length
+        codepointsSeen = codepointOffset
+        done = true
+      } else {
+        codepointsSeen += codepoints.length
+        pos = nodeAbsStart + node.nodeSize
       }
     } else {
-      pos += node.nodeSize
-      remaining -= 1
+      // Non-text inline node (atom, e.g. inline-embed): counts as 1 codepoint.
+      const remaining = codepointOffset - codepointsSeen
+      if (remaining <= 0) {
+        pos = nodeAbsStart
+        done = true
+      } else if (remaining <= 1) {
+        pos = nodeAbsStart + node.nodeSize
+        codepointsSeen = codepointOffset
+        done = true
+      } else {
+        codepointsSeen += 1
+        pos = nodeAbsStart + node.nodeSize
+      }
     }
   })
 
@@ -158,6 +182,10 @@ export function createBlockHighlightPlugin(): Plugin {
             case 'clear':
               return DecorationSet.empty
           }
+        }
+
+        if (tr.selectionSet && tr.selection instanceof TextSelection && !tr.selection.empty) {
+          return DecorationSet.empty
         }
 
         // Keep existing decorations mapped through any document changes.

--- a/frontend/packages/editor/src/blocknote/core/extensions/RangeSelection/RangeSelectionPlugin.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/RangeSelection/RangeSelectionPlugin.ts
@@ -32,6 +32,64 @@ type RangeSelectionEvents = {
 const SETTLE_DELAY_MS = 10
 
 /**
+ * Converts a ProseMirror document position into a zero-based Unicode
+ * codepoint offset relative to the start of a block content node.
+ *
+ * Text nodes count by Unicode codepoint, while non-text inline nodes (for
+ * example inline embeds) count as one codepoint. This mirrors fragment-link
+ * rendering so edit-mode toolbar actions and loaded/read-only selections
+ * produce identical block ranges.
+ */
+export function prosemirrorPosToBlockTextOffset(
+  doc: import('prosemirror-model').Node,
+  docPos: number,
+  blockContentBeforePos: number,
+): number {
+  const blockContentNode = doc.resolve(blockContentBeforePos + 1).parent
+
+  // docPos is an absolute position. The start of blockContent's first child
+  // sits at blockContentBeforePos + 1 (the opening token of blockContent).
+  const targetOffset = docPos - (blockContentBeforePos + 1)
+
+  let codepoints = 0
+  let done = false
+
+  // Walk each inline child of the blockContent node and accumulate
+  // codepoints until `targetOffset` (in UTF-16 units within the parent
+  // content) falls inside or just before the current child.
+  //
+  // `nodeOffset` is the cumulative UTF-16 offset of `node` within
+  // blockContent — it stays absolute, so we compare `targetOffset`
+  // against it directly instead of decrementing as we go. This keeps
+  // ranges stable when marks or inline embeds split the paragraph into
+  // multiple inline children.
+  blockContentNode.forEach((node, nodeOffset) => {
+    if (done) return
+    const nodeEnd = nodeOffset + node.nodeSize
+
+    if (node.isText && node.text) {
+      if (targetOffset >= nodeEnd) {
+        codepoints += Array.from(node.text).length
+      } else if (targetOffset > nodeOffset) {
+        const slice = node.text.slice(0, targetOffset - nodeOffset)
+        codepoints += Array.from(slice).length
+        done = true
+      } else {
+        done = true
+      }
+    } else {
+      if (targetOffset >= nodeEnd) {
+        codepoints += 1
+      } else {
+        done = true
+      }
+    }
+  })
+
+  return codepoints
+}
+
+/**
  * Internal ProseMirror PluginView that watches selection changes and emits
  * {@link RangeSelectionState} to React whenever there is a non-empty text
  * selection while the editor is read-only.
@@ -61,6 +119,10 @@ class RangeSelectionView<BSchema extends BlockSchema> implements PluginView {
   ) {
     this.pmView.dom.addEventListener('mousedown', this.onMouseDown)
     this.pmView.dom.addEventListener('mouseup', this.onMouseUp)
+    // Mobile / touch: mirror the pointer lifecycle so the bubble settles after
+    // the OS finishes adjusting the text selection handles.
+    this.pmView.dom.addEventListener('touchstart', this.onMouseDown, {passive: true})
+    this.pmView.dom.addEventListener('touchend', this.onMouseUp, {passive: true})
   }
 
   // ---------------------------------------------------------------------------
@@ -82,53 +144,6 @@ class RangeSelectionView<BSchema extends BlockSchema> implements PluginView {
         referenceRect: null,
       })
     }
-  }
-
-  /**
-   * Converts a ProseMirror document position into a zero-based Unicode
-   * codepoint offset relative to the start of the containing block's text
-   * content.
-   *
-   * The implementation walks through each inline node in the blockContent node
-   * and accumulates codepoint counts until the target offset is reached.  For
-   * non-text inline nodes (e.g. inline embeds) a single codepoint of width 1 is
-   * assumed per node.
-   */
-  private posToBlockTextOffset(docPos: number, blockContentBeforePos: number): number {
-    const state = this.pmView.state
-    const blockContentNode = state.doc.resolve(blockContentBeforePos + 1).parent
-
-    // docPos is an absolute position.  The start of blockContent's first child
-    // sits at blockContentBeforePos + 1 (the opening token of blockContent).
-    const offsetWithinContent = docPos - (blockContentBeforePos + 1)
-
-    let codepoints = 0
-    let remaining = offsetWithinContent
-
-    blockContentNode.forEach((node, nodeOffset) => {
-      if (remaining <= 0) return
-
-      if (node.isText && node.text) {
-        const nodeEnd = nodeOffset + node.nodeSize
-        if (nodeOffset < remaining && remaining <= nodeEnd) {
-          // Target position falls inside this text node.
-          const slice = node.text.slice(0, remaining - nodeOffset)
-          codepoints += Array.from(slice).length
-          remaining = 0
-        } else if (nodeOffset < remaining) {
-          codepoints += Array.from(node.text).length
-          remaining -= node.nodeSize
-        }
-      } else {
-        // Non-text inline node (atom): count as 1 codepoint.
-        if (nodeOffset < remaining) {
-          codepoints += 1
-          remaining -= node.nodeSize
-        }
-      }
-    })
-
-    return codepoints
   }
 
   // ---------------------------------------------------------------------------
@@ -192,8 +207,8 @@ class RangeSelectionView<BSchema extends BlockSchema> implements PluginView {
       }
     })
 
-    const rangeStart = this.posToBlockTextOffset(from, blockContentBeforePos)
-    const rangeEnd = this.posToBlockTextOffset(to, blockContentBeforePos)
+    const rangeStart = prosemirrorPosToBlockTextOffset(state.doc, from, blockContentBeforePos)
+    const rangeEnd = prosemirrorPosToBlockTextOffset(state.doc, to, blockContentBeforePos)
 
     const referenceRect = posToDOMRect(view, from, to)
 
@@ -212,6 +227,8 @@ class RangeSelectionView<BSchema extends BlockSchema> implements PluginView {
     }
     this.pmView.dom.removeEventListener('mousedown', this.onMouseDown)
     this.pmView.dom.removeEventListener('mouseup', this.onMouseUp)
+    this.pmView.dom.removeEventListener('touchstart', this.onMouseDown)
+    this.pmView.dom.removeEventListener('touchend', this.onMouseUp)
 
     if (this.currentState.show) {
       this.emitState({

--- a/frontend/packages/editor/src/blocknote/react/RangeSelection/RangeSelectionPositioner.tsx
+++ b/frontend/packages/editor/src/blocknote/react/RangeSelection/RangeSelectionPositioner.tsx
@@ -1,5 +1,6 @@
 import {useHideOnDocumentScroll} from '@shm/shared/models/use-document-machine'
 import {Link, MessageSquare} from 'lucide-react'
+import {TextSelection} from 'prosemirror-state'
 import React, {useCallback, useEffect, useRef, useState} from 'react'
 import {BlockNoteEditor} from '../../core/BlockNoteEditor'
 import {BlockSchema} from '../../core/extensions/Blocks/api/blockTypes'
@@ -81,6 +82,7 @@ export function RangeSelectionPositioner<BSchema extends BlockSchema = BlockSche
   })
 
   const rectRef = useRef<DOMRect | null>(null)
+  const lastTouchActionAtRef = useRef(0)
 
   useEffect(() => {
     const plugin = editor.rangeSelection
@@ -102,6 +104,21 @@ export function RangeSelectionPositioner<BSchema extends BlockSchema = BlockSche
     }, []),
   )
 
+  // Hide on visualViewport resize (e.g. mobile soft-keyboard opens). The
+  // OS selection rect we cached becomes stale once the layout shifts.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const vv = window.visualViewport
+    if (!vv) return
+    const handle = () => {
+      setSelectionState({show: false, blockId: null, rangeStart: null, rangeEnd: null, referenceRect: null})
+    }
+    vv.addEventListener('resize', handle)
+    return () => {
+      vv.removeEventListener('resize', handle)
+    }
+  }, [])
+
   if (
     !selectionState.show ||
     !selectionState.referenceRect ||
@@ -114,37 +131,74 @@ export function RangeSelectionPositioner<BSchema extends BlockSchema = BlockSche
 
   const rect = selectionState.referenceRect
   const {blockId, rangeStart, rangeEnd} = selectionState
+  const clearTextSelection = () => {
+    setSelectionState({show: false, blockId: null, rangeStart: null, rangeEnd: null, referenceRect: null})
+    clearEditorTextSelection(editor)
+  }
+  const runCopyFragmentLink = () => {
+    onCopyFragmentLink?.(blockId, rangeStart, rangeEnd)
+    clearTextSelection()
+  }
+  const runComment = () => {
+    onComment?.(blockId, rangeStart, rangeEnd)
+    clearTextSelection()
+  }
+  const suppressSyntheticClick = () => {
+    lastTouchActionAtRef.current = Date.now()
+  }
+  const shouldIgnoreSyntheticClick = () => Date.now() - lastTouchActionAtRef.current < 700
 
   // Position the bubble centered above the selection, 8 px above the top edge.
   // `fixed` positioning lets us use the viewport-relative coords from
-  // getBoundingClientRect / posToDOMRect directly.
+  // getBoundingClientRect / posToDOMRect directly. Clamp to the visual viewport
+  // so the bubble does not fall under the iOS selection magnifier or off-screen.
+  const viewportWidth = typeof window !== 'undefined' ? window.visualViewport?.width ?? window.innerWidth ?? 1024 : 1024
+  const viewportHeight =
+    typeof window !== 'undefined' ? window.visualViewport?.height ?? window.innerHeight ?? 768 : 768
+  const desiredLeft = rect.left + rect.width / 2
+  const clampedLeft = Math.min(Math.max(desiredLeft, 60), Math.max(60, viewportWidth - 60))
+  // Keep an extra 48px margin below the top of the viewport so the bubble does
+  // not get clipped under a sticky header / iOS dynamic island.
+  const desiredTop = rect.top - 8
+  const clampedTop = Math.min(Math.max(desiredTop, 48), Math.max(48, viewportHeight - 48))
   const bubbleStyle: React.CSSProperties = {
     position: 'fixed',
-    top: rect.top - 8,
-    left: rect.left + rect.width / 2,
+    top: clampedTop,
+    left: clampedLeft,
     transform: 'translate(-50%, -100%)',
     zIndex: 50,
   }
 
   return (
-    <div style={bubbleStyle} onMouseDown={stopPropagation}>
+    <div style={bubbleStyle} onMouseDown={stopPropagation} onTouchStart={stopPropagationTouch}>
       <div className="bg-popover flex items-center gap-1 rounded-md border p-1 shadow-md transition-all duration-150">
         {onCopyFragmentLink && (
           <button
             type="button"
             aria-label="Copy link to selection"
             title="Copy Link"
-            className="text-muted-foreground hover:bg-accent hover:text-foreground rounded p-1"
+            className="text-muted-foreground hover:bg-accent hover:text-foreground rounded p-2"
             onMouseDown={(e) => {
               e.preventDefault()
               e.stopPropagation()
             }}
+            onTouchStart={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+            }}
+            onTouchEnd={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              suppressSyntheticClick()
+              runCopyFragmentLink()
+            }}
             onClick={(e) => {
               e.stopPropagation()
-              onCopyFragmentLink(blockId, rangeStart, rangeEnd)
+              if (shouldIgnoreSyntheticClick()) return
+              runCopyFragmentLink()
             }}
           >
-            <Link size={14} />
+            <Link size={16} />
           </button>
         )}
         {onComment && (
@@ -152,17 +206,28 @@ export function RangeSelectionPositioner<BSchema extends BlockSchema = BlockSche
             type="button"
             aria-label="Comment on selection"
             title="Comment"
-            className="text-muted-foreground hover:bg-accent hover:text-foreground rounded p-1"
+            className="text-muted-foreground hover:bg-accent hover:text-foreground rounded p-2"
             onMouseDown={(e) => {
               e.preventDefault()
               e.stopPropagation()
             }}
+            onTouchStart={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+            }}
+            onTouchEnd={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              suppressSyntheticClick()
+              runComment()
+            }}
             onClick={(e) => {
               e.stopPropagation()
-              onComment(blockId, rangeStart, rangeEnd)
+              if (shouldIgnoreSyntheticClick()) return
+              runComment()
             }}
           >
-            <MessageSquare size={14} />
+            <MessageSquare size={16} />
           </button>
         )}
       </div>
@@ -177,4 +242,31 @@ export function RangeSelectionPositioner<BSchema extends BlockSchema = BlockSche
 /** Prevents mousedown events on the bubble from clearing the editor selection. */
 function stopPropagation(e: React.MouseEvent) {
   e.stopPropagation()
+}
+
+/** Prevents touchstart events on the bubble from collapsing the OS text
+ * selection. Without this, tapping the bubble on iOS deselects the text
+ * before the click handler can read it. */
+function stopPropagationTouch(e: React.TouchEvent) {
+  // Don't preventDefault here — that would block subsequent click events
+  // generated by the touch. Only stop propagation so the OS keeps the selection.
+  e.stopPropagation()
+}
+
+/** Clears the visible browser/ProseMirror selection after fragment actions. */
+function clearEditorTextSelection<BSchema extends BlockSchema>(editor: EditorWithRangeSelection<BSchema>) {
+  const view = editor._tiptapEditor?.view
+  if (view && !view.isDestroyed) {
+    const {state} = view
+    const pos = Math.min(Math.max(state.selection.to, 0), state.doc.content.size)
+    try {
+      view.dispatch(state.tr.setSelection(TextSelection.create(state.doc, pos)))
+    } catch {
+      // Ignore invalid positions; clearing the native selection below is still useful.
+    }
+  }
+
+  if (typeof window !== 'undefined') {
+    window.getSelection()?.removeAllRanges()
+  }
 }

--- a/frontend/packages/editor/src/comment-editor.tsx
+++ b/frontend/packages/editor/src/comment-editor.tsx
@@ -15,6 +15,7 @@ import {Plugin, PluginKey} from '@tiptap/pm/state'
 import {useEffect, useLayoutEffect, useRef, useState} from 'react'
 import avatarPlaceholder from './assets/avatar.png'
 import {BlockNoteEditor, getBlockInfoFromPos, useBlockNote} from './blocknote'
+import {insertOrUpdateBlock} from './blocknote/core/extensions/SlashMenu/defaultSlashMenuItems'
 import {FILE_DROP_INSERTED_EVENT} from './blocknote/core/extensions/DragMedia/DragExtension'
 import {HyperMediaEditorView} from './editor-view'
 import {createHypermediaDocLinkPlugin} from './hypermedia-link-plugin'
@@ -82,6 +83,7 @@ export function useCommentEditor(
   onMobileMentionTriggerRef.current = onMobileMentionTrigger
   const onMobileSlashTriggerRef = useRef(onMobileSlashTrigger)
   onMobileSlashTriggerRef.current = onMobileSlashTrigger
+  const editorRef = useRef<BlockNoteEditor<typeof hmBlockSchema> | null>(null)
 
   const editor = useBlockNote<typeof hmBlockSchema>({
     onEditorContentChange(editor: BlockNoteEditor<typeof hmBlockSchema>) {
@@ -92,6 +94,19 @@ export function useCommentEditor(
       universalClient,
       gwUrl,
       domainResolver,
+      onPasteHypermediaBlockFragment: (resolvedHmUrl: string) => {
+        const ed = editorRef.current
+        if (!ed) return false
+        insertOrUpdateBlock(
+          ed,
+          {
+            type: 'embed',
+            props: {url: resolvedHmUrl, view: 'Content'},
+          } as any,
+          true,
+        )
+        return true
+      },
     },
 
     // onEditorReady: (e) => {
@@ -176,6 +191,8 @@ export function useCommentEditor(
       ],
     },
   })
+
+  editorRef.current = editor
 
   return {
     editor,

--- a/frontend/packages/editor/src/document-editor.tsx
+++ b/frontend/packages/editor/src/document-editor.tsx
@@ -18,6 +18,7 @@ import {Plugin, PluginKey, TextSelection} from 'prosemirror-state'
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {
   BlockHoverActionsPositioner,
+  BlockNoteEditor,
   BlockNoteView,
   FormattingToolbarPositioner,
   FullBlockSelectionObserver,
@@ -32,6 +33,7 @@ import {
   type FormattingToolbarProps,
 } from './blocknote'
 import {blockHighlightPluginKey} from './blocknote/core/extensions/BlockHighlight/BlockHighlightPlugin'
+import {insertOrUpdateBlock} from './blocknote/core/extensions/SlashMenu/defaultSlashMenuItems'
 import {applyReadOnlyClickSelectionGuard, shouldKeepEditModeForPointerTarget} from './click-edit-mode-guard'
 import {useDraftActions} from './draft-actions-context'
 import {FragmentActionsContext, type FragmentActions} from './fragment-actions-context'
@@ -73,6 +75,7 @@ export function DocumentEditor({
   onBlockCitationClick,
   onBlockCommentClick,
   onBlockSelect,
+  onTextSelection,
   onEditorReady,
   onBlocksFullSelected,
   draftCursorPosition,
@@ -122,9 +125,17 @@ export function DocumentEditor({
     actorRef.send({type: 'edit.start'})
   }, [actorRef])
 
+  const onTextSelectionRef = useRef(onTextSelection)
+  onTextSelectionRef.current = onTextSelection
+
   // Suppress change events during programmatic content replacement
   // (e.g. when loading draft content on edit-mode entry).
   const suppressChangeRef = useRef(false)
+
+  // Ref to the BlockNote editor for use inside option callbacks that are
+  // created before the editor instance exists (e.g. the paste handler's
+  // block-fragment landing callback).
+  const docEditorRef = useRef<BlockNoteEditor<HMBlockSchema> | null>(null)
 
   // Freeze blocks once editing starts so document query refetches don't
   // recreate the editor and lose the user's edits (or loaded draft content).
@@ -146,7 +157,7 @@ export function DocumentEditor({
     const editorBlocks = isEditorFormat
       ? (effectiveBlocks as any[])
       : hmBlocksToEditorContent(effectiveBlocks, {childrenType: 'Group'})
-    return editorBlocks.length > 0 ? editorBlocks : [{type: 'paragraph' as const, id: 'empty'}]
+    return editorBlocks.length > 0 ? editorBlocks : [{type: 'paragraph' as const}]
   }, [effectiveBlocks])
 
   const editor = useBlockNote<HMBlockSchema>(
@@ -173,6 +184,21 @@ export function DocumentEditor({
         openUrl: linkExtensionOptions?.openUrl ?? openUrl,
         renderHref: linkExtensionOptions?.renderHref ?? renderHref,
         handleModifiedClicks: linkExtensionOptions?.handleModifiedClicks ?? !!openRouteNewWindow,
+        onPasteHypermediaBlockFragment:
+          linkExtensionOptions?.onPasteHypermediaBlockFragment ??
+          ((resolvedHmUrl: string) => {
+            const ed = docEditorRef.current
+            if (!ed) return false
+            insertOrUpdateBlock(
+              ed,
+              {
+                type: 'embed',
+                props: {url: resolvedHmUrl, view: 'Content'},
+              } as any,
+              true,
+            )
+            return true
+          }),
       },
       _tiptapOptions: {
         extensions: [
@@ -191,6 +217,36 @@ export function DocumentEditor({
                   return selectAllEditorContent(editor)
                 },
               }
+            },
+          }),
+          Extension.create({
+            name: 'document-text-selection-observer',
+            priority: 0,
+            addProseMirrorPlugins() {
+              const pluginKey = new PluginKey('documentTextSelectionObserver')
+              let lastSelectionKey: string | null = null
+
+              return [
+                new Plugin({
+                  key: pluginKey,
+                  view: () => ({
+                    update(view, prevState) {
+                      const selection = view.state.selection
+                      if (selection.eq(prevState.selection)) return
+
+                      if (!(selection instanceof TextSelection) || selection.empty) {
+                        lastSelectionKey = null
+                        return
+                      }
+
+                      const selectionKey = `${selection.from}:${selection.to}`
+                      if (selectionKey === lastSelectionKey) return
+                      lastSelectionKey = selectionKey
+                      onTextSelectionRef.current?.()
+                    },
+                  }),
+                }),
+              ]
             },
           }),
           Extension.create({
@@ -307,6 +363,10 @@ export function DocumentEditor({
     },
     [initialContent],
   )
+
+  // Keep the editor ref current so the paste-handler block-fragment landing
+  // callback can resolve to the same editor instance.
+  docEditorRef.current = editor
 
   // Expose the suppress ref on the editor so external consumers (e.g. auto-rebase)
   // can wrap programmatic `replaceBlocks` calls without triggering `change` events.

--- a/frontend/packages/editor/src/embed-block.tsx
+++ b/frontend/packages/editor/src/embed-block.tsx
@@ -468,7 +468,14 @@ function EditorEmbedContent({
       block={block}
       parentBlockId={parentBlockId}
       openOnClick={openOnClick}
-      renderDocumentContent={({embedBlocks, id}) => <EmbedEditorView blocks={embedBlocks} id={id} />}
+      renderDocumentContent={({embedBlocks, id, blockRef, blockRange}) => (
+        <EmbedEditorView
+          blocks={embedBlocks}
+          id={id}
+          focusBlockId={blockRef ?? undefined}
+          blockRange={blockRange ?? undefined}
+        />
+      )}
     />
   )
 }

--- a/frontend/packages/editor/src/embed-editor.tsx
+++ b/frontend/packages/editor/src/embed-editor.tsx
@@ -1,15 +1,16 @@
 import {hmBlocksToEditorContent} from '@seed-hypermedia/client/hmblock-to-editorblock'
-import type {HMBlockNode, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import type {BlockRange, HMBlockNode, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {RenderResourceProvider} from '@shm/shared'
-import {useMemo} from 'react'
+import {useEffect, useMemo} from 'react'
 import {BlockNoteEditor, useBlockNote} from './blocknote'
+import {blockHighlightPluginKey} from './blocknote/core/extensions/BlockHighlight/BlockHighlightPlugin'
 import {BlockNoteView} from './blocknote/react/BlockNoteView'
 import {hmBlockSchema, HMBlockSchema} from './schema'
 
 export function useEmbedEditor(blocks: HMBlockNode[]): BlockNoteEditor<HMBlockSchema> {
   const initialContent = useMemo(() => {
     const editorBlocks = hmBlocksToEditorContent(blocks, {childrenType: 'Group'})
-    return editorBlocks.length > 0 ? editorBlocks : [{type: 'paragraph' as const, id: 'empty'}]
+    return editorBlocks.length > 0 ? editorBlocks : [{type: 'paragraph' as const}]
   }, [blocks])
 
   return useBlockNote(
@@ -30,10 +31,16 @@ export function EmbedEditorView({
   blocks,
   id,
   depth = 1,
+  focusBlockId,
+  blockRange,
 }: {
   blocks: HMBlockNode[]
   id: UnpackedHypermediaId
   depth?: number
+  /** Block id within the embedded content to focus-highlight. */
+  focusBlockId?: string
+  /** Codepoint range within `focusBlockId` to highlight instead of the whole block. */
+  blockRange?: BlockRange | null
 }) {
   if (depth > MAX_EMBED_DEPTH) {
     return null
@@ -50,14 +57,44 @@ export function EmbedEditorView({
           e.preventDefault()
         }}
       >
-        <EmbedEditorInner blocks={blocks} />
+        <EmbedEditorInner blocks={blocks} focusBlockId={focusBlockId} blockRange={blockRange ?? undefined} />
       </div>
     </RenderResourceProvider>
   )
 }
 
-function EmbedEditorInner({blocks}: {blocks: HMBlockNode[]}) {
+function EmbedEditorInner({
+  blocks,
+  focusBlockId,
+  blockRange,
+}: {
+  blocks: HMBlockNode[]
+  focusBlockId?: string
+  blockRange?: BlockRange
+}) {
   const editor = useEmbedEditor(blocks)
+
+  const rangeStart = blockRange && 'start' in blockRange ? blockRange.start : null
+  const rangeEnd = blockRange && 'end' in blockRange ? blockRange.end : null
+
+  useEffect(() => {
+    const view = editor._tiptapEditor?.view
+    if (!view) return
+    if (focusBlockId && rangeStart != null && rangeEnd != null) {
+      view.dispatch(
+        view.state.tr.setMeta(blockHighlightPluginKey, {
+          type: 'rangeFocus',
+          blockId: focusBlockId,
+          start: rangeStart,
+          end: rangeEnd,
+        }),
+      )
+    } else if (focusBlockId) {
+      view.dispatch(view.state.tr.setMeta(blockHighlightPluginKey, {type: 'focus', blockId: focusBlockId}))
+    } else {
+      view.dispatch(view.state.tr.setMeta(blockHighlightPluginKey, {type: 'clear'}))
+    }
+  }, [editor, focusBlockId, rangeStart, rangeEnd])
 
   return (
     <BlockNoteView editor={editor} className="hm-prose">

--- a/frontend/packages/editor/src/hm-formatting-toolbar.tsx
+++ b/frontend/packages/editor/src/hm-formatting-toolbar.tsx
@@ -17,8 +17,10 @@ import {Tooltip} from '@shm/ui/tooltip'
 import {usePopoverState} from '@shm/ui/use-popover-state'
 import {cn} from '@shm/ui/utils'
 import {ChevronDown, FileText, Link, ListChecks, MessageSquare} from 'lucide-react'
+import {TextSelection} from 'prosemirror-state'
 import {useEffect, useRef, useState} from 'react'
 import {BlockNoteEditor, BlockSpec, getBlockInfoFromSelection, PropSchema, updateGroupCommand} from './blocknote/core'
+import {prosemirrorPosToBlockTextOffset} from './blocknote/core/extensions/RangeSelection/RangeSelectionPlugin'
 import {getNearestBlockPos} from './blocknote/core/extensions/Blocks/helpers/getBlockInfoFromPos'
 import {getGroupInfoFromPos} from './blocknote/core/extensions/Blocks/helpers/getGroupInfoFromPos'
 import {
@@ -114,45 +116,28 @@ function getSelectionFragment(editor: BlockNoteEditor<any>): {
     }
   })
 
-  const rangeStart = posToBlockTextOffset(state, from, blockContentBeforePos)
-  const rangeEnd = posToBlockTextOffset(state, to, blockContentBeforePos)
+  const rangeStart = prosemirrorPosToBlockTextOffset(state.doc, from, blockContentBeforePos)
+  const rangeEnd = prosemirrorPosToBlockTextOffset(state.doc, to, blockContentBeforePos)
 
   return {blockId, rangeStart, rangeEnd}
 }
 
-/** Converts a ProseMirror position to a codepoint offset within the block's text. */
-function posToBlockTextOffset(
-  state: import('prosemirror-state').EditorState,
-  docPos: number,
-  blockContentBeforePos: number,
-): number {
-  const blockContentNode = state.doc.resolve(blockContentBeforePos + 1).parent
-  const offsetWithinContent = docPos - (blockContentBeforePos + 1)
-
-  let codepoints = 0
-  let remaining = offsetWithinContent
-
-  blockContentNode.forEach((node, nodeOffset) => {
-    if (remaining <= 0) return
-    if (node.isText && node.text) {
-      const nodeEnd = nodeOffset + node.nodeSize
-      if (nodeOffset < remaining && remaining <= nodeEnd) {
-        const slice = node.text.slice(0, remaining - nodeOffset)
-        codepoints += Array.from(slice).length
-        remaining = 0
-      } else if (nodeOffset < remaining) {
-        codepoints += Array.from(node.text).length
-        remaining -= node.nodeSize
-      }
-    } else {
-      if (nodeOffset < remaining) {
-        codepoints += 1
-        remaining -= node.nodeSize
-      }
+/** Clears the visible browser/ProseMirror text selection after fragment actions. */
+function clearEditorTextSelection(editor: BlockNoteEditor<any>) {
+  const view = editor._tiptapEditor?.view
+  if (view && !view.isDestroyed) {
+    const {state} = view
+    const pos = Math.min(Math.max(state.selection.to, 0), state.doc.content.size)
+    try {
+      view.dispatch(state.tr.setSelection(TextSelection.create(state.doc, pos)))
+    } catch {
+      // Ignore invalid positions; clearing the native selection below is still useful.
     }
-  })
+  }
 
-  return codepoints
+  if (typeof window !== 'undefined') {
+    window.getSelection()?.removeAllRanges()
+  }
 }
 
 const toggleStyles = [
@@ -433,7 +418,10 @@ export function HMFormattingToolbar<Schema extends Record<string, BlockSpec<stri
                     className="rounded-md hover:bg-black/10 dark:hover:bg-white/10"
                     onClick={() => {
                       const frag = getSelectionFragment(props.editor)
-                      if (frag) fragmentActions.onComment(frag.blockId, frag.rangeStart, frag.rangeEnd)
+                      if (frag) {
+                        fragmentActions.onComment(frag.blockId, frag.rangeStart, frag.rangeEnd)
+                        clearEditorTextSelection(props.editor)
+                      }
                     }}
                   >
                     <MessageSquare className="size-4" />
@@ -447,7 +435,10 @@ export function HMFormattingToolbar<Schema extends Record<string, BlockSpec<stri
                     className="rounded-md hover:bg-black/10 dark:hover:bg-white/10"
                     onClick={() => {
                       const frag = getSelectionFragment(props.editor)
-                      if (frag) fragmentActions.onCopyFragmentLink(frag.blockId, frag.rangeStart, frag.rangeEnd)
+                      if (frag) {
+                        fragmentActions.onCopyFragmentLink(frag.blockId, frag.rangeStart, frag.rangeEnd)
+                        clearEditorTextSelection(props.editor)
+                      }
                     }}
                   >
                     <Link className="size-4" />

--- a/frontend/packages/editor/src/readonly-viewer.tsx
+++ b/frontend/packages/editor/src/readonly-viewer.tsx
@@ -62,7 +62,7 @@ export function ReadOnlyViewer({
   )
   const initialContent = useMemo(() => {
     const editorBlocks = hmBlocksToEditorContent(blocks, {childrenType: 'Group'})
-    return editorBlocks.length > 0 ? editorBlocks : [{type: 'paragraph' as const, id: 'empty'}]
+    return editorBlocks.length > 0 ? editorBlocks : [{type: 'paragraph' as const}]
   }, [blocks])
 
   const editor = useBlockNote<HMBlockSchema>(

--- a/frontend/packages/editor/src/tiptap-extension-link/helpers/pasteHandler.ts
+++ b/frontend/packages/editor/src/tiptap-extension-link/helpers/pasteHandler.ts
@@ -21,6 +21,11 @@ type PasteHandlerOptions = {
   linkOnPaste?: boolean
   gwUrl: StateStream<string>
   checkWebUrl: (url: string) => Promise<any>
+  /** When provided and a `hm://…#blockId[...]` URL is pasted into an empty
+   * selection, this callback receives the resolved hm URL (with the resolved
+   * version filled in when needed) so the host editor can insert an Embed
+   * block instead of falling back to a link mark. */
+  onPasteHypermediaBlockFragment?: (resolvedHmUrl: string) => void | boolean
 }
 
 export function pasteHandler(options: PasteHandlerOptions): Plugin {
@@ -251,6 +256,11 @@ export function pasteHandler(options: PasteHandlerOptions): Plugin {
                     version: resolvedVersion,
                   }),
                 )
+                // Block-fragment links → host can land them as Embed blocks.
+                if (unpackedHmId.blockRef && options.onPasteHypermediaBlockFragment) {
+                  const handled = options.onPasteHypermediaBlockFragment(normalizedHmUrl)
+                  if (handled !== false) return
+                }
                 if (title) {
                   view.dispatch(
                     tr.insertText(title, pos).addMark(
@@ -304,6 +314,10 @@ export function pasteHandler(options: PasteHandlerOptions): Plugin {
               .catch((err) => {
                 // Fallback: use original URL without resolved version
                 const normalizedHmUrl = packHmId(hmId(unpackedHmId.uid, unpackedHmId))
+                if (unpackedHmId.blockRef && options.onPasteHypermediaBlockFragment) {
+                  const handled = options.onPasteHypermediaBlockFragment(normalizedHmUrl)
+                  if (handled !== false) return
+                }
                 view.dispatch(
                   tr.insertText(normalizedHmUrl, pos).addMark(
                     pos,

--- a/frontend/packages/editor/src/tiptap-extension-link/link.ts
+++ b/frontend/packages/editor/src/tiptap-extension-link/link.ts
@@ -49,6 +49,13 @@ export interface LinkOptions {
    * If enabled, modified clicks are handled by the platform openUrl handler.
    */
   handleModifiedClicks?: boolean
+  /**
+   * Called when a Hypermedia URL with a `blockRef` (block-fragment link) is
+   * pasted into an empty selection. Implementations should insert an
+   * Embed block to replace the cursor block. Returning truthy signals that
+   * the paste was handled and the default link-mark fallback is skipped.
+   */
+  onPasteHypermediaBlockFragment?: (resolvedHmUrl: string) => void | boolean
 }
 
 /** Returns the canonical raw href stored on a rendered link element. */
@@ -245,6 +252,7 @@ export const Link = Mark.create<LinkOptions>({
         type: this.type,
         linkOnPaste: this.options.linkOnPaste,
         checkWebUrl: this.options.checkWebUrl,
+        onPasteHypermediaBlockFragment: this.options.onPasteHypermediaBlockFragment,
       }),
     )
 

--- a/frontend/packages/shared/src/__tests__/optimistic-comment.test.ts
+++ b/frontend/packages/shared/src/__tests__/optimistic-comment.test.ts
@@ -224,6 +224,21 @@ describe('applyOptimisticComment', () => {
     expect(blockData?.comments?.[0]?.id).toBe(commentRecordId)
   })
 
+  it('accepts the new QuotingTarget shape with a range', () => {
+    const qc = createQueryClient()
+    const comment = makeComment()
+    const quoting = {blockId: 'blockXYZ', range: {start: 1, end: 4}}
+
+    const blockTargetId = {...docId, blockRef: quoting.blockId}
+    const blockKey = [queryKeys.BLOCK_DISCUSSIONS, blockTargetId]
+    qc.setQueryData(blockKey, {comments: [], authors: {}})
+
+    applyOptimisticComment(qc, docId, comment, authorMetadata, quoting)
+
+    const blockData = qc.getQueryData<HMListCommentsOutput>(blockKey)
+    expect(blockData?.comments).toHaveLength(1)
+  })
+
   it('skips BLOCK_DISCUSSIONS when no quoting block is given', () => {
     const qc = createQueryClient()
     const comment = makeComment()

--- a/frontend/packages/shared/src/client/__tests__/editorblock-to-hmblock.test.ts
+++ b/frontend/packages/shared/src/client/__tests__/editorblock-to-hmblock.test.ts
@@ -52,6 +52,33 @@ describe('EditorBlock to HMBlock', () => {
       expect(val).toEqual(result)
     })
 
+    test('paragraph replaces reserved empty fallback id', () => {
+      const editorBlock: EditorBlock = {
+        id: 'empty',
+        type: 'paragraph',
+        children: [],
+        props: {},
+        content: [
+          {
+            type: 'text',
+            text: 'Hello world',
+            styles: {},
+          },
+        ],
+      }
+
+      const val = editorBlockToHMBlock(editorBlock)
+
+      expect(val.id).not.toBe('empty')
+      expect(val.id).toHaveLength(8)
+      expect(val).toMatchObject({
+        type: 'Paragraph',
+        text: 'Hello world',
+        annotations: [],
+        attributes: {},
+      })
+    })
+
     test('paragraph with styles formats', () => {
       const editorBlock: EditorBlock = {
         id: 'foo',

--- a/frontend/packages/shared/src/client/__tests__/hmblock-to-editorblock.test.ts
+++ b/frontend/packages/shared/src/client/__tests__/hmblock-to-editorblock.test.ts
@@ -391,6 +391,52 @@ describe('HMBlock to EditorBlock', () => {
       expect(val).toEqual(result)
     })
 
+    test('paragraph with inline embed consumes visible annotation text', () => {
+      const hmBlock: HMBlock = {
+        id: 'foo',
+        type: 'Paragraph',
+        text: 'Hello Seed document!',
+        annotations: [
+          {
+            type: 'Embed',
+            starts: [6],
+            attributes: {},
+            ends: [19],
+            link: 'hm://asdf1234/docs/seed-document',
+          },
+        ],
+        attributes: {},
+        revision: 'revision123',
+      }
+      const result: EditorBlock = {
+        id: 'foo',
+        type: 'paragraph',
+        children: [],
+        props: {
+          revision: 'revision123',
+        },
+        content: [
+          {
+            type: 'text',
+            text: 'Hello ',
+            styles: {},
+          },
+          {
+            type: 'inline-embed',
+            link: 'hm://asdf1234/docs/seed-document',
+            styles: {},
+          },
+          {
+            type: 'text',
+            text: '!',
+            styles: {},
+          },
+        ],
+      }
+      const val = hmBlockToEditorBlock(hmBlock)
+      expect(val).toEqual(result)
+    })
+
     test('heading', () => {
       const hmBlock: HMBlockHeading = {
         id: 'foo',

--- a/frontend/packages/shared/src/document-content-props.ts
+++ b/frontend/packages/shared/src/document-content-props.ts
@@ -32,6 +32,13 @@ export type LinkExtensionOptions = {
   renderHref?: (url: string) => string
   /** Whether the link mark should be rendered as `<a>` (clickable) or `<span>`. */
   openOnClick?: boolean
+  /**
+   * Called when a Hypermedia URL whose fragment targets a specific block
+   * (`#blockId[start:end]`) is pasted into an empty selection. Implementations
+   * typically replace the cursor block with an Embed block referencing the URL.
+   * Return `false` to fall back to the default link-mark behavior.
+   */
+  onPasteHypermediaBlockFragment?: (resolvedHmUrl: string) => void | boolean
 }
 
 export type DocumentContentProps = {
@@ -48,6 +55,8 @@ export type DocumentContentProps = {
     startCommentingNow?: boolean,
   ) => void
   onBlockSelect?: (blockId: string, opts?: BlockRange & {copyToClipboard?: boolean}) => void
+  /** Called when the user creates a non-empty text selection inside the document editor. */
+  onTextSelection?: () => void
   /** Called when the set of fully-selected blocks changes. Receives the IDs of blocks whose entire content is covered by the current selection. */
   onBlocksFullSelected?: (blockIds: string[]) => void
   /** Called when the editor instance is created. Used by the desktop app to capture the editor ref for draft saving. */

--- a/frontend/packages/shared/src/optimistic-comment.ts
+++ b/frontend/packages/shared/src/optimistic-comment.ts
@@ -1,4 +1,5 @@
 import {commentRecordIdFromBlob, trimTrailingEmptyBlocks} from '@seed-hypermedia/client'
+import type {QuotingTarget} from '@seed-hypermedia/client'
 import {
   hmIdPathToEntityQueryPath,
   HMBlockNode,
@@ -25,6 +26,9 @@ export type BuildOptimisticCommentParams = {
   contentBlocks: HMBlockNode[]
   replyParentId?: string
   threadRootVersion?: string
+  /** Structured quote target (preferred). */
+  quoting?: QuotingTarget
+  /** Deprecated alias retained for callers still passing only a block id. */
   quotingBlockId?: string
   visibility?: 'PUBLIC' | 'PRIVATE'
 }
@@ -43,8 +47,9 @@ export async function buildOptimisticComment(params: BuildOptimisticCommentParam
 
   // Apply same transformations as createComment: trim trailing empty blocks + wrap with embed if quoting
   let content = trimTrailingEmptyBlocks(params.contentBlocks)
-  if (params.quotingBlockId) {
-    content = wrapQuotedContent(content, params.docId, params.docVersion, params.quotingBlockId)
+  const quoting = resolveQuoting(params)
+  if (quoting) {
+    content = wrapQuotedContent(content, params.docId, params.docVersion, quoting)
   }
 
   return {
@@ -68,7 +73,7 @@ function wrapQuotedContent(
   content: HMBlockNode[],
   docId: UnpackedHypermediaId,
   docVersion: string,
-  quotingBlockId: string,
+  quoting: QuotingTarget,
 ): HMBlockNode[] {
   return [
     {
@@ -78,11 +83,29 @@ function wrapQuotedContent(
         text: '',
         attributes: {childrenType: 'Group', view: 'Content'},
         annotations: [],
-        link: packHmId({...docId, blockRef: quotingBlockId, version: docVersion}),
+        link: packHmId({
+          ...docId,
+          blockRef: quoting.blockId,
+          blockRange: quoting.range ?? null,
+          version: docVersion,
+          latest: false,
+        }),
       },
       children: content,
     } as HMBlockNode,
   ]
+}
+
+/** Reconciles legacy `quotingBlockId` and the new `quoting` param. */
+function resolveQuoting(params: {quoting?: QuotingTarget; quotingBlockId?: string}): QuotingTarget | undefined {
+  if (params.quoting) {
+    if (params.quoting.range && params.quoting.range.start === params.quoting.range.end) {
+      return {blockId: params.quoting.blockId}
+    }
+    return params.quoting
+  }
+  if (params.quotingBlockId) return {blockId: params.quotingBlockId}
+  return undefined
 }
 
 function generateBlockId(length: number): string {
@@ -105,9 +128,11 @@ export function applyOptimisticComment(
   targetId: UnpackedHypermediaId,
   comment: HMComment,
   authorMetadata?: HMMetadataPayload | null,
-  quotingBlockId?: string,
+  quoting?: QuotingTarget | string,
 ): () => void {
   const rollbacks: (() => void)[] = []
+  // Back-compat: callers used to pass `quotingBlockId: string` as the 5th arg.
+  const quotingTarget: QuotingTarget | undefined = typeof quoting === 'string' ? {blockId: quoting} : quoting
 
   // Update DOCUMENT_COMMENTS cache
   const commentsKey = [queryKeys.DOCUMENT_COMMENTS, targetId]
@@ -123,8 +148,8 @@ export function applyOptimisticComment(
   rollbacks.push(() => qc.setQueryData(commentsKey, prevComments))
 
   // Also update BLOCK_DISCUSSIONS cache when quoting a specific block
-  if (quotingBlockId) {
-    const blockTargetId = {...targetId, blockRef: quotingBlockId}
+  if (quotingTarget) {
+    const blockTargetId = {...targetId, blockRef: quotingTarget.blockId}
     const blockKey = [queryKeys.BLOCK_DISCUSSIONS, blockTargetId]
     const prevBlock = qc.getQueryData<HMListCommentsOutput>(blockKey)
     if (prevBlock) {

--- a/frontend/packages/ui/src/__tests__/embed-wrapper.test.tsx
+++ b/frontend/packages/ui/src/__tests__/embed-wrapper.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import React from 'react'
+import {createRoot, type Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {hmId} from '@shm/shared/utils/entity-id-url'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {EmbedWrapper} from '../embed-wrapper'
+;(globalThis as typeof globalThis & {React?: typeof React; IS_REACT_ACT_ENVIRONMENT?: boolean}).React = React
+;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('@shm/shared/routing', () => ({
+  useRouteLink: () => ({}),
+}))
+
+vi.mock('@shm/shared/utils/navigation', () => ({
+  useNavRoute: () => ({key: 'document', id: {id: 'hm://uid-1/doc', uid: 'uid-1', path: ['doc']}}),
+}))
+
+vi.mock('../highlight-context', () => ({
+  useHighlighter: () => () => ({}),
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+describe('EmbedWrapper', () => {
+  it('does not apply legacy range-elision class to ranged embeds', () => {
+    act(() => {
+      root.render(
+        <EmbedWrapper
+          id={hmId('uid-1', {path: ['doc'], blockRef: 'block-1', blockRange: {start: 1, end: 3}})}
+          parentBlockId={null}
+          isRange
+        >
+          <span>whole block content</span>
+        </EmbedWrapper>,
+      )
+    })
+
+    const wrapper = container.querySelector('[data-content-type="embed"]') as HTMLElement | null
+    expect(wrapper).toBeTruthy()
+    expect(wrapper?.className).not.toContain('hm-embed-range-wrapper')
+    expect(wrapper?.dataset.isRange).toBe('true')
+  })
+})

--- a/frontend/packages/ui/src/blocks-content.css
+++ b/frontend/packages/ui/src/blocks-content.css
@@ -20,19 +20,3 @@
 .feed-item-container .embed-side-annotation {
   display: none !important;
 }
-
-/* Range-fragment embed: when an embed points at a sub-span of the
- * source block, show the fragment and elide the surrounding text. */
-.hm-embed-range-wrapper span:not(.hm-embed-range) {
-  display: none !important;
-}
-
-.hm-embed-range-wrapper span.hm-embed-range:before,
-.hm-embed-range-wrapper span.hm-embed-range:after {
-  content: '...';
-}
-
-.hm-embed-range-wrapper span.hm-embed-range {
-  font-weight: lighter !important;
-  font-style: italic !important;
-}

--- a/frontend/packages/ui/src/embed-views.tsx
+++ b/frontend/packages/ui/src/embed-views.tsx
@@ -229,11 +229,20 @@ export function BlockEmbedContent({
     embedBlocks: HMBlockNode[]
     document: HMDocument | null | undefined
     id: UnpackedHypermediaId
+    /** Block id within the embedded document to scroll-anchor / focus-highlight. */
+    blockRef?: string | null
+    /** Codepoint range within `blockRef` to highlight when the link targets a fragment. */
+    blockRange?: import('@seed-hypermedia/client/hm-types').BlockRange | null
   }) => React.ReactNode
 }) {
   const [showReferenced, setShowReferenced] = useState(false)
   const renderResourceStack = useRenderResourceStack()
-  const id = unpackHmId(block.link)
+  const rawId = unpackHmId(block.link)
+  // When the link targets a specific codepoint range we MUST resolve against
+  // the pinned version, otherwise later edits to the source doc shift the
+  // range and the highlight lands on different text. Force `latest:false`
+  // whenever blockRange is present, even on legacy links that still carry `&l`.
+  const id = rawId && rawId.blockRange && rawId.version ? {...rawId, latest: false} : rawId
 
   const resource = useResource(id, {subscribed: true})
   // Check tombstone on latest version for version-pinned embeds.
@@ -533,6 +542,8 @@ function BlockEmbedContentDocument(props: {
     embedBlocks: HMBlockNode[]
     document: HMDocument | null | undefined
     id: UnpackedHypermediaId
+    blockRef?: string | null
+    blockRange?: BlockRange | null
   }) => React.ReactNode
 }) {
   const {
@@ -553,27 +564,11 @@ function BlockEmbedContentDocument(props: {
     const selectedBlock =
       props.blockRef && document?.content ? getBlockNodeById(document.content, props.blockRef) : null
 
-    // @ts-expect-error
-    const currentAnnotations = selectedBlock?.block?.annotations || []
     const embedBlocks = props.blockRef
       ? selectedBlock
         ? [
             {
               ...selectedBlock,
-              block: {
-                ...selectedBlock.block,
-                annotations:
-                  props.blockRange && 'start' in props.blockRange
-                    ? [
-                        ...currentAnnotations,
-                        {
-                          type: 'Range',
-                          starts: [props.blockRange.start],
-                          ends: [props.blockRange.end],
-                        },
-                      ]
-                    : currentAnnotations,
-              },
               children:
                 props.blockRange && 'expanded' in props.blockRange && props.blockRange.expanded
                   ? [...(selectedBlock.children || [])]
@@ -630,6 +625,8 @@ function BlockEmbedContentDocument(props: {
             embedBlocks: embedData.data.embedBlocks as HMBlockNode[],
             document,
             id,
+            blockRef: props.blockRef,
+            blockRange: props.blockRange ?? null,
           })}
         </>
       )
@@ -641,6 +638,7 @@ function BlockEmbedContentDocument(props: {
           id={id}
           blockId={blockId}
           blockRef={props.blockRef}
+          blockRange={props.blockRange ?? null}
           onCopyBlockLink={(bid) => {
             embedOnBlockSelect(bid, {copyToClipboard: true, start: 0, end: 0})
           }}
@@ -691,6 +689,7 @@ function EmbedContentFallback({
   id,
   blockId,
   blockRef,
+  blockRange,
   onCopyBlockLink,
   showReferenced,
   onShowReferenced,
@@ -700,6 +699,8 @@ function EmbedContentFallback({
   id: UnpackedHypermediaId
   blockId: string
   blockRef: string | null
+  /** Codepoint range to highlight inside `blockRef`. Absent ⇒ whole block. */
+  blockRange?: BlockRange | null
   onCopyBlockLink?: (blockId: string) => void
   showReferenced: boolean
   onShowReferenced: (show: boolean) => void
@@ -726,9 +727,21 @@ function EmbedContentFallback({
 
   if (!Viewer) return null
 
+  // Only forward a codepoint range — `{expanded: true}` should not highlight.
+  const fragmentRange =
+    blockRange && 'start' in blockRange && 'end' in blockRange && typeof blockRange.start === 'number'
+      ? blockRange
+      : undefined
+
   return (
     <>
-      <Viewer blocks={blocks} resourceId={id} onCopyBlockLink={onCopyBlockLink} />
+      <Viewer
+        blocks={blocks}
+        resourceId={id}
+        onCopyBlockLink={onCopyBlockLink}
+        focusBlockId={blockRef && fragmentRange ? blockRef : undefined}
+        blockRange={fragmentRange}
+      />
       {showReferenced ? (
         <div className="flex justify-end">
           <Tooltip content="The latest reference was not found. Click to try again.">

--- a/frontend/packages/ui/src/embed-wrapper.tsx
+++ b/frontend/packages/ui/src/embed-wrapper.tsx
@@ -64,9 +64,9 @@ export function EmbedWrapper({
         blockStyles,
         !hideBorder && 'border-l-primary border-l-3',
         'm-0 rounded-none',
-        isRange && 'hm-embed-range-wrapper',
         openOnClick && effectiveRoute && 'cursor-pointer text-inherit no-underline',
       )}
+      data-is-range={isRange ? 'true' : undefined}
       data-content-type="embed"
       data-url={packHmId(id)}
       data-view={viewType}

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -227,21 +227,56 @@ type CommentDraftTarget = {
   docId: string
   commentId?: string
   quotingBlockId?: string
+  quotingRangeStart?: number
+  quotingRangeEnd?: number
+}
+
+function extractQuotingRange(blockRange?: BlockRange | null): {start: number; end: number} | undefined {
+  if (!blockRange) return undefined
+  if (
+    'start' in blockRange &&
+    'end' in blockRange &&
+    typeof blockRange.start === 'number' &&
+    typeof blockRange.end === 'number'
+  ) {
+    return {start: blockRange.start, end: blockRange.end}
+  }
+  return undefined
+}
+
+function getCommentEditorRouteKey(params?: {
+  openComment?: string
+  targetBlockId?: string
+  blockRange?: BlockRange | null
+}) {
+  const range = extractQuotingRange(params?.blockRange ?? null)
+  return [params?.openComment ?? 'new', params?.targetBlockId ?? 'document', range?.start ?? '', range?.end ?? ''].join(
+    ':',
+  )
 }
 
 function getCommentDraftTarget(
   docId: UnpackedHypermediaId,
-  params?: {openComment?: string; targetBlockId?: string},
+  params?: {openComment?: string; targetBlockId?: string; blockRange?: BlockRange | null},
 ): CommentDraftTarget {
+  const range = extractQuotingRange(params?.blockRange ?? null)
   return {
     docId: docId.id,
     commentId: params?.openComment,
     quotingBlockId: params?.targetBlockId,
+    quotingRangeStart: range?.start,
+    quotingRangeEnd: range?.end,
   }
 }
 
 function areSameCommentDraftTarget(a: CommentDraftTarget, b: CommentDraftTarget) {
-  return a.docId === b.docId && a.commentId === b.commentId && a.quotingBlockId === b.quotingBlockId
+  return (
+    a.docId === b.docId &&
+    a.commentId === b.commentId &&
+    a.quotingBlockId === b.quotingBlockId &&
+    a.quotingRangeStart === b.quotingRangeStart &&
+    a.quotingRangeEnd === b.quotingRangeEnd
+  )
 }
 
 export function shouldSuppressMainCommentEditor({
@@ -252,7 +287,7 @@ export function shouldSuppressMainCommentEditor({
 }: {
   docId: UnpackedHypermediaId
   activeView: ActiveView
-  discussionsParams?: {openComment?: string; targetBlockId?: string}
+  discussionsParams?: {openComment?: string; targetBlockId?: string; blockRange?: BlockRange | null}
   panelRoute: DocumentPanelRoute | null
 }) {
   if (activeView !== 'comments' || panelRoute?.key !== 'comments') return false
@@ -262,6 +297,7 @@ export function shouldSuppressMainCommentEditor({
     getCommentDraftTarget(panelRoute.id, {
       openComment: panelRoute.openComment,
       targetBlockId: panelRoute.targetBlockId,
+      blockRange: panelRoute.blockRange,
     }),
   )
 }
@@ -315,6 +351,8 @@ function getActiveView(routeKey: string): ActiveView {
 export interface CommentEditorProps {
   docId: UnpackedHypermediaId
   quotingBlockId?: string
+  /** Codepoint range within the quoted block. Absent ⇒ whole-block quote. */
+  quotingRange?: {start: number; end: number}
   commentId?: string
   isReplying?: boolean
   /** Focus the editor on mount. Renamed from `autoFocus` to avoid `jsx-a11y/no-autofocus`; focus driven imperatively. */
@@ -1104,6 +1142,7 @@ function DocumentBody({
 
   const route = useNavRoute()
   const navigate = useNavigate()
+  const replaceRoute = useNavigate('replace')
 
   // Extract panel from route (only document/feed routes have panels)
   const panelRoute = getRoutePanel(route) as DocumentPanelRoute | null
@@ -1140,7 +1179,6 @@ function DocumentBody({
   const {scrollToBlock} = useBlockScroll(routeBlockRef)
 
   // On mount, sync URL hash (#blockId) into route if not already present
-  const replaceRoute = useNavigate('replace')
   useEffect(() => {
     if (typeof window === 'undefined') return
     const hash = window.location.hash
@@ -1505,6 +1543,20 @@ function DocumentBody({
     ],
   )
 
+  const handleTextSelection = useCallback(() => {
+    if (route.key !== 'document' && route.key !== 'feed') return
+    if (!route.id.blockRef && !route.id.blockRange) return
+
+    replaceRoute({
+      ...route,
+      id: {
+        ...route.id,
+        blockRef: null,
+        blockRange: null,
+      },
+    })
+  }, [route, replaceRoute])
+
   // Activity filter change handler (main page)
   const handleMainActivityFilterChange = (filter: {filterEventType?: string[]}) => {
     if (route.key === 'activity') {
@@ -1780,6 +1832,7 @@ function DocumentBody({
           onBlockCitationClick={handleBlockCitationClick}
           onBlockCommentClick={handleBlockCommentClick}
           onBlockSelect={handleBlockSelect}
+          onTextSelection={handleTextSelection}
           isUnpublishedDraft={isUnpublishedDraft}
           isBlockInPublishedVersion={isBlockInPublishedVersion}
           CommentEditor={CommentEditor}
@@ -1846,9 +1899,20 @@ function DocumentBody({
               commentEditor={
                 CommentEditor ? (
                   <CommentEditor
-                    key={panelRoute?.key === 'comments' ? panelRoute.openComment : undefined}
+                    key={
+                      panelRoute?.key === 'comments'
+                        ? getCommentEditorRouteKey({
+                            openComment: panelRoute.openComment,
+                            targetBlockId: panelRoute.targetBlockId,
+                            blockRange: panelRoute.blockRange,
+                          })
+                        : undefined
+                    }
                     docId={docId}
                     quotingBlockId={panelRoute?.key === 'comments' ? panelRoute.targetBlockId : undefined}
+                    quotingRange={
+                      panelRoute?.key === 'comments' ? extractQuotingRange(panelRoute.blockRange) : undefined
+                    }
                     commentId={panelRoute?.key === 'comments' ? panelRoute.openComment : undefined}
                     isReplying={
                       panelRoute?.key === 'comments' ? panelRoute.isReplying ?? !!panelRoute.openComment : false
@@ -2250,9 +2314,14 @@ function CommentsPanelContent({
         commentEditor={
           CommentEditor ? (
             <CommentEditor
-              key={panelRoute.openComment}
+              key={getCommentEditorRouteKey({
+                openComment: panelRoute.openComment,
+                targetBlockId: panelRoute.targetBlockId,
+                blockRange: panelRoute.blockRange,
+              })}
               docId={docId}
               quotingBlockId={panelRoute.targetBlockId}
+              quotingRange={extractQuotingRange(panelRoute.blockRange)}
               commentId={panelRoute.openComment}
               isReplying={panelRoute.isReplying ?? !!panelRoute.openComment}
               replyCommentVersion={panelRoute.replyCommentVersion}
@@ -2317,6 +2386,7 @@ function MainContent({
   onBlockCitationClick,
   onBlockCommentClick,
   onBlockSelect,
+  onTextSelection,
   isUnpublishedDraft,
   isBlockInPublishedVersion,
   CommentEditor,
@@ -2364,6 +2434,7 @@ function MainContent({
     startCommentingNow?: boolean,
   ) => void
   onBlockSelect?: (blockId: string, opts?: BlockRangeSelectOptions) => void
+  onTextSelection?: () => void
   isUnpublishedDraft?: boolean
   isBlockInPublishedVersion?: (blockId: string) => boolean
   CommentEditor?: React.ComponentType<CommentEditorProps>
@@ -2421,9 +2492,14 @@ function MainContent({
           commentEditor={
             CommentEditor && !suppressCommentEditor ? (
               <CommentEditor
-                key={discussionsParams?.openComment}
+                key={getCommentEditorRouteKey({
+                  openComment: discussionsParams?.openComment,
+                  targetBlockId: discussionsParams?.targetBlockId,
+                  blockRange: discussionsParams?.blockRange,
+                })}
                 docId={docId}
                 quotingBlockId={discussionsParams?.targetBlockId}
+                quotingRange={extractQuotingRange(discussionsParams?.blockRange)}
                 commentId={discussionsParams?.openComment}
                 isReplying={discussionsParams?.isReplying ?? !!discussionsParams?.openComment}
                 replyCommentVersion={discussionsParams?.replyCommentVersion}
@@ -2451,6 +2527,7 @@ function MainContent({
           onBlockCitationClick={onBlockCitationClick}
           onBlockCommentClick={onBlockCommentClick}
           onBlockSelect={onBlockSelect}
+          onTextSelection={onTextSelection}
           isUnpublishedDraft={isUnpublishedDraft}
           isBlockInPublishedVersion={isBlockInPublishedVersion}
           directory={directory}
@@ -2482,6 +2559,7 @@ function ContentViewWithOutline({
   onBlockCitationClick,
   onBlockCommentClick,
   onBlockSelect,
+  onTextSelection,
   isUnpublishedDraft,
   isBlockInPublishedVersion,
   directory,
@@ -2512,6 +2590,7 @@ function ContentViewWithOutline({
     startCommentingNow?: boolean,
   ) => void
   onBlockSelect?: (blockId: string, opts?: BlockRangeSelectOptions) => void
+  onTextSelection?: () => void
   isUnpublishedDraft?: boolean
   isBlockInPublishedVersion?: (blockId: string) => boolean
   directory?: import('@seed-hypermedia/client/hm-types').HMDocumentInfo[]
@@ -2559,7 +2638,7 @@ function ContentViewWithOutline({
                   }}
                   outline={outline}
                   id={docId}
-                  activeBlockId={docId.blockRef}
+                  activeBlockId={resourceId.blockRef}
                 />
               </DocNavigationWrapper>
             </div>
@@ -2572,12 +2651,13 @@ function ContentViewWithOutline({
           <DocumentContentComponent
             blocks={existingDraftContent ?? document.content}
             resourceId={resourceId}
-            focusBlockId={docId.blockRef ?? undefined}
-            focusBlockRange={docId.blockRange ?? undefined}
+            focusBlockId={resourceId.blockRef ?? undefined}
+            focusBlockRange={resourceId.blockRange ?? undefined}
             blockCitations={blockCitations}
             onBlockCitationClick={onBlockCitationClick}
             onBlockCommentClick={onBlockCommentClick}
             onBlockSelect={onBlockSelect}
+            onTextSelection={onTextSelection}
             onEditorReady={onEditorReady}
             draftCursorPosition={existingDraftCursorPosition}
             perspectiveAccountUid={perspectiveAccountUid}


### PR DESCRIPTION
## Summary
- Add structured quote targets with codepoint ranges so comments can reference exact text fragments inside a block.
- Persist fragment-aware comment drafts and pending comment intents across desktop and web flows.
- Render and highlight ranged fragment embeds using pinned document versions to keep selections stable after source edits.
- Improve selection tooling for copy/comment actions, including mobile touch handling and clearing stale selections after actions.
- Add tests for ranged comment links, optimistic comments, selection offset mapping, inline embeds, and embed wrapper behavior.