### PR TITLE
feat(document): restore previous document versions

### DIFF
--- a/frontend/apps/desktop/src/components/document-actions-provider.tsx
+++ b/frontend/apps/desktop/src/components/document-actions-provider.tsx
@@ -15,15 +15,16 @@ import {DocumentActionsProvider} from '@shm/shared/document-actions-context'
 import {queryResource} from '@shm/shared/models/queries'
 import {invalidateQueries, queryClient} from '@shm/shared/models/query-client'
 import {queryKeys} from '@shm/shared/models/query-keys'
+import {replaceRouteDocumentId} from '@shm/shared/routes'
 import {hmId, latestId, pathMatches} from '@shm/shared/utils/entity-id-url'
-import {useNavigate} from '@shm/shared/utils/navigation'
+import {useNavigate, useNavRoute} from '@shm/shared/utils/navigation'
 import {SizableText} from '@shm/ui/text'
 import {useAppDialog} from '@shm/ui/universal-dialog'
 import {useMutation} from '@tanstack/react-query'
 import {nanoid} from 'nanoid'
 import {PropsWithChildren, useCallback, useMemo} from 'react'
 import {ResourceVisibility} from '@shm/shared/client/.generated/documents/v3alpha/documents_pb'
-import {buildRestoreVersionChanges} from '@shm/shared/utils/restore-document-version'
+import {buildRestoreVersionChanges, getRestoreVersionGeneration} from '@shm/shared/utils/restore-document-version'
 import {hmIdPathToEntityQueryPath} from '@shm/shared/utils/path-api'
 import {toast} from 'sonner'
 
@@ -32,6 +33,7 @@ export function DesktopDocumentActionsProvider({children}: PropsWithChildren) {
   const myAccountIds = useMyAccountIds()
   const bookmarks = useBookmarks()
   const navigate = useNavigate()
+  const currentRoute = useNavRoute()
   const {exportDocument, openDirectory} = useAppContext()
   const {onCopyReference} = useUniversalAppContext()
   const universalClient = useUniversalClient()
@@ -246,7 +248,7 @@ export function DesktopDocumentActionsProvider({children}: PropsWithChildren) {
           capability,
           visibility: ResourceVisibility.UNSPECIFIED,
           genesis: latestDocument.genesis,
-          generation: latestDocument.generationInfo?.generation,
+          generation: getRestoreVersionGeneration(latestDocument),
         })
 
         const draftId = getDraftId(targetId)
@@ -260,7 +262,7 @@ export function DesktopDocumentActionsProvider({children}: PropsWithChildren) {
         invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT])
         if (draftId) invalidateQueries([queryKeys.DRAFT, draftId])
 
-        navigate({key: 'document', id: targetId})
+        navigate(replaceRouteDocumentId(currentRoute, targetId))
         toast.success('Document restored successfully')
       } catch (error) {
         console.error('Failed to restore document version:', error)
@@ -268,7 +270,7 @@ export function DesktopDocumentActionsProvider({children}: PropsWithChildren) {
         throw error
       }
     },
-    [getDraftId, navigate, selectedAccountId, universalClient],
+    [currentRoute, getDraftId, navigate, selectedAccountId, universalClient],
   )
 
   const value = useMemo(

--- a/frontend/apps/desktop/src/components/document-actions-provider.tsx
+++ b/frontend/apps/desktop/src/components/document-actions-provider.tsx
@@ -15,13 +15,16 @@ import {DocumentActionsProvider} from '@shm/shared/document-actions-context'
 import {queryResource} from '@shm/shared/models/queries'
 import {invalidateQueries, queryClient} from '@shm/shared/models/query-client'
 import {queryKeys} from '@shm/shared/models/query-keys'
-import {hmId, pathMatches} from '@shm/shared/utils/entity-id-url'
+import {hmId, latestId, pathMatches} from '@shm/shared/utils/entity-id-url'
 import {useNavigate} from '@shm/shared/utils/navigation'
 import {SizableText} from '@shm/ui/text'
 import {useAppDialog} from '@shm/ui/universal-dialog'
 import {useMutation} from '@tanstack/react-query'
 import {nanoid} from 'nanoid'
 import {PropsWithChildren, useCallback, useMemo} from 'react'
+import {ResourceVisibility} from '@shm/shared/client/.generated/documents/v3alpha/documents_pb'
+import {buildRestoreVersionChanges} from '@shm/shared/utils/restore-document-version'
+import {hmIdPathToEntityQueryPath} from '@shm/shared/utils/path-api'
 import {toast} from 'sonner'
 
 export function DesktopDocumentActionsProvider({children}: PropsWithChildren) {
@@ -197,6 +200,77 @@ export function DesktopDocumentActionsProvider({children}: PropsWithChildren) {
 
   const getDraftId = useCallback((id: UnpackedHypermediaId) => getDraft(id)?.id, [getDraft])
 
+  const onRestoreDocumentVersion = useCallback(
+    async (id: UnpackedHypermediaId, selectedVersion: HMDocument) => {
+      if (!selectedAccountId) {
+        toast.error('Select an account before restoring a version')
+        return
+      }
+      if (!universalClient.publishDocument) {
+        toast.error('Restore is not available in this client')
+        return
+      }
+
+      try {
+        const targetId = latestId(id)
+        const latestResource = await queryClient.fetchQuery(queryResource(universalClient, targetId))
+        const latestDocument = latestResource?.type === 'document' ? latestResource.document : null
+        if (!latestDocument?.version) throw new Error('Could not load the latest document version')
+        if (latestDocument.version === selectedVersion.version) {
+          toast.info('This version is already the latest version')
+          return
+        }
+
+        const changes = buildRestoreVersionChanges(latestDocument, selectedVersion)
+        if (!changes.length) {
+          toast.info('This version matches the latest version')
+          return
+        }
+
+        let capability = ''
+        if (selectedAccountId !== targetId.uid) {
+          const result = await universalClient.request('ListCapabilities', {targetId})
+          const rawCapability = result.capabilities.find(
+            (cap: any) => cap.delegate === selectedAccountId && String(cap.role || '').toUpperCase() === 'WRITER',
+          )
+          if (!rawCapability?.id) throw new Error('Could not find write capability for selected account')
+          capability = rawCapability.id
+        }
+
+        await universalClient.publishDocument({
+          signerAccountUid: selectedAccountId,
+          account: targetId.uid,
+          path: hmIdPathToEntityQueryPath(targetId.path || []),
+          baseVersion: latestDocument.version,
+          changes,
+          capability,
+          visibility: ResourceVisibility.UNSPECIFIED,
+          genesis: latestDocument.genesis,
+          generation: latestDocument.generationInfo?.generation,
+        })
+
+        const draftId = getDraftId(targetId)
+        if (draftId) {
+          await client.drafts.delete.mutate(draftId)
+        }
+
+        invalidateQueries([queryKeys.ENTITY])
+        invalidateQueries([queryKeys.ACTIVITY_FEED])
+        invalidateQueries([queryKeys.DRAFTS_LIST])
+        invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT])
+        if (draftId) invalidateQueries([queryKeys.DRAFT, draftId])
+
+        navigate({key: 'document', id: targetId})
+        toast.success('Document restored successfully')
+      } catch (error) {
+        console.error('Failed to restore document version:', error)
+        toast.error(error instanceof Error ? error.message : 'Failed to restore document version')
+        throw error
+      }
+    },
+    [getDraftId, navigate, selectedAccountId, universalClient],
+  )
+
   const value = useMemo(
     () => ({
       selectedAccountUid: selectedAccountId ?? undefined,
@@ -208,6 +282,7 @@ export function DesktopDocumentActionsProvider({children}: PropsWithChildren) {
       onDeleteDocument,
       onBranchDocument,
       onDuplicateDocument,
+      onRestoreDocumentVersion,
       onExportDocument,
       onCopyLink,
       getDraftId,
@@ -223,6 +298,7 @@ export function DesktopDocumentActionsProvider({children}: PropsWithChildren) {
       onDeleteDocument,
       onBranchDocument,
       onDuplicateDocument,
+      onRestoreDocumentVersion,
       onExportDocument,
       onCopyLink,
       getDraftId,

--- a/frontend/apps/desktop/src/components/editing-toolbar.tsx
+++ b/frontend/apps/desktop/src/components/editing-toolbar.tsx
@@ -15,6 +15,7 @@ import {
   DraftActionsToolbar as SharedDraftActionsToolbar,
   EditingDocToolsRight as SharedEditingDocToolsRight,
 } from '@shm/ui/editing-toolbar'
+import {createDocumentVersionsPanelRoute} from '@shm/ui/document-versions-panel'
 import {MenuItemType} from '@shm/ui/options-dropdown'
 import {toast} from '@shm/ui/toast'
 import {useCallback, useMemo} from 'react'
@@ -103,7 +104,7 @@ export function useDesktopToolbarCallbacks(docId: UnpackedHypermediaId): {
         navigate({
           key: 'document',
           id,
-          panel: {key: 'activity', id, filterEventType: ['Ref']},
+          panel: createDocumentVersionsPanelRoute(id),
         } as any)
       },
     }),

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -74,6 +74,7 @@ import {useNavigationDispatch, useNavRoute} from '@shm/shared/utils/navigation'
 import {entityQueryPathToHmIdPath} from '@shm/shared/utils/path-api'
 import {CloudOff, Download, Trash, UploadCloud} from '@shm/ui/icons'
 import {copyUrlToClipboardWithFeedback} from '@shm/ui/copy-to-clipboard'
+import {createDocumentVersionsPanelRoute} from '@shm/ui/document-versions-panel'
 import {MenuItemType} from '@shm/ui/options-dropdown'
 import {ResourcePage} from '@shm/ui/resource-page-common'
 import {SizableText} from '@shm/ui/text'
@@ -719,7 +720,7 @@ export default function DesktopResourcePage() {
       replace({
         key: 'document',
         id: docId,
-        panel: {key: 'activity', id: docId, filterEventType: ['Ref']},
+        panel: createDocumentVersionsPanelRoute(docId),
       })
     },
   })

--- a/frontend/apps/desktop/src/utils/__tests__/publish-document.test.ts
+++ b/frontend/apps/desktop/src/utils/__tests__/publish-document.test.ts
@@ -55,6 +55,32 @@ describe('shouldUseDaemonCreateDocumentChange', () => {
       }),
     ).toBe(false)
   })
