### PR TITLE
refactor(ui): standardize option menus

### DIFF
--- a/frontend/apps/desktop/src/components/inline-new-document-card.tsx
+++ b/frontend/apps/desktop/src/components/inline-new-document-card.tsx
@@ -6,13 +6,8 @@ import {hmId} from '@shm/shared/utils/entity-id-url'
 import {invalidateQueries} from '@shm/shared/models/query-client'
 import {queryKeys} from '@shm/shared/models/query-keys'
 import {Button} from '@shm/ui/button'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@shm/ui/components/dropdown-menu'
 import {DraftBadge} from '@shm/ui/draft-badge'
+import {OptionsDropdown} from '@shm/ui/options-dropdown'
 import {toast} from '@shm/ui/toast'
 import {ImageIcon, MoreVertical, Pencil, Trash2} from 'lucide-react'
 import {useCallback, useEffect, useRef, useState} from 'react'
@@ -160,23 +155,29 @@ export function InlineNewDocumentCard({draft, autoFocus}: {draft: HMListedDraft;
               <Pencil className="size-3" />
               Edit
             </Button>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="iconSm">
+            <OptionsDropdown
+              align="end"
+              button={
+                <Button variant="ghost" size="iconSm" aria-label="Draft options">
                   <MoreVertical className="size-4" />
                 </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={openDraft}>
-                  <Pencil className="size-4" />
-                  Open Draft
-                </DropdownMenuItem>
-                <DropdownMenuItem className="text-destructive" onClick={() => deleteDraft.mutate(draft.id)}>
-                  <Trash2 className="size-4" />
-                  Delete Draft
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+              }
+              menuItems={[
+                {
+                  key: 'open',
+                  label: 'Open Draft',
+                  icon: <Pencil className="size-4" />,
+                  onClick: openDraft,
+                },
+                {
+                  key: 'delete',
+                  label: 'Delete Draft',
+                  icon: <Trash2 className="size-4" />,
+                  variant: 'destructive',
+                  onClick: () => deleteDraft.mutate(draft.id),
+                },
+              ]}
+            />
           </div>
         </div>
       </div>

--- a/frontend/apps/desktop/src/components/sidebar.tsx
+++ b/frontend/apps/desktop/src/components/sidebar.tsx
@@ -26,12 +26,6 @@ import {LibraryEntryUpdateSummary} from '@shm/ui/activity'
 import {UIAvatar} from '@shm/ui/avatar'
 import {Button} from '@shm/ui/button'
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@shm/ui/components/dropdown-menu'
-import {
   SidebarContent,
   SidebarFooter as SidebarFooterLayout,
   SidebarGroup,
@@ -48,6 +42,7 @@ import {useImageUrl} from '@shm/ui/get-file-url'
 import {HMIcon} from '@shm/ui/hm-icon'
 import {CircleOff} from '@shm/ui/icons'
 import {SmallListItem} from '@shm/ui/list-item'
+import {OptionsDropdown} from '@shm/ui/options-dropdown'
 import {SizableText} from '@shm/ui/text'
 import {Tooltip} from '@shm/ui/tooltip'
 import {cn} from '@shm/ui/utils'
@@ -532,39 +527,31 @@ function JoinedSiteListItem({
           )}
         </div>
       </SidebarMenuButton>
-      <DropdownMenu>
-        <SidebarMenuAction asChild>
-          <DropdownMenuTrigger
-            className="hover:bg-sidebar-accent flex items-center justify-center rounded-md p-1"
-            onClick={(e) => e.stopPropagation()}
-          >
+      <OptionsDropdown
+        side="right"
+        align="start"
+        button={
+          <SidebarMenuAction aria-label="Joined site options" onClick={(e) => e.stopPropagation()}>
             <MoreHorizontal className="size-4" />
-          </DropdownMenuTrigger>
-        </SidebarMenuAction>
-        <DropdownMenuContent side="right" align="start">
-          <DropdownMenuItem
-            onClick={(e) => {
-              e.stopPropagation()
-              navigate({key: 'all-documents', id})
-            }}
-          >
-            <LayoutList className="size-4" />
-            All Documents
-          </DropdownMenuItem>
-          <SidebarSeparator />
-          <DropdownMenuItem
-            variant="destructive"
-            disabled={isPending}
-            onClick={(e) => {
-              e.stopPropagation()
-              leaveSite()
-            }}
-          >
-            <CircleOff className="size-4" />
-            Leave Site
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+          </SidebarMenuAction>
+        }
+        menuItems={[
+          {
+            key: 'all-documents',
+            label: 'All Documents',
+            icon: <LayoutList className="size-4" />,
+            onClick: () => navigate({key: 'all-documents', id}),
+          },
+          {
+            key: 'leave',
+            label: 'Leave Site',
+            icon: <CircleOff className="size-4" />,
+            variant: 'destructive',
+            disabled: isPending,
+            onClick: () => leaveSite(),
+          },
+        ]}
+      />
     </>
   )
 }
@@ -669,29 +656,25 @@ function FollowingListItem({
           <span className="truncate text-left text-sm font-bold select-none">{metadata?.name || 'Untitled'}</span>
         </div>
       </SidebarMenuButton>
-      <DropdownMenu>
-        <SidebarMenuAction asChild>
-          <DropdownMenuTrigger
-            className="hover:bg-sidebar-accent flex items-center justify-center rounded-md p-1"
-            onClick={(e) => e.stopPropagation()}
-          >
+      <OptionsDropdown
+        side="right"
+        align="start"
+        button={
+          <SidebarMenuAction aria-label="Following options" onClick={(e) => e.stopPropagation()}>
             <MoreHorizontal className="size-4" />
-          </DropdownMenuTrigger>
-        </SidebarMenuAction>
-        <DropdownMenuContent side="right" align="start">
-          <DropdownMenuItem
-            variant="destructive"
-            disabled={isPending}
-            onClick={(e) => {
-              e.stopPropagation()
-              unfollowProfile()
-            }}
-          >
-            <CircleOff className="size-4" />
-            Unfollow
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+          </SidebarMenuAction>
+        }
+        menuItems={[
+          {
+            key: 'unfollow',
+            label: 'Unfollow',
+            icon: <CircleOff className="size-4" />,
+            variant: 'destructive',
+            disabled: isPending,
+            onClick: () => unfollowProfile(),
+          },
+        ]}
+      />
     </>
   )
 }

--- a/frontend/apps/desktop/src/pages/settings.tsx
+++ b/frontend/apps/desktop/src/pages/settings.tsx
@@ -87,12 +87,6 @@ import {
 import {Badge} from '@shm/ui/components/badge'
 import {Checkbox} from '@shm/ui/components/checkbox'
 import {Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle} from '@shm/ui/components/dialog'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@shm/ui/components/dropdown-menu'
 import {Input} from '@shm/ui/components/input'
 import {Label} from '@shm/ui/components/label'
 import {RadioGroup, RadioGroupItem} from '@shm/ui/components/radio-group'
@@ -104,6 +98,7 @@ import {copyTextToClipboard} from '@shm/ui/copy-to-clipboard'
 import {Field} from '@shm/ui/form-fields'
 import {HMIcon} from '@shm/ui/hm-icon'
 import {Copy, ExternalLink, Undo} from '@shm/ui/icons'
+import {OptionsDropdown} from '@shm/ui/options-dropdown'
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@shm/ui/select-dropdown'
 import {Separator} from '@shm/ui/separator'
 import {Spinner} from '@shm/ui/spinner'
@@ -2051,8 +2046,10 @@ function ProviderListActions({
 
   return (
     <>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
+      <OptionsDropdown
+        align="end"
+        contentClassName="w-44"
+        button={
           <Button
             size="iconSm"
             variant="ghost"
@@ -2061,34 +2058,37 @@ function ProviderListActions({
           >
             <MoreHorizontal className="size-4" />
           </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-44">
-          <DropdownMenuItem onSelect={onEdit}>
-            <Pencil className="size-4" />
-            Edit
-          </DropdownMenuItem>
-          {!isDefault ? (
-            <DropdownMenuItem onSelect={onSetDefault}>
-              <Check className="size-4" />
-              Use by default
-            </DropdownMenuItem>
-          ) : null}
-          <DropdownMenuItem onSelect={onDuplicate}>
-            <CopyIcon className="size-4" />
-            Duplicate
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            className="text-destructive"
-            onSelect={(event) => {
-              event.preventDefault()
-              setIsDeleteDialogOpen(true)
-            }}
-          >
-            <Trash className="size-4" />
-            Delete
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+        }
+        menuItems={[
+          {
+            key: 'edit',
+            label: 'Edit',
+            icon: <Pencil className="size-4" />,
+            onClick: onEdit,
+          },
+          !isDefault
+            ? {
+                key: 'default',
+                label: 'Use by default',
+                icon: <Check className="size-4" />,
+                onClick: onSetDefault,
+              }
+            : null,
+          {
+            key: 'duplicate',
+            label: 'Duplicate',
+            icon: <CopyIcon className="size-4" />,
+            onClick: onDuplicate,
+          },
+          {
+            key: 'delete',
+            label: 'Delete',
+            icon: <Trash className="size-4" />,
+            variant: 'destructive',
+            onClick: () => setIsDeleteDialogOpen(true),
+          },
+        ]}
+      />
 
       <AlertDialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
         <AlertDialogPortal>

--- a/frontend/packages/editor/src/embed-block.tsx
+++ b/frontend/packages/editor/src/embed-block.tsx
@@ -11,23 +11,13 @@ import {useEditorGate} from '@shm/shared/models/use-editor-gate'
 import {packHmId, unpackHmId} from '@shm/shared/utils/entity-id-url'
 import {useNavigate} from '@shm/shared/utils/navigation'
 import {Button} from '@shm/ui/button'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
-  DropdownMenuTrigger,
-} from '@shm/ui/components/dropdown-menu'
 import {Input} from '@shm/ui/components/input'
 import {DraftBadge} from '@shm/ui/draft-badge'
 import {BlockEmbedCard, BlockEmbedComments, BlockEmbedContent, BlockEmbedLink} from '@shm/ui/embed-views'
 import {useImageUrl} from '@shm/ui/get-file-url'
 import {ExternalLink, FileText, MoreHorizontal} from '@shm/ui/icons'
 import {useDocumentCardMenuItems} from '@shm/ui/newspaper'
-import {MenuItemType} from '@shm/ui/options-dropdown'
+import {MenuItemType, OptionsDropdown} from '@shm/ui/options-dropdown'
 import {RecentSearchResultItem, SearchResultItem} from '@shm/ui/search'
 import {Separator} from '@shm/ui/separator'
 import {SizableText} from '@shm/ui/text'
@@ -259,9 +249,9 @@ function DraftEmbedPlaceholder({
         </div>
       </div>
 
-      {/* 3-dot menu */}
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
+      <OptionsDropdown
+        align="end"
+        button={
           <Button
             variant="outline"
             size="icon"
@@ -273,32 +263,24 @@ function DraftEmbedPlaceholder({
           >
             <MoreHorizontal className="size-4" />
           </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem
-            onClick={(e) => {
-              e.preventDefault()
-              e.stopPropagation()
-              void handleOpen()
-            }}
-            disabled={!draftActions?.onOpenDraft || !draft}
-          >
-            <Pencil className="size-4" />
-            Open draft
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            variant="destructive"
-            onClick={async (e) => {
-              e.preventDefault()
-              e.stopPropagation()
-              editor.removeBlocks([blockId])
-            }}
-          >
-            <Trash2 className="size-4" />
-            Remove card
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+        }
+        menuItems={[
+          {
+            key: 'open',
+            label: 'Open draft',
+            icon: <Pencil className="size-4" />,
+            disabled: !draftActions?.onOpenDraft || !draft,
+            onClick: () => void handleOpen(),
+          },
+          {
+            key: 'remove',
+            label: 'Remove card',
+            icon: <Trash2 className="size-4" />,
+            variant: 'destructive',
+            onClick: () => editor.removeBlocks([blockId]),
+          },
+        ]}
+      />
     </div>
   )
 }
@@ -445,49 +427,6 @@ const EmbedDisplay = ({editor, block, assign}: DisplayComponentProps) => {
   return content
 }
 
-function renderMenuItem(item: MenuItemType, close: () => void): React.ReactNode {
-  if (item.children && item.children.length > 0) {
-    return (
-      <DropdownMenuSub key={item.key}>
-        <DropdownMenuSubTrigger>
-          {item.icon}
-          <SizableText>{item.label}</SizableText>
-        </DropdownMenuSubTrigger>
-        <DropdownMenuSubContent>
-          {item.children.map((child) => (
-            <DropdownMenuItem
-              key={child.key}
-              variant={child.variant}
-              onClick={(e) => {
-                e.stopPropagation()
-                close()
-                child.onClick?.(e as any)
-              }}
-            >
-              {child.icon}
-              <SizableText>{child.label}</SizableText>
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuSubContent>
-      </DropdownMenuSub>
-    )
-  }
-  return (
-    <DropdownMenuItem
-      key={item.key}
-      variant={item.variant}
-      onClick={(e) => {
-        e.stopPropagation()
-        close()
-        item.onClick?.(e as any)
-      }}
-    >
-      {item.icon}
-      <SizableText>{item.label}</SizableText>
-    </DropdownMenuItem>
-  )
-}
-
 /** 3-dot contextual menu for a selected subdocument embed. */
 function SubdocumentMenu({
   editor,
@@ -498,8 +437,6 @@ function SubdocumentMenu({
   block: Block<HMBlockSchema>
   docId: UnpackedHypermediaId
 }) {
-  const [open, setOpen] = useState(false)
-  const close = useCallback(() => setOpen(false), [])
   const docResource = useResource(docId)
   const doc = docResource.data?.type === 'document' ? docResource.data.document : null
   const baseItems = useDocumentCardMenuItems(docId, doc)
@@ -592,14 +529,12 @@ function SubdocumentMenu({
       : item,
   )
 
-  // Reorder so destructive items render at the bottom with a separator.
   const allItems = [...prependedItems, ...enhancedBaseItems]
-  const nonDestructive = allItems.filter((i) => i.variant !== 'destructive')
-  const destructive = allItems.filter((i) => i.variant === 'destructive')
 
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
-      <DropdownMenuTrigger asChild>
+    <OptionsDropdown
+      align="end"
+      button={
         <Button
           variant="ghost"
           size="icon"
@@ -612,15 +547,9 @@ function SubdocumentMenu({
         >
           <MoreHorizontal className="size-3.5" />
         </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        {nonDestructive.map((item) => renderMenuItem(item, close))}
-        {destructive.length > 0 && nonDestructive.length > 0 && (
-          <DropdownMenuSeparator className="bg-black/10 dark:bg-white/10" />
-        )}
-        {destructive.map((item) => renderMenuItem(item, close))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+      }
+      menuItems={allItems}
+    />
   )
 }
 

--- a/frontend/packages/ui/src/__tests__/options-dropdown.test.tsx
+++ b/frontend/packages/ui/src/__tests__/options-dropdown.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import React from 'react'
+import {createRoot, type Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {OptionsDropdown, type MenuItemType} from '../options-dropdown'
+;(globalThis as typeof globalThis & {React?: typeof React; IS_REACT_ACT_ENVIRONMENT?: boolean}).React = React
+;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+
+if (!('PointerEvent' in window)) {
+  ;(window as any).PointerEvent = MouseEvent
+}
+if (!HTMLElement.prototype.hasPointerCapture) {
+  HTMLElement.prototype.hasPointerCapture = () => false
+}
+if (!HTMLElement.prototype.setPointerCapture) {
+  HTMLElement.prototype.setPointerCapture = () => {}
+}
+if (!HTMLElement.prototype.releasePointerCapture) {
+  HTMLElement.prototype.releasePointerCapture = () => {}
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+  document.body.querySelectorAll('[data-slot="dropdown-menu-content"]').forEach((node) => node.remove())
+})
+
+function renderMenu(items: MenuItemType[], props: Partial<React.ComponentProps<typeof OptionsDropdown>> = {}) {
+  act(() => {
+    root.render(<OptionsDropdown menuItems={items} {...props} />)
+  })
+}
+
+function openMenu() {
+  const trigger = container.querySelector('[data-slot="dropdown-menu-trigger"]') as HTMLElement
+  act(() => {
+    trigger.dispatchEvent(new PointerEvent('pointerdown', {bubbles: true, cancelable: true, button: 0, ctrlKey: false}))
+  })
+}
+
+function basicItem(overrides: Partial<MenuItemType> = {}): MenuItemType {
+  return {
+    key: 'item',
+    label: 'Item',
+    icon: <span data-testid="icon" />,
+    onClick: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('OptionsDropdown shared action menu', () => {
+  it('uses a provided custom trigger button', () => {
+    renderMenu([basicItem()], {
+      button: <button aria-label="Custom actions">Custom trigger</button>,
+    })
+
+    expect(container.querySelector('[aria-label="Custom actions"]')?.textContent).toBe('Custom trigger')
+  })
+
+  it('keeps hidden hover triggers visible while the dropdown is open', () => {
+    renderMenu([basicItem()])
+
+    expect(container.querySelector('[data-slot="dropdown-menu-trigger"]')?.className).toContain(
+      'data-[state=open]:opacity-100',
+    )
+  })
+
+  it('renders disabled items as disabled and does not invoke them', () => {
+    const onClick = vi.fn()
+    renderMenu([basicItem({label: 'Disabled item', disabled: true, onClick})])
+
+    openMenu()
+    const disabledItem = document.body.querySelector('[role="menuitem"][data-disabled]') as HTMLElement | null
+
+    expect(disabledItem?.textContent).toContain('Disabled item')
+    act(() => {
+      disabledItem?.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))
+    })
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('orders destructive items after non-destructive items with a separator', () => {
+    renderMenu([
+      basicItem({key: 'delete', label: 'Delete', variant: 'destructive'}),
+      basicItem({key: 'open', label: 'Open'}),
+    ])
+
+    openMenu()
+    const content = document.body.querySelector('[data-slot="dropdown-menu-content"]')
+    const labels = Array.from(content?.querySelectorAll('[role="menuitem"]') ?? []).map((node) => node.textContent)
+
+    expect(labels).toEqual(['Open', 'Delete'])
+    expect(content?.querySelector('[data-slot="dropdown-menu-separator"]')).not.toBeNull()
+  })
+})
+
+import {SidebarMenuAction, SidebarMenuItem} from '../components/sidebar'
+
+describe('OptionsDropdown sidebar trigger integration', () => {
+  it('opens when using SidebarMenuAction as the custom trigger', () => {
+    renderMenu([basicItem({label: 'Sidebar Action'})], {
+      side: 'right',
+      align: 'start',
+      button: (
+        <SidebarMenuAction aria-label="Sidebar options" onClick={(event) => event.stopPropagation()}>
+          Actions
+        </SidebarMenuAction>
+      ),
+    })
+
+    openMenu()
+
+    expect(document.body.querySelector('[data-slot="dropdown-menu-content"]')?.textContent).toContain('Sidebar Action')
+  })
+})
+
+describe('SidebarMenuAction ref integration', () => {
+  it('forwards refs to its underlying button for Radix asChild positioning', () => {
+    const ref = React.createRef<HTMLButtonElement>()
+
+    act(() => {
+      root.render(
+        <SidebarMenuItem>
+          <SidebarMenuAction ref={ref}>Actions</SidebarMenuAction>
+        </SidebarMenuItem>,
+      )
+    })
+
+    expect(ref.current?.tagName).toBe('BUTTON')
+  })
+})

--- a/frontend/packages/ui/src/components/sidebar.tsx
+++ b/frontend/packages/ui/src/components/sidebar.tsx
@@ -103,23 +103,23 @@ function SidebarMenuButton({
   )
 }
 
-function SidebarMenuAction({
-  className,
-  asChild = false,
-  ...props
-}: React.ComponentProps<'button'> & {asChild?: boolean}) {
-  const Comp = asChild ? Slot : 'button'
-  return (
-    <Comp
-      data-slot="sidebar-menu-action"
-      className={cn(
-        'text-sidebar-foreground/70 hover:text-sidebar-foreground absolute top-1/2 right-1 flex -translate-y-1/2 items-center justify-center rounded-md p-1 opacity-0 group-hover/menu-item:opacity-100 focus-within:opacity-100 has-[[data-state=open]]:opacity-100',
-        className,
-      )}
-      {...props}
-    />
-  )
-}
+const SidebarMenuAction = React.forwardRef<HTMLButtonElement, React.ComponentProps<'button'> & {asChild?: boolean}>(
+  ({className, asChild = false, ...props}, ref) => {
+    const Comp = asChild ? Slot : 'button'
+    return (
+      <Comp
+        ref={ref}
+        data-slot="sidebar-menu-action"
+        className={cn(
+          'text-sidebar-foreground/70 hover:text-sidebar-foreground absolute top-1/2 right-1 flex -translate-y-1/2 items-center justify-center rounded-md p-1 opacity-0 group-hover/menu-item:opacity-100 focus-within:opacity-100 has-[[data-state=open]]:opacity-100',
+          className,
+        )}
+        {...props}
+      />
+    )
+  },
+)
+SidebarMenuAction.displayName = 'SidebarMenuAction'
 
 function SidebarMenuBadge({className, ...props}: React.ComponentProps<'div'>) {
   return (

--- a/frontend/packages/ui/src/inline-draft-card.tsx
+++ b/frontend/packages/ui/src/inline-draft-card.tsx
@@ -2,8 +2,8 @@ import {HMListedDraft} from '@seed-hypermedia/client/hm-types'
 import {ImageIcon, MoreVertical, Pencil, Trash2} from 'lucide-react'
 import {useCallback, useEffect, useRef, useState} from 'react'
 import {Button} from './button'
-import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from './components/dropdown-menu'
 import {DraftBadge} from './draft-badge'
+import {OptionsDropdown} from './options-dropdown'
 import {cn} from './utils'
 
 export interface InlineDraftCardProps {
@@ -131,23 +131,29 @@ export function InlineDraftCard({
             </div>
           </div>
           <div className="flex items-center justify-end py-3 pr-2 pl-4" onClick={(e) => e.stopPropagation()}>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="iconSm">
+            <OptionsDropdown
+              align="end"
+              button={
+                <Button variant="ghost" size="iconSm" aria-label="Draft options">
                   <MoreVertical className="size-4" />
                 </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={openDraft}>
-                  <Pencil className="size-4" />
-                  Open Draft
-                </DropdownMenuItem>
-                <DropdownMenuItem className="text-destructive" onClick={() => onDeleteDraft(draft.id)}>
-                  <Trash2 className="size-4" />
-                  Delete Draft
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+              }
+              menuItems={[
+                {
+                  key: 'open',
+                  label: 'Open Draft',
+                  icon: <Pencil className="size-4" />,
+                  onClick: openDraft,
+                },
+                {
+                  key: 'delete',
+                  label: 'Delete Draft',
+                  icon: <Trash2 className="size-4" />,
+                  variant: 'destructive',
+                  onClick: () => onDeleteDraft(draft.id),
+                },
+              ]}
+            />
           </div>
         </div>
       </div>

--- a/frontend/packages/ui/src/inline-draft-list-item.tsx
+++ b/frontend/packages/ui/src/inline-draft-list-item.tsx
@@ -2,8 +2,8 @@ import {HMListedDraft} from '@seed-hypermedia/client/hm-types'
 import {FileText, MoreVertical, Pencil, Trash2} from 'lucide-react'
 import {useCallback, useEffect, useRef, useState} from 'react'
 import {Button} from './button'
-import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from './components/dropdown-menu'
 import {DraftBadge} from './draft-badge'
+import {OptionsDropdown} from './options-dropdown'
 
 export interface InlineDraftListItemProps {
   draft: HMListedDraft
@@ -108,23 +108,29 @@ export function InlineDraftListItem({
           <DraftBadge />
         </div>
         <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="iconSm">
+          <OptionsDropdown
+            align="end"
+            button={
+              <Button variant="ghost" size="iconSm" aria-label="Draft options">
                 <MoreVertical className="size-4" />
               </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={openDraft}>
-                <Pencil className="size-4" />
-                Open Draft
-              </DropdownMenuItem>
-              <DropdownMenuItem className="text-destructive" onClick={() => onDeleteDraft(draft.id)}>
-                <Trash2 className="size-4" />
-                Delete Draft
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+            }
+            menuItems={[
+              {
+                key: 'open',
+                label: 'Open Draft',
+                icon: <Pencil className="size-4" />,
+                onClick: openDraft,
+              },
+              {
+                key: 'delete',
+                label: 'Delete Draft',
+                icon: <Trash2 className="size-4" />,
+                variant: 'destructive',
+                onClick: () => onDeleteDraft(draft.id),
+              },
+            ]}
+          />
         </div>
       </div>
     </div>

--- a/frontend/packages/ui/src/options-dropdown.tsx
+++ b/frontend/packages/ui/src/options-dropdown.tsx
@@ -50,6 +50,7 @@ function MenuItemHelpIcon({content}: {content: string}) {
   )
 }
 
+/** Describes one action row rendered by the shared three-dot options menu. */
 export type MenuItemType = {
   key: string
   label: string
@@ -59,8 +60,79 @@ export type MenuItemType = {
   variant?: 'default' | 'destructive'
   children?: MenuItemType[]
   tooltip?: string
+  disabled?: boolean
 }
 
+function orderMenuItems(menuItems: (MenuItemType | null)[]) {
+  const presentItems = menuItems.filter((item): item is MenuItemType => item != null)
+  const nonDestructive = presentItems.filter((item) => item.variant !== 'destructive')
+  const destructive = presentItems.filter((item) => item.variant === 'destructive')
+  const firstDestructiveIndex = nonDestructive.length > 0 && destructive.length > 0 ? nonDestructive.length : -1
+  return {ordered: [...nonDestructive, ...destructive], firstDestructiveIndex}
+}
+
+function MenuItemLabel({item}: {item: MenuItemType}) {
+  return item.subLabel ? (
+    <div className="flex flex-col gap-1">
+      <SizableText>{item.label}</SizableText>
+      <SizableText size="sm" className="text-muted-foreground text-xs">
+        {item.subLabel}
+      </SizableText>
+    </div>
+  ) : (
+    <SizableText>{item.label}</SizableText>
+  )
+}
+
+function renderMenuItem(item: MenuItemType, close: () => void) {
+  if (item.children) {
+    return (
+      <DropdownMenuSub>
+        <DropdownMenuSubTrigger disabled={item.disabled}>
+          {item.icon}
+          <SizableText>{item.label}</SizableText>
+        </DropdownMenuSubTrigger>
+        <DropdownMenuSubContent>
+          {item.children.map((child) => (
+            <DropdownMenuItem
+              key={child.key}
+              variant={child.variant}
+              disabled={child.disabled}
+              onClick={(e) => {
+                e.stopPropagation()
+                if (child.disabled) return
+                close()
+                child.onClick?.(e as any)
+              }}
+            >
+              {child.icon}
+              <SizableText>{child.label}</SizableText>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuSubContent>
+      </DropdownMenuSub>
+    )
+  }
+
+  return (
+    <DropdownMenuItem
+      variant={item.variant}
+      disabled={item.disabled}
+      onClick={(e) => {
+        e.stopPropagation()
+        if (item.disabled) return
+        close()
+        item.onClick?.(e as any)
+      }}
+    >
+      {item.icon}
+      <MenuItemLabel item={item} />
+      {item.tooltip ? <MenuItemHelpIcon content={item.tooltip} /> : null}
+    </DropdownMenuItem>
+  )
+}
+
+/** Renders the shared three-dot action menu used by row, card, and document option controls. */
 export function OptionsDropdown({
   menuItems,
   hiddenUntilItemHover,
@@ -68,6 +140,10 @@ export function OptionsDropdown({
   align,
   className,
   size = 'icon',
+  button,
+  triggerClassName,
+  contentClassName,
+  ariaLabel = 'Open options',
 }: {
   menuItems: (MenuItemType | null)[]
   hiddenUntilItemHover?: boolean
@@ -77,8 +153,13 @@ export function OptionsDropdown({
   align?: DropdownMenuContentProps['align']
   size?: ButtonProps['size']
   className?: string
+  triggerClassName?: string
+  contentClassName?: string
+  ariaLabel?: string
 }) {
   const popoverState = usePopoverState()
+  const {ordered, firstDestructiveIndex} = orderMenuItems(menuItems)
+  const close = () => popoverState.onOpenChange(false)
 
   return (
     <div
@@ -86,80 +167,32 @@ export function OptionsDropdown({
         'flex group-hover/item:opacity-100',
         !popoverState.open && hiddenUntilItemHover ? 'opacity-0' : 'opacity-100',
         className,
-        popoverState.open && '!opacity-100', // Force visible when dropdown is open
+        popoverState.open && '!opacity-100',
       )}
     >
       <DropdownMenu open={popoverState.open} onOpenChange={popoverState.onOpenChange}>
-        <DropdownMenuTrigger className={cn(buttonVariants({variant: 'outline', size}), 'no-window-drag')}>
-          <MoreHorizontal className="size-3.5" />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent className="p-1" side={side} align={align}>
+        {button ? (
+          <DropdownMenuTrigger asChild className={cn('no-window-drag', triggerClassName)}>
+            {button}
+          </DropdownMenuTrigger>
+        ) : (
+          <DropdownMenuTrigger
+            aria-label={ariaLabel}
+            className={cn(buttonVariants({variant: 'outline', size}), 'no-window-drag', triggerClassName)}
+          >
+            <MoreHorizontal className="size-3.5" />
+          </DropdownMenuTrigger>
+        )}
+        <DropdownMenuContent className={cn('p-1', contentClassName)} side={side} align={align}>
           <div className="flex flex-col">
-            {(() => {
-              // Filter items so destructive items are rendered at the bottom of the menu
-              const presentItems = menuItems.filter((item): item is MenuItemType => item != null)
-              const nonDestructive = presentItems.filter((item) => item.variant !== 'destructive')
-              const destructive = presentItems.filter((item) => item.variant === 'destructive')
-              const ordered = [...nonDestructive, ...destructive]
-              const firstDestructiveIndex =
-                nonDestructive.length > 0 && destructive.length > 0 ? nonDestructive.length : -1
-
-              return ordered.map((item, index) => (
-                <div key={item.key}>
-                  {index === firstDestructiveIndex ? (
-                    // Show separator before first destructive item
-                    <DropdownMenuSeparator className="bg-black/10 dark:bg-white/10" />
-                  ) : null}
-                  {item.children ? (
-                    <DropdownMenuSub>
-                      <DropdownMenuSubTrigger>
-                        {item.icon}
-                        <SizableText>{item.label}</SizableText>
-                      </DropdownMenuSubTrigger>
-                      <DropdownMenuSubContent>
-                        {item.children.map((child) => (
-                          <DropdownMenuItem
-                            key={child.key}
-                            variant={child.variant}
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              popoverState.onOpenChange(false)
-                              child.onClick?.(e as any)
-                            }}
-                          >
-                            {child.icon}
-                            <SizableText>{child.label}</SizableText>
-                          </DropdownMenuItem>
-                        ))}
-                      </DropdownMenuSubContent>
-                    </DropdownMenuSub>
-                  ) : (
-                    <DropdownMenuItem
-                      variant={item.variant}
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        popoverState.onOpenChange(false)
-                        item.onClick?.(e as any)
-                      }}
-                    >
-                      {item.icon}
-                      {item.subLabel ? (
-                        <div className="flex flex-col gap-1">
-                          <SizableText>{item.label}</SizableText>
-
-                          <SizableText size="sm" className="text-muted-foreground text-xs">
-                            {item.subLabel}
-                          </SizableText>
-                        </div>
-                      ) : (
-                        <SizableText>{item.label}</SizableText>
-                      )}
-                      {item.tooltip ? <MenuItemHelpIcon content={item.tooltip} /> : null}
-                    </DropdownMenuItem>
-                  )}
-                </div>
-              ))
-            })()}
+            {ordered.map((item, index) => (
+              <div key={item.key}>
+                {index === firstDestructiveIndex ? (
+                  <DropdownMenuSeparator className="bg-black/10 dark:bg-white/10" />
+                ) : null}
+                {renderMenuItem(item, close)}
+              </div>
+            ))}
           </div>
         </DropdownMenuContent>
       </DropdownMenu>


### PR DESCRIPTION
## Summary
- Replace several one-off dropdown menu implementations with the shared `OptionsDropdown` component.
- Extend `OptionsDropdown` to support custom triggers, disabled items, content styling, nested items, and consistent destructive action ordering.
- Add coverage for shared menu behavior and sidebar trigger ref forwarding.