### PR TITLE
feat(desktop): sign Windows builds with DigiCert KeyLocker

### DIFF
--- a/.github/workflows/dev-desktop.yml
+++ b/.github/workflows/dev-desktop.yml
@@ -60,18 +60,18 @@ jobs:
     strategy:
       matrix:
         config:
-          - os: macos-15-large
-            arch: x64
-            goarch: amd64
-            daemon_name: x86_64-apple-darwin
-          - os: macos-15-xlarge
-            arch: arm64
-            goarch: arm64
-            daemon_name: aarch64-apple-darwin
-          - os: ubuntu-latest
-            arch: x64
-            goarch: amd64
-            daemon_name: x86_64-unknown-linux-gnu
+          # - os: macos-15-large
+          #   arch: x64
+          #   goarch: amd64
+          #   daemon_name: x86_64-apple-darwin
+          # - os: macos-15-xlarge
+          #   arch: arm64
+          #   goarch: arm64
+          #   daemon_name: aarch64-apple-darwin
+          # - os: ubuntu-latest
+          #   arch: x64
+          #   goarch: amd64
+          #   daemon_name: x86_64-unknown-linux-gnu
           # Keep Windows desktop builds on VS 2022 while the pinned Node
           # 22/pnpm/electron node-gyp stack cannot detect VS 2026 (18.x) on
           # windows-2025.
@@ -271,6 +271,24 @@ jobs:
             Write-Host "Installed and added 7-Zip to PATH"
           }
 
+      - name: Setup DigiCert KeyLocker client certificate (Windows)
+        if: startsWith(matrix.config.os, 'windows')
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
+
+      - name: Setup DigiCert KeyLocker signing tools (Windows)
+        if: startsWith(matrix.config.os, 'windows')
+        uses: digicert/code-signing-software-trust-action@v1
+        with:
+          simple-signing-mode: true
+        env:
+          SM_HOST: ${{ vars.SM_HOST }}
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_CLIENT_CERT_FILE: 'D:\Certificate_pkcs12.p12'
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+
       - name: Build, package and make (Win32)
         if: startsWith(matrix.config.os, 'windows')
         shell: powershell
@@ -304,87 +322,12 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_KEY }}
           AWS_DEFAULT_REGION: eu-west-2
           SEED_P2P_TESTNET_NAME: 'dev'
