### PR TITLE
feat(query-block): add author filters

### DIFF
--- a/docs/query-block-filters.md
+++ b/docs/query-block-filters.md
@@ -1,0 +1,50 @@
+# Query Block Filters
+
+## Problem
+
+Query blocks can choose a directory, traversal mode, sort, and limit, but cannot narrow results by document attributes.
+The immediate need is filtering a query block to documents where a given account is one of the document authors. A
+similar stored filter model should also support publish-date filtering without redesigning the query shape.
+
+## Solution
+
+Store filters on the query object as `query.filters`, a sibling to `includes`, `sort`, and `limit`:
+
+```ts
+{
+  includes: [{space, path, mode}],
+  sort: [{term: 'UpdateTime', reverse: false}],
+  limit: 10,
+  filters: [
+    {type: 'Author', uid: '<account-id>'},
+    {type: 'PublishDate', from: '2024-01-01', to: '2024-12-31'},
+  ],
+}
+```
+
+The shared query resolver fetches the directory, applies filters, then sorts and limits results. Author filters match if
+any stored author UID equals the requested UID. Publish-date filters use `metadata.displayPublishTime` when available
+and fall back to `updateTime`.
+
+## Scope
+
+- Add `HMQueryFilter` schema/type support for `Author` and `PublishDate` filters.
+- Persist filters through query block editor props and HM block conversion.
+- Add editor controls for multi-select author account autocomplete by profile name and publish-date range.
+- Apply filters in shared query block resolution before sorting and limiting.
+- Cover persistence and resolver behavior with tests.
+
+## Rabbit Holes
+
+- Server-side filtering in `ListDirectory` for pagination-scale efficiency.
+- Multi-include query semantics.
+- Rich account picker/autocomplete for author selection.
+- More date modes, such as create time, update time, activity time, or exact publication timestamp source selection.
+- Complex boolean logic UI for nested AND/OR groups.
+
+## No Gos
+
+- Do not place filters inside `includes[]`; include entries remain only `{space, path, mode}`.
+- Do not add one-off top-level fields like `authorFilter`; use the generic `filters` array.
+- Do not store author profile names in filters; store selected account IDs only.
+- Do not change backend proto/API in this iteration unless query block pagination requires server-side filtering later.

--- a/docs/query-block-filters.md
+++ b/docs/query-block-filters.md
@@ -3,8 +3,7 @@
 ## Problem
 
 Query blocks can choose a directory, traversal mode, sort, and limit, but cannot narrow results by document attributes.
-The immediate need is filtering a query block to documents where a given account is one of the document authors. A
-similar stored filter model should also support publish-date filtering without redesigning the query shape.
+The immediate need is filtering a query block to documents where a given account is one of the document authors.
 
 ## Solution
 
@@ -17,20 +16,18 @@ Store filters on the query object as `query.filters`, a sibling to `includes`, `
   limit: 10,
   filters: [
     {type: 'Author', uid: '<account-id>'},
-    {type: 'PublishDate', from: '2024-01-01', to: '2024-12-31'},
   ],
 }
 ```
 
 The shared query resolver fetches the directory, applies filters, then sorts and limits results. Author filters match if
-any stored author UID equals the requested UID. Publish-date filters use `metadata.displayPublishTime` when available
-and fall back to `updateTime`.
+any stored author UID equals one of the requested account IDs.
 
 ## Scope
 
-- Add `HMQueryFilter` schema/type support for `Author` and `PublishDate` filters.
+- Add `HMQueryFilter` schema/type support for `Author` filters.
 - Persist filters through query block editor props and HM block conversion.
-- Add editor controls for multi-select author account autocomplete by profile name and publish-date range.
+- Add editor controls for multi-select author account autocomplete by profile name.
 - Apply filters in shared query block resolution before sorting and limiting.
 - Cover persistence and resolver behavior with tests.
 
@@ -39,7 +36,7 @@ and fall back to `updateTime`.
 - Server-side filtering in `ListDirectory` for pagination-scale efficiency.
 - Multi-include query semantics.
 - Rich account picker/autocomplete for author selection.
-- More date modes, such as create time, update time, activity time, or exact publication timestamp source selection.
+- Date filters, such as publish time, create time, update time, activity time, or exact timestamp source selection.
 - Complex boolean logic UI for nested AND/OR groups.
 
 ## No Gos

--- a/frontend/apps/desktop/src/editor/query-block.tsx
+++ b/frontend/apps/desktop/src/editor/query-block.tsx
@@ -13,7 +13,7 @@ import {NavRoute} from '@shm/shared/routes'
 import {hmId} from '@shm/shared/utils/entity-id-url'
 import {Button} from '@shm/ui/button'
 import {Input} from '@shm/ui/components/input'
-import {Field, SelectField, SwitchField} from '@shm/ui/form-fields'
+import {SelectField, SwitchField} from '@shm/ui/form-fields'
 import {Pencil, Search, Trash} from '@shm/ui/icons'
 import {useQueryBlockFrontendPerf} from '@shm/ui/query-block-frontend-perf'
 import {LazyViewportMount} from '@shm/ui/lazy-viewport-mount'
