### PR TITLE
fix(desktop): align titlebar with locked sidebar width

### DIFF
--- a/frontend/apps/desktop/src/__tests__/sidebar-titlebar-width.test.ts
+++ b/frontend/apps/desktop/src/__tests__/sidebar-titlebar-width.test.ts
@@ -1,0 +1,13 @@
+import {describe, expect, it} from 'vitest'
+import {getSidebarTitlebarWidth} from '../sidebar-context'
+
+describe('getSidebarTitlebarWidth', () => {
+  it('uses the measured sidebar pixel width when the sidebar is locked', () => {
+    expect(getSidebarTitlebarWidth({isLocked: true, sidebarWidthPx: 283.6})).toBe('284px')
+  })
+
+  it('does not project panel percentages into viewport units', () => {
+    expect(getSidebarTitlebarWidth({isLocked: true, sidebarWidthPx: null})).toBeUndefined()
+    expect(getSidebarTitlebarWidth({isLocked: false, sidebarWidthPx: 284})).toBeUndefined()
+  })
+})

--- a/frontend/apps/desktop/src/components/__tests__/titlebar-layout.test.tsx
+++ b/frontend/apps/desktop/src/components/__tests__/titlebar-layout.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import {createRoot, Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, describe, expect, it} from 'vitest'
+import {TitlebarMainRow} from '../titlebar-layout'
+;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+function renderLayout(props: {sidebarLocked: boolean; sidebarWidth?: string}) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+
+  act(() => {
+    root?.render(
+      <TitlebarMainRow
+        sidebarLocked={props.sidebarLocked}
+        sidebarWidth={props.sidebarWidth}
+        sidebarControl={<button type="button">sidebar toggle</button>}
+        navigation={<button type="button">back</button>}
+        omnibar={<input aria-label="omnibar" />}
+        actions={<button type="button">account</button>}
+      />,
+    )
+  })
+
+  return container
+}
+
+afterEach(() => {
+  if (root) {
+    act(() => root?.unmount())
+  }
+  container?.remove()
+  root = null
+  container = null
+})
+
+describe('TitlebarMainRow', () => {
+  it('sizes and right-aligns the sidebar region when the sidebar is locked', () => {
+    const rendered = renderLayout({sidebarLocked: true, sidebarWidth: '284px'})
+
+    const sidebarRegion = rendered.querySelector('[data-titlebar-sidebar-region]') as HTMLDivElement
+    const navigationRegion = rendered.querySelector('[data-titlebar-navigation-region]') as HTMLDivElement
+    const omnibarRegion = rendered.querySelector('[data-titlebar-omnibar-region]') as HTMLDivElement
+
+    expect(sidebarRegion.style.width).toBe('284px')
+    expect(sidebarRegion.className).toContain('justify-end')
+    expect(sidebarRegion.contains(navigationRegion)).toBe(false)
+    expect(navigationRegion.compareDocumentPosition(omnibarRegion) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('leaves the sidebar region unsized when the sidebar is closed', () => {
+    const rendered = renderLayout({sidebarLocked: false, sidebarWidth: '284px'})
+
+    const sidebarRegion = rendered.querySelector('[data-titlebar-sidebar-region]') as HTMLDivElement
+
+    expect(sidebarRegion.style.width).toBe('')
+    expect(sidebarRegion.className).toContain('justify-start')
+    expect(sidebarRegion.className).toContain('pl-2')
+  })
+})

--- a/frontend/apps/desktop/src/components/sidebar-base.tsx
+++ b/frontend/apps/desktop/src/components/sidebar-base.tsx
@@ -109,6 +109,33 @@ export function GenericSidebarContainer({
     prevMediaGtSm.current = media.gtSm
   }, [media.gtSm])
 
+  useLayoutEffect(() => {
+    const element = panelContentRef.current
+    if (!element) return
+
+    const updateSidebarWidthPx = () => {
+      if (!isLocked) return
+      const width = element.getBoundingClientRect().width
+      if (width > 0) ctx.onSidebarWidthPxChange(width)
+    }
+
+    updateSidebarWidthPx()
+
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', updateSidebarWidthPx)
+      return () => {
+        window.removeEventListener('resize', updateSidebarWidthPx)
+      }
+    }
+
+    const resizeObserver = new ResizeObserver(updateSidebarWidthPx)
+    resizeObserver.observe(element)
+
+    return () => {
+      resizeObserver.disconnect()
+    }
+  }, [ctx, isLocked])
+
   return (
     <>
       {isFocused && !isLocked && !isWindowTooNarrowForHoverSidebar ? (

--- a/frontend/apps/desktop/src/components/titlebar-common.tsx
+++ b/frontend/apps/desktop/src/components/titlebar-common.tsx
@@ -497,13 +497,13 @@ export function NavigationButtons() {
   const dispatch = useNavigationDispatch()
   if (!state) return null
   return (
-    <div className="no-window-drag flex">
+    <div className="no-window-drag flex shrink-0">
       <Button
         size="icon"
         onClick={() => dispatch({type: 'pop'})}
         variant="ghost"
         disabled={state.routeIndex <= 0}
-        className="rounded-tl-0 rounded-bl-0"
+        className="rounded-tl-0 rounded-bl-0 shrink-0"
       >
         <Back className="size-4" />
       </Button>
@@ -512,7 +512,7 @@ export function NavigationButtons() {
         size="icon"
         onClick={() => dispatch({type: 'forward'})}
         disabled={state.routeIndex >= state.routes.length - 1}
-        className="rounded-tr-0 rounded-br-0"
+        className="rounded-tr-0 rounded-br-0 shrink-0"
       >
         <Forward className="size-4" />
       </Button>
@@ -556,7 +556,7 @@ export function NavMenuButton({left}: {left?: ReactNode}) {
   }
 
   return (
-    <div className="ml-2 flex flex-1 items-center">
+    <div className="flex shrink-0 items-center">
       {left || <div />}
       {ctx && (
         <div className="no-window-drag relative z-10">
@@ -567,6 +567,8 @@ export function NavMenuButton({left}: {left?: ReactNode}) {
             <Button
               size="icon"
               key={key}
+              aria-label={tooltip}
+              className="shrink-0"
               // onMouseEnter={ctx.onMenuHover}
               // onMouseLeave={ctx.onMenuHoverLeave}
               onClick={handleClick}

--- a/frontend/apps/desktop/src/components/titlebar-layout.tsx
+++ b/frontend/apps/desktop/src/components/titlebar-layout.tsx
@@ -1,0 +1,49 @@
+import {cn} from '@shm/ui/utils'
+import React, {ReactNode} from 'react'
+
+export function TitlebarMainRow({
+  sidebarLocked,
+  sidebarWidth,
+  sidebarControl,
+  navigation,
+  omnibar,
+  actions,
+  className,
+}: {
+  sidebarLocked: boolean
+  sidebarWidth?: string
+  sidebarControl: ReactNode
+  navigation: ReactNode
+  omnibar: ReactNode
+  actions: ReactNode
+  className?: string
+}) {
+  return (
+    <div className={cn('window-drag flex w-full min-w-0 items-center pr-2', className)} data-titlebar-layout>
+      <div
+        className={cn(
+          'window-drag flex shrink-0 items-center',
+          sidebarLocked ? 'justify-end pr-2' : 'justify-start pl-2',
+        )}
+        style={sidebarLocked && sidebarWidth ? {width: sidebarWidth} : undefined}
+        data-titlebar-sidebar-region
+      >
+        {sidebarControl}
+      </div>
+      <div className="window-drag flex min-w-0 flex-1 items-center" data-titlebar-main-region>
+        <div className="window-drag flex shrink-0 items-center" data-titlebar-navigation-region>
+          {navigation}
+        </div>
+        <div className="flex min-w-0 flex-1 items-center overflow-hidden px-2" data-titlebar-omnibar-region>
+          {omnibar}
+        </div>
+      </div>
+      <div
+        className="window-drag flex min-w-0 shrink-0 items-center justify-end overflow-hidden"
+        data-titlebar-actions-region
+      >
+        {actions}
+      </div>
+    </div>
+  )
+}

--- a/frontend/apps/desktop/src/components/titlebar-macos.tsx
+++ b/frontend/apps/desktop/src/components/titlebar-macos.tsx
@@ -1,11 +1,15 @@
-import {useSidebarWidth} from '@/sidebar-context'
+import {useSidebarContext, useSidebarWidth} from '@/sidebar-context'
+import {useStream} from '@shm/shared/use-stream'
 import {TitleText, TitlebarWrapper} from '@shm/ui/titlebar'
 import {TitleBarProps} from './titlebar'
 import {NavMenuButton, NavigationButtons, Omnibar, PageActionButtons} from './titlebar-common'
+import {TitlebarMainRow} from './titlebar-layout'
 
 export default function TitleBarMacos(props: TitleBarProps) {
   const {clean, cleanTitle, ...restProps} = props
   const sidebarWidth = useSidebarWidth()
+  const sidebarContext = useSidebarContext()
+  const isSidebarLocked = !!useStream(sidebarContext.isLocked)
   if (clean) {
     return (
       <TitlebarWrapper className="min-h-0" {...restProps}>
@@ -18,31 +22,24 @@ export default function TitleBarMacos(props: TitleBarProps) {
 
   return (
     <TitlebarWrapper {...restProps}>
-      <div className="window-drag flex w-full items-center justify-between pr-2">
-        <div className="flex-basis-0 window-drag flex min-w-min items-center">
-          <div
-            className="window-drag flex flex-1 items-center gap-2 px-0"
-            style={{
-              minWidth: `calc(${sidebarWidth})`,
-            }}
-          >
-            <NavMenuButton
-              left={
+      <TitlebarMainRow
+        sidebarLocked={isSidebarLocked}
+        sidebarWidth={sidebarWidth}
+        sidebarControl={
+          <NavMenuButton
+            left={
+              isSidebarLocked ? undefined : (
                 <div
                   className="w-[72px]" // this width to stay away from the macOS window traffic lights
                 />
-              }
-            />
-            <NavigationButtons />
-          </div>
-        </div>
-        <div className="flex flex-1 items-center gap-2 overflow-x-hidden px-2">
-          <Omnibar />
-        </div>
-        <div className="flex-basis-0 window-drag flex min-w-min items-center justify-end">
-          <PageActionButtons {...restProps} />
-        </div>
-      </div>
+              )
+            }
+          />
+        }
+        navigation={<NavigationButtons />}
+        omnibar={<Omnibar />}
+        actions={<PageActionButtons {...restProps} />}
+      />
     </TitlebarWrapper>
   )
 }

--- a/frontend/apps/desktop/src/components/titlebar-windows-linux.tsx
+++ b/frontend/apps/desktop/src/components/titlebar-windows-linux.tsx
@@ -1,13 +1,17 @@
 import {CloseButton, WindowsLinuxWindowControls} from '@/components/window-controls'
-import {useSidebarWidth} from '@/sidebar-context'
+import {useSidebarContext, useSidebarWidth} from '@/sidebar-context'
+import {useStream} from '@shm/shared/use-stream'
 import {TitlebarWrapper, TitleText} from '@shm/ui/titlebar'
 import {TitleBarProps} from './titlebar'
 import {NavigationButtons, NavMenuButton, Omnibar, PageActionButtons} from './titlebar-common'
+import {TitlebarMainRow} from './titlebar-layout'
 import './titlebar-windows-linux.css'
 import {SystemMenu} from './windows-linux-titlebar'
 
 export default function TitleBarWindows(props: TitleBarProps) {
   const sidebarWidth = useSidebarWidth()
+  const sidebarContext = useSidebarContext()
+  const isSidebarLocked = !!useStream(sidebarContext.isLocked)
 
   if (props.clean) {
     return (
@@ -28,29 +32,21 @@ export default function TitleBarWindows(props: TitleBarProps) {
 
   return (
     <WindowsLinuxTitleBar
-      right={<PageActionButtons />}
-      left={
-        <div className="window-drag flex flex-1 items-start gap-2 px-0" style={{minWidth: sidebarWidth}}>
-          <NavMenuButton />
-          <NavigationButtons />
-        </div>
+      content={
+        <TitlebarMainRow
+          sidebarLocked={isSidebarLocked}
+          sidebarWidth={sidebarWidth}
+          sidebarControl={<NavMenuButton />}
+          navigation={<NavigationButtons />}
+          omnibar={<Omnibar />}
+          actions={<PageActionButtons />}
+        />
       }
-      title={<Omnibar />}
     />
   )
 }
 
-export function WindowsLinuxTitleBar({
-  left,
-  title,
-  right,
-  platform,
-}: {
-  title: React.ReactNode
-  left?: React.ReactNode
-  right?: React.ReactNode
-  platform?: string
-}) {
+export function WindowsLinuxTitleBar({content, platform}: {content: React.ReactNode; platform?: string}) {
   return (
     <div className="flex flex-col">
       <div
@@ -65,16 +61,7 @@ export function WindowsLinuxTitleBar({
       </div>
 
       {/* @ts-expect-error */}
-      <TitlebarWrapper platform={platform}>
-        <div className="window-drag flex justify-between pr-2">
-          <div className="window-drag flex min-w-min basis-0 items-center">{left}</div>
-          <div className="flex flex-1 items-center overflow-x-hidden px-2">
-            {/* <Title /> */}
-            {title}
-          </div>
-          <div className="window-drag flex min-w-min basis-0 items-center justify-end pr-2">{right}</div>
-        </div>
-      </TitlebarWrapper>
+      <TitlebarWrapper platform={platform}>{content}</TitlebarWrapper>
     </div>
   )
 }

--- a/frontend/apps/desktop/src/sidebar-context.tsx
+++ b/frontend/apps/desktop/src/sidebar-context.tsx
@@ -13,7 +13,9 @@ type SidebarContextValue = {
   isHoverVisible: StateStream<boolean>
   isLocked: StateStream<boolean>
   sidebarWidth: StateStream<number>
+  sidebarWidthPx: StateStream<number | null>
   onSidebarResize: (width: number) => void
+  onSidebarWidthPxChange: (width: number) => void
   widthStorage: {
     getItem: (name: string) => string
     setItem: (name: string, value: string) => void
@@ -23,6 +25,17 @@ type SidebarContextValue = {
 export const SidebarContext = createContext<SidebarContextValue | null>(null)
 
 export const SidebarWidth = 220
+
+export function getSidebarTitlebarWidth({
+  isLocked,
+  sidebarWidthPx,
+}: {
+  isLocked: boolean
+  sidebarWidthPx: number | null | undefined
+}) {
+  if (!isLocked || !sidebarWidthPx || sidebarWidthPx <= 0) return undefined
+  return `${Math.round(sidebarWidthPx)}px`
+}
 
 export function SidebarContextProvider(props: PropsWithChildren<{}>) {
   const state = useNavigationState()
@@ -36,6 +49,7 @@ export function SidebarContextProvider(props: PropsWithChildren<{}>) {
           typeof state?.sidebarLocked === 'boolean' ? state.sidebarLocked : true,
         )
         const [setSidebarWidth, sidebarWidth] = writeableStateStream<number>(state?.sidebarWidth || 15)
+        const [setSidebarWidthPx, sidebarWidthPx] = writeableStateStream<number | null>(null)
         let closeTimeout: null | NodeJS.Timeout = null
         let hoverOpenTimeout: null | NodeJS.Timeout = null
         function onMenuHover() {
@@ -84,6 +98,9 @@ export function SidebarContextProvider(props: PropsWithChildren<{}>) {
           dispatch({type: 'sidebarWidth', value: width})
           setSidebarWidth(width)
         }
+        function onSidebarWidthPxChange(width: number) {
+          setSidebarWidthPx(width)
+        }
 
         const widthStorage = {
           getItem(name: string) {
@@ -117,6 +134,7 @@ export function SidebarContextProvider(props: PropsWithChildren<{}>) {
           isHoverVisible,
           isLocked,
           sidebarWidth,
+          sidebarWidthPx,
           onMenuHover,
           onMenuHoverDelayed,
           onMenuHoverLeave,
@@ -124,6 +142,7 @@ export function SidebarContextProvider(props: PropsWithChildren<{}>) {
           onLockSidebarOpen,
           onCloseSidebar,
           onSidebarResize,
+          onSidebarWidthPxChange,
           widthStorage,
         }
       }, [])}
@@ -141,11 +160,12 @@ export function useSidebarContext() {
 
 export function useSidebarWidth() {
   const sidebarContext = useSidebarContext()
-  const sidebarWidth = useStream(sidebarContext.sidebarWidth)
+  const isLocked = !!useStream(sidebarContext.isLocked)
+  const sidebarWidthPx = useStream(sidebarContext.sidebarWidthPx)
 
   const minWidth = useMemo(() => {
-    return `calc(${sidebarWidth}vw)`
-  }, [sidebarWidth])
+    return getSidebarTitlebarWidth({isLocked, sidebarWidthPx})
+  }, [isLocked, sidebarWidthPx])
 
   return minWidth
 }


### PR DESCRIPTION
## Summary
- Aligns the titlebar sidebar controls to the measured locked sidebar width so the sidebar boundary and titlebar controls line up.
- Separates sidebar toggle, navigation, omnibar, and page actions into stable titlebar regions across macOS and Windows/Linux.
- Adds focused tests for locked sidebar titlebar width calculation and layout behavior.

## Related
- Issue #791

---

Fixes #791