### PR TITLE
fix(frontend): improve block hover action targeting

### DIFF
--- a/frontend/packages/editor/src/blocknote/core/BlockNoteEditor.ts
+++ b/frontend/packages/editor/src/blocknote/core/BlockNoteEditor.ts
@@ -276,7 +276,8 @@ export class BlockNoteEditor<BSchema extends BlockSchema = HMBlockSchema> {
     this.hyperlinkToolbar = isReadOnly ? null : new HyperlinkToolbarProsemirrorPlugin(this)
     this.linkMenu = isReadOnly ? null : new LinkMenuProsemirrorPlugin(this)
 
-    // Read-only UI plugins: for document + viewer (not embed)
+    // Non-embed UI plugins: hover actions work across editor states, while
+    // range/full-block selection suppress themselves when not applicable.
     this.blockHoverActions = isEmbed ? null : new BlockHoverActionsProsemirrorPlugin(this)
     this.rangeSelection = isEmbed ? null : new RangeSelectionProsemirrorPlugin(this)
     this.fullBlockSelection = isEmbed ? null : new FullBlockSelectionProsemirrorPlugin(this)

--- a/frontend/packages/editor/src/blocknote/core/extensions/BlockHoverActions/BlockHoverActionsPlugin.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/BlockHoverActions/BlockHoverActionsPlugin.test.ts
@@ -1,0 +1,187 @@
+import {Schema} from 'prosemirror-model'
+import {EditorState, TextSelection} from 'prosemirror-state'
+import {EditorView} from 'prosemirror-view'
+import {afterEach, describe, expect, it} from 'vitest'
+import {BlockHoverActionsProsemirrorPlugin, BlockHoverActionsState} from './BlockHoverActionsPlugin'
+
+const schema = new Schema({
+  nodes: {
+    doc: {content: 'blockNode+'},
+    blockNode: {
+      content: 'paragraph blockChildren?',
+      attrs: {id: {default: ''}},
+      toDOM: (node) => ['div', {'data-node-type': 'blockNode', 'data-id': node.attrs.id}, 0],
+    },
+    blockChildren: {
+      content: 'blockNode+',
+      toDOM: () => ['div', {'data-node-type': 'blockChildren'}, 0],
+    },
+    paragraph: {content: 'text*', toDOM: () => ['p', {'data-content-type': 'paragraph'}, 0]},
+    text: {group: 'inline'},
+  },
+})
+
+const views: EditorView[] = []
+const mounts: HTMLElement[] = []
+
+afterEach(() => {
+  for (const view of views.splice(0)) {
+    view.destroy()
+  }
+  for (const mount of mounts.splice(0)) {
+    mount.remove()
+  }
+})
+
+function createView(editable: boolean, doc = createSingleBlockDoc()) {
+  const hoverActions = new BlockHoverActionsProsemirrorPlugin({} as any)
+  const updates: BlockHoverActionsState[] = []
+  hoverActions.onUpdate((state) => updates.push(state))
+
+  const state = EditorState.create({doc, plugins: [hoverActions.plugin]})
+  const mount = document.createElement('div')
+  document.body.appendChild(mount)
+  mounts.push(mount)
+
+  const view = new EditorView(mount, {
+    state,
+    editable: () => editable,
+  })
+  views.push(view)
+
+  return {view, updates}
+}
+
+function createSingleBlockDoc() {
+  return schema.nodes.doc.create(
+    null,
+    schema.nodes.blockNode.create({id: 'block-1'}, schema.nodes.paragraph.create(null, schema.text('hello world'))),
+  )
+}
+
+function createNestedBlockDoc() {
+  return schema.nodes.doc.create(
+    null,
+    schema.nodes.blockNode.create({id: 'parent'}, [
+      schema.nodes.paragraph.create(null, schema.text('parent')),
+      schema.nodes.blockChildren.create(
+        null,
+        schema.nodes.blockNode.create({id: 'child'}, schema.nodes.paragraph.create(null, schema.text('child'))),
+      ),
+    ]),
+  )
+}
+
+function dispatchMouseMove(element: HTMLElement) {
+  element.dispatchEvent(new MouseEvent('mousemove', {clientX: 10, clientY: 10, bubbles: true}))
+}
+
+function setRect(element: HTMLElement, rect: Partial<DOMRect>) {
+  Object.defineProperty(element, 'getBoundingClientRect', {
+    configurable: true,
+    value: () =>
+      ({
+        top: 0,
+        right: 100,
+        bottom: 20,
+        left: 0,
+        width: 100,
+        height: 20,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+        ...rect,
+      }) as DOMRect,
+  })
+}
+
+describe('BlockHoverActionsProsemirrorPlugin', () => {
+  it('emits hover state while the editor is editable', () => {
+    const {view, updates} = createView(true)
+
+    dispatchMouseMove(view.dom.querySelector('[data-content-type="paragraph"]') as HTMLElement)
+
+    expect(updates.at(-1)).toMatchObject({show: true, blockId: 'block-1'})
+  })
+
+  it('hides when text selection is active', () => {
+    const {view, updates} = createView(true)
+    dispatchMouseMove(view.dom.querySelector('[data-content-type="paragraph"]') as HTMLElement)
+
+    view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, 3, 8)))
+
+    expect(updates.at(-1)).toMatchObject({show: false, blockId: null})
+  })
+
+  it('keeps hover visible when the pointer leaves into the hover actions bridge', () => {
+    const {view, updates} = createView(true)
+    dispatchMouseMove(view.dom.querySelector('[data-content-type="paragraph"]') as HTMLElement)
+
+    const bridge = document.createElement('div')
+    bridge.dataset.bnBlockHoverActions = 'true'
+    document.body.appendChild(bridge)
+    view.dom.dispatchEvent(new MouseEvent('mouseleave', {relatedTarget: bridge}))
+    bridge.remove()
+
+    expect(updates.at(-1)).toMatchObject({show: true, blockId: 'block-1'})
+  })
+
+  it('targets nested block content instead of the parent block wrapper', () => {
+    const {view, updates} = createView(true, createNestedBlockDoc())
+    const childContent = view.dom.querySelector('[data-id="child"] > [data-content-type="paragraph"]') as HTMLElement
+
+    dispatchMouseMove(childContent)
+
+    expect(updates.at(-1)).toMatchObject({show: true, blockId: 'child'})
+  })
+
+  it('hides over nested children gaps instead of falling back to the parent block', () => {
+    const {view, updates} = createView(true, createNestedBlockDoc())
+    const parentContent = view.dom.querySelector('[data-id="parent"] > [data-content-type="paragraph"]') as HTMLElement
+    const childrenWrapper = view.dom.querySelector('[data-node-type="blockChildren"]') as HTMLElement
+
+    dispatchMouseMove(parentContent)
+    dispatchMouseMove(childrenWrapper)
+
+    expect(updates.at(-1)).toMatchObject({show: false, blockId: null})
+  })
+
+  it('keeps hover visible while crossing the current block gutter', () => {
+    const {view, updates} = createView(true)
+    const content = view.dom.querySelector('[data-content-type="paragraph"]') as HTMLElement
+    const block = view.dom.querySelector('[data-id="block-1"]') as HTMLElement
+    setRect(content, {right: 100})
+
+    dispatchMouseMove(content)
+    block.dispatchEvent(new MouseEvent('mousemove', {clientX: 110, clientY: 10, bubbles: true}))
+
+    expect(updates.at(-1)).toMatchObject({show: true, blockId: 'block-1'})
+  })
+
+  it('keeps hover visible when leaving the editor through the current block gutter', () => {
+    const {view, updates} = createView(true)
+    const content = view.dom.querySelector('[data-content-type="paragraph"]') as HTMLElement
+    setRect(content, {right: 100})
+
+    dispatchMouseMove(content)
+    view.dom.dispatchEvent(new MouseEvent('mouseleave', {clientX: 110, clientY: 10}))
+
+    expect(updates.at(-1)).toMatchObject({show: true, blockId: 'block-1'})
+  })
+
+  it('keeps hover visible over a supernumber badge for the current block', () => {
+    const {view, updates} = createView(true)
+    const content = view.dom.querySelector('[data-content-type="paragraph"]') as HTMLElement
+    const block = view.dom.querySelector('[data-id="block-1"]') as HTMLElement
+    const badge = document.createElement('button')
+    badge.className = 'bn-supernumber-badge'
+    badge.dataset.blockId = 'block-1'
+    block.appendChild(badge)
+    setRect(content, {right: 100})
+
+    dispatchMouseMove(content)
+    dispatchMouseMove(badge)
+
+    expect(updates.at(-1)).toMatchObject({show: true, blockId: 'block-1'})
+  })
+})

