### PR TITLE
feat(editor): highlight inbound citation fragments

### DIFF
--- a/.agents/skills/write-project-document/SKILL.md
+++ b/.agents/skills/write-project-document/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: write-project-document
+description: Create concise project documents in Markdown with the sections Problem, Solution, Scope, Rabbit Holes, and No Gos. Use when the user asks to draft, structure, or refine a project document, project brief, proposal, feature spec, or planning note in this specific Seed-style format.
+---
+
+# Write Project Document
+
+Create comprehensive project document in Markdown with the sections Problem, Solution, Scope, Rabbit Holes, and No Gos based on the current context, draft, solution and scope in this specific session. write the document in the `./docs/projects/` folder (create the folder if not present).
+
+<support-material>
+
+## Output format
+
+Always produce these sections in this order:
+
+```markdown
+# <Project title>
+
+## Problem
+
+## Solution
+
+## Scope
+
+## Rabbit Holes
+
+## No Gos
+```
+
+Use bullets when the content is easier to scan. Use paragraphs only where narrative explanation is clearer.
+
+## Section guidance
+
+- **Problem**: State the user pain, product gap, or operational issue. Explain why it matters now. Avoid solution details unless needed for context.
+- **Solution**: Describe the proposed approach in concrete terms. Include the user-facing behavior and the system changes only at the level needed for planning. Define what will be included. Prefer crisp bullets that can later become implementation tasks or acceptance criteria. if you can also add user stories to it the better.
+- **Scope**: the timeframe it will require to implement the solution. if the plan is multi-phase or multi-step, you can define the timeframe for each one and also dependencies of each phase/section
+- **Rabbit Holes**: List tempting investigations, extensions, or refactors that could consume time but are not required for the first useful version.
+- **No Gos**: List explicit non-goals, constraints, and things the project should not do.
+
+## Working style
+
+If inputs are sparse, draft a useful first version with clearly labeled assumptions instead of blocking. Ask clarifying questions only when a missing decision would materially change the project direction.
+
+Keep the document practical and opinionated. Favor specific statements over generic product-planning language.
+
+</support-material>

--- a/.agents/skills/write-project-document/agents/openai.yaml
+++ b/.agents/skills/write-project-document/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Write Project Document"
+  short_description: "Draft project docs with clear scope"
+  default_prompt: "Use $write-project-document to draft a markdown project document for this idea."

--- a/docs/fragment-citation-highlights-project.md
+++ b/docs/fragment-citation-highlights-project.md
@@ -1,0 +1,102 @@
+# Fragment Citation Highlights
+
+## Problem
+
+Seed documents already support precise references to block fragments, but the target document does not make those incoming references visible when someone reads it.
+
+Today, a user can load a document that is being cited by other documents or comments and have no immediate visual signal that specific text ranges are part of an active conversation or reference graph. This creates a few problems:
+
+- Readers miss important context around why a sentence or paragraph matters.
+- Authors cannot easily see which exact fragments are being cited elsewhere.
+- Comments and cross-document references feel disconnected from the text they refer to.
+- The citation graph exists in the data model, but it is not exposed at the reading/editing surface.
+
+The goal of this feature is to make inbound fragment citations visible directly inside the document, using the same highlight language users already understand from selected block fragments and comments.
+
+<!-- Add screenshot/video: document before citation highlights -->
+<!-- Add screenshot/video: document with citation highlights enabled -->
+
+## Solution
+
+Add a document rendering plugin that highlights every inbound citation targeting a block fragment range, such as:
+
+```text
+#BLOCKID[START:END]
+```
+
+When a document finishes loading, the UI reads all citations for that document, filters them to ranged block-fragment targets, and passes those ranges into an editor decoration plugin.
+
+The plugin renders highlight decorations over the cited text offsets using the existing `bn-range-highlight-focus` visual language, plus citation-specific classes for stacking/overlap behavior.
+
+Core behavior:
+
+- Fragment citations are visible by default when opening a document.
+- Highlights are decoration-only and do not mutate document content.
+- Highlight updates do not create undo/redo history entries.
+- The feature works whether the editor is loaded/read-only or currently editable.
+- A toggle in the document three-dot menu lets users show or hide citation highlights in memory.
+- Clicking a highlighted fragment opens the related citation context:
+  - If exactly one citation exists at that fragment, open it directly.
+  - If multiple citations overlap, show a small popover listing each citation.
+- Popover rows display:
+  - Document citations: document title.
+  - Comment citations: author avatar and a 50-character comment preview with ellipsis.
+- Overlapping highlights visually stack so dense citation areas appear darker.
+
+For navigation:
+
+- Clicking a document citation opens the source document/window with the source fragment highlighted.
+- Clicking a comment citation opens the comment in the right panel.
+
+<!-- Add screenshot/video: single citation direct-open behavior -->
+<!-- Add screenshot/video: multiple citation popover -->
+<!-- Add screenshot/video: comment citation row with avatar + preview -->
+
+## Scope (time to development)
+
+Estimated implementation scope: **2-4 development days** for the first production-ready version, assuming citation data is already available from the current document citation query.
+
+Breakdown:
+
+| Area | Estimate | Notes |
+| --- | ---: | --- |
+| Citation filtering + normalization | 0.5 day | Parse inbound mentions and keep only ranged block-fragment targets. |
+| Editor decoration plugin | 1 day | Render range highlights without document mutations or history entries. Reuse main block-fragment offset mapping behavior. |
+| Click handling + navigation | 0.5-1 day | Direct-open single citation; popover for overlapping/multiple citations. |
+| Toggle in document menu | 0.25 day | In-memory toggle, enabled by default. |
+| Popover UI polish | 0.5 day | Document title rows, comment avatar rows, preview text, empty/loading states if needed. |
+| Tests + rebase validation | 0.5-1 day | Unit tests for offsets/overlaps; typecheck; targeted editor tests; full frontend test pass. |
+
+Current spike status:
+
+- The core editor plugin exists.
+- The feature is wired into document rendering.
+- Single citation clicks open directly.
+- Multiple overlapping citations render a popover.
+- Comment citations show avatar + preview instead of “empty comment”.
+- The implementation has been reconciled with main’s newer block-fragment highlighting refactor.
+
+## Rabbit Holes
+
+Potential complexity areas to avoid or defer during the first version:
+
+- **Persistent preferences**: keeping the toggle in local storage, account settings, or synced settings. The current version is intentionally in-memory. A future version could support URL parameters or persisted preferences.
+- **Server-side precomputation**: deriving citation ranges on the backend or storing highlight indexes. The spike uses the current citation data in memory.
+- **Advanced color semantics**: assigning different colors by source type, author, age, or exact/non-exact versions. The first version only needs visible highlight stacking.
+- **Complex overlap layout**: rendering separate lanes, gutters, or annotation connectors for overlapping citations. Darker stacked highlights are enough for now.
+- **Full citation management UI**: editing, deleting, resolving, or grouping citations from the popover. The popover is discovery/navigation only.
+- **Perfect previews for every source type**: document title and comment preview are enough for the meeting/demo. More source metadata can come later.
+- **Analytics/instrumentation**: useful later, but not necessary to validate the UX.
+
+## No Gos
+
+Things this feature should explicitly not do in the first implementation:
+
+- Do not change document content to render citation highlights.
+- Do not create editor transactions that land in undo/redo history.
+- Do not depend on the editor being read-only; it must work while editing too.
+- Do not block document rendering while citation metadata is loading.
+- Do not persist the toggle yet.
+- Do not introduce a new highlight style unrelated to existing block-fragment/comment highlights.
+- Do not open a popover when only one citation is present; single citation clicks should navigate directly.
+- Do not show placeholder text like “empty comment” for comment citations when comment metadata is available.

