### PR TITLE
fix(editor): hide query new-doc placeholder under banner

### DIFF
--- a/frontend/packages/editor/src/query-block-draft-items.tsx
+++ b/frontend/packages/editor/src/query-block-draft-items.tsx
@@ -1,0 +1,77 @@
+import {QueryBlockDraftSlotData} from '@shm/shared/query-block-drafts-context'
+import {InlineDraftCard} from '@shm/ui/inline-draft-card'
+import {InlineDraftListItem} from '@shm/ui/inline-draft-list-item'
+import {NewDocumentCard} from '@shm/ui/new-document-card'
+import {NewDocumentListItem} from '@shm/ui/new-document-list-item'
+import {ReactNode} from 'react'
+
+/** Builds draft and create-button elements that appear before query block results. */
+export function buildSlotItems(
+  slot: QueryBlockDraftSlotData | null,
+  style: 'Card' | 'List',
+  banner: boolean,
+  hasQueryResults = false,
+): {prependItems?: ReactNode[]; bannerContent?: ReactNode} {
+  if (!slot) return {}
+  const {drafts, onCreateDraft, onOpenDraft, onDeleteDraft, onUpdateDraftName} = slot
+  const hasDrafts = drafts.length > 0 && !!onOpenDraft && !!onDeleteDraft && !!onUpdateDraftName
+  const shouldHideCreateButton = style === 'Card' && banner && (hasDrafts || hasQueryResults)
+
+  const createButton =
+    onCreateDraft && !shouldHideCreateButton ? (
+      style === 'Card' ? (
+        <NewDocumentCard key="new-doc-btn" onCreateDraft={onCreateDraft} />
+      ) : (
+        <NewDocumentListItem key="new-doc-btn" onCreateDraft={onCreateDraft} />
+      )
+    ) : null
+
+  if (!hasDrafts) {
+    return createButton ? {prependItems: [createButton]} : {}
+  }
+
+  if (style === 'Card') {
+    const cards = drafts.map(({draft, autoFocus}) => (
+      <InlineDraftCard
+        key={`draft-${draft.id}`}
+        draft={draft}
+        autoFocus={autoFocus}
+        onOpenDraft={onOpenDraft!}
+        onDeleteDraft={onDeleteDraft!}
+        onUpdateDraftName={onUpdateDraftName!}
+      />
+    ))
+    if (banner && cards.length > 0) {
+      const bannerDraft = drafts[0]!
+      const bannerEl = (
+        <InlineDraftCard
+          key={`draft-banner-${bannerDraft.draft.id}`}
+          draft={bannerDraft.draft}
+          autoFocus={bannerDraft.autoFocus}
+          banner
+          onOpenDraft={onOpenDraft!}
+          onDeleteDraft={onDeleteDraft!}
+          onUpdateDraftName={onUpdateDraftName!}
+        />
+      )
+      const remainingCards = cards.slice(1)
+      return {
+        prependItems: createButton ? [createButton, ...remainingCards] : remainingCards,
+        bannerContent: bannerEl,
+      }
+    }
+    return {prependItems: createButton ? [createButton, ...cards] : cards}
+  }
+
+  const listItems = drafts.map(({draft, autoFocus}) => (
+    <InlineDraftListItem
+      key={`draft-${draft.id}`}
+      draft={draft}
+      autoFocus={autoFocus}
+      onOpenDraft={onOpenDraft!}
+      onDeleteDraft={onDeleteDraft!}
+      onUpdateDraftName={onUpdateDraftName!}
+    />
+  ))
+  return {prependItems: createButton ? [createButton, ...listItems] : listItems}
+}