--- a/frontend/packages/editor/src/blocknote/core/extensions/BlockHoverActions/BlockHoverActionsPlugin.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/BlockHoverActions/BlockHoverActionsPlugin.ts
@@ -81,20 +81,71 @@ class BlockHoverActionsView<BSchema extends BlockSchema> implements PluginView {
   // -------------------------------------------------------------------------
 
   /**
-   * Walks up the DOM from `element` until a node that carries `data-id` is
-   * found.  Returns `null` if none is found before reaching the editor root.
+   * Walks up the DOM from `node` until a block content element is found.
+   * Returns `null` if the pointer is over a block wrapper or nested children
+   * area instead of an actual block content element.
    */
-  private findBlockElement(element: HTMLElement): HTMLElement | null {
-    let node: HTMLElement | null = element
+  private findBlockContentElement(node: Node | null): HTMLElement | null {
+    let element: HTMLElement | null =
+      node?.nodeType === Node.TEXT_NODE ? node.parentElement : node instanceof HTMLElement ? node : null
 
-    while (node && node !== this.pmView.dom) {
-      if (node.hasAttribute('data-id')) {
-        return node
+    while (element && element !== this.pmView.dom) {
+      if (element.hasAttribute('data-content-type')) {
+        return element
       }
-      node = node.parentElement
+      element = element.parentElement
     }
 
     return null
+  }
+
+  /**
+   * Finds the block node that owns a block content element. The direct
+   * `data-content-type` target is used first so hovering nested children does
+   * not accidentally select the parent block wrapper.
+   */
+  private findOwningBlockElement(contentElement: HTMLElement): HTMLElement | null {
+    let element: HTMLElement | null = contentElement.parentElement
+
+    while (element && element !== this.pmView.dom) {
+      if (element.getAttribute('data-node-type') === 'blockNode' && element.hasAttribute('data-id')) {
+        return element
+      }
+      element = element.parentElement
+    }
+
+    return null
+  }
+
+  private findBlockElementById(blockId: string): HTMLElement | null {
+    return this.pmView.dom.querySelector(`[data-node-type="blockNode"][data-id="${blockId}"]`) as HTMLElement | null
+  }
+
+  private findBlockContentElementForBlock(blockElement: HTMLElement): HTMLElement | null {
+    return Array.from(blockElement.children).find((child) =>
+      child.hasAttribute('data-content-type'),
+    ) as HTMLElement | null
+  }
+
+  private keepHoverInCurrentRightGutter(event: MouseEvent, requireCurrentBlockTarget: boolean): boolean {
+    if (!this.currentState.show || !this.currentState.blockId || !this.currentState.referenceRect) {
+      return false
+    }
+
+    if (requireCurrentBlockTarget) {
+      const target = event.target
+      if (!(target instanceof Element)) {
+        return false
+      }
+
+      const currentBlock = this.findBlockElementById(this.currentState.blockId)
+      if (!currentBlock?.contains(target)) {
+        return false
+      }
+    }
+
+    const rect = this.currentState.referenceRect
+    return event.clientX >= rect.right && event.clientY >= rect.top && event.clientY <= rect.bottom
   }
 
   private emitState(state: BlockHoverActionsState) {
@@ -117,12 +168,6 @@ class BlockHoverActionsView<BSchema extends BlockSchema> implements PluginView {
   }
 
   private handleMouseMove(event: MouseEvent) {
-    // Only show hover actions in read-only mode.
-    if (this.pmView.editable) {
-      this.hide()
-      return
-    }
-
     if (!this.pmView.dom.isConnected) {
       this.hide()
       return
@@ -134,43 +179,31 @@ class BlockHoverActionsView<BSchema extends BlockSchema> implements PluginView {
       return
     }
 
-    // Use posAtCoords to find the ProseMirror position under the cursor.
-    const coords = {left: event.clientX, top: event.clientY}
-    const posResult = this.pmView.posAtCoords(coords)
+    const supernumberBadge = event.target instanceof Element ? event.target.closest('.bn-supernumber-badge') : null
+    const supernumberBlockId = supernumberBadge instanceof HTMLElement ? supernumberBadge.dataset.blockId : undefined
 
-    if (!posResult) {
+    if (supernumberBlockId) {
+      const blockElement = this.findBlockElementById(supernumberBlockId)
+      const contentElement = blockElement ? this.findBlockContentElementForBlock(blockElement) : null
+
+      if (blockElement && contentElement) {
+        const referenceRect = contentElement.getBoundingClientRect()
+        this.emitState({show: true, blockId: supernumberBlockId, referenceRect})
+        return
+      }
+    }
+
+    const contentElement = this.findBlockContentElement(event.target as Node | null)
+    if (!contentElement) {
+      if (this.keepHoverInCurrentRightGutter(event, true)) {
+        return
+      }
+
       this.hide()
       return
     }
 
-    // Walk up from the DOM node returned by posAtCoords to find the block element.
-    let domNode: Node | null = null
-
-    // posResult.inside can be -1 (outside any node), so use pos as fallback.
-    if (posResult.inside >= 0) {
-      domNode = this.pmView.nodeDOM(posResult.inside) as Node | null
-    }
-
-    if (!domNode) {
-      const domAtResult = this.pmView.domAtPos(posResult.pos)
-      domNode = domAtResult.node
-    }
-
-    if (!domNode) {
-      this.hide()
-      return
-    }
-
-    // Normalise text nodes to their parent element.
-    const element: HTMLElement = (domNode.nodeType === Node.TEXT_NODE ? domNode.parentElement : domNode) as HTMLElement
-
-    if (!element) {
-      this.hide()
-      return
-    }
-
-    const blockElement = this.findBlockElement(element)
-
+    const blockElement = this.findOwningBlockElement(contentElement)
     if (!blockElement) {
       this.hide()
       return
@@ -186,7 +219,7 @@ class BlockHoverActionsView<BSchema extends BlockSchema> implements PluginView {
     // On touch-only devices, suppress for block types whose own click action
     // competes with the hover action buttons.
     if (isTouchOnlyDevice) {
-      const contentType = blockElement.querySelector('[data-content-type]')?.getAttribute('data-content-type')
+      const contentType = contentElement.getAttribute('data-content-type')
       if (contentType && TOUCH_SUPPRESSED_BLOCK_CONTENT_TYPES.has(contentType)) {
         this.hide()
         return
@@ -198,12 +231,21 @@ class BlockHoverActionsView<BSchema extends BlockSchema> implements PluginView {
       return
     }
 
-    const referenceRect = blockElement.getBoundingClientRect()
+    const referenceRect = contentElement.getBoundingClientRect()
 
     this.emitState({show: true, blockId, referenceRect})
   }
 
-  onMouseLeave = () => {
+  onMouseLeave = (event?: MouseEvent) => {
+    const relatedTarget = event?.relatedTarget
+    if (relatedTarget instanceof Element && relatedTarget.closest('[data-bn-block-hover-actions="true"]')) {
+      return
+    }
+
+    if (event && this.keepHoverInCurrentRightGutter(event, false)) {
+      return
+    }
+
     if (!this.frozen) {
       this.hide()
     }
@@ -241,7 +283,8 @@ export const blockHoverActionsPluginKey = new PluginKey('BlockHoverActionsPlugin
  * ProseMirror plugin that tracks which block the cursor is hovering over and
  * exposes that information to React via an {@link EventEmitter}.
  *
- * Only active in **read-only** mode (`!view.editable`).
+ * Active in editable and read-only mode; hidden while a non-empty text
+ * selection is active so it does not overlap selection-specific toolbars.
  *
  * @example
  * ```ts

--- a/frontend/packages/editor/src/blocknote/react/BlockHoverActions/BlockHoverActionsPositioner.test.tsx
+++ b/frontend/packages/editor/src/blocknote/react/BlockHoverActions/BlockHoverActionsPositioner.test.tsx
@@ -1,0 +1,126 @@
+import {createRoot, Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {BlockHoverActionsState} from '../../core/extensions/BlockHoverActions/BlockHoverActionsPlugin'
+import {BlockHoverActionsPositioner} from './BlockHoverActionsPositioner'
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('@shm/shared/models/use-document-machine', () => ({
+  useHideOnDocumentScroll: vi.fn(),
+}))
+
+type Listener = (state: BlockHoverActionsState) => void
+
+let container: HTMLDivElement
+let root: Root
+let listeners: Listener[]
+let editorDom: HTMLDivElement
+
+beforeEach(() => {
+  listeners = []
+  editorDom = document.createElement('div')
+  container = document.createElement('div')
+  document.body.appendChild(editorDom)
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  editorDom.remove()
+  container.remove()
+})
+
+function rect(top: number, right: number): DOMRect {
+  return {
+    top,
+    right,
+    bottom: top + 20,
+    left: right - 100,
+    width: 100,
+    height: 20,
+    x: right - 100,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect
+}
+
+function renderPositioner() {
+  const plugin = {
+    onUpdate: (listener: Listener) => {
+      listeners.push(listener)
+      return () => {
+        listeners = listeners.filter((item) => item !== listener)
+      }
+    },
+    freeze: vi.fn(),
+    unfreeze: vi.fn(),
+  }
+  const editor = {
+    blockHoverActions: plugin,
+    prosemirrorView: {dom: editorDom},
+  } as any
+
+  act(() => {
+    root.render(<BlockHoverActionsPositioner editor={editor} onCopyBlockLink={() => {}} onStartComment={() => {}} />)
+  })
+
+  return {plugin}
+}
+
+describe('BlockHoverActionsPositioner', () => {
+  it('stacks actions vertically to the right of a supernumber badge', () => {
+    const block = document.createElement('div')
+    block.dataset.id = 'block-1'
+    editorDom.appendChild(block)
+
+    const badge = document.createElement('button')
+    badge.className = 'bn-supernumber-badge'
+    badge.dataset.blockId = 'block-1'
+    Object.defineProperty(badge, 'getBoundingClientRect', {
+      value: () => rect(30, 124),
+    })
+    block.appendChild(badge)
+
+    renderPositioner()
+
+    act(() => {
+      listeners[0]({show: true, blockId: 'block-1', referenceRect: rect(30, 100)})
+    })
+
+    const copyButton = container.querySelector('[aria-label="Copy block link"]') as HTMLElement
+    const card = copyButton.parentElement as HTMLElement
+    const wrapper = card.parentElement as HTMLElement
+
+    expect(card.className).toContain('flex-col')
+    expect(wrapper.dataset.bnBlockHoverActions).toBe('true')
+    expect(wrapper.style.left).toBe('100px')
+    expect(wrapper.style.paddingLeft).toBe('44px')
+    const bridge = container.querySelector('[data-bn-block-hover-bridge="true"]') as HTMLElement
+    expect(bridge.style.width).toBe('44px')
+    expect(bridge.className).toContain('pointer-events-none')
+    expect(wrapper.className).toContain('pointer-events-none')
+    expect(block.classList.contains('bn-block-hover-highlight')).toBe(true)
+  })
+
+  it('pins the vertical actions inside the viewport when right placement would overflow', () => {
+    Object.defineProperty(window, 'innerWidth', {value: 130, configurable: true})
+    const block = document.createElement('div')
+    block.dataset.id = 'block-1'
+    editorDom.appendChild(block)
+
+    renderPositioner()
+
+    act(() => {
+      listeners[0]({show: true, blockId: 'block-1', referenceRect: rect(30, 100)})
+    })
+
+    const copyButton = container.querySelector('[aria-label="Copy block link"]') as HTMLElement
+    const wrapper = copyButton.parentElement?.parentElement as HTMLElement
+
+    expect(wrapper.style.right).toBe('4px')
+    expect(wrapper.style.left).toBe('')
+  })
+})

--- a/frontend/packages/editor/src/blocknote/react/BlockHoverActions/BlockHoverActionsPositioner.tsx
+++ b/frontend/packages/editor/src/blocknote/react/BlockHoverActions/BlockHoverActionsPositioner.tsx
@@ -10,6 +10,10 @@ import {
 import {BlockSchema} from '../../core/extensions/Blocks/api/blockTypes'
 
 const HOVER_BG_CLASS = 'bn-block-hover-highlight'
+const HOVER_BRIDGE_PX = 16
+const POPOVER_GAP_PX = 4
+const VIEWPORT_PADDING_PX = 4
+const VERTICAL_POPOVER_WIDTH_ESTIMATE_PX = 40
 
 /**
  * Helper type: once `blockHoverActions` is registered on the editor the
@@ -37,14 +41,16 @@ export type BlockHoverActionsPositionerProps<BSchema extends BlockSchema = Block
 // ---------------------------------------------------------------------------
 
 /**
- * Renders a small floating action card anchored to the top-right corner of the
- * block currently under the mouse cursor.
+ * Renders a small vertical floating action card anchored to the top-right
+ * corner of the block currently under the mouse cursor.
  *
  * Subscribe to the editor's `blockHoverActions` plugin via the EventEmitter and
- * position itself using the block's bounding rect.
+ * position itself using the block's bounding rect. When a block has a
+ * supernumber badge, the card anchors just to the right of that badge so both
+ * controls remain visible.
  *
- * Only active when the editor is in **read-only** mode (the plugin suppresses
- * emissions when the editor is editable).
+ * Active in editable and read-only editor states; the plugin suppresses
+ * emissions while text selection is active.
  *
  * @example
  * ```tsx
@@ -60,6 +66,7 @@ export function BlockHoverActionsPositioner<BSchema extends BlockSchema = BlockS
   onCopyBlockLink,
   onStartComment,
 }: BlockHoverActionsPositionerProps<BSchema>): React.ReactElement | null {
+  const hasActions = !!(onCopyBlockLink || onStartComment)
   const [hoverState, setHoverState] = useState<BlockHoverActionsState>({
     show: false,
     blockId: null,
@@ -117,60 +124,73 @@ export function BlockHoverActionsPositioner<BSchema extends BlockSchema = BlockS
     }, []),
   )
 
-  if (!hoverState.show || !hoverState.referenceRect || !hoverState.blockId) {
+  if (!hasActions || !hoverState.show || !hoverState.referenceRect || !hoverState.blockId) {
     return null
   }
 
   const rect = hoverState.referenceRect
   const blockId = hoverState.blockId
+  const supernumberBadges = Array.from(
+    editor.prosemirrorView.dom.querySelectorAll('.bn-supernumber-badge'),
+  ) as HTMLElement[]
+  const supernumberBadge = supernumberBadges.find((badge) => badge.dataset.blockId === blockId)
+  const anchorRect = supernumberBadge?.isConnected ? supernumberBadge.getBoundingClientRect() : rect
+  const bridgeWidth = Math.max(
+    HOVER_BRIDGE_PX + POPOVER_GAP_PX,
+    anchorRect.right - rect.right + HOVER_BRIDGE_PX + POPOVER_GAP_PX,
+  )
 
-  // Anchor the card to the top-right of the block, nudged up by 16px so it
-  // sits slightly above the block's first line (keeps positioning consistent
-  // regardless of block height — tall blocks no longer place the card in the
-  // middle). The wrapper overlaps the block by ~8px on its left side so the
-  // cursor can travel from the block into the buttons without crossing a gap
-  // and losing hover; small padding on the right keeps outward mouse travel
-  // forgiving too.
+  // Anchor the vertical card to the right of the supernumber badge when
+  // present, otherwise to the block's right edge. The outer wrapper starts at
+  // the content edge and contains an invisible bridge all the way to the card,
+  // which keeps hover alive across the supernumber gap.
   //
   // On narrow viewports (mobile) the block typically fills the screen, so
-  // the default left-anchored positioning would push the second button past
-  // the right edge and clip it. Detect that case and pin the card to the
-  // viewport's right edge instead so all buttons stay visible.
-  const OVERLAP_PX = 8
-  const TOP_OFFSET_PX = -16
-  // Generous estimate so the overflow check still fires when the popover is
-  // wider than expected.
-  const POPOVER_WIDTH_ESTIMATE_PX = 120
+  // the default right-of-block positioning can clip. Pin the card inside the
+  // viewport so all buttons stay visible.
   const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : Infinity
-  const wouldOverflow = rect.right - OVERLAP_PX + POPOVER_WIDTH_ESTIMATE_PX > viewportWidth
+  const visibleLeft = rect.right + bridgeWidth
+  const wouldOverflow = visibleLeft + VERTICAL_POPOVER_WIDTH_ESTIMATE_PX > viewportWidth - VIEWPORT_PADDING_PX
+  const activeBridgeWidth = wouldOverflow ? HOVER_BRIDGE_PX : bridgeWidth
   const style: React.CSSProperties = wouldOverflow
-    ? {
+    ? ({
         position: 'fixed',
-        top: rect.top + TOP_OFFSET_PX,
-        right: 4,
+        top: rect.top,
+        right: VIEWPORT_PADDING_PX,
+        paddingLeft: HOVER_BRIDGE_PX,
+        minHeight: rect.height,
         zIndex: 50,
-      }
-    : {
+        transition: 'top 150ms ease-out, left 150ms ease-out, right 150ms ease-out',
+      } as React.CSSProperties)
+    : ({
         position: 'fixed',
-        top: rect.top + TOP_OFFSET_PX,
-        left: rect.right - OVERLAP_PX,
+        top: rect.top,
+        left: rect.right,
+        paddingLeft: bridgeWidth,
+        paddingRight: VIEWPORT_PADDING_PX,
+        minHeight: rect.height,
         zIndex: 50,
-        paddingLeft: OVERLAP_PX,
-        paddingRight: 4,
-      }
+        transition: 'top 150ms ease-out, left 150ms ease-out, right 150ms ease-out',
+      } as React.CSSProperties)
 
   return (
-    <div
-      style={style}
-      onMouseEnter={() => editor.blockHoverActions?.freeze()}
-      onMouseLeave={() => {
-        editor.blockHoverActions?.unfreeze()
-        // Clear highlight immediately when leaving the card.
-        highlightedElRef.current?.classList.remove(HOVER_BG_CLASS)
-        highlightedElRef.current = null
-      }}
-    >
-      <div className="bg-popover flex items-center gap-1 rounded-md border p-1 shadow-sm">
+    <div data-bn-block-hover-actions="true" className="pointer-events-none" style={style}>
+      <div
+        aria-hidden="true"
+        data-bn-block-hover-bridge="true"
+        className="pointer-events-none absolute top-0 left-0 h-full rounded-sm"
+        style={{width: activeBridgeWidth}}
+      />
+      <div
+        className="bg-popover pointer-events-auto relative z-50 flex flex-col items-center gap-1 rounded-md border p-1 shadow-sm"
+        onMouseEnter={() => editor.blockHoverActions?.freeze()}
+        onMouseLeave={() => {
+          editor.blockHoverActions?.unfreeze()
+          // Clear highlight immediately when leaving the card.
+          highlightedElRef.current?.classList.remove(HOVER_BG_CLASS)
+          highlightedElRef.current = null
+        }}
+      >
         {onCopyBlockLink && (
           <button
             type="button"

--- a/frontend/packages/editor/src/document-editor.tsx
+++ b/frontend/packages/editor/src/document-editor.tsx
@@ -823,7 +823,7 @@ export function DocumentEditor({
             </>
           )}
 
-          {/* Read-only extensions */}
+          {/* Viewer/hover extensions */}
           <ImageGalleryOverlay editor={editor} resolveImageUrl={getImageUrl} />
           <BlockHoverActionsPositioner
             editor={editor}


### PR DESCRIPTION
## Summary
- Enables block hover actions across editable and read-only editor states while suppressing them during active text selection.
- Improves hover targeting for nested blocks, block gutters, and supernumber badges so actions stay anchored to the intended block.
- Updates hover action positioning to a vertical card that avoids viewport overflow and keeps the block highlight stable.
- Adds focused tests for hover targeting and positioner behavior.

fixes #747 