### PR TITLE
fix(editor): stop embed flashing on ancestor renders

### DIFF
--- a/dev
+++ b/dev
@@ -305,18 +305,68 @@ def main():
 
     @cmd(cmds, "run-web", "Run Web app for development.")
     def run_web(args):
-        run("./scripts/cleanup-web.sh")
-        run("pnpm install")
+        import atexit
+        import socket
+
         run("plz build //:pnpm")
-        return run(
-            "pnpm web",
-            args=args,
-        )
+
+        backend = None
+        if "SEED_NO_DAEMON_SPAWN" not in os.environ:
+            web_daemon_ports = [58000, 58001, 58002]
+            busy_ports = []
+            for port in web_daemon_ports:
+                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                    if sock.connect_ex(("127.0.0.1", port)) == 0:
+                        busy_ports.append(port)
+
+            if busy_ports:
+                print(
+                    "⚠️  Not starting web backend because port(s) already in use: "
+                    + ", ".join(str(port) for port in busy_ports),
+                    flush=True,
+                )
+            else:
+                run("plz build //backend:seed-daemon")
+
+                data_dir = os.path.abspath(".dev-data/web")
+                os.makedirs(data_dir, exist_ok=True)
+
+                backend_env = os.environ.copy()
+                backend_env["LLAMA_LOG"] = "error"
+                backend = subprocess.Popen(
+                    [
+                        "plz",
+                        "run",
+                        "//backend:seed-daemon",
+                        "--",
+                        "-p2p.port=58000",
+                        "-http.port=58001",
+                        "-grpc.port=58002",
+                        f"-data-dir={data_dir}",
+                    ],
+                    env=backend_env,
+                    start_new_session=True,
+                )
+
+        def stop_backend():
+            if backend is not None and backend.poll() is None:
+                print(f"🛑 Stopping web backend (pid {backend.pid})…", flush=True)
+                try:
+                    os.killpg(os.getpgid(backend.pid), 15)
+                except ProcessLookupError:
+                    pass
+
+        atexit.register(stop_backend)
+
+        try:
+            return run("pnpm web", args=args)
+        finally:
+            stop_backend()
 
     @cmd(cmds, "build-web", "Build web app for production.")
     def build_web(args):
         run("./scripts/cleanup-frontend.sh")
