### PR TITLE
fix(editor): handle unknown block types without crashing (#807)

### DIFF
--- a/frontend/apps/web/app/styles.css
+++ b/frontend/apps/web/app/styles.css
@@ -266,9 +266,32 @@ body {
   margin: 3px 0;
 }
 
+/* === UNKNOWN / UNSUPPORTED BLOCK === */
+.ssr-content-placeholder .hm-unknown-block {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 6px;
+  border: 1px solid #fca5a5;
+  background-color: #fee2e2;
+  padding: 8px;
+  margin: 3px 0;
+}
+.ssr-content-placeholder .hm-unknown-block-label {
+  font-size: 0.875rem;
+  color: #b91c1c;
+}
+
 /* === DARK MODE === */
 .dark .ssr-content-placeholder .blockContent[data-content-type='code-block'] {
   background-color: rgba(0, 0, 0, 0.5);
+}
+.dark .ssr-content-placeholder .hm-unknown-block {
+  border-color: #991b1b;
+  background-color: #450a0a;
+}
+.dark .ssr-content-placeholder .hm-unknown-block-label {
+  color: #fca5a5;
 }
 .dark .ssr-content-placeholder .blockChildren[data-list-type='Blockquote'] {
   border-left-color: rgb(255 255 255 / 0.3);

--- a/frontend/packages/client/src/editorblock-to-hmblock.ts
+++ b/frontend/packages/client/src/editorblock-to-hmblock.ts
@@ -43,8 +43,48 @@ type MutableBlock = {
   attributes: Record<string, unknown>
 }
 
+/**
+ * Reconstruct the original HMBlock for an unknown/unsupported editor block.
+ *
+ * Unknown blocks carry their untouched server representation (JSON-stringified)
+ * in `props.originalData`. We round-trip that verbatim so corrupt blocks — or
+ * blocks of a type this client version simply doesn't understand yet — survive
+ * an edit/publish cycle without being mutated or dropped. The block `id` is
+ * taken from the editor block so it stays in sync if it was regenerated during
+ * de-duplication.
+ */
+function unknownEditorBlockToHMBlock(editorBlock: EditorBlock): HMBlock {
+  const props = (editorBlock.props ?? {}) as {originalData?: string; originalType?: string}
+
+  if (props.originalData) {
+    try {
+      const parsed = JSON.parse(props.originalData)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return {...parsed, id: editorBlock.id} as unknown as HMBlock
+      }
+    } catch {
+      // Unparseable original data — fall through to a minimal reconstruction.
+    }
+  }
+
+  // No recoverable original data: emit a minimal block that still preserves the
+  // original type string so nothing downstream crashes.
+  return {
+    id: editorBlock.id,
+    type: props.originalType || 'unknown',
+    text: '',
+    annotations: [],
+    attributes: {},
+  } as unknown as HMBlock
+}
+
 /** Convert a single BlockNote EditorBlock into an HMBlock. */
 export function editorBlockToHMBlock(editorBlock: EditorBlock): HMBlock {
+  // Unknown blocks are preserved as-is from their original server data.
+  if (editorBlock.type === 'unknown') {
+    return unknownEditorBlockToHMBlock(editorBlock)
+  }
+
   const blockType = toHMBlockType(editorBlock.type)
   if (!blockType) throw new Error('Unsupported block type ' + editorBlock.type)
 

--- a/frontend/packages/editor/src/ssr-render.test.ts
+++ b/frontend/packages/editor/src/ssr-render.test.ts
@@ -176,4 +176,32 @@ describe('renderDocumentToHTML', () => {
     expect(html).not.toContain('data-text-color')
     expect(html).toContain('hello')
   })
+
+  // Issue #807: an unknown block type must surface as an error block while the
+  // rest of the document keeps rendering.
+  it('renders an error block for an unknown block type and still renders siblings/children', () => {
+    const html = renderDocumentToHTML([
+      {
+        block: {id: 'empty', type: '', text: '', link: '', annotations: []},
+        children: [{block: {id: 'a', type: 'Paragraph', text: 'Abierto', annotations: []}, children: []}],
+      },
+      {block: {id: 'b', type: 'Paragraph', text: 'Debates', annotations: []}, children: []},
+    ] as HMBlockNode[])
+
+    expect(html).toContain('block-unknown')
+    expect(html).toContain('data-content-type="unknown"')
+    expect(html).toContain('Unsupported Block:')
+    // Children of the corrupt block and sibling blocks still render.
+    expect(html).toContain('Abierto')
+    expect(html).toContain('Debates')
+  })
+
+  it('keeps the text fallback for known-but-SSR-unhandled types (e.g. Nostr)', () => {
+    const html = renderDocumentToHTML([
+      {block: {id: 'n', type: 'Nostr', text: 'nostr text', annotations: []}, children: []},
+    ] as HMBlockNode[])
+
+    expect(html).not.toContain('block-unknown')
+    expect(html).toContain('nostr text')
+  })
 })

