### PR TITLE
fix(editor): preserve draft edits during autosave

### DIFF
--- a/frontend/apps/desktop/src/app-drafts.ts
+++ b/frontend/apps/desktop/src/app-drafts.ts
@@ -60,6 +60,8 @@ import {error} from './logger'
 
 const draftsDir = join(userDataPath, 'drafts')
 const draftIndexPath = join(draftsDir, 'index.json')
+const draftBackupsDir = join(draftsDir, '.history')
+const MAX_DRAFT_BACKUPS = 20
 
 let draftIndex: HMListedDraft[] | undefined = undefined
 
@@ -353,6 +355,38 @@ async function saveDraftIndex() {
   await fs.writeFile(draftIndexPath, JSON.stringify(draftIndex, null, 2))
 }
 
+async function snapshotDraftFile(draftId: string, reason: 'overwrite' | 'delete') {
+  const file = await resolveDraftFile(draftId)
+  if (!file) return
+  try {
+    await fs.mkdir(draftBackupsDir, {recursive: true})
+    const raw = await fs.readFile(file.path, 'utf-8')
+    const backupName = `${draftId}-${Date.now()}-${reason}${file.ext}`
+    await fs.writeFile(join(draftBackupsDir, backupName), raw)
+    await pruneDraftBackups(draftId)
+  } catch (err) {
+    console.warn(`Failed to snapshot draft ${draftId} before ${reason}:`, err)
+  }
+}
+
+async function pruneDraftBackups(draftId: string) {
+  let files: string[]
+  try {
+    files = await fs.readdir(draftBackupsDir)
+  } catch {
+    return
+  }
+  const backups = files
+    .filter((file) => file.startsWith(`${draftId}-`))
+    .sort()
+    .reverse()
+  for (const old of backups.slice(MAX_DRAFT_BACKUPS)) {
+    try {
+      await fs.unlink(join(draftBackupsDir, old))
+    } catch {}
+  }
+}
+
 /**
  * Resolve the filename on disk for a given draft ID.
  * Checks the file map first, then falls back to scanning common patterns.
@@ -527,6 +561,7 @@ export const draftsApi = t.router({
       }
 
       const draftId = input.id || nanoid(10)
+      await snapshotDraftFile(draftId, 'overwrite')
 
       // Build the index entry with deps and navigation included
       const newDraft = {
@@ -577,6 +612,7 @@ export const draftsApi = t.router({
       }
     }),
   delete: t.procedure.input(z.string()).mutation(async ({input}) => {
+    await snapshotDraftFile(input, 'delete')
     draftIndex = draftIndex?.filter((d) => d.id !== input)
     await saveDraftIndex()
 

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -58,6 +58,7 @@ import {
   PublishInput,
   PushDocumentInput,
   WriteDraftInput,
+  WriteDraftOutput,
 } from '@shm/shared/models/document-machine'
 import {useDocumentInspector} from '@shm/shared/models/document-machine-inspect'
 import {selectContext, useDocumentMachineRef} from '@shm/shared/models/use-document-machine'
@@ -375,7 +376,7 @@ export default function DesktopResourcePage() {
   // Account ID flows through machine context → actor input (no closure deps).
   const writeDraftActor = useMemo(
     () =>
-      fromPromise<{id: string}, WriteDraftInput>(async ({input}) => {
+      fromPromise<WriteDraftOutput, WriteDraftInput>(async ({input}) => {
         const editor = editorRef.current
         const content = editor ? editor.topLevelBlocks : []
         const cursorPosition = editor?._tiptapEditor?.view?.state?.selection?.$anchor?.pos ?? undefined
@@ -442,7 +443,7 @@ export default function DesktopResourcePage() {
           wroteEmbedBlocks: contentSummary.embedBlocks,
         })
         // console.log('[writeDraft] saved successfully:', {draftId: result.id})
-        return result
+        return {...result, content, cursorPosition}
       }),
     [],
   )

--- a/frontend/apps/web/app/document-edit/web-document-actors.ts
+++ b/frontend/apps/web/app/document-edit/web-document-actors.ts
@@ -24,6 +24,7 @@ import {
   type PublishInput,
   type PushDocumentInput,
   type WriteDraftInput,
+  type WriteDraftOutput,
 } from '@shm/shared/models/document-machine'
 import {invalidateAfterPublish} from '@shm/shared/models/post-publish-cache'
 import {invalidateQueries, refetchQueriesByKey} from '@shm/shared/models/query-client'
@@ -80,7 +81,7 @@ export function createWebDocumentMachine(deps: CreateWebDocumentMachineDeps) {
 }
 
 function makeWriteDraftActor(deps: CreateWebDocumentMachineDeps) {
-  return fromPromise<{id: string}, WriteDraftInput>(async ({input}) => {
+  return fromPromise<WriteDraftOutput, WriteDraftInput>(async ({input}) => {
     const editor = deps.getEditor()
     const editorBlocks = editor?.getTopLevelBlocks() ?? []
     const cursorPosition = editor?.getCursorPosition?.() ?? null
@@ -118,7 +119,8 @@ function makeWriteDraftActor(deps: CreateWebDocumentMachineDeps) {
       cursorPosition,
     }
     await putWebDocDraft(record)
-    return {id: draftId}
+    invalidateQueries(['web-doc-draft', deps.docId.id])
+    return {id: draftId, content, cursorPosition}
   })
 }
 

--- a/frontend/apps/web/app/document-edit/web-draft-db.test.ts
+++ b/frontend/apps/web/app/document-edit/web-draft-db.test.ts
@@ -8,9 +8,11 @@ import {
   deleteWebDocDraft,
   getLatestWebDocDraftForDoc,
   getWebDocDraft,
+  listWebDocDraftSnapshots,
   listWebDocDraftsForAccount,
   listWebDocDraftsForDoc,
   putWebDocDraft,
+  restoreWebDocDraftSnapshot,
   type WebDocDraft,
 } from './web-draft-db'
 
@@ -97,6 +99,34 @@ describe('web-draft-db', () => {
     await deleteWebDocDraft('gone')
     expect(await getWebDocDraft('gone')).toBeNull()
     await deleteWebDocDraft('gone') // no throw on second delete
+  })
+
+  it('keeps recoverable snapshots before overwriting a draft', async () => {
+    await putWebDocDraft(
+      makeDraft({draftId: 'safe', content: [{block: {id: 'b1', type: 'Paragraph', text: 'first'}} as any]}),
+    )
+    await putWebDocDraft(
+      makeDraft({draftId: 'safe', content: [{block: {id: 'b1', type: 'Paragraph', text: 'second'}} as any]}),
+    )
+
+    const snapshots = await listWebDocDraftSnapshots('safe')
+    expect(snapshots).toHaveLength(1)
+    expect((snapshots[0]?.draft.content[0]?.block as any)?.text).toBe('first')
+  })
+
+  it('can restore a draft snapshot', async () => {
+    await putWebDocDraft(
+      makeDraft({draftId: 'restore', content: [{block: {id: 'b1', type: 'Paragraph', text: 'first'}} as any]}),
+    )
+    await putWebDocDraft(
+      makeDraft({draftId: 'restore', content: [{block: {id: 'b1', type: 'Paragraph', text: 'second'}} as any]}),
+    )
+    const [snapshot] = await listWebDocDraftSnapshots('restore')
+
+    await restoreWebDocDraftSnapshot(snapshot!.snapshotId)
+
+    const restored = await getWebDocDraft('restore')
+    expect((restored?.content[0]?.block as any)?.text).toBe('first')
   })
 
   it('cleanupOldWebDocDrafts prunes only old entries', async () => {

--- a/frontend/apps/web/app/document-edit/web-draft-db.ts
+++ b/frontend/apps/web/app/document-edit/web-draft-db.ts
@@ -44,12 +44,26 @@ export interface WebDocDraft {
 }
 
 const DB_NAME = 'web-doc-drafts-01'
-const DB_VERSION = 1
+const DB_VERSION = 2
 const STORE = 'drafts-01'
+const SNAPSHOT_STORE = 'draft-snapshots-01'
 const INDEX_DOC = 'docId'
 const INDEX_UPDATED = 'updatedAt'
+const INDEX_DRAFT_ID = 'draftId'
 
 const DEFAULT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
+const MAX_SNAPSHOTS_PER_DRAFT = 20
+
+export interface WebDocDraftSnapshot {
+  /** Primary key for this recoverable snapshot. */
+  snapshotId: string
+  /** Draft id this snapshot can restore. */
+  draftId: string
+  /** Wall-clock timestamp when the snapshot was created. */
+  createdAt: number
+  /** Full draft record before it was overwritten or deleted. */
+  draft: WebDocDraft
+}
 
 let dbPromise: Promise<IDBDatabase> | null = null
 
