### PR TITLE
fix(frontend): preserve drafts across version changes

### DIFF
--- a/frontend/apps/desktop/src/components/editing-toolbar.tsx
+++ b/frontend/apps/desktop/src/components/editing-toolbar.tsx
@@ -5,6 +5,7 @@ import {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {useResource} from '@shm/shared/models/entity'
 import {selectDraftId, useDocumentSelector} from '@shm/shared/models/use-document-machine'
 import {createSiteUrl, createWebHMUrl, hmId} from '@shm/shared/utils/entity-id-url'
+import {useNavRoute} from '@shm/shared/utils/navigation'
 import {pathNameify} from '@shm/shared/utils/path'
 import {computeInlineDraftPublishPath} from '@shm/shared/utils/publish-paths'
 import {
@@ -13,6 +14,7 @@ import {
   EditingDocToolsRight as SharedEditingDocToolsRight,
 } from '@shm/ui/editing-toolbar'
 import {MenuItemType} from '@shm/ui/options-dropdown'
+import {toast} from '@shm/ui/toast'
 import {useCallback, useMemo} from 'react'
 import {useDeleteDraftDialog} from './delete-draft-dialog'
 
@@ -64,12 +66,13 @@ function useUnpublishedChildCount(): number {
 }
 
 /** Build all desktop-specific callbacks for the shared toolbar. */
-function useDesktopToolbarCallbacks(docId: UnpackedHypermediaId): {
+export function useDesktopToolbarCallbacks(docId: UnpackedHypermediaId): {
   callbacks: EditingToolbarCallbacks
   deleteDraftDialog: ReturnType<typeof useDeleteDraftDialog>
 } {
   const deleteDraftDialog = useDeleteDraftDialog()
   const navigate = useNavigate('replace')
+  const route = useNavRoute()
   const getDocumentUrl = useDocumentUrlWithSite(docId.uid)
 
   const callbacks: EditingToolbarCallbacks = useMemo(
@@ -78,7 +81,14 @@ function useDesktopToolbarCallbacks(docId: UnpackedHypermediaId): {
       onDiscardConfirm: (discardDraftId: string, send) => {
         deleteDraftDialog.open({
           draftId: discardDraftId,
-          onConfirm: () => send({type: 'edit.discard'}),
+          onConfirm: () => {
+            send({type: 'edit.discard'})
+            navigate({
+              ...(route.key === 'document' ? route : {key: 'document'}),
+              id: {...docId, version: null},
+            } as any)
+            toast.success('Draft changes discarded')
+          },
         })
       },
       slugify: pathNameify,
@@ -91,7 +101,7 @@ function useDesktopToolbarCallbacks(docId: UnpackedHypermediaId): {
         } as any)
       },
     }),
-    [getDocumentUrl, deleteDraftDialog, navigate],
+    [getDocumentUrl, deleteDraftDialog, navigate, docId, route],
   )
 
   return {callbacks, deleteDraftDialog}

--- a/frontend/apps/desktop/src/models/documents.ts
+++ b/frontend/apps/desktop/src/models/documents.ts
@@ -272,7 +272,7 @@ export function usePublishResource(
             // Probe whether a doc already exists at the original destination.
             // The result drives two things:
             //  1. Whether to apply the inline-first-publish slug rename below.
-            //  2. `latestHeads` for the shallow rebase against the live doc.
+            //  2. Fallback base version for legacy drafts that have no deps.
             // Skipped for legacy first-publishes (no `editId` outer arg) because
             // there is no doc to fetch yet.
             let existingDocVersion: string | null = null
@@ -350,55 +350,25 @@ export function usePublishResource(
 
             const docPath = hmIdPathToEntityQueryPath(resolvedDestinationId.path || [])
 
-            // Bump the draft to the current latest heads before publishing. Until the
-            // rebase flow lands, this is a shallow "rebase": baseVersion = latest, and
-            // the minimal block diff is applied on top. Blocks the user didn't touch keep
-            // the latest's content; blocks the user edited overwrite (last-writer-wins).
-            // The draft's persisted `deps` is also updated so a retry after failure (or a
-            // subsequent publish from the same draft) starts from the new base.
-            let latestHeads: string[] = []
+            // Publish from the draft's persisted base deps. Remote updates are
+            // handled by the document-machine rebase flow; do not silently bump
+            // deps to the newest head here, especially after a conflict was
+            // ignored to keep the user's local editor content stable.
             let latestVersion = ''
             if (existingDocVersion) {
               latestVersion = existingDocVersion
-              latestHeads = existingDocVersion.split('.')
               // console.log('[publish] using existing latest heads', {
               //   account: resolvedDestinationId.uid,
               //   path: docPath,
               //   latestVersion,
-              //   latestHeads,
               // })
             }
             const draftDeps = draft.deps ?? []
-            const baseVersion = latestVersion || draftDeps.join('.')
-
-            const depsChanged =
-              latestHeads.length > 0 &&
-              (latestHeads.length !== draftDeps.length || latestHeads.some((h) => !draftDeps.includes(h)))
-            if (depsChanged) {
-              // console.log('[publish] persisting rebased deps to draft', {
-              //   draftId: draft.id,
-              //   from: draftDeps,
-              //   to: latestHeads,
-              // })
-              await client.drafts.write.mutate({
-                id: draft.id,
-                locationUid: draft.locationUid,
-                locationPath: draft.locationPath,
-                editUid: draft.editUid,
-                editPath: draft.editPath,
-                metadata: draft.metadata,
-                content: draft.content,
-                deps: latestHeads,
-                navigation: draft.navigation,
-                visibility: draft.visibility,
-              })
-            }
+            const baseVersion = draftDeps.length ? draftDeps.join('.') : latestVersion
 
             // console.log('[publish] computed baseVersion', {
             //   draftDeps,
-            //   latestHeads,
             //   baseVersion,
-            //   depsChanged,
             // })
 
             const publishInput = {
@@ -424,7 +394,7 @@ export function usePublishResource(
             //   resultVersion: updatedDoc.version,
             // })
 
-            // Inspect the Change blob the server produced to verify deps = latestHeads.
+            // Inspect the Change blob the server produced to verify deps.
             try {
               const changesResp = await grpcClient.documents.listDocumentChanges({
                 account: resolvedDestinationId.uid,
@@ -437,10 +407,7 @@ export function usePublishResource(
               //   newChangeId: newChange?.id,
               //   deps: newChange?.deps,
               //   author: newChange?.author,
-              //   expectedDeps: latestHeads,
-              //   depsMatch:
-              //     newChange?.deps?.length === latestHeads.length &&
-              //     (newChange?.deps ?? []).every((d) => latestHeads.includes(d)),
+              //   expectedDeps: draftDeps,
               //   allChanges: changesResp.changes.map((c) => ({id: c.id, deps: c.deps})),
               // })
             } catch (err) {

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -10,7 +10,7 @@ import {DesktopQueryBlockDraftSlot} from '@/components/desktop-query-block-draft
 import {DesktopDocumentActionsProvider} from '@/components/document-actions-provider'
 import {EditNavHeaderPane} from '@/components/edit-nav-header-pane'
 import {useEditProfileDialog} from '@/components/edit-profile-dialog'
-import {EditingDocToolsRight} from '@/components/editing-toolbar'
+import {EditingDocToolsRight, useDesktopToolbarCallbacks} from '@/components/editing-toolbar'
 // import {InlineNewDocumentCard} from '@/components/inline-new-document-card'
 import {JoinButton} from '@/components/join-button'
 import {MoveDialog} from '@/components/move-dialog'
@@ -121,7 +121,7 @@ export default function DesktopResourcePage() {
   const documentResourceId = hasLocationOnlyDraft || isDraftRouteLookupPending ? null : docId
 
   const capability = useSelectedAccountCapability(docId)
-  const canEdit = roleCanWrite(capability?.role)
+  const canEdit = roleCanWrite(capability?.role) && !docId.version
   const myAccountIds = useMyAccountIds()
 
   // Fetch draft content early so the editor can be initialized with draft blocks
@@ -414,6 +414,9 @@ export default function DesktopResourcePage() {
       fromPromise<void, DiscardDraftInput>(async ({input}) => {
         await deleteDraftsForCleanup(input.draftId, input.deletedChildDraftIds)
         await client.drafts.delete.mutate(input.draftId)
+        invalidateQueries([queryKeys.DRAFT, input.draftId])
+        invalidateQueries([queryKeys.DRAFTS_LIST])
+        invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT])
       }),
     [],
   )
@@ -775,6 +778,8 @@ export default function DesktopResourcePage() {
           />
         )
       : undefined
+  const {callbacks: draftVersionToolbarCallbacks, deleteDraftDialog: draftVersionDeleteDraftDialog} =
+    useDesktopToolbarCallbacks(docId)
 
   const onAfterReply = useCallback(
     (_docId: UnpackedHypermediaId, comment: HMComment) => {
@@ -823,6 +828,8 @@ export default function DesktopResourcePage() {
                     existingDraftCursorPosition={draftQuery.data?.cursorPosition}
                     existingDraftMineTouchedIds={draftQuery.data?.mineTouchedIds}
                     existingDraftBaseBlocks={draftQuery.data?.baseBlocks}
+                    existingDraftDeps={draftQuery.data?.deps}
+                    draftVersionOnDiscardConfirm={draftVersionToolbarCallbacks.onDiscardConfirm}
                     rightActions={<JoinButton siteUid={docId.uid} />}
                     onEditProfile={onEditProfile}
                     inspect={inspect}
@@ -841,6 +848,7 @@ export default function DesktopResourcePage() {
                       canEdit && !docId.path?.length ? <EditNavHeaderPane homeId={hmId(docId.uid)} /> : undefined
                     }
                   />
+                  {draftVersionDeleteDraftDialog.content}
                 </QuerySearchInputProvider>
               </QueryBlockDraftsProvider>
             </DesktopDraftBreadcrumbProvider>

--- a/frontend/apps/web/app/document-edit/web-document-actors.test.ts
+++ b/frontend/apps/web/app/document-edit/web-document-actors.test.ts
@@ -209,7 +209,7 @@ describe('publishWebDocument', () => {
     const prepareCall = deps.requestMock.mock.calls.find((c: any) => c[0] === 'PrepareDocumentChange')!
     const args = prepareCall[1]
     expect(args.account).toBe(OWNER)
-    expect(args.baseVersion).toBe('baseline-version')
+    expect(args.baseVersion).toBe('old-head')
     expect(args.capability).toBe('')
 
     const opCases = (args.changes as any[]).map((c) => c.op?.case)

--- a/frontend/apps/web/app/document-edit/web-document-actors.ts
+++ b/frontend/apps/web/app/document-edit/web-document-actors.ts
@@ -27,6 +27,7 @@ import {
 } from '@shm/shared/models/document-machine'
 import {invalidateAfterPublish} from '@shm/shared/models/post-publish-cache'
 import {invalidateQueries, refetchQueriesByKey} from '@shm/shared/models/query-client'
+import {queryKeys} from '@shm/shared/models/query-keys'
 import type {UniversalClient} from '@shm/shared/universal-client'
 import {
   compareBlocksWithMap,
@@ -128,6 +129,9 @@ function makePublishDocumentActor(deps: CreateWebDocumentMachineDeps) {
 function makeDiscardDraftActor() {
   return fromPromise<void, DiscardDraftInput>(async ({input}) => {
     await discardWebDocDraft(input.draftId, input.deletedChildDraftIds)
+    invalidateQueries([queryKeys.DRAFT, input.draftId])
+    invalidateQueries([queryKeys.DRAFTS_LIST])
+    invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT])
   })
 }
 
@@ -171,7 +175,7 @@ export async function publishWebDocument(input: PublishInput, deps: CreateWebDoc
   const allChanges = [...navChanges, ...metadataChanges, ...blockDiff.changes, ...deleteChanges]
 
   const latestVersion = editDocument?.version ?? ''
-  const baseVersion = latestVersion || (draft.deps.length ? draft.deps.join('.') : '')
+  const baseVersion = draft.deps.length ? draft.deps.join('.') : latestVersion
   const isPrivate = draft.visibility === 'PRIVATE' || editDocument?.visibility === 'PRIVATE'
   const currentPath = deps.docId.path ?? []
   const isPlaceholderPath = isWebDraftPlaceholderPath(currentPath, draft.draftId)

--- a/frontend/apps/web/app/web-resource-page.tsx
+++ b/frontend/apps/web/app/web-resource-page.tsx
@@ -18,6 +18,7 @@ import {InspectorPage} from '@shm/ui/inspector-page'
 import {DocumentActionsProvider} from '@shm/shared/document-actions-context'
 import {CommentEditorProps, ResourcePage} from '@shm/ui/resource-page-common'
 import {Spinner} from '@shm/ui/spinner'
+import {toast} from '@shm/ui/toast'
 import {useAppDialog} from '@shm/ui/universal-dialog'
 import {EditingDocToolsRight, type EditingToolbarCallbacks} from '@shm/ui/editing-toolbar'
 import {lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState} from 'react'
@@ -38,12 +39,7 @@ import {useWebCanEdit} from './document-edit/use-web-can-edit'
 import {createWebDocumentMachine} from './document-edit/web-document-actors'
 import {WebDraftActionsProvider} from './document-edit/web-draft-actions-provider'
 import {WebQueryBlockDraftSlot} from './document-edit/web-query-block-draft-slot'
-import {
-  cleanupOldWebDocDrafts,
-  deleteWebDocDraft,
-  getLatestWebDocDraftForDoc,
-  getWebDocDraft,
-} from './document-edit/web-draft-db'
+import {cleanupOldWebDocDrafts, getLatestWebDocDraftForDoc, getWebDocDraft} from './document-edit/web-draft-db'
 import {makeWebFileUpload} from './document-edit/web-image-upload'
 import {getWebDraftPlaceholderId} from './document-edit/web-draft-path'
 
@@ -165,23 +161,16 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
     enabled: typeof window !== 'undefined' && !!signingAccountId && (canEdit || !!placeholderDraftId),
     staleTime: 60_000,
   })
-  // Detect and auto-delete stale IDB drafts whose base version doesn't match
-  // the current published version. Happens when published from desktop/another session.
+  // Keep local drafts even when their base is no longer latest. Remote updates
+  // are handled by the document machine's queued rebase flow; deleting here can
+  // destroy a valid in-progress draft when the user is merely viewing a pinned
+  // historical version.
   const draftData = draftQuery.data
-  const isDraftStale = useMemo(() => {
-    if (!draftData || !docId.version) return false
-    return !draftData.deps.includes(docId.version)
-  }, [draftData, docId.version])
-
-  useEffect(() => {
-    if (isDraftStale && draftData) {
-      deleteWebDocDraft(draftData.draftId).catch(() => {})
-    }
-  }, [isDraftStale, draftData])
+  const isDraftStale = false
 
   const canEditLocalPlaceholderDraft =
     !!placeholderDraftId && !!draftData && !!signingAccountId && draftData.signingAccountId === signingAccountId
-  const effectiveCanEdit = canEdit || canEditLocalPlaceholderDraft
+  const effectiveCanEdit = (canEdit || canEditLocalPlaceholderDraft) && !docId.version
   const effectiveCapabilityCid = capability && capability.id !== '_owner' ? capability.id : draftData?.capabilityCid
 
   // Build a documentMachine wired to web actors. Stable per (docId, signing identity, capability).
@@ -278,6 +267,11 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
       onDiscardConfirm: (draftId: string, send) => {
         if (window.confirm('Discard draft changes?')) {
           send({type: 'edit.discard'})
+          replaceRouteRef.current({
+            ...(route.key === 'document' ? route : {key: 'document'}),
+            id: {...docId, version: null},
+          } as any)
+          toast.success('Draft changes discarded')
         }
       },
       slugify: pathNameify,
@@ -290,7 +284,7 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
         } as any)
       },
     }),
-    [origin, originHomeId, navigate],
+    [origin, originHomeId, navigate, docId, route],
   )
 
   const showPublishToolbar = route.key === 'document'
@@ -382,6 +376,8 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
                 existingDraftVisibility={draftData?.visibility}
                 existingDraftContent={existingDraftContent}
                 existingDraftCursorPosition={existingDraftCursorPosition}
+                existingDraftDeps={draftData?.deps}
+                draftVersionOnDiscardConfirm={webToolbarCallbacks.onDiscardConfirm}
                 editingFloatingActions={editingFloatingActions}
                 fileUpload={fileUpload}
               />

--- a/frontend/packages/editor/src/document-editor.tsx
+++ b/frontend/packages/editor/src/document-editor.tsx
@@ -435,6 +435,23 @@ export function DocumentEditor({
   initialContentRef.current = initialContent
   const draftCursorPositionRef = useRef(draftCursorPosition)
   draftCursorPositionRef.current = draftCursorPosition
+  const lastReadOnlyContentKeyRef = useRef('')
+
+  useEffect(() => {
+    if (isEditing) return
+    const contentKey = JSON.stringify(initialContent)
+    if (contentKey === lastReadOnlyContentKeyRef.current) return
+    lastReadOnlyContentKeyRef.current = contentKey
+
+    suppressChangeRef.current = true
+    try {
+      editor.replaceBlocks(editor.topLevelBlocks, initialContent)
+    } finally {
+      suppressChangeRef.current = false
+    }
+    actorRef.send({type: 'editor.baselineUpdate', blocks: editor.topLevelBlocks as any})
+    actorRef.send({type: 'childDraftRefs.changed', draftIds: collectChildDraftIds(editor.topLevelBlocks)})
+  }, [actorRef, editor, initialContent, isEditing])
 
   const handlersRef = useEditorHandlersRef()
 
@@ -499,12 +516,8 @@ export function DocumentEditor({
           view.focus()
         }
 
-        // Apply immediately, but also re-apply on the next frame to survive
-        // Radix's focus restoration when entering editing from the
-        // confirmingOldVersionEdit dialog. Radix moves focus back to the
-        // previously focused element after the dialog unmounts, which can
-        // steal focus from the editor — reapplying after the Radix cleanup
-        // lets our cursor placement win.
+        // Apply immediately, but also re-apply on the next frame so focus
+        // restoration from surrounding UI cannot steal focus from the editor.
         applySelection()
         requestAnimationFrame(() => {
           if (view.isDestroyed) return

--- a/frontend/packages/shared/src/models/__tests__/document-machine-rebase.test.ts
+++ b/frontend/packages/shared/src/models/__tests__/document-machine-rebase.test.ts
@@ -108,7 +108,7 @@ describe('documentMachine rebase transitions', () => {
     actor.stop()
   })
 
-  it('rebase.detectConflict transitions rebase region to conflict', () => {
+  it('rebase.detectConflict clears pending remote update and stays idle', () => {
     const actor = createTestActor()
     enterEditing(actor)
     actor.send({type: 'document.remoteUpdate', document: remoteDocument})
@@ -119,17 +119,14 @@ describe('documentMachine rebase transitions', () => {
     })
     const snapshot = actor.getSnapshot()
     const ctx = snapshot.context
-    expect(ctx.pendingRebase).toEqual({
-      kind: 'conflict',
-      conflictedBlockIds: ['b1'],
-      author: 'Alice',
-    })
-    expect(ctx.pendingRemoteDocument).toBe(remoteDocument)
-    expect(snapshot.matches({editing: {rebase: 'conflict'}})).toBe(true)
+    expect(ctx.pendingRebase).toBeNull()
+    expect(ctx.pendingRemoteDocument).toBeNull()
+    expect(ctx.pendingRemoteVersion).toBeNull()
+    expect(snapshot.matches({editing: {rebase: 'idle'}})).toBe(true)
     actor.stop()
   })
 
-  it('rebase.dismiss clears pendingRebase but keeps pendingRemoteDocument', () => {
+  it('rebase.dismiss clears pendingRebase and pendingRemoteDocument', () => {
     const actor = createTestActor()
     enterEditing(actor)
     actor.send({type: 'document.remoteUpdate', document: remoteDocument})
@@ -141,7 +138,8 @@ describe('documentMachine rebase transitions', () => {
     actor.send({type: 'rebase.dismiss'})
     const ctx = actor.getSnapshot().context
     expect(ctx.pendingRebase).toBeNull()
-    expect(ctx.pendingRemoteDocument).toBe(remoteDocument)
+    expect(ctx.pendingRemoteDocument).toBeNull()
+    expect(ctx.pendingRemoteVersion).toBeNull()
     actor.stop()
   })
 
@@ -164,38 +162,7 @@ describe('documentMachine rebase transitions', () => {
     actor.stop()
   })
 
-  it('rebase.apply from conflict region returns to idle', () => {
-    const actor = createTestActor()
-    enterEditing(actor)
-    actor.send({type: 'document.remoteUpdate', document: remoteDocument})
-    actor.send({
-      type: 'rebase.detectConflict',
-      conflictedBlockIds: ['b1'],
-      author: 'Alice',
-    })
-    expect(actor.getSnapshot().matches({editing: {rebase: 'conflict'}})).toBe(true)
-    actor.send({type: 'rebase.apply', mergedBlocks: remoteDocument.content, newDocument: remoteDocument})
-    expect(actor.getSnapshot().matches({editing: {rebase: 'idle'}})).toBe(true)
-    expect(actor.getSnapshot().context.pendingRebase).toBeNull()
-    actor.stop()
-  })
-
-  it('rebase.dismiss returns rebase region to idle from conflict', () => {
-    const actor = createTestActor()
-    enterEditing(actor)
-    actor.send({type: 'document.remoteUpdate', document: remoteDocument})
-    actor.send({
-      type: 'rebase.detectConflict',
-      conflictedBlockIds: ['b1'],
-      author: 'Alice',
-    })
-    expect(actor.getSnapshot().matches({editing: {rebase: 'conflict'}})).toBe(true)
-    actor.send({type: 'rebase.dismiss'})
-    expect(actor.getSnapshot().matches({editing: {rebase: 'idle'}})).toBe(true)
-    actor.stop()
-  })
-
-  it('publish.start succeeds even while rebase region is in conflict (mine-wins is auto-applied)', async () => {
+  it('publish.start succeeds after conflict is ignored and cleared', async () => {
     const actor = createTestActor()
     enterEditing(actor)
     actor.send({type: 'document.remoteUpdate', document: remoteDocument})
@@ -208,9 +175,8 @@ describe('documentMachine rebase transitions', () => {
       conflictedBlockIds: ['b1'],
       author: 'Alice',
     })
-    expect(actor.getSnapshot().matches({editing: {rebase: 'conflict'}})).toBe(true)
-    // Conflicts no longer block publish — mine-wins is auto-applied and the
-    // user can ship at any time. Publish should proceed.
+    expect(actor.getSnapshot().matches({editing: {rebase: 'idle'}})).toBe(true)
+    expect(actor.getSnapshot().context.pendingRemoteDocument).toBeNull()
     actor.send({type: 'publish.start'})
     expect(actor.getSnapshot().matches('publishing')).toBe(true)
     actor.stop()

--- a/frontend/packages/shared/src/models/__tests__/document-machine.test.ts
+++ b/frontend/packages/shared/src/models/__tests__/document-machine.test.ts
@@ -290,6 +290,31 @@ describe('DocumentLifecycle machine', () => {
     actor.stop()
   })
 
+  it('loaded → edit.start (isLatest=false) → stays loaded', () => {
+    const actor = createTestActor({isLatest: false})
+    actor.start()
+    loadDocument(actor)
+    actor.send({type: 'edit.start'})
+    expect(actor.getSnapshot().value).toBe('loaded')
+    actor.stop()
+  })
+
+  it('draft.resolved preserves stored draft deps when auto-entering editing', () => {
+    const actor = createTestActor()
+    actor.start()
+    actor.send({
+      type: 'draft.resolved',
+      draftId: 'my-draft',
+      content: [{block: {id: 'b1', type: 'Paragraph', text: 'draft text', attributes: {}}, children: []}],
+      cursorPosition: null,
+      deps: ['older-base'],
+    })
+    actor.send({type: 'document.loaded', document: mockDocument})
+    expect(actor.getSnapshot().value).toEqual({editing: {draft: 'idle', saveIndicator: 'hidden', rebase: 'idle'}})
+    expect(actor.getSnapshot().context.deps).toEqual(['older-base'])
+    actor.stop()
+  })
+
   it('editing.idle → change → editing.changed', () => {
     const actor = createTestActor()
     actor.start()
@@ -787,6 +812,7 @@ describe('DocumentLifecycle machine', () => {
     // existingDraftId sets draftReady: true, so only document.loaded is needed
     const actor = createTestActor({canEdit: false, existingDraftId: 'draft-1'})
     actor.start()
+    actor.send({type: 'capability.changed', canEdit: true})
     actor.send({type: 'document.loaded', document: mockDocument})
     // shouldAutoEdit is true (from existingDraftId), draftReady is true,
     // documentReady is now true → transitions to loaded → always to editing
@@ -976,35 +1002,12 @@ describe('DocumentLifecycle machine', () => {
     actor.stop()
   })
 
-  it('edit.start on old version → confirmingOldVersionEdit', () => {
+  it('edit.start on old version → stays loaded', () => {
     const actor = createTestActor({isLatest: false})
     actor.start()
     loadDocument(actor)
     expect(actor.getSnapshot().context.isLatestVersion).toBe(false)
     actor.send({type: 'edit.start'})
-    expect(actor.getSnapshot().value).toBe('confirmingOldVersionEdit')
-    actor.stop()
-  })
-
-  it('confirmingOldVersionEdit → edit.confirm → editing with deps set', () => {
-    const actor = createTestActor({isLatest: false})
-    actor.start()
-    loadDocument(actor)
-    actor.send({type: 'edit.start'})
-    expect(actor.getSnapshot().value).toBe('confirmingOldVersionEdit')
-    actor.send({type: 'edit.confirm'})
-    expect(actor.getSnapshot().value).toEqual({editing: {draft: 'idle', saveIndicator: 'hidden', rebase: 'idle'}})
-    expect(actor.getSnapshot().context.deps).toEqual(['bafyabc.bafydef'])
-    actor.stop()
-  })
-
-  it('confirmingOldVersionEdit → edit.cancel → back to loaded', () => {
-    const actor = createTestActor({isLatest: false})
-    actor.start()
-    loadDocument(actor)
-    actor.send({type: 'edit.start'})
-    expect(actor.getSnapshot().value).toBe('confirmingOldVersionEdit')
-    actor.send({type: 'edit.cancel'})
     expect(actor.getSnapshot().value).toBe('loaded')
     actor.stop()
   })
@@ -1018,9 +1021,7 @@ describe('DocumentLifecycle machine', () => {
     actor.stop()
   })
 
-  it('edit.start on old version with existing draft → skips dialog, goes to editing', () => {
-    // A draft already exists for this document, meaning the user previously
-    // confirmed "Edit Anyway". They should not be prompted again.
+  it('edit.start with stale existing draft → enters editing', () => {
     const actor = createTestActor({isLatest: false})
     actor.start()
     actor.send({type: 'document.loaded', document: mockDocument})
@@ -1030,46 +1031,12 @@ describe('DocumentLifecycle machine', () => {
       content: [],
       cursorPosition: null,
     })
-    expect(actor.getSnapshot().value).toBe('loaded')
+    expect(actor.getSnapshot().value).toEqual({editing: {draft: 'idle', saveIndicator: 'hidden', rebase: 'idle'}})
     expect(actor.getSnapshot().context.draftId).toBe('existing-draft')
-    actor.send({type: 'edit.start'})
-    expect(actor.getSnapshot().value).toEqual({editing: {draft: 'idle', saveIndicator: 'hidden', rebase: 'idle'}})
     actor.stop()
   })
 
-  it('confirm → write draft → cancel → edit.start again → no dialog', async () => {
-    // Once the first autosave creates a draft, subsequent edit.start clicks
-    // must bypass the confirmation dialog.
-    const machine = documentMachine.provide({
-      actors: {
-        writeDraft: fromPromise<{id: string}, any>(async () => ({id: 'draft-new'})),
-        publishDocument: fromPromise<HMDocument, any>(async () => mockDocument),
-        discardDraft: fromPromise<void, any>(async () => {}),
-      },
-      delays: {autosaveTimeout: 10, saveIndicatorDismiss: 10},
-    })
-    const actor = createActor(machine, {
-      input: {documentId: mockDocumentId, canEdit: true, isLatest: false},
-    })
-    actor.start()
-    actor.send({type: 'document.loaded', document: mockDocument})
-    actor.send({type: 'draft.resolved', draftId: null, content: null, cursorPosition: null})
-    actor.send({type: 'edit.start'})
-    expect(actor.getSnapshot().value).toBe('confirmingOldVersionEdit')
-    actor.send({type: 'edit.confirm'})
-    actor.send({type: 'change'})
-    await new Promise((r) => setTimeout(r, 80))
-    expect(actor.getSnapshot().context.draftId).toBe('draft-new')
-    actor.send({type: 'edit.cancel'})
-    expect(actor.getSnapshot().value).toBe('loaded')
-    expect(actor.getSnapshot().context.draftId).toBe('draft-new')
-    actor.send({type: 'edit.start'})
-    expect(actor.getSnapshot().value).toEqual({editing: {draft: 'idle', saveIndicator: 'hidden', rebase: 'idle'}})
-    actor.stop()
-  })
-
-  it('confirm → discard → edit.start again → dialog re-appears', async () => {
-    // edit.discard clears the draft, so the user must confirm again.
+  it('old version cannot create a draft through edit.start/change', async () => {
     const machine = documentMachine.provide({
       actors: {
         writeDraft: fromPromise<{id: string}, any>(async () => ({id: 'draft-disc'})),
@@ -1085,16 +1052,10 @@ describe('DocumentLifecycle machine', () => {
     actor.send({type: 'document.loaded', document: mockDocument})
     actor.send({type: 'draft.resolved', draftId: null, content: null, cursorPosition: null})
     actor.send({type: 'edit.start'})
-    actor.send({type: 'edit.confirm'})
     actor.send({type: 'change'})
     await new Promise((r) => setTimeout(r, 80))
-    expect(actor.getSnapshot().context.draftId).toBe('draft-disc')
-    actor.send({type: 'edit.discard'})
-    await new Promise((r) => setTimeout(r, 0))
     expect(actor.getSnapshot().value).toBe('loaded')
     expect(actor.getSnapshot().context.draftId).toBeNull()
-    actor.send({type: 'edit.start'})
-    expect(actor.getSnapshot().value).toBe('confirmingOldVersionEdit')
     actor.stop()
   })
 
@@ -1118,7 +1079,7 @@ describe('DocumentLifecycle machine', () => {
     actor.stop()
   })
 
-  it('auto-edit with draft on old version → stays loaded (no auto-edit)', () => {
+  it('auto-edit with stale draft → enters editing', () => {
     const actor = createTestActor({isLatest: false})
     actor.start()
     actor.send({
@@ -1128,9 +1089,8 @@ describe('DocumentLifecycle machine', () => {
       cursorPosition: null,
     })
     actor.send({type: 'document.loaded', document: mockDocument})
-    // Should NOT auto-transition to editing because isLatestVersion is false
-    expect(actor.getSnapshot().value).toBe('loaded')
-    expect(actor.getSnapshot().context.shouldAutoEdit).toBe(true) // still set, but guard blocks it
+    expect(actor.getSnapshot().value).toEqual({editing: {draft: 'idle', saveIndicator: 'hidden', rebase: 'idle'}})
+    expect(actor.getSnapshot().context.shouldAutoEdit).toBe(false)
     actor.stop()
   })
 

--- a/frontend/packages/shared/src/models/document-machine.ts
+++ b/frontend/packages/shared/src/models/document-machine.ts
@@ -159,7 +159,6 @@ export type DocumentMachineEvent =
   | {type: 'childDraftRefs.changed'; draftIds: string[]}
   | {type: 'capability.changed'; canEdit: boolean}
   | {type: 'account.changed'; signingAccountId?: string; publishAccountUid?: string}
-  | {type: 'edit.confirm'}
   | {type: 'version.changed'; isLatest: boolean}
   | {type: 'draft.existing'; draftId: string}
   | {
@@ -168,6 +167,7 @@ export type DocumentMachineEvent =
       content: HMBlockNode[] | null
       cursorPosition: number | null
       metadata?: HMMetadata | null
+      deps?: string[] | null
       /** Block IDs the user previously touched in this draft (persisted across reloads). */
       mineTouchedIds?: string[] | null
       /** Three-way merge base captured when the draft was first started or last rebased. */
@@ -304,7 +304,10 @@ export const documentMachine = setup({
       },
     }),
     setDepsFromPublished: assign({
-      deps: ({context}) => (context.publishedVersion ? [context.publishedVersion] : context.deps),
+      deps: ({context}) => {
+        if (context.draftId && context.deps.length) return context.deps
+        return context.publishedVersion ? [context.publishedVersion] : context.deps
+      },
     }),
     setPendingRemoteVersion: assign({
       pendingRemoteVersion: ({event}) => {
@@ -485,6 +488,11 @@ export const documentMachine = setup({
     clearPendingRebase: assign({
       pendingRebase: null,
     }),
+    clearPendingRemoteUpdate: assign({
+      pendingRemoteVersion: null,
+      pendingRemoteDocument: null,
+      pendingRebase: null,
+    }),
     setPathOverrideFromEvent: assign({
       pendingPathOverride: ({context, event}) => {
         if (event.type !== 'publish.start') return context.pendingPathOverride
@@ -549,6 +557,10 @@ export const documentMachine = setup({
       metadata: ({event, context}) => {
         if (event.type === 'draft.resolved' && event.metadata) return event.metadata
         return context.metadata
+      },
+      deps: ({event, context}) => {
+        if (event.type === 'draft.resolved' && event.deps && event.deps.length) return event.deps
+        return context.deps
       },
       mineTouchedIds: ({event, context}) => {
         if (event.type === 'draft.resolved' && event.mineTouchedIds && event.mineTouchedIds.length) {
@@ -638,18 +650,8 @@ export const documentMachine = setup({
   },
   guards: {
     canTransitionToEditing: ({context}) => {
-      const result = context.canEdit
+      const result = context.canEdit && (context.isLatestVersion || !!context.draftId)
       // console.log('[DocMachine] guard canTransitionToEditing', {
-      //   canEdit: context.canEdit,
-      //   isLatestVersion: context.isLatestVersion,
-      //   draftId: context.draftId,
-      //   result,
-      // })
-      return result
-    },
-    canEditOldVersion: ({context}) => {
-      const result = context.canEdit && !context.isLatestVersion && context.draftId === null
-      // console.log('[DocMachine] guard canEditOldVersion', {
       //   canEdit: context.canEdit,
       //   isLatestVersion: context.isLatestVersion,
       //   draftId: context.draftId,
@@ -785,17 +787,11 @@ export const documentMachine = setup({
 
     loaded: {
       on: {
-        'edit.start': [
-          {
-            target: 'confirmingOldVersionEdit',
-            guard: 'canEditOldVersion',
-          },
-          {
-            target: 'editing',
-            guard: 'canTransitionToEditing',
-            actions: ['setDepsFromPublished', 'snapshotBaseBlocks'],
-          },
-        ],
+        'edit.start': {
+          target: 'editing',
+          guard: 'canTransitionToEditing',
+          actions: ['setDepsFromPublished', 'snapshotBaseBlocks'],
+        },
         'edit.discard': [
           {
             target: 'discarding',
@@ -826,36 +822,9 @@ export const documentMachine = setup({
       },
       always: {
         target: 'editing',
-        guard: ({context}) => context.shouldAutoEdit && context.isLatestVersion,
+        guard: ({context}) =>
+          context.shouldAutoEdit && context.canEdit && (context.isLatestVersion || !!context.draftId),
         actions: ['clearShouldAutoEdit', 'setDepsFromPublished', 'snapshotBaseBlocks'],
-      },
-    },
-
-    confirmingOldVersionEdit: {
-      entry: () => console.log('[DocMachine] enter confirmingOldVersionEdit'),
-      exit: () => console.log('[DocMachine] exit confirmingOldVersionEdit'),
-      on: {
-        'edit.confirm': {
-          target: 'editing',
-          actions: [
-            () => console.log('[DocMachine] edit.confirm received → editing'),
-            'setDepsFromPublished',
-            'snapshotBaseBlocks',
-          ],
-        },
-        'edit.cancel': {
-          target: 'loaded',
-          actions: [() => console.log('[DocMachine] edit.cancel received in confirmingOldVersionEdit → loaded')],
-        },
-        'capability.changed': {
-          actions: ['setCanEdit'],
-        },
-        'account.changed': {
-          actions: ['setAccountIds'],
-        },
-        'version.changed': {
-          actions: ['setIsLatestVersion'],
-        },
       },
     },
 
@@ -1175,8 +1144,7 @@ export const documentMachine = setup({
               },
               on: {
                 'rebase.detectConflict': {
-                  target: 'conflict',
-                  actions: ['setRebaseConflict'],
+                  actions: ['clearPendingRemoteUpdate'],
                 },
                 // Auto-merge applied from idle stays in idle; the action
                 // updates context (document/deps/baseBlocks) and clears
@@ -1197,7 +1165,7 @@ export const documentMachine = setup({
                 },
                 'rebase.dismiss': {
                   target: 'idle',
-                  actions: ['clearPendingRebase'],
+                  actions: ['clearPendingRemoteUpdate'],
                 },
               },
             },

--- a/frontend/packages/shared/src/models/use-document-machine.ts
+++ b/frontend/packages/shared/src/models/use-document-machine.ts
@@ -254,7 +254,7 @@ export function useVersionLatestSync(isLatest: boolean) {
  * Sends `draft.resolved` once the draft query has fully settled:
  * - `undefined` = still loading (document or draft content not yet available)
  * - `{draftId: null, content: null}` = no draft exists
- * - `{draftId: string, content: HMBlockNode[]}` = draft exists and content is loaded
+ * - `{draftId: string, content: HMBlockNode[], deps: string[]}` = draft exists and content/base are loaded
  *
  * The machine's `loading` state waits for both `document.loaded` and
  * `draft.resolved` before transitioning to `loaded`, eliminating the
@@ -267,6 +267,7 @@ export function useDraftResolutionSync(
         content: HMBlockNode[] | null
         cursorPosition: number | null
         metadata?: HMMetadata | null
+        deps?: string[] | null
         mineTouchedIds?: string[] | null
         baseBlocks?: HMBlockNode[] | null
       }
@@ -284,6 +285,7 @@ export function useDraftResolutionSync(
         content: resolved.content,
         cursorPosition: resolved.cursorPosition,
         metadata: resolved.metadata ?? null,
+        deps: resolved.deps ?? null,
         mineTouchedIds: resolved.mineTouchedIds ?? null,
         baseBlocks: resolved.baseBlocks ?? null,
       })
@@ -367,11 +369,6 @@ export function selectIsPublishing(snapshot: DocumentMachineSnapshot): boolean {
 /** Whether the machine is in the `error` state. */
 export function selectIsError(snapshot: DocumentMachineSnapshot): boolean {
   return snapshot.matches('error')
-}
-
-/** Whether the machine is in the `confirmingOldVersionEdit` state (waiting for user confirmation). */
-export function selectIsConfirmingOldVersionEdit(snapshot: DocumentMachineSnapshot): boolean {
-  return snapshot.matches('confirmingOldVersionEdit')
 }
 
 /** Whether the current user can edit this document. */
@@ -832,18 +829,25 @@ export function useAutoRebase({
           structuralTheirsAdds: Array.from(theirsMap.keys()).filter((id) => !baseMap.has(id)),
           conflictDetail,
         })
+
+        // For now conflicts are non-blocking and must not mutate the user's
+        // in-progress editor state. Keep local content as-is, clear the
+        // pending remote update in the machine, and let publish continue from
+        // the draft's current base. We should only advance deps to a remote
+        // head after a real merge has been applied.
+        actorRef.send({
+          type: 'rebase.detectConflict',
+          conflictedBlockIds: classification.conflictedBlockIds,
+          author: authorName,
+        })
+        onConflictDetected?.({
+          conflictedBlockIds: classification.conflictedBlockIds,
+          author: authorName,
+        })
+        return
       }
 
-      // Default conflict picks to "mine wins" so the user's in-progress edits
-      // are preserved while non-conflicting blocks fold in from theirs. The
-      // conflict UI (Phase B) can later let the user opt into theirs per block.
-      const conflictPicks: Record<string, 'mine' | 'theirs'> = {}
-      if (!classification.autoMergeable) {
-        for (const id of classification.conflictedBlockIds) {
-          conflictPicks[id] = 'mine'
-        }
-      }
-      const merged = applyRebasePlan(mineNodes, remoteDoc.content ?? [], classification.plan, conflictPicks)
+      const merged = applyRebasePlan(mineNodes, remoteDoc.content ?? [], classification.plan, {})
       console.log('[Rebase hook] applying merge', {
         mergedBlockIds: merged.map((n) => n.block?.id),
         author: authorName,
@@ -1015,17 +1019,6 @@ export function useAutoRebase({
       // Kick the autosave pipeline so the merged blocks hit the draft file on disk.
       // Without this, a reload before the user's next keystroke reverts the merge.
       actorRef.send({type: 'change'})
-      // If the rebase carried unresolved conflicts, re-record them in machine
-      // context so the UI can surface a "conflicts kept your version" indicator.
-      // Mine-wins picks were already baked into the merged blocks above; this
-      // event is purely informational and does NOT block publish.
-      if (!classification.autoMergeable) {
-        actorRef.send({
-          type: 'rebase.detectConflict',
-          conflictedBlockIds: classification.conflictedBlockIds,
-          author: authorName,
-        })
-      }
       const postSnap = actorRef.getSnapshot()
       console.log('[Rebase hook] post-apply state', {
         stateValue: postSnap.value,
@@ -1035,14 +1028,7 @@ export function useAutoRebase({
         pendingRemoteDocument: !!postSnap.context.pendingRemoteDocument,
         pendingRebase: postSnap.context.pendingRebase,
       })
-      if (!classification.autoMergeable) {
-        onConflictDetected?.({
-          conflictedBlockIds: classification.conflictedBlockIds,
-          author: authorName,
-        })
-      } else {
-        onAutoMerged?.(authorName)
-      }
+      onAutoMerged?.(authorName)
     }, idleDebounceMs)
     return () => clearTimeout(timer)
   }, [

--- a/frontend/packages/ui/src/__tests__/feed.test.ts
+++ b/frontend/packages/ui/src/__tests__/feed.test.ts
@@ -1,0 +1,45 @@
+import {describe, expect, it} from 'vitest'
+import {getDraftVersionInsertIndex, shouldShowDraftVersionEntry} from '../feed'
+
+const draft = {
+  docId: {
+    id: 'hm://doc',
+    uid: 'doc',
+    path: [],
+    version: null,
+    blockRef: null,
+    blockRange: null,
+    hostname: null,
+    scheme: null,
+  },
+  draftId: 'draft-1',
+  deps: ['base-version'],
+}
+
+function docUpdate(version: string) {
+  return {
+    type: 'doc-update',
+    id: `event-${version}`,
+    time: Date.now(),
+    document: {version},
+  } as any
+}
+
+describe('draft versions feed helpers', () => {
+  it('shows the synthetic draft row only in versions history', () => {
+    expect(shouldShowDraftVersionEntry(['Ref'], draft)).toBe(true)
+    expect(shouldShowDraftVersionEntry([], draft)).toBe(false)
+    expect(shouldShowDraftVersionEntry(['Comment'], draft)).toBe(false)
+    expect(shouldShowDraftVersionEntry(['Ref'], undefined)).toBe(false)
+  })
+
+  it('places newer published versions above the draft and the base version below it', () => {
+    const events = [docUpdate('newer-version'), docUpdate('base-version'), docUpdate('older-version')]
+    expect(getDraftVersionInsertIndex(events, draft)).toBe(1)
+  })
+
+  it('places drafts without a visible base version at the top', () => {
+    expect(getDraftVersionInsertIndex([docUpdate('latest-version')], {...draft, deps: ['missing-base']})).toBe(0)
+    expect(getDraftVersionInsertIndex([docUpdate('latest-version')], {...draft, deps: []})).toBe(0)
+  })
+})

--- a/frontend/packages/ui/src/__tests__/resource-page-common.test.ts
+++ b/frontend/packages/ui/src/__tests__/resource-page-common.test.ts
@@ -1,6 +1,10 @@
 import {hmId} from '@shm/shared'
 import {describe, expect, it} from 'vitest'
-import {getCommentReplyPanelRoute, shouldSuppressMainCommentEditor} from '../resource-page-common'
+import {
+  getCommentReplyPanelRoute,
+  shouldSuppressMainCommentEditor,
+  shouldUseDraftForRenderedDocument,
+} from '../resource-page-common'
 
 describe('shouldSuppressMainCommentEditor', () => {
   const docId = hmId('alice', {path: ['doc']})
@@ -104,5 +108,34 @@ describe('getCommentReplyPanelRoute', () => {
       openComment: 'alice/other-comment-tsid',
     })
     expect(panelRoute.id.path).toEqual(['other-doc'])
+  })
+})
+
+describe('shouldUseDraftForRenderedDocument', () => {
+  it('uses a draft on the unpinned latest route', () => {
+    expect(
+      shouldUseDraftForRenderedDocument({
+        docId: hmId('alice', {path: ['doc']}),
+        existingDraft: {id: 'draft-1', metadata: {name: 'Draft'}} as any,
+      }),
+    ).toBe(true)
+  })
+
+  it('ignores a draft on a version-pinned snapshot route', () => {
+    expect(
+      shouldUseDraftForRenderedDocument({
+        docId: hmId('alice', {path: ['doc'], version: 'old-version'}),
+        existingDraft: {id: 'draft-1', metadata: {name: 'Draft'}} as any,
+      }),
+    ).toBe(false)
+  })
+
+  it('does not use a draft when no draft exists', () => {
+    expect(
+      shouldUseDraftForRenderedDocument({
+        docId: hmId('alice', {path: ['doc']}),
+        existingDraft: false,
+      }),
+    ).toBe(false)
   })
 })

--- a/frontend/packages/ui/src/feed.tsx
+++ b/frontend/packages/ui/src/feed.tsx
@@ -9,8 +9,8 @@ import {useActivityFeed} from '@shm/shared/use-activity-feed'
 import {commentIdToHmId, getCommentTargetId, getVersionHeads, hmId} from '@shm/shared/utils/entity-id-url'
 import {useNavRoute} from '@shm/shared/utils/navigation'
 import merge from 'lodash/merge'
-import {CircleAlert, Link, Merge, Trash2} from 'lucide-react'
-import {useEffect, useMemo, useRef} from 'react'
+import {CircleAlert, FilePen, Link, Merge, Trash2, X} from 'lucide-react'
+import {Fragment, useEffect, useMemo, useRef} from 'react'
 import {SelectionContent} from './accessories'
 import {useReadOnlyViewer} from '@shm/shared/readonly-viewer-context'
 import {Button} from './button'
@@ -26,6 +26,30 @@ import {Separator} from './separator'
 import {Spinner} from './spinner'
 import {Tooltip} from './tooltip'
 import {cn} from './utils'
+import {type DocumentMachineEvent} from '@shm/shared/models/document-machine'
+import {useDocumentSend} from '@shm/shared/models/use-document-machine'
+
+export type DraftVersionEntry = {
+  docId: UnpackedHypermediaId
+  draftId: string
+  deps?: string[]
+  metadata?: {name?: string}
+  onDiscardConfirm?: (draftId: string, send: (event: DocumentMachineEvent) => void) => void
+}
+
+export function shouldShowDraftVersionEntry(
+  filterEventType: HMListEventsParams['filterEventType'] | undefined,
+  draftVersionEntry: DraftVersionEntry | undefined,
+) {
+  return !!draftVersionEntry && !!filterEventType?.includes('Ref')
+}
+
+export function getDraftVersionInsertIndex(events: LoadedEvent[], draft: DraftVersionEntry | undefined) {
+  if (!draft?.deps?.length) return 0
+  const baseVersions = new Set(draft.deps)
+  const baseIndex = events.findIndex((event) => event.type === 'doc-update' && baseVersions.has(event.document.version))
+  return baseIndex === -1 ? 0 : baseIndex
+}
 
 export function Feed({
   filterResource,
@@ -33,12 +57,14 @@ export function Feed({
   filterEventType,
   targetDomain,
   size = 'md',
+  draftVersionEntry,
 }: {
   size?: 'sm' | 'md'
   filterResource: HMListEventsParams['filterResource']
   filterAuthors?: HMListEventsParams['filterAuthors']
   filterEventType?: HMListEventsParams['filterEventType']
   targetDomain?: string
+  draftVersionEntry?: DraftVersionEntry
 }) {
   const observerRef = useRef<IntersectionObserver>()
   const lastElementNodeRef = useRef<HTMLDivElement>(null)
@@ -124,6 +150,8 @@ export function Feed({
   useHackyAuthorsSubscriptions(authorIds)
 
   const isSingleResource = filterResource && !filterResource.endsWith('*') ? true : false
+  const shouldRenderDraftVersion = shouldShowDraftVersionEntry(filterEventType, draftVersionEntry)
+  const draftInsertIndex = shouldRenderDraftVersion ? getDraftVersionInsertIndex(allEvents, draftVersionEntry) : -1
 
   if (error) {
     return (
@@ -155,13 +183,36 @@ export function Feed({
   return (
     <SelectionContent>
       <div>
-        {allEvents.map((e) => {
+        {allEvents.map((e, index) => {
           const route = getEventRoute(e)
 
           if (e.type == 'comment' && e.replyingComment) {
             return (
-              <div key={`${e.type}-${e.id}-${e.time}`}>
-                <EventCommentWithReply
+              <Fragment key={`row-${e.type}-${e.id}-${e.time}`}>
+                {index === draftInsertIndex && draftVersionEntry ? (
+                  <DraftVersionItem draft={draftVersionEntry} hasNewerPublishedVersion={draftInsertIndex > 0} />
+                ) : null}
+                <div>
+                  <EventCommentWithReply
+                    isSingleResource={isSingleResource}
+                    event={e}
+                    route={route}
+                    targetDomain={targetDomain}
+                    size={size}
+                  />
+                  <Separator />
+                </div>
+              </Fragment>
+            )
+          }
+
+          return (
+            <Fragment key={`row-${e.type}-${e.id}-${e.time}`}>
+              {index === draftInsertIndex && draftVersionEntry ? (
+                <DraftVersionItem draft={draftVersionEntry} hasNewerPublishedVersion={draftInsertIndex > 0} />
+              ) : null}
+              <div>
+                <EventItem
                   isSingleResource={isSingleResource}
                   event={e}
                   route={route}
@@ -170,22 +221,12 @@ export function Feed({
                 />
                 <Separator />
               </div>
-            )
-          }
-
-          return (
-            <div key={`${e.type}-${e.id}-${e.time}`}>
-              <EventItem
-                isSingleResource={isSingleResource}
-                event={e}
-                route={route}
-                targetDomain={targetDomain}
-                size={size}
-              />
-              <Separator />
-            </div>
+            </Fragment>
           )
         })}
+        {draftInsertIndex === allEvents.length && draftVersionEntry ? (
+          <DraftVersionItem draft={draftVersionEntry} hasNewerPublishedVersion={draftInsertIndex > 0} />
+        ) : null}
         {!isLoading && <div className="h-20" ref={lastElementNodeRef} />}
       </div>
       {isFetchingNextPage && <div className="text-muted-foreground py-3 text-center">Loading more…</div>}
@@ -193,6 +234,71 @@ export function Feed({
         <div className="text-muted-foreground py-3 text-center">No more events</div>
       )}
     </SelectionContent>
+  )
+}
+
+function DraftVersionItem({
+  draft,
+  hasNewerPublishedVersion,
+}: {
+  draft: DraftVersionEntry
+  hasNewerPublishedVersion: boolean
+}) {
+  const currentRoute = useNavRoute()
+  const send = useDocumentSend()
+  const draftRoute = {
+    key: 'document' as const,
+    id: hmId(draft.docId.uid, {
+      path: draft.docId.path,
+    }),
+  }
+  const draftLinkProps = useRouteLink(merge({}, currentRoute, draftRoute))
+  const isCurrentDraftRoute =
+    currentRoute.key === 'document' &&
+    currentRoute.id.uid === draft.docId.uid &&
+    currentRoute.id.version === null &&
+    JSON.stringify(currentRoute.id.path ?? []) === JSON.stringify(draft.docId.path ?? [])
+
+  return (
+    <div
+      className={cn(
+        'bg-accent hover:bg-accent group dark:hover:bg-accent flex items-start gap-2 px-4 py-4 transition-colors',
+        isCurrentDraftRoute && 'ring-border ring-1 ring-inset',
+      )}
+      {...draftLinkProps}
+    >
+      <div className="bg-muted flex size-[24px] shrink-0 items-center justify-center rounded-full">
+        <FilePen className="text-muted-foreground size-3.5" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-foreground text-sm font-medium">Unpublished Changes</span>
+          {hasNewerPublishedVersion ? (
+            <span className="rounded-full bg-amber-500/10 px-1.5 py-0.5 text-[11px] font-medium text-amber-700 dark:text-amber-300">
+              Newer version above
+            </span>
+          ) : null}
+        </div>
+      </div>
+      <Tooltip content="Discard changes">
+        <Button
+          size="icon"
+          variant="ghost"
+          className="text-muted-foreground hover:text-destructive -m-1 size-7 shrink-0 opacity-70 hover:opacity-100"
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            if (draft.onDiscardConfirm) {
+              draft.onDiscardConfirm(draft.draftId, send)
+            } else if (window.confirm('Discard draft changes?')) {
+              send({type: 'edit.discard'})
+            }
+          }}
+        >
+          <X className="size-3.5" />
+        </Button>
+      </Tooltip>
+    </div>
   )
 }
 

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -46,14 +46,12 @@ import {
   documentMachine,
   DocumentMachineProvider,
   selectContext,
-  selectIsConfirmingOldVersionEdit,
   selectIsEditing,
   selectIsUnpublishedDraft,
   selectPublishedVersion,
   useAccountSync,
   useAutoRebase,
   useCapabilitySync,
-  useDocumentMachineRef,
   useDocumentNavigationOptional,
   useDocumentSelector,
   useDocumentSend,
@@ -63,7 +61,7 @@ import {
   useScrollSync,
   useVersionLatestSync,
 } from '@shm/shared/models/use-document-machine'
-import type {TransientResourceError} from '@shm/shared/models/document-machine'
+import type {DocumentMachineEvent, TransientResourceError} from '@shm/shared/models/document-machine'
 import {useEditorGate} from '@shm/shared/models/use-editor-gate'
 import {getRoutePanel} from '@shm/shared/routes'
 import {getBreadcrumbDocumentIds, isDraftPathSegment} from '@shm/shared/utils/breadcrumbs'
@@ -74,23 +72,13 @@ import {CSSProperties, lazy, ReactNode, Suspense, useCallback, useEffect, useMem
 import {AllDocumentsPage} from './all-documents-page'
 import {AccountPage} from './account-page'
 import {CollaboratorsPage} from './collaborators-page'
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from './components/alert-dialog'
 import {ScrollArea} from './components/scroll-area'
 import {DirectoryPageContent} from './directory-page'
 import {DiscussionsPageContent} from './discussions-page'
 import {DocumentCover} from './document-cover'
 import {AuthorPayload, BreadcrumbEntry, Breadcrumbs, DocumentHeader} from './document-header'
 import {DocumentTools} from './document-tools'
-import {Feed} from './feed'
+import {Feed, type DraftVersionEntry} from './feed'
 import {FeedFilters} from './feed-filters'
 import {useDocumentLayout} from './layout'
 import {MembersFacepile} from './members-facepile'
@@ -215,6 +203,21 @@ export function shouldSuppressMainCommentEditor({
   )
 }
 
+export function shouldUseDraftForRenderedDocument({
+  docId,
+  existingDraft,
+}: {
+  docId: UnpackedHypermediaId
+  existingDraft?: HMExistingDraft | false
+}) {
+  if (!existingDraft) return false
+  // Version-pinned routes are immutable snapshots. Even when a draft exists for
+  // the same path, the snapshot must render exactly the selected version and
+  // must not inherit draft content or draft actions.
+  if (docId.version) return false
+  return true
+}
+
 export function getCommentReplyPanelRoute({
   docId,
   comment,
@@ -298,6 +301,10 @@ export interface ResourcePageProps {
   existingDraftMineTouchedIds?: string[]
   /** Three-way merge base captured at draft start or last rebase, persisted across reloads. */
   existingDraftBaseBlocks?: HMBlockNode[]
+  /** Base deps captured for the draft. Used by platform wrappers and tests. */
+  existingDraftDeps?: string[]
+  /** Platform-specific confirm workflow for discarding the synthetic versions-panel draft row. */
+  draftVersionOnDiscardConfirm?: (draftId: string, send: (event: DocumentMachineEvent) => void) => void
   /** Pre-rendered document content HTML for SSR (avoids blank flash before editor loads) */
   ssrContentHTML?: string | null
   /** Platform-specific page footer (web only) */
@@ -379,6 +386,8 @@ export function ResourcePage({
   existingDraftCursorPosition,
   existingDraftMineTouchedIds,
   existingDraftBaseBlocks,
+  existingDraftDeps,
+  draftVersionOnDiscardConfirm,
   floatingButtons,
   pageFooter,
   inlineCards,
@@ -663,17 +672,37 @@ export function ResourcePage({
     )
   }
 
+  const shouldUseDraft = shouldUseDraftForRenderedDocument({docId, existingDraft})
+  const effectiveCanEdit = canEdit && !docId.version
+  const effectiveExistingDraft = shouldUseDraft ? existingDraft : false
+  const effectiveExistingDraftVisibility = shouldUseDraft ? existingDraftVisibility : undefined
+  const effectiveExistingDraftContent = shouldUseDraft ? existingDraftContent : undefined
+  const effectiveExistingDraftCursorPosition = shouldUseDraft ? existingDraftCursorPosition : undefined
+  const effectiveExistingDraftMineTouchedIds = shouldUseDraft ? existingDraftMineTouchedIds : undefined
+  const effectiveExistingDraftBaseBlocks = shouldUseDraft ? existingDraftBaseBlocks : undefined
+  const effectiveExistingDraftDeps = shouldUseDraft ? existingDraftDeps : undefined
+  const draftVersionEntry = existingDraft
+    ? {
+        docId,
+        draftId: existingDraft.id,
+        deps: existingDraftDeps,
+        metadata: existingDraft.metadata,
+        onDiscardConfirm: draftVersionOnDiscardConfirm,
+      }
+    : undefined
+
   return (
     <DocumentMachineProvider
       // Key on the route id so the machine actor is recreated when the URL
       // path changes (e.g. after first publish from `-${draftId}` → real slug).
       // Without this, useActorRef keeps the original actor instance and its
       // context still references the old documentId/editPath.
-      key={docId.id}
+      key={`${docId.id}@${docId.version ?? 'latest'}`}
       input={{
         documentId: docId,
-        canEdit,
+        canEdit: effectiveCanEdit,
         isLatest,
+        deps: effectiveExistingDraftDeps,
         editUid: docId.uid,
         editPath: docId.path ?? undefined,
         signingAccountId,
@@ -700,19 +729,21 @@ export function ResourcePage({
           CommentEditor={CommentEditor}
           optionsMenuItems={optionsMenuItems}
           extraMenuItems={extraMenuItems}
-          existingDraft={existingDraft}
-          existingDraftVisibility={existingDraftVisibility}
-          existingDraftContent={existingDraftContent}
-          existingDraftCursorPosition={existingDraftCursorPosition}
-          existingDraftMineTouchedIds={existingDraftMineTouchedIds}
-          existingDraftBaseBlocks={existingDraftBaseBlocks}
+          existingDraft={effectiveExistingDraft}
+          existingDraftVisibility={effectiveExistingDraftVisibility}
+          existingDraftContent={effectiveExistingDraftContent}
+          existingDraftCursorPosition={effectiveExistingDraftCursorPosition}
+          existingDraftMineTouchedIds={effectiveExistingDraftMineTouchedIds}
+          existingDraftBaseBlocks={effectiveExistingDraftBaseBlocks}
+          existingDraftDeps={effectiveExistingDraftDeps}
+          draftVersionEntry={draftVersionEntry}
           floatingButtons={floatingButtons}
           pageFooter={pageFooter}
           inlineCards={inlineCards}
           inlineInsert={inlineInsert}
           DocumentContentComponent={DocumentContentComponent}
           onEditorReady={onEditorReady}
-          canEdit={canEdit}
+          canEdit={effectiveCanEdit}
           editingFloatingActions={editingFloatingActions}
           draftActions={draftActions}
           signingAccountId={signingAccountId}
@@ -909,6 +940,8 @@ function DocumentBody({
   existingDraftCursorPosition,
   existingDraftMineTouchedIds,
   existingDraftBaseBlocks,
+  existingDraftDeps,
+  draftVersionEntry,
   floatingButtons,
   pageFooter,
   inlineCards,
@@ -942,6 +975,8 @@ function DocumentBody({
   existingDraftCursorPosition?: number
   existingDraftMineTouchedIds?: string[]
   existingDraftBaseBlocks?: HMBlockNode[]
+  existingDraftDeps?: string[]
+  draftVersionEntry?: DraftVersionEntry
   floatingButtons?: ReactNode
   pageFooter?: ReactNode
   inlineCards?: ReactNode
@@ -994,6 +1029,7 @@ function DocumentBody({
           content: HMBlockNode[] | null
           cursorPosition: number | null
           metadata?: import('@seed-hypermedia/client/hm-types').HMMetadata | null
+          deps?: string[] | null
           mineTouchedIds?: string[] | null
           baseBlocks?: HMBlockNode[] | null
         }
@@ -1008,6 +1044,7 @@ function DocumentBody({
         content: existingDraftContent,
         cursorPosition: existingDraftCursorPosition ?? null,
         metadata: existingDraft.metadata ?? null,
+        deps: existingDraftDeps ?? null,
         mineTouchedIds: existingDraftMineTouchedIds ?? null,
         baseBlocks: existingDraftBaseBlocks ?? null,
       }
@@ -1019,6 +1056,7 @@ function DocumentBody({
     existingDraft,
     existingDraftContent,
     existingDraftCursorPosition,
+    existingDraftDeps,
     existingDraftMineTouchedIds,
     existingDraftBaseBlocks,
   ])
@@ -1027,7 +1065,6 @@ function DocumentBody({
   const isEditing = useDocumentSelector(selectIsEditing)
   const isUnpublishedDraft = useDocumentSelector(selectIsUnpublishedDraft)
   const ctx = useDocumentSelector(selectContext)
-
   // Set of block ids present in the currently published version of the document.
   const publishedBlockIds = useMemo(() => {
     const ids = new Set<string>()
@@ -1809,6 +1846,7 @@ function DocumentBody({
           perspectiveAccountUid={perspectiveAccountUid}
           linkExtensionOptions={linkExtensionOptions}
           fileUpload={fileUpload}
+          draftVersionEntry={draftVersionEntry}
         />
       </div>
       {pageFooter ? <div className="mt-auto">{pageFooter}</div> : null}
@@ -1832,14 +1870,10 @@ function DocumentBody({
     }
   }
 
-  // Dialog for confirming edits on older document versions
-  const oldVersionEditDialog = <OldVersionEditDialog />
-
   // Mobile: use document scroll with bottom bar and panel sheet
   if (isMobile) {
     return (
       <>
-        {oldVersionEditDialog}
         <div className="relative flex flex-1 flex-col pb-20" ref={elementRef}>
           <GotoLatestBanner isLatest={isLatest} id={docId} document={document} />
           {mainPageContent}
@@ -1903,13 +1937,13 @@ function DocumentBody({
         CommentEditor={CommentEditor}
         siteUrl={siteUrl}
         fileUpload={fileUpload}
+        draftVersionEntry={draftVersionEntry}
       />
     </ScrollArea>
   ) : null
 
   return (
     <div className="relative flex flex-1 flex-col overflow-hidden" ref={elementRef}>
-      {oldVersionEditDialog}
       <PanelLayout
         panelKey={panelKey}
         panelContent={panelContent}
@@ -2108,59 +2142,6 @@ function EditableDocumentHeader({
   )
 }
 
-function OldVersionEditDialog() {
-  const isConfirming = useDocumentSelector(selectIsConfirmingOldVersionEdit)
-  const actorRef = useDocumentMachineRef()
-  const send = useDocumentSend()
-  return (
-    <AlertDialog
-      open={isConfirming}
-      onOpenChange={(open) => {
-        // Only send edit.cancel when the dialog closes while we're still
-        // waiting for confirmation (overlay click / Escape). Clicking "Edit
-        // Anyway" sends edit.confirm first, transitioning out of
-        // confirmingOldVersionEdit; Radix then closes the dialog and fires
-        // onOpenChange(false) — we must not send edit.cancel in that case
-        // because it would bounce us back to `loaded` and re-prompt on the
-        // next click. Read the machine's *current* snapshot (not the
-        // React-rendered value) because onOpenChange fires synchronously
-        // inside the same event handler as edit.confirm.
-        if (!open && actorRef.getSnapshot().matches('confirmingOldVersionEdit')) {
-          send({type: 'edit.cancel'})
-        }
-      }}
-    >
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Edit older version?</AlertDialogTitle>
-          <AlertDialogDescription>
-            You are viewing an older version of this document. Editing it will create a new branch in the document
-            history, separate from the latest version.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel
-            onClick={() => {
-              console.log('[OldVersionEditDialog] Cancel clicked')
-              send({type: 'edit.cancel'})
-            }}
-          >
-            Cancel
-          </AlertDialogCancel>
-          <AlertDialogAction
-            onClick={() => {
-              console.log('[OldVersionEditDialog] Edit Anyway clicked')
-              send({type: 'edit.confirm'})
-            }}
-          >
-            Edit Anyway
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-  )
-}
-
 /** Auto-resize a textarea to fit its content. */
 function applyTitleResize(el: HTMLTextAreaElement) {
   el.style.height = 'auto'
@@ -2175,6 +2156,7 @@ function PanelContentRenderer({
   CommentEditor,
   siteUrl,
   fileUpload,
+  draftVersionEntry,
 }: {
   panelRoute: DocumentPanelRoute
   docId: UnpackedHypermediaId
@@ -2182,13 +2164,20 @@ function PanelContentRenderer({
   CommentEditor?: React.ComponentType<CommentEditorProps>
   siteUrl?: string
   fileUpload?: (file: File) => Promise<string>
+  draftVersionEntry?: DraftVersionEntry
 }) {
   switch (panelRoute.key) {
     case 'options':
       return <DocumentOptionsPanel docId={docId} fileUpload={fileUpload} />
     case 'activity':
       return (
-        <Feed size="sm" filterResource={docId.id} filterEventType={panelRoute.filterEventType} targetDomain={siteUrl} />
+        <Feed
+          size="sm"
+          filterResource={docId.id}
+          filterEventType={panelRoute.filterEventType}
+          targetDomain={siteUrl}
+          draftVersionEntry={draftVersionEntry}
+        />
       )
     case 'comments':
       return (
@@ -2363,6 +2352,7 @@ function MainContent({
   perspectiveAccountUid,
   linkExtensionOptions,
   fileUpload,
+  draftVersionEntry,
 }: {
   docId: UnpackedHypermediaId
   resourceId: UnpackedHypermediaId
@@ -2411,6 +2401,7 @@ function MainContent({
   perspectiveAccountUid?: string | null
   linkExtensionOptions?: LinkExtensionOptions
   fileUpload?: (file: File) => Promise<string>
+  draftVersionEntry?: DraftVersionEntry
 }) {
   const {originHomeId} = useUniversalAppContext()
   const navigate = useNavigate()
@@ -2447,6 +2438,7 @@ function MainContent({
             filterResource={docId.id}
             filterEventType={activityFilterEventType || []}
             targetDomain={siteUrl}
+            draftVersionEntry={draftVersionEntry}
           />
         </PageLayout>
       )


### PR DESCRIPTION
## Summary
- Preserve existing draft content and base deps when viewing or publishing across document version changes.
- Prevent editing version-pinned document snapshots while still allowing existing drafts to be resumed from the latest route.
- Add an unpublished draft entry in version history with discard support and cache invalidation after draft discard.
- Update rebase behavior so conflicts keep local editor content stable instead of silently advancing draft deps.
- Add focused tests for draft rendering, version-history draft placement, publish base versions, and document-machine transitions.