+
+  it('keeps explicit-generation publishes on the seed client path', () => {
+    expect(
+      shouldUseDaemonCreateDocumentChange({
+        signerAccountUid: 'alice',
+        account: 'alice',
+        path: '/foo',
+        baseVersion: 'bafy-base',
+        genesis: 'bafy-genesis',
+        generation: 123,
+        changes: [],
+      }),
+    ).toBe(false)
+  })
+
+  it('still uses daemon createDocumentChange for brand-new home documents with explicit generation', () => {
+    expect(
+      shouldUseDaemonCreateDocumentChange({
+        signerAccountUid: 'alice',
+        account: 'alice',
+        path: '',
+        generation: 123,
+        changes: [],
+      }),
+    ).toBe(true)
+  })
 })
 
 describe('createDocumentChangeRequest', () => {
@@ -180,6 +206,47 @@ describe('publishDesktopDocument', () => {
         account: 'alice',
         path: '/foo',
         baseVersion: 'bafy-base',
+        changes: [{op: {case: 'setMetadata', value: {key: 'name', value: 'Foo'}}}],
+      },
+      signer,
+    )
+  })
+
+  it('passes explicit generation through the seed client path', async () => {
+    const createDocumentChange = vi.fn().mockResolvedValue(undefined)
+    const publishDocument = vi.fn().mockResolvedValue(undefined)
+    const signer = {
+      getPublicKey: vi.fn(async () => new Uint8Array([1])),
+      sign: vi.fn(async () => new Uint8Array([2])),
+    }
+    const getSigner = vi.fn(() => signer)
+
+    await publishDesktopDocument(
+      {
+        createDocumentChange,
+        publishDocument,
+        getSigner,
+      },
+      {
+        signerAccountUid: 'alice',
+        account: 'alice',
+        path: '/foo',
+        baseVersion: 'bafy-base',
+        genesis: 'bafy-genesis',
+        generation: 123,
+        changes: [{op: {case: 'setMetadata', value: {key: 'name', value: 'Foo'}}}],
+      },
+    )
+
+    expect(createDocumentChange).not.toHaveBeenCalled()
+    expect(getSigner).toHaveBeenCalledWith('alice')
+    expect(publishDocument).toHaveBeenCalledWith(
+      {
+        account: 'alice',
+        path: '/foo',
+        baseVersion: 'bafy-base',
+        genesis: 'bafy-genesis',
+        generation: 123,
         changes: [{op: {case: 'setMetadata', value: {key: 'name', value: 'Foo'}}}],
       },
       signer,

--- a/frontend/apps/desktop/src/utils/publish-document.ts
+++ b/frontend/apps/desktop/src/utils/publish-document.ts
@@ -20,6 +20,10 @@ type PublishDesktopDocumentDeps = {
 
 /** Uses the daemon publish path for updates to existing published documents and new root documents. */
 export function shouldUseDaemonCreateDocumentChange(input: PublishDocumentInput): boolean {
+  // The daemon CreateDocumentChange request cannot carry an explicit generation.
+  // Keep existing-document publishes on the seed client path so restores stay in the latest generation.
+  if (input.generation != null && input.baseVersion && input.genesis) return false
+
   // Use daemon for updates to existing documents (has baseVersion and genesis),
   // and for new root documents (path is empty) which need genesis creation
   // via ensureProfileGenesis — PrepareChange cannot handle this.

--- a/frontend/apps/web/app/document-edit/web-restore-document-version.test.ts
+++ b/frontend/apps/web/app/document-edit/web-restore-document-version.test.ts
@@ -1,0 +1,121 @@
+import 'fake-indexeddb/auto'
+import {indexedDB} from 'fake-indexeddb'
+import type {HMBlockNode, HMDocument, HMSigner, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {restoreWebDocumentVersion} from './web-restore-document-version'
+import {_resetWebDocDraftDBForTesting, getWebDocDraft, putWebDocDraft} from './web-draft-db'
+
+vi.mock('@seed-hypermedia/client', async () => {
+  const actual = await vi.importActual<typeof import('@seed-hypermedia/client')>('@seed-hypermedia/client')
+  return {
+    ...actual,
+    signDocumentChange: vi.fn(async () => ({
+      changeCid: {toString: () => 'restored-version'},
+      publishInput: {blobs: []},
+    })),
+  }
+})
+
+const DB_NAME = 'web-doc-drafts-01'
+
+function dropDB(): Promise<void> {
+  return new Promise((resolve) => {
+    const req = indexedDB.deleteDatabase(DB_NAME)
+    req.onsuccess = () => resolve()
+    req.onerror = () => resolve()
+  })
+}
+
+function id(): UnpackedHypermediaId {
+  return {
+    uid: 'z1',
+    path: ['doc'],
+    id: 'hm://z1/doc',
+    version: null,
+    latest: false,
+    blockRef: null,
+    blockRange: null,
+    hostname: null,
+    scheme: 'hm',
+  } as UnpackedHypermediaId
+}
+
+function node(blockId: string, text: string): HMBlockNode {
+  return {block: {id: blockId, type: 'Paragraph', text} as any, children: []}
+}
+
+function doc(overrides: Partial<HMDocument>): HMDocument {
+  return {
+    account: 'z1',
+    path: '/doc',
+    version: 'latest-version',
+    authors: [],
+    content: [],
+    metadata: {},
+    visibility: 'PUBLIC',
+    createTime: '',
+    updateTime: '',
+    genesis: 'genesis',
+    generationInfo: {generation: 5n},
+    ...overrides,
+  } as HMDocument
+}
+
+describe('restoreWebDocumentVersion', () => {
+  beforeEach(async () => {
+    _resetWebDocDraftDBForTesting()
+    await dropDB()
+    _resetWebDocDraftDBForTesting()
+  })
+
+  it('publishes selected content on top of latest and removes the current web draft', async () => {
+    const targetId = id()
+    await putWebDocDraft({
+      draftId: 'draft-1',
+      docId: targetId.id,
+      signingAccountId: 'z1',
+      content: [],
+      metadata: {},
+      deps: ['latest-version'],
+      navigation: null,
+      locationUid: null,
+      locationPath: null,
+      editUid: 'z1',
+      editPath: ['doc'],
+      cursorPosition: null,
+    })
+
+    const latest = doc({content: [node('a', 'latest'), node('b', 'delete')], metadata: {name: 'Latest'}})
+    const selected = doc({version: 'old-version', content: [node('a', 'old')], metadata: {name: 'Old'}})
+    const restored = doc({version: 'restored-version', content: selected.content, metadata: selected.metadata})
+    const request = vi.fn(async (key: string, input: any) => {
+      if (key === 'Resource') {
+        return input.version === 'restored-version'
+          ? {type: 'document', document: restored, id: targetId}
+          : {type: 'document', document: latest, id: targetId}
+      }
+      if (key === 'PrepareDocumentChange') return {unsignedChange: new Uint8Array([1])}
+      throw new Error(`unexpected request ${key}`)
+    })
+    const publish = vi.fn(async () => ({}))
+
+    const result = await restoreWebDocumentVersion(
+      {targetId, selectedVersion: selected, signerAccountUid: 'z1'},
+      {
+        client: {request, publish} as any,
+        getSigner: () => ({getPublicKey: vi.fn(), sign: vi.fn()}) as unknown as HMSigner,
+      },
+    )
+
+    expect(result.version).toBe('restored-version')
+    expect(publish).toHaveBeenCalledTimes(1)
+    const prepareCall = request.mock.calls.find(([key]) => key === 'PrepareDocumentChange')
+    expect(prepareCall?.[1].baseVersion).toBe('latest-version')
+    expect(prepareCall?.[1].changes.map((change: any) => change.op.case)).toEqual([
+      'setAttribute',
+      'replaceBlock',
+      'deleteBlock',
+    ])
+    await expect(getWebDocDraft('draft-1')).resolves.toBeNull()
+  })
+})

--- a/frontend/apps/web/app/document-edit/web-restore-document-version.test.ts
+++ b/frontend/apps/web/app/document-edit/web-restore-document-version.test.ts
@@ -1,4 +1,5 @@
 import 'fake-indexeddb/auto'
+import {signDocumentChange} from '@seed-hypermedia/client'
 import {indexedDB} from 'fake-indexeddb'
 import type {HMBlockNode, HMDocument, HMSigner, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
@@ -63,6 +64,7 @@ function doc(overrides: Partial<HMDocument>): HMDocument {
 
 describe('restoreWebDocumentVersion', () => {
   beforeEach(async () => {
+    vi.mocked(signDocumentChange).mockClear()
     _resetWebDocDraftDBForTesting()
     await dropDB()
     _resetWebDocDraftDBForTesting()
@@ -111,10 +113,19 @@ describe('restoreWebDocumentVersion', () => {
     expect(publish).toHaveBeenCalledTimes(1)
     const prepareCall = request.mock.calls.find(([key]) => key === 'PrepareDocumentChange')
     expect(prepareCall?.[1].baseVersion).toBe('latest-version')
+    expect(signDocumentChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        genesis: 'genesis',
+        generation: 5n,
+      }),
+      expect.anything(),
+    )
     expect(prepareCall?.[1].changes.map((change: any) => change.op.case)).toEqual([
       'setAttribute',
-      'replaceBlock',
       'deleteBlock',
+      'deleteBlock',
+      'moveBlock',
+      'replaceBlock',
     ])
     await expect(getWebDocDraft('draft-1')).resolves.toBeNull()
   })

--- a/frontend/apps/web/app/document-edit/web-restore-document-version.ts
+++ b/frontend/apps/web/app/document-edit/web-restore-document-version.ts
@@ -1,0 +1,94 @@
+import {signDocumentChange} from '@seed-hypermedia/client'
+import type {HMDocument, HMSigner, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {ResourceVisibility} from '@shm/shared/client/.generated/documents/v3alpha/documents_pb'
+import {invalidateAfterPublish} from '@shm/shared/models/post-publish-cache'
+import {invalidateQueries, refetchQueriesByKey} from '@shm/shared/models/query-client'
+import {queryKeys} from '@shm/shared/models/query-keys'
+import type {UniversalClient} from '@shm/shared/universal-client'
+import {latestId} from '@shm/shared/utils/entity-id-url'
+import {hmIdPathToEntityQueryPath} from '@shm/shared/utils/path-api'
+import {buildRestoreVersionChanges} from '@shm/shared/utils/restore-document-version'
+import {deleteWebDocDraft, getLatestWebDocDraftForDoc} from './web-draft-db'
+
+export type RestoreWebDocumentVersionInput = {
+  targetId: UnpackedHypermediaId
+  selectedVersion: HMDocument
+  signerAccountUid: string
+  capabilityCid?: string
+}
+
+export type RestoreWebDocumentVersionDeps = {
+  client: UniversalClient
+  getSigner: (accountUid: string) => HMSigner
+}
+
+/** Restores a document version on web without going through the draft publish flow. */
+export async function restoreWebDocumentVersion(
+  input: RestoreWebDocumentVersionInput,
+  deps: RestoreWebDocumentVersionDeps,
+): Promise<HMDocument> {
+  const targetId = latestId(input.targetId)
+  const latestResource = await deps.client.request('Resource', targetId)
+  const latestDocument = latestResource.type === 'document' ? latestResource.document : null
+  if (!latestDocument?.version) throw new Error('Could not load the latest document version')
+  if (latestDocument.version === input.selectedVersion.version)
+    throw new Error('This version is already the latest version')
+
+  const changes = buildRestoreVersionChanges(latestDocument, input.selectedVersion)
+  if (!changes.length) throw new Error('This version matches the latest version')
+
+  const path = hmIdPathToEntityQueryPath(targetId.path || [])
+  const visibility = ResourceVisibility.UNSPECIFIED
+  const prepareResult = (await deps.client.request(
+    'PrepareDocumentChange' as any,
+    {
+      account: targetId.uid,
+      path,
+      baseVersion: latestDocument.version,
+      changes: changes as any,
+      capability: input.capabilityCid ?? '',
+      visibility,
+    } as any,
+  )) as any
+
+  const existingGenerationRaw = latestDocument.generationInfo?.generation
+  const existingGenerationNum = existingGenerationRaw != null ? Number(existingGenerationRaw) : 0
+  const nextGeneration = Math.max(Date.now(), existingGenerationNum + 1)
+  const {changeCid, publishInput} = await signDocumentChange(
+    {
+      account: targetId.uid,
+      path,
+      unsignedChange: prepareResult.unsignedChange,
+      genesis: latestDocument.genesis,
+      generation: nextGeneration,
+      capability: input.capabilityCid ?? '',
+      visibility,
+    },
+    deps.getSigner(input.signerAccountUid),
+  )
+
+  await deps.client.publish(publishInput)
+
+  const after = await deps.client.request('Resource', {
+    ...targetId,
+    version: changeCid.toString(),
+    latest: false,
+  })
+  if (after.type !== 'document') throw new Error('post-restore resource is not a document')
+
+  const draft = await getLatestWebDocDraftForDoc(targetId.id)
+  if (draft) {
+    await deleteWebDocDraft(draft.draftId)
+  }
+
+  invalidateAfterPublish(targetId, after.document)
+  invalidateQueries([queryKeys.ACTIVITY_FEED])
+  invalidateQueries(['web-doc-draft', targetId.id])
+  try {
+    await refetchQueriesByKey(['web-doc-draft', targetId.id])
+  } catch {
+    // Non-critical: the stale draft cache will clear on the next mount.
+  }
+
+  return after.document
+}

--- a/frontend/apps/web/app/document-edit/web-restore-document-version.ts
+++ b/frontend/apps/web/app/document-edit/web-restore-document-version.ts
@@ -7,7 +7,7 @@ import {queryKeys} from '@shm/shared/models/query-keys'
 import type {UniversalClient} from '@shm/shared/universal-client'
 import {latestId} from '@shm/shared/utils/entity-id-url'
 import {hmIdPathToEntityQueryPath} from '@shm/shared/utils/path-api'
-import {buildRestoreVersionChanges} from '@shm/shared/utils/restore-document-version'
+import {buildRestoreVersionChanges, getRestoreVersionGeneration} from '@shm/shared/utils/restore-document-version'
 import {deleteWebDocDraft, getLatestWebDocDraftForDoc} from './web-draft-db'
 
 export type RestoreWebDocumentVersionInput = {
@@ -51,16 +51,13 @@ export async function restoreWebDocumentVersion(
     } as any,
   )) as any
 
-  const existingGenerationRaw = latestDocument.generationInfo?.generation
-  const existingGenerationNum = existingGenerationRaw != null ? Number(existingGenerationRaw) : 0
-  const nextGeneration = Math.max(Date.now(), existingGenerationNum + 1)
   const {changeCid, publishInput} = await signDocumentChange(
     {
       account: targetId.uid,
       path,
       unsignedChange: prepareResult.unsignedChange,
       genesis: latestDocument.genesis,
-      generation: nextGeneration,
+      generation: getRestoreVersionGeneration(latestDocument),
       capability: input.capabilityCid ?? '',
       visibility,
     },

--- a/frontend/apps/web/app/routes/$.tsx
+++ b/frontend/apps/web/app/routes/$.tsx
@@ -42,6 +42,7 @@ import {useNavigationState} from '@shm/shared/utils/navigation'
 import {InspectIpfsPage} from '@shm/ui/inspect-ipfs-page'
 import {useTx} from '@shm/shared/translation'
 import {SizableText} from '@shm/ui/text'
+import {shouldRevalidateDocumentRoute} from './revalidation'
 
 // Extended payload with view term and panel param for page routing
 type ExtendedSitePayload = SiteDocumentPayload & {
@@ -220,22 +221,7 @@ export function shouldRevalidate({
   nextUrl: URL
   defaultShouldRevalidate: boolean
 }) {
-  // Different pathname always revalidates
-  if (currentUrl.pathname !== nextUrl.pathname) {
-    return defaultShouldRevalidate
-  }
-
-  // Same pathname — check if data-affecting params changed
-  const currentV = currentUrl.searchParams.get('v')
-  const nextV = nextUrl.searchParams.get('v')
-  const currentL = currentUrl.searchParams.get('l')
-  const nextL = nextUrl.searchParams.get('l')
-
-  if (currentV === nextV && currentL === nextL) {
-    return false // Only cosmetic params (panel, view) changed
-  }
-
-  return defaultShouldRevalidate
+  return shouldRevalidateDocumentRoute({currentUrl, nextUrl, defaultShouldRevalidate})
 }
 
 export const loader = async ({params, request}: {params: Params; request: Request}) => {

--- a/frontend/apps/web/app/routes/_index.tsx
+++ b/frontend/apps/web/app/routes/_index.tsx
@@ -9,12 +9,25 @@ import {Params, useLoaderData} from '@remix-run/react'
 import {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {createDocumentNavRoute, ViewRouteKey} from '@shm/shared'
 import {DaemonErrorPage, loader as loaderFn, meta as metaFn} from './$'
+import {shouldRevalidateDocumentRoute} from './revalidation'
 
 export const loader = async ({params, request}: {params: Params; request: Request}) => {
   return await loaderFn({
     params,
     request,
   })
+}
+
+export function shouldRevalidate({
+  currentUrl,
+  nextUrl,
+  defaultShouldRevalidate,
+}: {
+  currentUrl: URL
+  nextUrl: URL
+  defaultShouldRevalidate: boolean
+}) {
+  return shouldRevalidateDocumentRoute({currentUrl, nextUrl, defaultShouldRevalidate})
 }
 
 type ExtendedSitePayload = SiteDocumentPayload & {

--- a/frontend/apps/web/app/routes/revalidation.ts
+++ b/frontend/apps/web/app/routes/revalidation.ts
@@ -1,0 +1,25 @@
+/** Decides whether the document route loader should re-run for a URL transition. */
+export function shouldRevalidateDocumentRoute({
+  currentUrl,
+  nextUrl,
+  defaultShouldRevalidate,
+}: {
+  currentUrl: URL
+  nextUrl: URL
+  defaultShouldRevalidate: boolean
+}) {
+  if (currentUrl.pathname !== nextUrl.pathname) {
+    return true
+  }
+
+  const currentV = currentUrl.searchParams.get('v')
+  const nextV = nextUrl.searchParams.get('v')
+  const currentL = currentUrl.searchParams.get('l')
+  const nextL = nextUrl.searchParams.get('l')
+
+  if (currentV === nextV && currentL === nextL) {
+    return false
+  }
+
+  return true
+}

--- a/frontend/apps/web/app/routes/route-revalidation.test.ts
+++ b/frontend/apps/web/app/routes/route-revalidation.test.ts
@@ -1,0 +1,46 @@
+import {describe, expect, it} from 'vitest'
+import {readFileSync} from 'node:fs'
+import {join} from 'node:path'
+import {shouldRevalidateDocumentRoute} from './revalidation'
+
+function url(path: string) {
+  return new URL(path, 'https://example.com')
+}
+
+describe('document route revalidation', () => {
+  it('revalidates when only the requested document version changes', () => {
+    expect(
+      shouldRevalidateDocumentRoute({
+        currentUrl: url('/doc?panel=activity/versions'),
+        nextUrl: url('/doc?v=version-1&panel=activity/versions'),
+        defaultShouldRevalidate: false,
+      }),
+    ).toBe(true)
+  })
+
+  it('does not revalidate for panel-only changes', () => {
+    expect(
+      shouldRevalidateDocumentRoute({
+        currentUrl: url('/doc?v=version-1'),
+        nextUrl: url('/doc?v=version-1&panel=activity/versions'),
+        defaultShouldRevalidate: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('revalidates when moving from an activity URL to a versioned document URL', () => {
+    expect(
+      shouldRevalidateDocumentRoute({
+        currentUrl: url('/doc/:activity/versions'),
+        nextUrl: url('/doc?v=version-1'),
+        defaultShouldRevalidate: false,
+      }),
+    ).toBe(true)
+  })
+
+  it('uses the same version revalidation on the home document route', () => {
+    const indexRouteSource = readFileSync(join(import.meta.dirname, '_index.tsx'), 'utf8')
+
+    expect(indexRouteSource).toContain('shouldRevalidateDocumentRoute')
+  })
+})

--- a/frontend/apps/web/app/web-resource-page.test.ts
+++ b/frontend/apps/web/app/web-resource-page.test.ts
@@ -1,0 +1,13 @@
+import {readFileSync} from 'node:fs'
+import {join} from 'node:path'
+import {describe, expect, it} from 'vitest'
+
+describe('WebResourcePage restore action wiring', () => {
+  it('only exposes the restore action when the web user can edit', () => {
+    const source = readFileSync(join(__dirname, 'web-resource-page.tsx'), 'utf8')
+
+    expect(source).toContain(
+      'onRestoreDocumentVersion={effectiveCanEdit && signingAccountId ? onRestoreDocumentVersion : undefined}',
+    )
+  })
+})

--- a/frontend/apps/web/app/web-resource-page.tsx
+++ b/frontend/apps/web/app/web-resource-page.tsx
@@ -1,4 +1,4 @@
-import {HMExistingDraft, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {HMDocument, HMExistingDraft, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {hmId, useJoinSite, useUniversalAppContext, useUniversalClient} from '@shm/shared'
 import {CommentsProvider, InlineEditCommentProps} from '@shm/shared/comments-service-provider'
 import {canCreateChildDocuments} from '@shm/shared/document-utils'
@@ -9,7 +9,7 @@ import {useResource} from '@shm/shared/models/entity'
 import {QueryBlockDraftsProvider} from '@shm/shared/query-block-drafts-context'
 import {getDraftPlaceholderParentId} from '@shm/shared/utils/breadcrumbs'
 import {useCommentNavigation} from '@shm/shared/utils/comment-navigation'
-import {createWebHMUrl} from '@shm/shared/utils/entity-id-url'
+import {createWebHMUrl, latestId} from '@shm/shared/utils/entity-id-url'
 import {useNavRoute, useNavigate} from '@shm/shared/utils/navigation'
 import {entityQueryPathToHmIdPath} from '@shm/shared/utils/path-api'
 import {pathNameify} from '@shm/shared/utils/path'
@@ -27,14 +27,7 @@ import {EditingDocToolsRight, type EditingToolbarCallbacks} from '@shm/ui/editin
 import {Trash} from '@shm/ui/icons'
 import type {MenuItemType} from '@shm/ui/options-dropdown'
 import {lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState} from 'react'
-import {
-  EditProfileDialog,
-  LogoutButton,
-  getCurrentSigner,
-  useCreateAccount,
-  useLocalKeyPair,
-  useVaultSuccessDialog,
-} from './auth'
+import {EditProfileDialog, LogoutButton, useCreateAccount, useLocalKeyPair, useVaultSuccessDialog} from './auth'
 import {preloadCommenting} from './client-lazy'
 import {setPendingIntent} from './local-db'
 import {PageFooter} from './page-footer'
@@ -48,6 +41,7 @@ import {cleanupOldWebDocDrafts, getLatestWebDocDraftForDoc, getWebDocDraft} from
 import {makeWebFileUpload} from './document-edit/web-image-upload'
 import {WebDraftBreadcrumbProvider} from './document-edit/web-draft-breadcrumb-provider'
 import {getWebDraftShellId, shouldUseLocalWebDraftShell} from './document-edit/web-draft-shell'
+import {restoreWebDocumentVersion} from './document-edit/web-restore-document-version'
 import {useWebDeleteDocumentDialog} from './web-delete-document-dialog'
 
 /** Lazy-loaded inline comment editor — avoids pulling the full editor bundle eagerly. */
@@ -391,6 +385,41 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
     replaceRoute,
   })
 
+  const onRestoreDocumentVersion = useCallback(
+    async (id: UnpackedHypermediaId, selectedVersion: HMDocument) => {
+      if (!effectiveCanEdit || !signingAccountId) {
+        toast.error('You do not have permission to restore this document')
+        return
+      }
+      if (!universalClient.getSigner) {
+        toast.error('Restore is not available in this client')
+        return
+      }
+
+      try {
+        await restoreWebDocumentVersion(
+          {
+            targetId: id,
+            selectedVersion,
+            signerAccountUid: signingAccountId,
+            capabilityCid: effectiveCapabilityCid,
+          },
+          {
+            client: universalClient,
+            getSigner: (accountUid) => universalClient.getSigner!(accountUid),
+          },
+        )
+        replaceRouteRef.current({key: 'document', id: latestId(id), panel: null} as any)
+        toast.success('Document restored successfully')
+      } catch (error) {
+        console.error('Failed to restore document version:', error)
+        toast.error(error instanceof Error ? error.message : 'Failed to restore document version')
+        throw error
+      }
+    },
+    [effectiveCanEdit, effectiveCapabilityCid, signingAccountId, universalClient],
+  )
+
   const [lastCreatedDraftId, setLastCreatedDraftId] = useState<string | null>(null)
   const canCreateInlineDraft = !useLocalDraftShell && canCreateChildDocs
 
@@ -406,6 +435,7 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
           selectedAccountUid={signingAccountId ?? undefined}
           myAccountIds={signingAccountId ? [signingAccountId] : []}
           onDeleteDocument={onDeleteDocument}
+          onRestoreDocumentVersion={effectiveCanEdit && signingAccountId ? onRestoreDocumentVersion : undefined}
         >
           <WebDraftActionsProvider
             canCreateInlineDraft={canCreateInlineDraft}

--- a/frontend/apps/web/app/web-resource-page.tsx
+++ b/frontend/apps/web/app/web-resource-page.tsx
@@ -1,48 +1,50 @@
 import {HMDocument, HMExistingDraft, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {hmId, useJoinSite, useUniversalAppContext, useUniversalClient} from '@shm/shared'
 import {CommentsProvider, InlineEditCommentProps} from '@shm/shared/comments-service-provider'
-import {canCreateChildDocuments} from '@shm/shared/document-utils'
 import {NOTIFY_SERVICE_HOST} from '@shm/shared/constants'
+import {DocumentActionsProvider} from '@shm/shared/document-actions-context'
 import type {DocumentContentProps} from '@shm/shared/document-content-props'
+import {canCreateChildDocuments} from '@shm/shared/document-utils'
 import {type EditorAccessor} from '@shm/shared/models/document-machine'
 import {useResource} from '@shm/shared/models/entity'
 import {QueryBlockDraftsProvider} from '@shm/shared/query-block-drafts-context'
+import {replaceRouteDocumentId} from '@shm/shared/routes'
 import {getDraftPlaceholderParentId} from '@shm/shared/utils/breadcrumbs'
 import {useCommentNavigation} from '@shm/shared/utils/comment-navigation'
 import {createWebHMUrl, latestId} from '@shm/shared/utils/entity-id-url'
 import {useNavRoute, useNavigate} from '@shm/shared/utils/navigation'
-import {entityQueryPathToHmIdPath} from '@shm/shared/utils/path-api'
 import {pathNameify} from '@shm/shared/utils/path'
+import {entityQueryPathToHmIdPath} from '@shm/shared/utils/path-api'
 import {computeInlineDraftPublishPath} from '@shm/shared/utils/publish-paths'
 import {getDraftReturnParentId, isReservedLazyDraftId} from '@shm/shared/utils/reserved-draft-ids'
-import {useQuery} from '@tanstack/react-query'
+import {createDocumentVersionsPanelRoute} from '@shm/ui/document-versions-panel'
+import {EditingDocToolsRight, type EditingToolbarCallbacks} from '@shm/ui/editing-toolbar'
+import {Trash} from '@shm/ui/icons'
 import {InlineSubscribeBox} from '@shm/ui/inline-subscribe-box'
 import {InspectorPage} from '@shm/ui/inspector-page'
-import {DocumentActionsProvider} from '@shm/shared/document-actions-context'
+import type {MenuItemType} from '@shm/ui/options-dropdown'
 import {CommentEditorProps, ResourcePage} from '@shm/ui/resource-page-common'
 import {Spinner} from '@shm/ui/spinner'
 import {toast} from '@shm/ui/toast'
 import {useAppDialog} from '@shm/ui/universal-dialog'
-import {EditingDocToolsRight, type EditingToolbarCallbacks} from '@shm/ui/editing-toolbar'
-import {Trash} from '@shm/ui/icons'
-import type {MenuItemType} from '@shm/ui/options-dropdown'
-import {lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {useQuery} from '@tanstack/react-query'
+import {Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {EditProfileDialog, LogoutButton, useCreateAccount, useLocalKeyPair, useVaultSuccessDialog} from './auth'
 import {preloadCommenting} from './client-lazy'
-import {setPendingIntent} from './local-db'
-import {PageFooter} from './page-footer'
-import {processPendingIntent} from './pending-intent'
-import {WebHeaderActions, WebSitePageShell, useWebCreateDocumentMenuItem, useWebMenuItems} from './web-utils'
 import {useWebCanEdit} from './document-edit/use-web-can-edit'
 import {createWebDocumentMachine} from './document-edit/web-document-actors'
 import {WebDraftActionsProvider} from './document-edit/web-draft-actions-provider'
-import {WebQueryBlockDraftSlot} from './document-edit/web-query-block-draft-slot'
-import {cleanupOldWebDocDrafts, getLatestWebDocDraftForDoc, getWebDocDraft} from './document-edit/web-draft-db'
-import {makeWebFileUpload} from './document-edit/web-image-upload'
 import {WebDraftBreadcrumbProvider} from './document-edit/web-draft-breadcrumb-provider'
+import {cleanupOldWebDocDrafts, getLatestWebDocDraftForDoc, getWebDocDraft} from './document-edit/web-draft-db'
 import {getWebDraftShellId, shouldUseLocalWebDraftShell} from './document-edit/web-draft-shell'
+import {makeWebFileUpload} from './document-edit/web-image-upload'
+import {WebQueryBlockDraftSlot} from './document-edit/web-query-block-draft-slot'
 import {restoreWebDocumentVersion} from './document-edit/web-restore-document-version'
+import {setPendingIntent} from './local-db'
+import {PageFooter} from './page-footer'
+import {processPendingIntent} from './pending-intent'
 import {useWebDeleteDocumentDialog} from './web-delete-document-dialog'
+import {WebHeaderActions, WebSitePageShell, useWebCreateDocumentMenuItem, useWebMenuItems} from './web-utils'
 
 /** Lazy-loaded inline comment editor — avoids pulling the full editor bundle eagerly. */
 const LazyWebInlineEditor = lazy(() => import('./commenting').then((mod) => ({default: mod.WebInlineEditBox})))
@@ -300,7 +302,7 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
         navigate({
           key: 'document',
           id,
-          panel: {key: 'activity', id, filterEventType: ['Ref']},
+          panel: createDocumentVersionsPanelRoute(id),
         } as any)
       },
     }),
@@ -409,7 +411,7 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
             getSigner: (accountUid) => universalClient.getSigner!(accountUid),
           },
         )
-        replaceRouteRef.current({key: 'document', id: latestId(id), panel: null} as any)
+        replaceRouteRef.current(replaceRouteDocumentId(route, latestId(id)))
         toast.success('Document restored successfully')
       } catch (error) {
         console.error('Failed to restore document version:', error)
@@ -417,7 +419,7 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
         throw error
       }
     },
-    [effectiveCanEdit, effectiveCapabilityCid, signingAccountId, universalClient],
+    [effectiveCanEdit, effectiveCapabilityCid, route, signingAccountId, universalClient],
   )
 
   const [lastCreatedDraftId, setLastCreatedDraftId] = useState<string | null>(null)

--- a/frontend/apps/web/app/web-utils.tsx
+++ b/frontend/apps/web/app/web-utils.tsx
@@ -30,6 +30,7 @@ import {MenuItemType} from '@shm/ui/options-dropdown'
 import {toast} from '@shm/ui/toast'
 import {Tooltip} from '@shm/ui/tooltip'
 import {useAppDialog} from '@shm/ui/universal-dialog'
+import {createDocumentVersionsPanelRoute} from '@shm/ui/document-versions-panel'
 import {useMedia} from '@shm/ui/use-media'
 import {cn} from '@shm/ui/utils'
 import {
@@ -113,7 +114,7 @@ export function useWebMenuItems(docId: UnpackedHypermediaId, options?: {includeI
           navigate({
             key: 'document',
             id: docId,
-            panel: {key: 'activity', id: docId, filterEventType: ['Ref']},
+            panel: createDocumentVersionsPanelRoute(docId),
           })
         },
       },

--- a/frontend/packages/shared/src/document-actions-context.tsx
+++ b/frontend/packages/shared/src/document-actions-context.tsx
@@ -16,6 +16,7 @@ export type DocumentActionsContextValue = {
   onDeleteDocument?: (id: UnpackedHypermediaId, onSuccess?: () => void) => void
   onBranchDocument?: (id: UnpackedHypermediaId) => void
   onDuplicateDocument?: (id: UnpackedHypermediaId) => void
+  onRestoreDocumentVersion?: (id: UnpackedHypermediaId, selectedVersion: HMDocument) => Promise<void> | void
   onExportDocument?: (doc: HMDocument) => void
   onCopyLink?: (id: UnpackedHypermediaId) => void
 
@@ -39,6 +40,7 @@ export function DocumentActionsProvider({children, ...value}: PropsWithChildren<
       value.onDeleteDocument,
       value.onBranchDocument,
       value.onDuplicateDocument,
+      value.onRestoreDocumentVersion,
       value.onExportDocument,
       value.onCopyLink,
       value.getDraftId,

--- a/frontend/packages/shared/src/utils/document-changes.ts
+++ b/frontend/packages/shared/src/utils/document-changes.ts
@@ -1,3 +1,4 @@
+import {Empty} from '@bufbuild/protobuf'
 import {EditorBlock} from '@seed-hypermedia/client/editor-types'
 import {editorBlockToHMBlock} from '@seed-hypermedia/client/editorblock-to-hmblock'
 import {HMBlock, HMBlockNode, HMMetadata, HMQuery} from '@seed-hypermedia/client/hm-types'
@@ -16,38 +17,57 @@ export type BlocksMapItem = {
   block: HMBlock
 }
 
-export function getDocAttributeChanges(metadata: HMMetadata) {
-  const changes = []
-  if (metadata.name !== undefined) changes.push(docAttributeChangeString(['name'], metadata.name))
-  if (metadata.summary !== undefined) changes.push(docAttributeChangeString(['summary'], metadata.summary))
-  if (metadata.icon !== undefined) changes.push(docAttributeChangeString(['icon'], metadata.icon))
-  if (metadata.thumbnail !== undefined) changes.push(docAttributeChangeString(['thumbnail'], metadata.thumbnail))
-  if (metadata.cover !== undefined) changes.push(docAttributeChangeString(['cover'], metadata.cover))
-  if (metadata.siteUrl !== undefined) changes.push(docAttributeChangeString(['siteUrl'], metadata.siteUrl))
-  if (metadata.layout !== undefined) changes.push(docAttributeChangeString(['layout'], metadata.layout))
-  if (metadata.displayAuthor !== undefined)
-    changes.push(docAttributeChangeString(['displayAuthor'], metadata.displayAuthor))
-  if (metadata.displayPublishTime !== undefined)
-    changes.push(docAttributeChangeString(['displayPublishTime'], metadata.displayPublishTime))
-  if (metadata.seedExperimentalLogo !== undefined)
-    changes.push(docAttributeChangeString(['seedExperimentalLogo'], metadata.seedExperimentalLogo))
-  if (metadata.seedExperimentalHomeOrder !== undefined)
-    changes.push(docAttributeChangeString(['seedExperimentalHomeOrder'], metadata.seedExperimentalHomeOrder))
-  if (metadata.showOutline !== undefined) changes.push(docAttributeChangeBool(['showOutline'], metadata.showOutline))
-  if (metadata.theme !== undefined) {
-    if (metadata.theme.headerLayout !== undefined)
-      changes.push(docAttributeChangeString(['theme', 'headerLayout'], metadata.theme.headerLayout))
-  }
-  if (metadata.contentWidth !== undefined) {
-    changes.push(docAttributeChangeString(['contentWidth'], metadata.contentWidth))
-  }
-  if (metadata.childrenType !== undefined) {
-    changes.push(docAttributeChangeString(['childrenType'], metadata.childrenType || ''))
-  }
-  if (metadata.showActivity !== undefined) {
-    changes.push(docAttributeChangeBool(['showActivity'], metadata.showActivity))
+export function getDocAttributeChanges(metadata: HMMetadata, baseMetadata?: HMMetadata) {
+  return getAttributeChangesForObject(
+    metadata as Record<string, unknown>,
+    baseMetadata as Record<string, unknown> | undefined,
+  )
+}
+
+function getAttributeChangesForObject(
+  metadata: Record<string, unknown>,
+  baseMetadata: Record<string, unknown> | undefined,
+) {
+  const changes: DocumentChange[] = []
+  const keys = new Set([...Object.keys(baseMetadata ?? {}), ...Object.keys(metadata ?? {})])
+  for (const key of Array.from(keys)) {
+    pushAttributeChanges(changes, [key], metadata?.[key], baseMetadata?.[key])
   }
   return changes
+}
+
+function pushAttributeChanges(changes: DocumentChange[], key: string[], value: unknown, baseValue: unknown) {
+  if (isPlainObject(value) || isPlainObject(baseValue)) {
+    const valueObj = isPlainObject(value) ? value : undefined
+    const baseObj = isPlainObject(baseValue) ? baseValue : undefined
+    const keys = new Set([...Object.keys(baseObj ?? {}), ...Object.keys(valueObj ?? {})])
+    for (const childKey of Array.from(keys)) {
+      pushAttributeChanges(changes, [...key, childKey], valueObj?.[childKey], baseObj?.[childKey])
+    }
+    return
+  }
+
+  if (baseValue !== undefined && value === undefined) {
+    changes.push(docAttributeChangeNull(key))
+    return
+  }
+  if (baseValue !== undefined && value === baseValue) return
+
+  if (typeof value === 'string') {
+    changes.push(docAttributeChangeString(key, value))
+  } else if (typeof value === 'boolean') {
+    changes.push(docAttributeChangeBool(key, value))
+  } else if (typeof value === 'number' && Number.isInteger(value)) {
+    changes.push(docAttributeChangeInt(key, value))
+  } else if (typeof value === 'bigint') {
+    changes.push(docAttributeChangeInt(key, value))
+  } else if (value === null) {
+    changes.push(docAttributeChangeNull(key))
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
 }
 
 type PrimitiveValue = string | number | boolean | null | undefined
@@ -78,21 +98,37 @@ function docAttributeChangeString(key: string[], value: string) {
     },
   })
 }
-// function docAttributeChangeInt(key: string[], value: number) {
-//   return new DocumentChange({
-//     op: {
-//       case: 'setAttribute',
-//       value: new DocumentChange_SetAttribute({
-//         blockId: '',
-//         key,
-//         value: {
-//           case: 'intValue',
-//           value: BigInt(value),
-//         },
-//       }),
-//     },
-//   })
-// }
+function docAttributeChangeInt(key: string[], value: number | bigint) {
+  return new DocumentChange({
+    op: {
+      case: 'setAttribute',
+      value: new DocumentChange_SetAttribute({
+        blockId: '',
+        key,
+        value: {
+          case: 'intValue',
+          value: BigInt(value),
+        },
+      }),
+    },
+  })
+}
+
+function docAttributeChangeNull(key: string[]) {
+  return new DocumentChange({
+    op: {
+      case: 'setAttribute',
+      value: new DocumentChange_SetAttribute({
+        blockId: '',
+        key,
+        value: {
+          case: 'nullValue',
+          value: new Empty(),
+        },
+      }),
+    },
+  })
+}
 function docAttributeChangeBool(key: string[], value: boolean) {
   return new DocumentChange({
     op: {

--- a/frontend/packages/shared/src/utils/restore-document-version.test.ts
+++ b/frontend/packages/shared/src/utils/restore-document-version.test.ts
@@ -1,0 +1,56 @@
+import type {HMBlockNode, HMDocument} from '@seed-hypermedia/client/hm-types'
+import {describe, expect, it} from 'vitest'
+import {buildRestoreMetadataChanges, buildRestoreVersionChanges} from './restore-document-version'
+
+function node(id: string, text: string): HMBlockNode {
+  return {
+    block: {
+      id,
+      type: 'Paragraph',
+      text,
+      attributes: {},
+      annotations: [],
+    } as HMBlockNode['block'],
+    children: [],
+  }
+}
+
+function doc(overrides: Partial<HMDocument>): HMDocument {
+  return {
+    account: 'z1',
+    path: '/doc',
+    version: 'v1',
+    authors: [],
+    content: [],
+    metadata: {},
+    visibility: 'PUBLIC',
+    createTime: '',
+    updateTime: '',
+    genesis: 'g1',
+    ...overrides,
+  }
+}
+
+describe('buildRestoreVersionChanges', () => {
+  it('builds replace and delete changes to make latest content match selected content', () => {
+    const changes = buildRestoreVersionChanges(
+      doc({content: [node('a', 'latest a'), node('b', 'latest b')]}),
+      doc({content: [node('a', 'old a')]}),
+    )
+
+    expect(changes.map((change) => change.op.case)).toEqual(['replaceBlock', 'deleteBlock'])
+    expect(changes[0]?.op.case === 'replaceBlock' ? changes[0].op.value.text : null).toBe('old a')
+    expect(changes[1]?.op.case === 'deleteBlock' ? changes[1].op.value : null).toBe('b')
+  })
+
+  it('restores metadata values and removes fields missing from selected version', () => {
+    const changes = buildRestoreMetadataChanges(
+      {name: 'Latest', summary: 'remove me', showOutline: true, theme: {headerLayout: 'Center'}},
+      {name: 'Old', showOutline: false},
+    )
+
+    const attrs = changes.map((change) => (change.op.case === 'setAttribute' ? change.op.value : null))
+    expect(attrs.map((attr) => attr?.key.join('.'))).toEqual(['name', 'summary', 'showOutline', 'theme.headerLayout'])
+    expect(attrs.map((attr) => attr?.value.case)).toEqual(['stringValue', 'nullValue', 'boolValue', 'nullValue'])
+  })
+})

--- a/frontend/packages/shared/src/utils/restore-document-version.test.ts
+++ b/frontend/packages/shared/src/utils/restore-document-version.test.ts
@@ -1,6 +1,6 @@
 import type {HMBlockNode, HMDocument} from '@seed-hypermedia/client/hm-types'
 import {describe, expect, it} from 'vitest'
-import {buildRestoreMetadataChanges, buildRestoreVersionChanges} from './restore-document-version'
+import {buildRestoreVersionChanges} from './restore-document-version'
 
 function node(id: string, text: string): HMBlockNode {
   return {
@@ -43,14 +43,44 @@ describe('buildRestoreVersionChanges', () => {
     expect(changes[1]?.op.case === 'deleteBlock' ? changes[1].op.value : null).toBe('b')
   })
 
-  it('restores metadata values and removes fields missing from selected version', () => {
-    const changes = buildRestoreMetadataChanges(
-      {name: 'Latest', summary: 'remove me', showOutline: true, theme: {headerLayout: 'Center'}},
-      {name: 'Old', showOutline: false},
+  it('restores arbitrary metadata values and removes fields missing from selected version', () => {
+    const changes = buildRestoreVersionChanges(
+      doc({
+        metadata: {
+          name: 'Latest',
+          summary: 'remove me',
+          showOutline: true,
+          theme: {headerLayout: 'Center'},
+          custom: {count: 2, stale: 'yes'},
+        } as any,
+      }),
+      doc({
+        metadata: {
+          name: 'Old',
+          showOutline: false,
+          custom: {count: 3, label: 'restored'},
+        } as any,
+      }),
     )
 
     const attrs = changes.map((change) => (change.op.case === 'setAttribute' ? change.op.value : null))
-    expect(attrs.map((attr) => attr?.key.join('.'))).toEqual(['name', 'summary', 'showOutline', 'theme.headerLayout'])
-    expect(attrs.map((attr) => attr?.value.case)).toEqual(['stringValue', 'nullValue', 'boolValue', 'nullValue'])
+    expect(attrs.map((attr) => attr?.key.join('.'))).toEqual([
+      'name',
+      'summary',
+      'showOutline',
+      'theme.headerLayout',
+      'custom.count',
+      'custom.stale',
+      'custom.label',
+    ])
+    expect(attrs.map((attr) => attr?.value.case)).toEqual([
+      'stringValue',
+      'nullValue',
+      'boolValue',
+      'nullValue',
+      'intValue',
+      'nullValue',
+      'stringValue',
+    ])
   })
 })

--- a/frontend/packages/shared/src/utils/restore-document-version.test.ts
+++ b/frontend/packages/shared/src/utils/restore-document-version.test.ts
@@ -1,6 +1,6 @@
 import type {HMBlockNode, HMDocument} from '@seed-hypermedia/client/hm-types'
 import {describe, expect, it} from 'vitest'
-import {buildRestoreVersionChanges} from './restore-document-version'
+import {buildRestoreVersionChanges, getRestoreVersionGeneration} from './restore-document-version'
 
 function node(id: string, text: string): HMBlockNode {
   return {
@@ -32,15 +32,26 @@ function doc(overrides: Partial<HMDocument>): HMDocument {
 }
 
 describe('buildRestoreVersionChanges', () => {
-  it('builds replace and delete changes to make latest content match selected content', () => {
+  it('deletes current content before inserting every selected-version block', () => {
     const changes = buildRestoreVersionChanges(
       doc({content: [node('a', 'latest a'), node('b', 'latest b')]}),
-      doc({content: [node('a', 'old a')]}),
+      doc({content: [node('a', 'old a'), node('c', 'old c')]}),
     )
 
-    expect(changes.map((change) => change.op.case)).toEqual(['replaceBlock', 'deleteBlock'])
-    expect(changes[0]?.op.case === 'replaceBlock' ? changes[0].op.value.text : null).toBe('old a')
+    expect(changes.map((change) => change.op.case)).toEqual([
+      'deleteBlock',
+      'deleteBlock',
+      'moveBlock',
+      'replaceBlock',
+      'moveBlock',
+      'replaceBlock',
+    ])
+    expect(changes[0]?.op.case === 'deleteBlock' ? changes[0].op.value : null).toBe('a')
     expect(changes[1]?.op.case === 'deleteBlock' ? changes[1].op.value : null).toBe('b')
+    expect(changes[2]?.op.case === 'moveBlock' ? changes[2].op.value.blockId : null).toBe('a')
+    expect(changes[3]?.op.case === 'replaceBlock' ? changes[3].op.value.text : null).toBe('old a')
+    expect(changes[4]?.op.case === 'moveBlock' ? changes[4].op.value.blockId : null).toBe('c')
+    expect(changes[5]?.op.case === 'replaceBlock' ? changes[5].op.value.text : null).toBe('old c')
   })
 
   it('restores arbitrary metadata values and removes fields missing from selected version', () => {
@@ -82,5 +93,20 @@ describe('buildRestoreVersionChanges', () => {
       'nullValue',
       'stringValue',
     ])
+  })
+})
+
+describe('getRestoreVersionGeneration', () => {
+  it('uses the latest document generation instead of creating a new one', () => {
+    expect(
+      getRestoreVersionGeneration(
+        doc({
+          generationInfo: {
+            genesis: 'g1',
+            generation: 123n,
+          },
+        }),
+      ),
+    ).toBe(123n)
   })
 })

--- a/frontend/packages/shared/src/utils/restore-document-version.ts
+++ b/frontend/packages/shared/src/utils/restore-document-version.ts
@@ -1,0 +1,99 @@
+import {hmBlocksToEditorContent} from '@seed-hypermedia/client/hmblock-to-editorblock'
+import type {HMDocument, HMMetadata} from '@seed-hypermedia/client/hm-types'
+import {Empty} from '@bufbuild/protobuf'
+import {DocumentChange_SetAttribute} from '../client'
+import {DocumentChange} from '../client/.generated/documents/v3alpha/documents_pb'
+import {compareBlocksWithMap, createBlocksMap, extractDeletes} from './document-changes'
+
+const metadataStringKeys = [
+  'name',
+  'summary',
+  'icon',
+  'thumbnail',
+  'cover',
+  'siteUrl',
+  'layout',
+  'displayAuthor',
+  'displayPublishTime',
+  'seedExperimentalLogo',
+  'seedExperimentalHomeOrder',
+  'contentWidth',
+  'importCategories',
+  'importTags',
+] as const
+
+const metadataBoolKeys = ['showOutline', 'showActivity'] as const
+
+/** Build document changes that restore selected version content and metadata on top of the latest document. */
+export function buildRestoreVersionChanges(latestDocument: HMDocument, selectedVersion: HMDocument): DocumentChange[] {
+  const latestBlocksMap = createBlocksMap(latestDocument.content ?? [], '')
+  const selectedEditorBlocks = hmBlocksToEditorContent(selectedVersion.content ?? [], {childrenType: 'Group'})
+  const blockDiff = compareBlocksWithMap(latestBlocksMap, selectedEditorBlocks, '')
+  const deleteChanges = extractDeletes(latestBlocksMap, blockDiff.touchedBlocks)
+  return [
+    ...buildRestoreMetadataChanges(latestDocument.metadata ?? {}, selectedVersion.metadata ?? {}),
+    ...blockDiff.changes,
+    ...deleteChanges,
+  ]
+}
+
+/** Build attribute changes that make latest metadata match selected metadata, including removals. */
+export function buildRestoreMetadataChanges(
+  latestMetadata: HMMetadata,
+  selectedMetadata: HMMetadata,
+): DocumentChange[] {
+  const changes: DocumentChange[] = []
+
+  for (const key of metadataStringKeys) {
+    pushMetadataValueChange(changes, [key], latestMetadata[key], selectedMetadata[key])
+  }
+  for (const key of metadataBoolKeys) {
+    pushMetadataValueChange(changes, [key], latestMetadata[key], selectedMetadata[key])
+  }
+  pushMetadataValueChange(
+    changes,
+    ['theme', 'headerLayout'],
+    latestMetadata.theme?.headerLayout,
+    selectedMetadata.theme?.headerLayout,
+  )
+
+  return changes
+}
+
+function pushMetadataValueChange(
+  changes: DocumentChange[],
+  key: string[],
+  latestValue: unknown,
+  selectedValue: unknown,
+) {
+  if (latestValue === selectedValue) return
+  if (typeof selectedValue === 'string') {
+    changes.push(attributeChange(key, {case: 'stringValue', value: selectedValue}))
+    return
+  }
+  if (typeof selectedValue === 'boolean') {
+    changes.push(attributeChange(key, {case: 'boolValue', value: selectedValue}))
+    return
+  }
+  if (selectedValue === undefined || selectedValue === null) {
+    if (latestValue !== undefined && latestValue !== null) {
+      changes.push(attributeChange(key, {case: 'nullValue', value: new Empty()}))
+    }
+  }
+}
+
+function attributeChange(
+  key: string[],
+  value: {case: 'stringValue'; value: string} | {case: 'boolValue'; value: boolean} | {case: 'nullValue'; value: Empty},
+) {
+  return new DocumentChange({
+    op: {
+      case: 'setAttribute',
+      value: new DocumentChange_SetAttribute({
+        blockId: '',
+        key,
+        value,
+      }),
+    },
+  })
+}

--- a/frontend/packages/shared/src/utils/restore-document-version.ts
+++ b/frontend/packages/shared/src/utils/restore-document-version.ts
@@ -1,28 +1,7 @@
 import {hmBlocksToEditorContent} from '@seed-hypermedia/client/hmblock-to-editorblock'
-import type {HMDocument, HMMetadata} from '@seed-hypermedia/client/hm-types'
-import {Empty} from '@bufbuild/protobuf'
-import {DocumentChange_SetAttribute} from '../client'
+import type {HMDocument} from '@seed-hypermedia/client/hm-types'
 import {DocumentChange} from '../client/.generated/documents/v3alpha/documents_pb'
-import {compareBlocksWithMap, createBlocksMap, extractDeletes} from './document-changes'
-
-const metadataStringKeys = [
-  'name',
-  'summary',
-  'icon',
-  'thumbnail',
-  'cover',
-  'siteUrl',
-  'layout',
-  'displayAuthor',
-  'displayPublishTime',
-  'seedExperimentalLogo',
-  'seedExperimentalHomeOrder',
-  'contentWidth',
-  'importCategories',
-  'importTags',
-] as const
-
-const metadataBoolKeys = ['showOutline', 'showActivity'] as const
+import {compareBlocksWithMap, createBlocksMap, extractDeletes, getDocAttributeChanges} from './document-changes'
 
 /** Build document changes that restore selected version content and metadata on top of the latest document. */
 export function buildRestoreVersionChanges(latestDocument: HMDocument, selectedVersion: HMDocument): DocumentChange[] {
@@ -31,69 +10,8 @@ export function buildRestoreVersionChanges(latestDocument: HMDocument, selectedV
   const blockDiff = compareBlocksWithMap(latestBlocksMap, selectedEditorBlocks, '')
   const deleteChanges = extractDeletes(latestBlocksMap, blockDiff.touchedBlocks)
   return [
-    ...buildRestoreMetadataChanges(latestDocument.metadata ?? {}, selectedVersion.metadata ?? {}),
+    ...getDocAttributeChanges(selectedVersion.metadata ?? {}, latestDocument.metadata ?? {}),
     ...blockDiff.changes,
     ...deleteChanges,
   ]
-}
-
-/** Build attribute changes that make latest metadata match selected metadata, including removals. */
-export function buildRestoreMetadataChanges(
-  latestMetadata: HMMetadata,
-  selectedMetadata: HMMetadata,
-): DocumentChange[] {
-  const changes: DocumentChange[] = []
-
-  for (const key of metadataStringKeys) {
-    pushMetadataValueChange(changes, [key], latestMetadata[key], selectedMetadata[key])
-  }
-  for (const key of metadataBoolKeys) {
-    pushMetadataValueChange(changes, [key], latestMetadata[key], selectedMetadata[key])
-  }
-  pushMetadataValueChange(
-    changes,
-    ['theme', 'headerLayout'],
-    latestMetadata.theme?.headerLayout,
-    selectedMetadata.theme?.headerLayout,
-  )
-
-  return changes
-}
-
-function pushMetadataValueChange(
-  changes: DocumentChange[],
-  key: string[],
-  latestValue: unknown,
-  selectedValue: unknown,
-) {
-  if (latestValue === selectedValue) return
-  if (typeof selectedValue === 'string') {
-    changes.push(attributeChange(key, {case: 'stringValue', value: selectedValue}))
-    return
-  }
-  if (typeof selectedValue === 'boolean') {
-    changes.push(attributeChange(key, {case: 'boolValue', value: selectedValue}))
-    return
-  }
-  if (selectedValue === undefined || selectedValue === null) {
-    if (latestValue !== undefined && latestValue !== null) {
-      changes.push(attributeChange(key, {case: 'nullValue', value: new Empty()}))
-    }
-  }
-}
-
-function attributeChange(
-  key: string[],
-  value: {case: 'stringValue'; value: string} | {case: 'boolValue'; value: boolean} | {case: 'nullValue'; value: Empty},
-) {
-  return new DocumentChange({
-    op: {
-      case: 'setAttribute',
-      value: new DocumentChange_SetAttribute({
-        blockId: '',
-        key,
-        value,
-      }),
-    },
-  })
 }

--- a/frontend/packages/shared/src/utils/restore-document-version.ts
+++ b/frontend/packages/shared/src/utils/restore-document-version.ts
@@ -1,17 +1,46 @@
 import {hmBlocksToEditorContent} from '@seed-hypermedia/client/hmblock-to-editorblock'
+import {editorBlockToHMBlock} from '@seed-hypermedia/client/editorblock-to-hmblock'
+import type {EditorBlock} from '@seed-hypermedia/client/editor-types'
 import type {HMDocument} from '@seed-hypermedia/client/hm-types'
-import {DocumentChange} from '../client/.generated/documents/v3alpha/documents_pb'
-import {compareBlocksWithMap, createBlocksMap, extractDeletes, getDocAttributeChanges} from './document-changes'
+import {Block, DocumentChange} from '../client/.generated/documents/v3alpha/documents_pb'
+import {createBlocksMap, extractDeletes, getDocAttributeChanges} from './document-changes'
 
 /** Build document changes that restore selected version content and metadata on top of the latest document. */
 export function buildRestoreVersionChanges(latestDocument: HMDocument, selectedVersion: HMDocument): DocumentChange[] {
   const latestBlocksMap = createBlocksMap(latestDocument.content ?? [], '')
   const selectedEditorBlocks = hmBlocksToEditorContent(selectedVersion.content ?? [], {childrenType: 'Group'})
-  const blockDiff = compareBlocksWithMap(latestBlocksMap, selectedEditorBlocks, '')
-  const deleteChanges = extractDeletes(latestBlocksMap, blockDiff.touchedBlocks)
   return [
     ...getDocAttributeChanges(selectedVersion.metadata ?? {}, latestDocument.metadata ?? {}),
-    ...blockDiff.changes,
-    ...deleteChanges,
+    ...extractDeletes(latestBlocksMap, []),
+    ...buildInsertBlockChanges(selectedEditorBlocks, ''),
   ]
+}
+
+/** Returns the existing generation that the restore publish must stay within. */
+export function getRestoreVersionGeneration(latestDocument: HMDocument): number | bigint {
+  const generation = latestDocument.generationInfo?.generation
+  if (generation == null) throw new Error('Could not load the latest document generation')
+  return generation
+}
+
+function buildInsertBlockChanges(blocks: EditorBlock[], parentId: string): DocumentChange[] {
+  return blocks.flatMap((block, index) => [
+    new DocumentChange({
+      op: {
+        case: 'moveBlock',
+        value: {
+          blockId: block.id,
+          leftSibling: index > 0 ? blocks[index - 1]?.id ?? '' : '',
+          parent: parentId,
+        },
+      },
+    }),
+    new DocumentChange({
+      op: {
+        case: 'replaceBlock',
+        value: Block.fromJson(editorBlockToHMBlock(block)),
+      },
+    }),
+    ...buildInsertBlockChanges(block.children, block.id),
+  ])
 }

--- a/frontend/packages/ui/src/__tests__/document-versions-panel.test.ts
+++ b/frontend/packages/ui/src/__tests__/document-versions-panel.test.ts
@@ -1,0 +1,39 @@
+import {hmId} from '@shm/shared/utils/entity-id-url'
+import {describe, expect, it} from 'vitest'
+import {
+  createDocumentVersionsPanelRoute,
+  DOCUMENT_VERSION_EVENT_TYPES,
+  isDocumentVersionsPanelRoute,
+} from '../document-versions-panel'
+
+describe('document versions panel route helpers', () => {
+  it('creates the shared versions panel activity route', () => {
+    const docId = hmId('z-test', {path: ['docs']})
+
+    expect(createDocumentVersionsPanelRoute(docId)).toEqual({
+      key: 'activity',
+      id: docId,
+      filterEventType: ['Ref'],
+    })
+  })
+
+  it('identifies only the versions activity panel route', () => {
+    const docId = hmId('z-test', {path: ['docs']})
+
+    expect(isDocumentVersionsPanelRoute(createDocumentVersionsPanelRoute(docId))).toBe(true)
+    expect(isDocumentVersionsPanelRoute({key: 'activity', id: docId})).toBe(false)
+    expect(isDocumentVersionsPanelRoute({key: 'activity', id: docId, filterEventType: ['Comment']})).toBe(false)
+    expect(isDocumentVersionsPanelRoute({key: 'comments', id: docId})).toBe(false)
+    expect(isDocumentVersionsPanelRoute(null)).toBe(false)
+  })
+
+  it('does not expose a mutable shared filter array through route creation', () => {
+    const docId = hmId('z-test')
+    const route = createDocumentVersionsPanelRoute(docId)
+
+    route.filterEventType?.push('Comment')
+
+    expect(DOCUMENT_VERSION_EVENT_TYPES).toEqual(['Ref'])
+    expect(createDocumentVersionsPanelRoute(docId).filterEventType).toEqual(['Ref'])
+  })
+})

--- a/frontend/packages/ui/src/__tests__/feed.test.ts
+++ b/frontend/packages/ui/src/__tests__/feed.test.ts
@@ -1,5 +1,11 @@
 import {describe, expect, it} from 'vitest'
-import {getDraftVersionInsertIndex, shouldShowDraftVersionEntry} from '../feed'
+import {
+  canShowRestoreVersionButton,
+  getDraftVersionInsertIndex,
+  getLatestDocUpdateVersion,
+  isSelectedDocUpdateVersion,
+  shouldShowDraftVersionEntry,
+} from '../feed'
 
 const draft = {
   docId: {
@@ -41,5 +47,47 @@ describe('draft versions feed helpers', () => {
   it('places drafts without a visible base version at the top', () => {
     expect(getDraftVersionInsertIndex([docUpdate('latest-version')], {...draft, deps: ['missing-base']})).toBe(0)
     expect(getDraftVersionInsertIndex([docUpdate('latest-version')], {...draft, deps: []})).toBe(0)
+  })
+})
+
+describe('version selection helpers', () => {
+  it('uses the newest doc-update event as the latest version for a document feed', () => {
+    expect(getLatestDocUpdateVersion([docUpdate('latest-version'), docUpdate('old-version')])).toBe('latest-version')
+  })
+
+  it('selects the explicit route version', () => {
+    expect(isSelectedDocUpdateVersion('version-1', 'version-1', false, 'version-2')).toBe(true)
+    expect(isSelectedDocUpdateVersion('version-2', 'version-1', false, 'version-2')).toBe(false)
+  })
+
+  it('selects the latest version when the route has no explicit version', () => {
+    expect(isSelectedDocUpdateVersion('latest-version', null, true, 'latest-version')).toBe(true)
+    expect(isSelectedDocUpdateVersion('old-version', null, true, 'latest-version')).toBe(false)
+  })
+})
+
+describe('restore version action helpers', () => {
+  it('allows restore when the provider exposes a selected account and restore action', () => {
+    expect(
+      canShowRestoreVersionButton({
+        isSingleResource: true,
+        selectedAccountUid: 'writer',
+        latestVersion: 'latest-version',
+        eventVersion: 'old-version',
+        hasRestoreAction: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('does not allow restore without a provider-selected account', () => {
+    expect(
+      canShowRestoreVersionButton({
+        isSingleResource: true,
+        selectedAccountUid: undefined,
+        latestVersion: 'latest-version',
+        eventVersion: 'old-version',
+        hasRestoreAction: true,
+      }),
+    ).toBe(false)
   })
 })

--- a/frontend/packages/ui/src/__tests__/resource-page-common.test.ts
+++ b/frontend/packages/ui/src/__tests__/resource-page-common.test.ts
@@ -1,11 +1,21 @@
 import {hmId} from '@shm/shared'
 import {describe, expect, it} from 'vitest'
 import {
+  getDocumentResourceRouteKey,
   getCommentReplyPanelRoute,
   hasUnpublishedDraftForResourceState,
   shouldSuppressMainCommentEditor,
   shouldUseDraftForRenderedDocument,
 } from '../resource-page-common'
+
+describe('getDocumentResourceRouteKey', () => {
+  it('changes when only the document version changes', () => {
+    const latest = hmId('alice', {path: ['doc'], latest: true})
+    const versioned = hmId('alice', {path: ['doc'], version: 'version-1', latest: false})
+
+    expect(getDocumentResourceRouteKey(latest)).not.toBe(getDocumentResourceRouteKey(versioned))
+  })
+})
 
 describe('shouldSuppressMainCommentEditor', () => {
   const docId = hmId('alice', {path: ['doc']})

--- a/frontend/packages/ui/src/document-versions-panel.tsx
+++ b/frontend/packages/ui/src/document-versions-panel.tsx
@@ -1,0 +1,46 @@
+import type {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import type {DocumentPanelRoute} from '@shm/shared/routes'
+import {activityFilterToSlug} from '@shm/shared/utils/entity-id-url'
+import {Feed, type DraftVersionEntry} from './feed'
+
+/** Activity event types that represent document version updates. */
+export const DOCUMENT_VERSION_EVENT_TYPES = ['Ref'] as const
+
+/** Builds the canonical side-panel route for document versions. */
+export function createDocumentVersionsPanelRoute(
+  docId: UnpackedHypermediaId,
+): Extract<DocumentPanelRoute, {key: 'activity'}> {
+  return {
+    key: 'activity',
+    id: docId,
+    filterEventType: [...DOCUMENT_VERSION_EVENT_TYPES],
+  }
+}
+
+/** Returns true when a document panel route is the canonical versions panel route. */
+export function isDocumentVersionsPanelRoute(route: DocumentPanelRoute | null | undefined): boolean {
+  return route?.key === 'activity' && activityFilterToSlug(route.filterEventType) === 'versions'
+}
+
+/** Shared Versions panel UI used by both web and desktop apps. */
+export function DocumentVersionsPanel({
+  docId,
+  targetDomain,
+  size = 'sm',
+  draftVersionEntry,
+}: {
+  docId: UnpackedHypermediaId
+  targetDomain?: string
+  size?: 'sm' | 'md'
+  draftVersionEntry?: DraftVersionEntry
+}) {
+  return (
+    <Feed
+      size={size}
+      filterResource={docId.id}
+      filterEventType={[...DOCUMENT_VERSION_EVENT_TYPES]}
+      targetDomain={targetDomain}
+      draftVersionEntry={draftVersionEntry}
+    />
+  )
+}

--- a/frontend/packages/ui/src/feed.tsx
+++ b/frontend/packages/ui/src/feed.tsx
@@ -1,21 +1,34 @@
-import {useDeleteComment, useHackyAuthorsSubscriptions} from '@shm/shared/comments-service-provider'
 import {HMBlockNode, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {useDeleteComment, useHackyAuthorsSubscriptions} from '@shm/shared/comments-service-provider'
+import {useDocumentActions} from '@shm/shared/document-actions-context'
 import {HMListEventsParams, LoadedCommentEvent, LoadedEvent} from '@shm/shared/models/activity-service'
+import {type DocumentMachineEvent} from '@shm/shared/models/document-machine'
 import {useResource, useSelectedAccountId} from '@shm/shared/models/entity'
+import {useDocumentSend} from '@shm/shared/models/use-document-machine'
+import {useReadOnlyViewer} from '@shm/shared/readonly-viewer-context'
 import {DocumentRoute, NavRoute} from '@shm/shared/routes'
 import {useRouteLink, useUniversalAppContext} from '@shm/shared/routing'
 import {useTx, useTxString} from '@shm/shared/translation'
 import {useActivityFeed} from '@shm/shared/use-activity-feed'
-import {commentIdToHmId, getCommentTargetId, getVersionHeads, hmId} from '@shm/shared/utils/entity-id-url'
+import {commentIdToHmId, getCommentTargetId, getVersionHeads, hmId, latestId} from '@shm/shared/utils/entity-id-url'
 import {useNavRoute} from '@shm/shared/utils/navigation'
 import merge from 'lodash/merge'
-import {CircleAlert, FilePen, Link, Merge, Trash2, X} from 'lucide-react'
-import {Fragment, useEffect, useMemo, useRef} from 'react'
+import {CircleAlert, FilePen, Link, Merge, RotateCcw, Trash2, X} from 'lucide-react'
+import {Fragment, useEffect, useMemo, useRef, useState} from 'react'
 import {SelectionContent} from './accessories'
-import {useReadOnlyViewer} from '@shm/shared/readonly-viewer-context'
 import {Button} from './button'
 import {CommentContent, useDeleteCommentDialog} from './comments'
-import {useCopyHmLink} from './use-copy-hm-link'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from './components/alert-dialog'
 import {HMIcon} from './hm-icon'
 import {ReplyArrow} from './icons'
 import {AuthorNameLink, DocumentNameLink, InlineDescriptor, Timestamp} from './inline-descriptor'
@@ -25,9 +38,8 @@ import {ResourceToken} from './resource-token'
 import {Separator} from './separator'
 import {Spinner} from './spinner'
 import {Tooltip} from './tooltip'
+import {useCopyHmLink} from './use-copy-hm-link'
 import {cn} from './utils'
-import {type DocumentMachineEvent} from '@shm/shared/models/document-machine'
-import {useDocumentSend} from '@shm/shared/models/use-document-machine'
 
 export type DraftVersionEntry = {
   docId: UnpackedHypermediaId
@@ -316,10 +328,16 @@ function EventHeaderContent({
   const tx = useTxString()
   const currentRoute = useNavRoute()
   const currentAccount = useSelectedAccountId()
+  const documentActions = useDocumentActions()
+  const latestDocId = event.type === 'doc-update' ? latestId(event.docId) : null
+  const latestResource = useResource(latestDocId)
+  const latestDocument = latestResource.data?.type === 'document' ? latestResource.data.document : null
   const deleteCommentMutation = useDeleteComment()
   const deleteCommentDialog = useDeleteCommentDialog()
   const copyHmLink = useCopyHmLink()
   const {origin: appOrigin, onPushReference} = useUniversalAppContext()
+  const [restoreDialogOpen, setRestoreDialogOpen] = useState(false)
+  const [isRestoring, setIsRestoring] = useState(false)
   if (event.type == 'comment') {
     const options: MenuItemType[] = []
     if (event.comment && currentAccount && currentAccount == event.comment.author) {
@@ -431,6 +449,63 @@ function EventHeaderContent({
 
   if (event.type == 'doc-update') {
     const docUpdateHeadCount = getVersionHeads(event.document.version).length
+    const isLatestVersion = latestDocument?.version === event.document.version
+    const canRestore = !!(
+      isSingleResource &&
+      currentAccount &&
+      latestDocument &&
+      documentActions.onRestoreDocumentVersion &&
+      !isLatestVersion
+    )
+    const restoreButton = canRestore ? (
+      <AlertDialog open={restoreDialogOpen} onOpenChange={setRestoreDialogOpen}>
+        <AlertDialogTrigger asChild>
+          <Button
+            size="xs"
+            variant="ghost"
+            className="text-muted-foreground hover-hover:opacity-0 hover-hover:group-hover:opacity-100 transition-opacity duration-200 ease-in-out"
+            onClick={(e) => {
+              e.stopPropagation()
+            }}
+          >
+            <RotateCcw className="size-3" />
+            Restore
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent onClick={(e) => e.stopPropagation()}>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Restore this version?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will create a new latest version using this version’s content and metadata. Any current draft for
+              this document will be removed after the restore succeeds.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isRestoring}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={isRestoring}
+              onClick={async (e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                if (!documentActions.onRestoreDocumentVersion) return
+                setIsRestoring(true)
+                try {
+                  await documentActions.onRestoreDocumentVersion(event.docId, event.document)
+                  setRestoreDialogOpen(false)
+                } catch {
+                  // The platform restore action owns user-facing error toasts.
+                } finally {
+                  setIsRestoring(false)
+                }
+              }}
+            >
+              {isRestoring ? 'Restoring…' : 'Restore'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    ) : null
+
     return (
       <div className="flex w-full items-start justify-between gap-2">
         <InlineDescriptor>
@@ -461,35 +536,38 @@ function EventHeaderContent({
             </Tooltip>
           ) : null}
         </InlineDescriptor>
-        <Tooltip content={tx('Copy Link to Version')}>
-          <Button
-            size="icon"
-            variant="ghost"
-            className="text-muted-foreground hover-hover:opacity-0 hover-hover:group-hover:opacity-100 transition-opacity duration-200 ease-in-out"
-            onClick={(e) => {
-              e.preventDefault()
-              e.stopPropagation()
-              if (!event.docId?.uid) return
-              const routeLatest =
-                currentRoute.key === 'document' || currentRoute.key === 'comments' || currentRoute.key === 'activity'
-                  ? currentRoute.id.latest
-                  : undefined
-              const versionedId = hmId(event.docId.uid, {
-                path: event.docId.path,
-                version: event.document.version,
-                latest: routeLatest ?? false,
-                hostname: targetDomain ?? null,
-              })
-              copyHmLink({
-                id: versionedId,
-                gatewayUrl: appOrigin ?? undefined,
-              })
-              onPushReference?.(versionedId)
-            }}
-          >
-            <Link className="size-3" />
-          </Button>
-        </Tooltip>
+        <div className="flex items-center gap-1">
+          {restoreButton}
+          <Tooltip content={tx('Copy Link to Version')}>
+            <Button
+              size="icon"
+              variant="ghost"
+              className="text-muted-foreground hover-hover:opacity-0 hover-hover:group-hover:opacity-100 transition-opacity duration-200 ease-in-out"
+              onClick={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                if (!event.docId?.uid) return
+                const routeLatest =
+                  currentRoute.key === 'document' || currentRoute.key === 'comments' || currentRoute.key === 'activity'
+                    ? currentRoute.id.latest
+                    : undefined
+                const versionedId = hmId(event.docId.uid, {
+                  path: event.docId.path,
+                  version: event.document.version,
+                  latest: routeLatest ?? false,
+                  hostname: targetDomain ?? null,
+                })
+                copyHmLink({
+                  id: versionedId,
+                  gatewayUrl: appOrigin ?? undefined,
+                })
+                onPushReference?.(versionedId)
+              }}
+            >
+              <Link className="size-3" />
+            </Button>
+          </Tooltip>
+        </div>
       </div>
     )
   }

--- a/frontend/packages/ui/src/feed.tsx
+++ b/frontend/packages/ui/src/feed.tsx
@@ -27,7 +27,6 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
 } from './components/alert-dialog'
 import {HMIcon} from './hm-icon'
 import {ReplyArrow} from './icons'
@@ -61,6 +60,39 @@ export function getDraftVersionInsertIndex(events: LoadedEvent[], draft: DraftVe
   const baseVersions = new Set(draft.deps)
   const baseIndex = events.findIndex((event) => event.type === 'doc-update' && baseVersions.has(event.document.version))
   return baseIndex === -1 ? 0 : baseIndex
+}
+
+/** Returns the newest document update version from an activity feed ordered newest-first. */
+export function getLatestDocUpdateVersion(events: LoadedEvent[]) {
+  return events.find((event) => event.type === 'doc-update')?.document.version ?? null
+}
+
+export function isSelectedDocUpdateVersion(
+  eventVersion: string | undefined,
+  routeVersion: string | null | undefined,
+  routeLatest: boolean | null | undefined,
+  latestVersion: string | null | undefined,
+) {
+  if (!eventVersion) return false
+  if (routeVersion) return eventVersion === routeVersion
+  return !!routeLatest && !!latestVersion && eventVersion === latestVersion
+}
+
+export function canShowRestoreVersionButton(input: {
+  isSingleResource?: boolean
+  selectedAccountUid?: string
+  latestVersion?: string | null
+  eventVersion?: string
+  hasRestoreAction?: boolean
+}) {
+  return !!(
+    input.isSingleResource &&
+    input.selectedAccountUid &&
+    input.latestVersion &&
+    input.eventVersion &&
+    input.hasRestoreAction &&
+    input.latestVersion !== input.eventVersion
+  )
 }
 
 export function Feed({
@@ -164,6 +196,7 @@ export function Feed({
   const isSingleResource = filterResource && !filterResource.endsWith('*') ? true : false
   const shouldRenderDraftVersion = shouldShowDraftVersionEntry(filterEventType, draftVersionEntry)
   const draftInsertIndex = shouldRenderDraftVersion ? getDraftVersionInsertIndex(allEvents, draftVersionEntry) : -1
+  const latestDocUpdateVersion = isSingleResource ? getLatestDocUpdateVersion(allEvents) : null
 
   if (error) {
     return (
@@ -211,6 +244,7 @@ export function Feed({
                     route={route}
                     targetDomain={targetDomain}
                     size={size}
+                    latestDocUpdateVersion={latestDocUpdateVersion}
                   />
                   <Separator />
                 </div>
@@ -230,6 +264,7 @@ export function Feed({
                   route={route}
                   targetDomain={targetDomain}
                   size={size}
+                  latestDocUpdateVersion={latestDocUpdateVersion}
                 />
                 <Separator />
               </div>
@@ -319,11 +354,13 @@ function EventHeaderContent({
   targetDomain,
   isSingleResource,
   route,
+  latestDocUpdateVersion,
 }: {
   event: LoadedEvent
   targetDomain?: string
   isSingleResource?: boolean
   route?: NavRoute | null
+  latestDocUpdateVersion?: string | null
 }) {
   const tx = useTxString()
   const currentRoute = useNavRoute()
@@ -332,6 +369,7 @@ function EventHeaderContent({
   const latestDocId = event.type === 'doc-update' ? latestId(event.docId) : null
   const latestResource = useResource(latestDocId)
   const latestDocument = latestResource.data?.type === 'document' ? latestResource.data.document : null
+  const latestVersion = latestDocUpdateVersion ?? latestDocument?.version
   const deleteCommentMutation = useDeleteComment()
   const deleteCommentDialog = useDeleteCommentDialog()
   const copyHmLink = useCopyHmLink()
@@ -449,29 +487,30 @@ function EventHeaderContent({
 
   if (event.type == 'doc-update') {
     const docUpdateHeadCount = getVersionHeads(event.document.version).length
-    const isLatestVersion = latestDocument?.version === event.document.version
-    const canRestore = !!(
-      isSingleResource &&
-      currentAccount &&
-      latestDocument &&
-      documentActions.onRestoreDocumentVersion &&
-      !isLatestVersion
-    )
+    const canRestore = canShowRestoreVersionButton({
+      isSingleResource,
+      selectedAccountUid: documentActions.selectedAccountUid,
+      latestVersion,
+      eventVersion: event.document.version,
+      hasRestoreAction: !!documentActions.onRestoreDocumentVersion,
+    })
     const restoreButton = canRestore ? (
       <AlertDialog open={restoreDialogOpen} onOpenChange={setRestoreDialogOpen}>
-        <AlertDialogTrigger asChild>
+        <Tooltip content="Restore">
           <Button
-            size="xs"
+            aria-label="Restore"
+            size="icon"
             variant="ghost"
             className="text-muted-foreground hover-hover:opacity-0 hover-hover:group-hover:opacity-100 transition-opacity duration-200 ease-in-out"
             onClick={(e) => {
+              e.preventDefault()
               e.stopPropagation()
+              setRestoreDialogOpen(true)
             }}
           >
             <RotateCcw className="size-3" />
-            Restore
           </Button>
-        </AlertDialogTrigger>
+        </Tooltip>
         <AlertDialogContent onClick={(e) => e.stopPropagation()}>
           <AlertDialogHeader>
             <AlertDialogTitle>Restore this version?</AlertDialogTitle>
@@ -741,12 +780,14 @@ function EventCommentWithReply({
   targetDomain,
   isSingleResource,
   size,
+  latestDocUpdateVersion,
 }: {
   event: LoadedCommentEvent
   route: NavRoute | null
   targetDomain?: string
   isSingleResource?: boolean
   size?: 'sm' | 'md'
+  latestDocUpdateVersion?: string | null
 }) {
   const linkProps = useRouteLink(route)
   const tx = useTx()
@@ -816,6 +857,7 @@ function EventCommentWithReply({
           event={event}
           targetDomain={targetDomain}
           route={route}
+          latestDocUpdateVersion={latestDocUpdateVersion}
         />
       </div>
       <div className="relative flex gap-2">
@@ -975,25 +1017,32 @@ function EventItem({
   targetDomain,
   isSingleResource,
   size,
+  latestDocUpdateVersion,
 }: {
   event: LoadedEvent
   route: NavRoute | null
   targetDomain?: string
   isSingleResource?: boolean
   size?: 'sm' | 'md'
+  latestDocUpdateVersion?: string | null
 }) {
   const currentRoute = useNavRoute()
   const linkProps = useRouteLink(route ? merge({}, currentRoute, route) : currentRoute)
+  const latestDocId = event.type === 'doc-update' ? latestId(event.docId) : null
+  const latestResource = useResource(latestDocId)
+  const latestDocument = latestResource.data?.type === 'document' ? latestResource.data.document : null
+  const latestVersion = latestDocUpdateVersion ?? latestDocument?.version
+  const routeId = currentRoute.key === 'document' ? currentRoute.id : null
+  const isSelectedVersion =
+    event.type === 'doc-update' &&
+    isSelectedDocUpdateVersion(event.document.version, routeId?.version, routeId?.latest, latestVersion)
 
   const tx = useTx()
   return (
     <div
       className={cn(
         'hover:bg-background group flex flex-col gap-2 px-4 py-4 transition-colors dark:hover:bg-black/10',
-        currentRoute.key == 'document' &&
-          event.type == 'doc-update' &&
-          event.docId.version == currentRoute.id.version &&
-          'bg-accent hover:bg-accent dark:hover:bg-accent',
+        isSelectedVersion && 'bg-accent hover:bg-accent dark:hover:bg-accent',
       )}
       {...(route ? linkProps : {})}
     >
@@ -1008,7 +1057,12 @@ function EventItem({
             />
           ) : null}
         </div>
-        <EventHeaderContent event={event} targetDomain={targetDomain} isSingleResource={isSingleResource} />
+        <EventHeaderContent
+          event={event}
+          targetDomain={targetDomain}
+          isSingleResource={isSingleResource}
+          latestDocUpdateVersion={latestDocUpdateVersion}
+        />
       </div>
       {isSingleResource && event.type == 'doc-update' ? null : (
         <div className="relative flex gap-2">

--- a/frontend/packages/ui/src/newspaper.tsx
+++ b/frontend/packages/ui/src/newspaper.tsx
@@ -30,6 +30,7 @@ import {
 import {HTMLAttributes, useMemo} from 'react'
 import {Button} from './button'
 import {copyUrlToClipboardWithFeedback} from './copy-to-clipboard'
+import {createDocumentVersionsPanelRoute} from './document-versions-panel'
 import {DraftBadge} from './draft-badge'
 import {FacePile} from './face-pile'
 import {useImageUrl} from './get-file-url'
@@ -78,7 +79,7 @@ export function useDocumentCardMenuItems(
         navigate({
           key: 'document',
           id: docId,
-          panel: {key: 'activity', id: docId, filterEventType: ['Ref']},
+          panel: createDocumentVersionsPanelRoute(docId),
         } as any)
       },
     })

--- a/frontend/packages/ui/src/panel-layout.tsx
+++ b/frontend/packages/ui/src/panel-layout.tsx
@@ -24,6 +24,8 @@ export interface PanelLayoutProps {
   panelContent: React.ReactNode | null
   panelKey: PanelSelectionOptions | null
   onPanelClose: () => void
+  /** True when the activity panel is being used as the shared versions panel. */
+  isVersionsPanel?: boolean
   /** For activity panel: current filter state */
   filterEventType?: string[]
   /** For activity panel: filter change handler */
@@ -61,6 +63,7 @@ export function PanelLayout({
   panelContent,
   panelKey,
   onPanelClose,
+  isVersionsPanel = false,
   filterEventType,
   onFilterChange,
   widthStorage,
@@ -94,7 +97,7 @@ export function PanelLayout({
     prevPanelKey.current = panelKey
   }, [panelKey, onPanelWidthChange])
 
-  const title = getPanelTitle(panelKey)
+  const title = isVersionsPanel ? 'Document Versions' : getPanelTitle(panelKey)
 
   return (
     <div ref={containerRef} className="flex h-full flex-1">
@@ -132,7 +135,7 @@ export function PanelLayout({
                         <X className="size-4" />
                       </Button>
                     </div>
-                    {panelKey === 'activity' && onFilterChange && (
+                    {panelKey === 'activity' && !isVersionsPanel && onFilterChange && (
                       <FeedFilters filterEventType={filterEventType} onFilterChange={onFilterChange} />
                     )}
                   </div>

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -80,6 +80,7 @@ import {DiscussionsPageContent} from './discussions-page'
 import {DocumentCover} from './document-cover'
 import {AuthorPayload, BreadcrumbEntry, Breadcrumbs, DocumentHeader} from './document-header'
 import {DocumentTools} from './document-tools'
+import {DocumentVersionsPanel, isDocumentVersionsPanelRoute} from './document-versions-panel'
 import {Feed, type DraftVersionEntry} from './feed'
 import {FeedFilters} from './feed-filters'
 import {useDocumentLayout} from './layout'
@@ -115,6 +116,11 @@ const LazyDocumentMachineDebugDrawer = lazy(() =>
 function extractPanelRoute(route: NavRoute): DocumentPanelRoute {
   const {panel, width, ...params} = route as any
   return params as DocumentPanelRoute
+}
+
+/** Returns a stable key for the exact document resource being viewed, including version state. */
+export function getDocumentResourceRouteKey(id: UnpackedHypermediaId): string {
+  return `${id.id}@${id.version ?? ''}@${id.latest ? 'latest' : ''}`
 }
 
 export type ActiveView =
@@ -479,11 +485,12 @@ export function ResourcePage({
   // returns below would unmount DocumentBody and destroy the XState actor on each blip.
   // Reset on route changes so a newly-created local draft never reuses the parent
   // document while its draft record is resolving.
-  const lastGoodRouteIdRef = useRef(docId.id)
+  const documentResourceRouteKey = getDocumentResourceRouteKey(docId)
+  const lastGoodRouteIdRef = useRef(documentResourceRouteKey)
   const hasEverLoadedRef = useRef(false)
   const lastGoodDocumentRef = useRef<HMDocument | null>(null)
-  if (lastGoodRouteIdRef.current !== docId.id) {
-    lastGoodRouteIdRef.current = docId.id
+  if (lastGoodRouteIdRef.current !== documentResourceRouteKey) {
+    lastGoodRouteIdRef.current = documentResourceRouteKey
     hasEverLoadedRef.current = false
     lastGoodDocumentRef.current = null
   }
@@ -2041,6 +2048,7 @@ function DocumentBody({
         panelKey={panelKey}
         panelContent={panelContent}
         onPanelClose={handlePanelClose}
+        isVersionsPanel={isDocumentVersionsPanelRoute(panelRoute)}
         filterEventType={panelRoute?.key === 'activity' ? panelRoute.filterEventType : undefined}
         onFilterChange={handleFilterChange}
       >
@@ -2263,6 +2271,11 @@ function PanelContentRenderer({
     case 'options':
       return <DocumentOptionsPanel docId={docId} fileUpload={fileUpload} />
     case 'activity':
+      if (isDocumentVersionsPanelRoute(panelRoute)) {
+        return (
+          <DocumentVersionsPanel size="sm" docId={docId} targetDomain={siteUrl} draftVersionEntry={draftVersionEntry} />
+        )
+      }
       return (
         <Feed
           size="sm"
@@ -2533,6 +2546,18 @@ function MainContent({
       )
 
     case 'activity':
+      if (activityFilterToSlug(activityFilterEventType) === 'versions') {
+        return (
+          <PageLayout contentMaxWidth={contentMaxWidth}>
+            <DocumentVersionsPanel
+              size="md"
+              docId={docId}
+              targetDomain={siteUrl}
+              draftVersionEntry={draftVersionEntry}
+            />
+          </PageLayout>
+        )
+      }
       return (
         <PageLayout contentMaxWidth={contentMaxWidth}>
           {activityFilterToSlug(activityFilterEventType) !== 'citations' && (


### PR DESCRIPTION
## Summary
- Add a restore action to document version history so older versions can be republished as the latest version.
- Support restore flows on both desktop and web, including permission handling, cache invalidation, navigation, and draft cleanup after a successful restore.
- Add shared restore change generation for document content and metadata, with tests covering metadata restoration and web restore publishing behavior.