--- a/frontend/packages/editor/src/ssr-render.ts
+++ b/frontend/packages/editor/src/ssr-render.ts
@@ -1,4 +1,5 @@
 import type {HMAnnotation, HMBlockChildrenType, HMBlockNode} from '@seed-hypermedia/client/hm-types'
+import {isKnownBlockType} from '@seed-hypermedia/client/hm-types'
 import {annotationContains} from '@seed-hypermedia/client/hmblock-to-editorblock'
 
 /** Version-keyed cache: document versions are immutable so entries never go stale. */
@@ -238,6 +239,13 @@ function renderBlockContent(
     }
 
     default: {
+      // Genuinely unknown block types render an error block matching the
+      // editor's UnknownBlock component, instead of silently degrading to a
+      // paragraph. Known-but-SSR-unhandled types (e.g. Nostr) keep the
+      // text fallback below.
+      if (!isKnownBlockType(block.type)) {
+        return renderUnknownBlock(block)
+      }
       if (text) {
         const inlineHtml = renderAnnotatedText(text, annotations, renderHref)
         return `<p class="blockContent inlineContent block-paragraph" data-content-type="paragraph">${inlineHtml}</p>`
@@ -245,6 +253,22 @@ function renderBlockContent(
       return `<div class="blockContent" data-content-type="paragraph"></div>`
     }
   }
+}
+
+/**
+ * Render an error block for an unknown/unsupported block type.
+ * Mirrors the editor's UnknownBlock component so the SSR placeholder looks the
+ * same before hydration replaces it with the interactive version.
+ */
+function renderUnknownBlock(block: any): string {
+  const originalType: string = block.type || 'Unknown'
+  return (
+    `<div class="blockContent block-unknown" data-content-type="unknown">` +
+    `<div class="hm-unknown-block">` +
+    `<span class="hm-unknown-block-label">Unsupported Block: ${esc(originalType)}</span>` +
+    `</div>` +
+    `</div>`
+  )
 }
 
 /**

--- a/frontend/packages/editor/src/unknown-block.tsx
+++ b/frontend/packages/editor/src/unknown-block.tsx
@@ -34,12 +34,11 @@ function UnknownBlockRender({block, editor}: {block: Block<HMBlockSchema>; edito
   }
 
   return (
-    <div className="block-content block-unknown flex flex-1 flex-col gap-2">
-      <div
-        className="flex cursor-pointer items-center gap-2 rounded-md border border-red-300 bg-red-100 p-2 dark:border-red-800 dark:bg-red-950"
-        onClick={() => setExpanded(!expanded)}
-        contentEditable={false}
-      >
+    <div
+      className="block-content block-unknown flex flex-1 flex-col overflow-hidden rounded-md border border-red-300 bg-red-100 dark:border-red-800 dark:bg-red-950"
+      contentEditable={false}
+    >
+      <div className="flex cursor-pointer items-center gap-2 p-2" onClick={() => setExpanded(!expanded)}>
         <AlertCircle className="size-4 text-red-600 dark:text-red-400" />
         <span className="flex-1 font-sans text-sm text-red-700 dark:text-red-300">
           Unsupported Block: {originalType}
@@ -51,11 +50,10 @@ function UnknownBlockRender({block, editor}: {block: Block<HMBlockSchema>; edito
         )}
       </div>
       {expanded && (
-        <pre
-          className="rounded-md border border-gray-200 bg-gray-100 p-2 dark:border-gray-700 dark:bg-gray-800"
-          contentEditable={false}
-        >
-          <code className="font-mono text-xs wrap-break-word">{JSON.stringify(parsedData, null, 2)}</code>
+        <pre className="mx-2 mb-2 overflow-auto rounded-md border border-red-200 bg-red-50/60 p-2 dark:border-red-900 dark:bg-red-950/60">
+          <code className="font-mono text-xs text-red-900 wrap-break-word dark:text-red-200">
+            {JSON.stringify(parsedData, null, 2)}
+          </code>
         </pre>
       )}
     </div>

--- a/frontend/packages/shared/src/client/__tests__/editorblock-to-hmblock.test.ts
+++ b/frontend/packages/shared/src/client/__tests__/editorblock-to-hmblock.test.ts
@@ -1298,4 +1298,100 @@ describe('EditorBlock to HMBlock', () => {
       expect(textColor).toEqual({type: 'TextColor', attributes: {value: 'red'}, link: '', starts: [0], ends: [4]})
     })
   })
+
+  describe('unknown blocks', () => {
+    test('round-trips an unknown block from originalData without mutating it', () => {
+      // The exact corrupt block from issue #807 (an empty-string block type).
+      const original = {
+        type: '',
+        id: 'empty',
+        revision: '',
+        annotations: [],
+        text: '',
+        link: '',
+      }
+      const editorBlock = {
+        id: 'empty',
+        type: 'unknown',
+        children: [],
+        content: [],
+        props: {
+          originalType: '',
+          originalData: JSON.stringify(original),
+        },
+      } as unknown as EditorBlock
+
+      const val = editorBlockToHMBlock(editorBlock)
+
+      expect(val).toEqual(original)
+    })
+
+    test('preserves an unknown future block type and its attributes verbatim', () => {
+      const original = {
+        type: 'Spreadsheet',
+        id: 'abc123',
+        text: '',
+        annotations: [],
+        attributes: {rows: 4, columns: 3, data: {a: 1}},
+        link: 'hm://example',
+      }
+      const editorBlock = {
+        id: 'abc123',
+        type: 'unknown',
+        children: [],
+        content: [],
+        props: {
+          originalType: 'Spreadsheet',
+          originalData: JSON.stringify(original),
+        },
+      } as unknown as EditorBlock
+
+      expect(editorBlockToHMBlock(editorBlock)).toEqual(original)
+    })
+
+    test('syncs the block id with the editor block when it was regenerated', () => {
+      const original = {type: 'Whatever', id: 'oldId', text: '', annotations: [], attributes: {}}
+      const editorBlock = {
+        id: 'newId',
+        type: 'unknown',
+        children: [],
+        content: [],
+        props: {originalType: 'Whatever', originalData: JSON.stringify(original)},
+      } as unknown as EditorBlock
+
+      const val = editorBlockToHMBlock(editorBlock) as unknown as {id: string; type: string}
+      expect(val.id).toBe('newId')
+      expect(val.type).toBe('Whatever')
+    })
+
+    test('falls back to a minimal block when originalData is unparseable', () => {
+      const editorBlock = {
+        id: 'broken',
+        type: 'unknown',
+        children: [],
+        content: [],
+        props: {originalType: 'Mystery', originalData: 'not json{'},
+      } as unknown as EditorBlock
+
+      expect(editorBlockToHMBlock(editorBlock)).toEqual({
+        id: 'broken',
+        type: 'Mystery',
+        text: '',
+        annotations: [],
+        attributes: {},
+      })
+    })
+
+    test('does not throw for an unknown block (regression for issue #807)', () => {
+      const editorBlock = {
+        id: 'empty',
+        type: 'unknown',
+        children: [],
+        content: [],
+        props: {originalType: '', originalData: '{"type":"","id":"empty"}'},
+      } as unknown as EditorBlock
+
+      expect(() => editorBlockToHMBlock(editorBlock)).not.toThrow()
+    })
+  })
 })

--- a/frontend/packages/shared/src/utils/document-changes.test.ts
+++ b/frontend/packages/shared/src/utils/document-changes.test.ts
@@ -182,4 +182,35 @@ describe('compareBlocksWithMap (publish-diff path)', () => {
 
     expect(selfMoves).toEqual([])
   })
+
+  // Regression for issue #807: an unknown/corrupt block type used to throw
+  // "Unsupported block type unknown" here, crashing the publish/change-count UI.
+  it('does not crash and emits no replaceBlock for an unchanged unknown block', () => {
+    const unknownServerBlock = {
+      id: 'empty',
+      type: '',
+      revision: '',
+      text: '',
+      link: '',
+      annotations: [],
+    }
+    const base: HMBlockNode[] = [{block: unknownServerBlock as HMBlockNode['block'], children: []}]
+    const unknownEditorBlock = {
+      id: 'empty',
+      type: 'unknown',
+      props: {originalType: '', originalData: JSON.stringify(unknownServerBlock)},
+      content: [],
+      children: [],
+    } as unknown as EditorBlock
+
+    const blocksMap = createBlocksMap(base, '')
+
+    let changes: ReturnType<typeof compareBlocksWithMap>['changes'] = []
+    expect(() => {
+      changes = compareBlocksWithMap(blocksMap, [unknownEditorBlock], '').changes
+    }).not.toThrow()
+
+    const replaces = changes.filter((change) => change.op?.case === 'replaceBlock')
+    expect(replaces).toEqual([])
+  })
 })


### PR DESCRIPTION
Fixes #807

## Problem

A document containing a corrupt / unknown block type — e.g. the example doc has a block with `type: ""` — crashed the entire page with **"Unsupported block type unknown"**.

Root cause: the frontend already had unknown-block scaffolding (the `hmBlockToEditorBlock` direction converts an unknown block into an editor `unknown` block, stashing the raw block in `props.originalData`, and a registered `UnknownBlock` editor component renders it). But the **reverse** converter `editorBlockToHMBlock` had no `unknown` case and threw. That throw fires from the change-count / publish diff path (`compareBlocksWithMap` → `useUnpublishedChangeCount` / publish mutation), which has no try/catch — so it took down desktop, web reader, and editing.

The `editorBlocksToHMBlockNodes` wrapper *did* catch the throw, but "recovered" by replacing the corrupt block with a placeholder paragraph — **silently destroying the original block data on save**.

## Fix

- **`editorBlockToHMBlock`** (core): round-trip `unknown` blocks from `props.originalData` back to the original `HMBlock` (with `id` synced to the editor block for move/replace consistency). This stops the crash and makes corrupt / forward-incompatible blocks **survive an edit/publish cycle unchanged**. Unknown blocks can only ever contain proto `Block` fields, so `Block.fromJson` round-trips them safely.
- **`ssr-render`**: render a red "Unsupported Block: …" error block for genuinely unknown types (gated on `isKnownBlockType`) instead of a blank paragraph, matching the editor's `UnknownBlock`. Known-but-SSR-unhandled types (e.g. Nostr) keep their text fallback.
- **`unknown-block` component**: wrap the header and the expandable raw-data viewer in a single red-outlined / pink-background container, so the expanded JSON stays inside the error block's styling.
- **`styles.css`**: SSR error-block styling (light + dark).
- **tests**: round-trip preservation, the `compareBlocksWithMap` crash regression, and SSR error-block rendering.

## Behavior / coverage

The bad document now mostly renders correctly; only the corrupt block shows an error block, and its children + sibling blocks render normally.

| Surface | Behavior |
|---|---|
| Editing (desktop & web) | Existing `UnknownBlock` red box with expandable raw-JSON viewer; selectable + deletable like media blocks |
| Reader / web | SSR error block, replaced on hydration by the interactive `UnknownBlock` |
| SSR | New error block (was a blank paragraph) |
| Save / publish (desktop & web) | Corrupt block round-trips unchanged; no longer crashes change-count |
| CLI | Uses the same `editorBlocksToHMBlockNodes` — now preserves unknown blocks |

## Testing

- client (126), shared conversion/changes (88), editor SSR (10) tests pass; all three packages typecheck clean.
- One editor test (`readonly-viewer-gallery`) fails, but it **also fails on clean `main`** — pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)