-
-      # - name: Sign Windows application with KeyLocker
-      #   if: startsWith(matrix.config.os, 'windows')
-      #   uses: digicert/keylocker-signing@v1
-      #   with:
-      #     api_key: ${{ secrets.KEYLOCKER_API_KEY }}
-      #     client_cert: ${{ secrets.KEYLOCKER_CERT }}
-      #     client_cert_password: ${{ secrets.KEYLOCKER_CERT_PASSWORD }}
-      #     keypair_alias: ${{ secrets.KEYLOCKER_KEYPAIR_ALIAS }}
-      #     input_file: frontend/apps/desktop/out/make/squirrel.windows/x64/seed-dev-${{ needs.build-info.outputs.version }}-win32-x64-setup.exe
-      #     timestamp_url: http://timestamp.digicert.com
-
-      - name: Create test certificate for signing (Windows)
-        if: startsWith(matrix.config.os, 'windows')
-        shell: powershell
-        run: |
-          # Create a test certificate for signing
-          $cert = New-SelfSignedCertificate -Type CodeSigningCert -Subject "CN=Test Code Signing" -KeyAlgorithm RSA -KeyLength 2048 -Provider "Microsoft Enhanced RSA and AES Cryptographic Provider" -KeyExportPolicy Exportable -KeyUsage DigitalSignature -CertStoreLocation Cert:\CurrentUser\My
-
-          # Export the certificate to a PFX file
-          $password = ConvertTo-SecureString -String "testpassword" -Force -AsPlainText
-          Export-PfxCertificate -Cert $cert -FilePath "test-cert.pfx" -Password $password
-
-          echo "Test certificate created: test-cert.pfx"
-
-      - name: Sign Windows application with test certificate
-        if: startsWith(matrix.config.os, 'windows')
-        shell: powershell
-        run: |
-          # Find the .exe installer file
-          $exeFile = Get-ChildItem -Path "frontend/apps/desktop/out/make" -Filter "*.exe" -Recurse | Select-Object -First 1
-
-          if ($exeFile) {
-            Write-Host "Signing: $($exeFile.FullName)"
-            
-            # Sign with the test certificate
-            $signResult = & "C:\Program Files (x86)\Windows Kits\10\App Certification Kit\signtool.exe" sign /f "test-cert.pfx" /p "testpassword" /t "http://timestamp.digicert.com" /fd sha256 /v "$($exeFile.FullName)"
-            
-            if ($LASTEXITCODE -eq 0) {
-              Write-Host "✅ Successfully signed: $($exeFile.FullName)"
-              
-              # Verify the signature (this will fail for self-signed certs, but that's expected)
-              Write-Host "Verifying signature (note: self-signed test certificates will show trust warnings)..."
-              
-              # Capture verification output without failing the script
-              $ErrorActionPreference = "Continue"
-              $verifyOutput = & "C:\Program Files (x86)\Windows Kits\10\App Certification Kit\signtool.exe" verify /v "$($exeFile.FullName)" 2>&1
-              $verifyExitCode = $LASTEXITCODE
-              Write-Host $verifyOutput
-              
-              # Check if the file has a signature (ignore exit codes for verification)
-              $signatureCheck = & "C:\Program Files (x86)\Windows Kits\10\App Certification Kit\signtool.exe" verify "$($exeFile.FullName)" 2>&1
-              $signatureCheckExitCode = $LASTEXITCODE
-              
-              # For test certificates, we expect "terminated in a root certificate which is not trusted"
-              # This means the file IS signed, just not with a trusted certificate
-              if ($signatureCheck -match "terminated in a root certificate which is not trusted" -or 
-                  $signatureCheck -match "SignTool Error: A certificate chain processed") {
-                Write-Host "✅ File is signed with test certificate (trust warnings are expected and normal)"
-                # Reset exit code to success since this is expected behavior
-                $global:LASTEXITCODE = 0
-              } elseif ($signatureCheck -match "No signature found") {
-                Write-Host "❌ File does not appear to be signed"
-                exit 1
-              } else {
-                Write-Host "✅ File appears to be signed (verification output: $signatureCheck)"
-                # Reset exit code to success
-                $global:LASTEXITCODE = 0
-              }
-              
-              Write-Host "🎉 Test signing workflow completed successfully!"
-              # Explicitly exit with success code
-              exit 0
-            } else {
-              Write-Host "❌ Failed to sign the file"
-              exit 1
-            }
-          } else {
-            Write-Host "No .exe file found to sign"
-            exit 1
-          }
+          WINDOWS_CODE_SIGNING: 'true'
+          SM_HOST: ${{ vars.SM_HOST }}
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_CLIENT_CERT_FILE: 'D:\Certificate_pkcs12.p12'
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+          SM_KEYPAIR_ALIAS: ${{ vars.SM_DEV_KEYPAIR_ALIAS || vars.SM_KEYPAIR_ALIAS }}
 
       - name: Upload daemon debug info to Sentry (Unix)
         if: ${{ !startsWith(matrix.config.os, 'windows') && env.SENTRY_AUTH_TOKEN != '' }}

--- a/.github/workflows/dev-desktop.yml
+++ b/.github/workflows/dev-desktop.yml
@@ -289,6 +289,21 @@ jobs:
           SM_CLIENT_CERT_FILE: 'D:\Certificate_pkcs12.p12'
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
 
