### PR TITLE
fix(editor): keep image captions editable on click

### DIFF
--- a/frontend/packages/editor/e2e/tests/image-caption.e2e.ts
+++ b/frontend/packages/editor/e2e/tests/image-caption.e2e.ts
@@ -1,0 +1,83 @@
+import {expect, test} from './fixtures'
+
+test.use({clipboardPermissions: false})
+
+test.describe('Image caption editing', () => {
+  test('keeps the cursor in the caption and preserves the image when typing below it', async ({
+    editorHelpers,
+    page,
+  }) => {
+    await page.evaluate(() => {
+      const editor = window.TEST_EDITOR?.editor
+      const firstBlock = editor?.topLevelBlocks?.[0]
+      if (!editor || !firstBlock) throw new Error('Editor not ready')
+
+      editor.insertBlocks(
+        [
+          {
+            type: 'image',
+            props: {
+              url: 'data:image/gif;base64,R0lGODlhAQABAAAAACw=',
+              name: 'caption-test.gif',
+              alt: 'Caption test image',
+            },
+            content: [],
+          },
+        ],
+        firstBlock.id,
+        'after',
+      )
+    })
+
+    const caption = page.locator('.image-caption').first()
+    await expect(caption).toBeVisible()
+    await caption.click()
+    await page.keyboard.type('A visible caption')
+
+    await expect(page.locator('.bn-media-selected')).toHaveCount(0)
+
+    const blocks = await editorHelpers.getAllBlocks()
+    const imageBlock = blocks.find((block: any) => block.type === 'image')
+    expect(imageBlock).toBeTruthy()
+    expect(imageBlock.content).toEqual([{type: 'text', text: 'A visible caption', styles: {}}])
+  })
+
+  test('moves from the caption to the next block on Enter', async ({editorHelpers, page}) => {
+    await page.evaluate(() => {
+      const editor = window.TEST_EDITOR?.editor
+      const firstBlock = editor?.topLevelBlocks?.[0]
+      if (!editor || !firstBlock) throw new Error('Editor not ready')
+
+      editor.insertBlocks(
+        [
+          {
+            type: 'image',
+            props: {
+              url: 'data:image/gif;base64,R0lGODlhAQABAAAAACw=',
+              name: 'caption-enter-test.gif',
+              alt: 'Caption enter test image',
+            },
+            content: [],
+          },
+        ],
+        firstBlock.id,
+        'after',
+      )
+    })
+
+    const caption = page.locator('.image-caption').first()
+    await expect(caption).toBeVisible()
+    await caption.click()
+    await page.keyboard.type('Caption text')
+    await page.keyboard.press('Enter')
+    await page.keyboard.type('Text below image')
+
+    const blocks = await editorHelpers.getAllBlocks()
+    const imageIndex = blocks.findIndex((block: any) => block.type === 'image')
+    expect(imageIndex).toBeGreaterThanOrEqual(0)
+    expect(blocks[imageIndex].content).toEqual([{type: 'text', text: 'Caption text', styles: {}}])
+
+    const followingParagraph = blocks.slice(imageIndex + 1).find((block: any) => block.type === 'paragraph')
+    expect(followingParagraph?.content).toEqual([{type: 'text', text: 'Text below image', styles: {}}])
+  })
+})

--- a/frontend/packages/editor/src/media-container.test.tsx
+++ b/frontend/packages/editor/src/media-container.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 import {createRoot, type Root} from 'react-dom/client'
 import {act} from 'react-dom/test-utils'
+import {Schema} from 'prosemirror-model'
+import {EditorState, NodeSelection} from 'prosemirror-state'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -20,12 +22,56 @@ function makeBlock() {
   return {id: 'block-1', type: 'image', props: {}, content: [], children: []} as any
 }
 
