### PR TITLE
feat(network): show peer domains in network dialog

### DIFF
--- a/frontend/apps/desktop/src/components/network-dialog.tsx
+++ b/frontend/apps/desktop/src/components/network-dialog.tsx
@@ -16,8 +16,10 @@ import {cn} from '@shm/ui/utils'
 import {Route} from 'lucide-react'
 import React from 'react'
 import {ColorValue} from 'react-native'
-import {HMPeerInfo, usePeers} from '../models/networking'
+import {HMPeerInfo, useDomainsByPeerId, usePeers} from '../models/networking'
 import {AddConnectionDialog} from './contacts-prompt'
+
+const EMPTY_DOMAINS: string[] = []
 
 export function useNetworkDialog() {
   return useAppDialog<true>(NetworkDialog)
@@ -26,6 +28,9 @@ export function useNetworkDialog() {
 export function NetworkDialog() {
   const peers = usePeers(false, {
     refetchInterval: 5_000,
+  })
+  const domainsByPeerId = useDomainsByPeerId({
+    refetchInterval: 30_000,
   })
   const {data: deviceInfo} = useDaemonInfo()
   const connectDialog = useAppDialog(AddConnectionDialog)
@@ -42,7 +47,14 @@ export function NetworkDialog() {
       <div className="h-[500px] overflow-hidden">
         <ScrollArea>
           {peers.data && peers.data.length ? (
-            peers.data.map((peer) => <PeerRow key={peer.id} peer={peer} myProtocol={deviceInfo?.protocolId || ''} />)
+            peers.data.map((peer) => (
+              <PeerRow
+                key={peer.id}
+                peer={peer}
+                myProtocol={deviceInfo?.protocolId || ''}
+                domains={domainsByPeerId.data?.get(peer.id) || EMPTY_DOMAINS}
+              />
+            ))
           ) : (
             <div className="flex flex-1 flex-col items-center justify-center gap-4 p-4">
               <NoConnection className="text-muted-foreground size-25" />
@@ -65,8 +77,18 @@ function getProtocolMessage(peer: HMPeerInfo, myProtocol: string) {
   return ` (Protocol: ${peer.protocol})`
 }
 
-const PeerRow = React.memo(function PeerRow({peer, myProtocol}: {peer: HMPeerInfo; myProtocol: string}) {
+const PeerRow = React.memo(function PeerRow({
+  peer,
+  myProtocol,
+  domains,
+}: {
+  peer: HMPeerInfo
+  myProtocol: string
+  domains: string[]
+}) {
   const {id, connectionStatus, protocol} = peer
+  const visibleDomains = domains.slice(0, 2)
+  const hiddenDomainCount = domains.length - visibleDomains.length
   // const isSite =
   //   account?.profile?.bio === 'Hypermedia Site. Powered by Mintter.'
   // const label = isSite
@@ -87,15 +109,33 @@ const PeerRow = React.memo(function PeerRow({peer, myProtocol}: {peer: HMPeerInf
   const isConnected = connectionStatus === ConnectionStatus.CONNECTED && protocol === myProtocol
   return (
     <div className="group flex min-h-8 flex-1 items-center justify-between p-2">
-      <div className="flex items-center gap-2">
+      <div className="flex min-w-0 items-center gap-2">
         <Tooltip content={getPeerStatus(connectionStatus) + getProtocolMessage(peer, myProtocol)}>
           <div className={cn('size-3 rounded-md', getPeerStatusIndicator(peer, myProtocol))} />
         </Tooltip>
-        <Tooltip content="Copy Peer ID">
-          <SizableText onClick={handleCopyPeerId}>{id.substring(id.length - 10)}</SizableText>
-        </Tooltip>
+        <div className="flex min-w-0 items-center gap-2">
+          <Tooltip content="Copy Peer ID">
+            <SizableText onClick={handleCopyPeerId}>{id.substring(id.length - 10)}</SizableText>
+          </Tooltip>
+          {domains.length ? (
+            <Tooltip content={domains.join(', ')}>
+              <div className="flex min-w-0 items-center gap-1">
+                {visibleDomains.map((domain) => (
+                  <SizableText key={domain} size="xs" color="muted" className="max-w-32 truncate">
+                    {domain}
+                  </SizableText>
+                ))}
+                {hiddenDomainCount > 0 ? (
+                  <SizableText size="xs" color="muted">
+                    +{hiddenDomainCount}
+                  </SizableText>
+                ) : null}
+              </div>
+            </Tooltip>
+          ) : null}
+        </div>
       </div>
-      <div className="group mx-3 flex gap-3">
+      <div className="group mx-3 flex shrink-0 gap-3">
         {/* <XStack gap="$2">
           {account && !isSite ? (
             <UIAvatar

--- a/frontend/apps/desktop/src/models/__tests__/networking.test.tsx
+++ b/frontend/apps/desktop/src/models/__tests__/networking.test.tsx
@@ -1,0 +1,107 @@
+import {grpcClient} from '@/grpc-client'
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import React, {useEffect} from 'react'
+import {createRoot, Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+import {useDomainsByPeerId} from '../networking'
+
+vi.mock('@/grpc-client', () => ({
+  grpcClient: {
+    daemon: {
+      listDomains: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('../gateway-settings', () => ({
+  useGatewayUrl: vi.fn(),
+}))
+
+Object.assign(globalThis, {IS_REACT_ACT_ENVIRONMENT: true})
+
+function DomainsProbe({onData}: {onData: (domainsByPeerId: Map<string, string[]>) => void}) {
+  const query = useDomainsByPeerId({
+    retry: false,
+  })
+  useEffect(() => {
+    if (query.data) onData(query.data)
+  }, [onData, query.data])
+  return null
+}
+
+function renderProbe(onData: (domainsByPeerId: Map<string, string[]>) => void) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <DomainsProbe onData={onData} />
+      </QueryClientProvider>,
+    )
+  })
+  return {container, root}
+}
+
+async function waitForQueryData(onData: ReturnType<typeof vi.fn>) {
+  for (let i = 0; i < 10 && !onData.mock.calls.length; i++) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+  }
+  expect(onData).toHaveBeenCalled()
+}
+
+describe('useDomainsByPeerId', () => {
+  let container: HTMLDivElement | undefined
+  let root: Root | undefined
+
+  beforeEach(() => {
+    vi.mocked(grpcClient.daemon.listDomains).mockReset()
+  })
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount()
+      })
+    }
+    container?.remove()
+    root = undefined
+    container = undefined
+  })
+
+  test('groups sorted unique domains by peer id', async () => {
+    vi.mocked(grpcClient.daemon.listDomains).mockResolvedValue({
+      domains: [
+        {domain: 'beta.example', peerId: 'peer-1'},
+        {domain: 'alpha.example', peerId: 'peer-1'},
+        {domain: 'beta.example', peerId: 'peer-1'},
+        {domain: 'peer-two.example', peerId: 'peer-2'},
+        {domain: '', peerId: 'peer-3'},
+        {domain: 'missing-peer.example', peerId: ''},
+      ],
+    } as any)
+
+    const onData = vi.fn()
+    const rendered = renderProbe(onData)
+    container = rendered.container
+    root = rendered.root
+
+    await waitForQueryData(onData)
+    const domainsByPeerId = onData.mock.calls.at(-1)?.[0] as Map<string, string[]>
+
+    expect(domainsByPeerId.get('peer-1')).toEqual(['alpha.example', 'beta.example'])
+    expect(domainsByPeerId.get('peer-2')).toEqual(['peer-two.example'])
+    expect(domainsByPeerId.has('peer-3')).toBe(false)
+    expect(domainsByPeerId.has('')).toBe(false)
+  })
+})

--- a/frontend/apps/desktop/src/models/networking.ts
+++ b/frontend/apps/desktop/src/models/networking.ts
@@ -72,6 +72,35 @@ export function useIsGatewayConnected() {
 
 export type HMPeerInfo = PlainMessage<PeerInfo>
 
+/** Returns tracked domains grouped by the peer ID they resolve to. */
+export function useDomainsByPeerId(options: UseQueryOptions<Map<string, string[]>, ConnectError> = {}) {
+  return useQuery<Map<string, string[]>, ConnectError>({
+    queryKey: [queryKeys.DOMAINS_LIST],
+    queryFn: async () => {
+      try {
+        const listed = await grpcClient.daemon.listDomains({})
+        const byPeerId = new Map<string, string[]>()
+        listed.domains.forEach((info) => {
+          const peerId = info.peerId.trim()
+          const domain = info.domain.trim()
+          if (!peerId || !domain) return
+          const domains = byPeerId.get(peerId)
+          if (domains) domains.push(domain)
+          else byPeerId.set(peerId, [domain])
+        })
+        byPeerId.forEach((domains, peerId) => {
+          byPeerId.set(peerId, Array.from(new Set(domains)).sort())
+        })
+        return byPeerId
+      } catch {
+        return new Map()
+      }
+    },
+    enabled: true,
+    ...options,
+  })
+}
+
 export function usePeers(filterConnected: boolean, options: UseQueryOptions<HMPeerInfo[] | null, ConnectError> = {}) {
   return useQuery<HMPeerInfo[] | null, ConnectError>({
     queryKey: [queryKeys.PEERS, filterConnected],


### PR DESCRIPTION
## Summary
- Show tracked domains beside each peer in the desktop network connections dialog.
- Limit visible domains per peer with a count for additional domains and a tooltip containing the full list.
- Add coverage for grouping, sorting, and de-duplicating domains by peer ID.