### PR TITLE
fix(vault): proxy IPFS blobs through vault server

### DIFF
--- a/vault/Dockerfile
+++ b/vault/Dockerfile
@@ -17,5 +17,7 @@ WORKDIR /app
 COPY --from=build /build/vault/dist/ .
 VOLUME /data
 ENV SEED_VAULT_DB_PATH=/data/vault.sqlite
+ENV SEED_VAULT_BACKEND_HTTP_BASE_URL=http://seed-daemon:56001
+ENV SEED_VAULT_BACKEND_GRPC_BASE_URL=http://seed-daemon:56001
 EXPOSE 3000
 CMD ["bun", "run", "--no-install", "main.js"]

--- a/vault/src/frontend/index.tsx
+++ b/vault/src/frontend/index.tsx
@@ -11,17 +11,18 @@ import './styles.css'
 const elem = document.getElementById('root')
 if (!elem) throw new Error('root element not found')
 const rootElem = elem
+const blockstoreBaseUrl = '/vault'
 
 // Apply theme before first paint to prevent flash of wrong theme.
 initTheme()
 
 async function bootstrap() {
   const client = new FetchClient()
-  const {backendHttpBaseUrl, notificationServerUrl} = await client.getConfig()
+  const {notificationServerUrl} = await client.getConfig()
   const appStore = createStore(
     client,
-    new IndexedDBBlockstore(new RemoteBlockstore(backendHttpBaseUrl)),
-    backendHttpBaseUrl,
+    new IndexedDBBlockstore(new RemoteBlockstore(blockstoreBaseUrl)),
+    blockstoreBaseUrl,
     notificationServerUrl,
   )
   const router = createRouter()

--- a/vault/src/main.ts
+++ b/vault/src/main.ts
@@ -87,6 +87,7 @@ async function main() {
     },
     error: handleError,
     routes: {
+      ...createIPFSProxyRoutes(cfg.backend.httpBaseUrl),
       ...createAPIRoutes(svc),
       // In development, proxy /hm/api/config to the web app (shares the same daemon in prod).
       '/hm/api/config': {
@@ -145,6 +146,47 @@ async function main() {
 
 if (import.meta.main) {
   main()
+}
+
+function createIPFSProxyRoutes(backendHttpBaseUrl: string): Bun.Serve.Routes<undefined, string> {
+  return {
+    '/vault/ipfs/:cid': {
+      GET: (req) => proxyIPFSRequest(req, backendHttpBaseUrl),
+      POST: (req) => proxyIPFSRequest(req, backendHttpBaseUrl),
+    },
+  }
+}
+
+async function proxyIPFSRequest(req: BunRequest, backendHttpBaseUrl: string): Promise<Response> {
+  const cid = req.params.cid
+  if (!cid) {
+    return new Response('Missing CID', {status: 400})
+  }
+
+  const sourceUrl = new URL(req.url)
+  const upstreamUrl = new URL(`/ipfs/${encodeURIComponent(cid)}`, backendHttpBaseUrl)
+  upstreamUrl.search = sourceUrl.search
+
+  const headers = new Headers(req.headers)
+  headers.delete('host')
+  headers.delete('cookie')
+  headers.delete('authorization')
+
+  const upstreamResponse = await fetch(upstreamUrl, {
+    method: req.method,
+    headers,
+    body: req.method === 'GET' || req.method === 'HEAD' ? undefined : req.body,
+    redirect: 'manual',
+  })
+
+  const responseHeaders = new Headers(upstreamResponse.headers)
+  responseHeaders.delete('set-cookie')
+
+  return new Response(upstreamResponse.body, {
+    status: upstreamResponse.status,
+    statusText: upstreamResponse.statusText,
+    headers: responseHeaders,
+  })
 }
 
 function createAPIRoutes(svc: apisvc.Service): Bun.Serve.Routes<undefined, string> {


### PR DESCRIPTION
Fixes dev vault profile publishing by routing IPFS blob reads/writes through the vault server.

Adds /vault/ipfs/:cid GET/POST proxy routes to forward blob requests to the configured daemon backend.
Updates the vault frontend to use same-origin /vault/ipfs/{cid} instead of depending on public /ipfs/* routing.
Sets Docker defaults so the vault container talks to seed-daemon:56001 internally.
Validation:

bun run tsgo --noEmit
bun test (196 pass)