### PR TITLE
Fix weak bold styling in shared hm-prose typography

### DIFF
--- a/frontend/packages/editor/e2e/test-app/TestEditor.tsx
+++ b/frontend/packages/editor/e2e/test-app/TestEditor.tsx
@@ -1,5 +1,6 @@
 import '@/blocknote/core/style.css'
 import '@/editor.css'
+import '@shm/ui/hm-prose.css'
 import {HMFormattingToolbar} from '@shm/editor/hm-formatting-toolbar'
 import {HypermediaLinkPreview} from '@shm/editor/hm-link-preview'
 import {SearchResultItem, UniversalAppProvider, writeableStateStream} from '@shm/shared'

--- a/frontend/packages/editor/e2e/tests/selection-toolbar.e2e.ts
+++ b/frontend/packages/editor/e2e/tests/selection-toolbar.e2e.ts
@@ -249,6 +249,10 @@ test.describe('Formatting Toolbar', () => {
       // Verify bold mark is applied
       const hasBoldAfterApply = await editorHelpers.hasMarkType('bold')
       expect(hasBoldAfterApply).toBe(true)
+      const renderedBold = page.locator('[data-testid="editor-container"] strong').first()
+      await expect(renderedBold).toHaveText('Bold text')
+      const renderedBoldWeight = await renderedBold.evaluate((element) => getComputedStyle(element).fontWeight)
+      expect(renderedBoldWeight).toBe('700')
 
       // Remove bold formatting with toolbar button
       await editorHelpers.selectAll()

--- a/frontend/packages/ui/src/hm-prose.css
+++ b/frontend/packages/ui/src/hm-prose.css
@@ -303,7 +303,7 @@
 /* ---------- Inline marks ---------- */
 .hm-prose strong,
 .hm-prose b {
-  font-weight: 500;
+  font-weight: 700;
   color: inherit;
 }
 .hm-prose em,


### PR DESCRIPTION
Implemented the bold-visual fix across all shared .hm-prose surfaces by making semantic bold render at font-weight: 700, and added an editor E2E regression that checks rendered bold styling instead of only checking the ProseMirror mark.

Files changed: frontend/packages/ui/src/hm-prose.css, frontend/packages/editor/e2e/test-app/TestEditor.tsx, frontend/packages/editor/e2e/tests/selection-toolbar.e2e.ts
This should affect editor, viewer, embeds, and other surfaces that share .hm-prose
Validation was attempted but blocked in this worktree because the local JS dependencies/toolchain are not fully installed (tsc/prettier unavailable)