+      - name: List DigiCert keypairs visible to CI (Windows)
+        if: startsWith(matrix.config.os, 'windows')
+        shell: powershell
+        run: |
+          Write-Host "Listing all DigiCert keypairs visible to the GitHub Actions credentials"
+          smctl keypair list
+          Write-Host "Filtering for configured alias: $env:SM_KEYPAIR_ALIAS"
+          smctl keypair list --filter "alias=$env:SM_KEYPAIR_ALIAS"
+        env:
+          SM_HOST: ${{ vars.SM_HOST }}
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_CLIENT_CERT_FILE: 'D:\Certificate_pkcs12.p12'
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+          SM_KEYPAIR_ALIAS: ${{ vars.SM_DEV_KEYPAIR_ALIAS || vars.SM_KEYPAIR_ALIAS }}
+
       - name: Build, package and make (Win32)
         if: startsWith(matrix.config.os, 'windows')
         shell: powershell

--- a/.github/workflows/dev-desktop.yml
+++ b/.github/workflows/dev-desktop.yml
@@ -289,21 +289,6 @@ jobs:
           SM_CLIENT_CERT_FILE: 'D:\Certificate_pkcs12.p12'
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
 
-      - name: List DigiCert keypairs visible to CI (Windows)
-        if: startsWith(matrix.config.os, 'windows')
-        shell: powershell
-        run: |
-          Write-Host "Listing all DigiCert keypairs visible to the GitHub Actions credentials"
-          smctl keypair list
-          Write-Host "Filtering for configured alias: $env:SM_KEYPAIR_ALIAS"
-          smctl keypair list --filter "alias=$env:SM_KEYPAIR_ALIAS"
-        env:
-          SM_HOST: ${{ vars.SM_HOST }}
-          SM_API_KEY: ${{ secrets.SM_API_KEY }}
-          SM_CLIENT_CERT_FILE: 'D:\Certificate_pkcs12.p12'
-          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
-          SM_KEYPAIR_ALIAS: ${{ vars.SM_DEV_KEYPAIR_ALIAS || vars.SM_KEYPAIR_ALIAS }}
-
       - name: Build, package and make (Win32)
         if: startsWith(matrix.config.os, 'windows')
         shell: powershell

--- a/.github/workflows/dev-desktop.yml
+++ b/.github/workflows/dev-desktop.yml
@@ -60,18 +60,18 @@ jobs:
     strategy:
       matrix:
         config:
-          # - os: macos-15-large
-          #   arch: x64
-          #   goarch: amd64
-          #   daemon_name: x86_64-apple-darwin
-          # - os: macos-15-xlarge
-          #   arch: arm64
-          #   goarch: arm64
-          #   daemon_name: aarch64-apple-darwin
-          # - os: ubuntu-latest
-          #   arch: x64
-          #   goarch: amd64
-          #   daemon_name: x86_64-unknown-linux-gnu
+          - os: macos-15-large
+            arch: x64
+            goarch: amd64
+            daemon_name: x86_64-apple-darwin
+          - os: macos-15-xlarge
+            arch: arm64
+            goarch: arm64
+            daemon_name: aarch64-apple-darwin
+          - os: ubuntu-latest
+            arch: x64
+            goarch: amd64
+            daemon_name: x86_64-unknown-linux-gnu
           # Keep Windows desktop builds on VS 2022 while the pinned Node
           # 22/pnpm/electron node-gyp stack cannot detect VS 2026 (18.x) on
           # windows-2025.

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -261,6 +261,24 @@ jobs:
             Write-Host "Installed and added 7-Zip to PATH"
           }
 
+      - name: Setup DigiCert KeyLocker client certificate (Windows)
+        if: startsWith(matrix.config.os, 'windows')
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
+
+      - name: Setup DigiCert KeyLocker signing tools (Windows)
+        if: startsWith(matrix.config.os, 'windows')
+        uses: digicert/code-signing-software-trust-action@v1
+        with:
+          simple-signing-mode: true
+        env:
+          SM_HOST: ${{ vars.SM_HOST }}
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_CLIENT_CERT_FILE: 'D:\Certificate_pkcs12.p12'
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+
       - name: Build, package and make (Win32)
         if: startsWith(matrix.config.os, 'windows')
         run: |