@@ -94,7 +94,7 @@ function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
   }, [block.props.querySort])
 
   const queryFilters: HMQueryBlockFilters = useMemo(() => {
-    return JSON.parse(block.props.queryFilters || defaultQueryFilters)
+    return parseQueryFilters(block.props.queryFilters)
   }, [block.props.queryFilters])
 
   const banner = useMemo(() => {
@@ -254,6 +254,16 @@ type HMQueryBlockIncludes = HMBlockQuery['attributes']['query']['includes']
 type HMQueryBlockSort = NonNullable<HMBlockQuery['attributes']['query']['sort']>
 type HMQueryBlockFilters = NonNullable<HMBlockQuery['attributes']['query']['filters']>
 
+function parseQueryFilters(rawFilters: string | undefined): HMQueryBlockFilters {
+  return JSON.parse(rawFilters || defaultQueryFilters).filter(
+    (filter: unknown) =>
+      filter &&
+      typeof filter === 'object' &&
+      (filter as {type?: unknown}).type === 'Author' &&
+      typeof (filter as {uid?: unknown}).uid === 'string',
+  )
+}
+
 function QuerySettings({
   queryDocName = '',
   block,
@@ -294,32 +304,21 @@ function QuerySettings({
   }, [block.props.defaultOpen])
 
   const authorFilters = queryFilters.filter((filter) => filter.type === 'Author')
-  const publishDateFilter = queryFilters.find((filter) => filter.type === 'PublishDate')
 
   const saveFilters = (filters: HMQueryBlockFilters) => {
-    onValuesChange({
-      id: null,
-      props: {
-        ...block.props,
-        queryFilters: JSON.stringify(filters),
-      },
+    const queryFilters = JSON.stringify(filters)
+    queueMicrotask(() => {
+      onValuesChange({
+        id: null,
+        props: {
+          queryFilters,
+        } as EditorQueryBlock['props'],
+      })
     })
   }
 
   const updateAuthorFilters = (uids: string[]) => {
-    const otherFilters = queryFilters.filter((filter) => filter.type !== 'Author')
-    saveFilters([...otherFilters, ...uids.map((uid) => ({type: 'Author' as const, uid}))] as HMQueryBlockFilters)
-  }
-
-  const updatePublishDateFilter = (dates: {from?: string; to?: string}) => {
-    const otherFilters = queryFilters.filter((filter) => filter.type !== 'PublishDate')
-    const nextFilter = {
-      type: 'PublishDate' as const,
-      from: dates.from ?? publishDateFilter?.from,
-      to: dates.to ?? publishDateFilter?.to,
-    }
-    const hasDate = !!nextFilter.from?.trim() || !!nextFilter.to?.trim()
-    saveFilters((hasDate ? [...otherFilters, nextFilter] : otherFilters) as HMQueryBlockFilters)
+    saveFilters(uids.map((uid) => ({type: 'Author' as const, uid})))
   }
 
   return (
@@ -416,23 +415,6 @@ function QuerySettings({
                 selectedUids={authorFilters.map((filter) => filter.uid)}
                 onSelectedUidsChange={updateAuthorFilters}
               />
-
-              <div className="flex gap-2">
-                <Field id={`query-publish-from-${block.id}`} label="Publish from">
-                  <Input
-                    type="date"
-                    value={publishDateFilter?.from ?? ''}
-                    onChangeText={(from) => updatePublishDateFilter({from})}
-                  />
-                </Field>
-                <Field id={`query-publish-to-${block.id}`} label="Publish to">
-                  <Input
-                    type="date"
-                    value={publishDateFilter?.to ?? ''}
-                    onChangeText={(to) => updatePublishDateFilter({to})}
-                  />
-                </Field>
-              </div>
 
               <SelectField
                 value={block.props.style}

--- a/frontend/apps/desktop/src/editor/query-block.tsx
+++ b/frontend/apps/desktop/src/editor/query-block.tsx
@@ -13,7 +13,7 @@ import {NavRoute} from '@shm/shared/routes'
 import {hmId} from '@shm/shared/utils/entity-id-url'
 import {Button} from '@shm/ui/button'
 import {Input} from '@shm/ui/components/input'
-import {SelectField, SwitchField} from '@shm/ui/form-fields'
+import {Field, SelectField, SwitchField} from '@shm/ui/form-fields'
 import {Pencil, Search, Trash} from '@shm/ui/icons'
 import {useQueryBlockFrontendPerf} from '@shm/ui/query-block-frontend-perf'
 import {LazyViewportMount} from '@shm/ui/lazy-viewport-mount'
@@ -26,9 +26,11 @@ import {Fragment} from '@tiptap/pm/model'
 import {NodeSelection, TextSelection} from 'prosemirror-state'
 import {FocusEvent, Profiler, useCallback, useEffect, useMemo, useState} from 'react'
 import {HMBlockSchema} from './schema'
+import {QueryAccountFilterInput} from '@shm/editor/query-account-filter-input'
 
 const defaultQueryIncludes = '[{"space":"","path":"","mode":"Children"}]'
 const defaultQuerySort = '[{"term":"UpdateTime","reverse":false}]'
+const defaultQueryFilters = '[]'
 
 export const QueryBlock = createReactBlockSpec({
   type: 'query',
@@ -49,6 +51,9 @@ export const QueryBlock = createReactBlockSpec({
     },
     querySort: {
       default: defaultQuerySort,
+    },
+    queryFilters: {
+      default: defaultQueryFilters,
     },
     banner: {
       default: 'false',
@@ -88,6 +93,10 @@ function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
     return JSON.parse(block.props.querySort || defaultQuerySort)
   }, [block.props.querySort])
 
+  const queryFilters: HMQueryBlockFilters = useMemo(() => {
+    return JSON.parse(block.props.queryFilters || defaultQueryFilters)
+  }, [block.props.queryFilters])
+
   const banner = useMemo(() => {
     return Boolean(block.props.banner == 'true')
   }, [block.props.banner])
@@ -103,9 +112,10 @@ function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
         includes: queryIncludes,
         sort: querySort,
         limit: queryLimit,
+        filters: queryFilters,
       },
     }
-  }, [queryIncludes, querySort, queryLimit])
+  }, [queryIncludes, querySort, queryLimit, queryFilters])
   const queryBlock = useQuery(queryQueryBlock(client, queryBlockInput))
   const sortedItems = queryBlock.data?.results ?? []
 
@@ -184,7 +194,7 @@ function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
         queryDocName={queryBlock.data?.queryTargetName || ''}
         queryIncludes={queryIncludes}
         querySort={querySort}
-        style={block.props.style as 'Card' | 'List'}
+        queryFilters={queryFilters}
         banner={banner}
         // @ts-expect-error
         block={block}
@@ -242,6 +252,7 @@ function BlankQueryBlockMessage({message}: {message: string}) {
 
 type HMQueryBlockIncludes = HMBlockQuery['attributes']['query']['includes']
 type HMQueryBlockSort = NonNullable<HMBlockQuery['attributes']['query']['sort']>
+type HMQueryBlockFilters = NonNullable<HMBlockQuery['attributes']['query']['filters']>
 
 function QuerySettings({
   queryDocName = '',
@@ -249,6 +260,7 @@ function QuerySettings({
   onValuesChange,
   queryIncludes,
   querySort,
+  queryFilters,
   editor,
   banner,
 }: {
@@ -256,6 +268,7 @@ function QuerySettings({
   block: EditorQueryBlock
   queryIncludes: HMQueryBlockIncludes
   querySort: HMQueryBlockSort
+  queryFilters: HMQueryBlockFilters
   banner: boolean
   onValuesChange: ({id, props}: {id: UnpackedHypermediaId | null; props: EditorQueryBlock['props']}) => void
   editor: BlockNoteEditor<HMBlockSchema>
@@ -267,16 +280,47 @@ function QuerySettings({
   useEffect(() => {
     // @ts-expect-error
     if (block.props.defaultOpen === 'true') {
-      editor.updateBlock(block.id, {
-        ...block,
-        // @ts-expect-error
-        props: {...block.props, defaultOpen: 'false'},
+      queueMicrotask(() => {
+        editor.updateBlock(block.id, {
+          ...block,
+          // @ts-expect-error
+          props: {...block.props, defaultOpen: 'false'},
+        })
       })
     }
     {
     }
     // @ts-expect-error
   }, [block.props.defaultOpen])
+
+  const authorFilters = queryFilters.filter((filter) => filter.type === 'Author')
+  const publishDateFilter = queryFilters.find((filter) => filter.type === 'PublishDate')
+
+  const saveFilters = (filters: HMQueryBlockFilters) => {
+    onValuesChange({
+      id: null,
+      props: {
+        ...block.props,
+        queryFilters: JSON.stringify(filters),
+      },
+    })
+  }
+
+  const updateAuthorFilters = (uids: string[]) => {
+    const otherFilters = queryFilters.filter((filter) => filter.type !== 'Author')
+    saveFilters([...otherFilters, ...uids.map((uid) => ({type: 'Author' as const, uid}))] as HMQueryBlockFilters)
+  }
+
+  const updatePublishDateFilter = (dates: {from?: string; to?: string}) => {
+    const otherFilters = queryFilters.filter((filter) => filter.type !== 'PublishDate')
+    const nextFilter = {
+      type: 'PublishDate' as const,
+      from: dates.from ?? publishDateFilter?.from,
+      to: dates.to ?? publishDateFilter?.to,
+    }
+    const hasDate = !!nextFilter.from?.trim() || !!nextFilter.to?.trim()
+    saveFilters((hasDate ? [...otherFilters, nextFilter] : otherFilters) as HMQueryBlockFilters)
+  }
 
   return (
     <>
@@ -367,6 +411,28 @@ function QuerySettings({
                   },
                 ]}
               />
+
+              <QueryAccountFilterInput
+                selectedUids={authorFilters.map((filter) => filter.uid)}
+                onSelectedUidsChange={updateAuthorFilters}
+              />
+
+              <div className="flex gap-2">
+                <Field id={`query-publish-from-${block.id}`} label="Publish from">
+                  <Input
+                    type="date"
+                    value={publishDateFilter?.from ?? ''}
+                    onChangeText={(from) => updatePublishDateFilter({from})}
+                  />
+                </Field>
+                <Field id={`query-publish-to-${block.id}`} label="Publish to">
+                  <Input
+                    type="date"
+                    value={publishDateFilter?.to ?? ''}
+                    onChangeText={(to) => updatePublishDateFilter({to})}
+                  />
+                </Field>
+              </div>
 
               <SelectField
                 value={block.props.style}

--- a/frontend/apps/desktop/src/models/blocks.ts
+++ b/frontend/apps/desktop/src/models/blocks.ts
@@ -143,6 +143,9 @@ function isQueryEqual(q1?: HMQuery, q2?: HMQuery): boolean {
   // Compare sorting arrays
   if (!isEqual(q1.sort || [], q2.sort || [])) return false
 
+  // Compare filters arrays
+  if (!isEqual(q1.filters || [], q2.filters || [])) return false
+
   // Compare includes arrays
   if (q1.includes.length !== q2.includes.length) return false
 

--- a/frontend/packages/client/src/blocks-to-markdown.ts
+++ b/frontend/packages/client/src/blocks-to-markdown.ts
@@ -620,12 +620,14 @@ async function resolveQuery(block: HMBlock, depth: number, ctx: ResolveContext):
       | {
           includes?: Array<{space: string; path?: string; mode?: string}>
           sort?: Array<{term: SortTerm; reverse?: boolean}>
+          filters?: Array<{type: 'Author'; uid: string} | {type: 'PublishDate'; from?: string; to?: string}>
           limit?: number
         }
       | undefined
 
     let includes: Array<{space: string; path?: string; mode: 'Children' | 'AllDescendants'}>
     let sort: Array<{term: SortTerm; reverse: boolean}> | undefined
+    let filters: Array<{type: 'Author'; uid: string} | {type: 'PublishDate'; from?: string; to?: string}> | undefined
     let limit: number | undefined
 
     if (queryConfig?.includes) {
@@ -635,6 +637,7 @@ async function resolveQuery(block: HMBlock, depth: number, ctx: ResolveContext):
         mode: (inc.mode as 'Children' | 'AllDescendants') || 'Children',
       }))
       sort = queryConfig.sort?.map((s) => ({term: s.term, reverse: s.reverse ?? false}))
+      filters = queryConfig.filters
       limit = queryConfig.limit
     } else {
       const space = (attrs?.space as string) || ''
@@ -652,6 +655,7 @@ async function resolveQuery(block: HMBlock, depth: number, ctx: ResolveContext):
     const results = await ctx.client.request('Query', {
       includes,
       sort: sort || [{term: 'UpdateTime', reverse: true}],
+      filters,
       limit: limit || 10,
     })
 

--- a/frontend/packages/client/src/blocks-to-markdown.ts
+++ b/frontend/packages/client/src/blocks-to-markdown.ts
@@ -620,14 +620,14 @@ async function resolveQuery(block: HMBlock, depth: number, ctx: ResolveContext):
       | {
           includes?: Array<{space: string; path?: string; mode?: string}>
           sort?: Array<{term: SortTerm; reverse?: boolean}>
-          filters?: Array<{type: 'Author'; uid: string} | {type: 'PublishDate'; from?: string; to?: string}>
+          filters?: Array<{type: 'Author'; uid: string}>
           limit?: number
         }
       | undefined
 
     let includes: Array<{space: string; path?: string; mode: 'Children' | 'AllDescendants'}>
     let sort: Array<{term: SortTerm; reverse: boolean}> | undefined
-    let filters: Array<{type: 'Author'; uid: string} | {type: 'PublishDate'; from?: string; to?: string}> | undefined
+    let filters: Array<{type: 'Author'; uid: string}> | undefined
     let limit: number | undefined
 
     if (queryConfig?.includes) {

--- a/frontend/packages/client/src/editor-types.ts
+++ b/frontend/packages/client/src/editor-types.ts
@@ -144,6 +144,7 @@ export type EditorQueryBlock = EditorBaseBlock & {
     queryLimit?: string
     queryIncludes?: string
     querySort?: string
+    queryFilters?: string
     banner?: 'true' | 'false'
   }
   content: Array<HMInlineContent>

--- a/frontend/packages/client/src/editorblock-to-hmblock.ts
+++ b/frontend/packages/client/src/editorblock-to-hmblock.ts
@@ -255,7 +255,15 @@ export function editorBlockToHMBlock(editorBlock: EditorBlock): HMBlock {
     }
     if (editorBlock.props.queryIncludes) query.includes = JSON.parse(editorBlock.props.queryIncludes)
     if (editorBlock.props.querySort) query.sort = JSON.parse(editorBlock.props.querySort)
-    if (editorBlock.props.queryFilters) query.filters = JSON.parse(editorBlock.props.queryFilters)
+    if (editorBlock.props.queryFilters) {
+      query.filters = JSON.parse(editorBlock.props.queryFilters).filter(
+        (filter: unknown) =>
+          filter &&
+          typeof filter === 'object' &&
+          (filter as {type?: unknown}).type === 'Author' &&
+          typeof (filter as {uid?: unknown}).uid === 'string',
+      )
+    }
     if (editorBlock.props.queryLimit) query.limit = Number(editorBlock.props.queryLimit)
     blockQuery.attributes.query = query
     blockQuery.attributes.banner = editorBlock.props.banner == 'true'

--- a/frontend/packages/client/src/editorblock-to-hmblock.ts
+++ b/frontend/packages/client/src/editorblock-to-hmblock.ts
@@ -249,12 +249,13 @@ export function editorBlockToHMBlock(editorBlock: EditorBlock): HMBlock {
   if (blockQuery && editorBlock.type == 'query') {
     blockQuery.attributes.style = editorBlock.props.style
     blockQuery.attributes.columnCount = Number(editorBlock.props.columnCount)
-    const query: {includes: unknown[]; sort: unknown[]; limit?: number} = {
+    const query: {includes: unknown[]; sort: unknown[]; filters?: unknown[]; limit?: number} = {
       includes: [],
       sort: [],
     }
     if (editorBlock.props.queryIncludes) query.includes = JSON.parse(editorBlock.props.queryIncludes)
     if (editorBlock.props.querySort) query.sort = JSON.parse(editorBlock.props.querySort)
+    if (editorBlock.props.queryFilters) query.filters = JSON.parse(editorBlock.props.queryFilters)
     if (editorBlock.props.queryLimit) query.limit = Number(editorBlock.props.queryLimit)
     blockQuery.attributes.query = query
     blockQuery.attributes.banner = editorBlock.props.banner == 'true'

--- a/frontend/packages/client/src/hm-types.ts
+++ b/frontend/packages/client/src/hm-types.ts
@@ -746,13 +746,19 @@ export const HMQueryFilterSchema = z.discriminatedUnion('type', [
     type: z.literal('Author'),
     uid: z.string(),
   }),
-  z.object({
-    type: z.literal('PublishDate'),
-    from: z.string().optional(),
-    to: z.string().optional(),
-  }),
 ])
 export type HMQueryFilter = z.infer<typeof HMQueryFilterSchema>
+
+function removeUnsupportedQueryFilters(val: unknown) {
+  if (!Array.isArray(val)) return val
+  return val.filter(
+    (filter) =>
+      filter &&
+      typeof filter === 'object' &&
+      (filter as {type?: unknown}).type === 'Author' &&
+      typeof (filter as {uid?: unknown}).uid === 'string',
+  )
+}
 
 export const HMQuerySchema = z.object({
   includes: z.array(HMQueryInclusionSchema),
@@ -761,7 +767,7 @@ export const HMQuerySchema = z.object({
     (val) => (val === '' || val === null || val === undefined ? undefined : val),
     z.coerce.number().optional(),
   ),
-  filters: z.array(HMQueryFilterSchema).optional(),
+  filters: z.preprocess(removeUnsupportedQueryFilters, z.array(HMQueryFilterSchema).optional()),
 })
 export type HMQuery = z.infer<typeof HMQuerySchema>
 

--- a/frontend/packages/client/src/hm-types.ts
+++ b/frontend/packages/client/src/hm-types.ts
@@ -741,6 +741,19 @@ export const HMQuerySortSchema = z.object({
 })
 export type HMQuerySort = z.infer<typeof HMQuerySortSchema>
 
+export const HMQueryFilterSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('Author'),
+    uid: z.string(),
+  }),
+  z.object({
+    type: z.literal('PublishDate'),
+    from: z.string().optional(),
+    to: z.string().optional(),
+  }),
+])
+export type HMQueryFilter = z.infer<typeof HMQueryFilterSchema>
+
 export const HMQuerySchema = z.object({
   includes: z.array(HMQueryInclusionSchema),
   sort: z.array(HMQuerySortSchema).optional(),
@@ -748,6 +761,7 @@ export const HMQuerySchema = z.object({
     (val) => (val === '' || val === null || val === undefined ? undefined : val),
     z.coerce.number().optional(),
   ),
+  filters: z.array(HMQueryFilterSchema).optional(),
 })
 export type HMQuery = z.infer<typeof HMQuerySchema>
 

--- a/frontend/packages/client/src/hmblock-to-editorblock.ts
+++ b/frontend/packages/client/src/hmblock-to-editorblock.ts
@@ -164,7 +164,15 @@ export function hmBlockToEditorBlock(block: HMBlock): EditorBlock {
     queryProps.columnCount = String(block.attributes?.columnCount || '')
     queryProps.queryIncludes = JSON.stringify(block.attributes?.query?.includes || [])
     queryProps.querySort = JSON.stringify(block.attributes?.query?.sort || {})
-    queryProps.queryFilters = JSON.stringify(block.attributes?.query?.filters || [])
+    queryProps.queryFilters = JSON.stringify(
+      (block.attributes?.query?.filters || []).filter(
+        (filter: unknown) =>
+          filter &&
+          typeof filter === 'object' &&
+          (filter as {type?: unknown}).type === 'Author' &&
+          typeof (filter as {uid?: unknown}).uid === 'string',
+      ),
+    )
     queryProps.banner = block.attributes?.banner ? 'true' : 'false'
     queryProps.queryLimit = String(block.attributes?.query?.limit || '')
   }

--- a/frontend/packages/client/src/hmblock-to-editorblock.ts
+++ b/frontend/packages/client/src/hmblock-to-editorblock.ts
@@ -164,6 +164,7 @@ export function hmBlockToEditorBlock(block: HMBlock): EditorBlock {
     queryProps.columnCount = String(block.attributes?.columnCount || '')
     queryProps.queryIncludes = JSON.stringify(block.attributes?.query?.includes || [])
     queryProps.querySort = JSON.stringify(block.attributes?.query?.sort || {})
+    queryProps.queryFilters = JSON.stringify(block.attributes?.query?.filters || [])
     queryProps.banner = block.attributes?.banner ? 'true' : 'false'
     queryProps.queryLimit = String(block.attributes?.query?.limit || '')
   }

--- a/frontend/packages/editor/src/query-account-filter-input.tsx
+++ b/frontend/packages/editor/src/query-account-filter-input.tsx
@@ -1,0 +1,93 @@
+import {HMMetadataPayload} from '@seed-hypermedia/client/hm-types'
+import {useRootDocuments} from '@shm/shared/models/entity'
+import {abbreviateUid} from '@shm/shared/utils/abbreviate'
+import {hmId} from '@shm/shared/utils/entity-id-url'
+import {AccountSearchResult, AccountTagInput, AccountTagInputItem} from '@shm/ui/account-tag-input'
+import {SizableText} from '@shm/ui/text'
+import {useMemo, useState} from 'react'
+
+type QueryAccountFilterInputProps = {
+  selectedUids: string[]
+  onSelectedUidsChange: (uids: string[]) => void
+}
+
+function accountLabel(account: HMMetadataPayload | undefined, uid: string) {
+  return account?.metadata?.name || abbreviateUid(uid)
+}
+
+function accountToResult(account: HMMetadataPayload): AccountSearchResult {
+  return {
+    id: account.id,
+    label: accountLabel(account, account.id.uid),
+    metadata: account.metadata ?? undefined,
+  }
+}
+
+export function QueryAccountFilterInput({selectedUids, onSelectedUidsChange}: QueryAccountFilterInputProps) {
+  const [search, setSearch] = useState('')
+  const accounts = useRootDocuments()
+  const accountByUid = useMemo(() => {
+    return new Map((accounts.data?.accounts ?? []).map((account) => [account.id.uid, account]))
+  }, [accounts.data?.accounts])
+  const selectedUidSet = useMemo(() => new Set(selectedUids), [selectedUids])
+  const searchTerm = search.trim().toLowerCase()
+
+  const selectedAccounts = useMemo<AccountSearchResult[]>(() => {
+    return selectedUids.map((uid) => {
+      const account = accountByUid.get(uid)
+      if (account) return accountToResult(account)
+      return {id: hmId(uid), label: abbreviateUid(uid)}
+    })
+  }, [accountByUid, selectedUids])
+
+  const matches = useMemo(() => {
+    if (!searchTerm) return []
+    return (accounts.data?.accounts ?? [])
+      .filter((account) => {
+        if (selectedUidSet.has(account.id.uid)) return false
+        const name = account.metadata?.name?.toLowerCase() ?? ''
+        return name.includes(searchTerm)
+      })
+      .sort((a, b) =>
+        accountLabel(a, a.id.uid).localeCompare(accountLabel(b, b.id.uid), undefined, {sensitivity: 'base'}),
+      )
+      .slice(0, 8)
+      .map(accountToResult)
+  }, [accounts.data?.accounts, searchTerm, selectedUidSet])
+
+  return (
+    <div className="flex flex-col gap-1">
+      <SizableText size="sm" color="muted">
+        Author accounts
+      </SizableText>
+      <div className="border-border bg-background rounded-md border">
+        <AccountTagInput
+          label="Author accounts"
+          value={search}
+          onChange={setSearch}
+          values={selectedAccounts}
+          onValuesChange={(values) => onSelectedUidsChange(values.map((value) => value.id.uid))}
+          placeholder={selectedUids.length ? 'Add author…' : 'Search profile name…'}
+        >
+          {matches.map((account) => (
+            <AccountTagInputItem
+              key={account.id.uid}
+              account={account}
+              onClick={() => {
+                onSelectedUidsChange([...selectedUids, account.id.uid])
+                setSearch('')
+              }}
+            >
+              Add &quot;{account.label}&quot;
+            </AccountTagInputItem>
+          ))}
+          {searchTerm && !matches.length ? (
+            <div className="text-muted-foreground px-3 py-2 text-sm">
+              {accounts.isLoading ? 'Searching accounts…' : 'No accounts match that profile name.'}
+            </div>
+          ) : null}
+        </AccountTagInput>
+      </div>
+    </div>
+  )
+}

--- a/frontend/packages/editor/src/query-block.tsx
+++ b/frontend/packages/editor/src/query-block.tsx
@@ -8,7 +8,7 @@ import {useUniversalClient} from '@shm/shared/routing'
 import {hmId} from '@shm/shared/utils/entity-id-url'
 import {Button} from '@shm/ui/button'
 import {Input} from '@shm/ui/components/input'
-import {SelectField, SwitchField} from '@shm/ui/form-fields'
+import {Field, SelectField, SwitchField} from '@shm/ui/form-fields'
 import {Pencil, Search, Trash} from '@shm/ui/icons'
 import {InlineDraftCard} from '@shm/ui/inline-draft-card'
 import {InlineDraftListItem} from '@shm/ui/inline-draft-list-item'
@@ -31,9 +31,11 @@ import {Block, BlockNoteEditor} from './blocknote'
 import {createReactBlockSpec} from './blocknote/react'
 import {useQuerySearchInput} from './query-search-context'
 import {HMBlockSchema} from './schema'
+import {QueryAccountFilterInput} from './query-account-filter-input'
 
 const defaultQueryIncludes = '[{"space":"","path":"","mode":"Children"}]'
 const defaultQuerySort = '[{"term":"UpdateTime","reverse":false}]'
+const defaultQueryFilters = '[]'
 
 export const QueryBlock = createReactBlockSpec({
   type: 'query',
@@ -54,6 +56,9 @@ export const QueryBlock = createReactBlockSpec({
     },
     querySort: {
       default: defaultQuerySort,
+    },
+    queryFilters: {
+      default: defaultQueryFilters,
     },
     banner: {
       default: 'false',
@@ -82,6 +87,7 @@ export const QueryBlock = createReactBlockSpec({
 
 type HMQueryBlockIncludes = HMBlockQuery['attributes']['query']['includes']
 type HMQueryBlockSort = NonNullable<HMBlockQuery['attributes']['query']['sort']>
+type HMQueryBlockFilters = NonNullable<HMBlockQuery['attributes']['query']['filters']>
 
 function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSchema>) {
   const client = useUniversalClient()
@@ -92,6 +98,10 @@ function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
   const querySort = useMemo(() => {
     return JSON.parse(block.props.querySort || defaultQuerySort)
   }, [block.props.querySort])
+
+  const queryFilters: HMQueryBlockFilters = useMemo(() => {
+    return JSON.parse(block.props.queryFilters || defaultQueryFilters)
+  }, [block.props.queryFilters])
 
   const banner = block.props.banner === 'true'
   const queryTargetId = useMemo<UnpackedHypermediaId | null>(() => {
@@ -113,9 +123,10 @@ function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
         includes: queryIncludes,
         sort: querySort,
         limit: queryLimit,
+        filters: queryFilters,
       },
     }
-  }, [queryIncludes, querySort, queryLimit])
+  }, [queryIncludes, querySort, queryLimit, queryFilters])
   const queryBlock = useQuery(queryQueryBlock(client, queryBlockInput))
   const sortedItems = queryBlock.data?.results ?? []
 
@@ -197,7 +208,7 @@ function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
             queryDocName={queryBlock.data?.queryTargetName || ''}
             queryIncludes={queryIncludes}
             querySort={querySort}
-            style={style}
+            queryFilters={queryFilters}
             banner={banner}
             // @ts-expect-error
             block={block}
@@ -298,6 +309,7 @@ function QuerySettings({
   onValuesChange,
   queryIncludes,
   querySort,
+  queryFilters,
   editor,
   banner,
   beginEditIfNeeded,
@@ -306,6 +318,7 @@ function QuerySettings({
   block: EditorQueryBlock
   queryIncludes: HMQueryBlockIncludes
   querySort: HMQueryBlockSort
+  queryFilters: HMQueryBlockFilters
   banner: boolean
   onValuesChange: ({id, props}: {id: UnpackedHypermediaId | null; props: EditorQueryBlock['props']}) => void
   editor: BlockNoteEditor<HMBlockSchema>
@@ -378,16 +391,47 @@ function QuerySettings({
   useEffect(() => {
     // @ts-expect-error
     if (block.props.defaultOpen === 'true') {
-      editor.updateBlock(block.id, {
-        ...block,
-        // @ts-expect-error
-        props: {...block.props, defaultOpen: 'false'},
+      queueMicrotask(() => {
+        editor.updateBlock(block.id, {
+          ...block,
+          // @ts-expect-error
+          props: {...block.props, defaultOpen: 'false'},
+        })
       })
     }
     {
     }
     // @ts-expect-error
   }, [block.props.defaultOpen])
+
+  const authorFilters = queryFilters.filter((filter) => filter.type === 'Author')
+  const publishDateFilter = queryFilters.find((filter) => filter.type === 'PublishDate')
+
+  const saveFilters = (filters: HMQueryBlockFilters) => {
+    onValuesChange({
+      id: null,
+      props: {
+        ...block.props,
+        queryFilters: JSON.stringify(filters),
+      },
+    })
+  }
+
+  const updateAuthorFilters = (uids: string[]) => {
+    const otherFilters = queryFilters.filter((filter) => filter.type !== 'Author')
+    saveFilters([...otherFilters, ...uids.map((uid) => ({type: 'Author' as const, uid}))] as HMQueryBlockFilters)
+  }
+
+  const updatePublishDateFilter = (dates: {from?: string; to?: string}) => {
+    const otherFilters = queryFilters.filter((filter) => filter.type !== 'PublishDate')
+    const nextFilter = {
+      type: 'PublishDate' as const,
+      from: dates.from ?? publishDateFilter?.from,
+      to: dates.to ?? publishDateFilter?.to,
+    }
+    const hasDate = !!nextFilter.from?.trim() || !!nextFilter.to?.trim()
+    saveFilters((hasDate ? [...otherFilters, nextFilter] : otherFilters) as HMQueryBlockFilters)
+  }
 
   return (
     <>
@@ -466,6 +510,28 @@ function QuerySettings({
                   {label: 'Show all Descendants', value: 'AllDescendants'},
                 ]}
               />
+
+              <QueryAccountFilterInput
+                selectedUids={authorFilters.map((filter) => filter.uid)}
+                onSelectedUidsChange={updateAuthorFilters}
+              />
+
+              <div className="flex gap-2">
+                <Field id={`query-publish-from-${block.id}`} label="Publish from">
+                  <Input
+                    type="date"
+                    value={publishDateFilter?.from ?? ''}
+                    onChangeText={(from) => updatePublishDateFilter({from})}
+                  />
+                </Field>
+                <Field id={`query-publish-to-${block.id}`} label="Publish to">
+                  <Input
+                    type="date"
+                    value={publishDateFilter?.to ?? ''}
+                    onChangeText={(to) => updatePublishDateFilter({to})}
+                  />
+                </Field>
+              </div>
 
               <SelectField
                 value={block.props.style}

--- a/frontend/packages/editor/src/query-block.tsx
+++ b/frontend/packages/editor/src/query-block.tsx
@@ -8,7 +8,7 @@ import {useUniversalClient} from '@shm/shared/routing'
 import {hmId} from '@shm/shared/utils/entity-id-url'
 import {Button} from '@shm/ui/button'
 import {Input} from '@shm/ui/components/input'
-import {Field, SelectField, SwitchField} from '@shm/ui/form-fields'
+import {SelectField, SwitchField} from '@shm/ui/form-fields'
 import {Pencil, Search, Trash} from '@shm/ui/icons'
 import {InlineDraftCard} from '@shm/ui/inline-draft-card'
 import {InlineDraftListItem} from '@shm/ui/inline-draft-list-item'
@@ -89,6 +89,16 @@ type HMQueryBlockIncludes = HMBlockQuery['attributes']['query']['includes']
 type HMQueryBlockSort = NonNullable<HMBlockQuery['attributes']['query']['sort']>
 type HMQueryBlockFilters = NonNullable<HMBlockQuery['attributes']['query']['filters']>
 
+function parseQueryFilters(rawFilters: string | undefined): HMQueryBlockFilters {
+  return JSON.parse(rawFilters || defaultQueryFilters).filter(
+    (filter: unknown) =>
+      filter &&
+      typeof filter === 'object' &&
+      (filter as {type?: unknown}).type === 'Author' &&
+      typeof (filter as {uid?: unknown}).uid === 'string',
+  )
+}
+
 function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSchema>) {
   const client = useUniversalClient()
   const queryIncludes: HMQueryBlockIncludes = useMemo(() => {
@@ -100,7 +110,7 @@ function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
   }, [block.props.querySort])
 
   const queryFilters: HMQueryBlockFilters = useMemo(() => {
-    return JSON.parse(block.props.queryFilters || defaultQueryFilters)
+    return parseQueryFilters(block.props.queryFilters)
   }, [block.props.queryFilters])
 
   const banner = block.props.banner === 'true'
@@ -405,32 +415,21 @@ function QuerySettings({
   }, [block.props.defaultOpen])
 
   const authorFilters = queryFilters.filter((filter) => filter.type === 'Author')
-  const publishDateFilter = queryFilters.find((filter) => filter.type === 'PublishDate')
 
   const saveFilters = (filters: HMQueryBlockFilters) => {
-    onValuesChange({
-      id: null,
-      props: {
-        ...block.props,
-        queryFilters: JSON.stringify(filters),
-      },
+    const queryFilters = JSON.stringify(filters)
+    queueMicrotask(() => {
+      onValuesChange({
+        id: null,
+        props: {
+          queryFilters,
+        } as EditorQueryBlock['props'],
+      })
     })
   }
 
   const updateAuthorFilters = (uids: string[]) => {
-    const otherFilters = queryFilters.filter((filter) => filter.type !== 'Author')
-    saveFilters([...otherFilters, ...uids.map((uid) => ({type: 'Author' as const, uid}))] as HMQueryBlockFilters)
-  }
-
-  const updatePublishDateFilter = (dates: {from?: string; to?: string}) => {
-    const otherFilters = queryFilters.filter((filter) => filter.type !== 'PublishDate')
-    const nextFilter = {
-      type: 'PublishDate' as const,
-      from: dates.from ?? publishDateFilter?.from,
-      to: dates.to ?? publishDateFilter?.to,
-    }
-    const hasDate = !!nextFilter.from?.trim() || !!nextFilter.to?.trim()
-    saveFilters((hasDate ? [...otherFilters, nextFilter] : otherFilters) as HMQueryBlockFilters)
+    saveFilters(uids.map((uid) => ({type: 'Author' as const, uid})))
   }
 
   return (
@@ -515,23 +514,6 @@ function QuerySettings({
                 selectedUids={authorFilters.map((filter) => filter.uid)}
                 onSelectedUidsChange={updateAuthorFilters}
               />
-
-              <div className="flex gap-2">
-                <Field id={`query-publish-from-${block.id}`} label="Publish from">
-                  <Input
-                    type="date"
-                    value={publishDateFilter?.from ?? ''}
-                    onChangeText={(from) => updatePublishDateFilter({from})}
-                  />
-                </Field>
-                <Field id={`query-publish-to-${block.id}`} label="Publish to">
-                  <Input
-                    type="date"
-                    value={publishDateFilter?.to ?? ''}
-                    onChangeText={(to) => updatePublishDateFilter({to})}
-                  />
-                </Field>
-              </div>
 
               <SelectField
                 value={block.props.style}

--- a/frontend/packages/shared/src/api-query-block.ts
+++ b/frontend/packages/shared/src/api-query-block.ts
@@ -235,6 +235,7 @@ export const QueryBlock: HMRequestImplementation<HMQueryBlockRequest> = {
             includes: input.query.includes.map(({space, path, mode}) => ({space, path, mode})),
             limit: input.query.limit ?? null,
             sortCount: input.query.sort?.length ?? 0,
+            filterCount: input.query.filters?.length ?? 0,
           },
           resolvedItemCount: perf.resolvedItemCount,
           returnedItemCount: perf.returnedItemCount,

--- a/frontend/packages/shared/src/client/__tests__/editorblock-to-hmblock.test.ts
+++ b/frontend/packages/shared/src/client/__tests__/editorblock-to-hmblock.test.ts
@@ -826,8 +826,7 @@ describe('EditorBlock to HMBlock', () => {
           banner: 'true',
           queryIncludes: '[{"space": "FOO_SPACE", "path": "", "mode": "Children"}]',
           querySort: '[{"term": "UpdateTime", "reverse": false}]',
-          queryFilters:
-            '[{"type": "Author", "uid": "author-a"}, {"type": "PublishDate", "from": "2024-01-01", "to": "2024-12-31"}]',
+          queryFilters: '[{"type": "Author", "uid": "author-a"}]',
           queryLimit: '10',
           style: 'Card',
           columnCount: '1',
@@ -846,10 +845,7 @@ describe('EditorBlock to HMBlock', () => {
           query: {
             includes: [{space: 'FOO_SPACE', path: '', mode: 'Children'}],
             sort: [{term: 'UpdateTime', reverse: false}],
-            filters: [
-              {type: 'Author', uid: 'author-a'},
-              {type: 'PublishDate', from: '2024-01-01', to: '2024-12-31'},
-            ],
+            filters: [{type: 'Author', uid: 'author-a'}],
             limit: 10,
           },
         },

--- a/frontend/packages/shared/src/client/__tests__/editorblock-to-hmblock.test.ts
+++ b/frontend/packages/shared/src/client/__tests__/editorblock-to-hmblock.test.ts
@@ -826,6 +826,8 @@ describe('EditorBlock to HMBlock', () => {
           banner: 'true',
           queryIncludes: '[{"space": "FOO_SPACE", "path": "", "mode": "Children"}]',
           querySort: '[{"term": "UpdateTime", "reverse": false}]',
+          queryFilters:
+            '[{"type": "Author", "uid": "author-a"}, {"type": "PublishDate", "from": "2024-01-01", "to": "2024-12-31"}]',
           queryLimit: '10',
           style: 'Card',
           columnCount: '1',
@@ -844,6 +846,10 @@ describe('EditorBlock to HMBlock', () => {
           query: {
             includes: [{space: 'FOO_SPACE', path: '', mode: 'Children'}],
             sort: [{term: 'UpdateTime', reverse: false}],
+            filters: [
+              {type: 'Author', uid: 'author-a'},
+              {type: 'PublishDate', from: '2024-01-01', to: '2024-12-31'},
+            ],
             limit: 10,
           },
         },

--- a/frontend/packages/shared/src/client/__tests__/hmblock-to-editorblock.test.ts
+++ b/frontend/packages/shared/src/client/__tests__/hmblock-to-editorblock.test.ts
@@ -874,10 +874,7 @@ describe('HMBlock to EditorBlock', () => {
           query: {
             includes: [{space: 'FOO_SPACE', path: '', mode: 'Children'}],
             sort: [{term: 'UpdateTime', reverse: false}],
-            filters: [
-              {type: 'Author', uid: 'author-a'},
-              {type: 'PublishDate', from: '2024-01-01', to: '2024-12-31'},
-            ],
+            filters: [{type: 'Author', uid: 'author-a'}],
           },
         },
         revision: 'revision123',
@@ -897,8 +894,7 @@ describe('HMBlock to EditorBlock', () => {
         props: {
           queryIncludes: '[{"space":"FOO_SPACE","path":"","mode":"Children"}]',
           querySort: '[{"term":"UpdateTime","reverse":false}]',
-          queryFilters:
-            '[{"type":"Author","uid":"author-a"},{"type":"PublishDate","from":"2024-01-01","to":"2024-12-31"}]',
+          queryFilters: '[{"type":"Author","uid":"author-a"}]',
           queryLimit: '',
           style: 'Card',
           columnCount: '1',

--- a/frontend/packages/shared/src/client/__tests__/hmblock-to-editorblock.test.ts
+++ b/frontend/packages/shared/src/client/__tests__/hmblock-to-editorblock.test.ts
@@ -874,6 +874,10 @@ describe('HMBlock to EditorBlock', () => {
           query: {
             includes: [{space: 'FOO_SPACE', path: '', mode: 'Children'}],
             sort: [{term: 'UpdateTime', reverse: false}],
+            filters: [
+              {type: 'Author', uid: 'author-a'},
+              {type: 'PublishDate', from: '2024-01-01', to: '2024-12-31'},
+            ],
           },
         },
         revision: 'revision123',
@@ -893,6 +897,8 @@ describe('HMBlock to EditorBlock', () => {
         props: {
           queryIncludes: '[{"space":"FOO_SPACE","path":"","mode":"Children"}]',
           querySort: '[{"term":"UpdateTime","reverse":false}]',
+          queryFilters:
+            '[{"type":"Author","uid":"author-a"},{"type":"PublishDate","from":"2024-01-01","to":"2024-12-31"}]',
           queryLimit: '',
           style: 'Card',
           columnCount: '1',

--- a/frontend/packages/shared/src/models/__tests__/directory.test.ts
+++ b/frontend/packages/shared/src/models/__tests__/directory.test.ts
@@ -19,6 +19,8 @@ function makeEntry(
     updateTime: string
     latestChangeTime: string
     latestCommentTime: string
+    authors: string[]
+    displayPublishTime: string
   }>,
 ): HMDocumentInfo {
   const path = overrides.path ?? ['projects', 'a']
@@ -26,7 +28,7 @@ function makeEntry(
     type: 'document',
     id: overrides.id ?? hmId('alice', {path}),
     path,
-    authors: [],
+    authors: overrides.authors ?? [],
     createTime: overrides.createTime ?? '2024-01-01T00:00:00Z',
     updateTime: overrides.updateTime ?? '2024-01-01T00:00:00Z',
     sortTime: new Date(overrides.updateTime ?? '2024-01-01T00:00:00Z'),
@@ -41,7 +43,10 @@ function makeEntry(
       isUnread: false,
     },
     generationInfo: {genesis: '', generation: 0n},
-    metadata: {name: overrides.name ?? path[path.length - 1] ?? 'Untitled'},
+    metadata: {
+      name: overrides.name ?? path[path.length - 1] ?? 'Untitled',
+      displayPublishTime: overrides.displayPublishTime,
+    },
     visibility: 'PUBLIC',
   } as unknown as HMDocumentInfo
 }
@@ -81,6 +86,83 @@ describe('createQueryResolver', () => {
       },
     })
     expect(result?.results.map((doc) => doc.metadata.name)).toEqual(['Newer', 'Older'])
+  })
+
+  it('filters results by author before sorting', async () => {
+    const parent = makeEntry({id: hmId('alice', {path: ['projects']}), path: ['projects'], name: 'Projects'})
+    const authoredByAlice = makeEntry({
+      id: hmId('alice', {path: ['projects', 'alice']}),
+      path: ['projects', 'alice'],
+      name: 'Alice',
+      authors: ['alice-author', 'co-author'],
+      updateTime: '2024-01-01T00:00:00Z',
+    })
+    const authoredByBob = makeEntry({
+      id: hmId('alice', {path: ['projects', 'bob']}),
+      path: ['projects', 'bob'],
+      name: 'Bob',
+      authors: ['bob-author'],
+      updateTime: '2024-03-01T00:00:00Z',
+    })
+
+    const listDirectory = vi.fn().mockResolvedValue({documents: [parent, authoredByBob, authoredByAlice]})
+    const resolver = createQueryResolver({documents: {listDirectory}} as any)
+
+    const result = await resolver({
+      includes: [{space: 'alice', path: '/projects', mode: 'AllDescendants'}],
+      sort: [{term: 'UpdateTime', reverse: false}],
+      filters: [{type: 'Author', uid: 'alice-author'}],
+    })
+
+    expect(result?.results.map((doc) => doc.metadata.name)).toEqual(['Alice'])
+  })
+
+  it('combines author OR filters with publish date range filters', async () => {
+    const inRangeAlice = makeEntry({
+      id: hmId('alice', {path: ['projects', 'in-range-alice']}),
+      path: ['projects', 'in-range-alice'],
+      name: 'In Range Alice',
+      authors: ['alice-author'],
+      displayPublishTime: '2024-02-15',
+    })
+    const inRangeBob = makeEntry({
+      id: hmId('alice', {path: ['projects', 'in-range-bob']}),
+      path: ['projects', 'in-range-bob'],
+      name: 'In Range Bob',
+      authors: ['bob-author'],
+      displayPublishTime: '2024-02-20',
+    })
+    const outOfRangeAlice = makeEntry({
+      id: hmId('alice', {path: ['projects', 'out-of-range-alice']}),
+      path: ['projects', 'out-of-range-alice'],
+      name: 'Out Of Range Alice',
+      authors: ['alice-author'],
+      displayPublishTime: '2023-12-31',
+    })
+    const wrongAuthor = makeEntry({
+      id: hmId('alice', {path: ['projects', 'wrong-author']}),
+      path: ['projects', 'wrong-author'],
+      name: 'Wrong Author',
+      authors: ['carol-author'],
+      displayPublishTime: '2024-02-15',
+    })
+
+    const listDirectory = vi.fn().mockResolvedValue({
+      documents: [wrongAuthor, outOfRangeAlice, inRangeBob, inRangeAlice],
+    })
+    const resolver = createQueryResolver({documents: {listDirectory}} as any)
+
+    const result = await resolver({
+      includes: [{space: 'alice', path: '/projects', mode: 'AllDescendants'}],
+      sort: [{term: 'Title', reverse: false}],
+      filters: [
+        {type: 'Author', uid: 'alice-author'},
+        {type: 'Author', uid: 'bob-author'},
+        {type: 'PublishDate', from: '2024-01-01', to: '2024-12-31'},
+      ],
+    })
+
+    expect(result?.results.map((doc) => doc.metadata.name)).toEqual(['In Range Alice', 'In Range Bob'])
   })
 
   it('still uses listDirectory for unsupported server sorts and applies client-side sorting', async () => {

--- a/frontend/packages/shared/src/models/__tests__/directory.test.ts
+++ b/frontend/packages/shared/src/models/__tests__/directory.test.ts
@@ -117,39 +117,30 @@ describe('createQueryResolver', () => {
     expect(result?.results.map((doc) => doc.metadata.name)).toEqual(['Alice'])
   })
 
-  it('combines author OR filters with publish date range filters', async () => {
-    const inRangeAlice = makeEntry({
-      id: hmId('alice', {path: ['projects', 'in-range-alice']}),
-      path: ['projects', 'in-range-alice'],
-      name: 'In Range Alice',
+  it('matches any selected author filter before sorting', async () => {
+    const parent = makeEntry({id: hmId('alice', {path: ['projects']}), path: ['projects'], name: 'Projects'})
+    const authoredByAlice = makeEntry({
+      id: hmId('alice', {path: ['projects', 'alice']}),
+      path: ['projects', 'alice'],
+      name: 'Alice',
       authors: ['alice-author'],
-      displayPublishTime: '2024-02-15',
     })
-    const inRangeBob = makeEntry({
-      id: hmId('alice', {path: ['projects', 'in-range-bob']}),
-      path: ['projects', 'in-range-bob'],
-      name: 'In Range Bob',
+    const authoredByBob = makeEntry({
+      id: hmId('alice', {path: ['projects', 'bob']}),
+      path: ['projects', 'bob'],
+      name: 'Bob',
       authors: ['bob-author'],
-      displayPublishTime: '2024-02-20',
     })
-    const outOfRangeAlice = makeEntry({
-      id: hmId('alice', {path: ['projects', 'out-of-range-alice']}),
-      path: ['projects', 'out-of-range-alice'],
-      name: 'Out Of Range Alice',
-      authors: ['alice-author'],
-      displayPublishTime: '2023-12-31',
-    })
-    const wrongAuthor = makeEntry({
-      id: hmId('alice', {path: ['projects', 'wrong-author']}),
-      path: ['projects', 'wrong-author'],
-      name: 'Wrong Author',
+    const authoredByCarol = makeEntry({
+      id: hmId('alice', {path: ['projects', 'carol']}),
+      path: ['projects', 'carol'],
+      name: 'Carol',
       authors: ['carol-author'],
-      displayPublishTime: '2024-02-15',
     })
 
-    const listDirectory = vi.fn().mockResolvedValue({
-      documents: [wrongAuthor, outOfRangeAlice, inRangeBob, inRangeAlice],
-    })
+    const listDirectory = vi
+      .fn()
+      .mockResolvedValue({documents: [parent, authoredByCarol, authoredByBob, authoredByAlice]})
     const resolver = createQueryResolver({documents: {listDirectory}} as any)
 
     const result = await resolver({
@@ -158,11 +149,10 @@ describe('createQueryResolver', () => {
       filters: [
         {type: 'Author', uid: 'alice-author'},
         {type: 'Author', uid: 'bob-author'},
-        {type: 'PublishDate', from: '2024-01-01', to: '2024-12-31'},
       ],
     })
 
-    expect(result?.results.map((doc) => doc.metadata.name)).toEqual(['In Range Alice', 'In Range Bob'])
+    expect(result?.results.map((doc) => doc.metadata.name)).toEqual(['Alice', 'Bob'])
   })
 
   it('still uses listDirectory for unsupported server sorts and applies client-side sorting', async () => {

--- a/frontend/packages/shared/src/models/directory.ts
+++ b/frontend/packages/shared/src/models/directory.ts
@@ -1,4 +1,10 @@
-import {HMDocumentInfo, HMQuery, HMQueryResult, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {
+  HMDocumentInfo,
+  HMQuery,
+  HMQueryFilter,
+  HMQueryResult,
+  UnpackedHypermediaId,
+} from '@seed-hypermedia/client/hm-types'
 import {SortAttribute} from '../client/.generated/documents/v3alpha/documents_pb'
 import {BIG_INT} from '../constants'
 import {queryBlockSortedItems} from '../content'
@@ -6,6 +12,73 @@ import {GRPCClient} from '../grpc-client'
 import {entityQueryPathToHmIdPath, hmId} from '../utils'
 import {hmIdPathToEntityQueryPath} from '../utils/path-api'
 import {prepareHMDocumentInfo} from './entity'
+
+function dateValueMs(value: unknown): number | null {
+  if (typeof value === 'string') {
+    const ms = Date.parse(value)
+    return Number.isNaN(ms) ? null : ms
+  }
+  if (value instanceof Date) return value.getTime()
+  if (value && typeof value === 'object' && 'seconds' in value) {
+    const seconds = Number((value as {seconds: unknown}).seconds)
+    const nanos = Number((value as {nanos?: unknown}).nanos ?? 0)
+    if (!Number.isFinite(seconds)) return null
+    return seconds * 1000 + Math.floor(nanos / 1_000_000)
+  }
+  return null
+}
+
+function publishDateMs(entry: HMDocumentInfo): number | null {
+  const displayPublishTime = entry.metadata.displayPublishTime
+  if (displayPublishTime) {
+    const ms = Date.parse(displayPublishTime)
+    if (!Number.isNaN(ms)) return ms
+  }
+  return dateValueMs(entry.updateTime)
+}
+
+function startDateMs(value: string | undefined): number | null {
+  if (!value?.trim()) return null
+  const ms = Date.parse(value)
+  return Number.isNaN(ms) ? null : ms
+}
+
+function endDateMs(value: string | undefined): number | null {
+  if (!value?.trim()) return null
+  const ms = Date.parse(value)
+  if (Number.isNaN(ms)) return null
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return ms + 24 * 60 * 60 * 1000 - 1
+  return ms
+}
+
+function filterQueryResults(entries: HMDocumentInfo[], filters: HMQueryFilter[] | undefined): HMDocumentInfo[] {
+  if (!filters?.length) return entries
+
+  const authorUids = filters
+    .filter((filter): filter is Extract<HMQueryFilter, {type: 'Author'}> => filter.type === 'Author')
+    .map((filter) => filter.uid)
+    .filter(Boolean)
+  const publishDateFilters = filters.filter(
+    (filter): filter is Extract<HMQueryFilter, {type: 'PublishDate'}> => filter.type === 'PublishDate',
+  )
+
+  return entries.filter((entry) => {
+    if (authorUids.length && !authorUids.some((uid) => entry.authors.includes(uid))) return false
+
+    for (const filter of publishDateFilters) {
+      const from = startDateMs(filter.from)
+      const to = endDateMs(filter.to)
+      if (from == null && to == null) continue
+
+      const publishDate = publishDateMs(entry)
+      if (publishDate == null) return false
+      if (from != null && publishDate < from) return false
+      if (to != null && publishDate > to) return false
+    }
+
+    return true
+  })
+}
 
 function createDirectoryResolver(client: GRPCClient) {
   async function getDirectory(
@@ -48,7 +121,7 @@ function createDirectoryResolver(client: GRPCClient) {
 export function createQueryResolver(client: GRPCClient) {
   const getDirectory = createDirectoryResolver(client)
   async function getQueryResults(query: HMQuery): Promise<HMQueryResult | null> {
-    const {includes, sort} = query
+    const {includes, sort, filters} = query
     if (includes.length !== 1) return null // only support one include for now
     const {path, mode, space} = includes[0]!
     const inId = hmId(space, {
@@ -57,10 +130,11 @@ export function createQueryResolver(client: GRPCClient) {
     const dir = await getDirectory(inId, mode, sort)
     if (!inId) return null
 
+    const filteredDir = filterQueryResults(dir, filters)
     const sortedDir = sort
-      ? queryBlockSortedItems({entries: dir, sort})
+      ? queryBlockSortedItems({entries: filteredDir, sort})
       : queryBlockSortedItems({
-          entries: dir,
+          entries: filteredDir,
           sort: [{term: 'UpdateTime', reverse: false}],
         })
     return {in: inId, results: sortedDir, mode} satisfies HMQueryResult

--- a/frontend/packages/shared/src/models/directory.ts
+++ b/frontend/packages/shared/src/models/directory.ts
@@ -13,71 +13,13 @@ import {entityQueryPathToHmIdPath, hmId} from '../utils'
 import {hmIdPathToEntityQueryPath} from '../utils/path-api'
 import {prepareHMDocumentInfo} from './entity'
 
-function dateValueMs(value: unknown): number | null {
-  if (typeof value === 'string') {
-    const ms = Date.parse(value)
-    return Number.isNaN(ms) ? null : ms
-  }
-  if (value instanceof Date) return value.getTime()
-  if (value && typeof value === 'object' && 'seconds' in value) {
-    const seconds = Number((value as {seconds: unknown}).seconds)
-    const nanos = Number((value as {nanos?: unknown}).nanos ?? 0)
-    if (!Number.isFinite(seconds)) return null
-    return seconds * 1000 + Math.floor(nanos / 1_000_000)
-  }
-  return null
-}
-
-function publishDateMs(entry: HMDocumentInfo): number | null {
-  const displayPublishTime = entry.metadata.displayPublishTime
-  if (displayPublishTime) {
-    const ms = Date.parse(displayPublishTime)
-    if (!Number.isNaN(ms)) return ms
-  }
-  return dateValueMs(entry.updateTime)
-}
-
-function startDateMs(value: string | undefined): number | null {
-  if (!value?.trim()) return null
-  const ms = Date.parse(value)
-  return Number.isNaN(ms) ? null : ms
-}
-
-function endDateMs(value: string | undefined): number | null {
-  if (!value?.trim()) return null
-  const ms = Date.parse(value)
-  if (Number.isNaN(ms)) return null
-  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return ms + 24 * 60 * 60 * 1000 - 1
-  return ms
-}
-
 function filterQueryResults(entries: HMDocumentInfo[], filters: HMQueryFilter[] | undefined): HMDocumentInfo[] {
   if (!filters?.length) return entries
 
-  const authorUids = filters
-    .filter((filter): filter is Extract<HMQueryFilter, {type: 'Author'}> => filter.type === 'Author')
-    .map((filter) => filter.uid)
-    .filter(Boolean)
-  const publishDateFilters = filters.filter(
-    (filter): filter is Extract<HMQueryFilter, {type: 'PublishDate'}> => filter.type === 'PublishDate',
-  )
+  const authorUids = filters.map((filter) => filter.uid).filter(Boolean)
+  if (!authorUids.length) return entries
 
-  return entries.filter((entry) => {
-    if (authorUids.length && !authorUids.some((uid) => entry.authors.includes(uid))) return false
-
-    for (const filter of publishDateFilters) {
-      const from = startDateMs(filter.from)
-      const to = endDateMs(filter.to)
-      if (from == null && to == null) continue
-
-      const publishDate = publishDateMs(entry)
-      if (publishDate == null) return false
-      if (from != null && publishDate < from) return false
-      if (to != null && publishDate > to) return false
-    }
-
-    return true
-  })
+  return entries.filter((entry) => authorUids.some((uid) => entry.authors.includes(uid)))
 }
 
 function createDirectoryResolver(client: GRPCClient) {

--- a/frontend/packages/ui/src/account-tag-input.tsx
+++ b/frontend/packages/ui/src/account-tag-input.tsx
@@ -27,8 +27,18 @@ interface AccountTagInputProps extends Omit<Ariakit.ComboboxProps, 'onChange'> {
 }
 
 export const AccountTagInput = forwardRef<HTMLInputElement, AccountTagInputProps>(function AccountTagInput(props, ref) {
-  const {label, defaultValue, value, onChange, defaultValues, values, onValuesChange, children, ...comboboxProps} =
-    props
+  const {
+    label,
+    defaultValue,
+    value,
+    onChange,
+    defaultValues,
+    values,
+    onValuesChange,
+    children,
+    className,
+    ...comboboxProps
+  } = props
 
   const comboboxRef = useRef<HTMLInputElement>(null)
   const defaultComboboxId = useId()
@@ -123,14 +133,22 @@ export const AccountTagInput = forwardRef<HTMLInputElement, AccountTagInputProps
             </Ariakit.CompositeItem>
           )
         })}
-        <div role="cell" className="flex flex-1 flex-col">
+        <div role="cell" className="flex min-w-0 flex-1 flex-col">
           <Ariakit.CompositeItem
             id={comboboxId}
             render={
               <CompositeInput
                 ref={comboboxRef}
                 onKeyDown={onInputKeyDown}
-                render={<Ariakit.Combobox ref={ref} store={combobox} className="combobox" {...comboboxProps} />}
+                render={
+                  <Ariakit.Combobox
+                    ref={ref}
+                    store={combobox}
+                    size={1}
+                    className={`combobox w-full min-w-0 ${className ?? ''}`}
+                    {...comboboxProps}
+                  />
+                }
               />
             }
           />
@@ -194,13 +212,23 @@ interface AccountTagInputItemProps extends Ariakit.SelectItemProps {
 
 export const AccountTagInputItem = forwardRef<HTMLDivElement, AccountTagInputItemProps>(
   function AccountTagInputItem(props, ref) {
+    const {onMouseDown, onClick, ...itemProps} = props
     const resource = useResource(props.account?.id)
     const metadata =
       props.account?.metadata ?? (resource.data?.type === 'document' ? resource.data.document?.metadata : undefined)
     return (
       <Ariakit.SelectItem
         ref={ref}
-        {...props}
+        {...itemProps}
+        onMouseDown={(event) => {
+          event.preventDefault()
+          event.stopPropagation()
+          onMouseDown?.(event)
+        }}
+        onClick={(event) => {
+          event.stopPropagation()
+          onClick?.(event)
+        }}
         render={
           <Ariakit.ComboboxItem
             render={<AccountTagInputItemContent className="combobox-item" render={props.render} />}

--- a/frontend/packages/ui/src/account-tag-input.tsx
+++ b/frontend/packages/ui/src/account-tag-input.tsx
@@ -1,0 +1,233 @@
+import * as Ariakit from '@ariakit/react'
+import {CompositeInput} from '@ariakit/react-core/composite/composite-input'
+import {HMMetadata, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {useAccount, useResource} from '@shm/shared/models/entity'
+import {abbreviateUid} from '@shm/shared/utils/abbreviate'
+import {forwardRef, useEffect, useId, useRef} from 'react'
+import './combobox.css'
+import {HMIcon, LoadedHMIcon} from './hm-icon'
+import {X} from './icons'
+import {SizableText} from './text'
+
+export type AccountSearchResult = {
+  id: UnpackedHypermediaId
+  label: string
+  unresolved?: boolean
+  metadata?: HMMetadata
+}
+
+interface AccountTagInputProps extends Omit<Ariakit.ComboboxProps, 'onChange'> {
+  label: string
+  value?: string
+  onChange?: (value: string) => void
+  defaultValue?: string
+  values?: Array<AccountSearchResult>
+  onValuesChange?: (values: Array<AccountSearchResult>) => void
+  defaultValues?: Array<AccountSearchResult>
+}
+
+export const AccountTagInput = forwardRef<HTMLInputElement, AccountTagInputProps>(function AccountTagInput(props, ref) {
+  const {label, defaultValue, value, onChange, defaultValues, values, onValuesChange, children, ...comboboxProps} =
+    props
+
+  const comboboxRef = useRef<HTMLInputElement>(null)
+  const defaultComboboxId = useId()
+  const comboboxId = comboboxProps.id || defaultComboboxId
+
+  const combobox = Ariakit.useComboboxStore({
+    value,
+    defaultValue,
+    setValue: onChange,
+    resetValueOnHide: true,
+  })
+
+  // @ts-expect-error Ariakit's generic Select store value works here but TS cannot infer the array type.
+  const select = Ariakit.useSelectStore<AccountSearchResult>({
+    combobox,
+    value: values,
+    defaultValue: defaultValues,
+    setValue: onValuesChange,
+  })
+
+  const composite = Ariakit.useCompositeStore({
+    defaultActiveId: comboboxId,
+  })
+
+  const selectedValues = select.useState('value')
+
+  useEffect(() => combobox.setValue(''), [selectedValues, combobox])
+
+  const toggleValueFromSelectedValues = (value: AccountSearchResult) => {
+    // @ts-expect-error Ariakit supports updater callbacks for controlled values.
+    select.setValue((prevSelectedValues: Array<AccountSearchResult>) => {
+      const index = prevSelectedValues.indexOf(value)
+      if (index !== -1) {
+        return prevSelectedValues.filter((v) => v.id.id != value.id.id)
+      }
+      return [...prevSelectedValues, value]
+    })
+  }
+
+  const onItemClick = (value: AccountSearchResult) => () => {
+    toggleValueFromSelectedValues(value)
+  }
+
+  const onItemKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'Backspace' || event.key === 'Delete') {
+      event.currentTarget.click()
+    }
+  }
+
+  const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== 'Backspace') return
+    const {selectionStart, selectionEnd} = event.currentTarget
+    const isCaretAtTheBeginning = selectionStart === 0 && selectionEnd === 0
+    if (!isCaretAtTheBeginning) return
+    // @ts-expect-error Ariakit supports updater callbacks for controlled values.
+    select.setValue((values: Array<AccountSearchResult>) => {
+      if (!values.length) return values
+      return values.slice(0, values.length - 1)
+    })
+    combobox.hide()
+  }
+
+  return (
+    <Ariakit.Composite
+      store={composite}
+      role="grid"
+      aria-label={label}
+      className="tag-grid"
+      onMouseDown={(event) => event.stopPropagation()}
+      onClick={(event) => {
+        event.stopPropagation()
+        comboboxRef.current?.focus()
+      }}
+      render={<div className="flex flex-1 rounded-md p-1" />}
+    >
+      <Ariakit.CompositeRow role="row" render={<div className="flex w-full flex-wrap gap-1" />}>
+        {/* @ts-expect-error Ariakit selected value state is the AccountSearchResult array configured above. */}
+        {selectedValues.map((selectedValue: AccountSearchResult) => {
+          return (
+            <Ariakit.CompositeItem
+              key={selectedValue.id.id}
+              role="gridcell"
+              onClick={onItemClick(selectedValue)}
+              onKeyDown={onItemKeyDown}
+              onFocus={combobox.hide}
+              render={
+                <div className="bg-background border-border flex min-h-6 items-center gap-1 rounded-md border p-1 px-2 hover:bg-black/10 dark:hover:bg-white/10" />
+              }
+            >
+              <SelectedAccountItem value={selectedValue} />
+              <X size={12} />
+            </Ariakit.CompositeItem>
+          )
+        })}
+        <div role="cell" className="flex flex-1 flex-col">
+          <Ariakit.CompositeItem
+            id={comboboxId}
+            render={
+              <CompositeInput
+                ref={comboboxRef}
+                onKeyDown={onInputKeyDown}
+                render={<Ariakit.Combobox ref={ref} store={combobox} className="combobox" {...comboboxProps} />}
+              />
+            }
+          />
+        </div>
+        <Ariakit.ComboboxPopover
+          store={combobox}
+          portal
+          sameWidth
+          gutter={8}
+          render={
+            <Ariakit.SelectList
+              // @ts-expect-error Ariakit store value is configured as AccountSearchResult[].
+              store={select}
+              render={<div className="z-100 rounded-sm bg-white dark:bg-black" />}
+            />
+          }
+        >
+          {children}
+        </Ariakit.ComboboxPopover>
+      </Ariakit.CompositeRow>
+    </Ariakit.Composite>
+  )
+})
+
+function SelectedAccountItem({value}: {value: AccountSearchResult}) {
+  if (value.metadata) {
+    return (
+      <>
+        <HMIcon id={value.id} name={value.metadata.name} icon={value.metadata.icon} size={20} />
+        <SizableText>{value.metadata.name || value.label}</SizableText>
+      </>
+    )
+  }
+
+  if (value.unresolved) return <UnresolvedAccountItem value={value} />
+
+  return (
+    <>
+      <LoadedHMIcon id={value.id} size={20} />
+      <SizableText>{value.label}</SizableText>
+    </>
+  )
+}
+
+function UnresolvedAccountItem({value}: {value: AccountSearchResult}) {
+  const account = useAccount(value.id.uid, {subscribe: true})
+  const metadata = account.data?.metadata
+  const label = metadata?.name || abbreviateUid(value.id.uid)
+  return (
+    <>
+      <HMIcon id={value.id} name={metadata?.name} icon={metadata?.icon} size={20} />
+      <SizableText>{label}</SizableText>
+    </>
+  )
+}
+
+interface AccountTagInputItemProps extends Ariakit.SelectItemProps {
+  children?: React.ReactNode
+  account?: AccountSearchResult
+}
+
+export const AccountTagInputItem = forwardRef<HTMLDivElement, AccountTagInputItemProps>(
+  function AccountTagInputItem(props, ref) {
+    const resource = useResource(props.account?.id)
+    const metadata =
+      props.account?.metadata ?? (resource.data?.type === 'document' ? resource.data.document?.metadata : undefined)
+    return (
+      <Ariakit.SelectItem
+        ref={ref}
+        {...props}
+        render={
+          <Ariakit.ComboboxItem
+            render={<AccountTagInputItemContent className="combobox-item" render={props.render} />}
+          />
+        }
+      >
+        <div className="flex flex-1 justify-start gap-2">
+          {metadata && props.account?.id ? (
+            <HMIcon size={16} name={metadata.name} icon={metadata.icon} id={props.account.id} />
+          ) : null}
+          <div className="flex flex-1">
+            <SizableText size="sm" className="text-currentColor">
+              {props.children || props.account?.label}
+            </SizableText>
+          </div>
+        </div>
+      </Ariakit.SelectItem>
+    )
+  },
+)
+
+const AccountTagInputItemContent = forwardRef<any, any>(function AccountTagInputItemContent(props, ref) {
+  let {render, children, ...restProps} = props
+
+  return (
+    <div ref={ref} {...restProps} className="combobox-item data-[active-item]:bg-accent flex flex-1 gap-2 p-3">
+      {render ? render : children}
+    </div>
+  )
+})

--- a/frontend/packages/ui/src/collaborators-page.tsx
+++ b/frontend/packages/ui/src/collaborators-page.tsx
@@ -1,42 +1,22 @@
-import * as Ariakit from '@ariakit/react'
-import {CompositeInput} from '@ariakit/react-core/composite/composite-input'
-import {
-  HMCapability,
-  HMMetadata,
-  HMMetadataPayload,
-  HMSiteMember,
-  UnpackedHypermediaId,
-} from '@seed-hypermedia/client/hm-types'
+import {HMCapability, HMMetadataPayload, HMSiteMember, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {resolveHypermediaUrl, type DomainResolverFn} from '@seed-hypermedia/client'
 import {useRouteLink} from '@shm/shared'
 import {useAddCapabilities, useSelectedAccountCapability} from '@shm/shared/models/capabilities'
-import {
-  useAccount,
-  useCapabilities,
-  useCollaborators,
-  useResource,
-  useSelectedAccountId,
-  useSiteMembers,
-} from '@shm/shared/models/entity'
+import {useCapabilities, useCollaborators, useSelectedAccountId, useSiteMembers} from '@shm/shared/models/entity'
 import {useSearch} from '@shm/shared/models/search'
 import {abbreviateUid} from '@shm/shared/utils/abbreviate'
 import {hmId, hmIdToURL, unpackHmId} from '@shm/shared/utils/entity-id-url'
 import {Users} from 'lucide-react'
-import {forwardRef, useCallback, useEffect, useId, useMemo, useRef, useState} from 'react'
+import {useCallback, useMemo, useState} from 'react'
 import {Button} from './button'
-import './combobox.css'
-import {HMIcon, LoadedHMIcon} from './hm-icon'
-import {ArrowRight, X} from './icons'
+import {AccountSearchResult, AccountTagInput, AccountTagInputItem} from './account-tag-input'
+import {HMIcon} from './hm-icon'
+import {ArrowRight} from './icons'
 import {Spinner} from './spinner'
 import {SizableText} from './text'
 import {toast} from './toast'
 
-type SearchResult = {
-  id: UnpackedHypermediaId
-  label: string
-  unresolved?: boolean
-  metadata?: HMMetadata
-}
+type SearchResult = AccountSearchResult
 
 function AddCollaboratorForm({id, domainResolver}: {id: UnpackedHypermediaId; domainResolver?: DomainResolverFn}) {
   const myCapability = useSelectedAccountCapability(id, 'owner')
@@ -115,7 +95,7 @@ function AddCollaboratorForm({id, domainResolver}: {id: UnpackedHypermediaId; do
     <div className="flex flex-col gap-2 px-4 pt-4">
       <div className="border-border flex overflow-hidden rounded-md border-1">
         <div className="flex flex-1">
-          <TagInput
+          <AccountTagInput
             label="Members"
             value={search}
             onChange={handleSearchChange}
@@ -128,19 +108,19 @@ function AddCollaboratorForm({id, domainResolver}: {id: UnpackedHypermediaId; do
             {matches.map(
               (result) =>
                 result && (
-                  <TagInputItem
+                  <AccountTagInputItem
                     key={result.id.id}
                     onClick={() => {
                       setSelectedCollaborators((vals) => [...vals, result])
                     }}
-                    member={result}
+                    account={result}
                   >
                     Add &quot;{result?.label}&quot;
-                  </TagInputItem>
+                  </AccountTagInputItem>
                 ),
             )}
             {search && matches.length == 0 ? (
-              <TagInputItem
+              <AccountTagInputItem
                 onClick={async () => {
                   // Try resolving bare domains (e.g. "gabo.es")
                   if (search.includes('.')) {
@@ -160,9 +140,9 @@ function AddCollaboratorForm({id, domainResolver}: {id: UnpackedHypermediaId; do
                 }}
               >
                 Add &quot;{search}&quot;
-              </TagInputItem>
+              </AccountTagInputItem>
             ) : null}
-          </TagInput>
+          </AccountTagInput>
         </div>
         {selectedCollaborators.length ? (
           <Button
@@ -438,197 +418,3 @@ function DocumentCollaborators({
     </div>
   )
 }
-
-interface TagInputProps extends Omit<Ariakit.ComboboxProps, 'onChange'> {
-  label: string
-  value?: string
-  onChange?: (value: string) => void
-  defaultValue?: string
-  values?: Array<SearchResult>
-  onValuesChange?: (values: Array<SearchResult>) => void
-  defaultValues?: Array<SearchResult>
-}
-
-const TagInput = forwardRef<HTMLInputElement, TagInputProps>(function TagInput(props, ref) {
-  const {label, defaultValue, value, onChange, defaultValues, values, onValuesChange, children, ...comboboxProps} =
-    props
-
-  const comboboxRef = useRef<HTMLInputElement>(null)
-  const defaultComboboxId = useId()
-  const comboboxId = comboboxProps.id || defaultComboboxId
-
-  const combobox = Ariakit.useComboboxStore({
-    value,
-    defaultValue,
-    setValue: onChange,
-    resetValueOnHide: true,
-  })
-
-  // @ts-expect-error
-  const select = Ariakit.useSelectStore<SearchResult>({
-    combobox,
-    value: values,
-    defaultValue: defaultValues,
-    setValue: onValuesChange,
-  })
-
-  const composite = Ariakit.useCompositeStore({
-    defaultActiveId: comboboxId,
-  })
-
-  const selectedValues = select.useState('value')
-
-  // Reset the combobox value whenever an item is checked or unchecked.
-  useEffect(() => combobox.setValue(''), [selectedValues, combobox])
-
-  const toggleValueFromSelectedValues = (value: SearchResult) => {
-    // @ts-expect-error
-    select.setValue((prevSelectedValues: Array<SearchResult>) => {
-      const index = prevSelectedValues.indexOf(value)
-      if (index !== -1) {
-        return prevSelectedValues.filter((v: SearchResult) => v.id.id != value.id.id)
-      }
-      return [...prevSelectedValues, value]
-    })
-  }
-
-  const onItemClick = (value: SearchResult) => () => {
-    toggleValueFromSelectedValues(value)
-  }
-
-  const onItemKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
-    if (event.key === 'Backspace' || event.key === 'Delete') {
-      event.currentTarget.click()
-    }
-  }
-
-  const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key !== 'Backspace') return
-    const {selectionStart, selectionEnd} = event.currentTarget
-    const isCaretAtTheBeginning = selectionStart === 0 && selectionEnd === 0
-    if (!isCaretAtTheBeginning) return
-    // @ts-expect-error
-    select.setValue((values: Array<SearchResult>) => {
-      if (!values.length) return values
-      return values.slice(0, values.length - 1)
-    })
-    combobox.hide()
-  }
-
-  return (
-    <Ariakit.Composite
-      store={composite}
-      role="grid"
-      aria-label={label}
-      className="tag-grid"
-      onClick={() => comboboxRef.current?.focus()}
-      render={<div className="flex flex-1 rounded-md p-1" />}
-    >
-      <Ariakit.CompositeRow role="row" render={<div className="flex w-full flex-wrap gap-1" />}>
-        {/* @ts-expect-error */}
-        {selectedValues.map((value: SearchResult) => {
-          // TODO: (horacio): Should I cleanup the list from the `unresolved` value?
-          return (
-            <Ariakit.CompositeItem
-              key={value.id.id}
-              role="gridcell"
-              onClick={onItemClick(value)}
-              onKeyDown={onItemKeyDown}
-              onFocus={combobox.hide}
-              render={
-                <div className="bg-background border-border flex min-h-6 items-center gap-1 rounded-md border p-1 px-2 hover:bg-black/10 dark:hover:bg-white/10" />
-              }
-            >
-              {'unresolved' in value && value.unresolved ? (
-                <UnresolvedItem value={value} />
-              ) : (
-                <>
-                  <LoadedHMIcon id={value.id} size={20} />
-                  <SizableText>{value.label}</SizableText>
-                </>
-              )}
-              <X size={12} />
-            </Ariakit.CompositeItem>
-          )
-        })}
-        <div role="cell" className="flex flex-1 flex-col">
-          <Ariakit.CompositeItem
-            id={comboboxId}
-            render={
-              <CompositeInput
-                ref={comboboxRef}
-                onKeyDown={onInputKeyDown}
-                render={<Ariakit.Combobox ref={ref} store={combobox} className="combobox" {...comboboxProps} />}
-              />
-            }
-          />
-        </div>
-        <Ariakit.ComboboxPopover
-          store={combobox}
-          portal
-          sameWidth
-          gutter={8}
-          render={
-            <Ariakit.SelectList
-              // @ts-expect-error
-              store={select}
-              render={<div className="z-100 rounded-sm bg-white dark:bg-black" />}
-            />
-          }
-        >
-          {children}
-        </Ariakit.ComboboxPopover>
-      </Ariakit.CompositeRow>
-    </Ariakit.Composite>
-  )
-})
-
-function UnresolvedItem({value}: {value: SearchResult}) {
-  const account = useAccount(value.id.uid, {subscribe: true})
-  const metadata = account.data?.metadata
-  const label = metadata?.name || abbreviateUid(value.id.uid)
-  return (
-    <>
-      <HMIcon id={value.id} name={metadata?.name} icon={metadata?.icon} size={20} />
-      <SizableText>{label}</SizableText>
-    </>
-  )
-}
-
-interface TagInputItemProps extends Ariakit.SelectItemProps {
-  children?: React.ReactNode
-  member?: SearchResult
-}
-
-const TagInputItem = forwardRef<HTMLDivElement, TagInputItemProps>(function TagInputItem(props, ref) {
-  const resource = useResource(props.member?.id)
-  const metadata = resource.data?.type === 'document' ? resource.data.document?.metadata : undefined
-  return (
-    <Ariakit.SelectItem
-      ref={ref}
-      {...props}
-      render={<Ariakit.ComboboxItem render={<TagInputItemContent className="combobox-item" render={props.render} />} />}
-    >
-      <div className="flex flex-1 justify-start gap-2">
-        {metadata && props.member?.id ? (
-          <HMIcon size={16} name={metadata?.name} icon={metadata?.icon} id={props.member?.id} />
-        ) : null}
-        <div className="flex flex-1">
-          <SizableText size="sm" className="text-currentColor">
-            {props.children || props.member?.label}
-          </SizableText>
-        </div>
-      </div>
-    </Ariakit.SelectItem>
-  )
-})
-
-const TagInputItemContent = forwardRef<any, any>(function TagInputItemContent(props, ref) {
-  let {render, children, ...restProps} = props
-
-  return (
-    <div ref={ref} {...restProps} className="combobox-item data-[active-item]:bg-accent flex flex-1 gap-2 p-3">
-      {render ? render : children}
-    </div>
-  )
-})


### PR DESCRIPTION
## Summary

- Add query block filter support with persisted `Author` filters across editor and HM block conversion.
- Add an author account picker for query settings and reuse the account tag input in collaborator flows.
- Apply author filters during query resolution before sorting and limiting, with tests for persistence and resolver behavior.
- Document the query block filter model, current scope, and deferred follow-ups.