### PR TITLE
fix not found title on private documents

### DIFF
--- a/frontend/apps/web/app/__tests__/document-page-meta.test.ts
+++ b/frontend/apps/web/app/__tests__/document-page-meta.test.ts
@@ -10,6 +10,15 @@ vi.mock('@shm/editor/comment-editor', () => ({
   CommentEditor: () => null,
 }))
 
+vi.mock('@/loaders', () => ({
+  loadSiteResource: vi.fn(),
+  loadWebDraftPlaceholderResource: vi.fn(),
+}))
+
+vi.mock('@/site-config.server', () => ({
+  getConfig: vi.fn(),
+}))
+
 import {documentPageMeta} from '../routes/$'
 
 describe('documentPageMeta', () => {

--- a/frontend/apps/web/app/__tests__/document-page-meta.test.ts
+++ b/frontend/apps/web/app/__tests__/document-page-meta.test.ts
@@ -1,0 +1,32 @@
+import {Code} from '@connectrpc/connect'
+import {describe, expect, it} from 'vitest'
+import {wrap} from '../wrapping'
+import {documentPageMeta} from '../routes/$'
+
+describe('documentPageMeta', () => {
+  it('uses Private Document title for private documents', () => {
+    const meta = documentPageMeta({
+      data: wrap({
+        daemonError: {
+          code: Code.PermissionDenied,
+          message: 'permission denied',
+        },
+      } as any),
+    })
+
+    expect(meta).toEqual([{title: 'Private Document'}])
+  })
+
+  it('keeps Not Found title for missing documents', () => {
+    const meta = documentPageMeta({
+      data: wrap({
+        daemonError: {
+          code: Code.NotFound,
+          message: 'not found',
+        },
+      } as any),
+    })
+
+    expect(meta).toEqual([{title: 'Not Found'}])
+  })
+})

--- a/frontend/apps/web/app/__tests__/document-page-meta.test.ts
+++ b/frontend/apps/web/app/__tests__/document-page-meta.test.ts
@@ -6,6 +6,10 @@ vi.mock('@/client-lazy', () => ({
   WebCommenting: () => null,
 }))
 
+vi.mock('@shm/editor/comment-editor', () => ({
+  CommentEditor: () => null,
+}))
+
 import {documentPageMeta} from '../routes/$'
 
 describe('documentPageMeta', () => {

--- a/frontend/apps/web/app/__tests__/document-page-meta.test.ts
+++ b/frontend/apps/web/app/__tests__/document-page-meta.test.ts
@@ -1,6 +1,11 @@
 import {Code} from '@connectrpc/connect'
-import {describe, expect, it} from 'vitest'
+import {describe, expect, it, vi} from 'vitest'
 import {wrap} from '../wrapping'
+
+vi.mock('@/client-lazy', () => ({
+  WebCommenting: () => null,
+}))
+
 import {documentPageMeta} from '../routes/$'
 
 describe('documentPageMeta', () => {

--- a/frontend/apps/web/app/loaders.ts
+++ b/frontend/apps/web/app/loaders.ts
@@ -732,6 +732,11 @@ export async function loadSiteResource<T extends Record<string, unknown> = Recor
         message: e.message,
         code: e.code,
       }
+    } else if (e instanceof Error && e.message.toLowerCase().includes('permission')) {
+      daemonError = {
+        message: e.message,
+        code: Code.PermissionDenied,
+      }
     }
 
     return wrapJSON(

--- a/frontend/apps/web/app/routes/$.tsx
+++ b/frontend/apps/web/app/routes/$.tsx
@@ -175,7 +175,9 @@ const unregisteredMeta = defaultPageMeta('Welcome to Seed Hypermedia')
 export const documentPageMeta = ({data}: {data: Wrapped<SiteDocumentPayload>}): ReturnType<MetaFunction> => {
   const siteDocument = unwrap<SiteDocumentPayload>(data)
   if (!siteDocument?.document) {
-    return siteDocument ? [{title: 'Not Found'}] : []
+    return siteDocument
+      ? [{title: siteDocument.daemonError?.code === Code.PermissionDenied ? 'Private Document' : 'Not Found'}]
+      : []
   }
   const metadata = createResourceMetadata({
     id: siteDocument.comment ? commentIdToHmId(siteDocument.comment.id) : siteDocument.id,
@@ -403,6 +405,7 @@ export default function UnifiedDocumentPage() {
   if (
     siteData.daemonError &&
     siteData.daemonError.code !== Code.NotFound &&
+    siteData.daemonError.code !== Code.PermissionDenied &&
     !['profile', 'membership', 'followers', 'following'].includes(siteData.viewTerm || '')
   ) {
     return <DaemonErrorPage message={siteData.daemonError.message} code={siteData.daemonError.code} />

--- a/frontend/apps/web/app/routes/_index.tsx
+++ b/frontend/apps/web/app/routes/_index.tsx
@@ -37,7 +37,11 @@ export default function IndexPage() {
   }
 
   // Handle errors
-  if (data.daemonError && data.daemonError.code !== Code.NotFound) {
+  if (
+    data.daemonError &&
+    data.daemonError.code !== Code.NotFound &&
+    data.daemonError.code !== Code.PermissionDenied
+  ) {
     return <DaemonErrorPage message={data.daemonError.message} code={data.daemonError.code} />
   }
 

--- a/frontend/apps/web/app/routes/_index.tsx
+++ b/frontend/apps/web/app/routes/_index.tsx
@@ -37,11 +37,7 @@ export default function IndexPage() {
   }
 
   // Handle errors
-  if (
-    data.daemonError &&
-    data.daemonError.code !== Code.NotFound &&
-    data.daemonError.code !== Code.PermissionDenied
-  ) {
+  if (data.daemonError && data.daemonError.code !== Code.NotFound && data.daemonError.code !== Code.PermissionDenied) {
     return <DaemonErrorPage message={data.daemonError.message} code={data.daemonError.code} />
   }
 


### PR DESCRIPTION
## Summary

Fixes private documents showing `Not Found` as the page/browser title.

- Preserves permission-denied loader errors as `Code.PermissionDenied`
- Uses `Private Document` as the meta title for private document responses
- Allows permission-denied document routes to render the existing private document UI
- Adds regression tests for private vs not-found document meta titles

Closes #739

## Testing

- `git diff --check`
- Targeted Vitest run was not completed locally because `node_modules`/`vitest` were unavailable in the workspace.
