### PR TITLE
fix(ui): apply video chrome to actual players

### DIFF
--- a/frontend/packages/ui/src/__tests__/hm-prose-css.test.ts
+++ b/frontend/packages/ui/src/__tests__/hm-prose-css.test.ts
@@ -4,6 +4,15 @@ import {describe, expect, it} from 'vitest'
 
 const css = readFileSync(resolve(__dirname, '../hm-prose.css'), 'utf8')
 
+function getDeclarations(selectorPattern: RegExp) {
+  const ruleStart = css.search(selectorPattern)
+  expect(ruleStart).toBeGreaterThanOrEqual(0)
+
+  const declarationStart = css.indexOf('{', ruleStart)
+  const declarationEnd = css.indexOf('}', declarationStart)
+  return css.slice(declarationStart + 1, declarationEnd)
+}
+
 describe('hm-prose grid media layout', () => {
   it('neutralizes media breakout positioning inside grid cells', () => {
     const selectorPatterns = [
@@ -17,15 +26,32 @@ describe('hm-prose grid media layout', () => {
       expect(css).toMatch(selectorPattern)
     }
 
-    const ruleStart = css.search(selectorPatterns[0]!)
-    const declarationStart = css.indexOf('{', ruleStart)
-    const declarationEnd = css.indexOf('}', declarationStart)
-    const declarations = css.slice(declarationStart + 1, declarationEnd)
+    const declarations = getDeclarations(selectorPatterns[0]!)
 
     expect(declarations).toContain('position: static;')
     expect(declarations).toContain('left: auto;')
     expect(declarations).toContain('width: 100%;')
     expect(declarations).toContain('max-width: 100%;')
     expect(declarations).toContain('transform: none;')
+  })
+})
+
+describe('hm-prose video chrome', () => {
+  it('applies radius and shadows to actual video players instead of the wrapper', () => {
+    const lightPlayerSelector =
+      /\.hm-prose\s+\[data-content-type='video'\]\s+video,\s*\.hm-prose\s+\[data-content-type='video'\]\s+iframe/
+    const darkPlayerSelector =
+      /\.dark\s+\.hm-prose\s+\[data-content-type='video'\]\s+video,\s*\.dark\s+\.hm-prose\s+\[data-content-type='video'\]\s+iframe,\s*\[data-theme='dark'\]\s+\.hm-prose\s+\[data-content-type='video'\]\s+video,\s*\[data-theme='dark'\]\s+\.hm-prose\s+\[data-content-type='video'\]\s+iframe/
+
+    const lightPlayerDeclarations = getDeclarations(lightPlayerSelector)
+    expect(lightPlayerDeclarations).toContain('border-radius: 0.75rem;')
+    expect(lightPlayerDeclarations).toContain('box-shadow:')
+
+    const darkPlayerDeclarations = getDeclarations(darkPlayerSelector)
+    expect(darkPlayerDeclarations).toContain('box-shadow:')
+
+    const wrapperChromeSelector = /\.hm-prose\s+\[data-content-type='video'\]\s*\{/
+    const wrapperChromeRuleStart = css.search(wrapperChromeSelector)
+    expect(wrapperChromeRuleStart).toBe(-1)
   })
 })

--- a/frontend/packages/ui/src/hm-prose.css
+++ b/frontend/packages/ui/src/hm-prose.css
@@ -488,18 +488,20 @@
  * The <video>/<iframe> player fills an absolutely-positioned 16:9 box,
  * so its own width/height are owned by the block component — applying
  * image-style `height: auto` here breaks that and overflows the frame.
- * The corner radius, clip, and shadow ride on the block element so the
- * square-cornered player is masked to the rounded frame. */
-.hm-prose [data-content-type='video'] {
+ * The corner radius and shadow belong on the real player element, not the
+ * BlockNote wrapper, so resized videos get chrome only around the media. */
+.hm-prose [data-content-type='video'] video,
+.hm-prose [data-content-type='video'] iframe {
   border-radius: 0.75rem;
-  overflow: hidden;
   box-shadow:
     0 1px 2px rgba(0, 0, 0, 0.04),
     0 12px 28px rgba(0, 0, 0, 0.08);
 }
 
-.dark .hm-prose [data-content-type='video'],
-[data-theme='dark'] .hm-prose [data-content-type='video'] {
+.dark .hm-prose [data-content-type='video'] video,
+.dark .hm-prose [data-content-type='video'] iframe,
+[data-theme='dark'] .hm-prose [data-content-type='video'] video,
+[data-theme='dark'] .hm-prose [data-content-type='video'] iframe {
   box-shadow:
     0 1px 2px rgba(0, 0, 0, 0.4),
     0 16px 32px rgba(0, 0, 0, 0.45);


### PR DESCRIPTION
## Summary
- Applies rounded corners and shadows directly to video and iframe players instead of the video wrapper.
- Preserves dark-theme video shadows on the player elements.
- Adds CSS coverage to prevent wrapper-level video chrome from returning.

## Related
- fixes #802

---

Fixes #802