@@ -286,6 +304,12 @@ jobs:
           VITE_SEED_HOST_URL: 'https://host.seed.hyper.media'
           VITE_PLAUSIBLE_DOMAIN: 'stats.desktop.seedhypermedia.com'
           SENTRY_AUTH_TOKEN: '${{ secrets.SENTRY_AUTH_TOKEN }}'
+          WINDOWS_CODE_SIGNING: 'true'
+          SM_HOST: ${{ vars.SM_HOST }}
+          SM_API_KEY: ${{ secrets.SM_API_KEY }}
+          SM_CLIENT_CERT_FILE: 'D:\Certificate_pkcs12.p12'
+          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+          SM_KEYPAIR_ALIAS: ${{ vars.SM_PROD_KEYPAIR_ALIAS || vars.SM_KEYPAIR_ALIAS }}
 
       - name: Upload daemon debug info to Sentry (Unix)
         if: ${{ !startsWith(matrix.config.os, 'windows') && env.SENTRY_AUTH_TOKEN != '' }}

--- a/frontend/apps/desktop/forge.config.ts
+++ b/frontend/apps/desktop/forge.config.ts
@@ -12,6 +12,7 @@ import path from 'node:path'
 import packageJson from './package.json'
 // import setLanguages from 'electron-packager-languages'
 import fs from 'node:fs'
+import {signWindowsMakeResults, signWindowsPackagePaths} from './scripts/windows-signing'
 
 const {version} = packageJson
 const IS_PROD_DEV = version.includes('dev')