-function makeEditor(isEditable: boolean) {
+const schema = new Schema({
+  nodes: {
+    doc: {content: 'blockNode+'},
+    blockNode: {
+      group: 'blockNodeChild',
+      attrs: {id: {default: ''}},
+      content: 'block',
+      toDOM: (node) => ['div', {'data-node-type': 'blockNode', 'data-id': node.attrs.id}, 0],
+    },
+    image: {
+      group: 'block',
+      content: 'inline*',
+      selectable: true,
+      toDOM: () => ['div', {'data-content-type': 'image'}, 0],
+    },
+    text: {group: 'inline'},
+  },
+})
+
+function createSelectableEditorState() {
+  const doc = schema.node('doc', null, [schema.node('blockNode', {id: 'block-1'}, [schema.node('image')])])
+  return EditorState.create({schema, doc})
+}
+
+function makeEditor(isEditable: boolean, withView = false) {
+  let state = createSelectableEditorState()
+  const currentBlock = {id: 'block-1'}
+  const nextBlock = {id: 'block-2'}
+  const view = {
+    get state() {
+      return state
+    },
+    dispatch: vi.fn((tr) => {
+      state = state.apply(tr)
+    }),
+    focus: vi.fn(),
+  }
+
   return {
     isEditable,
+    renderType: 'editor',
     sideMenu: {blockDragStart: vi.fn(), blockDragEnd: vi.fn()},
     handleFileAttachment: undefined,
     commentEditor: false,
+    _tiptapEditor: withView ? {view} : undefined,
+    __view: view,
+    getTextCursorPosition: vi.fn(() => ({block: currentBlock, nextBlock})),
+    setTextCursorPosition: vi.fn(),
+    insertBlocks: vi.fn(),
+    focus: vi.fn(),
   } as any
 }
 
@@ -35,6 +81,7 @@ let root: Root
 beforeEach(() => {
   editorGate.canEdit = false
   editorGate.isEditing = false
+  editorGate.beginEditIfNeeded.mockClear()
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
@@ -71,5 +118,99 @@ describe('MediaContainer image caption', () => {
     editorGate.isEditing = true
     const caption = renderImageContainer(makeEditor(true))
     expect(caption.getAttribute('contentEditable')).toBe('true')
+  })
+
+  it('does not select the image block when the caption is clicked', () => {
+    editorGate.canEdit = true
+    editorGate.isEditing = true
+    const editor = makeEditor(true, true)
+    const caption = renderImageContainer(editor)
+
+    act(() => {
+      caption.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))
+    })
+
+    expect(editorGate.beginEditIfNeeded).not.toHaveBeenCalled()
+    expect(editor.__view.dispatch).not.toHaveBeenCalled()
+    expect(editor.__view.focus).not.toHaveBeenCalled()
+    expect(editor.__view.state.selection instanceof NodeSelection).toBe(false)
+  })
+
+  it('still selects the image block when the media surface is clicked', () => {
+    editorGate.canEdit = true
+    editorGate.isEditing = true
+    const editor = makeEditor(true, true)
+    act(() => {
+      root.render(
+        <MediaContainer editor={editor} block={makeBlock()} mediaType="image" assign={() => {}}>
+          <div data-testid="media-child" />
+        </MediaContainer>,
+      )
+    })
+
+    const mediaChild = container.querySelector('[data-testid="media-child"]') as HTMLElement
+    act(() => {
+      mediaChild.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))
+    })
+
+    expect(editorGate.beginEditIfNeeded).toHaveBeenCalledOnce()
+    expect(editor.__view.dispatch).toHaveBeenCalledOnce()
+    expect(editor.__view.focus).toHaveBeenCalledOnce()
+    expect(editor.__view.state.selection instanceof NodeSelection).toBe(true)
+  })
+
+  it('moves to the next block when Enter is pressed in the image caption', () => {
+    editorGate.canEdit = true
+    editorGate.isEditing = true
+    const editor = makeEditor(true)
+    const caption = renderImageContainer(editor)
+
+    const event = new KeyboardEvent('keydown', {key: 'Enter', bubbles: true, cancelable: true})
+    act(() => {
+      caption.dispatchEvent(event)
+    })
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(editor.setTextCursorPosition).toHaveBeenCalledWith({id: 'block-2'}, 'start')
+    expect(editor.insertBlocks).not.toHaveBeenCalled()
+    expect(editor.focus).toHaveBeenCalledOnce()
+  })
+
+  it('creates a paragraph below the image when Enter is pressed in the last image caption', () => {
+    editorGate.canEdit = true
+    editorGate.isEditing = true
+    const editor = makeEditor(true)
+    const insertedBlock = {id: 'inserted-block'}
+    editor.getTextCursorPosition
+      .mockReturnValueOnce({block: {id: 'block-1'}, nextBlock: undefined})
+      .mockReturnValueOnce({block: {id: 'block-1'}, nextBlock: insertedBlock})
+    const caption = renderImageContainer(editor)
+
+    const event = new KeyboardEvent('keydown', {key: 'Enter', bubbles: true, cancelable: true})
+    act(() => {
+      caption.dispatchEvent(event)
+    })
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(editor.insertBlocks).toHaveBeenCalledWith([{type: 'paragraph', content: ''}], 'block-1', 'after')
+    expect(editor.setTextCursorPosition).toHaveBeenCalledWith(insertedBlock, 'start')
+    expect(editor.focus).toHaveBeenCalledOnce()
+  })
+
+  it('lets Shift+Enter create a line break in the image caption', () => {
+    editorGate.canEdit = true
+    editorGate.isEditing = true
+    const editor = makeEditor(true)
+    const caption = renderImageContainer(editor)
+
+    const event = new KeyboardEvent('keydown', {key: 'Enter', shiftKey: true, bubbles: true, cancelable: true})
+    act(() => {
+      caption.dispatchEvent(event)
+    })
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(editor.setTextCursorPosition).not.toHaveBeenCalled()
+    expect(editor.insertBlocks).not.toHaveBeenCalled()
+    expect(editor.focus).not.toHaveBeenCalled()
   })
 })

