### PR TITLE
feat(frontend): support root children type metadata

### DIFF
--- a/frontend/apps/cli/src/commands/document.ts
+++ b/frontend/apps/cli/src/commands/document.ts
@@ -312,6 +312,7 @@ export function registerDocumentCommands(program: Command) {
     .option('--show-activity', 'Show document activity')
     .option('--no-show-activity', 'Hide document activity')
     .option('--content-width <value>', 'Content width (S, M, L)')
+    .option('--children-type <value>', 'Root children type (Group, Unordered, Ordered)')
     .option('--seed-experimental-logo <value>', 'Experimental logo (ipfs:// or file:// URL)')
     .option('--seed-experimental-home-order <value>', 'Home ordering (UpdatedFirst, CreatedFirst)')
     .option('--import-categories <value>', 'Import categories (comma-separated)')
@@ -478,6 +479,7 @@ export function registerDocumentCommands(program: Command) {
     .option('--show-activity', 'Show document activity')
     .option('--no-show-activity', 'Hide document activity')
     .option('--content-width <value>', 'Content width (S, M, L)')
+    .option('--children-type <value>', 'Root children type (Group, Unordered, Ordered)')
     .option('--seed-experimental-logo <value>', 'Experimental logo (ipfs:// or file:// URL)')
     .option('--seed-experimental-home-order <value>', 'Home ordering (UpdatedFirst, CreatedFirst)')
     .option('--import-categories <value>', 'Import categories (comma-separated)')
@@ -905,6 +907,7 @@ const METADATA_KEYS: (keyof HMMetadata)[] = [
   'showOutline',
   'showActivity',
   'contentWidth',
+  'childrenType',
   'seedExperimentalLogo',
   'seedExperimentalHomeOrder',
   'importCategories',

--- a/frontend/apps/web/app/loaders.ts
+++ b/frontend/apps/web/app/loaders.ts
@@ -390,6 +390,7 @@ async function loadResourcePayload(
     ? renderDocumentToHTML(document.content, {
         cacheKey,
         embeds,
+        rootChildrenType: document.metadata?.childrenType,
         renderHref: (url) =>
           hypermediaUrlToHref(url, {
             origin,

--- a/frontend/packages/client/src/blocks-to-markdown.ts
+++ b/frontend/packages/client/src/blocks-to-markdown.ts
@@ -48,6 +48,7 @@ const FM_STRING_KEYS: (keyof HMMetadata)[] = [
   'seedExperimentalLogo',
   'seedExperimentalHomeOrder',
   'contentWidth',
+  'childrenType',
   'importCategories',
   'importTags',
 ]

--- a/frontend/packages/client/src/hm-types.ts
+++ b/frontend/packages/client/src/hm-types.ts
@@ -532,6 +532,7 @@ export const HMDocumentMetadataSchema = z.object({
   showOutline: z.boolean().optional(),
   showActivity: z.boolean().optional(),
   contentWidth: z.union([z.literal('S'), z.literal('M'), z.literal('L')]).optional(),
+  childrenType: HMBlockChildrenTypeSchema.optional(),
   theme: z
     .object({
       headerLayout: z.union([z.literal('Center'), z.literal('')]).optional(),

--- a/frontend/packages/client/src/markdown-to-blocks.ts
+++ b/frontend/packages/client/src/markdown-to-blocks.ts
@@ -583,7 +583,7 @@ const METADATA_STRING_KEYS = [
 const METADATA_BOOLEAN_KEYS = ['showOutline', 'showActivity'] as const
 
 /** Enum-typed metadata keys (stored as strings). */
-const METADATA_ENUM_KEYS = ['seedExperimentalHomeOrder', 'contentWidth'] as const
+const METADATA_ENUM_KEYS = ['seedExperimentalHomeOrder', 'contentWidth', 'childrenType'] as const
 
 /**
  * Strip YAML frontmatter (--- delimited) from markdown content.

--- a/frontend/packages/editor/src/blocknote/core/BlockNoteEditor.ts
+++ b/frontend/packages/editor/src/blocknote/core/BlockNoteEditor.ts
@@ -27,6 +27,7 @@ import {Selection} from './extensions/Blocks/api/selectionTypes'
 import {getBlockInfoFromPos, getBlockInfoFromSelection} from './extensions/Blocks/helpers/getBlockInfoFromPos'
 
 import type {DomainResolverFn} from '@seed-hypermedia/client'
+import type {HMBlockChildrenType} from '@seed-hypermedia/client/hm-types'
 import type {LinkExtensionOptions} from '@shm/shared/document-content-props'
 import {Transaction} from 'prosemirror-state'
 import {MentionMenuProsemirrorPlugin} from '../../mention-menu-plugin'
@@ -166,6 +167,7 @@ export type BlockNoteEditorOptions<BSchema extends BlockSchema> = {
   handleFileAttachment?: HandleFileAttachmentFunction
   commentEditor?: boolean
   getResourceUrl?: (blockId?: string | null) => string | undefined
+  rootChildrenType?: HMBlockChildrenType
 }
 
 export type ImportWebFileResult =
@@ -364,7 +366,8 @@ export class BlockNoteEditor<BSchema extends BlockSchema = HMBlockSchema> {
 
         const ic = initialContent.map((block) => blockToNode(block, schema))
 
-        const root = schema.node('doc', undefined, schema.node('blockChildren', {listType: 'Group'}, ic))
+        const rootChildrenType = newOptions.rootChildrenType || 'Group'
+        const root = schema.node('doc', undefined, schema.node('blockChildren', {listType: rootChildrenType}, ic))
         // override the initialcontent
         editor.editor.options.content = root.toJSON()
       },

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/updateGroup.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/updateGroup.test.ts
@@ -52,6 +52,22 @@ describe('updateGroup command', () => {
     return editor.state
   }
 
+  it('updates the root group and notifies metadata when the first root block becomes a list', () => {
+    const doc = buildDoc(schema, [{id: 'item-1', text: '- '}])
+    const state = EditorState.create({doc, schema})
+    const editor = createMockEditor(state)
+    const onRootChildrenTypeChange = vi.fn()
+    editor._onRootChildrenTypeChange = onRootChildrenTypeChange
+
+    const pos = findPosInBlock(doc, 'item-1')
+    const command = updateGroupCommand(pos, 'Unordered', false)
+    const newState = runCommand(state, editor, command)!
+
+    expect(newState.doc.firstChild!.attrs.listType).toBe('Unordered')
+    expect(newState.doc.firstChild!.attrs.listLevel).toBe('1')
+    expect(onRootChildrenTypeChange).toHaveBeenCalledWith('Unordered')
+  })
+
   // Test 1: Toggle blockChildren from Group to Unordered
   //
   // BEFORE:                                    AFTER:

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/commands/updateGroup.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/commands/updateGroup.ts
@@ -53,9 +53,23 @@ export const updateGroupCommand = (
       return true
     }
 
-    // If block is first block in the document do nothing
-    if ($pos.node(depth - 1).type.name === 'doc' && container && group.firstChild?.attrs.id === container.attrs.id)
+    // The root blockChildren is persisted on document metadata, not on a parent block.
+    if ($pos.node(depth - 1).type.name === 'doc' && container && group.firstChild?.attrs.id === container.attrs.id) {
+      if ((listType === 'Unordered' || listType === 'Ordered') && dispatch) {
+        const tr = state.tr
+        tr.setNodeMarkup($pos.before(depth), null, {
+          ...group.attrs,
+          listType,
+          listLevel: '1',
+        })
+        dispatch(tr)
+        ;(
+          editor as unknown as {_onRootChildrenTypeChange?: (listType: HMBlockChildrenType) => void}
+        )._onRootChildrenTypeChange?.(listType)
+        return true
+      }
       return false
+    }
 
     // If block is not the first in its' group, sink list item and then update group
     if (

--- a/frontend/packages/editor/src/document-editor.tsx
+++ b/frontend/packages/editor/src/document-editor.tsx
@@ -52,6 +52,26 @@ export type {DocumentContentProps}
 /** Block types (data-content-type values) that trigger edit mode on click. */
 const TEXT_BLOCK_TYPES = new Set(['paragraph', 'heading', 'code-block'])
 
+function setEditorRootChildrenType(
+  editor: BlockNoteEditor<HMBlockSchema>,
+  childrenType: DocumentContentProps['rootChildrenType'],
+) {
+  const view = editor._tiptapEditor?.view
+  const rootGroup = view?.state.doc.firstChild
+  if (!view || rootGroup?.type.name !== 'blockChildren') return
+
+  const listType = childrenType || 'Group'
+  if (rootGroup.attrs.listType === listType) return
+
+  view.dispatch(
+    view.state.tr.setNodeMarkup(0, null, {
+      ...rootGroup.attrs,
+      listType,
+      listLevel: '1',
+    }),
+  )
+}
+
 /**
  * Walk up from `el` in the DOM looking for a `data-content-type` attribute.
  * Returns the value when found, or null if we reach `root` without finding one.
@@ -71,6 +91,7 @@ export function DocumentEditor({
   resourceId,
   focusBlockId,
   focusBlockRange,
+  rootChildrenType,
   blockCitations,
   onBlockCitationClick,
   onBlockCommentClick,
@@ -175,6 +196,7 @@ export function DocumentEditor({
         actorRef.send({type: 'change'})
       },
       initialContent,
+      rootChildrenType: rootChildrenType || 'Group',
       // Caller-provided options (universalClient, domainResolver, gwUrl,
       // checkWebUrl, queryClient, etc.) are required by pasteHandler to
       // (a) convert pasted web URLs to hm:// and (b) apply a link mark to
@@ -367,6 +389,34 @@ export function DocumentEditor({
   // Keep the editor ref current so the paste-handler block-fragment landing
   // callback can resolve to the same editor instance.
   docEditorRef.current = editor
+
+  useEffect(() => {
+    ;(
+      editor as unknown as {
+        _onRootChildrenTypeChange?: (childrenType: DocumentContentProps['rootChildrenType']) => void
+      }
+    )._onRootChildrenTypeChange = (childrenType) => {
+      if (childrenType === 'Unordered' || childrenType === 'Ordered') {
+        actorRef.send({type: 'rootChildrenType.change', childrenType})
+      }
+    }
+    return () => {
+      delete (
+        editor as unknown as {
+          _onRootChildrenTypeChange?: (childrenType: DocumentContentProps['rootChildrenType']) => void
+        }
+      )._onRootChildrenTypeChange
+    }
+  }, [actorRef, editor])
+
+  useEffect(() => {
+    suppressChangeRef.current = true
+    try {
+      setEditorRootChildrenType(editor, rootChildrenType)
+    } finally {
+      suppressChangeRef.current = false
+    }
+  }, [editor, rootChildrenType])
 
   // Expose the suppress ref on the editor so external consumers (e.g. auto-rebase)
   // can wrap programmatic `replaceBlocks` calls without triggering `change` events.

--- a/frontend/packages/editor/src/embed-block.tsx
+++ b/frontend/packages/editor/src/embed-block.tsx
@@ -729,12 +729,13 @@ function EditorEmbedContent({
       block={block}
       parentBlockId={parentBlockId}
       openOnClick={openOnClick}
-      renderDocumentContent={({embedBlocks, id, blockRef, blockRange}) => (
+      renderDocumentContent={({embedBlocks, id, blockRef, blockRange, rootChildrenType}) => (
         <EmbedEditorView
           blocks={embedBlocks}
           id={id}
           focusBlockId={blockRef ?? undefined}
           blockRange={blockRange ?? undefined}
+          rootChildrenType={rootChildrenType}
         />
       )}
     />

--- a/frontend/packages/editor/src/embed-editor.tsx
+++ b/frontend/packages/editor/src/embed-editor.tsx
@@ -1,5 +1,5 @@
 import {hmBlocksToEditorContent} from '@seed-hypermedia/client/hmblock-to-editorblock'
-import type {BlockRange, HMBlockNode, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import type {BlockRange, HMBlockChildrenType, HMBlockNode, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {hypermediaUrlToHref, RenderResourceProvider, useOpenUrl, useUniversalAppContext} from '@shm/shared'
 import type {LinkExtensionOptions} from '@shm/shared/document-content-props'
 import {useCallback, useEffect, useMemo} from 'react'
@@ -11,6 +11,7 @@ import {hmBlockSchema, HMBlockSchema} from './schema'
 export function useEmbedEditor(
   blocks: HMBlockNode[],
   linkExtensionOptions?: LinkExtensionOptions,
+  rootChildrenType?: HMBlockChildrenType,
 ): BlockNoteEditor<HMBlockSchema> {
   const initialContent = useMemo(() => {
     const editorBlocks = hmBlocksToEditorContent(blocks, {childrenType: 'Group'})
@@ -25,8 +26,9 @@ export function useEmbedEditor(
       linkExtensionOptions,
       // @ts-expect-error - EditorBlock/PartialBlock type mismatch
       initialContent,
+      rootChildrenType: rootChildrenType || 'Group',
     },
-    [initialContent, linkExtensionOptions],
+    [initialContent, linkExtensionOptions, rootChildrenType],
   )
 }
 
@@ -38,10 +40,12 @@ export function EmbedEditorView({
   depth = 1,
   focusBlockId,
   blockRange,
+  rootChildrenType,
 }: {
   blocks: HMBlockNode[]
   id: UnpackedHypermediaId
   depth?: number
+  rootChildrenType?: HMBlockChildrenType
   /** Block id within the embedded content to focus-highlight. */
   focusBlockId?: string
   /** Codepoint range within `focusBlockId` to highlight instead of the whole block. */
@@ -62,7 +66,12 @@ export function EmbedEditorView({
           e.preventDefault()
         }}
       >
-        <EmbedEditorInner blocks={blocks} focusBlockId={focusBlockId} blockRange={blockRange ?? undefined} />
+        <EmbedEditorInner
+          blocks={blocks}
+          focusBlockId={focusBlockId}
+          blockRange={blockRange ?? undefined}
+          rootChildrenType={rootChildrenType}
+        />
       </div>
     </RenderResourceProvider>
   )
@@ -72,10 +81,12 @@ function EmbedEditorInner({
   blocks,
   focusBlockId,
   blockRange,
+  rootChildrenType,
 }: {
   blocks: HMBlockNode[]
   focusBlockId?: string
   blockRange?: BlockRange
+  rootChildrenType?: HMBlockChildrenType
 }) {
   const openUrl = useOpenUrl()
   const {hmUrlHref, openRouteNewWindow, origin, originHomeId} = useUniversalAppContext()
@@ -96,7 +107,7 @@ function EmbedEditorInner({
     }),
     [openUrl, renderHref, openRouteNewWindow],
   )
-  const editor = useEmbedEditor(blocks, linkExtensionOptions)
+  const editor = useEmbedEditor(blocks, linkExtensionOptions, rootChildrenType)
 
   const rangeStart = blockRange && 'start' in blockRange ? blockRange.start : null
   const rangeEnd = blockRange && 'end' in blockRange ? blockRange.end : null

--- a/frontend/packages/editor/src/readonly-viewer.tsx
+++ b/frontend/packages/editor/src/readonly-viewer.tsx
@@ -1,5 +1,5 @@
 import {hmBlocksToEditorContent} from '@seed-hypermedia/client/hmblock-to-editorblock'
-import type {BlockRange, HMBlockNode, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import type {BlockRange, HMBlockChildrenType, HMBlockNode, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {
   hypermediaUrlToHref,
   RenderResourceProvider,
@@ -20,6 +20,7 @@ export interface ReadOnlyViewerProps {
   blocks: HMBlockNode[]
   resourceId?: UnpackedHypermediaId
   resourceKind?: RenderResourceKind
+  rootChildrenType?: HMBlockChildrenType
   textUnit?: number
   layoutUnit?: number
   className?: string
@@ -38,6 +39,7 @@ export function ReadOnlyViewer({
   blocks,
   resourceId,
   resourceKind = 'document',
+  rootChildrenType,
   textUnit,
   layoutUnit,
   className,
@@ -77,8 +79,9 @@ export function ReadOnlyViewer({
       } as any,
       // @ts-expect-error - EditorBlock/PartialBlock type mismatch
       initialContent,
+      rootChildrenType: rootChildrenType || 'Group',
     },
-    [initialContent, openUrl, renderHref],
+    [initialContent, openUrl, renderHref, rootChildrenType],
   )
 
   const rangeStart = blockRange && 'start' in blockRange ? blockRange.start : null

--- a/frontend/packages/editor/src/ssr-render.test.ts
+++ b/frontend/packages/editor/src/ssr-render.test.ts
@@ -3,6 +3,22 @@ import {describe, expect, it} from 'vitest'
 import {renderDocumentToHTML} from './ssr-render'
 
 describe('renderDocumentToHTML', () => {
+  it('renders the document root as an unordered list when rootChildrenType is Unordered', () => {
+    const html = renderDocumentToHTML(
+      [
+        {
+          block: {id: 'item-1', type: 'Paragraph', text: 'First', annotations: []},
+          children: [],
+        },
+      ] as HMBlockNode[],
+      {rootChildrenType: 'Unordered'},
+    )
+
+    expect(html).toContain('<ul class="blockChildren"')
+    expect(html).toContain('data-list-type="Unordered"')
+    expect(html).toContain('<li class="blockNode" data-node-type="blockNode" data-id="item-1"')
+  })
+
   it('uses renderHref for annotated links', () => {
     const html = renderDocumentToHTML(
       [

--- a/frontend/packages/editor/src/ssr-render.ts
+++ b/frontend/packages/editor/src/ssr-render.ts
@@ -1,4 +1,4 @@
-import type {HMAnnotation, HMBlockNode} from '@seed-hypermedia/client/hm-types'
+import type {HMAnnotation, HMBlockChildrenType, HMBlockNode} from '@seed-hypermedia/client/hm-types'
 import {annotationContains} from '@seed-hypermedia/client/hmblock-to-editorblock'
 
 /** Version-keyed cache: document versions are immutable so entries never go stale. */
@@ -21,6 +21,8 @@ export type SSRRenderOpts = {
   embeds?: Record<string, SSREmbedData>
   /** Converts raw document links into the href value emitted in SSR HTML. */
   renderHref?: (url: string) => string | null | undefined
+  /** Children type for the document root group; missing/null renders as a normal group. */
+  rootChildrenType?: HMBlockChildrenType
 }
 
 /**
@@ -43,7 +45,15 @@ export function renderDocumentToHTML(blocks: HMBlockNode[], opts?: SSRRenderOpts
     // Wrap in a blockChildren container at depth 1 (matching editor's root group).
     // `nestingDepth` tracks blockNode-ancestor count so headings can render
     // the right h-tag without trusting the stored level prop.
-    const inner = renderBlockChildren(blocks, 'Group', 1, null, embeds, renderHref, 0)
+    const inner = renderBlockChildren(
+      blocks,
+      normalizeChildrenType(opts?.rootChildrenType),
+      1,
+      null,
+      embeds,
+      renderHref,
+      0,
+    )
     if (!inner) return null
     const result = `<div class="ssr-content-placeholder hm-prose">${inner}</div>`
 

--- a/frontend/packages/shared/src/document-content-props.ts
+++ b/frontend/packages/shared/src/document-content-props.ts
@@ -1,5 +1,5 @@
 import type {DomainResolverFn} from '@seed-hypermedia/client'
-import type {BlockRange, HMBlockNode, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import type {BlockRange, HMBlockChildrenType, HMBlockNode, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import type {UniversalClient} from './universal-client'
 import type {StateStream} from './utils/stream'
 
@@ -44,6 +44,8 @@ export type LinkExtensionOptions = {
 export type DocumentContentProps = {
   blocks: HMBlockNode[]
   resourceId: UnpackedHypermediaId
+  /** Children type for the document root group; missing/null renders as a normal group. */
+  rootChildrenType?: HMBlockChildrenType
   focusBlockId?: string
   /** Optional codepoint range within `focusBlockId` to highlight instead of the whole block. */
   focusBlockRange?: BlockRange | null

--- a/frontend/packages/shared/src/models/__tests__/document-machine.test.ts
+++ b/frontend/packages/shared/src/models/__tests__/document-machine.test.ts
@@ -728,6 +728,17 @@ describe('DocumentLifecycle machine', () => {
     actor.stop()
   })
 
+  it('rootChildrenType.change updates metadata and marks the draft changed', () => {
+    const actor = createTestActor()
+    actor.start()
+    loadDocument(actor)
+    actor.send({type: 'edit.start'})
+    actor.send({type: 'rootChildrenType.change', childrenType: 'Unordered'})
+    expect(actor.getSnapshot().context.metadata).toEqual({childrenType: 'Unordered'})
+    expect(actor.getSnapshot().value).toEqual({editing: {draft: 'changed', saveIndicator: 'hidden', rebase: 'idle'}})
+    actor.stop()
+  })
+
   // -- capability.changed tests --
 
   it('capability.changed in loaded → updates canEdit', () => {

--- a/frontend/packages/shared/src/models/document-machine.ts
+++ b/frontend/packages/shared/src/models/document-machine.ts
@@ -1,5 +1,6 @@
 import {EditorBlock} from '@seed-hypermedia/client/editor-types'
 import {
+  HMBlockChildrenType,
   HMBlockNode,
   HMDocument,
   HMDraft,
@@ -142,6 +143,7 @@ export type DocumentMachineEvent =
   | {type: 'edit.start'}
   | {type: 'edit.cancel'}
   | {type: 'change'; metadata?: HMDraft['metadata']}
+  | {type: 'rootChildrenType.change'; childrenType: HMBlockChildrenType}
   | {type: 'change.navigation'; navigation: HMNavigationItem[]}
   | {type: 'reset.content'}
   | {
@@ -286,6 +288,9 @@ export const documentMachine = setup({
       metadata: ({context, event}) => {
         if (event.type === 'change' && event.metadata) {
           return {...context.metadata, ...event.metadata}
+        }
+        if (event.type === 'rootChildrenType.change') {
+          return {...context.metadata, childrenType: event.childrenType}
         }
         return context.metadata
       },
@@ -932,6 +937,10 @@ export const documentMachine = setup({
                   target: 'changed',
                   actions: ['setMetadata'],
                 },
+                'rootChildrenType.change': {
+                  target: 'changed',
+                  actions: ['setMetadata'],
+                },
                 'reset.content': {
                   target: 'changed',
                 },
@@ -952,6 +961,11 @@ export const documentMachine = setup({
             changed: {
               on: {
                 change: {
+                  target: 'changed',
+                  actions: ['setMetadata'],
+                  reenter: true,
+                },
+                'rootChildrenType.change': {
                   target: 'changed',
                   actions: ['setMetadata'],
                   reenter: true,
@@ -991,6 +1005,9 @@ export const documentMachine = setup({
               entry: ['resetChangeWhileSaving', raise({type: '_save.started'})],
               on: {
                 change: {
+                  actions: ['setHasChangedWhileSaving', 'setMetadata'],
+                },
+                'rootChildrenType.change': {
                   actions: ['setHasChangedWhileSaving', 'setMetadata'],
                 },
                 'reset.content': {
@@ -1058,6 +1075,9 @@ export const documentMachine = setup({
               entry: ['resetChangeWhileSaving', raise({type: '_save.started'})],
               on: {
                 change: {
+                  actions: ['setHasChangedWhileSaving', 'setMetadata'],
+                },
+                'rootChildrenType.change': {
                   actions: ['setHasChangedWhileSaving', 'setMetadata'],
                 },
                 'reset.content': {

--- a/frontend/packages/shared/src/utils/document-changes.test.ts
+++ b/frontend/packages/shared/src/utils/document-changes.test.ts
@@ -1,7 +1,7 @@
 import type {EditorBlock} from '@seed-hypermedia/client/editor-types'
 import type {HMBlockNode} from '@seed-hypermedia/client/hm-types'
 import {describe, expect, it} from 'vitest'
-import {compareBlocksWithMap, createBlocksMap, deduplicateBlockIds} from './document-changes'
+import {compareBlocksWithMap, createBlocksMap, deduplicateBlockIds, getDocAttributeChanges} from './document-changes'
 
 function para(id: string, children: EditorBlock[] = []): EditorBlock {
   return {
@@ -35,6 +35,20 @@ function publishedNode(id: string, text = '', children: HMBlockNode[] = []): HMB
     children,
   }
 }
+
+describe('getDocAttributeChanges', () => {
+  it('emits document childrenType metadata changes', () => {
+    const changes = getDocAttributeChanges({childrenType: 'Ordered'})
+
+    expect(changes).toHaveLength(1)
+    expect(changes[0]!.op.case).toBe('setAttribute')
+    if (changes[0]!.op.case !== 'setAttribute') throw new Error('expected setAttribute')
+    expect(changes[0]!.op.value.blockId).toBe('')
+    expect(changes[0]!.op.value.key).toEqual(['childrenType'])
+    expect(changes[0]!.op.value.value.case).toBe('stringValue')
+    expect(changes[0]!.op.value.value.value).toBe('Ordered')
+  })
+})
 
 describe('deduplicateBlockIds', () => {
   it('returns blocks unchanged when no duplicates', () => {

--- a/frontend/packages/shared/src/utils/document-changes.ts
+++ b/frontend/packages/shared/src/utils/document-changes.ts
@@ -41,6 +41,9 @@ export function getDocAttributeChanges(metadata: HMMetadata) {
   if (metadata.contentWidth !== undefined) {
     changes.push(docAttributeChangeString(['contentWidth'], metadata.contentWidth))
   }
+  if (metadata.childrenType !== undefined) {
+    changes.push(docAttributeChangeString(['childrenType'], metadata.childrenType || ''))
+  }
   if (metadata.showActivity !== undefined) {
     changes.push(docAttributeChangeBool(['showActivity'], metadata.showActivity))
   }

--- a/frontend/packages/ui/src/embed-views.tsx
+++ b/frontend/packages/ui/src/embed-views.tsx
@@ -2,6 +2,7 @@ import type {HMResource} from '@seed-hypermedia/client/hm-types'
 import {
   BlockRange,
   HMBlock,
+  HMBlockChildrenType,
   HMBlockEmbed,
   HMBlockNode,
   HMComment,
@@ -417,6 +418,7 @@ export function BlockEmbedContent({
     embedBlocks: HMBlockNode[]
     document: HMDocument | null | undefined
     id: UnpackedHypermediaId
+    rootChildrenType?: HMBlockChildrenType
     /** Block id within the embedded document to scroll-anchor / focus-highlight. */
     blockRef?: string | null
     /** Codepoint range within `blockRef` to highlight when the link targets a fragment. */
@@ -735,6 +737,7 @@ function BlockEmbedContentDocument(props: {
     embedBlocks: HMBlockNode[]
     document: HMDocument | null | undefined
     id: UnpackedHypermediaId
+    rootChildrenType?: HMBlockChildrenType
     blockRef?: string | null
     blockRange?: BlockRange | null
   }) => React.ReactNode
@@ -819,6 +822,7 @@ function BlockEmbedContentDocument(props: {
             embedBlocks: embedData.data.embedBlocks as HMBlockNode[],
             document,
             id,
+            rootChildrenType: props.blockRef ? 'Group' : document?.metadata?.childrenType,
             blockRef: props.blockRef,
             blockRange: props.blockRange ?? null,
           })}

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -2617,6 +2617,8 @@ function ContentViewWithOutline({
   linkExtensionOptions?: LinkExtensionOptions
   fileUpload?: (file: File) => Promise<string>
 }) {
+  const ctx = useDocumentSelector(selectContext)
+  const rootChildrenType = (ctx.metadata?.childrenType ?? document.metadata?.childrenType) || 'Group'
   const publishedOutline = useNodesOutline(document, docId)
   const draftOutline = useMemo(
     () => (existingDraftContent ? getDraftNodesOutline(existingDraftContent, docId) : null),
@@ -2663,6 +2665,7 @@ function ContentViewWithOutline({
           <DocumentContentComponent
             blocks={existingDraftContent ?? document.content}
             resourceId={resourceId}
+            rootChildrenType={rootChildrenType}
             focusBlockId={resourceId.blockRef ?? undefined}
             focusBlockRange={resourceId.blockRange ?? undefined}
             blockCitations={blockCitations}


### PR DESCRIPTION
## Summary
- Adds `childrenType` document metadata support across CLI create/update flows and Markdown frontmatter import/export.
- Persists root list type changes from the editor into document metadata so root ordered and unordered lists survive saves.
- Threads root children type through web loading, SSR rendering, read-only viewers, and embedded document rendering.
- Adds focused tests for metadata changes, document machine updates, root group editing, and SSR list output.