@@ -252,6 +253,7 @@ const config: ForgeConfig = {
   hooks: {
     postPackage: async (_config, options) => {
       console.info('PostPackage output paths:', options.outputPaths)
+      await signWindowsPackagePaths(options.outputPaths)
 
       for (const outputPath of options.outputPaths) {
         console.info(`\nListing contents of: ${outputPath}`)
@@ -264,6 +266,7 @@ const config: ForgeConfig = {
     },
     postMake: async (_config, results) => {
       console.info('PostMake results:', results)
+      return signWindowsMakeResults(results)
     },
   },
 }

--- a/frontend/apps/desktop/scripts/windows-signing.ts
+++ b/frontend/apps/desktop/scripts/windows-signing.ts
@@ -1,0 +1,131 @@
+import {execFileSync} from 'node:child_process'
+import path from 'node:path'
+
+/** Environment values used to decide whether Windows signing should run. */
+export type WindowsSigningEnv = Partial<Record<'CI' | 'WINDOWS_CODE_SIGNING' | 'SM_KEYPAIR_ALIAS', string>>
+
+/** A command invocation issued by the Windows signing helper. */
+export type WindowsSigningCommand = {
+  command: string
+  args: string[]
+}
+
+/** Function used to run signing commands, injectable for tests. */
+export type WindowsSigningCommandRunner = (command: WindowsSigningCommand) => void | Promise<void>
+
+/** Options accepted by the Windows signing helper. */
+export type WindowsSigningOptions = {
+  platform?: NodeJS.Platform | string
+  env?: WindowsSigningEnv
+  runCommand?: WindowsSigningCommandRunner
+}
+
+/** Minimal shape of Electron Forge make results used by the signing hook. */
+export type WindowsSigningMakeResult = {
+  platform: string
+  artifacts: string[]
+}
+
+/** Decision returned when evaluating whether Windows signing should run. */
+export type WindowsSigningPlan =
+  | {enabled: true; keypairAlias: string}
+  | {enabled: false; reason: 'not-windows' | 'not-enabled'}
+
+const SIGNABLE_WINDOWS_ARTIFACT_EXTENSIONS = new Set(['.exe'])
+
+/**
+ * Returns whether DigiCert KeyLocker signing is enabled for the current build.
+ *
+ * Signing is intentionally opt-in so local Windows builds do not require DigiCert credentials.
+ */
+export function getWindowsSigningPlan(options: WindowsSigningOptions = {}): WindowsSigningPlan {
+  const platform = options.platform ?? process.platform
+  const env = options.env ?? process.env
+
+  if (platform !== 'win32') {
+    return {enabled: false, reason: 'not-windows'}
+  }
+
+  if (env.CI !== 'true' || env.WINDOWS_CODE_SIGNING !== 'true') {
+    return {enabled: false, reason: 'not-enabled'}
+  }
+
+  const keypairAlias = env.SM_KEYPAIR_ALIAS?.trim()
+  if (!keypairAlias) {
+    throw new Error('WINDOWS_CODE_SIGNING is enabled, but SM_KEYPAIR_ALIAS is not set')
+  }
+
+  return {enabled: true, keypairAlias}
+}
+
+/** Signs and verifies packaged Windows app directories before Squirrel artifacts are created. */
+export async function signWindowsPackagePaths(
+  outputPaths: string[],
+  options: WindowsSigningOptions = {},
+): Promise<void> {
+  const plan = getWindowsSigningPlan(options)
+  if (!plan.enabled) {
+    console.info(`[windows-signing] Skipping package signing: ${plan.reason}`)
+    return
+  }
+
+  for (const outputPath of outputPaths) {
+    await signAndVerifyPath(outputPath, plan.keypairAlias, options)
+  }
+}
+
+/** Signs and verifies generated Windows setup executables after Squirrel artifacts are created. */
+export async function signWindowsMakeResults<T extends WindowsSigningMakeResult>(
+  makeResults: T[],
+  options: WindowsSigningOptions = {},
+): Promise<T[]> {
+  const plan = getWindowsSigningPlan(options)
+  if (!plan.enabled) {
+    console.info(`[windows-signing] Skipping make artifact signing: ${plan.reason}`)
+    return makeResults
+  }
+
+  for (const result of makeResults) {
+    if (result.platform !== 'win32') continue
+
+    for (const artifact of result.artifacts) {
+      if (!SIGNABLE_WINDOWS_ARTIFACT_EXTENSIONS.has(path.extname(artifact).toLowerCase())) continue
+
+      await signAndVerifyPath(artifact, plan.keypairAlias, options)
+    }
+  }
+
+  return makeResults
+}
+
+async function signAndVerifyPath(
+  inputPath: string,
+  keypairAlias: string,
+  options: WindowsSigningOptions,
+): Promise<void> {
+  const runCommand = options.runCommand ?? runCommandWithInheritedStdio
+  console.info(`[windows-signing] Signing ${inputPath}`)
+  await runCommand({
+    command: 'smctl',
+    args: [
+      'sign',
+      `--keypair-alias=${keypairAlias}`,
+      `--input=${inputPath}`,
+      '--simple',
+      '--unsigned',
+      '--sigalg=SHA256',
+      '--digalg=SHA256',
+      '--verbose',
+    ],
+  })
+
+  console.info(`[windows-signing] Verifying ${inputPath}`)
+  await runCommand({
+    command: 'smctl',
+    args: ['sign', 'verify', `--input=${inputPath}`],
+  })
+}
+
+function runCommandWithInheritedStdio({command, args}: WindowsSigningCommand): void {
+  execFileSync(command, args, {stdio: 'inherit'})
+}

--- a/frontend/apps/desktop/src/__tests__/windows-signing.test.ts
+++ b/frontend/apps/desktop/src/__tests__/windows-signing.test.ts
@@ -1,0 +1,126 @@
+import {describe, expect, test} from 'vitest'
+import {
+  getWindowsSigningPlan,
+  signWindowsMakeResults,
+  signWindowsPackagePaths,
+  type WindowsSigningCommand,
+} from '../../scripts/windows-signing'
+
+describe('windows signing plan', () => {
+  test('is disabled outside Windows', () => {
+    expect(
+      getWindowsSigningPlan({
+        platform: 'darwin',
+        env: {CI: 'true', WINDOWS_CODE_SIGNING: 'true', SM_KEYPAIR_ALIAS: 'seed'},
+      }),
+    ).toEqual({enabled: false, reason: 'not-windows'})
+  })
+
+  test('is disabled unless CI explicitly enables Windows code signing', () => {
+    expect(
+      getWindowsSigningPlan({
+        platform: 'win32',
+        env: {CI: 'true', SM_KEYPAIR_ALIAS: 'seed'},
+      }),
+    ).toEqual({enabled: false, reason: 'not-enabled'})
+  })
+
+  test('requires a KeyLocker keypair alias when enabled', () => {
+    expect(() =>
+      getWindowsSigningPlan({
+        platform: 'win32',
+        env: {CI: 'true', WINDOWS_CODE_SIGNING: 'true'},
+      }),
+    ).toThrow('SM_KEYPAIR_ALIAS')
+  })
+
+  test('enables signing on Windows CI when KeyLocker is configured', () => {
+    expect(
+      getWindowsSigningPlan({
+        platform: 'win32',
+        env: {CI: 'true', WINDOWS_CODE_SIGNING: 'true', SM_KEYPAIR_ALIAS: 'seed-prod'},
+      }),
+    ).toEqual({enabled: true, keypairAlias: 'seed-prod'})
+  })
+})
+
+describe('windows signing commands', () => {
+  test('signs and verifies packaged Windows app directories', async () => {
+    const commands: WindowsSigningCommand[] = []
+
+    await signWindowsPackagePaths(['C:/work/out/Seed-win32-x64'], {
+      platform: 'win32',
+      env: {CI: 'true', WINDOWS_CODE_SIGNING: 'true', SM_KEYPAIR_ALIAS: 'seed-prod'},
+      runCommand: (command) => {
+        commands.push(command)
+      },
+    })
+
+    expect(commands).toEqual([
+      {
+        command: 'smctl',
+        args: [
+          'sign',
+          '--keypair-alias=seed-prod',
+          '--input=C:/work/out/Seed-win32-x64',
+          '--simple',
+          '--unsigned',
+          '--sigalg=SHA256',
+          '--digalg=SHA256',
+          '--verbose',
+        ],
+      },
+      {
+        command: 'smctl',
+        args: ['sign', 'verify', '--input=C:/work/out/Seed-win32-x64'],
+      },
+    ])
+  })
+
+  test('signs only Windows setup executables from make results and preserves the result object', async () => {
+    const commands: WindowsSigningCommand[] = []
+    const makeResults = [
+      {
+        platform: 'win32',
+        artifacts: [
+          'C:/work/out/make/squirrel.windows/x64/seed-1.2.3-win32-x64-setup.exe',
+          'C:/work/out/make/squirrel.windows/x64/seed-1.2.3-full.nupkg',
+          'C:/work/out/make/squirrel.windows/x64/RELEASES',
+        ],
+      },
+      {
+        platform: 'linux',
+        artifacts: ['C:/work/out/make/deb/x64/seed.deb'],
+      },
+    ]
+
+    const returnedResults = await signWindowsMakeResults(makeResults, {
+      platform: 'win32',
+      env: {CI: 'true', WINDOWS_CODE_SIGNING: 'true', SM_KEYPAIR_ALIAS: 'seed-prod'},
+      runCommand: (command) => {
+        commands.push(command)
+      },
+    })
+
+    expect(returnedResults).toBe(makeResults)
+    expect(commands).toEqual([
+      {
+        command: 'smctl',
+        args: [
+          'sign',
+          '--keypair-alias=seed-prod',
+          '--input=C:/work/out/make/squirrel.windows/x64/seed-1.2.3-win32-x64-setup.exe',
+          '--simple',
+          '--unsigned',
+          '--sigalg=SHA256',
+          '--digalg=SHA256',
+          '--verbose',
+        ],
+      },
+      {
+        command: 'smctl',
+        args: ['sign', 'verify', '--input=C:/work/out/make/squirrel.windows/x64/seed-1.2.3-win32-x64-setup.exe'],
+      },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- Adds DigiCert KeyLocker setup to dev and release desktop workflows for Windows builds.
- Enables Windows code signing during Electron Forge packaging and make steps using configured CI credentials and keypair aliases.
- Replaces the temporary self-signed signing flow with real KeyLocker signing and verification.
- Adds tests covering signing enablement, required configuration, and artifact selection.