--- a/frontend/packages/editor/src/query-block.test.tsx
+++ b/frontend/packages/editor/src/query-block.test.tsx
@@ -1,0 +1,65 @@
+import {InlineDraftCard} from '@shm/ui/inline-draft-card'
+import {NewDocumentCard} from '@shm/ui/new-document-card'
+import {NewDocumentListItem} from '@shm/ui/new-document-list-item'
+import {isValidElement, ReactNode} from 'react'
+import {describe, expect, it, vi} from 'vitest'
+import {buildSlotItems} from './query-block-draft-items'
+
+function makeSlot(overrides: Partial<Parameters<typeof buildSlotItems>[0]> = {}) {
+  return {
+    drafts: [],
+    onCreateDraft: vi.fn(),
+    ...overrides,
+  } as NonNullable<Parameters<typeof buildSlotItems>[0]>
+}
+
+function makeDraft(id: string) {
+  return {
+    draft: {
+      id,
+      metadata: {name: `Draft ${id}`},
+    },
+  } as NonNullable<Parameters<typeof buildSlotItems>[0]>['drafts'][number]
+}
+
+function elementTypes(items: ReactNode[] | undefined) {
+  return items?.filter(isValidElement).map((item) => item.type) ?? []
+}
+
+describe('buildSlotItems', () => {
+  it('omits the new document card when a card query block will render a document banner', () => {
+    const result = buildSlotItems(makeSlot(), 'Card', true, true)
+
+    expect(result.prependItems).toBeUndefined()
+    expect(result.bannerContent).toBeUndefined()
+  })
+
+  it('keeps the new document card when banner mode has no banner to render yet', () => {
+    const result = buildSlotItems(makeSlot(), 'Card', true, false)
+
+    expect(elementTypes(result.prependItems)).toEqual([NewDocumentCard])
+  })
+
+  it('keeps the new document list item because list query blocks do not render banners', () => {
+    const result = buildSlotItems(makeSlot(), 'List', true, true)
+
+    expect(elementTypes(result.prependItems)).toEqual([NewDocumentListItem])
+  })
+
+  it('omits only the new document card when a draft renders as the banner', () => {
+    const result = buildSlotItems(
+      makeSlot({
+        drafts: [makeDraft('1'), makeDraft('2')],
+        onOpenDraft: vi.fn(),
+        onDeleteDraft: vi.fn(),
+        onUpdateDraftName: vi.fn(),
+      }),
+      'Card',
+      true,
+      false,
+    )
+
+    expect(isValidElement(result.bannerContent)).toBe(true)
+    expect(elementTypes(result.prependItems)).toEqual([InlineDraftCard])
+  })
+})

--- a/frontend/packages/editor/src/query-block.tsx
+++ b/frontend/packages/editor/src/query-block.tsx
@@ -10,11 +10,7 @@ import {Button} from '@shm/ui/button'
 import {Input} from '@shm/ui/components/input'
 import {SelectField, SwitchField} from '@shm/ui/form-fields'
 import {Pencil, Search, Trash} from '@shm/ui/icons'
-import {InlineDraftCard} from '@shm/ui/inline-draft-card'
-import {InlineDraftListItem} from '@shm/ui/inline-draft-list-item'
 import {LazyViewportMount} from '@shm/ui/lazy-viewport-mount'
-import {NewDocumentCard} from '@shm/ui/new-document-card'
-import {NewDocumentListItem} from '@shm/ui/new-document-list-item'
 import {QueryBlockContent} from '@shm/ui/query-block-content'
 import {useQueryBlockFrontendPerf} from '@shm/ui/query-block-frontend-perf'
 import {SizableText} from '@shm/ui/text'
@@ -24,11 +20,12 @@ import {useQuery} from '@tanstack/react-query'
 import {Fragment} from '@tiptap/pm/model'
 import {Node as PMNode} from 'prosemirror-model'
 import {NodeSelection} from 'prosemirror-state'
