### PR TITLE
fix(frontend): support location-only draft placeholder routes

### DIFF
--- a/frontend/apps/desktop/src/app-drafts.ts
+++ b/frontend/apps/desktop/src/app-drafts.ts
@@ -566,6 +566,10 @@ export const draftsApi = t.router({
         draftFileMap.set(draftId, `${draftId}.json`)
         appInvalidateQueries([queryKeys.DRAFTS_LIST])
         appInvalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT])
+        if (input.locationUid) appInvalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT, input.locationUid])
+        if (input.editUid && input.editUid !== input.locationUid) {
+          appInvalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT, input.editUid])
+        }
         appInvalidateQueries([queryKeys.DRAFT, draftId])
         return {id: draftId}
       } catch (err) {

--- a/frontend/apps/desktop/src/components/editing-toolbar.tsx
+++ b/frontend/apps/desktop/src/components/editing-toolbar.tsx
@@ -5,6 +5,7 @@ import {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {useResource} from '@shm/shared/models/entity'
 import {selectDraftId, useDocumentSelector} from '@shm/shared/models/use-document-machine'
 import {createSiteUrl, createWebHMUrl, hmId} from '@shm/shared/utils/entity-id-url'
+import {isDraftPlaceholderPath} from '@shm/shared/draft-breadcrumb-context'
 import {useNavRoute} from '@shm/shared/utils/navigation'
 import {pathNameify} from '@shm/shared/utils/path'
 import {computeInlineDraftPublishPath} from '@shm/shared/utils/publish-paths'
@@ -83,9 +84,12 @@ export function useDesktopToolbarCallbacks(docId: UnpackedHypermediaId): {
           draftId: discardDraftId,
           onConfirm: () => {
             send({type: 'edit.discard'})
+            const nextId = isDraftPlaceholderPath(docId.path, discardDraftId)
+              ? hmId(docId.uid, {path: docId.path?.slice(0, -1)})
+              : {...docId, version: null}
             navigate({
               ...(route.key === 'document' ? route : {key: 'document'}),
-              id: {...docId, version: null},
+              id: nextId,
             } as any)
             toast.success('Draft changes discarded')
           },

--- a/frontend/apps/desktop/src/models/accounts.ts
+++ b/frontend/apps/desktop/src/models/accounts.ts
@@ -59,6 +59,7 @@ export function useDraft(id: string | undefined) {
     queryKey: [queryKeys.DRAFT, id],
     queryFn: () => client.drafts.get.query(id),
     enabled: !!id,
+    keepPreviousData: false,
   })
 }
 

--- a/frontend/apps/desktop/src/models/documents.ts
+++ b/frontend/apps/desktop/src/models/documents.ts
@@ -33,7 +33,7 @@ import {extractRefs, getAnnotations} from '@shm/shared/content'
 import {prepareHMDocument} from '@shm/shared/document-utils'
 import {prepareHMDocumentInfo, useResource, useResources} from '@shm/shared/models/entity'
 import {invalidateAfterPublish} from '@shm/shared/models/post-publish-cache'
-import {invalidateQueries} from '@shm/shared/models/query-client'
+import {invalidateQueries, queryClient} from '@shm/shared/models/query-client'
 import {queryKeys} from '@shm/shared/models/query-keys'
 import {
   compareBlocksWithMap,
@@ -1043,6 +1043,12 @@ export function useCreateDraft(
       deps: plan.writeParams.deps ?? [],
     }
     await client.drafts.write.mutate(writeParams)
+    const accountUid = writeParams.locationUid || writeParams.editUid
+    if (accountUid) {
+      const drafts = await client.drafts.listAccount.query(accountUid)
+      queryClient.setQueryData([queryKeys.DRAFTS_LIST_ACCOUNT, accountUid], drafts)
+    }
+    invalidateQueries([queryKeys.DRAFTS_LIST])
     navigate({key: 'document', id: plan.routeId})
   }
 }

