### PR TITLE
Add expandable directory children

### DIFF
--- a/frontend/packages/ui/src/directory-page.tsx
+++ b/frontend/packages/ui/src/directory-page.tsx
@@ -264,11 +264,64 @@ export function DirectoryListViewWithActivity({
     <div className="flex flex-col gap-1">
       {items.map((item) =>
         item.isPublished ? (
-          <DocumentListItem key={item.id.id} item={item} draftId={item.draftId} accountsMetadata={accountsMetadata} />
+          <DirectoryDocumentTreeItem
+            key={item.id.id}
+            item={item}
+            draftId={item.draftId}
+            accountsMetadata={accountsMetadata}
+          />
         ) : (
           <DraftListItem key={item.draftId} draftId={item.draftId} metadata={item.metadata} />
         ),
       )}
+    </div>
+  )
+}
+
+function DirectoryDocumentTreeItem({
+  item,
+  draftId,
+  accountsMetadata,
+}: {
+  item: HMDocumentInfo & {draftId?: string; isPublished: true}
+  draftId?: string
+  accountsMetadata?: HMAccountsMetadata
+}) {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <div className="flex flex-col gap-1">
+      <DocumentListItem
+        item={item}
+        draftId={draftId}
+        accountsMetadata={accountsMetadata}
+        expandable={{
+          expanded,
+          onToggle: () => setExpanded((value) => !value),
+        }}
+      />
+      {expanded && <DirectoryDocumentChildren docId={item.id} />}
+    </div>
+  )
+}
+
+function DirectoryDocumentChildren({docId}: {docId: UnpackedHypermediaId}) {
+  const {items, accountsMetadata, isInitialLoading} = useDirectoryDataWithActivity(docId)
+
+  if (isInitialLoading) {
+    return (
+      <div className="border-border/70 text-muted-foreground ml-5 flex items-center gap-2 border-l py-2 pl-5 text-xs">
+        <Spinner className="size-3.5" />
+        Loading children…
+      </div>
+    )
+  }
+
+  if (!items.length) return null
+
+  return (
+    <div className="border-border/70 ml-5 border-l pl-5">
+      <DirectoryListViewWithActivity items={items} accountsMetadata={accountsMetadata} />
     </div>
   )
 }

--- a/frontend/packages/ui/src/document-list-item.tsx
+++ b/frontend/packages/ui/src/document-list-item.tsx
@@ -21,7 +21,7 @@ import {useDocumentActions} from '@shm/shared/document-actions-context'
 import {useInteractionSummary} from '@shm/shared/models/interaction-summary'
 import {createWebHMUrl, getVersionHeads, hmIdToURL} from '@shm/shared/utils/entity-id-url'
 import {useNavigate} from '@shm/shared/utils/navigation'
-import {Bookmark, Copy, Forward, GitFork, Globe, Link, Link2, MessageSquare, Pencil} from 'lucide-react'
+import {Bookmark, ChevronRight, Copy, Forward, GitFork, Globe, Link, Link2, MessageSquare, Pencil} from 'lucide-react'
 import {Fragment, useMemo} from 'react'
 import {LibraryEntryUpdateSummary} from './activity'
 import {Button} from './button'
@@ -54,6 +54,11 @@ interface DocumentListItemProps {
   indent?: boolean
   onClick?: (id: UnpackedHypermediaId) => void
   className?: string
+  expandable?: {
+    expanded: boolean
+    onToggle: () => void
+    isLoading?: boolean
+  }
 }
 
 export function DocumentListItem({
@@ -69,6 +74,7 @@ export function DocumentListItem({
   isRead,
   indent = false,
   onClick,
+  expandable,
 }: DocumentListItemProps) {
   const id = item.id
   const actions = useDocumentActions()
@@ -107,6 +113,11 @@ export function DocumentListItem({
   const summaryId = useMemo(() => hmId(id.uid, {path: id.path}), [id.uid, id.path])
   const interactionSummaryData = useInteractionSummary(summaryId, {enabled: !interactionSummary})
   const commentCount = interactionSummary?.comments ?? interactionSummaryData.data?.comments ?? 0
+  const childCount =
+    (interactionSummary && 'children' in interactionSummary ? interactionSummary.children : undefined) ??
+    interactionSummaryData.data?.children ??
+    0
+  const canExpand = !!expandable && (childCount > 0 || expandable.expanded || expandable.isLoading)
 
   const bookmarked = actions.isBookmarked?.(id) ?? false
   const isOwner = actions.selectedAccountUid === id.uid
@@ -268,6 +279,27 @@ export function DocumentListItem({
     >
       <a data-resourceid={id.id} {...linkProps} onClick={handleClick}>
         {indent && <div className="size-8 shrink-0" />}
+        {expandable && (
+          <button
+            type="button"
+            aria-label={expandable.expanded ? 'Collapse children' : 'Expand children'}
+            aria-expanded={expandable.expanded}
+            disabled={!canExpand}
+            className={cn(
+              'no-window-drag text-muted-foreground hover:bg-muted/70 -ml-2 flex size-7 shrink-0 items-center justify-center rounded-md transition-colors',
+              !canExpand && 'pointer-events-none invisible',
+            )}
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              expandable.onToggle()
+            }}
+          >
+            <ChevronRight
+              className={cn('size-4 transition-transform duration-150', expandable.expanded && 'rotate-90')}
+            />
+          </button>
+        )}
         <HMIcon size={28} id={id} name={metadata?.name} icon={metadata?.icon} />
         <div className="flex flex-1 flex-col overflow-hidden">
           {itemBreadcrumbs && itemBreadcrumbs.length > 1 && (


### PR DESCRIPTION
## Summary
- add chevron expand/collapse affordance to directory document items
- lazily render child directory items recursively for nested documents
- share the behavior through the existing directory list used by pages and panels

## Test
- pnpm --dir frontend/packages/ui typecheck
- pnpm --dir frontend/packages/ui format:write