-        run("./scripts/cleanup-web.sh")
+        run("./scripts/cleanup-site.sh")
         run("pnpm install")
         run("plz build //:pnpm")
         return run(

--- a/docs/block-fragment-annotation-card-plan.md
+++ b/docs/block-fragment-annotation-card-plan.md
@@ -1,0 +1,315 @@
+# Block Fragment Annotation Card Implementation Plan
+
+## Goal
+
+Implement Option C from the fragment annotation explorations: a reusable **BlockFragment** component that renders a selected paragraph fragment as a compact annotation card.
+
+Current behavior renders the whole paragraph and highlights the selected range. This is clear, but too tall in comment panels and embeds. The new default for valid text-range comments should show the selected fragment as the primary content, with clear provenance and an affordance to reveal the full paragraph context.
+
+Recommended product behavior:
+
+> For text-selection comments, show an annotation card by default. Provide “Show context” to reveal the existing full block viewer.
+
+## Relevant Files
+
+Start by reading:
+
+```txt
+frontend/AGENTS.md
+frontend/packages/ui/src/comments.tsx
+frontend/packages/ui/src/blocks-content-utils.ts
+frontend/packages/editor/src/readonly-viewer.tsx
+frontend/packages/shared/src/readonly-viewer-context.tsx
+frontend/packages/shared/src/document-to-text.ts
+frontend/packages/client/src/hm-types.ts
+```
+
+Most relevant current component:
+
+```tsx
+// frontend/packages/ui/src/comments.tsx
+export function QuotedDocBlock({
+  docId,
+  blockId,
+  doc,
+  blockRange,
+}: {
+  docId: UnpackedHypermediaId
+  blockId: string
+  doc: HMDocument
+  blockRange?: BlockRange
+})
+```
+
+Current behavior renders the full block with `Viewer`, passing `focusBlockId` and `blockRange` so the selected text is highlighted inside the full paragraph.
+
+## Proposed Files
+
+Prefer one new presentational UI file:
+
+```txt
+frontend/packages/ui/src/block-fragment.tsx
+```
+
+If text extraction becomes non-trivial, add a small helper file:
+
+```txt
+frontend/packages/ui/src/block-fragment-utils.ts
+```
+
+Keep the implementation minimal. Avoid adding a new utility file unless it materially improves readability or testability.
+
+## Component API
+
+Create a presentational component with a doc comment because it is exported.
+
+Suggested API:
+
+```tsx
+/** Renders a compact annotation card for a selected text fragment inside a block. */
+export function BlockFragment({
+  selectedText,
+  sourceLabel = 'Paragraph fragment',
+  sourceDescription,
+  onShowContext,
+  className,
+}: {
+  selectedText: string
+  sourceLabel?: ReactNode
+  sourceDescription?: ReactNode
+  onShowContext?: () => void
+  className?: string
+})
+```
+
+The component should be dumb: pass already-extracted `selectedText` into it. Do not make this component know about document/block structures.
+
+## Visual Direction
+
+Option C “Annotation card” shape:
+
+```txt
+┌─────────────────────────────┐
+│ “                           │
+│ highlights only the         │
+│ selected phrase             │
+│                             │
+│ Paragraph fragment          │
+│ [Show context]              │
+└─────────────────────────────┘
+```
+
+Design goals:
+
+- Selected fragment is visually primary.
+- The card clearly communicates “this is quoted selected text from a paragraph.”
+- The card is shorter than rendering the whole paragraph.
+- It fits narrow comment/accessory panels.
+- It feels native to Seed’s existing UI.
+
+Suggested styling:
+
+- rounded card
+- subtle border
+- quote mark or quote icon
+- warm highlighted/accented quote area
+- small muted provenance label
+- “Show context” as a small ghost/pill button
+
+Use existing primitives where practical:
+
+```tsx
+Button
+SizableText
+cn
+BlockQuote or lucide Quote icon
+```
+
+## Fragment Text Extraction
+
+Add a small helper near `QuotedDocBlock` or in `block-fragment-utils.ts`.
+
+Suggested signature:
+
+```tsx
+function getTextFragmentFromBlock(
+  block: HMBlockNode,
+  range: {start: number; end: number},
+): string | null
+```
+
+Behavior:
+
+1. Return `null` if the range is invalid.
+2. Extract plain text from paragraph-like block content.
+3. Slice by Unicode codepoint offsets, not UTF-16 offsets.
+4. Trim whitespace.
+5. Return `null` if the selected text is empty.
+
+Codepoint slicing pattern:
+
+```tsx
+const codepoints = Array.from(text)
+const selectedText = codepoints.slice(start, end).join('').trim()
+```
+
+Important: inspect the actual `HMBlockNode` shape before implementing. Reuse existing text extraction utilities if they already exist and are appropriate.
+
+Fallback to current full block viewer when:
+
+- there is no valid `{start, end}` range
+- the block type is unsupported
+- text extraction fails
+- selected text is empty
+- `blockRange` is a non-range variant such as `{expanded: true}`
+
+## Integration in `QuotedDocBlock`
+
+Modify:
+
+```txt
+frontend/packages/ui/src/comments.tsx
+```
+
+Current range detection:
+
+```tsx
+const fragmentRange = blockRange && 'start' in blockRange ? blockRange : undefined
+```
+
+Add local expand state:
+
+```tsx
+const [showFullContext, setShowFullContext] = useState(false)
+```
+
+Suggested flow:
+
+```tsx
+const selectedText = fragmentRange && blockContent
+  ? getTextFragmentFromBlock(blockContent, fragmentRange)
+  : null
+
+if (fragmentRange && selectedText && !showFullContext) {
+  return (
+    <BlockFragment
+      selectedText={selectedText}
+      sourceLabel="Paragraph fragment"
+      sourceDescription="Commenting on selected text"
+      onShowContext={() => setShowFullContext(true)}
+    />
+  )
+}
+
+return existing full Viewer rendering
+```
+
+The existing full `Viewer` rendering should remain the expanded/fallback state.
+
+For the first implementation, one-way expansion is acceptable. A “Hide context” control can be added later if it naturally fits.
+
+## Example Styling Starting Point
+
+This is only a starting point; adjust to nearby UI conventions.
+
+```tsx
+<div className={cn('bg-brand-50 dark:bg-brand-950 rounded-lg p-2', className)}>
+  <div className="border-border bg-background rounded-lg border p-3">
+    <div className="flex gap-3">
+      <BlockQuote className="text-primary mt-1 shrink-0" />
+      <div className="min-w-0 flex-1">
+        <div className="text-foreground text-base leading-snug font-semibold">
+          {selectedText}
+        </div>
+        <div className="text-muted-foreground mt-2 text-xs">
+          {sourceLabel}
+        </div>
+        {sourceDescription ? (
+          <div className="text-muted-foreground mt-0.5 text-xs">
+            {sourceDescription}
+          </div>
+        ) : null}
+        {onShowContext ? (
+          <Button variant="ghost" size="xs" className="mt-2" onClick={onShowContext}>
+            Show context
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+## Tests
+
+Add tests if practical.
+
+Suggested component test file:
+
+```txt
+frontend/packages/ui/src/__tests__/block-fragment.test.tsx
+```
+
+Minimum component tests:
+
+1. Renders selected fragment text.
+2. Renders source label/description.
+3. Calls `onShowContext` when the button is clicked.
+
+If adding a utility helper, add tests such as:
+
+```txt
+frontend/packages/ui/src/__tests__/block-fragment-utils.test.ts
+```
+
+Utility test cases:
+
+- extracts a simple range
+- handles range at text boundaries
+- handles emoji/codepoints correctly
+- returns `null` for invalid ranges
+- returns `null` for unsupported/missing text
+
+## Acceptance Criteria
+
+Implementation is done when:
+
+- Text-selection comments show the Option C annotation card by default.
+- The selected phrase is visually primary.
+- The card clearly says it is a paragraph fragment or selected text quote.
+- “Show context” reveals the existing full-paragraph rendering with range highlight.
+- Existing non-fragment block comments still render unchanged.
+- Unsupported fragments safely fall back to current behavior.
+- Typecheck passes.
+
+## Validation Commands
+
+From `frontend/`:
+
+```sh
+pnpm typecheck
+pnpm test
+pnpm format:write
+```
+
+For full frontend CI parity before pushing:
+
+```sh
+npx @redwoodjs/agent-ci run -w .github/workflows/test-frontend-parallel.yml -p --github-token
+```
+
+## Implementation Order for New Session
+
+1. Read `frontend/AGENTS.md`.
+2. Inspect `HMBlockNode` shape and existing text extraction utilities.
+3. Create `BlockFragment` presentational component.
+4. Add minimal fragment text extraction helper.
+5. Update `QuotedDocBlock` to render `BlockFragment` for valid text ranges.
+6. Preserve current `Viewer` as fallback/expanded state.
+7. Add focused tests.
+8. Run frontend typecheck/tests/format.
+9. Manually verify comment panel behavior for:
+   - full block comment
+   - text fragment comment
+   - expanded context state
+   - invalid/missing range fallback

--- a/docs/comment-request-spam-investigation.md
+++ b/docs/comment-request-spam-investigation.md
@@ -1,0 +1,128 @@
+# Comment Request Spam Investigation
+
+Date: 2026-05-28  
+Affected release: 2026.5.5  
+Area: Desktop sync/activity/comment UI
+
+## Summary
+
+The most likely source of the production request storm is the desktop activity sync loop in
+`frontend/apps/desktop/src/app-sync.ts`.
+
+For every new `Comment` activity event, the sync loop calls:
+
+```ts
+grpcClient.comments.getComment({id: cid})
+```
+
+The backend implements `GetComment` by calling `BatchGetComments` with a single ID, so frontend `GetComment` spam can
+appear in logs as `BatchGetComments` spam.
+
+## Likely Request Path
+
+```txt
+desktop app focused
+  -> activity monitor polls every ~1s
+  -> receives Comment events
+  -> processEventsInner()
+  -> calls grpcClient.comments.getComment() once per comment CID
+  -> backend GetComment()
+  -> backend BatchGetComments([id])
+```
+
+This matches reports of large numbers of `BatchGetComments` requests while sitting on comment screens or writing
+comments.
+
+## Amplifiers
+
+After detecting any comment event, the sync loop blanket-invalidates many query families:
+
+- `DOCUMENT_COMMENTS`
+- `DOCUMENT_DISCUSSION`
+- `BLOCK_DISCUSSIONS`
+- `COMMENTS`
+- `AUTHORED_COMMENTS`
+- `COMMENT_VERSIONS`
+- `ACTIVITY_FEED`
+- `FEED`
+
+Mounted comment/feed views then refetch, causing additional comment/list/reply-count requests.
+
+## Why `main` May Feel Better
+
+`main` does not appear to remove this frontend request generator, but it includes backend contention/performance fixes
+after `2026.5.5`, especially:
+
+- `37b54c67b`: coalesces peer writes and marks `BatchGetComments` read-only-style.
+- `123e81fdb`: defers/splits peer startup cleanup.
+
+These likely reduce SQLite/write-lock contention, making the app freeze less under the same request pattern.
+
+## Proposed Hotfix
+
+### 1. Stop Per-Comment `GetComment` in Activity Sync
+
+Modify `frontend/apps/desktop/src/app-sync.ts`.
+
+Remove the async per-comment lookup:
+
+```ts
+Promise.allSettled(commentCids.map((cid) => grpcClient.comments.getComment({id: cid})))
+```
+
+Do not fetch every comment just to invalidate interaction summaries.
+
+### 2. Prefer Target Info from Activity Mention Events
+
+Use `newMention` events where:
+
+```ts
+sourceType === 'comment/target'
+```
+
+to derive affected target docs and invalidate:
+
+```ts
+[queryKeys.DOCUMENT_INTERACTION_SUMMARY, targetDocId]
+```
+
+If target info is unavailable, skip targeted summary invalidation rather than issuing N comment fetches.
+
+### 3. Narrow Comment Invalidations
+
+Longer-term, avoid blanket invalidating all comment-related query families. Prefer target-specific keys where possible.
+
+## Tests to Add
+
+In `frontend/apps/desktop/src/__tests__/app-sync-activity.test.ts`, add tests that verify:
+
+1. Processing `Comment` events does not call `grpcClient.comments.getComment`.
+2. `comment/target` mention events invalidate `DOCUMENT_INTERACTION_SUMMARY` for the target doc.
+3. Multiple comment events are batched/deduplicated.
+4. Existing comment query invalidations still fire as expected.
+
+## Validation
+
+Manual repro/verification:
+
+1. Run the desktop app with `SEED_SYNC_PROFILE=1`.
+2. Open a document comment screen.
+3. Create or write a second comment.
+4. Watch console/network logs.
+5. Confirm there is no repeated `GetComment`/single-ID `BatchGetComments` storm from the sync loop.
+6. Confirm comments and interaction summaries still update.
+
+Recommended checks:
+
+```sh
+pnpm test frontend/apps/desktop/src/__tests__/app-sync-activity.test.ts
+pnpm typecheck
+```
+
+## Risk
+
+Low-to-medium.
+
+The hotfix may delay interaction summary count updates in cases where only raw comment events arrive without
+corresponding `comment/target` mention events. This is preferable to freezing the app. Comment lists themselves still
+refresh through existing comment invalidations.

--- a/docs/embed-rerender-postmortem.md
+++ b/docs/embed-rerender-postmortem.md
@@ -1,0 +1,130 @@
+# Post-mortem: embeds re-rendering / flashing every second (desktop)
+
+**Date:** 2026-06-03
+**Affected:** Desktop app, production release 2026.6.1 (latent in `main` too)
+**Severity:** Visible jank — embedded documents flashed/re-rendered ~once per second while viewing a document. No data loss.
+**Fix:** `fix(editor): stop embeds re-rendering on every ancestor render` + `fix(ui): render Spinner as <span> …`
+
+---
+
+## TL;DR
+
+`RenderResourceProvider` memoized its context value on the **`resource` object reference**, but every call site passes an **inline object literal** (`resource={{kind, id}}`). A new object every render → the memo recomputed every render → it produced a **new array** as the context value → **every embed in the subtree re-rendered whenever any ancestor re-rendered**.
+
+In production the ancestor (the document editor) re-renders ~once per second on the desktop activity-poll's query invalidations → embeds flashed every second. In dev you could trigger the same path just by scrolling.
+
+The fix: memoize the provider value on a **primitive identity key** instead of the object reference, plus memoize the embed's `id` so it stops handing a fresh `blockRange` prop downstream.
+
+---
+
+## Symptom
+
+- Open a document containing embedded documents on desktop.
+- The embeds visibly re-render / flash roughly once per second, even when nothing in them changed.
+- Web was unaffected. Only desktop.
+
+## What made it slippery
+
+We changed our root-cause hypothesis **three times** before landing it. Each false lead looked plausible and each was killed by a measurement, not an argument. Worth internalizing:
+
+1. **First guess — the 1s desktop activity poll invalidating `ENTITY` queries.**
+   `frontend/apps/desktop/src/app-sync.ts` polls the activity feed every 1s and invalidates React Query caches. Looked like the obvious "every second" culprit.
+   **Killed by:** profiling showed that on a quiet document the poll found **zero** events and fired **zero** `ENTITY` invalidations — yet embeds still re-rendered. (We even temporarily bumped the poll interval to 10s; the re-render cadence didn't budge.)
+
+2. **Second guess — the document editor re-applying its content.**
+   The editor's XState machine calls `applyInitialContent → editor.replaceBlocks` on entering the `editing` state, which rebuilds every tiptap NodeView (embeds are NodeViews). We saw repeated `flushSync` warnings from that path.
+   **Killed by:** instrumented logging showed `applyInitialContent` fires only a handful of times at **startup**, not continuously. (Those `flushSync` warnings are a real but separate, pre-existing, dev-only issue.)
+
+3. **Third guess — discovery progress stream churn.**
+   `useResource({subscribed:true}) → useDiscoveryState → useStream` re-renders on every discovery-progress write.
+   **Killed by:** discovery uses a unary RPC retried ~every 2s, far too slow to explain the ~10ms continuous re-render cascade we were measuring.
+
+4. **Actual cause — found with a "why-did-render" probe.**
+   We added a render logger that recorded *which tracked input changed reference* on each embed render. The answer was unambiguous:
+   - `BlockEmbedContent` re-rendered with `changed=[renderResourceStack]`
+   - `BlockEmbedContentDocument` re-rendered with `changed=[blockRange]`
+
+That single field ended the guessing.
+
+## Root cause
+
+`frontend/packages/shared/src/render-resource-context.tsx` provides the "render-resource ancestry stack" (used for embed-cycle detection) via React context:
+
+```tsx
+// BEFORE
+const value = useMemo(
+  () => (resource?.id ? [...parentStack, resource] : parentStack),
+  [parentStack, resource],          // <-- keyed on the resource OBJECT
+)
+```
+
+Every call site passes the resource as an **inline literal**:
+
+```tsx
+<RenderResourceProvider resource={{kind: 'document', id}}>   // new object every render
+```
+
+So `resource` is a new reference on every render → the `useMemo` dependency changes every render → `value` is a brand-new array every render. A React **context value identity change re-renders every consumer**, regardless of whether the consumer's own props/state changed. Every embed reads this context (`useRenderResourceStack()`), so **all embeds re-rendered on every ancestor render**.
+
+Why "every second" in production, "on scroll" in dev:
+- Both are just *ancestor re-renders*. The unstable context turned any ancestor render into an all-embeds render.
+- **Production:** the document editor re-renders ~1×/s from the activity poll's query invalidations (account/feed/etc. broadcasts) → embeds flash every second.
+- **Dev:** scrolling sends a `scroll` event into the document machine (`useScrollSync`), which re-renders the editor subtree → same cascade.
+
+Secondary amplifier: `BlockEmbedContent` recomputed `id` (via `unpackHmId(block.link)` + spread) on every render, so it handed `BlockEmbedContentDocument` a fresh `blockRange` object each time — re-rendering it even after the context was stabilized.
+
+## The fix
+
+`render-resource-context.tsx` — memoize on a **primitive identity key**, not the object:
+
+```tsx
+// AFTER
+const resourceKey = resource?.id
+  ? `${resource.kind}|${resource.id.id}|${resource.id.version ?? ''}|${resource.id.latest ? 1 : 0}|${resource.id.blockRef ?? ''}`
+  : ''
+const value = useMemo(
+  () => (resource?.id ? [...parentStack, resource] : parentStack),
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [parentStack, resourceKey],
+)
+```
+
+Now object-identity churn at the call sites is ignored; the array is rebuilt only when the resource *actually* changes. Because `parentStack` is itself a now-stable context value, the whole provider chain stabilizes.
+
+`embed-views.tsx` — memoize `id` on `block.link` so `id`/`id.blockRange` stay referentially stable across re-renders.
+
+### Result (measured)
+
+- Continuous ~10ms re-render churn: **gone.**
+- Residual renders: only `changed=[]` at the editor's natural ~2s ticks — i.e. the parent re-rendered with **no input change**, so React reconciles to the same DOM and there is **no visual flash**. These are benign; we deliberately did **not** add `React.memo` to chase them (it wouldn't bail without first stabilizing unstable callback props, and adds staleness risk for zero user-visible gain).
+
+## Why this was a latent footgun
+
+A `useMemo`/`useContext` value keyed on an object that callers construct inline is effectively **not memoized at all** — and when that value is a *context value*, the cost is paid by **every consumer in the subtree**, not just the provider. It's invisible until something upstream starts re-rendering often (here, a 1s poll), at which point it amplifies into a whole-subtree storm.
+
+## Lessons / how to avoid
+
+1. **Context values must be referentially stable.** If a provider's value is derived from props that callers pass as inline literals, memoize on **primitive keys**, not the object/array reference. Treat an unstable context value as a perf bug by default.
+2. **Measure, don't argue.** Three confident hypotheses were each wrong. A "1s symptom" does **not** imply a "1s timer" is the cause — it can be any ancestor that happens to re-render on that cadence. The decisive tool was a tiny *why-did-render* probe (`Object.is` diff of tracked inputs per render); a quick A/B (bump the poll to 10s) cheaply exonerated the prime suspect.
+3. **Distinguish trigger from amplifier.** The activity poll was the *trigger* (it re-renders the editor); the unstable context was the *amplifier* (it turned that into an all-embeds render). Fix the amplifier and the trigger becomes harmless.
+4. **A re-render is not a flash.** After the fix, embeds still re-render at ~2s with `changed=[]` — harmless, because no input changed so the DOM doesn't update. Don't over-optimize benign re-renders.
+
+## Related, separate issue (not the flashing)
+
+While investigating we noticed pre-existing, **dev-only** console warnings, unrelated to the flashing:
+
+- `flushSync was called from inside a lifecycle method` — from `applyInitialContent → editor.replaceBlocks` (tiptap mounts NodeViews with `flushSync`). The editor's init is intentionally synchronous, so we left this alone.
+- `validateDOMNesting: <div> cannot appear as a descendant of <p>` — the `Spinner` rendered a `<div>` inside the document-header author `<p>`/`<a>`. **Fixed** by rendering `Spinner` as a `<span>` (it was already styled `inline-block`, so visually identical and valid everywhere). This also removes a real web-SSR hydration risk.
+
+## Touched files
+
+- `frontend/packages/shared/src/render-resource-context.tsx` — primitive-key memo (primary fix).
+- `frontend/packages/ui/src/embed-views.tsx` — memoize embed `id` on `block.link`.
+- `frontend/packages/ui/src/spinner.tsx` — `<div>` → `<span>` (separate DOM-nesting fix).
+
+## How to verify
+
+1. Desktop: open a document with embeds; scroll and sit idle — embeds no longer flash/re-render (use React DevTools Profiler "Highlight updates" to confirm).
+2. Embed-cycle detection still works (open a self-embedding document → cycle banner).
+3. Block-fragment highlight still lands on the correct text.
+4. Spinners (author link, breadcrumb loading, page/embed loaders) still render and spin; `validateDOMNesting` warning is gone.

--- a/fragment-annotation-explorations.pen
+++ b/fragment-annotation-explorations.pen
@@ -1,0 +1,1976 @@
+{
+  "version": "2.10",
+  "children": [
+    {
+      "type": "frame",
+      "id": "azNdzR",
+      "x": 0,
+      "y": 0,
+      "name": "Fragment Annotation Explorations",
+      "width": 1640,
+      "height": 1320,
+      "fill": "$bg",
+      "clip": false,
+      "children": [
+        {
+          "type": "text",
+          "id": "txSPBa",
+          "name": "title",
+          "fill": "$fg-primary",
+          "content": "Fragment annotation rendering explorations",
+          "fontFamily": "Inter",
+          "fontSize": 34,
+          "fontWeight": "800",
+          "textGrowth": "fixed-width",
+          "width": 760,
+          "layoutPosition": "absolute",
+          "x": 64,
+          "y": 48
+        },
+        {
+          "type": "text",
+          "id": "tSCI0Z",
+          "name": "subtitle",
+          "fill": "$fg-secondary",
+          "content": "Four compact patterns for showing only the selected text while making provenance and hidden paragraph context obvious.",
+          "fontFamily": "Inter",
+          "fontSize": 15,
+          "fontWeight": "normal",
+          "textGrowth": "fixed-width",
+          "width": 860,
+          "lineHeight": 22,
+          "layoutPosition": "absolute",
+          "x": 64,
+          "y": 94
+        },
+        {
+          "type": "frame",
+          "id": "fpv2KA",
+          "name": "baseline label",
+          "width": 200,
+          "height": 30,
+          "clip": false,
+          "fill": "$quote-soft",
+          "cornerRadius": 999,
+          "children": [
+            {
+              "type": "text",
+              "id": "tmKmC3",
+              "name": "baseline label text",
+              "fill": "$quote-rail",
+              "content": "Same quote, same composer",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "800",
+              "layoutPosition": "absolute",
+              "x": 18,
+              "y": 8
+            }
+          ],
+          "layoutPosition": "absolute",
+          "x": 64,
+          "y": 148
+        },
+        {
+          "type": "frame",
+          "id": "f1PCDL",
+          "name": "A. Quote chip",
+          "width": 360,
+          "height": 780,
+          "clip": false,
+          "fill": "$card",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border"
+          },
+          "cornerRadius": 22,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000014",
+            "offset": {
+              "x": 0,
+              "y": 10
+            },
+            "blur": 30
+          },
+          "children": [
+            {
+              "type": "frame",
+              "id": "f32vNR",
+              "name": "variant rail",
+              "width": 5,
+              "height": 64,
+              "clip": false,
+              "fill": "$quote-rail",
+              "cornerRadius": 8,
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 0
+            },
+            {
+              "type": "text",
+              "id": "tNTibi",
+              "name": "variant title",
+              "fill": "$fg-primary",
+              "content": "A. Quote chip",
+              "fontFamily": "Inter",
+              "fontSize": 18,
+              "fontWeight": "800",
+              "textGrowth": "fixed-width",
+              "width": 284,
+              "layoutPosition": "absolute",
+              "x": 18,
+              "y": 0
+            },
+            {
+              "type": "text",
+              "id": "t93eFi",
+              "name": "variant subtitle",
+              "fill": "$fg-muted",
+              "content": "Most compact: fragment-only with ellipses and an explicit context action.",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "textGrowth": "fixed-width",
+              "width": 284,
+              "lineHeight": 17,
+              "layoutPosition": "absolute",
+              "x": 18,
+              "y": 28
+            },
+            {
+              "type": "frame",
+              "id": "fXHN5y",
+              "name": "source chip",
+              "width": 320,
+              "height": 48,
+              "clip": false,
+              "fill": "$muted-surface",
+              "cornerRadius": 12,
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "iwWGeQ",
+                  "name": "file icon",
+                  "width": 17,
+                  "height": 17,
+                  "iconFontName": "file-text",
+                  "iconFontFamily": "lucide",
+                  "fill": "$fg-secondary",
+                  "layoutPosition": "absolute",
+                  "x": 14,
+                  "y": 15
+                },
+                {
+                  "type": "text",
+                  "id": "tC2JtD",
+                  "name": "source title",
+                  "fill": "$fg-primary",
+                  "content": "Design notes",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "700",
+                  "layoutPosition": "absolute",
+                  "x": 42,
+                  "y": 10
+                },
+                {
+                  "type": "text",
+                  "id": "t1fuPA",
+                  "name": "source meta",
+                  "fill": "$fg-muted",
+                  "content": "Paragraph fragment \u00b7 block #intro",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "normal",
+                  "layoutPosition": "absolute",
+                  "x": 42,
+                  "y": 27
+                }
+              ],
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 92
+            },
+            {
+              "type": "frame",
+              "id": "fHNRyc",
+              "name": "quote preview",
+              "width": 320,
+              "height": 190,
+              "clip": false,
+              "fill": "$panel",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$border-soft"
+              },
+              "cornerRadius": 18,
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "i5jael",
+                  "name": "quote icon",
+                  "width": 18,
+                  "height": 18,
+                  "iconFontName": "quote",
+                  "iconFontFamily": "lucide",
+                  "fill": "$quote-rail",
+                  "layoutPosition": "absolute",
+                  "x": 24,
+                  "y": 26
+                },
+                {
+                  "type": "frame",
+                  "id": "fOC6Y0",
+                  "name": "fragment chip",
+                  "width": 218,
+                  "height": 66,
+                  "clip": false,
+                  "fill": "$quote-soft",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$quote-mark"
+                  },
+                  "cornerRadius": 16,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "tTCl69",
+                      "name": "chip fragment",
+                      "fill": "$fg-primary",
+                      "content": "\u2026 highlights only the selected phrase \u2026",
+                      "fontFamily": "Inter",
+                      "fontSize": 15,
+                      "fontWeight": "800",
+                      "textGrowth": "fixed-width",
+                      "width": 190,
+                      "lineHeight": 20,
+                      "layoutPosition": "absolute",
+                      "x": 14,
+                      "y": 15
+                    }
+                  ],
+                  "layoutPosition": "absolute",
+                  "x": 58,
+                  "y": 24
+                },
+                {
+                  "type": "frame",
+                  "id": "fqMcnQ",
+                  "name": "context action",
+                  "width": 150,
+                  "height": 28,
+                  "clip": false,
+                  "fill": "$panel",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$border-soft"
+                  },
+                  "cornerRadius": 999,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "tnQT6T",
+                      "name": "context action label",
+                      "fill": "$quote-rail",
+                      "content": "View full paragraph",
+                      "fontFamily": "Inter",
+                      "fontSize": 10,
+                      "fontWeight": "800",
+                      "layoutPosition": "absolute",
+                      "x": 16,
+                      "y": 8
+                    }
+                  ],
+                  "layoutPosition": "absolute",
+                  "x": 58,
+                  "y": 108
+                },
+                {
+                  "type": "text",
+                  "id": "txq4bD",
+                  "name": "provenance",
+                  "fill": "$fg-muted",
+                  "content": "Quoted from paragraph text",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "normal",
+                  "textGrowth": "fixed-width",
+                  "width": 190,
+                  "layoutPosition": "absolute",
+                  "x": 58,
+                  "y": 150
+                }
+              ],
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 170
+            },
+            {
+              "type": "frame",
+              "id": "fyB1cK",
+              "name": "comment composer",
+              "width": 320,
+              "height": 116,
+              "clip": false,
+              "fill": "$panel",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$border-soft"
+              },
+              "cornerRadius": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "f6BUiN",
+                  "name": "avatar",
+                  "width": 26,
+                  "height": 26,
+                  "clip": false,
+                  "fill": "$button",
+                  "cornerRadius": 999,
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "iADDkq",
+                      "name": "user icon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "user",
+                      "iconFontFamily": "lucide",
+                      "fill": "$ink-inverse",
+                      "layoutPosition": "absolute",
+                      "x": 6,
+                      "y": 6
+                    }
+                  ],
+                  "layoutPosition": "absolute",
+                  "x": 16,
+                  "y": 16
+                },
+                {
+                  "type": "text",
+                  "id": "thDsWc",
+                  "name": "composer placeholder",
+                  "fill": "$fg-muted",
+                  "content": "Comment on this fragment\u2026",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal",
+                  "textGrowth": "fixed-width",
+                  "width": 242,
+                  "layoutPosition": "absolute",
+                  "x": 54,
+                  "y": 18
+                },
+                {
+                  "type": "frame",
+                  "id": "fwgrKB",
+                  "name": "input hairline",
+                  "width": 242,
+                  "height": 1,
+                  "clip": false,
+                  "fill": "$border-soft",
+                  "cornerRadius": 999,
+                  "layoutPosition": "absolute",
+                  "x": 54,
+                  "y": 52
+                },
+                {
+                  "type": "frame",
+                  "id": "f1NuVI",
+                  "name": "comment button",
+                  "width": 82,
+                  "height": 26,
+                  "clip": false,
+                  "fill": "$button",
+                  "cornerRadius": 8,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "tKCnxZ",
+                      "name": "comment label",
+                      "fill": "$ink-inverse",
+                      "content": "Comment",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "700",
+                      "layoutPosition": "absolute",
+                      "x": 17,
+                      "y": 7
+                    }
+                  ],
+                  "layoutPosition": "absolute",
+                  "x": 216,
+                  "y": 76
+                }
+              ],
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 388
+            },
+            {
+              "type": "frame",
+              "id": "fmsrKB",
+              "name": "evaluation notes",
+              "width": 320,
+              "height": 116,
+              "clip": false,
+              "fill": "$muted-surface",
+              "cornerRadius": 14,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "tyB3EO",
+                  "name": "notes title",
+                  "fill": "$fg-primary",
+                  "content": "Why it works",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "800",
+                  "layoutPosition": "absolute",
+                  "x": 16,
+                  "y": 14
+                },
+                {
+                  "type": "text",
+                  "id": "tvYGqw",
+                  "name": "notes text",
+                  "fill": "$fg-secondary",
+                  "content": "Space saving: 5/5\nClarity: 4/5\nBest when the selected phrase is self-contained. Needs an obvious expand action.",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal",
+                  "textGrowth": "fixed-width",
+                  "width": 288,
+                  "lineHeight": 16,
+                  "layoutPosition": "absolute",
+                  "x": 16,
+                  "y": 36
+                }
+              ],
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 604
+            }
+          ],
+          "layoutPosition": "absolute",
+          "x": 64,
+          "y": 212
+        },
+        {
+          "type": "frame",
+          "id": "fjxJVq",
+          "name": "B. Cropped window",
+          "width": 360,
+          "height": 780,
+          "clip": false,
+          "fill": "$card",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border"
+          },
+          "cornerRadius": 22,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000014",
+            "offset": {
+              "x": 0,
+              "y": 10
+            },
+            "blur": 30
+          },
+          "children": [
+            {
+              "type": "frame",
+              "id": "fIkEir",
+              "name": "variant rail",
+              "width": 5,
+              "height": 64,
+              "clip": false,
+              "fill": "$blue-rail",
+              "cornerRadius": 8,
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 0
+            },
+            {
+              "type": "text",
+              "id": "tZvSdU",
+              "name": "variant title",
+              "fill": "$fg-primary",
+              "content": "B. Cropped window",
+              "fontFamily": "Inter",
+              "fontSize": 18,
+              "fontWeight": "800",
+              "textGrowth": "fixed-width",
+              "width": 284,
+              "layoutPosition": "absolute",
+              "x": 18,
+              "y": 0
+            },
+            {
+              "type": "text",
+              "id": "tCV83c",
+              "name": "variant subtitle",
+              "fill": "$fg-muted",
+              "content": "A one-block viewport: small before/after context plus inline highlight.",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "textGrowth": "fixed-width",
+              "width": 284,
+              "lineHeight": 17,
+              "layoutPosition": "absolute",
+              "x": 18,
+              "y": 28
+            },
+            {
+              "type": "frame",
+              "id": "fFXlRA",
+              "name": "source chip",
+              "width": 320,
+              "height": 48,
+              "clip": false,
+              "fill": "$muted-surface",
+              "cornerRadius": 12,
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "ilsnM4",
+                  "name": "file icon",
+                  "width": 17,
+                  "height": 17,
+                  "iconFontName": "file-text",
+                  "iconFontFamily": "lucide",
+                  "fill": "$fg-secondary",
+                  "layoutPosition": "absolute",
+                  "x": 14,
+                  "y": 15
+                },
+                {
+                  "type": "text",
+                  "id": "tUWA9i",
+                  "name": "source title",
+                  "fill": "$fg-primary",
+                  "content": "Design notes",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "700",
+                  "layoutPosition": "absolute",
+                  "x": 42,
+                  "y": 10
+                },
+                {
+                  "type": "text",
+                  "id": "tlcASl",
+                  "name": "source meta",
+                  "fill": "$fg-muted",
+                  "content": "Paragraph fragment \u00b7 block #intro",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "normal",
+                  "layoutPosition": "absolute",
+                  "x": 42,
+                  "y": 27
+                }
+              ],
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 92
+            },
+            {
+              "type": "frame",
+              "id": "fBZHHz",
+              "name": "quote preview",
+              "width": 320,
+              "height": 190,
+              "clip": false,
+              "fill": "$panel",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$border-soft"
+              },
+              "cornerRadius": 18,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "fUKzQG",
+                  "name": "left quote rail",
+                  "width": 4,
+                  "height": 122,
+                  "clip": false,
+                  "fill": "$blue-rail",
+                  "cornerRadius": 999,
+                  "layoutPosition": "absolute",
+                  "x": 22,
+                  "y": 26
+                },
+                {
+                  "type": "text",
+                  "id": "tmHwfc",
+                  "name": "context before",
+                  "fill": "$fg-muted",
+                  "content": "\u2026 entire paragraph and",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal",
+                  "textGrowth": "fixed-width",
+                  "width": 218,
+                  "layoutPosition": "absolute",
+                  "x": 44,
+                  "y": 26
+                },
+                {
+                  "type": "frame",
+                  "id": "fR7WJV",
+                  "name": "selection band",
+                  "width": 228,
+                  "height": 36,
+                  "clip": false,
+                  "fill": "$quote-soft",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$quote-mark"
+                  },
+                  "cornerRadius": 10,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "tnW7Pd",
+                      "name": "selected text",
+                      "fill": "$fg-primary",
+                      "content": "highlights only the selected phrase",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "800",
+                      "textGrowth": "fixed-width",
+                      "width": 204,
+                      "layoutPosition": "absolute",
+                      "x": 12,
+                      "y": 10
+                    }
+                  ],
+                  "layoutPosition": "absolute",
+                  "x": 44,
+                  "y": 56
+                },
+                {
+                  "type": "text",
+                  "id": "tgalUS",
+                  "name": "context after",
+                  "fill": "$fg-secondary",
+                  "content": "which is clear, but creates vertical noise \u2026",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal",
+                  "textGrowth": "fixed-width",
+                  "width": 218,
+                  "lineHeight": 17,
+                  "layoutPosition": "absolute",
+                  "x": 44,
+                  "y": 108
+                },
+                {
+                  "type": "frame",
+                  "id": "ffilYb",
+                  "name": "small badge",
+                  "width": 132,
+                  "height": 24,
+                  "clip": false,
+                  "fill": "$blue-soft",
+                  "cornerRadius": 999,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "tDP10I",
+                      "name": "badge text",
+                      "fill": "$blue-rail",
+                      "content": "Cropped context",
+                      "fontFamily": "Inter",
+                      "fontSize": 10,
+                      "fontWeight": "800",
+                      "layoutPosition": "absolute",
+                      "x": 14,
+                      "y": 7
+                    }
+                  ],
+                  "layoutPosition": "absolute",
+                  "x": 44,
+                  "y": 146
+                }
+              ],
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 170
+            },
+            {
+              "type": "frame",
+              "id": "f1Ri1i",
+              "name": "comment composer",
+              "width": 320,
+              "height": 116,
+              "clip": false,
+              "fill": "$panel",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$border-soft"
+              },
+              "cornerRadius": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "fblgU7",
+                  "name": "avatar",
+                  "width": 26,
+                  "height": 26,
+                  "clip": false,
+                  "fill": "$button",
+                  "cornerRadius": 999,
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "ikqM2I",
+                      "name": "user icon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "user",
+                      "iconFontFamily": "lucide",
+                      "fill": "$ink-inverse",
+                      "layoutPosition": "absolute",
+                      "x": 6,
+                      "y": 6
+                    }
+                  ],
+                  "layoutPosition": "absolute",
+                  "x": 16,
+                  "y": 16
+                },
+                {
+                  "type": "text",
+                  "id": "tmDEwc",
+                  "name": "composer placeholder",
+                  "fill": "$fg-muted",
+                  "content": "Comment on this fragment\u2026",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal",
+                  "textGrowth": "fixed-width",
+                  "width": 242,
+                  "layoutPosition": "absolute",
+                  "x": 54,
+                  "y": 18
+                },
+                {
+                  "type": "frame",
+                  "id": "fMgZNh",
+                  "name": "input hairline",
+                  "width": 242,
+                  "height": 1,
+                  "clip": false,
+                  "fill": "$border-soft",
+                  "cornerRadius": 999,
+                  "layoutPosition": "absolute",
+                  "x": 54,
+                  "y": 52
+                },
+                {
+                  "type": "frame",
+                  "id": "fIdfgZ",
+                  "name": "comment button",
+                  "width": 82,
+                  "height": 26,
+                  "clip": false,
+                  "fill": "$button",
+                  "cornerRadius": 8,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "thnyNc",
+                      "name": "comment label",
+                      "fill": "$ink-inverse",
+                      "content": "Comment",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "700",
+                      "layoutPosition": "absolute",
+                      "x": 17,
+                      "y": 7
+                    }
+                  ],
+                  "layoutPosition": "absolute",
+                  "x": 216,
+                  "y": 76
+                }
+              ],
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 388
+            },
+            {
+              "type": "frame",
+              "id": "fYhbXW",
+              "name": "evaluation notes",
+              "width": 320,
+              "height": 116,
+              "clip": false,
+              "fill": "$muted-surface",
+              "cornerRadius": 14,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "t7xhgE",
+                  "name": "notes title",
+                  "fill": "$fg-primary",
+                  "content": "Why it works",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "800",
+                  "layoutPosition": "absolute",
+                  "x": 16,
+                  "y": 14
+                },
+                {
+                  "type": "text",
+                  "id": "tvcLsI",
+                  "name": "notes text",
+                  "fill": "$fg-secondary",
+                  "content": "Space saving: 4/5\nClarity: 5/5\nBest default candidate because it keeps the current mental model but trims height.",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal",
+                  "textGrowth": "fixed-width",
+                  "width": 288,
+                  "lineHeight": 16,
+                  "layoutPosition": "absolute",
+                  "x": 16,
+                  "y": 36
+                }
+              ],
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 604
+            }
+          ],
+          "layoutPosition": "absolute",
+          "x": 448,
+          "y": 212
+        },
+        {
+          "type": "frame",
+          "id": "fQmOlL",
+          "name": "C. Annotation card",
+          "width": 360,
+          "height": 780,
+          "clip": false,
+          "fill": "$card",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border"
+          },
+          "cornerRadius": 22,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000014",
+            "offset": {
+              "x": 0,
+              "y": 10
+            },
+            "blur": 30
+          },
+          "children": [
+            {
+              "type": "frame",
+              "id": "fA7GB2",
+              "name": "variant rail",
+              "width": 5,
+              "height": 64,
+              "clip": false,
+              "fill": "$green-rail",
+              "cornerRadius": 8,
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 0
+            },
+            {
+              "type": "text",
+              "id": "tT5TTQ",
+              "name": "variant title",
+              "fill": "$fg-primary",
+              "content": "C. Annotation card",
+              "fontFamily": "Inter",
+              "fontSize": 18,
+              "fontWeight": "800",
+              "textGrowth": "fixed-width",
+              "width": 284,
+              "layoutPosition": "absolute",
+              "x": 18,
+              "y": 0
+            },
+            {
+              "type": "text",
+              "id": "tOPtTo",
+              "name": "variant subtitle",
+              "fill": "$fg-muted",
+              "content": "Promotes the selected fragment into a readable card with source metadata.",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "textGrowth": "fixed-width",
+              "width": 284,
+              "lineHeight": 17,
+              "layoutPosition": "absolute",
+              "x": 18,
+              "y": 28
+            },
+            {
+              "type": "frame",
+              "id": "fBpfnP",
+              "name": "source chip",
+              "width": 320,
+              "height": 48,
+              "clip": false,
+              "fill": "$muted-surface",
+              "cornerRadius": 12,
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "iDMuOv",
+                  "name": "file icon",
+                  "width": 17,
+                  "height": 17,
+                  "iconFontName": "file-text",
+                  "iconFontFamily": "lucide",
+                  "fill": "$fg-secondary",
+                  "layoutPosition": "absolute",
+                  "x": 14,
+                  "y": 15
+                },
+                {
+                  "type": "text",
+                  "id": "tnBhi5",
+                  "name": "source title",
+                  "fill": "$fg-primary",
+                  "content": "Design notes",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "700",
+                  "layoutPosition": "absolute",
+                  "x": 42,
+                  "y": 10
+                },
+                {
+                  "type": "text",
+                  "id": "tTb0wg",
+                  "name": "source meta",
+                  "fill": "$fg-muted",
+                  "content": "Paragraph fragment \u00b7 block #intro",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "normal",
+                  "layoutPosition": "absolute",
+                  "x": 42,
+                  "y": 27
+                }
+              ],
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 92
+            },
+            {
+              "type": "frame",
+              "id": "fd6hMA",
+              "name": "quote preview",
+              "width": 320,
+              "height": 190,
+              "clip": false,
+              "fill": "$panel",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$border-soft"
+              },
+              "cornerRadius": 18,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "fwYujZ",
+                  "name": "top accent",
+                  "width": 320,
+                  "height": 5,
+                  "clip": false,
+                  "fill": "$green-rail",
+                  "layoutPosition": "absolute",
+                  "x": 0,
+                  "y": 0
+                },
+                {
+                  "type": "text",
+                  "id": "t0oMlc",
+                  "name": "opening quote",
+                  "fill": "$green-rail",
+                  "content": "\u201c",
+                  "fontFamily": "Inter",
+                  "fontSize": 36,
+                  "fontWeight": "800",
+                  "layoutPosition": "absolute",
+                  "x": 22,
+                  "y": 24
+                },
+                {
+                  "type": "text",
+                  "id": "t4xr4i",
+                  "name": "fragment as body",
+                  "fill": "$fg-primary",
+                  "content": "highlights only the selected phrase",
+                  "fontFamily": "Inter",
+                  "fontSize": 19,
+                  "fontWeight": "800",
+                  "textGrowth": "fixed-width",
+                  "width": 214,
+                  "lineHeight": 25,
+                  "layoutPosition": "absolute",
+                  "x": 58,
+                  "y": 34
+                },
+                {
+                  "type": "text",
+                  "id": "tHwcUL",
+                  "name": "source caption",
+                  "fill": "$fg-secondary",
+                  "content": "Commenting on a paragraph fragment",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "700",
+                  "textGrowth": "fixed-width",
+                  "width": 210,
+                  "layoutPosition": "absolute",
+                  "x": 58,
+                  "y": 106
+                },
+                {
+                  "type": "frame",
+                  "id": "fQOaOO",
+                  "name": "show context",
+                  "width": 108,
+                  "height": 28,
+                  "clip": false,
+                  "fill": "$green-soft",
+                  "cornerRadius": 999,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "t2Dthw",
+                      "name": "show context label",
+                      "fill": "$green-rail",
+                      "content": "Show context",
+                      "fontFamily": "Inter",
+                      "fontSize": 10,
+                      "fontWeight": "800",
+                      "layoutPosition": "absolute",
+                      "x": 15,
+                      "y": 8
+                    }
+                  ],
+                  "layoutPosition": "absolute",
+                  "x": 58,
+                  "y": 136
+                }
+              ],
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 170
+            },
+            {
+              "type": "frame",
+              "id": "feDydF",
+              "name": "comment composer",
+              "width": 320,
+              "height": 116,
+              "clip": false,
+              "fill": "$panel",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$border-soft"
+              },
+              "cornerRadius": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "fPOTqm",
+                  "name": "avatar",
+                  "width": 26,
+                  "height": 26,
+                  "clip": false,
+                  "fill": "$button",
+                  "cornerRadius": 999,
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "iVQJcZ",
+                      "name": "user icon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "user",
+                      "iconFontFamily": "lucide",
+                      "fill": "$ink-inverse",
+                      "layoutPosition": "absolute",
+                      "x": 6,
+                      "y": 6
+                    }
+                  ],
+                  "layoutPosition": "absolute",
+                  "x": 16,
+                  "y": 16
+                },
+                {
+                  "type": "text",
+                  "id": "tPVXZ6",
+                  "name": "composer placeholder",
+                  "fill": "$fg-muted",
+                  "content": "Comment on this fragment\u2026",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal",
+                  "textGrowth": "fixed-width",
+                  "width": 242,
+                  "layoutPosition": "absolute",
+                  "x": 54,
+                  "y": 18
+                },
+                {
+                  "type": "frame",
+                  "id": "foKoop",
+                  "name": "input hairline",
+                  "width": 242,
+                  "height": 1,
+                  "clip": false,
+                  "fill": "$border-soft",
+                  "cornerRadius": 999,
+                  "layoutPosition": "absolute",
+                  "x": 54,
+                  "y": 52
+                },
+                {
+                  "type": "frame",
+                  "id": "fB92BD",
+                  "name": "comment button",
+                  "width": 82,
+                  "height": 26,
+                  "clip": false,
+                  "fill": "$button",
+                  "cornerRadius": 8,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "tFz9cZ",
+                      "name": "comment label",
+                      "fill": "$ink-inverse",
+                      "content": "Comment",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "700",
+                      "layoutPosition": "absolute",
+                      "x": 17,
+                      "y": 7
+                    }
+                  ],
+                  "layoutPosition": "absolute",
+                  "x": 216,
+                  "y": 76
+                }
+              ],
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 388
+            },
+            {
+              "type": "frame",
+              "id": "fsZBt5",
+              "name": "evaluation notes",
+              "width": 320,
+              "height": 116,
+              "clip": false,
+              "fill": "$muted-surface",
+              "cornerRadius": 14,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "tbaf3W",
+                  "name": "notes title",
+                  "fill": "$fg-primary",
+                  "content": "Why it works",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "800",
+                  "layoutPosition": "absolute",
+                  "x": 16,
+                  "y": 14
+                },
+                {
+                  "type": "text",
+                  "id": "trKK6c",
+                  "name": "notes text",
+                  "fill": "$fg-secondary",
+                  "content": "Space saving: 4/5\nClarity: 4/5\nGood for focused comment views. Risks feeling like standalone text if metadata is subtle.",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal",
+                  "textGrowth": "fixed-width",
+                  "width": 288,
+                  "lineHeight": 16,
+                  "layoutPosition": "absolute",
+                  "x": 16,
+                  "y": 36
+                }
+              ],
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 604
+            }
+          ],
+          "layoutPosition": "absolute",
+          "x": 832,
+          "y": 212
+        },
+        {
+          "type": "frame",
+          "id": "fN5TnA",
+          "name": "D. Provenance ribbon",
+          "width": 360,
+          "height": 780,
+          "clip": false,
+          "fill": "$card",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border"
+          },
+          "cornerRadius": 22,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000014",
+            "offset": {
+              "x": 0,
+              "y": 10
+            },
+            "blur": 30
+          },
+          "children": [
+            {
+              "type": "frame",
+              "id": "fgt0iy",
+              "name": "variant rail",
+              "width": 5,
+              "height": 64,
+              "clip": false,
+              "fill": "$quote-rail",
+              "cornerRadius": 8,
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 0
+            },
+            {
+              "type": "text",
+              "id": "tVUxhj",
+              "name": "variant title",
+              "fill": "$fg-primary",
+              "content": "D. Provenance ribbon",
+              "fontFamily": "Inter",
+              "fontSize": 18,
+              "fontWeight": "800",
+              "textGrowth": "fixed-width",
+              "width": 284,
+              "layoutPosition": "absolute",
+              "x": 18,
+              "y": 0
+            },
+            {
+              "type": "text",
+              "id": "tvgJj9",
+              "name": "variant subtitle",
+              "fill": "$fg-muted",
+              "content": "A visible anchor rail connects the quote fragment to the composer/thread.",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "textGrowth": "fixed-width",
+              "width": 284,
+              "lineHeight": 17,
+              "layoutPosition": "absolute",
+              "x": 18,
+              "y": 28
+            },
+            {
+              "type": "frame",
+              "id": "f9NOtg",
+              "name": "source chip",
+              "width": 320,
+              "height": 48,
+              "clip": false,
+              "fill": "$muted-surface",
+              "cornerRadius": 12,
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "il643M",
+                  "name": "file icon",
+                  "width": 17,
+                  "height": 17,
+                  "iconFontName": "file-text",
+                  "iconFontFamily": "lucide",
+                  "fill": "$fg-secondary",
+                  "layoutPosition": "absolute",
+                  "x": 14,
+                  "y": 15
+                },
+                {
+                  "type": "text",
+                  "id": "tHZFEg",
+                  "name": "source title",
+                  "fill": "$fg-primary",
+                  "content": "Design notes",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "700",
+                  "layoutPosition": "absolute",
+                  "x": 42,
+                  "y": 10
+                },
+                {
+                  "type": "text",
+                  "id": "t8rw3t",
+                  "name": "source meta",
+                  "fill": "$fg-muted",
+                  "content": "Paragraph fragment \u00b7 block #intro",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "normal",
+                  "layoutPosition": "absolute",
+                  "x": 42,
+                  "y": 27
+                }
+              ],
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 92
+            },
+            {
+              "type": "frame",
+              "id": "fvoRMl",
+              "name": "quote preview",
+              "width": 320,
+              "height": 190,
+              "clip": false,
+              "fill": "$panel",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$border-soft"
+              },
+              "cornerRadius": 18,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "f4p5Ng",
+                  "name": "thread line top",
+                  "width": 2,
+                  "height": 150,
+                  "clip": false,
+                  "fill": "$border",
+                  "cornerRadius": 999,
+                  "layoutPosition": "absolute",
+                  "x": 32,
+                  "y": 18
+                },
+                {
+                  "type": "frame",
+                  "id": "fgGJTW",
+                  "name": "anchor dot",
+                  "width": 18,
+                  "height": 18,
+                  "clip": false,
+                  "fill": "$quote-rail",
+                  "cornerRadius": 999,
+                  "layoutPosition": "absolute",
+                  "x": 24,
+                  "y": 22
+                },
+                {
+                  "type": "frame",
+                  "id": "fNOAHa",
+                  "name": "quote ribbon",
+                  "width": 222,
+                  "height": 88,
+                  "clip": false,
+                  "fill": "$quote-soft",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$quote-mark"
+                  },
+                  "cornerRadius": 16,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "tcYJdV",
+                      "name": "quote mark",
+                      "fill": "$quote-rail",
+                      "content": "\u201c",
+                      "fontFamily": "Inter",
+                      "fontSize": 24,
+                      "fontWeight": "800",
+                      "layoutPosition": "absolute",
+                      "x": 16,
+                      "y": 8
+                    },
+                    {
+                      "type": "text",
+                      "id": "t30inZ",
+                      "name": "ribbon fragment",
+                      "fill": "$fg-primary",
+                      "content": "highlights only the selected phrase",
+                      "fontFamily": "Inter",
+                      "fontSize": 15,
+                      "fontWeight": "800",
+                      "textGrowth": "fixed-width",
+                      "width": 156,
+                      "lineHeight": 20,
+                      "layoutPosition": "absolute",
+                      "x": 42,
+                      "y": 22
+                    }
+                  ],
+                  "layoutPosition": "absolute",
+                  "x": 58,
+                  "y": 22
+                },
+                {
+                  "type": "text",
+                  "id": "thGaUa",
+                  "name": "anchor label",
+                  "fill": "$fg-secondary",
+                  "content": "Anchored to paragraph \u00b7 Expand",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "700",
+                  "textGrowth": "fixed-width",
+                  "width": 210,
+                  "layoutPosition": "absolute",
+                  "x": 58,
+                  "y": 130
+                }
+              ],
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 170
+            },
+            {
+              "type": "frame",
+              "id": "fowwQW",
+              "name": "comment composer",
+              "width": 320,
+              "height": 116,
+              "clip": false,
+              "fill": "$panel",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$border-soft"
+              },
+              "cornerRadius": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "fwL8WR",
+                  "name": "avatar",
+                  "width": 26,
+                  "height": 26,
+                  "clip": false,
+                  "fill": "$button",
+                  "cornerRadius": 999,
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "irivQh",
+                      "name": "user icon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "user",
+                      "iconFontFamily": "lucide",
+                      "fill": "$ink-inverse",
+                      "layoutPosition": "absolute",
+                      "x": 6,
+                      "y": 6
+                    }
+                  ],
+                  "layoutPosition": "absolute",
+                  "x": 16,
+                  "y": 16
+                },
+                {
+                  "type": "text",
+                  "id": "tPGDTd",
+                  "name": "composer placeholder",
+                  "fill": "$fg-muted",
+                  "content": "Comment on this fragment\u2026",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal",
+                  "textGrowth": "fixed-width",
+                  "width": 242,
+                  "layoutPosition": "absolute",
+                  "x": 54,
+                  "y": 18
+                },
+                {
+                  "type": "frame",
+                  "id": "fLBdtQ",
+                  "name": "input hairline",
+                  "width": 242,
+                  "height": 1,
+                  "clip": false,
+                  "fill": "$border-soft",
+                  "cornerRadius": 999,
+                  "layoutPosition": "absolute",
+                  "x": 54,
+                  "y": 52
+                },
+                {
+                  "type": "frame",
+                  "id": "fGWNct",
+                  "name": "comment button",
+                  "width": 82,
+                  "height": 26,
+                  "clip": false,
+                  "fill": "$button",
+                  "cornerRadius": 8,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "t0BNgj",
+                      "name": "comment label",
+                      "fill": "$ink-inverse",
+                      "content": "Comment",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "700",
+                      "layoutPosition": "absolute",
+                      "x": 17,
+                      "y": 7
+                    }
+                  ],
+                  "layoutPosition": "absolute",
+                  "x": 216,
+                  "y": 76
+                }
+              ],
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 388
+            },
+            {
+              "type": "frame",
+              "id": "ffkbjG",
+              "name": "evaluation notes",
+              "width": 320,
+              "height": 116,
+              "clip": false,
+              "fill": "$muted-surface",
+              "cornerRadius": 14,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "tEO7Qp",
+                  "name": "notes title",
+                  "fill": "$fg-primary",
+                  "content": "Why it works",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "800",
+                  "layoutPosition": "absolute",
+                  "x": 16,
+                  "y": 14
+                },
+                {
+                  "type": "text",
+                  "id": "tvJH0L",
+                  "name": "notes text",
+                  "fill": "$fg-secondary",
+                  "content": "Space saving: 3/5\nClarity: 5/5\nGood when anchoring matters. Strong relationship between quoted fragment and reply box.",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal",
+                  "textGrowth": "fixed-width",
+                  "width": 288,
+                  "lineHeight": 16,
+                  "layoutPosition": "absolute",
+                  "x": 16,
+                  "y": 36
+                }
+              ],
+              "layoutPosition": "absolute",
+              "x": 0,
+              "y": 604
+            }
+          ],
+          "layoutPosition": "absolute",
+          "x": 1216,
+          "y": 212
+        },
+        {
+          "type": "frame",
+          "id": "fj20Rt",
+          "name": "baseline mini",
+          "width": 704,
+          "height": 240,
+          "clip": false,
+          "fill": "$card",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border"
+          },
+          "cornerRadius": 22,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000014",
+            "offset": {
+              "x": 0,
+              "y": 10
+            },
+            "blur": 30
+          },
+          "children": [
+            {
+              "type": "text",
+              "id": "tm2aPq",
+              "name": "baseline title",
+              "fill": "$fg-primary",
+              "content": "Current baseline / expanded state",
+              "fontFamily": "Inter",
+              "fontSize": 18,
+              "fontWeight": "800",
+              "layoutPosition": "absolute",
+              "x": 24,
+              "y": 22
+            },
+            {
+              "type": "text",
+              "id": "tjwIN8",
+              "name": "baseline desc",
+              "fill": "$fg-muted",
+              "content": "Keep this full-paragraph treatment as the expanded fallback, not the collapsed default.",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "textGrowth": "fixed-width",
+              "width": 460,
+              "layoutPosition": "absolute",
+              "x": 24,
+              "y": 50
+            },
+            {
+              "type": "frame",
+              "id": "fzPPNC",
+              "name": "baseline quote preview",
+              "width": 320,
+              "height": 128,
+              "clip": false,
+              "fill": "$panel",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$border-soft"
+              },
+              "cornerRadius": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "fuskgh",
+                  "name": "left quote rail",
+                  "width": 4,
+                  "height": 140,
+                  "clip": false,
+                  "fill": "$quote-rail",
+                  "cornerRadius": 999,
+                  "layoutPosition": "absolute",
+                  "x": 20,
+                  "y": 22
+                },
+                {
+                  "type": "icon_font",
+                  "id": "iG5EEK",
+                  "name": "quote icon",
+                  "width": 18,
+                  "height": 18,
+                  "iconFontName": "quote",
+                  "iconFontFamily": "lucide",
+                  "fill": "$quote-rail",
+                  "layoutPosition": "absolute",
+                  "x": 36,
+                  "y": 22
+                },
+                {
+                  "type": "text",
+                  "id": "tbjHyB",
+                  "name": "paragraph before",
+                  "fill": "$fg-secondary",
+                  "content": "The current implementation renders the entire paragraph and",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal",
+                  "textGrowth": "fixed-width",
+                  "width": 218,
+                  "lineHeight": 18,
+                  "layoutPosition": "absolute",
+                  "x": 64,
+                  "y": 22
+                },
+                {
+                  "type": "frame",
+                  "id": "f4oxRL",
+                  "name": "selected highlight",
+                  "width": 205,
+                  "height": 27,
+                  "clip": false,
+                  "fill": "$quote-soft",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$quote-mark"
+                  },
+                  "cornerRadius": 8,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "tngJXY",
+                      "name": "selected text",
+                      "fill": "$fg-primary",
+                      "content": "highlights only the selected phrase",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "700",
+                      "textGrowth": "fixed-width",
+                      "width": 186,
+                      "layoutPosition": "absolute",
+                      "x": 10,
+                      "y": 7
+                    }
+                  ],
+                  "layoutPosition": "absolute",
+                  "x": 64,
+                  "y": 70
+                },
+                {
+                  "type": "text",
+                  "id": "t2AK5s",
+                  "name": "paragraph after",
+                  "fill": "$fg-secondary",
+                  "content": "which is clear, but it creates a lot of vertical noise in narrow discussion panels.",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal",
+                  "textGrowth": "fixed-width",
+                  "width": 218,
+                  "lineHeight": 18,
+                  "layoutPosition": "absolute",
+                  "x": 64,
+                  "y": 112
+                }
+              ],
+              "layoutPosition": "absolute",
+              "x": 24,
+              "y": 88
+            },
+            {
+              "type": "text",
+              "id": "tJYH2Y",
+              "name": "baseline notes",
+              "fill": "$fg-secondary",
+              "content": "Recommendation: implement B as the default compact preview, then allow expanding into this full paragraph rendering when users need more context.",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "700",
+              "textGrowth": "fixed-width",
+              "width": 270,
+              "lineHeight": 21,
+              "layoutPosition": "absolute",
+              "x": 382,
+              "y": 96
+            }
+          ],
+          "layoutPosition": "absolute",
+          "x": 64,
+          "y": 1030
+        },
+        {
+          "type": "frame",
+          "id": "fQy2GN",
+          "name": "recommendation",
+          "width": 752,
+          "height": 240,
+          "clip": false,
+          "fill": "$card",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border"
+          },
+          "cornerRadius": 22,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000014",
+            "offset": {
+              "x": 0,
+              "y": 10
+            },
+            "blur": 30
+          },
+          "children": [
+            {
+              "type": "text",
+              "id": "tYUof0",
+              "name": "recommendation title",
+              "fill": "$fg-primary",
+              "content": "Recommendation",
+              "fontFamily": "Inter",
+              "fontSize": 18,
+              "fontWeight": "800",
+              "layoutPosition": "absolute",
+              "x": 24,
+              "y": 22
+            },
+            {
+              "type": "text",
+              "id": "tA6KGz",
+              "name": "recommendation body",
+              "fill": "$fg-secondary",
+              "content": "Default to B. Cropped window. It preserves the current \u201cthis is text inside a paragraph\u201d model, but reduces the quoted area to a compact viewport. Add a \u201cShow full paragraph\u201d control that swaps to the existing full Viewer rendering. Use A. Quote chip as an extra-compact option in embeds or dense lists.",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal",
+              "textGrowth": "fixed-width",
+              "width": 688,
+              "lineHeight": 22,
+              "layoutPosition": "absolute",
+              "x": 24,
+              "y": 58
+            }
+          ],
+          "layoutPosition": "absolute",
+          "x": 824,
+          "y": 1030
+        }
+      ]
+    }
+  ],
+  "variables": {
+    "bg": {
+      "type": "color",
+      "value": "#f6f1e8"
+    },
+    "card": {
+      "type": "color",
+      "value": "#fffdf8"
+    },
+    "panel": {
+      "type": "color",
+      "value": "#ffffff"
+    },
+    "fg-primary": {
+      "type": "color",
+      "value": "#211f1b"
+    },
+    "fg-secondary": {
+      "type": "color",
+      "value": "#625d52"
+    },
+    "fg-muted": {
+      "type": "color",
+      "value": "#8b8476"
+    },
+    "border": {
+      "type": "color",
+      "value": "#ddd5c7"
+    },
+    "border-soft": {
+      "type": "color",
+      "value": "#eee6d8"
+    },
+    "quote-rail": {
+      "type": "color",
+      "value": "#b86b2b"
+    },
+    "quote-soft": {
+      "type": "color",
+      "value": "#fff4d7"
+    },
+    "quote-mark": {
+      "type": "color",
+      "value": "#f6d784"
+    },
+    "blue-rail": {
+      "type": "color",
+      "value": "#3b6f8f"
+    },
+    "blue-soft": {
+      "type": "color",
+      "value": "#eaf4f8"
+    },
+    "green-rail": {
+      "type": "color",
+      "value": "#487a52"
+    },
+    "green-soft": {
+      "type": "color",
+      "value": "#edf7ee"
+    },
+    "ink-inverse": {
+      "type": "color",
+      "value": "#fffdf8"
+    },
+    "button": {
+      "type": "color",
+      "value": "#211f1b"
+    },
+    "muted-surface": {
+      "type": "color",
+      "value": "#f7f2e9"
+    },
+    "rounded-sm": {
+      "type": "number",
+      "value": 6
+    },
+    "rounded-md": {
+      "type": "number",
+      "value": 10
+    },
+    "rounded-lg": {
+      "type": "number",
+      "value": 14
+    },
+    "rounded-xl": {
+      "type": "number",
+      "value": 18
+    }
+  },
+  "imports": []
+}

--- a/frontend/packages/editor/src/block-selection-wrapper.test.ts
+++ b/frontend/packages/editor/src/block-selection-wrapper.test.ts
@@ -1,0 +1,56 @@
+import {Schema} from 'prosemirror-model'
+import {EditorState, NodeSelection, TextSelection} from 'prosemirror-state'
+import {describe, expect, it} from 'vitest'
+import {computeSelected} from './block-selection-wrapper'
+
+const schema = new Schema({
+  nodes: {
+    doc: {
+      content: 'blockNode+',
+    },
+    blockNode: {
+      group: 'blockNodeChild',
+      attrs: {
+        id: {default: ''},
+      },
+      content: 'block',
+      toDOM: () => ['div', {'data-node-type': 'blockNode'}, 0],
+    },
+    image: {
+      group: 'block',
+      content: 'text*',
+      toDOM: () => ['figure', {'data-content-type': 'image'}, 0],
+    },
+    text: {
+      group: 'inline',
+    },
+  },
+})
+
+function makeEditor(selection: EditorState['selection']) {
+  const state = EditorState.create({schema, doc, selection})
+  return {
+    _tiptapEditor: {
+      view: {
+        state,
+      },
+    },
+  } as any
+}
+
+const doc = schema.node('doc', null, [schema.node('blockNode', {id: 'image-block'}, [schema.node('image')])])
+const block = {id: 'image-block'} as any
+
+describe('computeSelected', () => {
+  it('does not select empty media blocks for collapsed text selections', () => {
+    const editor = makeEditor(TextSelection.create(doc, 2))
+
+    expect(computeSelected(editor, block)).toBe(false)
+  })
+
+  it('selects media blocks for node selections', () => {
+    const editor = makeEditor(NodeSelection.create(doc, 1))
+
+    expect(computeSelected(editor, block)).toBe(true)
+  })
+})

--- a/frontend/packages/editor/src/block-selection-wrapper.tsx
+++ b/frontend/packages/editor/src/block-selection-wrapper.tsx
@@ -10,7 +10,11 @@ import {useEditorSelectionChange} from './blocknote/react/hooks/useEditorSelecti
 import './blockSelection.css'
 import {HMBlockSchema} from './schema'
 
-function computeSelected(editor: BlockNoteEditor<HMBlockSchema>, block: Block<HMBlockSchema>): boolean {
+/**
+ * Returns true when the current editor selection should show selected-block
+ * media chrome for the given block.
+ */
+export function computeSelected(editor: BlockNoteEditor<HMBlockSchema>, block: Block<HMBlockSchema>): boolean {
   const {view} = editor._tiptapEditor
   const {selection} = view.state
 
@@ -26,6 +30,8 @@ function computeSelected(editor: BlockNoteEditor<HMBlockSchema>, block: Block<HM
       if (node.attrs && node.attrs.id === block.id) return true
     }
   } else if (selection instanceof TextSelection) {
+    if (selection.empty) return false
+
     const {from, to} = selection
     let found = false
     view.state.doc.descendants((node: PMNode, pos: number) => {

--- a/frontend/packages/shared/src/render-resource-context.tsx
+++ b/frontend/packages/shared/src/render-resource-context.tsx
@@ -22,7 +22,22 @@ export function RenderResourceProvider({
   children: React.ReactNode
 }) {
   const parentStack = useContext(RenderResourceStackContext)
-  const value = useMemo(() => (resource?.id ? [...parentStack, resource] : parentStack), [parentStack, resource])
+  // Memoize on a primitive identity key, NOT the `resource` object reference.
+  // Call sites pass an inline `resource={{kind, id}}` literal, so a reference-keyed
+  // memo recomputes every render — producing a new stack array that re-renders
+  // every descendant embed on any ancestor render (scroll, query invalidation, …).
+  // Keying on the resource's stable fields keeps the array referentially stable
+  // until the resource actually changes.
+  const resourceKey = resource?.id
+    ? `${resource.kind}|${resource.id.id}|${resource.id.version ?? ''}|${resource.id.latest ? 1 : 0}|${
+        resource.id.blockRef ?? ''
+      }`
+    : ''
+  const value = useMemo(
+    () => (resource?.id ? [...parentStack, resource] : parentStack),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [parentStack, resourceKey],
+  )
   return <RenderResourceStackContext.Provider value={value}>{children}</RenderResourceStackContext.Provider>
 }
 

--- a/frontend/packages/ui/src/embed-views.tsx
+++ b/frontend/packages/ui/src/embed-views.tsx
@@ -425,12 +425,17 @@ export function BlockEmbedContent({
 }) {
   const [showReferenced, setShowReferenced] = useState(false)
   const renderResourceStack = useRenderResourceStack()
-  const rawId = unpackHmId(block.link)
-  // When the link targets a specific codepoint range we MUST resolve against
-  // the pinned version, otherwise later edits to the source doc shift the
-  // range and the highlight lands on different text. Force `latest:false`
-  // whenever blockRange is present, even on legacy links that still carry `&l`.
-  const id = rawId && rawId.blockRange && rawId.version ? {...rawId, latest: false} : rawId
+  // Memoize on `block.link` so `id` (and `id.blockRange`) keep a stable reference
+  // across re-renders — otherwise every render hands `BlockEmbedContentDocument`
+  // a fresh `blockRange` prop, re-rendering it needlessly.
+  const id = useMemo(() => {
+    const rawId = unpackHmId(block.link)
+    // When the link targets a specific codepoint range we MUST resolve against
+    // the pinned version, otherwise later edits to the source doc shift the
+    // range and the highlight lands on different text. Force `latest:false`
+    // whenever blockRange is present, even on legacy links that still carry `&l`.
+    return rawId && rawId.blockRange && rawId.version ? {...rawId, latest: false} : rawId
+  }, [block.link])
 
   const resource = useResource(id, {subscribed: true})
   // Check tombstone on latest version for version-pinned embeds.

--- a/frontend/packages/ui/src/spinner.tsx
+++ b/frontend/packages/ui/src/spinner.tsx
@@ -1,13 +1,16 @@
 import {cn} from './utils'
 import * as React from 'react'
 
-export type SpinnerProps = React.HTMLAttributes<HTMLDivElement> & {
+export type SpinnerProps = React.HTMLAttributes<HTMLSpanElement> & {
   size?: 'small' | 'large'
   color?: string
   hide?: boolean
 }
 
-export const Spinner = React.forwardRef<HTMLDivElement, SpinnerProps>(
+// Rendered as a <span> (not <div>) so it stays valid phrasing content — it is
+// frequently placed inside <p>/<a> (e.g. the document-header author link), where
+// a <div> triggers `validateDOMNesting` warnings and force-closes the <p>.
+export const Spinner = React.forwardRef<HTMLSpanElement, SpinnerProps>(
   ({size = 'small', color, hide = false, className, ...props}, ref) => {
     const sizeClasses = {
       small: 'size-4 border-2',
@@ -15,7 +18,7 @@ export const Spinner = React.forwardRef<HTMLDivElement, SpinnerProps>(
     }
 
     return (
-      <div
+      <span
         ref={ref}
         className={cn(
           'inline-block animate-spin rounded-full border-solid border-current border-r-transparent',


### PR DESCRIPTION
## Summary
- Stabilizes render-resource context values so embedded documents no longer flash or fully re-render on routine parent renders.
- Memoizes embed link parsing to keep fragment range props stable across renders.
- Fixes invalid spinner DOM nesting by rendering `Spinner` as a phrasing-safe `<span>`.
- Improves local web dev by making `dev run-web` start its backend when ports are free, and records follow-up investigation/planning docs for comments and fragment annotations.