-import {FocusEvent, Profiler, ReactNode, useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {FocusEvent, Profiler, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {createPortal} from 'react-dom'
 import {BlockSelectionWrapper} from './block-selection-wrapper'
 import {Block, BlockNoteEditor} from './blocknote'
 import {createReactBlockSpec} from './blocknote/react'
+import {buildSlotItems} from './query-block-draft-items'
 import {useQuerySearchInput} from './query-search-context'
 import {HMBlockSchema} from './schema'
 
@@ -148,7 +145,7 @@ function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
   const {DraftSlot} = useQueryBlockDrafts()
 
   const renderContent = (slot: QueryBlockDraftSlotData | null) => {
-    const {prependItems, bannerContent} = buildSlotItems(slot, style, banner)
+    const {prependItems, bannerContent} = buildSlotItems(slot, style, banner, sortedItems.length > 0)
     return (
       <QueryBlockContent
         items={sortedItems}
@@ -223,73 +220,6 @@ function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
       </div>
     </BlockSelectionWrapper>
   )
-}
-
-function buildSlotItems(
-  slot: QueryBlockDraftSlotData | null,
-  style: 'Card' | 'List',
-  banner: boolean,
-): {prependItems?: ReactNode[]; bannerContent?: ReactNode} {
-  if (!slot) return {}
-  const {drafts, onCreateDraft, onOpenDraft, onDeleteDraft, onUpdateDraftName} = slot
-
-  const createButton = onCreateDraft ? (
-    style === 'Card' ? (
-      <NewDocumentCard key="new-doc-btn" onCreateDraft={onCreateDraft} />
-    ) : (
-      <NewDocumentListItem key="new-doc-btn" onCreateDraft={onCreateDraft} />
-    )
-  ) : null
-
-  const hasDrafts = drafts.length > 0 && !!onOpenDraft && !!onDeleteDraft && !!onUpdateDraftName
-  if (!hasDrafts) {
-    return createButton ? {prependItems: [createButton]} : {}
-  }
-
-  if (style === 'Card') {
-    const cards = drafts.map(({draft, autoFocus}) => (
-      <InlineDraftCard
-        key={`draft-${draft.id}`}
-        draft={draft}
-        autoFocus={autoFocus}
-        onOpenDraft={onOpenDraft!}
-        onDeleteDraft={onDeleteDraft!}
-        onUpdateDraftName={onUpdateDraftName!}
-      />
-    ))
-    if (banner && cards.length > 0) {
-      const bannerDraft = drafts[0]!
-      const bannerEl = (
-        <InlineDraftCard
-          key={`draft-banner-${bannerDraft.draft.id}`}
-          draft={bannerDraft.draft}
-          autoFocus={bannerDraft.autoFocus}
-          banner
-          onOpenDraft={onOpenDraft!}
-          onDeleteDraft={onDeleteDraft!}
-          onUpdateDraftName={onUpdateDraftName!}
-        />
-      )
-      const remainingCards = cards.slice(1)
-      return {
-        prependItems: createButton ? [createButton, ...remainingCards] : remainingCards,
-        bannerContent: bannerEl,
-      }
-    }
-    return {prependItems: createButton ? [createButton, ...cards] : cards}
-  }
-
-  const listItems = drafts.map(({draft, autoFocus}) => (
-    <InlineDraftListItem
-      key={`draft-${draft.id}`}
-      draft={draft}
-      autoFocus={autoFocus}
-      onOpenDraft={onOpenDraft!}
-      onDeleteDraft={onDeleteDraft!}
-      onUpdateDraftName={onUpdateDraftName!}
-    />
-  ))
-  return {prependItems: createButton ? [createButton, ...listItems] : listItems}
 }
 
 function QuerySettings({

--- a/frontend/packages/editor/src/unknown-block.tsx
+++ b/frontend/packages/editor/src/unknown-block.tsx
@@ -51,7 +51,7 @@ function UnknownBlockRender({block, editor}: {block: Block<HMBlockSchema>; edito
       </div>
       {expanded && (
         <pre className="mx-2 mb-2 overflow-auto rounded-md border border-red-200 bg-red-50/60 p-2 dark:border-red-900 dark:bg-red-950/60">
-          <code className="font-mono text-xs text-red-900 wrap-break-word dark:text-red-200">
+          <code className="font-mono text-xs wrap-break-word text-red-900 dark:text-red-200">
             {JSON.stringify(parsedData, null, 2)}
           </code>
         </pre>


### PR DESCRIPTION
## Summary
- hides the new document card placeholder for card-style query blocks when a banner is already being shown
- preserves the create action for card query blocks before banner content exists, and for list-style query blocks
- adds focused coverage for query block draft and banner item rendering

fixes #776

---

Fixes #776