### PR TITLE
feat(web): fix web document creation

### DIFF
--- a/frontend/apps/desktop/src/components/desktop-draft-actions-provider.tsx
+++ b/frontend/apps/desktop/src/components/desktop-draft-actions-provider.tsx
@@ -5,6 +5,7 @@ import {DraftActions, DraftActionsContext} from '@shm/editor/draft-actions-conte
 import {invalidateQueries} from '@shm/shared/models/query-client'
 import {queryKeys} from '@shm/shared/models/query-keys'
 import {hmId} from '@shm/shared/utils/entity-id-url'
+import {buildInlineDraftWrite} from '@shm/shared/utils/inline-draft'
 import {nanoid} from 'nanoid'
 import {PropsWithChildren, useMemo, useState} from 'react'
 
@@ -26,24 +27,16 @@ export function DesktopDraftActionsProvider({
       // execute runs imperatively outside React, so it consumes a plain async function.
       onCreateInlineDraft: canCreateInlineDraft
         ? async (parentId, options) => {
-            const draftId = nanoid(10)
-            const parentPath = parentId.path || []
-            const draftPath = [...parentPath, `-${draftId}`]
-            await client.drafts.write.mutate({
-              id: draftId,
-              locationUid: parentId.uid,
-              locationPath: parentPath,
-              editUid: parentId.uid,
-              editPath: draftPath,
-              metadata: {name: options?.name ?? ''},
-              content: options?.initialContent ?? [],
-              deps: [],
-              visibility: 'PUBLIC',
+            const writeParams = buildInlineDraftWrite({
+              parentId,
+              draftId: nanoid(10),
+              options,
             })
+            await client.drafts.write.mutate(writeParams)
             invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT, parentId.uid])
             invalidateQueries([queryKeys.DRAFTS_LIST])
-            setLastCreatedInlineDraftId(draftId)
-            return {draftId, draftPath}
+            setLastCreatedInlineDraftId(writeParams.id)
+            return {draftId: writeParams.id, draftPath: writeParams.editPath}
           }
         : undefined,
       useInlineDraft: useDraft,

--- a/frontend/apps/desktop/src/models/documents.ts
+++ b/frontend/apps/desktop/src/models/documents.ts
@@ -41,6 +41,9 @@ import {
   extractDeletes,
   getDocAttributeChanges,
 } from '@shm/shared/utils/document-changes'
+import {filterChildDrafts} from '@shm/shared/utils/draft-children'
+import {buildInlineDraftWrite} from '@shm/shared/utils/inline-draft'
+export {filterChildDrafts}
 import {hmId, hmIdToURL, unpackHmId} from '@shm/shared/utils/entity-id-url'
 import {entityQueryPathToHmIdPath, hmIdPathToEntityQueryPath} from '@shm/shared/utils/path-api'
 import {DocNavigationItem} from '@shm/ui/navigation'
@@ -104,15 +107,6 @@ export function useChildDrafts(parentId?: UnpackedHypermediaId) {
   }, [drafts.data, parentId])
 }
 
-/** Return drafts that are located under parentId, excluding drafts editing parentId itself. */
-export function filterChildDrafts(drafts: HMListedDraft[], parentId: UnpackedHypermediaId): HMListedDraft[] {
-  return drafts.filter((draft) => {
-    const locationId = (draft as HMListedDraftWithLocation).locationId
-    if (!locationId || locationId.id !== parentId.id) return false
-    const editId = (draft as HMListedDraftWithLocation).editId
-    return editId?.id !== parentId.id
-  })
-}
 
 /** Preserve existing draft anchors when autosave rewrites a draft index entry. */
 export function resolveDraftWriteAnchors(
@@ -144,27 +138,13 @@ export function useCreateInlineDraft(parentId: UnpackedHypermediaId | undefined)
   return useMutation({
     mutationFn: async ({visibility}: {visibility?: HMResourceVisibility} = {}) => {
       if (!parentId) throw new Error('No parent ID')
-      const draftId = nanoid(10)
-      // The draft lives at parent + `-${draftId}` so it has a stable, unique
-      // path before publish. We set BOTH locationUid/Path (so useChildDrafts
-      // — which filters by parent location — keeps listing it under the
-      // parent) AND editUid/Path (so useExistingDraft can find it when the
-      // unified editor mounts at the new doc's route URL).
-      const parentPath = parentId.path || []
-      const draftPath = [...parentPath, `-${draftId}`]
-      const writeParams = {
-        id: draftId,
-        locationUid: parentId.uid,
-        locationPath: parentPath,
-        editUid: parentId.uid,
-        editPath: draftPath,
-        metadata: {name: ''},
-        content: [],
-        deps: [],
+      const writeParams = buildInlineDraftWrite({
+        parentId,
+        draftId: nanoid(10),
         visibility: visibility ?? 'PUBLIC',
-      }
+      })
       await client.drafts.write.mutate(writeParams)
-      return {draftId, draftPath}
+      return {draftId: writeParams.id, draftPath: writeParams.editPath}
     },
     onSuccess: () => {
       invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT, parentId?.uid])

--- a/frontend/apps/desktop/src/models/documents.ts
+++ b/frontend/apps/desktop/src/models/documents.ts
@@ -107,7 +107,6 @@ export function useChildDrafts(parentId?: UnpackedHypermediaId) {
   }, [drafts.data, parentId])
 }
 