--- a/frontend/packages/client/src/hm-types.ts
+++ b/frontend/packages/client/src/hm-types.ts
@@ -1475,8 +1475,20 @@ export type HMListCommentsByAuthorRequest = z.infer<typeof HMListCommentsByAutho
 export const HMRawMentionSchema = z.object({
   source: z.string(),
   sourceType: z.string().optional(),
+  sourceContext: z.string().optional(),
+  sourceBlob: z
+    .object({
+      cid: z.string().optional(),
+      author: z.string().optional(),
+      createTime: HMTimestampSchema.optional(),
+    })
+    .optional(),
   sourceDocument: z.string().optional(),
+  target: z.string().optional(),
+  targetVersion: z.string().optional(),
   targetFragment: z.string().optional(),
+  mentionType: z.string().optional(),
+  isExactVersion: z.boolean().optional(),
   isExact: z.boolean().optional(),
 })
 export type HMRawMention = z.infer<typeof HMRawMentionSchema>

--- a/frontend/packages/editor/src/blocknote/core/extensions/CitationFragmentHighlight/CitationFragmentHighlightPlugin.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/CitationFragmentHighlight/CitationFragmentHighlightPlugin.test.ts
@@ -132,4 +132,46 @@ describe('CitationFragmentHighlightPlugin', () => {
     expect(onClick).not.toHaveBeenCalled()
     view.destroy()
   })
+
+  it('splits a highlight instead of expanding it when text is inserted inside', () => {
+    const onClick = vi.fn()
+    const {view, plugin} = createView(onClick)
+
+    view.dispatch(
+      view.state.tr
+        .setMeta(citationFragmentHighlightPluginKey, {
+          type: 'set',
+          citations: [citation('a', 0, 5)],
+        })
+        .setMeta('addToHistory', false),
+    )
+
+    const initialRange = citationFragmentHighlightPluginKey.getState(view.state)?.ranges[0]
+    expect(initialRange).toBeDefined()
+
+    const insertPos = initialRange!.from + 2
+    const initialTo = initialRange!.to
+    view.dispatch(view.state.tr.insertText('NEW', insertPos))
+
+    const pluginState = citationFragmentHighlightPluginKey.getState(view.state)
+    const ranges = pluginState?.ranges ?? []
+    const decorations = pluginState?.decorations.find() ?? []
+
+    expect(ranges).toEqual([
+      expect.objectContaining({from: initialRange!.from, to: insertPos}),
+      expect.objectContaining({from: insertPos + 3, to: initialTo + 3}),
+    ])
+    expect(decorations).toHaveLength(2)
+
+    const insertedTextHandled = plugin.props.handleClick?.call(
+      plugin,
+      view,
+      insertPos + 1,
+      new MouseEvent('click', {clientX: 10, clientY: 20}),
+    )
+
+    expect(insertedTextHandled).toBe(false)
+    expect(onClick).not.toHaveBeenCalled()
+    view.destroy()
+  })
 })

--- a/frontend/packages/editor/src/blocknote/core/extensions/CitationFragmentHighlight/CitationFragmentHighlightPlugin.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/CitationFragmentHighlight/CitationFragmentHighlightPlugin.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import type {CitationFragmentClick, CitationFragmentHighlight} from '@shm/shared/document-content-props'
+import {Schema} from 'prosemirror-model'
+import {EditorState} from 'prosemirror-state'
+import {EditorView} from 'prosemirror-view'
+import {describe, expect, it, vi} from 'vitest'
+import {
+  citationFragmentHighlightPluginKey,
+  createCitationFragmentHighlightPlugin,
+} from './CitationFragmentHighlightPlugin'
+
+function createSchema(): Schema {
+  return new Schema({
+    nodes: {
+      doc: {content: 'blockNode+'},
+      blockNode: {
+        content: 'paragraph',
+        attrs: {id: {default: ''}},
+        toDOM(node) {
+          return ['div', {dataId: node.attrs.id}, 0]
+        },
+      },
+      paragraph: {
+        group: 'block',
+        content: 'text*',
+        toDOM() {
+          return ['p', 0]
+        },
+      },
+      text: {group: 'inline'},
+    },
+  })
+}
+
+function citation(id: string, start: number, end: number): CitationFragmentHighlight {
+  return {
+    id,
+    targetBlockId: 'block-1',
+    targetRange: {start, end},
+    sourceType: 'document',
+    sourceId: null,
+    sourceDocumentId: null,
+    sourceBlockId: null,
+    sourceCommentId: null,
+    sourceAuthorUid: null,
+    raw: {source: `hm://source/${id}`, targetFragment: `block-1[${start}:${end}]`},
+  }
+}
+
+function createView(onClick = vi.fn()) {
+  const schema = createSchema()
+  const doc = schema.nodes.doc.create(null, [
+    schema.nodes.blockNode.create({id: 'block-1'}, schema.nodes.paragraph.create(null, schema.text('hello world'))),
+  ])
+  const plugin = createCitationFragmentHighlightPlugin({current: onClick})
+  const state = EditorState.create({schema, doc, plugins: [plugin]})
+  const view = new EditorView(document.createElement('div'), {state})
+  return {view, plugin, onClick}
+}
+
+describe('CitationFragmentHighlightPlugin', () => {
+  it('renders split inline decorations for overlapping citation fragments', () => {
+    const {view} = createView()
+
+    view.dispatch(
+      view.state.tr
+        .setMeta(citationFragmentHighlightPluginKey, {
+          type: 'set',
+          citations: [citation('a', 0, 5), citation('b', 3, 8)],
+        })
+        .setMeta('addToHistory', false),
+    )
+
+    const pluginState = citationFragmentHighlightPluginKey.getState(view.state)
+    const decorations = pluginState?.decorations.find() ?? []
+
+    expect(decorations).toHaveLength(3)
+    expect(decorations.map((deco) => deco.spec.class || deco.type.attrs.class)).toEqual([
+      expect.stringContaining('bn-citation-fragment-overlap-1'),
+      expect.stringContaining('bn-citation-fragment-overlap-2'),
+      expect.stringContaining('bn-citation-fragment-overlap-1'),
+    ])
+    view.destroy()
+  })
+
+  it('reports every citation covering the clicked position', () => {
+    const onClick = vi.fn()
+    const {view, plugin} = createView(onClick)
+
+    view.dispatch(
+      view.state.tr
+        .setMeta(citationFragmentHighlightPluginKey, {
+          type: 'set',
+          citations: [citation('a', 0, 5), citation('b', 3, 8)],
+        })
+        .setMeta('addToHistory', false),
+    )
+
+    const handled = plugin.props.handleClick?.call(plugin, view, 6, new MouseEvent('click', {clientX: 10, clientY: 20}))
+
+    expect(handled).toBe(true)
+    const payload = onClick.mock.calls[0]?.[0] as CitationFragmentClick
+    expect(payload.clientX).toBe(10)
+    expect(payload.clientY).toBe(20)
+    expect(payload.citations.map((item) => item.id).sort()).toEqual(['a', 'b'])
+    view.destroy()
+  })
+})

--- a/frontend/packages/editor/src/blocknote/core/extensions/CitationFragmentHighlight/CitationFragmentHighlightPlugin.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/CitationFragmentHighlight/CitationFragmentHighlightPlugin.test.ts
@@ -105,4 +105,31 @@ describe('CitationFragmentHighlightPlugin', () => {
     expect(payload.citations.map((item) => item.id).sort()).toEqual(['a', 'b'])
     view.destroy()
   })
+
+  it('keeps highlights visible but ignores clicks when interactivity is disabled', () => {
+    const onClick = vi.fn()
+    const {view, plugin} = createView(onClick)
+
+    view.dispatch(
+      view.state.tr
+        .setMeta(citationFragmentHighlightPluginKey, {
+          type: 'set',
+          citations: [citation('a', 0, 5)],
+          interactive: false,
+        })
+        .setMeta('addToHistory', false),
+    )
+
+    const pluginState = citationFragmentHighlightPluginKey.getState(view.state)
+    const decorations = pluginState?.decorations.find() ?? []
+    expect(decorations).toHaveLength(1)
+    expect(decorations[0]?.type.attrs.class).toContain('bn-citation-fragment-highlight')
+    expect(decorations[0]?.type.attrs.class).not.toContain('bn-citation-fragment-highlight-interactive')
+
+    const handled = plugin.props.handleClick?.call(plugin, view, 4, new MouseEvent('click', {clientX: 10, clientY: 20}))
+
+    expect(handled).toBe(false)
+    expect(onClick).not.toHaveBeenCalled()
+    view.destroy()
+  })
 })