--- a/frontend/packages/editor/src/media-container.tsx
+++ b/frontend/packages/editor/src/media-container.tsx
@@ -6,6 +6,7 @@ import {toast} from '@shm/ui/toast'
 import {cn} from '@shm/ui/utils'
 import {Node as PMNode} from 'prosemirror-model'
 import {NodeSelection} from 'prosemirror-state'
+import type {ElementType} from 'react'
 import {useRef, useState} from 'react'
 import {BlockNoteEditor} from './blocknote/core/BlockNoteEditor'
 import {Block} from './blocknote/core/extensions/Blocks/api/blockTypes'
@@ -204,6 +205,27 @@ export const MediaContainer = ({
     view.focus()
   }
 
+  const handleImageCaptionKeyDown = (event: React.KeyboardEvent<ElementType>) => {
+    if (event.key !== 'Enter' || event.shiftKey) return
+
+    event.preventDefault()
+    event.stopPropagation()
+
+    const cursorPosition = editor.getTextCursorPosition()
+    if (cursorPosition.block.id !== block.id) return
+
+    if (cursorPosition.nextBlock) {
+      editor.setTextCursorPosition(cursorPosition.nextBlock, 'start')
+    } else {
+      editor.insertBlocks([{type: 'paragraph', content: ''}], block.id, 'after')
+      const nextBlock = editor.getTextCursorPosition().nextBlock
+      if (nextBlock) editor.setTextCursorPosition(nextBlock, 'start')
+    }
+
+    ;(event.currentTarget as unknown as HTMLElement).blur()
+    editor.focus()
+  }
+
   const mediaProps = {
     ...styleProps,
     ...(isEmbed || !canAuthor ? {} : dragProps),
@@ -324,7 +346,14 @@ export const MediaContainer = ({
         )}
         {children}
       </div>
-      {mediaType === 'image' && <InlineContent className="image-caption" contentEditable={editor.isEditable} />}
+      {mediaType === 'image' && (
+        <InlineContent
+          className="image-caption"
+          contentEditable={editor.isEditable}
+          data-media-container-ignore-select
+          onKeyDown={handleImageCaptionKeyDown}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/packages/editor/src/unknown-block.tsx
+++ b/frontend/packages/editor/src/unknown-block.tsx
@@ -51,7 +51,7 @@ function UnknownBlockRender({block, editor}: {block: Block<HMBlockSchema>; edito
       </div>
       {expanded && (
         <pre className="mx-2 mb-2 overflow-auto rounded-md border border-red-200 bg-red-50/60 p-2 dark:border-red-900 dark:bg-red-950/60">
-          <code className="font-mono text-xs text-red-900 wrap-break-word dark:text-red-200">
+          <code className="font-mono text-xs wrap-break-word text-red-900 dark:text-red-200">
             {JSON.stringify(parsedData, null, 2)}
           </code>
         </pre>


### PR DESCRIPTION
## Summary
- Prevent image caption clicks from selecting the whole image, so typing adds caption text instead of replacing the image.
- Add Enter handling for image captions to move focus to the following paragraph, creating one when needed while preserving Shift+Enter line breaks.
- Cover caption editing and Enter behavior with editor unit tests and Playwright e2e coverage.

fixes #784

---

Fixes #784