@@ -69,6 +83,11 @@ function openDB(): Promise<IDBDatabase> {
         store.createIndex(INDEX_DOC, 'docId', {unique: false})
         store.createIndex(INDEX_UPDATED, 'updatedAt', {unique: false})
       }
+      if (!db.objectStoreNames.contains(SNAPSHOT_STORE)) {
+        const store = db.createObjectStore(SNAPSHOT_STORE, {keyPath: 'snapshotId'})
+        store.createIndex(INDEX_DRAFT_ID, 'draftId', {unique: false})
+        store.createIndex(INDEX_UPDATED, 'createdAt', {unique: false})
+      }
     }
     req.onsuccess = () => resolve(req.result)
     req.onerror = () => reject(req.error)
@@ -76,8 +95,8 @@ function openDB(): Promise<IDBDatabase> {
   return dbPromise
 }
 
-function tx(mode: IDBTransactionMode): Promise<IDBObjectStore> {
-  return openDB().then((db) => db.transaction(STORE, mode).objectStore(STORE))
+function tx(mode: IDBTransactionMode, storeName: string = STORE): Promise<IDBObjectStore> {
+  return openDB().then((db) => db.transaction(storeName, mode).objectStore(storeName))
 }
 
 function reqToPromise<T>(request: IDBRequest<T>): Promise<T> {
@@ -104,6 +123,8 @@ export async function getWebDocDraft(draftId: string): Promise<WebDocDraft | nul
 export async function putWebDocDraft(draft: Omit<WebDocDraft, 'updatedAt'> & {updatedAt?: number}): Promise<void> {
   if (!isBrowser()) return
   const record: WebDocDraft = {...draft, updatedAt: draft.updatedAt ?? Date.now()}
+  const existing = await getWebDocDraft(record.draftId)
+  if (existing) await saveDraftSnapshot(existing)
   const store = await tx('readwrite')
   await reqToPromise(store.put(record))
 }
@@ -111,8 +132,56 @@ export async function putWebDocDraft(draft: Omit<WebDocDraft, 'updatedAt'> & {up
 /** Delete a draft by id. Idempotent. */
 export async function deleteWebDocDraft(draftId: string): Promise<void> {
   if (!isBrowser()) return
+  const existing = await getWebDocDraft(draftId)
+  if (existing) await saveDraftSnapshot(existing)
   const store = await tx('readwrite')
   await reqToPromise(store.delete(draftId))
+}
+
+async function saveDraftSnapshot(draft: WebDocDraft): Promise<void> {
+  const createdAt = Date.now()
+  const snapshot: WebDocDraftSnapshot = {
+    snapshotId: `${draft.draftId}:${createdAt}:${Math.random().toString(36).slice(2)}`,
+    draftId: draft.draftId,
+    createdAt,
+    draft,
+  }
+  const store = await tx('readwrite', SNAPSHOT_STORE)
+  await reqToPromise(store.put(snapshot))
+  await pruneDraftSnapshots(draft.draftId)
+}
+
+async function pruneDraftSnapshots(draftId: string): Promise<void> {
+  const snapshots = await listWebDocDraftSnapshots(draftId)
+  const old = snapshots.slice(MAX_SNAPSHOTS_PER_DRAFT)
+  if (!old.length) return
+  const store = await tx('readwrite', SNAPSHOT_STORE)
+  for (const snapshot of old) {
+    await reqToPromise(store.delete(snapshot.snapshotId))
+  }
+}
+
+/** Return recoverable snapshots for a draft, newest first. */
+export async function listWebDocDraftSnapshots(draftId: string): Promise<WebDocDraftSnapshot[]> {
+  if (!isBrowser()) return []
+  try {
+    const store = await tx('readonly', SNAPSHOT_STORE)
+    const index = store.index(INDEX_DRAFT_ID)
+    const results = await reqToPromise<WebDocDraftSnapshot[]>(index.getAll(draftId))
+    return results.sort((a, b) => b.createdAt - a.createdAt)
+  } catch (err) {
+    console.warn('listWebDocDraftSnapshots failed', err)
+    return []
+  }
+}
+
+/** Restore a recoverable draft snapshot by writing it back to the active draft store. */
+export async function restoreWebDocDraftSnapshot(snapshotId: string): Promise<void> {
+  if (!isBrowser()) return
+  const store = await tx('readonly', SNAPSHOT_STORE)
+  const snapshot = await reqToPromise<WebDocDraftSnapshot | undefined>(store.get(snapshotId))
+  if (!snapshot) throw new Error(`web draft snapshot ${snapshotId} not found`)
+  await putWebDocDraft({...snapshot.draft, updatedAt: Date.now()})
 }
 
 /**
@@ -219,7 +288,8 @@ export async function cleanupOldWebDocDrafts(maxAgeMs: number = DEFAULT_MAX_AGE_
     const oldKeys = await reqToPromise<IDBValidKey[]>(index.getAllKeys(range))
     let deleted = 0
     for (const key of oldKeys) {
-      await reqToPromise(store.delete(key))
+      if (typeof key !== 'string') continue
+      await deleteWebDocDraft(key)
       deleted += 1
     }
     return deleted

--- a/frontend/packages/editor/src/document-editor.test.ts
+++ b/frontend/packages/editor/src/document-editor.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest'
-import {getDocumentSelectionObserverKey} from './document-editor'
+import {getDocumentSelectionObserverKey, shouldCancelEditOnOutsidePointer} from './document-editor'
 
 describe('getDocumentSelectionObserverKey', () => {
   it('returns a key for collapsed selections', () => {
@@ -8,5 +8,17 @@ describe('getDocumentSelectionObserverKey', () => {
 
   it('returns a key for range selections', () => {
     expect(getDocumentSelectionObserverKey({from: 12, to: 18})).toBe('12:18')
+  })
+})
+
+describe('shouldCancelEditOnOutsidePointer', () => {
+  it('does not cancel editing while changes are unsaved or saving', () => {
+    expect(shouldCancelEditOnOutsidePointer('changed')).toBe(false)
+    expect(shouldCancelEditOnOutsidePointer('saving')).toBe(false)
+  })
+
+  it('allows outside pointer cancellation when content is idle or saved', () => {
+    expect(shouldCancelEditOnOutsidePointer('idle')).toBe(true)
+    expect(shouldCancelEditOnOutsidePointer('saved')).toBe(true)
   })
 })

--- a/frontend/packages/editor/src/document-editor.tsx
+++ b/frontend/packages/editor/src/document-editor.tsx
@@ -9,6 +9,7 @@ import {useEditorHandlersRef} from '@shm/shared/models/editor-handlers-context'
 import {
   selectCanEdit,
   selectIsEditing,
+  selectSaveStatus,
   useDocumentMachineRef,
   useDocumentSelector,
 } from '@shm/shared/models/use-document-machine'
@@ -81,6 +82,11 @@ export function shouldRequirePublishForBlockAction({
 }): boolean {
   if (isBlockInPublishedVersion) return !isBlockInPublishedVersion(blockId)
   return !!isUnpublishedDraft
+}
+
+/** Return whether an outside pointer should exit edit mode for the current autosave state. */
+export function shouldCancelEditOnOutsidePointer(saveStatus: 'idle' | 'changed' | 'saving' | 'saved'): boolean {
+  return saveStatus !== 'changed' && saveStatus !== 'saving'
 }
 
 function shouldClearBlockHighlightOnMouseDown(target: EventTarget | null): boolean {
@@ -824,6 +830,7 @@ export function DocumentEditor({
 
     const handlePointerDown = (e: PointerEvent) => {
       if (shouldKeepEditModeForPointerTarget(e.target, domRoot)) return
+      if (!shouldCancelEditOnOutsidePointer(selectSaveStatus(actorRef.getSnapshot()))) return
       actorRef.send({type: 'edit.cancel'})
     }
 

--- a/frontend/packages/shared/src/models/__tests__/document-machine.test.ts
+++ b/frontend/packages/shared/src/models/__tests__/document-machine.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, it} from 'vitest'
 import {createActor, fromPromise} from 'xstate'
-import {documentMachine, DocumentMachineInput, PushDocumentInput} from '../document-machine'
-import {HMDocument} from '@seed-hypermedia/client/hm-types'
+import {documentMachine, DocumentMachineInput, PushDocumentInput, WriteDraftOutput} from '../document-machine'
+import {HMBlockNode, HMDocument} from '@seed-hypermedia/client/hm-types'
 
 const mockDocumentId = {
   id: 'hm://z6Mktest/doc',
@@ -237,6 +237,36 @@ describe('DocumentLifecycle machine', () => {
     expect(ctx.pendingRemoteDocument).toBeNull()
     expect(ctx.pendingRemoteVersion).toBeNull()
     expect(actor.getSnapshot().matches({editing: {rebase: 'idle'}})).toBe(true)
+    actor.stop()
+  })
+
+  it('updates draftContent after an autosave returns the saved content', async () => {
+    const savedContent: HMBlockNode[] = [
+      {block: {id: 'saved', type: 'Paragraph', text: 'latest draft', attributes: {}}, children: []},
+    ]
+    const machine = documentMachine.provide({
+      actors: {
+        writeDraft: fromPromise<WriteDraftOutput, any>(async () => ({
+          id: 'draft-123',
+          content: savedContent,
+          cursorPosition: 7,
+        })),
+        publishDocument: fromPromise<HMDocument, any>(async () => mockDocument),
+        discardDraft: fromPromise<void, any>(async () => {}),
+      },
+      delays: {autosaveTimeout: 10, saveIndicatorDismiss: 10},
+    })
+    const actor = createActor(machine, {
+      input: {documentId: mockDocumentId, canEdit: true},
+    })
+    actor.start()
+    loadDocument(actor)
+    actor.send({type: 'edit.start'})
+    actor.send({type: 'change'})
+    await new Promise((r) => setTimeout(r, 30))
+
+    expect(actor.getSnapshot().context.draftContent).toEqual(savedContent)
+    expect(actor.getSnapshot().context.draftCursorPosition).toBe(7)
     actor.stop()
   })
 

--- a/frontend/packages/shared/src/models/document-machine.ts
+++ b/frontend/packages/shared/src/models/document-machine.ts
@@ -225,6 +225,13 @@ export type WriteDraftInput = {
   baseBlocks: HMBlockNode[] | null
 }
 
+/** Output returned by draft writers after the saved draft hits local storage. */
+export type WriteDraftOutput = {
+  id: string
+  content?: HMBlockNode[] | null
+  cursorPosition?: number | null
+}
+
 /** Input for the publishDocument actor. */
 export type PublishInput = {
   documentId: UnpackedHypermediaId
@@ -343,6 +350,16 @@ export const documentMachine = setup({
     }),
     setDraftIdFromResult: assign({
       draftId: (_, params: {id: string}) => params.id,
+    }),
+    setDraftSavedSnapshotFromResult: assign({
+      draftContent: ({context}, params: WriteDraftOutput) => {
+        if (params.content !== undefined) return params.content ?? null
+        return context.draftContent
+      },
+      draftCursorPosition: ({context}, params: WriteDraftOutput) => {
+        if (params.cursorPosition !== undefined) return params.cursorPosition ?? null
+        return context.draftCursorPosition
+      },
     }),
     setDraftCreated: assign({
       draftCreated: true,
@@ -855,7 +872,7 @@ export const documentMachine = setup({
     hasPendingPublish: ({context}) => context.pendingPublish,
   },
   actors: {
-    writeDraft: fromPromise<{id: string}, WriteDraftInput>(async () => {
+    writeDraft: fromPromise<WriteDraftOutput, WriteDraftInput>(async () => {
       throw new Error('writeDraft actor must be provided via .provide()')
     }),
     publishDocument: fromPromise<HMDocument, PublishInput>(async () => {
@@ -1215,6 +1232,10 @@ export const documentMachine = setup({
                         type: 'setDraftIdFromResult',
                         params: ({event}: {event: any}) => event.output,
                       },
+                      {
+                        type: 'setDraftSavedSnapshotFromResult',
+                        params: ({event}: {event: any}) => event.output,
+                      },
                       'logSaveCompleted',
                     ],
                     reenter: true,
@@ -1225,6 +1246,10 @@ export const documentMachine = setup({
                       'setDraftCreated',
                       {
                         type: 'setDraftIdFromResult',
+                        params: ({event}: {event: any}) => event.output,
+                      },
+                      {
+                        type: 'setDraftSavedSnapshotFromResult',
                         params: ({event}: {event: any}) => event.output,
                       },
                       'logSaveCompleted',
@@ -1284,11 +1309,24 @@ export const documentMachine = setup({
                   {
                     target: 'saving',
                     guard: 'didChangeWhileSaving',
+                    actions: [
+                      {
+                        type: 'setDraftSavedSnapshotFromResult',
+                        params: ({event}: {event: any}) => event.output,
+                      },
+                    ],
                     reenter: true,
                   },
                   {
                     target: 'idle',
-                    actions: ['logSaveCompleted', raise({type: '_save.completed'})],
+                    actions: [
+                      {
+                        type: 'setDraftSavedSnapshotFromResult',
+                        params: ({event}: {event: any}) => event.output,
+                      },
+                      'logSaveCompleted',
+                      raise({type: '_save.completed'}),
+                    ],
                   },
                 ],
                 onError: {

--- a/frontend/packages/shared/src/models/use-document-machine.ts
+++ b/frontend/packages/shared/src/models/use-document-machine.ts
@@ -15,6 +15,7 @@ import {
   PendingRebase,
   PublishInput,
   TransientResourceError,
+  WriteDraftOutput,
   WriteDraftInput,
 } from './document-machine'
 import {EditorHandlers, EditorHandlersContext} from './editor-handlers-context'
@@ -32,7 +33,7 @@ export type DocumentMachineSnapshot = SnapshotFrom<typeof documentMachine>
 
 /** Actors that must be provided via `.provide()` before instantiating the machine. */
 export type DocumentMachineProvidedActors = {
-  writeDraft: (input: WriteDraftInput) => Promise<{id: string}>
+  writeDraft: (input: WriteDraftInput) => Promise<WriteDraftOutput>
   publishDocument: (input: PublishInput) => Promise<HMDocument>
   discardDraft: (input: DiscardDraftInput) => Promise<void>
 }

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -49,6 +49,7 @@ import {useInteractionSummary} from '@shm/shared/models/interaction-summary'
 import {
   documentMachine,
   DocumentMachineProvider,
+  selectBlocks,
   selectContext,
   selectIsEditing,
   selectIsUnpublishedDraft,
@@ -1174,6 +1175,8 @@ function DocumentBody({
   const isEditing = useDocumentSelector(selectIsEditing)
   const isUnpublishedDraft = useDocumentSelector(selectIsUnpublishedDraft)
   const ctx = useDocumentSelector(selectContext)
+  const savedDraftContent = useDocumentSelector(selectBlocks)
+  const effectiveContent = ctx.draftId ? savedDraftContent : existingDraftContent
   // Set of block ids present in the currently published version of the document.
   const publishedBlockIds = useMemo(() => {
     const ids = new Set<string>()
@@ -2001,7 +2004,7 @@ function DocumentBody({
           inlineInsert={inlineInsert}
           DocumentContentComponent={DocumentContentComponent}
           onEditorReady={handleEditorReadyWrapped}
-          existingDraftContent={existingDraftContent}
+          existingDraftContent={effectiveContent}
           existingDraftCursorPosition={existingDraftCursorPosition}
           ssrContentHTML={ssrContentHTML}
           perspectiveAccountUid={perspectiveAccountUid}


### PR DESCRIPTION
## Summary
- Keep autosaved draft content in sync with the document machine so mobile edits are not replaced by stale draft data.
- Prevent outside taps from cancelling edit mode while changes are unsaved or autosave is running.
- Add recoverable draft snapshots before overwrites/deletes on desktop and web, with snapshot restore coverage for web drafts.