--- a/frontend/packages/editor/src/blocknote/core/extensions/CitationFragmentHighlight/CitationFragmentHighlightPlugin.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/CitationFragmentHighlight/CitationFragmentHighlightPlugin.ts
@@ -11,7 +11,9 @@ export type CitationFragmentClickHandlerRef = {
   current?: ((event: CitationFragmentClick) => void) | null
 }
 
-type CitationFragmentHighlightAction = {type: 'set'; citations: CitationFragmentHighlight[]} | {type: 'clear'}
+type CitationFragmentHighlightAction =
+  | {type: 'set'; citations: CitationFragmentHighlight[]; interactive?: boolean}
+  | {type: 'clear'}
 
 type CitationDecorationRange = {
   from: number
@@ -22,6 +24,7 @@ type CitationDecorationRange = {
 type CitationFragmentHighlightState = {
   decorations: DecorationSet
   ranges: CitationDecorationRange[]
+  interactive: boolean
 }
 
 /** Plugin key used to dispatch citation fragment highlight actions. */
@@ -30,7 +33,7 @@ export const citationFragmentHighlightPluginKey = new PluginKey<CitationFragment
 )
 
 function emptyState(): CitationFragmentHighlightState {
-  return {decorations: DecorationSet.empty, ranges: []}
+  return {decorations: DecorationSet.empty, ranges: [], interactive: true}
 }
 
 function findBlockContent(
@@ -61,6 +64,7 @@ function findBlockContent(
 function buildCitationDecorations(
   doc: ProseMirrorNode,
   citations: CitationFragmentHighlight[],
+  interactive = true,
 ): CitationFragmentHighlightState {
   const decorations: Decoration[] = []
   const ranges: CitationDecorationRange[] = []
@@ -97,9 +101,10 @@ function buildCitationDecorations(
       if (to <= from) continue
 
       const overlap = Math.min(covering.length, 4)
+      const interactiveClass = interactive ? ' bn-citation-fragment-highlight-interactive' : ''
       decorations.push(
         Decoration.inline(from, to, {
-          class: `bn-range-highlight-focus bn-citation-fragment-highlight bn-citation-fragment-overlap-${overlap}`,
+          class: `bn-range-highlight-focus bn-citation-fragment-highlight${interactiveClass} bn-citation-fragment-overlap-${overlap}`,
           'data-citation-fragment': 'true',
           'data-citation-ids': covering.map((citation) => citation.id).join(','),
         }),
@@ -108,7 +113,7 @@ function buildCitationDecorations(
     }
   }
 
-  return {decorations: DecorationSet.create(doc, decorations), ranges}
+  return {decorations: DecorationSet.create(doc, decorations), ranges, interactive}
 }
 
 function mapRanges(
@@ -142,7 +147,7 @@ export function createCitationFragmentHighlightPlugin(handlerRef: CitationFragme
         const action: CitationFragmentHighlightAction | undefined = tr.getMeta(citationFragmentHighlightPluginKey)
 
         if (action?.type === 'set') {
-          return buildCitationDecorations(tr.doc, action.citations)
+          return buildCitationDecorations(tr.doc, action.citations, action.interactive ?? true)
         }
 
         if (action?.type === 'clear') {
@@ -154,6 +159,7 @@ export function createCitationFragmentHighlightPlugin(handlerRef: CitationFragme
         return {
           decorations: oldState.decorations.map(tr.mapping, tr.doc),
           ranges: mapRanges(oldState.ranges, tr),
+          interactive: oldState.interactive,
         }
       },
     },
@@ -165,16 +171,20 @@ export function createCitationFragmentHighlightPlugin(handlerRef: CitationFragme
 
       handleClick(view, pos, event) {
         const pluginState = citationFragmentHighlightPluginKey.getState(view.state)
+        if (!pluginState?.interactive) return false
+
         const ranges = pluginState?.ranges ?? []
         const citations = ranges
           .filter((range) => range.from <= pos && pos <= range.to)
           .flatMap((range) => range.citations)
 
         if (!citations.length) return false
+        const handler = handlerRef.current
+        if (!handler) return false
 
         const unique = new Map<string, CitationFragmentHighlight>()
         for (const citation of citations) unique.set(citation.id, citation)
-        handlerRef.current?.({
+        handler({
           citations: Array.from(unique.values()),
           clientX: event.clientX,
           clientY: event.clientY,

--- a/frontend/packages/editor/src/blocknote/core/extensions/CitationFragmentHighlight/CitationFragmentHighlightPlugin.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/CitationFragmentHighlight/CitationFragmentHighlightPlugin.ts
@@ -1,6 +1,7 @@
 import type {CitationFragmentClick, CitationFragmentHighlight} from '@shm/shared/document-content-props'
 import {Node as ProseMirrorNode} from 'prosemirror-model'
 import {Plugin, PluginKey} from 'prosemirror-state'
+import type {StepMap} from 'prosemirror-transform'
 import {Decoration, DecorationSet} from 'prosemirror-view'
 import {codepointOffsetToPos} from '../BlockHighlight/BlockHighlightPlugin'
 
@@ -66,7 +67,6 @@ function buildCitationDecorations(
   citations: CitationFragmentHighlight[],
   interactive = true,
 ): CitationFragmentHighlightState {
-  const decorations: Decoration[] = []
   const ranges: CitationDecorationRange[] = []
   const byBlock = new Map<string, CitationFragmentHighlight[]>()
 
@@ -100,33 +100,83 @@ function buildCitationDecorations(
       const to = codepointOffsetToPos(found.content, found.contentBeforePos, end)
       if (to <= from) continue
 
-      const overlap = Math.min(covering.length, 4)
-      const interactiveClass = interactive ? ' bn-citation-fragment-highlight-interactive' : ''
-      decorations.push(
-        Decoration.inline(from, to, {
-          class: `bn-range-highlight-focus bn-citation-fragment-highlight${interactiveClass} bn-citation-fragment-overlap-${overlap}`,
-          'data-citation-fragment': 'true',
-          'data-citation-ids': covering.map((citation) => citation.id).join(','),
-        }),
-      )
       ranges.push({from, to, citations: covering})
     }
   }
 
-  return {decorations: DecorationSet.create(doc, decorations), ranges, interactive}
+  return {decorations: createDecorationSetFromRanges(doc, ranges, interactive), ranges, interactive}
+}
+
+function createDecorationSetFromRanges(doc: ProseMirrorNode, ranges: CitationDecorationRange[], interactive: boolean) {
+  return DecorationSet.create(
+    doc,
+    ranges.map((range) => {
+      const overlap = Math.min(range.citations.length, 4)
+      const interactiveClass = interactive ? ' bn-citation-fragment-highlight-interactive' : ''
+      return Decoration.inline(range.from, range.to, {
+        class: `bn-range-highlight-focus bn-citation-fragment-highlight${interactiveClass} bn-citation-fragment-overlap-${overlap}`,
+        'data-citation-fragment': 'true',
+        'data-citation-ids': range.citations.map((citation) => citation.id).join(','),
+      })
+    }),
+  )
+}
+
+function mapRangeThroughStep(range: CitationDecorationRange, stepMap: StepMap): CitationDecorationRange[] {
+  const changedRanges: {oldStart: number; oldEnd: number}[] = []
+  stepMap.forEach((oldStart: number, oldEnd: number) => {
+    changedRanges.push({oldStart, oldEnd})
+  })
+
+  const mapPiece = (from: number, to: number, fromAssoc: -1 | 1, toAssoc: -1 | 1) => {
+    if (to <= from) return null
+    const mappedFrom = stepMap.map(from, fromAssoc)
+    const mappedTo = stepMap.map(to, toAssoc)
+    if (mappedTo <= mappedFrom) return null
+    return {...range, from: mappedFrom, to: mappedTo}
+  }
+
+  if (!changedRanges.length) {
+    const mapped = mapPiece(range.from, range.to, 1, -1)
+    return mapped ? [mapped] : []
+  }
+
+  const mappedRanges: CitationDecorationRange[] = []
+  let cursor = range.from
+  let cursorAssoc: -1 | 1 = 1
+
+  for (const {oldStart, oldEnd} of changedRanges) {
+    if (oldStart >= range.to) break
+    if (oldEnd <= cursor) continue
+    if (oldEnd <= range.from) continue
+
+    const splitStart = Math.max(oldStart, range.from)
+    if (splitStart > cursor) {
+      const mapped = mapPiece(cursor, Math.min(splitStart, range.to), cursorAssoc, -1)
+      if (mapped) mappedRanges.push(mapped)
+    }
+
+    cursor = oldEnd > oldStart ? Math.max(cursor, oldEnd) : Math.max(cursor, oldStart)
+    cursorAssoc = 1
+  }
+
+  if (cursor < range.to) {
+    const mapped = mapPiece(cursor, range.to, cursorAssoc, -1)
+    if (mapped) mappedRanges.push(mapped)
+  }
+
+  return mappedRanges
 }
 
 function mapRanges(
   ranges: CitationDecorationRange[],
   tr: Parameters<NonNullable<Plugin['spec']['state']>['apply']>[0],
 ) {
-  return ranges
-    .map((range) => ({
-      ...range,
-      from: tr.mapping.map(range.from, 1),
-      to: tr.mapping.map(range.to, -1),
-    }))
-    .filter((range) => range.to > range.from)
+  let mappedRanges = ranges
+  for (const stepMap of tr.mapping.maps) {
+    mappedRanges = mappedRanges.flatMap((range) => mapRangeThroughStep(range, stepMap))
+  }
+  return mappedRanges
 }
 
 /**
@@ -156,9 +206,10 @@ export function createCitationFragmentHighlightPlugin(handlerRef: CitationFragme
 
         if (!tr.docChanged) return oldState
 
+        const ranges = mapRanges(oldState.ranges, tr)
         return {
-          decorations: oldState.decorations.map(tr.mapping, tr.doc),
-          ranges: mapRanges(oldState.ranges, tr),
+          decorations: createDecorationSetFromRanges(tr.doc, ranges, oldState.interactive),
+          ranges,
           interactive: oldState.interactive,
         }
       },

--- a/frontend/packages/editor/src/blocknote/core/extensions/CitationFragmentHighlight/CitationFragmentHighlightPlugin.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/CitationFragmentHighlight/CitationFragmentHighlightPlugin.ts
@@ -1,0 +1,186 @@
+import type {CitationFragmentClick, CitationFragmentHighlight} from '@shm/shared/document-content-props'
+import {Node as ProseMirrorNode} from 'prosemirror-model'
+import {Plugin, PluginKey} from 'prosemirror-state'
+import {Decoration, DecorationSet} from 'prosemirror-view'
+import {codepointOffsetToPos} from '../BlockHighlight/BlockHighlightPlugin'
+
+import './citation-fragment-highlight.css'
+
+/** Mutable callback ref read by the citation fragment highlight plugin. */
+export type CitationFragmentClickHandlerRef = {
+  current?: ((event: CitationFragmentClick) => void) | null
+}
+
+type CitationFragmentHighlightAction = {type: 'set'; citations: CitationFragmentHighlight[]} | {type: 'clear'}
+
+type CitationDecorationRange = {
+  from: number
+  to: number
+  citations: CitationFragmentHighlight[]
+}
+
+type CitationFragmentHighlightState = {
+  decorations: DecorationSet
+  ranges: CitationDecorationRange[]
+}
+
+/** Plugin key used to dispatch citation fragment highlight actions. */
+export const citationFragmentHighlightPluginKey = new PluginKey<CitationFragmentHighlightState>(
+  'citationFragmentHighlightPlugin',
+)
+
+function emptyState(): CitationFragmentHighlightState {
+  return {decorations: DecorationSet.empty, ranges: []}
+}
+
+function findBlockContent(
+  doc: ProseMirrorNode,
+  blockId: string,
+): {content: ProseMirrorNode; contentBeforePos: number} | null {
+  let result: {content: ProseMirrorNode; contentBeforePos: number} | null = null
+
+  doc.descendants((node, pos) => {
+    if (result) return false
+    if (node.type.name === 'blockNode' && node.attrs['id'] === blockId) {
+      const blockBeforePos = pos
+      let contentBeforePos = blockBeforePos
+      node.forEach((child, offset) => {
+        if (child.type.spec.group === 'block') {
+          contentBeforePos = blockBeforePos + offset + 1
+          result = {content: child, contentBeforePos}
+        }
+      })
+      return false
+    }
+    return undefined
+  })
+
+  return result
+}
+
+function buildCitationDecorations(
+  doc: ProseMirrorNode,
+  citations: CitationFragmentHighlight[],
+): CitationFragmentHighlightState {
+  const decorations: Decoration[] = []
+  const ranges: CitationDecorationRange[] = []
+  const byBlock = new Map<string, CitationFragmentHighlight[]>()
+
+  for (const citation of citations) {
+    if (citation.targetRange.end <= citation.targetRange.start) continue
+    const blockCitations = byBlock.get(citation.targetBlockId) ?? []
+    blockCitations.push(citation)
+    byBlock.set(citation.targetBlockId, blockCitations)
+  }
+
+  for (const [blockId, blockCitations] of Array.from(byBlock.entries())) {
+    const found = findBlockContent(doc, blockId)
+    if (!found) continue
+
+    const endpoints: number[] = Array.from(
+      new Set(blockCitations.flatMap((citation) => [citation.targetRange.start, citation.targetRange.end])),
+    ).sort((a, b) => a - b)
+
+    for (let i = 0; i < endpoints.length - 1; i++) {
+      const start = endpoints[i]
+      const end = endpoints[i + 1]
+      if (start == null || end == null) continue
+      if (end <= start) continue
+
+      const covering = blockCitations.filter(
+        (citation) => citation.targetRange.start < end && citation.targetRange.end > start,
+      )
+      if (!covering.length) continue
+
+      const from = codepointOffsetToPos(found.content, found.contentBeforePos, start)
+      const to = codepointOffsetToPos(found.content, found.contentBeforePos, end)
+      if (to <= from) continue
+
+      const overlap = Math.min(covering.length, 4)
+      decorations.push(
+        Decoration.inline(from, to, {
+          class: `bn-range-highlight-focus bn-citation-fragment-highlight bn-citation-fragment-overlap-${overlap}`,
+          'data-citation-fragment': 'true',
+          'data-citation-ids': covering.map((citation) => citation.id).join(','),
+        }),
+      )
+      ranges.push({from, to, citations: covering})
+    }
+  }
+
+  return {decorations: DecorationSet.create(doc, decorations), ranges}
+}
+
+function mapRanges(
+  ranges: CitationDecorationRange[],
+  tr: Parameters<NonNullable<Plugin['spec']['state']>['apply']>[0],
+) {
+  return ranges
+    .map((range) => ({
+      ...range,
+      from: tr.mapping.map(range.from, 1),
+      to: tr.mapping.map(range.to, -1),
+    }))
+    .filter((range) => range.to > range.from)
+}
+
+/**
+ * Creates a decoration-only plugin for inbound ranged citation fragments.
+ *
+ * Dispatch actions with `tr.setMeta(citationFragmentHighlightPluginKey, action)`.
+ * Callers should also set `tr.setMeta('addToHistory', false)` so highlight
+ * refreshes never participate in undo/redo history.
+ */
+export function createCitationFragmentHighlightPlugin(handlerRef: CitationFragmentClickHandlerRef): Plugin {
+  return new Plugin<CitationFragmentHighlightState>({
+    key: citationFragmentHighlightPluginKey,
+
+    state: {
+      init: emptyState,
+
+      apply(tr, oldState) {
+        const action: CitationFragmentHighlightAction | undefined = tr.getMeta(citationFragmentHighlightPluginKey)
+
+        if (action?.type === 'set') {
+          return buildCitationDecorations(tr.doc, action.citations)
+        }
+
+        if (action?.type === 'clear') {
+          return emptyState()
+        }
+
+        if (!tr.docChanged) return oldState
+
+        return {
+          decorations: oldState.decorations.map(tr.mapping, tr.doc),
+          ranges: mapRanges(oldState.ranges, tr),
+        }
+      },
+    },
+
+    props: {
+      decorations(state) {
+        return citationFragmentHighlightPluginKey.getState(state)?.decorations ?? DecorationSet.empty
+      },
+
+      handleClick(view, pos, event) {
+        const pluginState = citationFragmentHighlightPluginKey.getState(view.state)
+        const ranges = pluginState?.ranges ?? []
+        const citations = ranges
+          .filter((range) => range.from <= pos && pos <= range.to)
+          .flatMap((range) => range.citations)
+
+        if (!citations.length) return false
+
+        const unique = new Map<string, CitationFragmentHighlight>()
+        for (const citation of citations) unique.set(citation.id, citation)
+        handlerRef.current?.({
+          citations: Array.from(unique.values()),
+          clientX: event.clientX,
+          clientY: event.clientY,
+        })
+        return true
+      },
+    },
+  })
+}

--- a/frontend/packages/editor/src/blocknote/core/extensions/CitationFragmentHighlight/citation-fragment-highlight.css
+++ b/frontend/packages/editor/src/blocknote/core/extensions/CitationFragmentHighlight/citation-fragment-highlight.css
@@ -1,0 +1,23 @@
+.bn-citation-fragment-highlight {
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-color: hsl(var(--muted-foreground) / 0.35);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.bn-citation-fragment-overlap-1 {
+  background-color: hsl(var(--warning, 45 100% 65%) / 0.28);
+}
+
+.bn-citation-fragment-overlap-2 {
+  background-color: hsl(var(--warning, 45 100% 60%) / 0.42);
+}
+
+.bn-citation-fragment-overlap-3 {
+  background-color: hsl(var(--warning, 45 100% 55%) / 0.56);
+}
+
+.bn-citation-fragment-overlap-4 {
+  background-color: hsl(var(--warning, 45 100% 50%) / 0.7);
+}

--- a/frontend/packages/editor/src/blocknote/core/extensions/CitationFragmentHighlight/citation-fragment-highlight.css
+++ b/frontend/packages/editor/src/blocknote/core/extensions/CitationFragmentHighlight/citation-fragment-highlight.css
@@ -9,18 +9,38 @@
   cursor: pointer;
 }
 
+.bn-citation-fragment-highlight-interactive:hover {
+  text-decoration-color: hsl(var(--foreground) / 0.55);
+}
+
 .bn-citation-fragment-overlap-1 {
   background-color: hsl(var(--warning, 45 100% 65%) / 0.28);
+}
+
+.bn-citation-fragment-highlight-interactive.bn-citation-fragment-overlap-1:hover {
+  background-color: hsl(var(--warning, 45 100% 60%) / 0.38);
 }
 
 .bn-citation-fragment-overlap-2 {
   background-color: hsl(var(--warning, 45 100% 60%) / 0.42);
 }
 
+.bn-citation-fragment-highlight-interactive.bn-citation-fragment-overlap-2:hover {
+  background-color: hsl(var(--warning, 45 100% 55%) / 0.52);
+}
+
 .bn-citation-fragment-overlap-3 {
   background-color: hsl(var(--warning, 45 100% 55%) / 0.56);
 }
 
+.bn-citation-fragment-highlight-interactive.bn-citation-fragment-overlap-3:hover {
+  background-color: hsl(var(--warning, 45 100% 50%) / 0.66);
+}
+
 .bn-citation-fragment-overlap-4 {
   background-color: hsl(var(--warning, 45 100% 50%) / 0.7);
+}
+
+.bn-citation-fragment-highlight-interactive.bn-citation-fragment-overlap-4:hover {
+  background-color: hsl(var(--warning, 45 100% 45%) / 0.8);
 }

--- a/frontend/packages/editor/src/blocknote/core/extensions/CitationFragmentHighlight/citation-fragment-highlight.css
+++ b/frontend/packages/editor/src/blocknote/core/extensions/CitationFragmentHighlight/citation-fragment-highlight.css
@@ -1,9 +1,12 @@
 .bn-citation-fragment-highlight {
-  cursor: pointer;
   text-decoration: underline;
   text-decoration-color: hsl(var(--muted-foreground) / 0.35);
   text-decoration-thickness: 1px;
   text-underline-offset: 2px;
+}
+
+.bn-citation-fragment-highlight-interactive {
+  cursor: pointer;
 }
 
 .bn-citation-fragment-overlap-1 {

--- a/frontend/packages/editor/src/blocknote/core/extensions/CitationFragmentHighlight/citation-fragment-highlight.css
+++ b/frontend/packages/editor/src/blocknote/core/extensions/CitationFragmentHighlight/citation-fragment-highlight.css
@@ -1,16 +1,5 @@
-.bn-citation-fragment-highlight {
-  text-decoration: underline;
-  text-decoration-color: hsl(var(--muted-foreground) / 0.35);
-  text-decoration-thickness: 1px;
-  text-underline-offset: 2px;
-}
-
 .bn-citation-fragment-highlight-interactive {
   cursor: pointer;
-}
-
-.bn-citation-fragment-highlight-interactive:hover {
-  text-decoration-color: hsl(var(--foreground) / 0.55);
 }
 
 .bn-citation-fragment-overlap-1 {

--- a/frontend/packages/editor/src/document-editor.tsx
+++ b/frontend/packages/editor/src/document-editor.tsx
@@ -601,11 +601,12 @@ export function DocumentEditor({
       .setMeta(citationFragmentHighlightPluginKey, {
         type: citationFragmentHighlights?.length ? 'set' : 'clear',
         citations: citationFragmentHighlights ?? [],
+        interactive: !isEditing,
       })
       .setMeta('addToHistory', false)
 
     view.dispatch(tr)
-  }, [editor, citationFragmentHighlights])
+  }, [editor, citationFragmentHighlights, isEditing])
 
   // Attach DOM click listener for click-to-edit. Using a DOM listener (rather
   // than a ProseMirror plugin) gives us reliable access to the raw event target
@@ -643,6 +644,11 @@ export function DocumentEditor({
       // If the click landed on a link, let the link plugin handle navigation.
       // Do not enter edit mode and do not preventDefault.
       if (target.closest?.('.link, a[href]')) return
+
+      // If the click landed on an interactive citation fragment highlight, let
+      // the citation highlight plugin open the source document/comment instead
+      // of entering edit mode.
+      if (target.closest?.('[data-citation-fragment="true"]')) return
 
       // If a non-empty ProseMirror selection existed at mousedown, treat the
       // click as "dismiss my selection" rather than "enter edit mode".

--- a/frontend/packages/editor/src/document-editor.tsx
+++ b/frontend/packages/editor/src/document-editor.tsx
@@ -33,6 +33,10 @@ import {
   type FormattingToolbarProps,
 } from './blocknote'
 import {blockHighlightPluginKey} from './blocknote/core/extensions/BlockHighlight/BlockHighlightPlugin'
+import {
+  citationFragmentHighlightPluginKey,
+  createCitationFragmentHighlightPlugin,
+} from './blocknote/core/extensions/CitationFragmentHighlight/CitationFragmentHighlightPlugin'
 import {insertOrUpdateBlock} from './blocknote/core/extensions/SlashMenu/defaultSlashMenuItems'
 import {applyReadOnlyClickSelectionGuard, shouldKeepEditModeForPointerTarget} from './click-edit-mode-guard'
 import {useDraftActions} from './draft-actions-context'
@@ -71,6 +75,8 @@ export function DocumentEditor({
   resourceId,
   focusBlockId,
   focusBlockRange,
+  citationFragmentHighlights,
+  onCitationFragmentClick,
   blockCitations,
   onBlockCitationClick,
   onBlockCommentClick,
@@ -108,6 +114,8 @@ export function DocumentEditor({
 
   const canEditRef = useRef(canEdit)
   canEditRef.current = canEdit
+  const citationFragmentClickRef = useRef(onCitationFragmentClick)
+  citationFragmentClickRef.current = onCitationFragmentClick
 
   // Stores the ProseMirror position of the pending click so that when the
   // machine transitions to editing we can place the cursor there.
@@ -206,6 +214,12 @@ export function DocumentEditor({
             name: 'hypermedia-link',
             addProseMirrorPlugins() {
               return [createHypermediaDocLinkPlugin({domainResolver: linkExtensionOptions?.domainResolver}).plugin]
+            },
+          }),
+          Extension.create({
+            name: 'citation-fragment-highlight',
+            addProseMirrorPlugins() {
+              return [createCitationFragmentHighlightPlugin(citationFragmentClickRef)]
             },
           }),
           Extension.create({
@@ -578,6 +592,20 @@ export function DocumentEditor({
       view.dispatch(view.state.tr.setMeta(blockHighlightPluginKey, {type: 'clear'}))
     }
   }, [editor, focusBlockId, rangeStart, rangeEnd])
+
+  useEffect(() => {
+    const view = editor._tiptapEditor?.view
+    if (!view) return
+
+    const tr = view.state.tr
+      .setMeta(citationFragmentHighlightPluginKey, {
+        type: citationFragmentHighlights?.length ? 'set' : 'clear',
+        citations: citationFragmentHighlights ?? [],
+      })
+      .setMeta('addToHistory', false)
+
+    view.dispatch(tr)
+  }, [editor, citationFragmentHighlights])
 
   // Attach DOM click listener for click-to-edit. Using a DOM listener (rather
   // than a ProseMirror plugin) gives us reliable access to the raw event target

--- a/frontend/packages/shared/src/document-content-props.ts
+++ b/frontend/packages/shared/src/document-content-props.ts
@@ -1,11 +1,35 @@
 import type {DomainResolverFn} from '@seed-hypermedia/client'
-import type {BlockRange, HMBlockNode, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import type {BlockRange, HMBlockNode, HMRawMention, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import type {UniversalClient} from './universal-client'
 import type {StateStream} from './utils/stream'
 
 /** Options for block range selection with optional clipboard copy. */
 export type BlockRangeSelectOptions = BlockRange & {
   copyToClipboard?: boolean
+}
+
+/** A normalized ranged citation target rendered as a document text decoration. */
+export type CitationFragmentHighlight = {
+  id: string
+  targetBlockId: string
+  targetRange: {
+    start: number
+    end: number
+  }
+  sourceType: 'document' | 'comment' | 'unknown'
+  sourceId: UnpackedHypermediaId | null
+  sourceDocumentId: UnpackedHypermediaId | null
+  sourceBlockId: string | null
+  sourceCommentId: string | null
+  sourceAuthorUid: string | null
+  raw: HMRawMention
+}
+
+/** Click payload emitted by the citation fragment highlight editor plugin. */
+export type CitationFragmentClick = {
+  citations: CitationFragmentHighlight[]
+  clientX: number
+  clientY: number
 }
 
 /**
@@ -47,6 +71,10 @@ export type DocumentContentProps = {
   focusBlockId?: string
   /** Optional codepoint range within `focusBlockId` to highlight instead of the whole block. */
   focusBlockRange?: BlockRange | null
+  /** Ranged inbound citations rendered as text fragment highlights. */
+  citationFragmentHighlights?: CitationFragmentHighlight[]
+  /** Called when a citation fragment highlight is clicked. */
+  onCitationFragmentClick?: (event: CitationFragmentClick) => void
   blockCitations?: Record<string, {citations: number; comments: number}> | null
   onBlockCitationClick?: (blockId?: string | null) => void
   onBlockCommentClick?: (

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -4,8 +4,10 @@ import {
   HMComment,
   HMDocument,
   HMExistingDraft,
+  HMRawMention,
   UnpackedHypermediaId,
 } from '@seed-hypermedia/client/hm-types'
+import {useQuery} from '@tanstack/react-query'
 import {
   createInspectNavRoute,
   DocumentPanelRoute,
@@ -28,6 +30,8 @@ import {
 import {DEFAULT_GATEWAY_URL, IS_DESKTOP, NOTIFY_SERVICE_HOST} from '@shm/shared/constants'
 import type {
   BlockRangeSelectOptions,
+  CitationFragmentClick,
+  CitationFragmentHighlight,
   DocumentContentProps,
   LinkExtensionOptions,
 } from '@shm/shared/document-content-props'
@@ -35,6 +39,7 @@ import {findDraftForPath, isDraftPlaceholderPath, useDraftsForAccountSafe} from 
 import {
   useAccount,
   useAccountsMetadata,
+  useCitations,
   useDirectory,
   useIsLatest,
   useResource,
@@ -73,9 +78,10 @@ import {
   getCommentTargetId,
   hmIdToURL,
   parseFragment,
+  routeToUrl,
 } from '@shm/shared/utils/entity-id-url'
 import {useNavigate, useNavRoute} from '@shm/shared/utils/navigation'
-import {FilePen, Layers, Link2, Search} from 'lucide-react'
+import {FilePen, Layers, Link2, Quote, Search} from 'lucide-react'
 import {CSSProperties, lazy, ReactNode, Suspense, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {AccountPage} from './account-page'
 import {CollaboratorsPage} from './collaborators-page'
@@ -89,6 +95,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from './components/alert-dialog'
+import {Popover, PopoverAnchor, PopoverContent} from './components/popover'
 import {ScrollArea} from './components/scroll-area'
 import {copyUrlToClipboardWithFeedback} from './copy-to-clipboard'
 import {DirectoryPageContent} from './directory-page'
@@ -118,6 +125,7 @@ import {PanelLayout} from './panel-layout'
 import {GotoLatestBanner, SiteHeader} from './site-header'
 import {Spinner} from './spinner'
 import {toast} from './toast'
+import {HMIcon} from './hm-icon'
 import {UnreferencedDocuments} from './unreferenced-documents'
 import {useBlockScroll} from './use-block-scroll'
 import {useCopyHmLink} from './use-copy-hm-link'
@@ -213,6 +221,194 @@ export function useCommonMenuItems(docId: UnpackedHypermediaId): MenuItemType[] 
       },
     ],
     [navigate, docId, isMobile, onCopyReference, onPushReference, origin],
+  )
+}
+
+function sourceTypeKind(sourceType?: string): CitationFragmentHighlight['sourceType'] {
+  const normalized = sourceType?.toLowerCase() ?? ''
+  if (normalized.startsWith('doc/') || normalized === 'ref') return 'document'
+  if (normalized.startsWith('comment/') || normalized === 'comment') return 'comment'
+  return 'unknown'
+}
+
+function sourceCommentId(source?: string): string | null {
+  if (!source) return null
+  if (source.startsWith('hm://')) return source.slice('hm://'.length)
+  const unpacked = unpackHmId(source)
+  if (!unpacked) return source || null
+  return [unpacked.uid, ...(unpacked.path ?? [])].join('/')
+}
+
+function normalizeCitationFragmentHighlights(citations: HMRawMention[] | undefined): CitationFragmentHighlight[] {
+  return (citations ?? []).flatMap((citation, index) => {
+    const fragment = parseFragment(citation.targetFragment ?? null)
+    if (!fragment?.blockId || fragment.start == null || fragment.end == null || fragment.end <= fragment.start) {
+      return []
+    }
+
+    const kind = sourceTypeKind(citation.sourceType)
+    const sourceId = unpackHmId(citation.source) ?? null
+    const sourceDocumentId =
+      kind === 'comment' ? unpackHmId(citation.sourceDocument || citation.source) ?? sourceId : sourceId
+    const sourceBlockId = citation.sourceContext?.trim() || null
+
+    return [
+      {
+        id: `${citation.source || 'unknown'}:${citation.targetFragment || ''}:${citation.sourceContext || ''}:${index}`,
+        targetBlockId: fragment.blockId,
+        targetRange: {start: fragment.start, end: fragment.end},
+        sourceType: kind,
+        sourceId:
+          kind === 'document' && sourceId
+            ? {
+                ...sourceId,
+                version: citation.sourceBlob?.cid || sourceId.version || null,
+                blockRef: sourceBlockId,
+                blockRange: sourceBlockId ? {expanded: true} : null,
+              }
+            : sourceId,
+        sourceDocumentId,
+        sourceBlockId,
+        sourceCommentId: kind === 'comment' ? sourceCommentId(citation.source) : null,
+        sourceAuthorUid: citation.sourceBlob?.author || sourceId?.uid || null,
+        raw: citation,
+      },
+    ]
+  })
+}
+
+function blockNodeText(node: HMBlockNode): string {
+  const ownText = node.block ? getBlockText(node.block) : ''
+  const childText = (node.children ?? []).map(blockNodeText).join(' ')
+  return `${ownText} ${childText}`.trim()
+}
+
+function commentPreviewText(comment: HMComment | undefined): string {
+  if (!comment) return 'Loading comment…'
+  const text = comment.content.map(blockNodeText).join(' ').replace(/\s+/g, ' ').trim()
+  if (!text) return 'Comment'
+  if (text.length <= 50) return text
+  return `${text.slice(0, 50).trimEnd()}…`
+}
+
+function documentCitationTitle(citation: CitationFragmentHighlight, resource?: ReturnType<typeof useResource>['data']) {
+  if (resource?.type === 'document')
+    return resource.document?.metadata?.name || citation.sourceId?.path?.join('/') || 'Untitled document'
+  return citation.sourceId?.path?.join('/') || citation.sourceId?.uid || 'Document citation'
+}
+
+function CitationFragmentPopover({
+  click,
+  onClose,
+  onCitationSelect,
+}: {
+  click: CitationFragmentClick
+  onClose: () => void
+  onCitationSelect: (citation: CitationFragmentHighlight) => void
+}) {
+  const {universalClient} = useUniversalAppContext()
+  const documentCitations = click.citations.filter(
+    (citation) => citation.sourceType === 'document' && citation.sourceId,
+  )
+  const documentResources = useResources(
+    documentCitations.map((citation) => citation.sourceId),
+    {enabled: documentCitations.length > 0},
+  )
+  const sourceDocumentIds = Array.from(
+    new Map(
+      click.citations
+        .filter((citation) => citation.sourceType === 'comment' && citation.sourceDocumentId)
+        .map((citation) => [citation.sourceDocumentId!.id, citation.sourceDocumentId!]),
+    ).values(),
+  )
+  const commentsQuery = useQuery({
+    queryKey: ['citation-fragment-comment-previews', sourceDocumentIds.map((id) => id.id).join('|')],
+    queryFn: async () => {
+      const entries = await Promise.all(
+        sourceDocumentIds.map(async (id) => {
+          const result = await universalClient.request('ListComments', {targetId: id})
+          return [id.id, result] as const
+        }),
+      )
+      return Object.fromEntries(entries)
+    },
+    enabled: sourceDocumentIds.length > 0,
+  })
+  const accountMetadata = useAccountsMetadata(
+    Array.from(
+      new Set(click.citations.map((citation) => citation.sourceAuthorUid).filter((uid): uid is string => !!uid)),
+    ),
+  )
+  const documentResourceByCitation = new Map(
+    documentCitations.map((citation, index) => [citation.id, documentResources[index]?.data]),
+  )
+
+  return (
+    <Popover open onOpenChange={(open) => !open && onClose()}>
+      <PopoverAnchor asChild>
+        <span
+          className="pointer-events-none fixed z-50 size-px"
+          style={{left: click.clientX, top: click.clientY}}
+          aria-hidden="true"
+        />
+      </PopoverAnchor>
+      <PopoverContent align="start" side="bottom" className="w-80 p-2">
+        <div className="flex flex-col gap-1">
+          <div className="text-muted-foreground px-2 py-1 text-xs font-medium">
+            Cited {click.citations.length === 1 ? 'here' : `${click.citations.length} times here`}
+          </div>
+          {click.citations.map((citation) => {
+            const commentData = citation.sourceDocumentId
+              ? commentsQuery.data?.[citation.sourceDocumentId.id]
+              : undefined
+            const comment = commentData?.comments?.find((item: HMComment) => item.id === citation.sourceCommentId)
+            const authorUid = comment?.author || citation.sourceAuthorUid || undefined
+            const author = authorUid ? commentData?.authors?.[authorUid] || accountMetadata.data[authorUid] : null
+            return (
+              <button
+                key={citation.id}
+                type="button"
+                className="hover:bg-accent flex w-full items-start gap-2 rounded-md px-2 py-2 text-left"
+                onClick={() => onCitationSelect(citation)}
+              >
+                {citation.sourceType === 'comment' ? (
+                  <>
+                    {authorUid ? (
+                      <HMIcon
+                        id={hmId(authorUid)}
+                        name={author?.metadata?.name}
+                        icon={author?.metadata?.icon}
+                        size={24}
+                      />
+                    ) : (
+                      <div className="bg-muted size-6 shrink-0 rounded-full" />
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <div className="text-muted-foreground truncate text-xs">
+                        {author?.metadata?.name || authorUid || 'Comment'}
+                      </div>
+                      <div className="line-clamp-2 text-sm">{commentPreviewText(comment)}</div>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <Quote className="text-muted-foreground mt-0.5 size-4 shrink-0" />
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-medium">
+                        {documentCitationTitle(citation, documentResourceByCitation.get(citation.id))}
+                      </div>
+                      {citation.sourceBlockId ? (
+                        <div className="text-muted-foreground truncate text-xs">Block {citation.sourceBlockId}</div>
+                      ) : null}
+                    </div>
+                  </>
+                )}
+              </button>
+            )
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
   )
 }
 
@@ -1234,6 +1430,8 @@ function DocumentBody({
   const siteMembers = useSiteMembers(siteId)
   const directory = useDirectory(docId)
   const interactionSummary = useInteractionSummary(docId)
+  const citationsDocId = useMemo(() => ({...docId, blockRef: null, blockRange: null}), [docId])
+  const citations = useCitations(citationsDocId)
 
   // Breadcrumbs: fetch parent documents for non-home docs
   const breadcrumbIds = useMemo(() => {
@@ -1438,10 +1636,64 @@ function DocumentBody({
 
   // Block tools handlers
   const blockCitations = useMemo(() => interactionSummary.data?.blocks || null, [interactionSummary.data?.blocks])
+  const [showCitationFragments, setShowCitationFragments] = useState(true)
+  const [citationFragmentClick, setCitationFragmentClick] = useState<CitationFragmentClick | null>(null)
+  const citationFragmentHighlights = useMemo(
+    () => (showCitationFragments ? normalizeCitationFragmentHighlights(citations.data?.citations) : []),
+    [showCitationFragments, citations.data?.citations],
+  )
   const copyHmLink = useCopyHmLink()
   // Current origin for gateway-format links (web: site's own URL; desktop: the
   // configured gateway). Used as a fallback when the document has no site URL.
-  const {origin: appOrigin, experiments} = useUniversalAppContext()
+  const {origin: appOrigin, originHomeId, experiments, openRouteNewWindow, openUrl} = useUniversalAppContext()
+
+  const handleCitationFragmentSelect = useCallback(
+    (citation: CitationFragmentHighlight) => {
+      setCitationFragmentClick(null)
+      if (citation.sourceType === 'comment' && citation.sourceDocumentId && citation.sourceCommentId) {
+        if (route.key !== 'document' && route.key !== 'feed') return
+        navigate({
+          ...route,
+          panel: {
+            key: 'comments',
+            id: citation.sourceDocumentId,
+            openComment: citation.sourceCommentId,
+          } as any,
+        })
+        return
+      }
+
+      if (citation.sourceType === 'document' && citation.sourceId) {
+        const sourceRoute: NavRoute = {
+          key: 'document',
+          id: {
+            ...citation.sourceId,
+            blockRef: citation.sourceBlockId,
+            blockRange: citation.sourceBlockId ? {expanded: true} : null,
+          },
+        }
+        if (openRouteNewWindow) {
+          openRouteNewWindow(sourceRoute)
+        } else {
+          const href = routeToUrl(sourceRoute, {hostname: appOrigin, originHomeId}) || hmIdToURL(sourceRoute.id)
+          openUrl(href, true)
+        }
+      }
+    },
+    [appOrigin, navigate, openRouteNewWindow, openUrl, originHomeId, route],
+  )
+
+  const handleCitationFragmentClick = useCallback(
+    (click: CitationFragmentClick) => {
+      const [singleCitation] = click.citations
+      if (singleCitation && click.citations.length === 1) {
+        handleCitationFragmentSelect(singleCitation)
+        return
+      }
+      setCitationFragmentClick(click)
+    },
+    [handleCitationFragmentSelect],
+  )
 
   const handleBlockCitationClick = useCallback(
     (blockId?: string | null) => {
@@ -1606,9 +1858,21 @@ function DocumentBody({
       },
     }
   }, [canEdit, panelKey, route, replaceRoute])
+  const citationFragmentToggleMenuItem = useMemo<MenuItemType>(
+    () => ({
+      key: 'citation-fragments-toggle',
+      label: showCitationFragments ? 'Hide fragment citations' : 'Show fragment citations',
+      icon: <Quote className="size-4" />,
+      onClick: () => {
+        setShowCitationFragments((value) => !value)
+        setCitationFragmentClick(null)
+      },
+    }),
+    [showCitationFragments],
+  )
 
   const allMenuItems = useMemo(() => {
-    let unorderedItems: MenuItemType[] = [...commonMenuItems, ...(extraMenuItems || [])]
+    let unorderedItems: MenuItemType[] = [...commonMenuItems, citationFragmentToggleMenuItem, ...(extraMenuItems || [])]
     if (inspectMenuItem) unorderedItems.push(inspectMenuItem)
     if (documentOptionsMenuItem) unorderedItems.push(documentOptionsMenuItem)
     // Drop share/copy-link entries while the doc is an unpublished draft —
@@ -1637,7 +1901,14 @@ function DocumentBody({
       if (item.variant === 'destructive') orderedItems.push(item)
     }
     return orderedItems
-  }, [extraMenuItems, commonMenuItems, inspectMenuItem, documentOptionsMenuItem, isUnpublishedDraft])
+  }, [
+    extraMenuItems,
+    commonMenuItems,
+    citationFragmentToggleMenuItem,
+    inspectMenuItem,
+    documentOptionsMenuItem,
+    isUnpublishedDraft,
+  ])
 
   const hasOptions = allMenuItems.length > 0
   const actionButtons = hasOptions ? <OptionsDropdown menuItems={allMenuItems} align="end" side="bottom" /> : null
@@ -1841,6 +2112,8 @@ function DocumentBody({
           activityFilterEventType={route.key === 'activity' ? route.filterEventType : undefined}
           onActivityFilterChange={handleMainActivityFilterChange}
           blockCitations={blockCitations}
+          citationFragmentHighlights={citationFragmentHighlights}
+          onCitationFragmentClick={handleCitationFragmentClick}
           onBlockCitationClick={handleBlockCitationClick}
           onBlockCommentClick={handleBlockCommentClick}
           onBlockSelect={handleBlockSelect}
@@ -1861,6 +2134,13 @@ function DocumentBody({
           linkExtensionOptions={linkExtensionOptions}
           fileUpload={fileUpload}
         />
+        {citationFragmentClick ? (
+          <CitationFragmentPopover
+            click={citationFragmentClick}
+            onClose={() => setCitationFragmentClick(null)}
+            onCitationSelect={handleCitationFragmentSelect}
+          />
+        ) : null}
       </div>
       {pageFooter ? <div className="mt-auto">{pageFooter}</div> : null}
     </div>
@@ -1899,7 +2179,7 @@ function DocumentBody({
         {mobilePanelOpen && (
           <MobilePanelSheet isOpen={mobilePanelOpen} title={getPanelTitle(panelKey)} onClose={handlePanelClose}>
             <DiscussionsPageContent
-              docId={docId}
+              docId={panelRoute?.key === 'comments' ? panelRoute.id : docId}
               showTitle={false}
               showOpenInPanel={false}
               contentMaxWidth={contentMaxWidth}
@@ -1920,7 +2200,7 @@ function DocumentBody({
                           })
                         : undefined
                     }
-                    docId={docId}
+                    docId={panelRoute?.key === 'comments' ? panelRoute.id : docId}
                     quotingBlockId={panelRoute?.key === 'comments' ? panelRoute.targetBlockId : undefined}
                     quotingRange={
                       panelRoute?.key === 'comments' ? extractQuotingRange(panelRoute.blockRange) : undefined
@@ -2244,7 +2524,7 @@ function PanelContentRenderer({
     case 'comments':
       return (
         <CommentsPanelContent
-          docId={docId}
+          docId={panelRoute.id ?? docId}
           panelRoute={panelRoute}
           contentMaxWidth={contentMaxWidth}
           targetDomain={siteUrl}
@@ -2395,6 +2675,8 @@ function MainContent({
   activityFilterEventType,
   onActivityFilterChange,
   blockCitations,
+  citationFragmentHighlights,
+  onCitationFragmentClick,
   onBlockCitationClick,
   onBlockCommentClick,
   onBlockSelect,
@@ -2439,6 +2721,8 @@ function MainContent({
   activityFilterEventType?: string[]
   onActivityFilterChange?: (filter: {filterEventType?: string[]}) => void
   blockCitations?: Record<string, {citations: number; comments: number}> | null
+  citationFragmentHighlights?: CitationFragmentHighlight[]
+  onCitationFragmentClick?: (event: CitationFragmentClick) => void
   onBlockCitationClick?: (blockId?: string | null) => void
   onBlockCommentClick?: (
     blockId?: string | null,
@@ -2536,6 +2820,8 @@ function MainContent({
           showSidebars={showSidebars}
           showCollapsed={showCollapsed}
           blockCitations={blockCitations}
+          citationFragmentHighlights={citationFragmentHighlights}
+          onCitationFragmentClick={onCitationFragmentClick}
           onBlockCitationClick={onBlockCitationClick}
           onBlockCommentClick={onBlockCommentClick}
           onBlockSelect={onBlockSelect}
@@ -2568,6 +2854,8 @@ function ContentViewWithOutline({
   showSidebars,
   showCollapsed,
   blockCitations,
+  citationFragmentHighlights,
+  onCitationFragmentClick,
   onBlockCitationClick,
   onBlockCommentClick,
   onBlockSelect,
@@ -2595,6 +2883,8 @@ function ContentViewWithOutline({
   showSidebars: boolean
   showCollapsed: boolean
   blockCitations?: Record<string, {citations: number; comments: number}> | null
+  citationFragmentHighlights?: CitationFragmentHighlight[]
+  onCitationFragmentClick?: (event: CitationFragmentClick) => void
   onBlockCitationClick?: (blockId?: string | null) => void
   onBlockCommentClick?: (
     blockId?: string | null,
@@ -2665,6 +2955,8 @@ function ContentViewWithOutline({
             resourceId={resourceId}
             focusBlockId={resourceId.blockRef ?? undefined}
             focusBlockRange={resourceId.blockRange ?? undefined}
+            citationFragmentHighlights={citationFragmentHighlights}
+            onCitationFragmentClick={onCitationFragmentClick}
             blockCitations={blockCitations}
             onBlockCitationClick={onBlockCitationClick}
             onBlockCommentClick={onBlockCommentClick}


### PR DESCRIPTION
## Summary
- Add editor decorations for inbound ranged citation fragments, including overlap-aware highlight styling and hover states.
- Wire citation fragment data into document pages with a menu toggle to show or hide highlights.
- Support click behavior for citation highlights: single citations navigate directly, while overlapping citations show a popover with document or comment context.
- Keep citation highlight clicks disabled while editing and split highlights around inserted text so new content is not incorrectly included.
- Add tests for overlapping decorations, click payloads, disabled interactivity, and inserted-text behavior.
- Add a project document for fragment citation highlights and a `write-project-document` agent skill.