--- a/frontend/apps/desktop/src/models/drafts.ts
+++ b/frontend/apps/desktop/src/models/drafts.ts
@@ -1,6 +1,9 @@
 import {HMDraft, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {hmId, NavRoute, pathMatches} from '@shm/shared'
+import {isDraftPathSegment} from '@shm/shared/utils/breadcrumbs'
+import {useDraft} from '@/models/accounts'
 import {isLocationOnlyDraftRoute} from '@/utils/draft-route'
+import {useEffect, useRef, useState} from 'react'
 import {useAccountDraftList} from './documents'
 
 export function draftLocationId(draft: HMDraft | null | undefined) {
@@ -26,15 +29,61 @@ export function draftEditId(draft: HMDraft | null | undefined) {
 export function useExistingDraft(route: NavRoute) {
   const id = getRouteResourceId(route)
   const drafts = useAccountDraftList(id?.uid)
-  if (!id) return false
-  // While drafts are loading, return undefined so the machine waits.
-  // Once loaded, return the matching draft or false (no draft).
-  if (!drafts.data) return undefined
-  const existingDraft = drafts.data.find((d) => {
+  const lastPathSegment = id?.path?.at(-1)
+  const placeholderDraftId = isDraftPathSegment(lastPathSegment) ? lastPathSegment!.slice(1) : undefined
+  const placeholderDraft = useDraft(placeholderDraftId)
+  const placeholderRouteId = id && placeholderDraftId ? id.id : null
+  const checkedMissingPlaceholderRef = useRef<string | null>(null)
+  const [isCheckingMissingPlaceholder, setIsCheckingMissingPlaceholder] = useState(false)
+
+  const listDraft = drafts.data?.find((d) => {
+    if (!id) return false
     if (d.editUid) return id.uid === d.editUid && pathMatches(d.editPath || [], id.path)
     return isLocationOnlyDraftRoute(id, d)
   })
-  return existingDraft || false
+  const directDraft =
+    id && placeholderDraft.data && isLocationOnlyDraftRoute(id, placeholderDraft.data) ? placeholderDraft.data : null
+  const existingDraft = listDraft || directDraft
+
+  useEffect(() => {
+    if (!placeholderRouteId) {
+      checkedMissingPlaceholderRef.current = null
+      setIsCheckingMissingPlaceholder(false)
+      return
+    }
+    if (!drafts.data || existingDraft || drafts.isFetching || placeholderDraft.isFetching) return
+    if (checkedMissingPlaceholderRef.current === placeholderRouteId) return
+
+    let cancelled = false
+    setIsCheckingMissingPlaceholder(true)
+    drafts.refetch().finally(() => {
+      if (cancelled) return
+      checkedMissingPlaceholderRef.current = placeholderRouteId
+      setIsCheckingMissingPlaceholder(false)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [placeholderRouteId, drafts.data, drafts.isFetching, placeholderDraft.isFetching, existingDraft, drafts.refetch])
+
+  if (!id) return false
+  // While drafts are loading, return undefined so the machine waits.
+  // Once loaded, return the matching draft or false (no draft).
+  if (existingDraft) return existingDraft
+  if (!drafts.data) return undefined
+  if (placeholderRouteId) {
+    const needsFreshPlaceholderCheck = checkedMissingPlaceholderRef.current !== placeholderRouteId
+    if (
+      drafts.isFetching ||
+      placeholderDraft.isLoading ||
+      placeholderDraft.isFetching ||
+      isCheckingMissingPlaceholder ||
+      needsFreshPlaceholderCheck
+    ) {
+      return undefined
+    }
+  }
+  return false
 }
 
 function getRouteResourceId(route: NavRoute): UnpackedHypermediaId | null {

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -119,15 +119,20 @@ export default function DesktopResourcePage() {
   const hasLocationOnlyDraft =
     !!existingDraftRecord && !!existingDraftRecord.locationUid && !existingDraftRecord.editUid
   const documentResourceId = hasLocationOnlyDraft || isDraftRouteLookupPending ? null : docId
+  const capabilityId =
+    hasLocationOnlyDraft && existingDraftRecord?.locationUid
+      ? hmId(existingDraftRecord.locationUid, {path: existingDraftRecord.locationPath})
+      : docId
 
-  const capability = useSelectedAccountCapability(docId)
+  const capability = useSelectedAccountCapability(capabilityId)
   const canEdit = roleCanWrite(capability?.role)
   const myAccountIds = useMyAccountIds()
 
   // Fetch draft content early so the editor can be initialized with draft blocks
   // instead of published blocks (avoids the flash + replaceBlocks race condition)
   const draftQuery = useDraft(existingDraft ? existingDraft.id : undefined)
-  const existingDraftContent = draftQuery.data?.content
+  const draftData = existingDraft && draftQuery.data?.id === existingDraft.id ? draftQuery.data : undefined
+  const existingDraftContent = draftData?.content
 
   // When another window writes to this draft (e.g. a child publish appended a
   // card embed via auto-link-parent), the editor's in-memory ProseMirror state
@@ -822,16 +827,17 @@ export default function DesktopResourcePage() {
                 <QuerySearchInputProvider value={SearchInput}>
                   <ResourcePage
                     docId={docId}
+                    resourceId={documentResourceId}
                     canEdit={canEdit}
                     CommentEditor={CommentBox}
                     optionsMenuItems={menuItems}
                     existingDraft={existingDraft}
-                    existingDraftVisibility={draftQuery.data?.visibility}
+                    existingDraftVisibility={draftData?.visibility}
                     existingDraftContent={existingDraftContent}
-                    existingDraftCursorPosition={draftQuery.data?.cursorPosition}
-                    existingDraftMineTouchedIds={draftQuery.data?.mineTouchedIds}
-                    existingDraftBaseBlocks={draftQuery.data?.baseBlocks}
-                    existingDraftDeps={draftQuery.data?.deps}
+                    existingDraftCursorPosition={draftData?.cursorPosition}
+                    existingDraftMineTouchedIds={draftData?.mineTouchedIds}
+                    existingDraftBaseBlocks={draftData?.baseBlocks}
+                    existingDraftDeps={draftData?.deps}
                     draftVersionOnDiscardConfirm={draftVersionToolbarCallbacks.onDiscardConfirm}
                     rightActions={<JoinButton siteUid={docId.uid} />}
                     onEditProfile={onEditProfile}

--- a/frontend/apps/desktop/src/utils/__tests__/publish-utils.test.ts
+++ b/frontend/apps/desktop/src/utils/__tests__/publish-utils.test.ts
@@ -391,7 +391,7 @@ describe('computeNewDraftParams', () => {
     expect(result?.writeParams.locationPath).toEqual(['random-path-21'])
   })
 
-  it('public new doc encodes draft id placeholder in editPath', () => {
+  it('public new doc stores a location-only draft and routes to the draft placeholder path', () => {
     const draftParams = {
       locationUid: 'location-uid',
       locationPath: ['docs', 'sub'],
@@ -407,8 +407,6 @@ describe('computeNewDraftParams', () => {
       id: 'draft-id-10',
       locationUid: 'location-uid',
       locationPath: ['docs', 'sub'],
-      editUid: 'location-uid',
-      editPath: ['docs', 'sub', '-draft-id-10'],
       deps: undefined,
       visibility: 'PUBLIC',
     })

--- a/frontend/apps/desktop/src/utils/publish-utils.ts
+++ b/frontend/apps/desktop/src/utils/publish-utils.ts
@@ -95,9 +95,9 @@ export function resolvePublishPath(args: {
  * Three cases:
  * 1. Editing an existing doc — `editUid`/`editPath` provided. Document route
  *    targets that doc; draft writer records edit anchor + deps.
- * 2. Public new doc at a location — `locationUid` provided. Draft path becomes
- *    `[...locationPath, '-${draftId}']` so `useExistingDraft` can match the
- *    document route via editUid/editPath.
+ * 2. Public new doc at a location — `locationUid` provided. Draft stays
+ *    location-only, while the route targets `[...locationPath, '-${draftId}']`;
+ *    `useExistingDraft` matches that placeholder route back to the local draft.
  * 3. Private doc — needs a `locationUid` (or `selectedAccountId`) and a random
  *    path so the doc has a stable home before publish.
  *
@@ -165,19 +165,17 @@ export function computeNewDraftParams(
 
   if (draftParams.locationUid) {
     const locationPath = draftParams.locationPath || []
-    const editPath = [...locationPath, `-${draftId}`]
+    const routePath = [...locationPath, `-${draftId}`]
     return {
       draftId,
       writeParams: {
         id: draftId,
         locationUid: draftParams.locationUid,
         locationPath,
-        editUid: draftParams.locationUid,
-        editPath,
         deps: draftParams.deps,
         visibility: visibility ?? 'PUBLIC',
       },
-      routeId: hmId(draftParams.locationUid, {path: editPath}),
+      routeId: hmId(draftParams.locationUid, {path: routePath}),
     }
   }
 

--- a/frontend/apps/web/app/document-edit/web-create-draft.test.ts
+++ b/frontend/apps/web/app/document-edit/web-create-draft.test.ts
@@ -63,8 +63,8 @@ describe('createWebDocumentDraft', () => {
       capabilityCid: 'cap-1',
       locationUid: 'site',
       locationPath: ['parent'],
-      editUid: 'site',
-      editPath: ['parent', '-draft-1'],
+      editUid: null,
+      editPath: null,
       visibility: 'PUBLIC',
     })
   })

--- a/frontend/apps/web/app/document-edit/web-create-draft.ts
+++ b/frontend/apps/web/app/document-edit/web-create-draft.ts
@@ -10,6 +10,8 @@ import {
   parseMarkdown,
 } from '@seed-hypermedia/client/markdown-to-blocks'
 import {hmId} from '@shm/shared'
+import {invalidateQueries} from '@shm/shared/models/query-client'
+import {queryKeys} from '@shm/shared/models/query-keys'
 import {buildInlineDraftWrite} from '@shm/shared/utils/inline-draft'
 import {nanoid} from 'nanoid'
 import {putWebDocDraft} from './web-draft-db'
@@ -79,6 +81,7 @@ export async function createWebDocumentDraft({
   }
 
   const routeId = hmId(locationId.uid, {path: editPath})
+  const isNavigatedPublicDraft = !isPrivate && !!navigate
 
   await putWebDocDraft({
     draftId,
@@ -91,11 +94,13 @@ export async function createWebDocumentDraft({
     navigation: null,
     locationUid: locationId.uid,
     locationPath,
-    editUid: locationId.uid,
-    editPath,
+    editUid: isNavigatedPublicDraft ? null : locationId.uid,
+    editPath: isNavigatedPublicDraft ? null : editPath,
     cursorPosition: null,
     visibility,
   })
+  invalidateQueries([queryKeys.DRAFTS_LIST])
+  invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT, locationId.uid])
 
   console.log('[web-create-doc] createWebDocumentDraft', {
     locationId: locationId.id,

--- a/frontend/apps/web/app/document-edit/web-draft-breadcrumb-provider.tsx
+++ b/frontend/apps/web/app/document-edit/web-draft-breadcrumb-provider.tsx
@@ -1,0 +1,31 @@
+import {DraftBreadcrumbContext, DraftBreadcrumbContextValue} from '@shm/shared/draft-breadcrumb-context'
+import {queryKeys} from '@shm/shared/models/query-keys'
+import {useQuery} from '@tanstack/react-query'
+import {PropsWithChildren, useMemo} from 'react'
+import {listWebDocDraftsForAccount, webDraftToListedDraft} from './web-draft-db'
+
+function useWebAccountDraftList(uid: string | undefined) {
+  return useQuery({
+    queryKey: [queryKeys.DRAFTS_LIST_ACCOUNT, uid],
+    queryFn: async () => {
+      const drafts = await listWebDocDraftsForAccount(uid)
+      return drafts.map(webDraftToListedDraft)
+    },
+    enabled: !!uid,
+  })
+}
+
+/** Provides IndexedDB-backed local web drafts to shared document UI. */
+export function WebDraftBreadcrumbProvider({children}: PropsWithChildren) {
+  const value = useMemo<DraftBreadcrumbContextValue>(
+    () => ({
+      useDraftsForAccount: (uid: string | undefined) => {
+        const query = useWebAccountDraftList(uid)
+        return {data: query.data, isLoading: query.isLoading}
+      },
+    }),
+    [],
+  )
+
+  return <DraftBreadcrumbContext.Provider value={value}>{children}</DraftBreadcrumbContext.Provider>
+}

--- a/frontend/apps/web/app/document-edit/web-draft-db.test.ts
+++ b/frontend/apps/web/app/document-edit/web-draft-db.test.ts
@@ -8,6 +8,7 @@ import {
   deleteWebDocDraft,
   getLatestWebDocDraftForDoc,
   getWebDocDraft,
+  listWebDocDraftsForAccount,
   listWebDocDraftsForDoc,
   putWebDocDraft,
   type WebDocDraft,
@@ -72,6 +73,16 @@ describe('web-draft-db', () => {
 
     const bDrafts = await listWebDocDraftsForDoc('hm://B')
     expect(bDrafts.map((d) => d.draftId)).toEqual(['d-3'])
+  })
+
+  it('lists drafts filtered by account uid, newest first', async () => {
+    await putWebDocDraft(makeDraft({draftId: 'loc-old', locationUid: 'site', updatedAt: 1}))
+    await putWebDocDraft(makeDraft({draftId: 'edit-new', editUid: 'site', updatedAt: 3}))
+    await putWebDocDraft(makeDraft({draftId: 'other', locationUid: 'other', editUid: 'other', updatedAt: 4}))
+
+    const drafts = await listWebDocDraftsForAccount('site')
+
+    expect(drafts.map((d) => d.draftId)).toEqual(['edit-new', 'loc-old'])
   })
 
   it('returns latest draft for docId', async () => {

--- a/frontend/apps/web/app/document-edit/web-draft-db.ts
+++ b/frontend/apps/web/app/document-edit/web-draft-db.ts
@@ -173,6 +173,21 @@ export function webDraftToListedDraft(draft: WebDocDraft): HMListedDraftWithLoca
   } as HMListedDraftWithLocation
 }
 
+/** Return all drafts for a given account uid, newest first. */
+export async function listWebDocDraftsForAccount(accountUid: string | undefined): Promise<WebDocDraft[]> {
+  if (!accountUid || !isBrowser()) return []
+  try {
+    const store = await tx('readonly')
+    const all = await reqToPromise<WebDocDraft[]>(store.getAll())
+    return all
+      .filter((draft) => draft.locationUid === accountUid || draft.editUid === accountUid)
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+  } catch (err) {
+    console.warn('listWebDocDraftsForAccount failed', err)
+    return []
+  }
+}
+
 /** Return all drafts for a given docId, newest first. */
 export async function listWebDocDraftsForDoc(docId: string): Promise<WebDocDraft[]> {
   if (!isBrowser()) return []

--- a/frontend/apps/web/app/web-resource-page.tsx
+++ b/frontend/apps/web/app/web-resource-page.tsx
@@ -41,7 +41,8 @@ import {WebDraftActionsProvider} from './document-edit/web-draft-actions-provide
 import {WebQueryBlockDraftSlot} from './document-edit/web-query-block-draft-slot'
 import {cleanupOldWebDocDrafts, getLatestWebDocDraftForDoc, getWebDocDraft} from './document-edit/web-draft-db'
 import {makeWebFileUpload} from './document-edit/web-image-upload'
-import {getWebDraftPlaceholderId} from './document-edit/web-draft-path'
+import {WebDraftBreadcrumbProvider} from './document-edit/web-draft-breadcrumb-provider'
+import {getWebDraftPlaceholderId, isWebDraftPlaceholderPath} from './document-edit/web-draft-path'
 
 /** Lazy-loaded inline comment editor — avoids pulling the full editor bundle eagerly. */
 const LazyWebInlineEditor = lazy(() => import('./commenting').then((mod) => ({default: mod.WebInlineEditBox})))
@@ -160,12 +161,20 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
     },
     enabled: typeof window !== 'undefined' && !!signingAccountId && (canEdit || !!placeholderDraftId),
     staleTime: 60_000,
+    keepPreviousData: false,
   })
   // Keep local drafts even when their base is no longer latest. Remote updates
   // are handled by the document machine's queued rebase flow; deleting here can
   // destroy a valid in-progress draft when the user is merely viewing a pinned
   // historical version.
-  const draftData = draftQuery.data
+  const loadedDraftData = draftQuery.data
+  const draftData =
+    loadedDraftData &&
+    (placeholderDraftId
+      ? loadedDraftData.draftId === placeholderDraftId && loadedDraftData.docId === docId.id
+      : loadedDraftData.docId === docId.id)
+      ? loadedDraftData
+      : null
   const isDraftStale = false
 
   const canEditLocalPlaceholderDraft =
@@ -267,9 +276,12 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
       onDiscardConfirm: (draftId: string, send) => {
         if (window.confirm('Discard draft changes?')) {
           send({type: 'edit.discard'})
+          const nextId = isWebDraftPlaceholderPath(docId.path, draftId)
+            ? hmId(docId.uid, {path: docId.path?.slice(0, -1)})
+            : {...docId, version: null}
           replaceRouteRef.current({
             ...(route.key === 'document' ? route : {key: 'document'}),
-            id: {...docId, version: null},
+            id: nextId,
           } as any)
           toast.success('Draft changes discarded')
         }
@@ -353,34 +365,37 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
               lastCreatedDraftId={lastCreatedDraftId}
               setLastCreatedDraftId={setLastCreatedDraftId}
             >
-              <ResourcePage
-                docId={docId}
-                CommentEditor={CommentEditor}
-                pageFooter={<PageFooter id={docId} hideDeviceLinkToast={true} />}
-                onEditProfile={onEditProfile}
-                profileHeaderButtons={profileHeaderButtons}
-                onFollowClick={onFollowClick}
-                rightActions={<WebHeaderActions siteUid={docId.uid} />}
-                optionsMenuItems={optionsMenuItems}
-                inlineInsert={inlineInsert}
-                DocumentContentComponent={DocumentContentComponent}
-                ssrContentHTML={ssrContentHTML}
-                perspectiveAccountUid={ownAccountUid}
-                linkExtensionOptions={linkExtensionOptions}
-                canEdit={effectiveCanEdit}
-                machine={machine}
-                signingAccountId={signingAccountId ?? undefined}
-                publishAccountUid={signingAccountId ?? undefined}
-                onEditorReady={onEditorReady}
-                existingDraft={existingDraft}
-                existingDraftVisibility={draftData?.visibility}
-                existingDraftContent={existingDraftContent}
-                existingDraftCursorPosition={existingDraftCursorPosition}
-                existingDraftDeps={draftData?.deps}
-                draftVersionOnDiscardConfirm={webToolbarCallbacks.onDiscardConfirm}
-                editingFloatingActions={editingFloatingActions}
-                fileUpload={fileUpload}
-              />
+              <WebDraftBreadcrumbProvider>
+                <ResourcePage
+                  docId={docId}
+                  resourceId={placeholderDraftId ? null : docId}
+                  CommentEditor={CommentEditor}
+                  pageFooter={<PageFooter id={docId} hideDeviceLinkToast={true} />}
+                  onEditProfile={onEditProfile}
+                  profileHeaderButtons={profileHeaderButtons}
+                  onFollowClick={onFollowClick}
+                  rightActions={<WebHeaderActions siteUid={docId.uid} />}
+                  optionsMenuItems={optionsMenuItems}
+                  inlineInsert={inlineInsert}
+                  DocumentContentComponent={DocumentContentComponent}
+                  ssrContentHTML={ssrContentHTML}
+                  perspectiveAccountUid={ownAccountUid}
+                  linkExtensionOptions={linkExtensionOptions}
+                  canEdit={effectiveCanEdit}
+                  machine={machine}
+                  signingAccountId={signingAccountId ?? undefined}
+                  publishAccountUid={signingAccountId ?? undefined}
+                  onEditorReady={onEditorReady}
+                  existingDraft={existingDraft}
+                  existingDraftVisibility={draftData?.visibility}
+                  existingDraftContent={existingDraftContent}
+                  existingDraftCursorPosition={existingDraftCursorPosition}
+                  existingDraftDeps={draftData?.deps}
+                  draftVersionOnDiscardConfirm={webToolbarCallbacks.onDiscardConfirm}
+                  editingFloatingActions={editingFloatingActions}
+                  fileUpload={fileUpload}
+                />
+              </WebDraftBreadcrumbProvider>
             </QueryBlockDraftsProvider>
           </WebDraftActionsProvider>
         </DocumentActionsProvider>

--- a/frontend/packages/ui/src/__tests__/unreferenced-documents.test.tsx
+++ b/frontend/packages/ui/src/__tests__/unreferenced-documents.test.tsx
@@ -3,10 +3,26 @@ import React from 'react'
 import {createRoot, Root} from 'react-dom/client'
 ;(globalThis as typeof globalThis & {React?: typeof React}).React = React
 import {act} from 'react-dom/test-utils'
-import type {HMBlockNode, HMDocumentInfo, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import type {HMBlockNode, HMDocumentInfo, HMListedDraft, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 const canSeePrivateDocsMock = vi.hoisted(() => vi.fn(() => false))
+
+vi.mock('@shm/shared', async () => {
+  const actual = await vi.importActual<typeof import('@shm/shared')>('@shm/shared')
+  return {
+    ...actual,
+    useRouteLink: (route: any) => ({
+      href:
+        route?.key === 'draft'
+          ? `/draft/${route.id}`
+          : route?.key === 'document'
+          ? `/doc/${route.id.path?.join('/') ?? ''}`
+          : '/',
+      onClick: undefined,
+    }),
+  }
+})
 
 vi.mock('@shm/shared/models/capabilities', () => ({
   useCanSeePrivateDocs: canSeePrivateDocsMock,
@@ -20,6 +36,7 @@ vi.mock('../document-list-item', async () => {
   }
 })
 
+import {DraftBreadcrumbContext, type HMListedDraftWithLocation} from '@shm/shared/draft-breadcrumb-context'
 import {UnreferencedDocuments} from '../unreferenced-documents'
 ;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -83,6 +100,27 @@ function makeBlock(block: any, children?: HMBlockNode[]): HMBlockNode {
   return {block, children}
 }
 
+function makeDraft(id: string, uid: string, parentPath: string[], name: string): HMListedDraftWithLocation {
+  return {
+    id,
+    locationUid: uid,
+    locationPath: parentPath,
+    locationId: makeId(uid, parentPath),
+    metadata: {name},
+    lastUpdateTime: Date.now(),
+    visibility: 'PUBLIC',
+    deps: [],
+  } as HMListedDraft & HMListedDraftWithLocation
+}
+
+function withDrafts(node: React.ReactNode, drafts: HMListedDraftWithLocation[]) {
+  return (
+    <DraftBreadcrumbContext.Provider value={{useDraftsForAccount: () => ({data: drafts, isLoading: false})}}>
+      {node}
+    </DraftBreadcrumbContext.Provider>
+  )
+}
+
 describe('UnreferencedDocuments', () => {
   let rendered: {container: HTMLDivElement; root: Root} | undefined
 
@@ -114,6 +152,35 @@ describe('UnreferencedDocuments', () => {
     expect(rendered.container.textContent).not.toContain('Linked Child')
     expect(rendered.container.textContent).not.toContain('Unreferenced Documents')
     expect(rendered.container.querySelector('button')).toBeNull()
+  })
+
+  it('renders unreferenced child drafts from the current directory', () => {
+    rendered = renderNode(
+      withDrafts(
+        <UnreferencedDocuments
+          docId={makeId('uid1', ['parent'])}
+          content={[
+            makeBlock({
+              type: 'Embed',
+              id: 'embed-draft',
+              link: 'hm://uid1/parent/-draft-linked',
+              attributes: {draftId: 'draft-linked'},
+            }),
+          ]}
+          directory={[]}
+        />,
+        [
+          makeDraft('draft-linked', 'uid1', ['parent'], 'Linked Draft'),
+          makeDraft('draft-loose', 'uid1', ['parent'], 'Loose Draft'),
+          makeDraft('draft-other-parent', 'uid1', ['other'], 'Other Parent Draft'),
+        ],
+      ),
+    )
+
+    expect(rendered.container.textContent).toContain('Loose Draft')
+    expect(rendered.container.textContent).not.toContain('Linked Draft')
+    expect(rendered.container.textContent).not.toContain('Other Parent Draft')
+    expect(rendered.container.querySelector('a')?.getAttribute('href')).toBe('/doc/parent/-draft-loose')
   })
 
   it('returns null when there are no directory items', () => {

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -285,6 +285,8 @@ export interface CommentEditorProps {
 
 export interface ResourcePageProps {
   docId: UnpackedHypermediaId
+  /** Resource ID to fetch for published content. Pass null for local-only draft routes that must not hit the backend. */
+  resourceId?: UnpackedHypermediaId | null
   /** Factory to create comment editor - platform-specific (web vs desktop) */
   CommentEditor?: React.ComponentType<CommentEditorProps>
   /** Complete platform-specific menu items for the options dropdown */
@@ -379,6 +381,7 @@ function getPanelTitle(panelKey: string | null): string {
 
 export function ResourcePage({
   docId,
+  resourceId,
   CommentEditor,
   optionsMenuItems,
   extraMenuItems,
@@ -433,7 +436,8 @@ export function ResourcePage({
     [docId, replaceRoute, route],
   )
 
-  const resource = useResource(docId, {
+  const resourceFetchId = resourceId === undefined ? docId : resourceId
+  const resource = useResource(resourceFetchId, {
     subscribed: true,
     recursive: true,
     onRedirectOrDeleted: handleResourceRedirect,
@@ -443,9 +447,17 @@ export function ResourcePage({
   // subsequent transient resource failures (refetch errors, discovery flapping, transient
   // not-found from a stale daemon `latest` pointer). Without this sticky gate, the early
   // returns below would unmount DocumentBody and destroy the XState actor on each blip.
+  // Reset on route changes so a newly-created local draft never reuses the parent
+  // document while its draft record is resolving.
+  const lastGoodRouteIdRef = useRef(docId.id)
   const hasEverLoadedRef = useRef(false)
   const lastGoodDocumentRef = useRef<HMDocument | null>(null)
-  if (resource.data?.type === 'document') {
+  if (lastGoodRouteIdRef.current !== docId.id) {
+    lastGoodRouteIdRef.current = docId.id
+    hasEverLoadedRef.current = false
+    lastGoodDocumentRef.current = null
+  }
+  if (resourceFetchId && resource.data?.type === 'document' && resource.data.id.id === resourceFetchId.id) {
     hasEverLoadedRef.current = true
     lastGoodDocumentRef.current = resource.data.document
   }
@@ -453,7 +465,7 @@ export function ResourcePage({
   // docId.uid determines the site header — for site-profile, docId IS the site context
   const siteHomeId = hmId(docId.uid, {latest: true})
   const siteHomeResource = useResource(siteHomeId, {subscribed: true})
-  const isLatest = useIsLatest(docId, resource)
+  const isLatest = useIsLatest(resourceFetchId, resource)
 
   const siteHomeDocument = siteHomeResource.data?.type === 'document' ? siteHomeResource.data.document : null
 
@@ -511,6 +523,17 @@ export function ResourcePage({
     )
   }
 
+  if (resourceFetchId === null && existingDraft === undefined) {
+    return (
+      <PageWrapper siteHomeId={siteHomeId} docId={docId} headerData={headerData} rightActions={rightActions}>
+        <div className="flex flex-1 items-center justify-center">
+          <Spinner />
+        </div>
+        {pageFooter}
+      </PageWrapper>
+    )
+  }
+
   // Loading state - should not show during SSR if data was prefetched
   if (resource.isInitialLoading && !hasEverLoadedRef.current) {
     return (
@@ -529,8 +552,8 @@ export function ResourcePage({
   // document so the document machine can transition to "loaded" → editing.
   const hasUnpublishedDraft =
     !!existingDraft &&
-    canEdit &&
-    (resource.isDiscovering ||
+    (resourceFetchId === null ||
+      resource.isDiscovering ||
       !resource.data ||
       resource.data.type === 'not-found' ||
       (resource.data.type === 'error' && !resource.data.message?.toLowerCase?.().includes('permission')))
@@ -651,7 +674,7 @@ export function ResourcePage({
   // exists, fabricate a placeholder so DocumentBody / the document machine
   // can transition to "loaded" → editing for the new-document case.
   let document: HMDocument
-  if (resource.data?.type === 'document') {
+  if (resourceFetchId && resource.data?.type === 'document' && resource.data.id.id === resourceFetchId.id) {
     document = resource.data.document
   } else if (lastGoodDocumentRef.current) {
     // Transient refetch failure / not-found / discovery flap — keep showing the last
@@ -680,7 +703,8 @@ export function ResourcePage({
   }
 
   const shouldUseDraft = shouldUseDraftForRenderedDocument({docId, existingDraft, isLatest})
-  const effectiveCanEdit = canEdit && (!docId.version || isLatest || shouldUseDraft)
+  const effectiveCanEdit =
+    (canEdit || (resourceFetchId === null && !!existingDraft)) && (!docId.version || isLatest || shouldUseDraft)
   const effectiveExistingDraft = shouldUseDraft ? existingDraft : false
   const effectiveExistingDraftVisibility = shouldUseDraft ? existingDraftVisibility : undefined
   const effectiveExistingDraftContent = shouldUseDraft ? existingDraftContent : undefined

--- a/frontend/packages/ui/src/unreferenced-documents.tsx
+++ b/frontend/packages/ui/src/unreferenced-documents.tsx
@@ -1,9 +1,27 @@
 import {EditorBlock} from '@seed-hypermedia/client/editor-types'
-import {HMBlockNode, HMDocumentInfo, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
-import {editorBlocksToHMBlockNodes, extractAllContentRefs, hasQueryBlockTargetingSelf} from '@shm/shared'
+import {
+  HMBlockNode,
+  HMDocumentInfo,
+  HMListedDraft,
+  HMMetadata,
+  UnpackedHypermediaId,
+} from '@seed-hypermedia/client/hm-types'
+import {
+  editorBlocksToHMBlockNodes,
+  extractAllContentRefs,
+  getMetadataName,
+  hasQueryBlockTargetingSelf,
+  hmId,
+  useRouteLink,
+} from '@shm/shared'
 import {useCanSeePrivateDocs} from '@shm/shared/models/capabilities'
+import {useDraftsForAccountSafe, type HMListedDraftWithLocation} from '@shm/shared/draft-breadcrumb-context'
+import {collectChildDraftIds} from '@shm/shared/utils/child-draft-refs'
 import {useMemo} from 'react'
 import {DocumentListItem} from './document-list-item'
+import {Button} from './button'
+import {DraftBadge} from './draft-badge'
+import {SizableText} from './text'
 
 function toHMBlockNodes(blocks: EditorBlock[] | HMBlockNode[]): HMBlockNode[] {
   const first = blocks[0]
@@ -24,14 +42,13 @@ export function UnreferencedDocuments({
   directory: HMDocumentInfo[] | undefined
 }) {
   const canSeePrivate = useCanSeePrivateDocs(docId)
+  const drafts = useDraftsForAccountSafe(docId.uid)
 
-  const unreferencedDocs = useMemo(() => {
-    if (!directory || directory.length === 0) return []
-
+  const {unreferencedDocs, unreferencedDrafts} = useMemo(() => {
     const sourceContent = draftContent && draftContent.length > 0 ? toHMBlockNodes(draftContent) : content
 
     if (hasQueryBlockTargetingSelf(sourceContent, docId.uid, docId.path)) {
-      return []
+      return {unreferencedDocs: [], unreferencedDrafts: []}
     }
 
     const allRefs = extractAllContentRefs(sourceContent)
@@ -41,13 +58,24 @@ export function UnreferencedDocuments({
         referencedIds.add(ref.refId.id)
       }
     })
+    const referencedDraftIds = new Set(collectChildDraftIds(sourceContent))
 
-    return directory
+    const unreferencedDocs = (directory ?? [])
       .filter((child) => canSeePrivate || child.visibility !== 'PRIVATE')
       .filter((child) => !referencedIds.has(child.id.id))
-  }, [content, draftContent, directory, docId.uid, docId.path, canSeePrivate])
 
-  if (unreferencedDocs.length === 0) return null
+    const currentPath = docId.path ?? []
+    const unreferencedDrafts = (drafts.data ?? [])
+      .filter((draft) => draft.locationId?.uid === docId.uid)
+      .filter((draft) => pathEquals(draft.locationId?.path ?? [], currentPath))
+      .filter((draft) => !draft.editId)
+      .filter((draft) => canSeePrivate || draft.visibility !== 'PRIVATE')
+      .filter((draft) => !referencedDraftIds.has(draft.id))
+
+    return {unreferencedDocs, unreferencedDrafts}
+  }, [content, draftContent, directory, drafts.data, docId.uid, docId.path, canSeePrivate])
+
+  if (unreferencedDocs.length === 0 && unreferencedDrafts.length === 0) return null
 
   return (
     <div className="mt-8 border-t pt-4 pb-16">
@@ -55,7 +83,40 @@ export function UnreferencedDocuments({
         {unreferencedDocs.map((item) => (
           <DocumentListItem key={item.id.id} item={item} />
         ))}
+        {unreferencedDrafts.map((draft) => (
+          <UnreferencedDraftListItem key={draft.id} draft={draft} />
+        ))}
       </div>
     </div>
+  )
+}
+
+function pathEquals(a: string[], b: string[]) {
+  if (a.length !== b.length) return false
+  return a.every((segment, index) => segment === b[index])
+}
+
+function UnreferencedDraftListItem({draft}: {draft: HMListedDraftWithLocation | HMListedDraft}) {
+  const locationId = 'locationId' in draft ? draft.locationId : undefined
+  const linkProps = useRouteLink(
+    locationId
+      ? {key: 'document', id: hmId(locationId.uid, {path: [...(locationId.path ?? []), `-${draft.id}`]})}
+      : {key: 'draft', id: draft.id},
+  )
+  return (
+    <Button
+      asChild
+      variant="ghost"
+      className="h-auto w-full items-center justify-start border-none bg-transparent bg-white px-4 py-2 shadow-sm hover:shadow-md dark:bg-black"
+    >
+      <a {...linkProps}>
+        <div className="flex flex-1 items-center gap-1.5 overflow-hidden">
+          <SizableText className="truncate text-left font-sans">
+            {getMetadataName(draft.metadata as HMMetadata)}
+          </SizableText>
+          <DraftBadge />
+        </div>
+      </a>
+    </Button>
   )
 }


### PR DESCRIPTION
## Summary
- Keep public new-document drafts location-only while routing users through draft placeholder paths.
- Ensure desktop and web draft placeholder routes load the correct local draft without fetching nonexistent published resources.
- Add web draft breadcrumb support and include unreferenced child drafts in document listings.
- Refresh draft list caches after draft creation and update tests for the new draft workflow.

fixes #741 