-
 /** Preserve existing draft anchors when autosave rewrites a draft index entry. */
 export function resolveDraftWriteAnchors(
   existingDraft: Pick<HMDraft, 'locationUid' | 'locationPath' | 'editUid' | 'editPath'> | null | undefined,

--- a/frontend/apps/web/app/document-edit/web-create-draft.test.ts
+++ b/frontend/apps/web/app/document-edit/web-create-draft.test.ts
@@ -43,7 +43,7 @@ describe('createWebDocumentDraft', () => {
 
   it('creates a public child draft at a placeholder path and navigates to it', async () => {
     const navigate = vi.fn()
-    const routeId = await createWebDocumentDraft({
+    const {routeId} = await createWebDocumentDraft({
       locationId: makeDocId('site', ['parent']),
       signingAccountId: 'author',
       visibility: 'PUBLIC',
@@ -71,7 +71,7 @@ describe('createWebDocumentDraft', () => {
 
   it('creates a private draft at a generated private path', async () => {
     const navigate = vi.fn()
-    const routeId = await createWebDocumentDraft({
+    const {routeId} = await createWebDocumentDraft({
       locationId: makeDocId('site', ['parent']),
       signingAccountId: 'author',
       visibility: 'PRIVATE',
@@ -93,7 +93,7 @@ describe('createWebDocumentDraft', () => {
 
   it('stores imported content and metadata when provided', async () => {
     const navigate = vi.fn()
-    const routeId = await createWebDocumentDraft({
+    const {routeId} = await createWebDocumentDraft({
       locationId: makeDocId('site', []),
       signingAccountId: 'author',
       metadata: {name: 'Imported Title'},
@@ -110,7 +110,7 @@ describe('createWebDocumentDraft', () => {
 
   it('imports a Markdown file into a named draft', async () => {
     const navigate = vi.fn()
-    const routeId = await createWebDocumentDraftFromMarkdownFile({
+    const {routeId} = await createWebDocumentDraftFromMarkdownFile({
       file: new File(['# Imported Title\n\nHello import'], 'fallback.md', {type: 'text/markdown'}),
       locationId: makeDocId('site', []),
       signingAccountId: 'author',
@@ -124,7 +124,7 @@ describe('createWebDocumentDraft', () => {
   })
 
   it('preserves Markdown frontmatter metadata on import', async () => {
-    const routeId = await createWebDocumentDraftFromMarkdownFile({
+    const {routeId} = await createWebDocumentDraftFromMarkdownFile({
       file: new File(['---\ntitle: Frontmatter Title\nsummary: Imported summary\n---\n\nBody text'], 'fallback.md', {
         type: 'text/markdown',
       }),

--- a/frontend/apps/web/app/document-edit/web-create-draft.ts
+++ b/frontend/apps/web/app/document-edit/web-create-draft.ts
@@ -10,19 +10,35 @@ import {
   parseMarkdown,
 } from '@seed-hypermedia/client/markdown-to-blocks'
 import {hmId} from '@shm/shared'
+import {buildInlineDraftWrite} from '@shm/shared/utils/inline-draft'
 import {nanoid} from 'nanoid'
 import {putWebDocDraft} from './web-draft-db'
 
 /** Route emitted after a local web document draft is created. */
 export type WebDocumentDraftRoute = {key: 'document'; id: UnpackedHypermediaId}
 
-/** Create a local web document draft and navigate to its document route. */
+/** Result returned by {@link createWebDocumentDraft}. */
+export type CreateWebDocumentDraftResult = {
+  /** Route id (uid + edit path) of the new draft. */
+  routeId: UnpackedHypermediaId
+  /** Persistent draft id (used as `embed.draftId` on inline embed inserts). */
+  draftId: string
+  /** Edit path of the new draft under its parent. */
+  draftPath: string[]
+}
+
+/**
+ * Create a local web document draft and optionally navigate to its document
+ * route. When `navigate` is omitted (slash menu / query block "+"), the draft
+ * is persisted but the route does not change — callers receive the new draft
+ * id so they can insert an inline embed without leaving the current document.
+ */
 export async function createWebDocumentDraft({
   locationId,
   signingAccountId,
   visibility = 'PUBLIC',
-  content = [],
-  metadata = {},
+  content,
+  metadata,
   navigate,
   generateDraftId = () => nanoid(10),
   generatePath = () => nanoid(21),
@@ -34,14 +50,31 @@ export async function createWebDocumentDraft({
   content?: HMBlockNode[]
   metadata?: HMMetadata
   capabilityCid?: string
-  navigate: (route: WebDocumentDraftRoute) => void
+  navigate?: (route: WebDocumentDraftRoute) => void
   generateDraftId?: () => string
   generatePath?: () => string
-}): Promise<UnpackedHypermediaId> {
+}): Promise<CreateWebDocumentDraftResult> {
   const draftId = generateDraftId()
   const isPrivate = visibility === 'PRIVATE'
-  const locationPath = isPrivate ? [generatePath()] : locationId.path || []
-  const editPath = isPrivate ? locationPath : [...locationPath, `-${draftId}`]
+
+  let locationPath: string[]
+  let editPath: string[]
+  let writeMetadata: HMMetadata
+  let writeContent: HMBlockNode[]
+
+  if (isPrivate) {
+    locationPath = [generatePath()]
+    editPath = locationPath
+    writeMetadata = metadata ?? {}
+    writeContent = content ?? []
+  } else {
+    const writeParams = buildInlineDraftWrite({parentId: locationId, draftId, visibility})
+    locationPath = writeParams.locationPath
+    editPath = writeParams.editPath
+    writeMetadata = metadata ?? writeParams.metadata
+    writeContent = content ?? writeParams.content
+  }
+
   const routeId = hmId(locationId.uid, {path: editPath})
 
   await putWebDocDraft({
@@ -49,8 +82,8 @@ export async function createWebDocumentDraft({
     docId: routeId.id,
     signingAccountId,
     ...(capabilityCid ? {capabilityCid} : {}),
-    content,
-    metadata,
+    content: writeContent,
+    metadata: writeMetadata,
     deps: [],
     navigation: null,
     locationUid: locationId.uid,
@@ -61,8 +94,16 @@ export async function createWebDocumentDraft({
     visibility,
   })
 
-  navigate({key: 'document', id: routeId})
-  return routeId
+  console.log('[web-create-doc] createWebDocumentDraft', {
+    locationId: locationId.id,
+    draftId,
+    draftPath: editPath,
+    visibility,
+    willNavigate: !!navigate,
+  })
+
+  if (navigate) navigate({key: 'document', id: routeId})
+  return {routeId, draftId, draftPath: editPath}
 }
 
 function parseMarkdownImport(markdown: string, fileName: string): {metadata: HMMetadata; markdown: string} {
@@ -101,7 +142,7 @@ export async function createWebDocumentDraftFromMarkdownFile({
   signingAccountId: string
   capabilityCid?: string
   navigate: (route: WebDocumentDraftRoute) => void
-}): Promise<UnpackedHypermediaId> {
+}): Promise<CreateWebDocumentDraftResult> {
   const text = await file.text()
   const {metadata, markdown} = parseMarkdownImport(text, file.name)
 

--- a/frontend/apps/web/app/document-edit/web-create-draft.ts
+++ b/frontend/apps/web/app/document-edit/web-create-draft.ts
@@ -71,7 +71,10 @@ export async function createWebDocumentDraft({
     const writeParams = buildInlineDraftWrite({parentId: locationId, draftId, visibility})
     locationPath = writeParams.locationPath
     editPath = writeParams.editPath
-    writeMetadata = metadata ?? writeParams.metadata
+    // Don't seed an empty `name`: persisting `{name: ''}` makes the publish flow
+    // emit a setAttribute(name, '') change. Keep metadata empty unless provided,
+    // matching the original web behavior.
+    writeMetadata = metadata ?? {}
     writeContent = content ?? writeParams.content
   }
 

--- a/frontend/apps/web/app/document-edit/web-document-actors.ts
+++ b/frontend/apps/web/app/document-edit/web-document-actors.ts
@@ -115,7 +115,11 @@ function makePublishDocumentActor(deps: CreateWebDocumentMachineDeps) {
     try {
       return await publishWebDocument(input, deps)
     } catch (err) {
-      console.error('[WebPublish] failed', err)
+      // SeedClientError carries the daemon's real gRPC message in `.body`; the
+      // `.message` only has the HTTP statusText. Surface both so publish
+      // failures show the actual cause instead of a bare "Internal Server Error".
+      const body = (err as {body?: string})?.body
+      console.error('[WebPublish] failed', err, body ? {serverError: body} : undefined)
       throw err
     }
   })

--- a/frontend/apps/web/app/document-edit/web-draft-actions-provider.tsx
+++ b/frontend/apps/web/app/document-edit/web-draft-actions-provider.tsx
@@ -7,12 +7,7 @@ import {buildInlineDraftWrite} from '@shm/shared/utils/inline-draft'
 import {useQuery} from '@tanstack/react-query'
 import {nanoid} from 'nanoid'
 import {PropsWithChildren, useMemo, useState} from 'react'
-import {
-  deleteWebDocDraft,
-  getWebDocDraft,
-  putWebDocDraft,
-  webDraftToListedDraft,
-} from './web-draft-db'
+import {deleteWebDocDraft, getWebDocDraft, putWebDocDraft, webDraftToListedDraft} from './web-draft-db'
 
 /** Hook returning a reactive web draft, shaped as a HMListedDraftWithLocation
  * so it satisfies the shared `DraftActions.useInlineDraft` contract. */
@@ -125,13 +120,7 @@ export function WebDraftActionsProvider({
         setLastCreatedInlineDraftId((current) => (current === draftId ? null : current))
       },
     }),
-    [
-      canCreateInlineDraft,
-      signingAccountId,
-      capabilityCid,
-      navigate,
-      lastCreatedInlineDraftId,
-    ],
+    [canCreateInlineDraft, signingAccountId, capabilityCid, navigate, lastCreatedInlineDraftId],
   )
 
   return <DraftActionsContext.Provider value={value}>{children}</DraftActionsContext.Provider>

--- a/frontend/apps/web/app/document-edit/web-draft-actions-provider.tsx
+++ b/frontend/apps/web/app/document-edit/web-draft-actions-provider.tsx
@@ -73,7 +73,10 @@ export function WebDraftActionsProvider({
                 signingAccountId,
                 ...(capabilityCid ? {capabilityCid} : {}),
                 content: writeParams.content,
-                metadata: writeParams.metadata,
+                // Avoid persisting an empty `name` — it would emit a
+                // setAttribute(name, '') on publish. Only seed a name when the
+                // caller ("Turn into doc") supplied one.
+                metadata: options?.name ? {name: options.name} : {},
                 deps: writeParams.deps,
                 navigation: null,
                 locationUid: writeParams.locationUid,

--- a/frontend/apps/web/app/document-edit/web-draft-actions-provider.tsx
+++ b/frontend/apps/web/app/document-edit/web-draft-actions-provider.tsx
@@ -1,0 +1,135 @@
+import {DraftActions, DraftActionsContext} from '@shm/editor/draft-actions-context'
+import {invalidateQueries} from '@shm/shared/models/query-client'
+import {queryKeys} from '@shm/shared/models/query-keys'
+import {useNavigate} from '@shm/shared/utils/navigation'
+import {hmId} from '@shm/shared/utils/entity-id-url'
+import {buildInlineDraftWrite} from '@shm/shared/utils/inline-draft'
+import {useQuery} from '@tanstack/react-query'
+import {nanoid} from 'nanoid'
+import {PropsWithChildren, useMemo, useState} from 'react'
+import {
+  deleteWebDocDraft,
+  getWebDocDraft,
+  putWebDocDraft,
+  webDraftToListedDraft,
+} from './web-draft-db'
+
+/** Hook returning a reactive web draft, shaped as a HMListedDraftWithLocation
+ * so it satisfies the shared `DraftActions.useInlineDraft` contract. */
+function useWebInlineDraft(id: string | undefined) {
+  const query = useQuery({
+    queryKey: [queryKeys.DRAFT, id],
+    queryFn: async () => {
+      if (!id) return null
+      const draft = await getWebDocDraft(id)
+      return draft ? webDraftToListedDraft(draft) : null
+    },
+    enabled: !!id,
+  })
+  return {data: query.data}
+}
+
+/**
+ * Web mirror of `DesktopDraftActionsProvider`. Wires the editor's
+ * `DraftActionsContext` to IndexedDB-backed web drafts so the slash menu's
+ * "New document" entry and inline child draft embeds work on the web.
+ *
+ * Pass `canCreateInlineDraft={false}` when the current document is itself an
+ * unpublished web draft — child drafts under a placeholder path segment would
+ * be orphaned on publish.
+ */
+export function WebDraftActionsProvider({
+  canCreateInlineDraft = true,
+  signingAccountId,
+  capabilityCid,
+  children,
+}: PropsWithChildren<{
+  canCreateInlineDraft?: boolean
+  signingAccountId?: string
+  capabilityCid?: string
+}>) {
+  const navigate = useNavigate()
+  const [lastCreatedInlineDraftId, setLastCreatedInlineDraftId] = useState<string | null>(null)
+
+  const value = useMemo<DraftActions>(
+    () => ({
+      onCreateInlineDraft:
+        canCreateInlineDraft && signingAccountId
+          ? async (parentId, options) => {
+              const writeParams = buildInlineDraftWrite({
+                parentId,
+                draftId: nanoid(10),
+                options,
+              })
+              console.log('[web-create-doc] slashMenu onCreateInlineDraft', {
+                parentId: parentId.id,
+                draftId: writeParams.id,
+                hasInitialContent: !!options?.initialContent?.length,
+              })
+              const routeId = hmId(parentId.uid, {path: writeParams.editPath})
+              await putWebDocDraft({
+                draftId: writeParams.id,
+                docId: routeId.id,
+                signingAccountId,
+                ...(capabilityCid ? {capabilityCid} : {}),
+                content: writeParams.content,
+                metadata: writeParams.metadata,
+                deps: writeParams.deps,
+                navigation: null,
+                locationUid: writeParams.locationUid,
+                locationPath: writeParams.locationPath,
+                editUid: writeParams.editUid,
+                editPath: writeParams.editPath,
+                cursorPosition: null,
+                visibility: writeParams.visibility,
+              })
+              invalidateQueries([queryKeys.DRAFT, writeParams.id])
+              invalidateQueries([queryKeys.DRAFTS_LIST])
+              invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT, parentId.uid])
+              setLastCreatedInlineDraftId(writeParams.id)
+              return {draftId: writeParams.id, draftPath: writeParams.editPath}
+            }
+          : undefined,
+      useInlineDraft: useWebInlineDraft,
+      onDeleteDraft: async (id) => {
+        await deleteWebDocDraft(id)
+        invalidateQueries([queryKeys.DRAFT, id])
+        invalidateQueries([queryKeys.DRAFTS_LIST])
+        invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT])
+      },
+      onOpenDraft: (draftId, draftPath) => {
+        getWebDocDraft(draftId).then((draft) => {
+          if (!draft) return
+          const editUid = draft.editUid ?? draft.locationUid
+          if (!editUid) return
+          const editPath = draft.editPath?.length ? draft.editPath : draftPath
+          navigate({key: 'document', id: hmId(editUid, {path: editPath})})
+        })
+      },
+      onUpdateDraftName: async (draftId, name) => {
+        const draft = await getWebDocDraft(draftId)
+        if (!draft) throw new Error(`Draft ${draftId} not found`)
+        await putWebDocDraft({
+          ...draft,
+          metadata: {...draft.metadata, name},
+        })
+        invalidateQueries([queryKeys.DRAFT, draftId])
+        invalidateQueries([queryKeys.DRAFTS_LIST])
+        invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT])
+      },
+      lastCreatedInlineDraftId,
+      clearLastCreatedInlineDraftId: (draftId) => {
+        setLastCreatedInlineDraftId((current) => (current === draftId ? null : current))
+      },
+    }),
+    [
+      canCreateInlineDraft,
+      signingAccountId,
+      capabilityCid,
+      navigate,
+      lastCreatedInlineDraftId,
+    ],
+  )
+
+  return <DraftActionsContext.Provider value={value}>{children}</DraftActionsContext.Provider>
+}

--- a/frontend/apps/web/app/document-edit/web-draft-db.ts
+++ b/frontend/apps/web/app/document-edit/web-draft-db.ts
@@ -6,12 +6,7 @@
  * index on `docId` lets us look up the latest draft for a document on mount.
  */
 
-import type {
-  HMBlockNode,
-  HMMetadata,
-  HMNavigationItem,
-  HMResourceVisibility,
-} from '@seed-hypermedia/client/hm-types'
+import type {HMBlockNode, HMMetadata, HMNavigationItem, HMResourceVisibility} from '@seed-hypermedia/client/hm-types'
 import {hmId} from '@shm/shared/utils/entity-id-url'
 import type {HMListedDraftWithLocation} from '@shm/shared/draft-breadcrumb-context'
 
@@ -135,9 +130,7 @@ export async function listWebDocChildDrafts(
     const all = await reqToPromise<WebDocDraft[]>(store.getAll())
     return all
       .filter(
-        (draft) =>
-          draft.locationUid === parentLocationUid &&
-          pathEquals(draft.locationPath ?? [], parentLocationPath),
+        (draft) => draft.locationUid === parentLocationUid && pathEquals(draft.locationPath ?? [], parentLocationPath),
       )
       .sort((a, b) => b.updatedAt - a.updatedAt)
   } catch (err) {

--- a/frontend/apps/web/app/document-edit/web-draft-db.ts
+++ b/frontend/apps/web/app/document-edit/web-draft-db.ts
@@ -6,7 +6,14 @@
  * index on `docId` lets us look up the latest draft for a document on mount.
  */
 
-import type {HMBlockNode, HMMetadata, HMNavigationItem, HMResourceVisibility} from '@seed-hypermedia/client/hm-types'
+import type {
+  HMBlockNode,
+  HMMetadata,
+  HMNavigationItem,
+  HMResourceVisibility,
+} from '@seed-hypermedia/client/hm-types'
+import {hmId} from '@shm/shared/utils/entity-id-url'
+import type {HMListedDraftWithLocation} from '@shm/shared/draft-breadcrumb-context'
 
 export interface WebDocDraft {
   /** Primary key — stable id assigned on first save. */
@@ -111,6 +118,66 @@ export async function deleteWebDocDraft(draftId: string): Promise<void> {
   if (!isBrowser()) return
   const store = await tx('readwrite')
   await reqToPromise(store.delete(draftId))
+}
+
+/**
+ * Return all drafts located under `parentLocationUid` + `parentLocationPath`,
+ * newest first. Used by the query-block draft slot to render inline child
+ * draft cards under the query target.
+ */
+export async function listWebDocChildDrafts(
+  parentLocationUid: string,
+  parentLocationPath: string[],
+): Promise<WebDocDraft[]> {
+  if (!isBrowser()) return []
+  try {
+    const store = await tx('readonly')
+    const all = await reqToPromise<WebDocDraft[]>(store.getAll())
+    return all
+      .filter(
+        (draft) =>
+          draft.locationUid === parentLocationUid &&
+          pathEquals(draft.locationPath ?? [], parentLocationPath),
+      )
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+  } catch (err) {
+    console.warn('listWebDocChildDrafts failed', err)
+    return []
+  }
+}
+
+function pathEquals(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
+/**
+ * Adapt the stored web draft record to the shared `HMListedDraftWithLocation`
+ * shape so providers can hand drafts to shared editor + query-block UIs that
+ * already speak the desktop draft list shape.
+ */
+export function webDraftToListedDraft(draft: WebDocDraft): HMListedDraftWithLocation {
+  const locationUid = draft.locationUid ?? undefined
+  const editUid = draft.editUid ?? undefined
+  const locationPath = draft.locationPath ?? undefined
+  const editPath = draft.editPath ?? undefined
+  return {
+    id: draft.draftId,
+    locationUid,
+    locationPath,
+    editUid,
+    editPath,
+    metadata: (draft.metadata ?? {}) as HMMetadata,
+    visibility: draft.visibility ?? 'PUBLIC',
+    deps: draft.deps,
+    navigation: draft.navigation ?? undefined,
+    lastUpdateTime: draft.updatedAt,
+    locationId: locationUid ? hmId(locationUid, {path: locationPath ?? []}) : undefined,
+    editId: editUid ? hmId(editUid, {path: editPath ?? []}) : undefined,
+  } as HMListedDraftWithLocation
 }
 
 /** Return all drafts for a given docId, newest first. */

--- a/frontend/apps/web/app/document-edit/web-query-block-draft-slot.tsx
+++ b/frontend/apps/web/app/document-edit/web-query-block-draft-slot.tsx
@@ -1,0 +1,115 @@
+import {useResource} from '@shm/shared/models/entity'
+import {invalidateQueries} from '@shm/shared/models/query-client'
+import {queryKeys} from '@shm/shared/models/query-keys'
+import {roleCanWrite, useSelectedAccountCapability} from '@shm/shared/models/capabilities'
+import {QueryBlockDraftSlotProps, useQueryBlockDrafts} from '@shm/shared/query-block-drafts-context'
+import {useNavigate} from '@shm/shared/utils/navigation'
+import {hmId} from '@shm/shared/utils/entity-id-url'
+import {useQuery} from '@tanstack/react-query'
+import {useCallback, useMemo} from 'react'
+import {useLocalKeyPair} from '../auth'
+import {createWebDocumentDraft} from './web-create-draft'
+import {
+  deleteWebDocDraft,
+  getWebDocDraft,
+  listWebDocChildDrafts,
+  putWebDocDraft,
+  webDraftToListedDraft,
+} from './web-draft-db'
+
+/**
+ * Web mirror of `DesktopQueryBlockDraftSlot`. Lists inline child drafts of the
+ * query target from IndexedDB and exposes create / open / delete / rename
+ * callbacks to the editor's `<QueryBlock />` slot UI.
+ */
+export function WebQueryBlockDraftSlot({targetId, children}: QueryBlockDraftSlotProps) {
+  const navigate = useNavigate()
+  const userKeyPair = useLocalKeyPair()
+  const signingAccountId = userKeyPair?.delegatedAccountUid ?? null
+  const capability = useSelectedAccountCapability(targetId ?? undefined)
+  const canEdit = roleCanWrite(capability?.role)
+
+  const resource = useResource(targetId ?? undefined)
+  const doc = resource.data?.type === 'document' ? resource.data.document : undefined
+  const isPrivate = doc?.visibility === 'PRIVATE'
+
+  const {lastCreatedDraftId, setLastCreatedDraftId} = useQueryBlockDrafts()
+
+  const childDraftsQuery = useQuery({
+    queryKey: [queryKeys.DRAFTS_LIST_ACCOUNT, targetId?.uid ?? null, ...(targetId?.path ?? [])],
+    queryFn: async () => {
+      if (!targetId) return []
+      const rows = await listWebDocChildDrafts(targetId.uid, targetId.path ?? [])
+      return rows.map(webDraftToListedDraft)
+    },
+    enabled: !!targetId,
+  })
+
+  const drafts = useMemo(() => {
+    const list = childDraftsQuery.data ?? []
+    return list.map((draft) => ({draft, autoFocus: draft.id === lastCreatedDraftId}))
+  }, [childDraftsQuery.data, lastCreatedDraftId])
+
+  const onCreateDraft = useMemo(() => {
+    if (!targetId || !canEdit || isPrivate || !signingAccountId) return undefined
+    return () => {
+      void createWebDocumentDraft({
+        locationId: targetId,
+        signingAccountId,
+        visibility: 'PUBLIC',
+      }).then(({draftId}) => {
+        console.log('[web-create-doc] queryBlock onCreateDraft', {
+          targetId: targetId.id,
+          draftId,
+        })
+        setLastCreatedDraftId?.(draftId)
+        invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT, targetId.uid])
+        invalidateQueries([queryKeys.DRAFTS_LIST])
+      })
+    }
+  }, [targetId, canEdit, isPrivate, signingAccountId, setLastCreatedDraftId])
+
+  const onOpenDraft = useCallback(
+    (draftId: string) => {
+      getWebDocDraft(draftId).then((draft) => {
+        if (!draft) return
+        const editUid = draft.editUid ?? draft.locationUid
+        if (!editUid) return
+        const editPath = draft.editPath ?? []
+        navigate({key: 'document', id: hmId(editUid, {path: editPath})})
+      })
+    },
+    [navigate],
+  )
+
+  const onDeleteDraft = useCallback(async (draftId: string) => {
+    await deleteWebDocDraft(draftId)
+    invalidateQueries([queryKeys.DRAFT, draftId])
+    invalidateQueries([queryKeys.DRAFTS_LIST])
+    invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT])
+  }, [])
+
+  const onUpdateDraftName = useCallback(async (draftId: string, name: string) => {
+    const draft = await getWebDocDraft(draftId)
+    if (!draft) return
+    await putWebDocDraft({
+      ...draft,
+      metadata: {...draft.metadata, name},
+    })
+    invalidateQueries([queryKeys.DRAFT, draftId])
+    invalidateQueries([queryKeys.DRAFTS_LIST])
+    invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT])
+  }, [])
+
+  return (
+    <>
+      {children({
+        drafts,
+        onCreateDraft,
+        onOpenDraft,
+        onDeleteDraft,
+        onUpdateDraftName,
+      })}
+    </>
+  )
+}

--- a/frontend/apps/web/app/web-resource-page.tsx
+++ b/frontend/apps/web/app/web-resource-page.tsx
@@ -5,6 +5,7 @@ import {NOTIFY_SERVICE_HOST} from '@shm/shared/constants'
 import type {DocumentContentProps} from '@shm/shared/document-content-props'
 import {type EditorAccessor} from '@shm/shared/models/document-machine'
 import {useResource} from '@shm/shared/models/entity'
+import {QueryBlockDraftsProvider} from '@shm/shared/query-block-drafts-context'
 import {useCommentNavigation} from '@shm/shared/utils/comment-navigation'
 import {createWebHMUrl} from '@shm/shared/utils/entity-id-url'
 import {useNavRoute, useNavigate} from '@shm/shared/utils/navigation'
@@ -35,6 +36,8 @@ import {processPendingIntent} from './pending-intent'
 import {WebHeaderActions, WebSitePageShell, useWebCreateDocumentMenuItem} from './web-utils'
 import {useWebCanEdit} from './document-edit/use-web-can-edit'
 import {createWebDocumentMachine} from './document-edit/web-document-actors'
+import {WebDraftActionsProvider} from './document-edit/web-draft-actions-provider'
+import {WebQueryBlockDraftSlot} from './document-edit/web-query-block-draft-slot'
 import {
   cleanupOldWebDocDrafts,
   deleteWebDocDraft,
@@ -331,6 +334,9 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
     replaceRoute,
   })
 
+  const [lastCreatedDraftId, setLastCreatedDraftId] = useState<string | null>(null)
+  const canCreateInlineDraft = !placeholderDraftId
+
   return (
     <WebSitePageShell siteUid={docId.uid}>
       <CommentsProvider
@@ -339,6 +345,16 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
         renderInlineEditor={renderWebInlineEditor}
       >
         <DocumentActionsProvider onCopyLink={() => {}}>
+          <WebDraftActionsProvider
+            canCreateInlineDraft={canCreateInlineDraft}
+            signingAccountId={signingAccountId ?? undefined}
+            capabilityCid={effectiveCapabilityCid}
+          >
+            <QueryBlockDraftsProvider
+              DraftSlot={WebQueryBlockDraftSlot}
+              lastCreatedDraftId={lastCreatedDraftId}
+              setLastCreatedDraftId={setLastCreatedDraftId}
+            >
           <ResourcePage
             docId={docId}
             CommentEditor={CommentEditor}
@@ -365,6 +381,8 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
             editingFloatingActions={editingFloatingActions}
             fileUpload={fileUpload}
           />
+            </QueryBlockDraftsProvider>
+          </WebDraftActionsProvider>
         </DocumentActionsProvider>
       </CommentsProvider>
       {editProfileDialog.content}

--- a/frontend/apps/web/app/web-resource-page.tsx
+++ b/frontend/apps/web/app/web-resource-page.tsx
@@ -355,32 +355,32 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
               lastCreatedDraftId={lastCreatedDraftId}
               setLastCreatedDraftId={setLastCreatedDraftId}
             >
-          <ResourcePage
-            docId={docId}
-            CommentEditor={CommentEditor}
-            pageFooter={<PageFooter id={docId} hideDeviceLinkToast={true} />}
-            onEditProfile={onEditProfile}
-            profileHeaderButtons={profileHeaderButtons}
-            onFollowClick={onFollowClick}
-            rightActions={<WebHeaderActions siteUid={docId.uid} />}
-            extraMenuItems={extraMenuItems}
-            inlineInsert={inlineInsert}
-            DocumentContentComponent={DocumentContentComponent}
-            ssrContentHTML={ssrContentHTML}
-            perspectiveAccountUid={ownAccountUid}
-            linkExtensionOptions={linkExtensionOptions}
-            canEdit={effectiveCanEdit}
-            machine={machine}
-            signingAccountId={signingAccountId ?? undefined}
-            publishAccountUid={signingAccountId ?? undefined}
-            onEditorReady={onEditorReady}
-            existingDraft={existingDraft}
-            existingDraftVisibility={draftData?.visibility}
-            existingDraftContent={existingDraftContent}
-            existingDraftCursorPosition={existingDraftCursorPosition}
-            editingFloatingActions={editingFloatingActions}
-            fileUpload={fileUpload}
-          />
+              <ResourcePage
+                docId={docId}
+                CommentEditor={CommentEditor}
+                pageFooter={<PageFooter id={docId} hideDeviceLinkToast={true} />}
+                onEditProfile={onEditProfile}
+                profileHeaderButtons={profileHeaderButtons}
+                onFollowClick={onFollowClick}
+                rightActions={<WebHeaderActions siteUid={docId.uid} />}
+                extraMenuItems={extraMenuItems}
+                inlineInsert={inlineInsert}
+                DocumentContentComponent={DocumentContentComponent}
+                ssrContentHTML={ssrContentHTML}
+                perspectiveAccountUid={ownAccountUid}
+                linkExtensionOptions={linkExtensionOptions}
+                canEdit={effectiveCanEdit}
+                machine={machine}
+                signingAccountId={signingAccountId ?? undefined}
+                publishAccountUid={signingAccountId ?? undefined}
+                onEditorReady={onEditorReady}
+                existingDraft={existingDraft}
+                existingDraftVisibility={draftData?.visibility}
+                existingDraftContent={existingDraftContent}
+                existingDraftCursorPosition={existingDraftCursorPosition}
+                editingFloatingActions={editingFloatingActions}
+                fileUpload={fileUpload}
+              />
             </QueryBlockDraftsProvider>
           </WebDraftActionsProvider>
         </DocumentActionsProvider>

--- a/frontend/apps/web/app/web-utils.tsx
+++ b/frontend/apps/web/app/web-utils.tsx
@@ -75,6 +75,11 @@ export function useWebCreateDocumentMenuItem({
   const createDraft = useCallback(
     (visibility?: HMResourceVisibility) => {
       if (!signingAccountId) return
+      console.log('[web-create-doc] menu createDraft', {
+        locationId: locationId.id,
+        visibility,
+        signingAccountId,
+      })
       void createWebDocumentDraft({
         locationId,
         signingAccountId,

--- a/frontend/packages/shared/src/utils/draft-children.test.ts
+++ b/frontend/packages/shared/src/utils/draft-children.test.ts
@@ -1,0 +1,64 @@
+import {HMListedDraft} from '@seed-hypermedia/client/hm-types'
+import {describe, expect, it} from 'vitest'
+import {hmId} from './entity-id-url'
+import {filterChildDrafts} from './draft-children'
+
+function draft({
+  id,
+  locationPath,
+  editPath,
+}: {
+  id: string
+  locationPath?: string[]
+  editPath?: string[]
+}): HMListedDraft {
+  const locationId = locationPath ? hmId('acct', {path: locationPath}) : undefined
+  const editId = editPath ? hmId('acct', {path: editPath}) : undefined
+  return {
+    id,
+    locationUid: locationPath ? 'acct' : undefined,
+    locationPath,
+    editUid: editPath ? 'acct' : undefined,
+    editPath,
+    metadata: {name: ''},
+    visibility: 'PUBLIC',
+    deps: [],
+    lastUpdateTime: 1,
+    locationId,
+    editId,
+  } as HMListedDraft
+}
+
+describe('filterChildDrafts', () => {
+  it('keeps drafts located under the parent while excluding drafts editing the parent itself', () => {
+    const parentId = hmId('acct', {path: ['parent']})
+    const childDraft = draft({
+      id: 'child-draft',
+      locationPath: ['parent'],
+      editPath: ['parent', '-child-draft'],
+    })
+    const selfDraft = draft({
+      id: 'self-draft',
+      locationPath: ['parent'],
+      editPath: ['parent'],
+    })
+    const siblingDraft = draft({
+      id: 'sibling-draft',
+      locationPath: ['sibling'],
+      editPath: ['sibling', '-sibling-draft'],
+    })
+
+    expect(filterChildDrafts([childDraft, selfDraft, siblingDraft], parentId)).toEqual([childDraft])
+  })
+
+  it('keeps root child drafts with an empty root location path', () => {
+    const rootId = hmId('acct', {path: []})
+    const childDraft = draft({
+      id: 'root-child-draft',
+      locationPath: [],
+      editPath: ['-root-child-draft'],
+    })
+
+    expect(filterChildDrafts([childDraft], rootId)).toEqual([childDraft])
+  })
+})

--- a/frontend/packages/shared/src/utils/draft-children.ts
+++ b/frontend/packages/shared/src/utils/draft-children.ts
@@ -1,0 +1,16 @@
+import type {HMListedDraft, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import type {HMListedDraftWithLocation} from '../draft-breadcrumb-context'
+
+/**
+ * Return drafts located under `parentId`, excluding drafts that edit `parentId`
+ * itself. Used by query-block draft slots on every platform to list inline
+ * child drafts of the query target.
+ */
+export function filterChildDrafts(drafts: HMListedDraft[], parentId: UnpackedHypermediaId): HMListedDraft[] {
+  return drafts.filter((draft) => {
+    const locationId = (draft as HMListedDraftWithLocation).locationId
+    if (!locationId || locationId.id !== parentId.id) return false
+    const editId = (draft as HMListedDraftWithLocation).editId
+    return editId?.id !== parentId.id
+  })
+}

--- a/frontend/packages/shared/src/utils/inline-draft.test.ts
+++ b/frontend/packages/shared/src/utils/inline-draft.test.ts
@@ -1,0 +1,45 @@
+import {describe, expect, it} from 'vitest'
+import {hmId} from './entity-id-url'
+import {buildInlineDraftWrite} from './inline-draft'
+
+describe('buildInlineDraftWrite', () => {
+  it('builds a public inline draft under a nested parent', () => {
+    const parentId = hmId('acct', {path: ['parent']})
+    const write = buildInlineDraftWrite({parentId, draftId: 'abc12345'})
+    expect(write).toEqual({
+      id: 'abc12345',
+      locationUid: 'acct',
+      locationPath: ['parent'],
+      editUid: 'acct',
+      editPath: ['parent', '-abc12345'],
+      metadata: {name: ''},
+      content: [],
+      deps: [],
+      visibility: 'PUBLIC',
+    })
+  })
+
+  it('builds an inline draft under the root with no parent path', () => {
+    const parentId = hmId('acct')
+    const write = buildInlineDraftWrite({parentId, draftId: 'rootkid'})
+    expect(write.locationPath).toEqual([])
+    expect(write.editPath).toEqual(['-rootkid'])
+  })
+
+  it('seeds optional content + name', () => {
+    const parentId = hmId('acct', {path: ['parent']})
+    const write = buildInlineDraftWrite({
+      parentId,
+      draftId: 'seeded',
+      options: {name: 'My doc', initialContent: [{block: {id: 'b1', type: 'paragraph', text: 'hi'}} as any]},
+    })
+    expect(write.metadata).toEqual({name: 'My doc'})
+    expect(write.content).toHaveLength(1)
+  })
+
+  it('honors visibility override', () => {
+    const parentId = hmId('acct', {path: ['parent']})
+    const write = buildInlineDraftWrite({parentId, draftId: 'priv', visibility: 'PRIVATE'})
+    expect(write.visibility).toBe('PRIVATE')
+  })
+})

--- a/frontend/packages/shared/src/utils/inline-draft.ts
+++ b/frontend/packages/shared/src/utils/inline-draft.ts
@@ -1,4 +1,9 @@
-import type {HMBlockNode, HMMetadata, HMResourceVisibility, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import type {
+  HMBlockNode,
+  HMMetadata,
+  HMResourceVisibility,
+  UnpackedHypermediaId,
+} from '@seed-hypermedia/client/hm-types'
 
 /** Options accepted by inline draft creation across platforms. Structural — keep
  * in sync with editor's `CreateInlineDraftOptions` (which is a superset). */

--- a/frontend/packages/shared/src/utils/inline-draft.ts
+++ b/frontend/packages/shared/src/utils/inline-draft.ts
@@ -1,0 +1,61 @@
+import type {HMBlockNode, HMMetadata, HMResourceVisibility, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+
+/** Options accepted by inline draft creation across platforms. Structural — keep
+ * in sync with editor's `CreateInlineDraftOptions` (which is a superset). */
+export type InlineDraftOptions = {
+  initialContent?: HMBlockNode[]
+  name?: string
+}
+
+/**
+ * Write payload produced by {@link buildInlineDraftWrite}. Field names match
+ * `client.drafts.write.mutate` (desktop trpc) and `putWebDocDraft` (web
+ * IndexedDB) so platform providers can pass it through unchanged.
+ */
+export type InlineDraftWrite = {
+  id: string
+  locationUid: string
+  locationPath: string[]
+  editUid: string
+  editPath: string[]
+  metadata: HMMetadata
+  content: HMBlockNode[]
+  deps: string[]
+  visibility: HMResourceVisibility
+}
+
+/**
+ * Build the canonical inline-draft write payload. Both desktop and web call
+ * this so the on-disk draft shape stays identical regardless of storage
+ * backend. The draft lives at `parentPath + '-' + draftId` so it has a
+ * stable, unique path before publish; `locationUid/Path` track the parent
+ * (so child-draft listings include it) and `editUid/Path` track the new
+ * placeholder path (so existing-draft lookup hits when the editor mounts at
+ * the new doc's route URL).
+ */
+export function buildInlineDraftWrite({
+  parentId,
+  draftId,
+  options,
+  visibility = 'PUBLIC',
+}: {
+  parentId: UnpackedHypermediaId
+  draftId: string
+  options?: InlineDraftOptions
+  visibility?: HMResourceVisibility
+}): InlineDraftWrite {
+  const parentPath = parentId.path ?? []
+  const draftPath = [...parentPath, `-${draftId}`]
+  const metadata: HMMetadata = {name: options?.name ?? ''}
+  return {
+    id: draftId,
+    locationUid: parentId.uid,
+    locationPath: parentPath,
+    editUid: parentId.uid,
+    editPath: draftPath,
+    metadata,
+    content: options?.initialContent ?? [],
+    deps: [],
+    visibility,
+  }
+}


### PR DESCRIPTION
## Summary
- Add IndexedDB-backed web draft actions so editor slash-menu inline draft creation, opening, renaming, and deletion work on web.
- Add web query-block draft slots that list local child drafts and allow creating inline drafts under editable public documents.
- Share inline draft payload construction and child-draft filtering across desktop and web, with focused Vitest coverage.
- Avoid persisting empty draft names for web drafts so publish does not emit empty `name` attribute changes.
- Improve web publish error logging by surfacing daemon error bodies when available.

Fixes #705 