### PR TITLE
feat(desktop): agent setup, model providers, and trigger cleanup

### DIFF
--- a/agents/docs/desktop-ui.md
+++ b/agents/docs/desktop-ui.md
@@ -199,7 +199,9 @@ Benefits:
   share URL of the form `<server>/agents/<agentId>/sessions/<sessionId>#event=<eventId>`;
 - in-app `hm://` link handling;
 - same streaming cursor treatment;
-- same tool-call bubbles, including raw-debug details and `read` document links;
+- same tool-call bubbles, including raw-debug details, richer `read` summaries that prefer document titles over raw
+  `hm://` URLs, and richer write summaries/detail cards such as linked `Create document: <title>` rows for
+  `document.create`;
 - tool bubble selection is driven by the unified registry at `agents/protocol/src/tool-registry.ts`, shared with the
   model-facing tool descriptions and schemas.
 

--- a/agents/docs/persistence.md
+++ b/agents/docs/persistence.md
@@ -248,7 +248,7 @@ Current scheme:
 
 ```ts
 {
-  _: 'GetSession', sessionId, afterSeq
+  _: ('GetSession', sessionId, afterSeq)
 }
 ```
 

--- a/agents/docs/security.md
+++ b/agents/docs/security.md
@@ -17,7 +17,7 @@ Every HTTP action is a signed `SignedActionEnvelope`:
 
 ```ts
 {
-  type: 'AgentsAction', signer, sig, account, action
+  type: ('AgentsAction', signer, sig, account, action)
 }
 ```
 

--- a/agents/docs/write-tool-implementation-notes.md
+++ b/agents/docs/write-tool-implementation-notes.md
@@ -39,11 +39,9 @@ can resolve a signer by either profile name or public key.
 ### Draft persistence
 
 - `agents/src/sqlite-schema.sql`
-
   - Adds the `agent_drafts` table and indexes.
 
 - `agents/src/sqlite.ts`
-
   - Adds a migration for `agent_drafts`.
 
 - `agents/src/sqlite.test.ts`
@@ -65,11 +63,9 @@ can resolve a signer by either profile name or public key.
 ### Docs
 
 - `agents/docs/write-tool-cli-parity-plan.md`
-
   - Detailed planning/design document for CLI parity and future work.
 
 - `agents/docs/write-tool-implementation-notes.md`
-
   - This file.
 
 - Existing docs updated to stop describing signing/publishing tools as purely future work.

--- a/agents/protocol/src/index.ts
+++ b/agents/protocol/src/index.ts
@@ -232,7 +232,6 @@ export type AgentTriggerInput = {
   enabled?: boolean
   source: AgentTriggerSource
   prompt: string | AgentPromptBlock[]
-  cooldownMs?: number
 }
 
 /** Patch used to edit an activity trigger. */
@@ -241,7 +240,6 @@ export type AgentTriggerPatch = {
   enabled?: boolean
   source?: AgentTriggerSource
   prompt?: string | AgentPromptBlock[]
-  cooldownMs?: number | null
 }
 
 /** Activity source/filter that decides when an agent trigger fires. */
@@ -334,7 +332,6 @@ export type AgentTriggerInfo = {
   enabled: boolean
   source: AgentTriggerSource
   prompt: string | AgentPromptBlock[]
-  cooldownMs?: number
   createdAt: number
   updatedAt: number
   lastCheckedAt?: number

--- a/agents/protocol/src/index.ts
+++ b/agents/protocol/src/index.ts
@@ -398,12 +398,48 @@ export type SessionEventPayload =
   | {type: 'error'; message: string}
   | Record<string, unknown>
 
+/** Cumulative token usage for the current agent run, updated as turns complete. */
+export type AgentRunUsage = {
+  /** Input/prompt tokens billed so far in this run. */
+  input: number
+  /** Output/completion tokens generated so far in this run. */
+  output: number
+  /** Cached input tokens read so far in this run. */
+  cacheRead: number
+  /** Input tokens written to cache so far in this run. */
+  cacheWrite: number
+  /** Sum of all token categories above. */
+  total: number
+}
+
+/** What the agent is actively doing right now, surfaced live to the UI. */
+export type AgentRunActivity = {
+  /**
+   * Coarse phase of the current run:
+   * - `starting`: the run was accepted and the model request is being prepared
+   * - `thinking`: waiting on the model before any text/tool output
+   * - `responding`: assistant text is streaming in
+   * - `tool`: a tool call is executing (see `toolName`)
+   * - `finalizing`: the run is wrapping up
+   */
+  phase: 'starting' | 'thinking' | 'responding' | 'tool' | 'finalizing'
+  /** Tool currently executing, when `phase` is `tool`. */
+  toolName?: string
+  /** Optional short human-readable detail (e.g. tool argument summary). */
+  detail?: string
+}
+
 /** Server-sent WebSocket event after a signed subscription. */
 export type AgentWSEvent =
   | {_: 'connected'; connectedAt: number}
   | {_: 'subscribed'; key: string; accountId: string}
   | {_: 'append'; key: `sessions/${string}`; event: SessionEvent}
-  | {_: 'appendPartial'; key: `sessions/${string}`; partialId: string; patch: {textDelta?: string; done?: boolean}}
+  | {
+      _: 'appendPartial'
+      key: `sessions/${string}`
+      partialId: string
+      patch: {textDelta?: string; done?: boolean; usage?: AgentRunUsage; activity?: AgentRunActivity}
+    }
   | {_: 'change'; key: `sessions/${string}`; value: SessionInfo}
   | {_: 'change'; key: `agents/${string}`; value: AgentInfo}
   | {_: 'change'; key: `account/${string}`; value: {reason: string; agentId?: string; sessionId?: string}}

--- a/agents/protocol/src/tool-registry.ts
+++ b/agents/protocol/src/tool-registry.ts
@@ -34,7 +34,7 @@ export type ToolRenderDetail = {
 
 export type ToolRenderCustomView = {
   command: string
-  kind: 'new-comment'
+  kind: 'write-command'
 }
 
 export type ToolRenderMetadata = {
@@ -361,7 +361,30 @@ export const seedToolRegistry: SeedToolRegistry = {
         {label: 'Input', source: 'input'},
         {label: 'Output', source: 'output'},
       ],
-      customViews: [{command: 'comment.create', kind: 'new-comment'}],
+      customViews: [
+        {command: 'draft.create', kind: 'write-command'},
+        {command: 'draft.update', kind: 'write-command'},
+        {command: 'draft.get', kind: 'write-command'},
+        {command: 'draft.list', kind: 'write-command'},
+        {command: 'draft.delete', kind: 'write-command'},
+        {command: 'draft.publish', kind: 'write-command'},
+        {command: 'document.create', kind: 'write-command'},
+        {command: 'document.update', kind: 'write-command'},
+        {command: 'document.delete', kind: 'write-command'},
+        {command: 'document.fork', kind: 'write-command'},
+        {command: 'document.move', kind: 'write-command'},
+        {command: 'document.redirect', kind: 'write-command'},
+        {command: 'document.ref', kind: 'write-command'},
+        {command: 'comment.create', kind: 'write-command'},
+        {command: 'comment.update', kind: 'write-command'},
+        {command: 'comment.delete', kind: 'write-command'},
+        {command: 'capability.create', kind: 'write-command'},
+        {command: 'capability.grant', kind: 'write-command'},
+        {command: 'contact.create', kind: 'write-command'},
+        {command: 'contact.delete', kind: 'write-command'},
+        {command: 'profile.update', kind: 'write-command'},
+        {command: 'profile.alias', kind: 'write-command'},
+      ],
     },
     runtimes: ['agent-service'],
     userConfigurable: true,

--- a/agents/protocol/src/tool-registry.ts
+++ b/agents/protocol/src/tool-registry.ts
@@ -409,6 +409,10 @@ export const seedToolRegistry: SeedToolRegistry = {
     runtimes: ['agent-service'],
     hidden: true,
   },
+  // write_file: {},
+  // read_file: {},
+  // exexcute_bash: {},
+  // search_web: {}
 }
 
 export type SeedToolName = keyof typeof seedToolRegistry

--- a/agents/src/activity-monitor.ts
+++ b/agents/src/activity-monitor.ts
@@ -170,9 +170,10 @@ export class ActivityMonitor {
 
   #getWatermark(accountId: string): Watermark | null {
     const row = this.#db
-      .query<{cursor_cbor: Uint8Array; last_success_at: number | null}, [string, string]>(
-        `SELECT cursor_cbor, last_success_at FROM activity_watermarks WHERE account_id = ? AND server_url = ?`,
-      )
+      .query<
+        {cursor_cbor: Uint8Array; last_success_at: number | null},
+        [string, string]
+      >(`SELECT cursor_cbor, last_success_at FROM activity_watermarks WHERE account_id = ? AND server_url = ?`)
       .get(accountId, this.#options.hmServerUrl)
     if (!row) return null
     const decoded = cbor.decode<Watermark>(row.cursor_cbor)

--- a/agents/src/api-service.test.ts
+++ b/agents/src/api-service.test.ts
@@ -1350,7 +1350,12 @@ describe('api service', () => {
       expect(openAICallCount).toBeGreaterThanOrEqual(2)
       expect(
         events.flatMap((event) => {
-          if (event.type === 'session-partial') return [event.done ? 'partial_done' : `partial:${event.textDelta}`]
+          if (event.type === 'session-partial') {
+            if (event.done) return ['partial_done']
+            // Ignore progress-only partials (activity/token-usage updates carry no text delta).
+            if (typeof event.textDelta !== 'string') return []
+            return [`partial:${event.textDelta}`]
+          }
           if (event.type !== 'session-event') return []
           const payload = event.event.event as {type?: string; role?: string}
           if (!['message', 'tool_call', 'tool_result'].includes(payload.type || '')) return []

--- a/agents/src/api-service.test.ts
+++ b/agents/src/api-service.test.ts
@@ -586,7 +586,6 @@ describe('api service', () => {
             trigger: {
               name: ' Comments on spec ',
               prompt: ' Please triage this comment. ',
-              cooldownMs: 60000,
               source: {type: 'document-comment', resource: ' hm://z6Mkdoc/spec ', author: ' z6Mkauthor '},
             },
           },
@@ -598,7 +597,6 @@ describe('api service', () => {
         agentId: createdAgent.agentId,
         name: 'Comments on spec',
         enabled: true,
-        cooldownMs: 60000,
         source: {type: 'document-comment', resource: 'hm://z6Mkdoc/spec', author: 'z6Mkauthor'},
       })
       expect(agentPromptText(createdTrigger.trigger.prompt)).toBe('Please triage this comment.')
@@ -612,7 +610,6 @@ describe('api service', () => {
             trigger: {
               name: ' Comments on spec ',
               prompt: ' Please triage this comment. ',
-              cooldownMs: 60000,
               source: {type: 'document-comment', resource: ' hm://z6Mkdoc/spec ', author: ' z6Mkauthor '},
             },
           },
@@ -634,7 +631,6 @@ describe('api service', () => {
             triggerId: createdTrigger.trigger.id,
             patch: {
               enabled: false,
-              cooldownMs: null,
               source: {type: 'user-mention', mentionedAccount: ' z6Mkmentioned ', resourcePrefix: ' hm://z6Mksite '},
             },
           },
@@ -846,7 +842,6 @@ describe('api service', () => {
                   children: [],
                 },
               ],
-              cooldownMs: 60000,
               source: {type: 'document-comment', resource: 'hm://z6Mkdoc/spec'},
             },
           },
@@ -877,10 +872,7 @@ describe('api service', () => {
       }
       expect(processed).toMatchObject({checked: 1, matched: 1, fired: 1, skipped: 0, errors: 0})
       await expect(
-        svc.processActivityEvent(blobs.principalToString(account.principal), {
-          ...event,
-          newBlob: {...event.newBlob, cid: 'bafycomment2'},
-        }),
+        svc.processActivityEvent(blobs.principalToString(account.principal), event),
       ).resolves.toMatchObject({
         checked: 1,
         matched: 1,

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -82,6 +82,8 @@ export type ServiceEvent =
       partialId: string
       textDelta?: string
       done?: boolean
+      usage?: api.AgentRunUsage
+      activity?: api.AgentRunActivity
     }
   | {type: 'account-change'; accountId: string; reason: string; agentId?: string; sessionId?: string}
 
@@ -274,9 +276,7 @@ export class Service {
       .query<
         {id: string; name: string; type: string; config_cbor: Uint8Array; created_at: number; updated_at: number},
         [string]
-      >(
-        `SELECT id, name, type, config_cbor, created_at, updated_at FROM model_providers WHERE account_id = ? ORDER BY updated_at DESC`,
-      )
+      >(`SELECT id, name, type, config_cbor, created_at, updated_at FROM model_providers WHERE account_id = ? ORDER BY updated_at DESC`)
       .all(accountId)
     return {
       _: 'ListModelProvidersResponse',
@@ -297,9 +297,10 @@ export class Service {
   async #listProviderModels(accountId: string, rawProviderName: string): Promise<api.ListProviderModelsResponse> {
     const providerName = normalizeBoundedString(rawProviderName, 'Model provider', MAX_NAME_BYTES)
     const row = this.#db
-      .query<{config_cbor: Uint8Array}, [string, string]>(
-        `SELECT config_cbor FROM model_providers WHERE account_id = ? AND name = ?`,
-      )
+      .query<
+        {config_cbor: Uint8Array},
+        [string, string]
+      >(`SELECT config_cbor FROM model_providers WHERE account_id = ? AND name = ?`)
       .get(accountId, providerName)
     if (!row) throw new APIError(404, 'Model provider not found')
 
@@ -321,9 +322,7 @@ export class Service {
       .query<
         {id: string; name: string; metadata_cbor: Uint8Array | null; created_at: number; updated_at: number},
         [string]
-      >(
-        `SELECT id, name, metadata_cbor, created_at, updated_at FROM secrets WHERE account_id = ? ORDER BY updated_at DESC`,
-      )
+      >(`SELECT id, name, metadata_cbor, created_at, updated_at FROM secrets WHERE account_id = ? ORDER BY updated_at DESC`)
       .all(accountId)
 
     return {
@@ -447,9 +446,10 @@ export class Service {
   #deleteSigningIdentity(accountId: string, rawName: string): api.DeleteSigningIdentityResponse {
     const name = normalizeBoundedString(rawName, 'Signing key', MAX_NAME_BYTES)
     const row = this.#db
-      .query<{metadata_cbor: Uint8Array | null}, [string, string]>(
-        `SELECT metadata_cbor FROM secrets WHERE account_id = ? AND name = ?`,
-      )
+      .query<
+        {metadata_cbor: Uint8Array | null},
+        [string, string]
+      >(`SELECT metadata_cbor FROM secrets WHERE account_id = ? AND name = ?`)
       .get(accountId, name)
     if (!row?.metadata_cbor) throw new APIError(404, 'Signing identity not found')
     const metadata = cbor.decode<Record<string, unknown>>(row.metadata_cbor)
@@ -467,9 +467,10 @@ export class Service {
     const provider = normalizeProvider(rawProvider)
     const now = Date.now()
     const existing = this.#db
-      .query<{id: string; created_at: number}, [string, string]>(
-        `SELECT id, created_at FROM model_providers WHERE account_id = ? AND name = ?`,
-      )
+      .query<
+        {id: string; created_at: number},
+        [string, string]
+      >(`SELECT id, created_at FROM model_providers WHERE account_id = ? AND name = ?`)
       .get(accountId, name)
     const id = existing?.id ?? crypto.randomUUID()
     const createdAt = existing?.created_at ?? now
@@ -501,9 +502,10 @@ export class Service {
   #deleteModelProvider(accountId: string, rawName: string): api.DeleteModelProviderResponse {
     const name = normalizeBoundedString(rawName, 'Provider name', MAX_NAME_BYTES)
     const row = this.#db
-      .query<{config_cbor: Uint8Array}, [string, string]>(
-        `SELECT config_cbor FROM model_providers WHERE account_id = ? AND name = ?`,
-      )
+      .query<
+        {config_cbor: Uint8Array},
+        [string, string]
+      >(`SELECT config_cbor FROM model_providers WHERE account_id = ? AND name = ?`)
       .get(accountId, name)
     if (!row) throw new APIError(404, 'Model provider not found')
 
@@ -529,9 +531,10 @@ export class Service {
     const ciphertext = await encryptSecret(this.#db, value)
     const now = Date.now()
     const existing = this.#db
-      .query<{id: string; created_at: number}, [string, string]>(
-        `SELECT id, created_at FROM secrets WHERE account_id = ? AND name = ?`,
-      )
+      .query<
+        {id: string; created_at: number},
+        [string, string]
+      >(`SELECT id, created_at FROM secrets WHERE account_id = ? AND name = ?`)
       .get(accountId, name)
     const id = existing?.id ?? crypto.randomUUID()
     const createdAt = existing?.created_at ?? now
@@ -557,9 +560,10 @@ export class Service {
     const signingKeys = definition.signingKeys || (definition.signingKey ? [definition.signingKey] : [])
     for (const signingKey of signingKeys) {
       const row = this.#db
-        .query<{metadata_cbor: Uint8Array | null}, [string, string]>(
-          `SELECT metadata_cbor FROM secrets WHERE account_id = ? AND name = ?`,
-        )
+        .query<
+          {metadata_cbor: Uint8Array | null},
+          [string, string]
+        >(`SELECT metadata_cbor FROM secrets WHERE account_id = ? AND name = ?`)
         .get(accountId, signingKey)
       if (!row?.metadata_cbor) throw new APIError(400, 'Signing key not found')
       const metadata = cbor.decode<Record<string, unknown>>(row.metadata_cbor)
@@ -731,7 +735,7 @@ export class Service {
         ? undefined
         : patch.cooldownMs === null
           ? undefined
-          : patch.cooldownMs ?? existing.cooldownMs
+          : (patch.cooldownMs ?? existing.cooldownMs)
     const next: api.AgentTriggerInfo = {...existing, ...patch, cooldownMs, updatedAt: Date.now()}
     this.#db.run(
       `UPDATE agent_triggers
@@ -834,9 +838,10 @@ export class Service {
   #setSessionTitleFromAgent(accountId: string, sessionId: string, rawTitle: string): api.SessionInfo {
     const title = normalizeBoundedString(rawTitle, 'Session title', MAX_NAME_BYTES)
     const existing = this.#db
-      .query<{title_source: string}, [string, string]>(
-        `SELECT title_source FROM sessions WHERE account_id = ? AND id = ?`,
-      )
+      .query<
+        {title_source: string},
+        [string, string]
+      >(`SELECT title_source FROM sessions WHERE account_id = ? AND id = ?`)
       .get(accountId, sessionId)
     if (!existing) throw new APIError(404, 'Session not found')
 
@@ -876,9 +881,10 @@ export class Service {
     const requestCBOR = normalizedId === undefined ? undefined : cbor.encode({sessionId, content})
     if (normalizedId !== undefined && requestCBOR !== undefined) {
       const existing = this.#db
-        .query<{request_cbor: Uint8Array; response_cbor: Uint8Array}, [string, string, string]>(
-          `SELECT request_cbor, response_cbor FROM action_idempotency WHERE account_id = ? AND action = ? AND client_request_id = ?`,
-        )
+        .query<
+          {request_cbor: Uint8Array; response_cbor: Uint8Array},
+          [string, string, string]
+        >(`SELECT request_cbor, response_cbor FROM action_idempotency WHERE account_id = ? AND action = ? AND client_request_id = ?`)
         .get(accountId, 'MessageSession', normalizedId)
       if (existing) {
         if (!bytesEqual(existing.request_cbor, requestCBOR))
@@ -1026,9 +1032,10 @@ export class Service {
     if (!signingKeys.length) return basePrompt
     const identities = signingKeys.flatMap((name) => {
       const row = this.#db
-        .query<{metadata_cbor: Uint8Array | null}, [string, string]>(
-          `SELECT metadata_cbor FROM secrets WHERE account_id = ? AND name = ?`,
-        )
+        .query<
+          {metadata_cbor: Uint8Array | null},
+          [string, string]
+        >(`SELECT metadata_cbor FROM secrets WHERE account_id = ? AND name = ?`)
         .get(accountId, name)
       if (!row?.metadata_cbor) return []
       const metadata = cbor.decode<Record<string, unknown>>(row.metadata_cbor)
@@ -1056,9 +1063,10 @@ export class Service {
     const session = this.#getSessionInfo(accountId, sessionId)
     if (!session) throw new APIError(404, 'Session not found')
     const providerRow = this.#db
-      .query<{config_cbor: Uint8Array}, [string, string]>(
-        `SELECT config_cbor FROM model_providers WHERE account_id = ? AND name = ?`,
-      )
+      .query<
+        {config_cbor: Uint8Array},
+        [string, string]
+      >(`SELECT config_cbor FROM model_providers WHERE account_id = ? AND name = ?`)
       .get(accountId, definition.modelProvider)
     if (!providerRow) throw new APIError(400, 'Model provider not found')
     const provider = cbor.decode<api.ModelProviderConfig>(providerRow.config_cbor)
@@ -1139,6 +1147,39 @@ export class Service {
     let finalError: string | undefined
     let assistantEvent: api.SessionEvent | undefined
     const appendedToolCalls = new Set<string>()
+    const toolStartedAt = new Map<string, number>()
+
+    const runStartedAt = Date.now()
+    let turnCount = 0
+    let streamingLogOpen = false
+    const runUsage: api.AgentRunUsage = {input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0}
+    const logRun = (message: string, fields: Record<string, unknown> = {}): void => {
+      console.info(`[agents/runtime] ${message}`, {
+        sessionId,
+        agentId: session.agentId,
+        provider: providerName,
+        model: definition.model,
+        ...fields,
+      })
+    }
+    const logRunError = (message: string, fields: Record<string, unknown> = {}): void => {
+      console.error(`[agents/runtime] ${message}`, {
+        sessionId,
+        agentId: session.agentId,
+        provider: providerName,
+        model: definition.model,
+        ...fields,
+      })
+    }
+    const endStreamingLog = (): void => {
+      if (!streamingLogOpen) return
+      process.stdout.write('\n')
+      streamingLogOpen = false
+    }
+    /** Emits a non-text progress patch (activity and/or cumulative token usage) for the current partial. */
+    const emitProgress = (patch: {activity?: api.AgentRunActivity; usage?: api.AgentRunUsage}): void => {
+      this.#emit({type: 'session-partial', accountId, agentId: session.agentId, sessionId, partialId, ...patch})
+    }
 
     const appendAssistantMessage = (content: string): void => {
       if (!content.trim()) return
@@ -1161,7 +1202,14 @@ export class Service {
 
     const unsubscribe = piSession.subscribe((event) => {
       if (event.type === 'message_update' && event.assistantMessageEvent.type === 'text_delta') {
-        partialText += event.assistantMessageEvent.delta
+        const delta = event.assistantMessageEvent.delta
+        if (!currentAssistantHadDelta) {
+          logRun('assistant text streaming', {partialId})
+          emitProgress({activity: {phase: 'responding'}})
+          streamingLogOpen = true
+        }
+        process.stdout.write(delta)
+        partialText += delta
         currentAssistantHadDelta = true
         this.#emit({
           type: 'session-partial',
@@ -1169,14 +1217,36 @@ export class Service {
           agentId: session.agentId,
           sessionId,
           partialId,
-          textDelta: event.assistantMessageEvent.delta,
+          textDelta: delta,
         })
         return
       }
       if (event.type === 'message_end' && event.message.role === 'assistant') {
-        const assistantMessage = event.message as {stopReason?: string; errorMessage?: string}
+        endStreamingLog()
+        const assistantMessage = event.message as {
+          stopReason?: string
+          errorMessage?: string
+          usage?: {input?: number; output?: number; cacheRead?: number; cacheWrite?: number}
+        }
+        turnCount += 1
+        const turnUsage = assistantMessage.usage
+        if (turnUsage) {
+          runUsage.input += turnUsage.input ?? 0
+          runUsage.output += turnUsage.output ?? 0
+          runUsage.cacheRead += turnUsage.cacheRead ?? 0
+          runUsage.cacheWrite += turnUsage.cacheWrite ?? 0
+          runUsage.total = runUsage.input + runUsage.output + runUsage.cacheRead + runUsage.cacheWrite
+        }
+        logRun('assistant turn complete', {
+          turn: turnCount,
+          stopReason: assistantMessage.stopReason,
+          textChars: partialText.length || piAssistantText(event.message).length,
+          tokens: {...runUsage},
+        })
+        emitProgress({usage: {...runUsage}, activity: {phase: 'thinking'}})
         if (assistantMessage.stopReason === 'error' || assistantMessage.stopReason === 'aborted') {
           finalError = assistantMessage.errorMessage || 'Agent run failed'
+          logRunError('assistant turn reported error', {stopReason: assistantMessage.stopReason, error: finalError})
           return
         }
         if (currentAssistantHadDelta) flushPartialAssistantMessage()
@@ -1186,10 +1256,20 @@ export class Service {
       }
       if (event.type === 'tool_execution_start') {
         if (event.toolName === seedToolRegistry.set_session_title.name) return
+        endStreamingLog()
         if (currentAssistantHadDelta) {
           flushPartialAssistantMessage()
           suppressCurrentAssistantEndFallback = true
         }
+        toolStartedAt.set(event.toolCallId, Date.now())
+        logRun('tool call start', {
+          tool: event.toolName,
+          toolCallId: event.toolCallId,
+          input: summarizeForLog(event.args),
+        })
+        emitProgress({
+          activity: {phase: 'tool', toolName: event.toolName, detail: summarizeToolArgs(event.args)},
+        })
         appendedToolCalls.add(event.toolCallId)
         this.#appendSessionEvent(
           accountId,
@@ -1202,6 +1282,15 @@ export class Service {
       }
       if (event.type === 'tool_execution_end') {
         if (event.toolName === seedToolRegistry.set_session_title.name) return
+        const startedAt = toolStartedAt.get(event.toolCallId)
+        toolStartedAt.delete(event.toolCallId)
+        logRun(event.isError ? 'tool call failed' : 'tool call end', {
+          tool: event.toolName,
+          toolCallId: event.toolCallId,
+          durationMs: startedAt ? Date.now() - startedAt : undefined,
+          result: summarizeForLog(event.isError ? piToolResultText(event.result) : piToolResultOutput(event.result)),
+        })
+        emitProgress({activity: {phase: 'thinking'}})
         if (!appendedToolCalls.has(event.toolCallId)) {
           this.#appendSessionEvent(
             accountId,
@@ -1233,6 +1322,7 @@ export class Service {
         return
       }
       if (event.type === 'agent_end') {
+        endStreamingLog()
         const lastAssistant = [...event.messages].reverse().find((message) => message.role === 'assistant') as
           | {stopReason?: string; errorMessage?: string}
           | undefined
@@ -1248,13 +1338,28 @@ export class Service {
     runningSession.abort = () => piSession.abort()
     this.#runningSessions.set(runningSessionKey, runningSession)
 
+    logRun('agent run starting', {activeTools: piSession.getActiveToolNames()})
+    emitProgress({activity: {phase: 'starting'}, usage: {...runUsage}})
+
     try {
       if (runningSession.stopped) throw new SessionStoppedError()
       await piSession.agent.continue()
+    } catch (error) {
+      endStreamingLog()
+      logRunError('agent run threw', {error: error instanceof Error ? error.message : String(error)})
+      throw error
     } finally {
+      endStreamingLog()
       this.#runningSessions.delete(runningSessionKey)
       unsubscribe()
       piSession.dispose()
+      logRun('agent run finished', {
+        durationMs: Date.now() - runStartedAt,
+        turns: turnCount,
+        tokens: {...runUsage},
+        stopped: runningSession.stopped,
+        error: finalError,
+      })
     }
 
     if (runningSession.stopped) {
@@ -1269,9 +1374,10 @@ export class Service {
 
   #piMessages(sessionId: string): unknown[] {
     const events = this.#db
-      .query<SessionEventRow, [string, number]>(
-        `SELECT id, session_id, seq, event_cbor, created_at FROM session_events WHERE session_id = ? AND seq > ? ORDER BY seq ASC`,
-      )
+      .query<
+        SessionEventRow,
+        [string, number]
+      >(`SELECT id, session_id, seq, event_cbor, created_at FROM session_events WHERE session_id = ? AND seq > ? ORDER BY seq ASC`)
       .all(sessionId, 0)
       .map(sessionEventRowToInfo)
 
@@ -1346,9 +1452,10 @@ export class Service {
 
   async #getSecretPlaintext(accountId: string, name: string): Promise<Uint8Array> {
     const row = this.#db
-      .query<{ciphertext: Uint8Array}, [string, string]>(
-        `SELECT ciphertext FROM secrets WHERE account_id = ? AND name = ?`,
-      )
+      .query<
+        {ciphertext: Uint8Array},
+        [string, string]
+      >(`SELECT ciphertext FROM secrets WHERE account_id = ? AND name = ?`)
       .get(accountId, name)
     if (!row) throw new APIError(400, 'Required secret is not configured')
     return decryptSecret(this.#db, row.ciphertext)
@@ -1363,9 +1470,10 @@ export class Service {
   ): api.SessionEvent {
     const seq =
       this.#db
-        .query<{seq: number}, [string]>(
-          `SELECT COALESCE(MAX(seq), 0) + 1 as seq FROM session_events WHERE session_id = ?`,
-        )
+        .query<
+          {seq: number},
+          [string]
+        >(`SELECT COALESCE(MAX(seq), 0) + 1 as seq FROM session_events WHERE session_id = ?`)
         .get(sessionId)?.seq ?? 1
     const id = crypto.randomUUID()
     this.#db.run(`INSERT INTO session_events (id, session_id, seq, event_cbor, created_at) VALUES (?, ?, ?, ?, ?)`, [
@@ -1450,9 +1558,10 @@ export class Service {
     try {
       if (normalizedId !== undefined && requestCBOR !== undefined) {
         const existing = this.#db
-          .query<{request_cbor: Uint8Array; response_cbor: Uint8Array}, [string, string, string]>(
-            `SELECT request_cbor, response_cbor FROM action_idempotency WHERE account_id = ? AND action = ? AND client_request_id = ?`,
-          )
+          .query<
+            {request_cbor: Uint8Array; response_cbor: Uint8Array},
+            [string, string, string]
+          >(`SELECT request_cbor, response_cbor FROM action_idempotency WHERE account_id = ? AND action = ? AND client_request_id = ?`)
           .get(accountId, action, normalizedId)
         if (existing) {
           if (!bytesEqual(existing.request_cbor, requestCBOR))
@@ -1994,6 +2103,32 @@ function sessionEventRowToInfo(row: SessionEventRow): api.SessionEvent {
     event: cbor.decode(row.event_cbor),
     createdAt: row.created_at,
   }
+}
+
+/** Collapses any value into a short single-line string for verbose server logs. */
+function summarizeForLog(value: unknown, maxLength = 600): string {
+  let text: string
+  if (typeof value === 'string') text = value
+  else if (value === undefined) text = ''
+  else {
+    try {
+      text = JSON.stringify(value)
+    } catch {
+      text = String(value)
+    }
+  }
+  text = text.replace(/\s+/g, ' ').trim()
+  return text.length > maxLength ? `${text.slice(0, maxLength)}…(+${text.length - maxLength} chars)` : text
+}
+
+/** Builds a compact one-line description of tool arguments for the live activity indicator. */
+function summarizeToolArgs(args: unknown): string | undefined {
+  if (!isRecord(args)) return typeof args === 'string' ? summarizeForLog(args, 80) : undefined
+  for (const key of ['id', 'url', 'query', 'path', 'command', 'name', 'title']) {
+    const value = args[key]
+    if (typeof value === 'string' && value.trim()) return summarizeForLog(value, 80)
+  }
+  return undefined
 }
 
 async function triggerPromptMessage(
@@ -2768,9 +2903,10 @@ async function resolveWriteSigner(
   const selected = matches[0]
   if (!selected) throw new APIError(400, 'Signing identity not found')
   const row = context.db
-    .query<{ciphertext: Uint8Array}, [string, string]>(
-      `SELECT ciphertext FROM secrets WHERE account_id = ? AND name = ?`,
-    )
+    .query<
+      {ciphertext: Uint8Array},
+      [string, string]
+    >(`SELECT ciphertext FROM secrets WHERE account_id = ? AND name = ?`)
     .get(context.accountId, selected.secretName)
   if (!row) throw new APIError(400, 'Signing identity secret not found')
   const keyPair = blobs.nobleKeyPairFromSeed(await decryptSecret(context.db, row.ciphertext))
@@ -2793,9 +2929,10 @@ async function listWriteSigningIdentities(
   const identities = []
   for (const secretName of deduped) {
     const row = db
-      .query<{metadata_cbor: Uint8Array | null}, [string, string]>(
-        `SELECT metadata_cbor FROM secrets WHERE account_id = ? AND name = ?`,
-      )
+      .query<
+        {metadata_cbor: Uint8Array | null},
+        [string, string]
+      >(`SELECT metadata_cbor FROM secrets WHERE account_id = ? AND name = ?`)
       .get(accountId, secretName)
     if (!row?.metadata_cbor) continue
     const metadata = cbor.decode<Record<string, unknown>>(row.metadata_cbor)
@@ -2822,9 +2959,10 @@ async function writeProfileUpdate(
   const published = await client.publish({blobs: [{cid: profile.cid.toString(), data: profile.data}]})
   const now = Date.now()
   const row = context.db
-    .query<{metadata_cbor: Uint8Array | null}, [string, string]>(
-      `SELECT metadata_cbor FROM secrets WHERE account_id = ? AND name = ?`,
-    )
+    .query<
+      {metadata_cbor: Uint8Array | null},
+      [string, string]
+    >(`SELECT metadata_cbor FROM secrets WHERE account_id = ? AND name = ?`)
     .get(context.accountId, signer.secretName)
   if (row?.metadata_cbor) {
     const metadata = cbor.decode<Record<string, unknown>>(row.metadata_cbor)

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -653,7 +653,7 @@ export class Service {
     this.#requireAgent(accountId, agentId)
     const rows = this.#db
       .query<AgentTriggerRow, [string, string]>(
-        `SELECT id, account_id, agent_id, name, enabled, source_cbor, prompt, cooldown_ms, created_at, updated_at,
+        `SELECT id, account_id, agent_id, name, enabled, source_cbor, prompt, created_at, updated_at,
                 last_checked_at, last_fired_at, last_error
          FROM agent_triggers
          WHERE account_id = ? AND agent_id = ?
@@ -700,8 +700,8 @@ export class Service {
     const now = Date.now()
     const id = crypto.randomUUID()
     this.#db.run(
-      `INSERT INTO agent_triggers (id, account_id, agent_id, name, enabled, source_cbor, prompt, cooldown_ms, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO agent_triggers (id, account_id, agent_id, name, enabled, source_cbor, prompt, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         id,
         accountId,
@@ -710,7 +710,6 @@ export class Service {
         trigger.enabled ? 1 : 0,
         cbor.encode(trigger.source),
         serializePromptBlocksForStorage(trigger.prompt),
-        trigger.cooldownMs ?? null,
         now,
         now,
       ],
@@ -729,24 +728,16 @@ export class Service {
     const existing = this.#getAgentTriggerInfo(accountId, triggerId)
     if (!existing) throw new APIError(404, 'Agent trigger not found')
     const patch = normalizeAgentTriggerPatch(rawPatch)
-    const nextSource = patch.source ?? existing.source
-    const cooldownMs =
-      nextSource.type === 'schedule'
-        ? undefined
-        : patch.cooldownMs === null
-          ? undefined
-          : (patch.cooldownMs ?? existing.cooldownMs)
-    const next: api.AgentTriggerInfo = {...existing, ...patch, cooldownMs, updatedAt: Date.now()}
+    const next: api.AgentTriggerInfo = {...existing, ...patch, updatedAt: Date.now()}
     this.#db.run(
       `UPDATE agent_triggers
-       SET name = ?, enabled = ?, source_cbor = ?, prompt = ?, cooldown_ms = ?, updated_at = ?, last_error = NULL
+       SET name = ?, enabled = ?, source_cbor = ?, prompt = ?, updated_at = ?, last_error = NULL
        WHERE account_id = ? AND id = ?`,
       [
         next.name,
         next.enabled ? 1 : 0,
         cbor.encode(next.source),
         serializePromptBlocksForStorage(next.prompt),
-        next.cooldownMs ?? null,
         next.updatedAt,
         accountId,
         triggerId,
@@ -1634,7 +1625,7 @@ export class Service {
   #getAgentTriggerInfo(accountId: string, triggerId: string): api.AgentTriggerInfo | null {
     const trigger = this.#db
       .query<AgentTriggerRow, [string, string]>(
-        `SELECT id, account_id, agent_id, name, enabled, source_cbor, prompt, cooldown_ms, created_at, updated_at,
+        `SELECT id, account_id, agent_id, name, enabled, source_cbor, prompt, created_at, updated_at,
                 last_checked_at, last_fired_at, last_error
          FROM agent_triggers WHERE account_id = ? AND id = ?`,
       )
@@ -1699,7 +1690,7 @@ export class Service {
   async processScheduledTriggers(now = Date.now()): Promise<TriggerProcessingResult> {
     const rows = this.#db
       .query<AgentTriggerRow, []>(
-        `SELECT id, account_id, agent_id, name, enabled, source_cbor, prompt, cooldown_ms, created_at, updated_at,
+        `SELECT id, account_id, agent_id, name, enabled, source_cbor, prompt, created_at, updated_at,
                 last_checked_at, last_fired_at, last_error
          FROM agent_triggers
          WHERE enabled = 1
@@ -1798,7 +1789,7 @@ export class Service {
     }
     const rows = this.#db
       .query<AgentTriggerRow, [string]>(
-        `SELECT id, account_id, agent_id, name, enabled, source_cbor, prompt, cooldown_ms, created_at, updated_at,
+        `SELECT id, account_id, agent_id, name, enabled, source_cbor, prompt, created_at, updated_at,
                 last_checked_at, last_fired_at, last_error
          FROM agent_triggers
          WHERE account_id = ? AND enabled = 1
@@ -1843,22 +1834,6 @@ export class Service {
           accountId,
           triggerId: trigger.id,
           activityKey,
-        })
-        skipped += 1
-        continue
-      }
-      if (trigger.cooldownMs && trigger.lastFiredAt && now - trigger.lastFiredAt < trigger.cooldownMs) {
-        this.#db.run(`UPDATE trigger_firings SET status = ? WHERE account_id = ? AND id = ?`, [
-          'skipped',
-          accountId,
-          firingId,
-        ])
-        console.log('[Agents Trigger] Skipping trigger firing during cooldown', {
-          accountId,
-          triggerId: trigger.id,
-          activityKey,
-          cooldownMs: trigger.cooldownMs,
-          lastFiredAt: trigger.lastFiredAt,
         })
         skipped += 1
         continue
@@ -1943,7 +1918,6 @@ type AgentTriggerRow = {
   enabled: number
   source_cbor: Uint8Array
   prompt: string
-  cooldown_ms: number | null
   created_at: number
   updated_at: number
   last_checked_at: number | null
@@ -2061,7 +2035,6 @@ function agentTriggerRowToInfo(row: AgentTriggerRow): api.AgentTriggerInfo {
     enabled: row.enabled !== 0,
     source: cbor.decode<api.AgentTriggerSource>(row.source_cbor),
     prompt: parseStoredPromptBlocks(row.prompt),
-    ...(row.cooldown_ms === null ? {} : {cooldownMs: row.cooldown_ms}),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     ...(row.last_checked_at === null ? {} : {lastCheckedAt: row.last_checked_at}),
@@ -2320,9 +2293,6 @@ function normalizeAgentTriggerInput(
     enabled: raw.enabled === undefined ? true : normalizeBoolean(raw.enabled, 'Trigger enabled'),
     source,
     prompt: normalizePromptBlocks(raw.prompt, 'Trigger prompt'),
-    ...(raw.cooldownMs === undefined || source.type === 'schedule'
-      ? {}
-      : {cooldownMs: normalizeOptionalPositiveInteger(raw.cooldownMs, 'Trigger cooldown')}),
   }
 }
 
@@ -2335,10 +2305,6 @@ function normalizeAgentTriggerPatch(
   if (raw.enabled !== undefined) patch.enabled = normalizeBoolean(raw.enabled, 'Trigger enabled')
   if (raw.source !== undefined) patch.source = normalizeAgentTriggerSource(raw.source)
   if (raw.prompt !== undefined) patch.prompt = normalizePromptBlocks(raw.prompt, 'Trigger prompt')
-  if (raw.cooldownMs !== undefined) {
-    patch.cooldownMs =
-      raw.cooldownMs === null ? null : normalizeOptionalPositiveInteger(raw.cooldownMs, 'Trigger cooldown')
-  }
   if (Object.keys(patch).length === 0) throw new APIError(400, 'Agent trigger patch is empty')
   return patch
 }

--- a/agents/src/auth.ts
+++ b/agents/src/auth.ts
@@ -35,9 +35,10 @@ export function verifyEnvelope(db: Database, envelope: api.SignedActionEnvelope)
 /** Returns whether a non-account signer has an AGENT authorization for the account. */
 export function isAuthorizedSigner(db: Database, accountId: string, signerId: string): boolean {
   const row = db
-    .query<{role: string}, [string, string]>(
-      `SELECT role FROM account_authorizations WHERE account_id = ? AND signer = ? LIMIT 1`,
-    )
+    .query<
+      {role: string},
+      [string, string]
+    >(`SELECT role FROM account_authorizations WHERE account_id = ? AND signer = ? LIMIT 1`)
     .get(accountId, signerId)
   return row?.role === 'AGENT' || row?.role === 'OWNER'
 }

--- a/agents/src/frontend/app.tsx
+++ b/agents/src/frontend/app.tsx
@@ -33,7 +33,6 @@ type TriggerInfo = {
   name: string
   enabled: boolean
   source: TriggerSource
-  cooldownMs?: number
   updatedAt: number
   lastCheckedAt?: number
   lastFiredAt?: number
@@ -364,7 +363,6 @@ function TriggerCard(props: {trigger: TriggerInfo}) {
         <span>
           {props.trigger.firingCount} firings
           {props.trigger.errorCount ? ` · ${props.trigger.errorCount} errors` : ''}
-          {props.trigger.cooldownMs ? ` · ${formatDuration(props.trigger.cooldownMs)} cooldown` : ''}
         </span>
         <span>{formatTime(props.trigger.lastFiringAt ?? props.trigger.lastFiredAt)}</span>
       </div>
@@ -537,12 +535,6 @@ function CodeBlock(props: {value: unknown}) {
 
 function formatTime(value?: number): string {
   return value ? dateFormatter.format(new Date(value)) : '—'
-}
-
-function formatDuration(ms: number): string {
-  if (ms >= 3_600_000) return `${Math.round(ms / 3_600_000)}h`
-  if (ms >= 60_000) return `${Math.round(ms / 60_000)}m`
-  return `${Math.round(ms / 1000)}s`
 }
 
 function formatUptime(value?: number): string {

--- a/agents/src/main.ts
+++ b/agents/src/main.ts
@@ -163,6 +163,8 @@ function summarizeWSEvent(event: api.AgentWSEvent): Record<string, unknown> {
       partialId: event.partialId,
       textDeltaBytes: event.patch.textDelta ? new TextEncoder().encode(event.patch.textDelta).byteLength : 0,
       done: event.patch.done === true,
+      activity: event.patch.activity?.phase,
+      totalTokens: event.patch.usage?.total,
     }
   }
   if (event._ === 'append') return {type: event._, key: event.key, seq: event.event.seq}
@@ -399,6 +401,10 @@ async function main(): Promise<void> {
         partialId: event.partialId,
         textDeltaBytes: event.textDelta ? new TextEncoder().encode(event.textDelta).byteLength : 0,
         done: event.done === true,
+        activity: event.activity
+          ? event.activity.phase + (event.activity.toolName ? `:${event.activity.toolName}` : '')
+          : undefined,
+        totalTokens: event.usage?.total,
         clients: clients.size,
       })
     }
@@ -415,7 +421,7 @@ async function main(): Promise<void> {
           _: 'appendPartial',
           key: `sessions/${event.sessionId}`,
           partialId: event.partialId,
-          patch: {textDelta: event.textDelta, done: event.done},
+          patch: {textDelta: event.textDelta, done: event.done, usage: event.usage, activity: event.activity},
         })
       } else if (event.type === 'session-change') {
         sendIfSubscribed(ws, `sessions/${event.session.id}`, {

--- a/agents/src/main.ts
+++ b/agents/src/main.ts
@@ -51,7 +51,6 @@ type AgentTriggerRow = {
   enabled: number
   source_cbor: Uint8Array | ArrayBuffer
   prompt: string
-  cooldown_ms: number | null
   created_at: number
   updated_at: number
   last_checked_at: number | null
@@ -218,7 +217,7 @@ function getDebugOverview(db: Database): {
     .all()
   const triggerRows = db
     .query<DebugTriggerRow, []>(
-      `SELECT t.id, t.account_id, t.agent_id, t.name, t.enabled, t.source_cbor, t.prompt, t.cooldown_ms,
+      `SELECT t.id, t.account_id, t.agent_id, t.name, t.enabled, t.source_cbor, t.prompt,
               t.created_at, t.updated_at, t.last_checked_at, t.last_fired_at, t.last_error,
               COUNT(f.id) AS firing_count,
               SUM(CASE WHEN f.status = 'error' THEN 1 ELSE 0 END) AS error_count,
@@ -310,7 +309,6 @@ function debugTriggerRowToInfo(row: DebugTriggerRow): DebugTrigger {
     enabled: row.enabled !== 0,
     source: cbor.decode<api.AgentTriggerSource>(toBytes(row.source_cbor)),
     prompt: row.prompt,
-    ...(row.cooldown_ms === null ? {} : {cooldownMs: row.cooldown_ms}),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     ...(row.last_checked_at === null ? {} : {lastCheckedAt: row.last_checked_at}),

--- a/frontend/apps/desktop/src/__tests__/agents-models.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/agents-models.test.tsx
@@ -126,6 +126,35 @@ describe('agent server models', () => {
     cleanupRendered(rendered.root, rendered.container, rendered.queryClient)
   })
 
+  it('seeds the configured server list with the built-in default in development', async () => {
+    process.env.NODE_ENV = 'development'
+
+    vi.resetModules()
+    const mod = await import('../models/agents')
+    const rendered = renderHook(() => mod.useAgentServerUrls())
+
+    await waitForCondition(() => rendered.result().data !== undefined)
+
+    expect(rendered.result().data).toEqual(['http://localhost:3050'])
+
+    cleanupRendered(rendered.root, rendered.container, rendered.queryClient)
+  })
+
+  it('does not re-seed the built-in default after the list is emptied in development', async () => {
+    process.env.NODE_ENV = 'development'
+    storeData['agent-server-urls'] = []
+
+    vi.resetModules()
+    const mod = await import('../models/agents')
+    const rendered = renderHook(() => mod.useAgentServerUrls())
+
+    await waitForCondition(() => rendered.result().data !== undefined)
+
+    expect(rendered.result().data).toEqual([])
+
+    cleanupRendered(rendered.root, rendered.container, rendered.queryClient)
+  })
+
   it('clears the stored default when the configured server list becomes empty', async () => {
     storeData['agent-server-url'] = 'http://localhost:3050'
     storeData['agent-server-urls'] = ['http://localhost:3050']

--- a/frontend/apps/desktop/src/__tests__/assistant-panel.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/assistant-panel.test.tsx
@@ -269,7 +269,7 @@ describe('AssistantPanel', () => {
     cleanupRendered(root, container)
   })
 
-  it('renders resource links for read tool bubbles', () => {
+  it('renders a user-facing read tool bubble', () => {
     mockState.chatSession = {
       providerId: 'provider-1',
       messages: [
@@ -300,12 +300,11 @@ describe('AssistantPanel', () => {
 
     const {container, root} = renderAssistantPanel()
     const openResourceButton = Array.from(container.querySelectorAll('button')).find(
-      (element) => element.textContent?.includes('Seed Notes in Seed'),
+      (element) => element.textContent === 'Seed Notes',
     )
 
-    expect(container.textContent).toContain('Read')
-    expect(container.textContent).toContain('Seed Notes in Seed')
-    expect(container.textContent).toContain('Read "Seed Notes".')
+    expect(container.textContent).toContain('Read document: Seed Notes')
+    expect(container.textContent).not.toContain('hm://z6Mkabc/projects/seed')
     expect(container.textContent).not.toContain('Project status and notes.')
 
     act(() => {
@@ -313,6 +312,15 @@ describe('AssistantPanel', () => {
     })
 
     expect(mockState.openUrl).toHaveBeenCalledWith('hm://z6Mkabc/projects/seed', false)
+
+    const expandButton = Array.from(container.querySelectorAll('button')).find(
+      (element) => element.getAttribute('title') === 'Show tool details',
+    )
+    act(() => {
+      expandButton?.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+    })
+
+    expect(container.textContent).toContain('Project status and notes.')
 
     cleanupRendered(root, container)
   })
@@ -368,7 +376,7 @@ describe('AssistantPanel', () => {
     })
 
     expect(mockState.openUrl).toHaveBeenCalledWith('hm://z6Mkdoc/spec/:comments/z6Mkdoc/spec/comment-1', false)
-    expect(mockState.openUrl).toHaveBeenCalledWith('hm://z6Mkauthor', false)
+    expect(mockState.openUrl).toHaveBeenCalledWith('hm://z6Mkauthor/:profile', false)
     expect(mockState.openUrl).toHaveBeenCalledWith('hm://z6Mkdoc/spec', false)
 
     const expandButton = Array.from(container.querySelectorAll('button')).find(
@@ -389,6 +397,107 @@ describe('AssistantPanel', () => {
 
     expect(document.body.textContent).toContain('Raw tool call payload captured during the assistant response.')
     expect(document.body.textContent).toContain('comment.create')
+
+    cleanupRendered(root, container)
+  })
+
+  it('renders the registry-defined document.create write UI', () => {
+    mockState.chatSession = {
+      providerId: 'provider-1',
+      messages: [
+        {
+          role: 'assistant',
+          content: '',
+          parts: [
+            {
+              type: 'tool',
+              id: 'tool-document',
+              name: 'write',
+              args: {
+                command: 'document.create',
+                input: {path: '/product-brief', name: 'Product Brief', body: '# Product Brief\n\nShip it.'},
+              },
+              result: 'document.create completed',
+              rawOutput: {
+                command: 'document.create',
+                id: 'hm://z6Mkdoc/product-brief',
+                signer: {profileName: 'Alice', publicKey: 'z6Mkauthor'},
+              },
+            },
+          ],
+          createdAt: '2026-03-18T00:00:00.000Z',
+        },
+      ],
+    }
+
+    const {container, root} = renderAssistantPanel()
+
+    expect(container.textContent).toContain('Create document: Product Brief')
+    expect(container.textContent).not.toContain('Write')
+    expect(container.textContent).not.toContain('document.create completed')
+
+    const documentButton = Array.from(container.querySelectorAll('button')).find(
+      (element) => element.textContent === 'Product Brief',
+    )
+
+    act(() => {
+      documentButton?.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+    })
+
+    expect(mockState.openUrl).toHaveBeenCalledWith('hm://z6Mkdoc/product-brief', false)
+
+    cleanupRendered(root, container)
+  })
+
+  it('renders the registry-defined document.update write UI with rendered content details', () => {
+    mockState.chatSession = {
+      providerId: 'provider-1',
+      messages: [
+        {
+          role: 'assistant',
+          content: '',
+          parts: [
+            {
+              type: 'tool',
+              id: 'tool-document-update',
+              name: 'write',
+              args: {
+                command: 'document.update',
+                input: {
+                  edit: 'hm://z6Mkdoc/product-brief',
+                  name: 'Product Brief',
+                  body: '# Product Brief\n\nUpdated plan.',
+                },
+              },
+              result: 'document.update completed',
+              rawOutput: {
+                command: 'document.update',
+                id: 'hm://z6Mkdoc/product-brief',
+                version: 'bafyupdate',
+              },
+            },
+          ],
+          createdAt: '2026-03-18T00:00:00.000Z',
+        },
+      ],
+    }
+
+    const {container, root} = renderAssistantPanel()
+
+    expect(container.textContent).toContain('Update document: Product Brief')
+    expect(container.textContent).not.toContain('document.update completed')
+    expect(container.textContent).not.toContain('Updated plan.')
+
+    const expandButton = Array.from(container.querySelectorAll('button')).find(
+      (element) => element.getAttribute('title') === 'Show tool details',
+    )
+    act(() => {
+      expandButton?.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+    })
+
+    expect(container.textContent).toContain('Updated plan.')
+    expect(container.textContent).not.toContain('"input"')
+    expect(container.textContent).not.toContain('"output"')
 
     cleanupRendered(root, container)
   })

--- a/frontend/apps/desktop/src/agents-client.ts
+++ b/frontend/apps/desktop/src/agents-client.ts
@@ -32,6 +32,10 @@ export type SessionEvent = AgentsProtocol.SessionEvent
 export type SessionEventPayload = AgentsProtocol.SessionEventPayload
 /** Server-sent WebSocket event after a signed subscription. */
 export type AgentWSEvent = AgentsProtocol.AgentWSEvent
+/** Cumulative token usage for the current agent run. */
+export type AgentRunUsage = AgentsProtocol.AgentRunUsage
+/** What the agent is actively doing right now. */
+export type AgentRunActivity = AgentsProtocol.AgentRunActivity
 /** Redacted provider metadata returned by the agents service. */
 export type ModelProviderInfo = AgentsProtocol.RedactedModelProvider
 /** Public model metadata returned by the agents service. */

--- a/frontend/apps/desktop/src/components/assistant-message-rendering.tsx
+++ b/frontend/apps/desktop/src/components/assistant-message-rendering.tsx
@@ -370,8 +370,40 @@ function getToolString(value: unknown, path: string): string | undefined {
 }
 
 function getToolCustomView(item: ChatToolPart) {
-  const command = getToolString(item.args, 'command')
+  const command = getToolString(item.args, 'command') || getToolString(item.rawOutput, 'command')
   return getSeedToolMetadata(item.name)?.render.customViews?.find((view) => view.command === command)
+}
+
+function getFirstToolString(value: unknown, paths: string[]): string | undefined {
+  for (const path of paths) {
+    const found = getToolString(value, path)
+    if (found) return found
+  }
+  return undefined
+}
+
+function getFirstToolValue(value: unknown, paths: string[]): unknown {
+  for (const path of paths) {
+    const found = getPathValues(value, path)[0]
+    if (found !== undefined) return found
+  }
+  return undefined
+}
+
+function isHMBlockNodeArray(value: unknown): value is HMBlockNode[] {
+  return Array.isArray(value) && value.every((item) => isRecord(item) && isRecord(item.block))
+}
+
+function parseToolBlocks(value: unknown, format?: string): HMBlockNode[] | undefined {
+  if (isHMBlockNodeArray(value)) return value
+  if (typeof value !== 'string' || format !== 'json') return undefined
+
+  try {
+    const parsed = JSON.parse(value)
+    return isHMBlockNodeArray(parsed) ? parsed : undefined
+  } catch {
+    return undefined
+  }
 }
 
 function buildCommentUrl(targetUrl: string, commentId: string): string {
@@ -390,55 +422,675 @@ function isCommentUrlForRecordId(value: string | undefined): value is string {
   return Boolean(value && /\/:comments\/[^/?#]+\/[^?#]+/.test(value))
 }
 
-function NewCommentSummary({item}: {item: ChatToolPart}) {
-  const output = item.rawOutput
-  const targetUrl = getToolString(output, 'targetUrl') || getToolString(output, 'target')
-  const commentRecordId = [getToolString(output, 'commentRecordId'), getToolString(output, 'commentId')].find(
-    isCommentRecordId,
+function commentInfoFromRecordId(recordId: string | undefined): {targetUrl: string; commentUrl: string} | undefined {
+  if (!isCommentRecordId(recordId)) return undefined
+  const normalized = recordId.replace(/^hm:\/\//, '')
+  const parts = normalized.split('/').filter(Boolean)
+  if (parts.length < 2) return undefined
+  const targetUrl = `hm://${parts.slice(0, -1).join('/')}`
+  return {targetUrl, commentUrl: buildCommentUrl(targetUrl, normalized)}
+}
+
+function buildProfileUrl(publicKey: string | undefined): string | undefined {
+  if (!publicKey) return undefined
+  if (publicKey.startsWith('hm://')) return publicKey
+  return `hm://${publicKey}/:profile`
+}
+
+function labelFromUrl(url: string | undefined, fallback = 'document'): string {
+  if (!url) return fallback
+  const normalized = url.replace(/^hm:\/\//, '').split(/[?#]/)[0]
+  const parts = normalized.split('/').filter(Boolean)
+  if (parts[1] === ':profile') return parts[0] || fallback
+  return parts.at(-1) || fallback
+}
+
+function getWriteCommand(item: ChatToolPart): string | undefined {
+  return getFirstToolString(item.args, ['command']) || getFirstToolString(item.rawOutput, ['command'])
+}
+
+function getWriteDocumentName(item: ChatToolPart, fallback = 'Untitled'): string {
+  return (
+    getFirstToolString(item.rawOutput, ['metadata.name', 'title']) ||
+    getFirstToolString(item.args, ['input.name', 'input.title', 'name', 'title', 'input.path', 'path']) ||
+    fallback
   )
-  const rawCommentUrl = getToolString(output, 'commentUrl')
-  const commentUrl = isCommentUrlForRecordId(rawCommentUrl)
-    ? rawCommentUrl
-    : targetUrl && commentRecordId
-      ? buildCommentUrl(targetUrl, commentRecordId)
-      : undefined
-  const authorPublicKey = getToolString(output, 'authorUrl') || getToolString(output, 'signer.publicKey')
-  const authorUrl = authorPublicKey?.startsWith('hm://')
-    ? authorPublicKey
-    : authorPublicKey
-      ? `hm://${authorPublicKey}`
-      : undefined
-  const authorName =
-    getToolString(output, 'authorName') || getToolString(output, 'signer.profileName') || authorPublicKey || 'Author'
-  const targetName = getToolString(output, 'targetName') || targetUrl || 'document'
+}
+
+function getWriteContent(item: ChatToolPart): {label: string; markdown?: string; blocks?: HMBlockNode[]} | undefined {
+  const command = getWriteCommand(item)
+  const label = command?.startsWith('comment.') ? 'Comment' : 'Content'
+  const outputMarkdown = getFirstToolString(item.rawOutput, ['markdown'])
+  if (outputMarkdown) return {label, markdown: outputMarkdown}
+
+  const format = getFirstToolString(item.args, ['input.format', 'format'])
+  const rawInputContent =
+    getFirstToolValue(item.args, ['input.body', 'input.text', 'body', 'text', 'input.content', 'content']) ??
+    getFirstToolValue(item.rawOutput, ['content'])
+  const blocks = parseToolBlocks(rawInputContent, format)
+  if (blocks) return {label, blocks}
+  if (typeof rawInputContent === 'string' && rawInputContent) return {label, markdown: rawInputContent}
+  return undefined
+}
+
+function getWriteMetadata(item: ChatToolPart): unknown {
+  return getFirstToolValue(item.rawOutput, ['metadata']) ?? getFirstToolValue(item.args, ['input.metadata', 'metadata'])
+}
+
+function getWritePrimaryDocumentUrl(item: ChatToolPart): string | undefined {
+  const command = getWriteCommand(item)
+  if (command === 'document.move') {
+    return (
+      getFirstToolString(item.rawOutput, ['destination', 'ref.id']) ||
+      getFirstToolString(item.args, [
+        'input.destination',
+        'input.destinationId',
+        'destination',
+        'destinationId',
+        'input.to',
+        'to',
+      ])
+    )
+  }
+  if (command === 'document.redirect') {
+    return (
+      getFirstToolString(item.rawOutput, ['target']) ||
+      getFirstToolString(item.args, ['input.to', 'to', 'input.target', 'target'])
+    )
+  }
+  if (command === 'draft.publish') {
+    return getFirstToolString(item.rawOutput, ['id'])
+  }
+  return (
+    getFirstToolString(item.rawOutput, ['url', 'resourceUrl', 'id', 'destination', 'target']) ||
+    getFirstToolString(item.args, ['input.edit', 'edit', 'input.id', 'id', 'input.target', 'target'])
+  )
+}
+
+function getWriteSourceDocumentUrl(item: ChatToolPart): string | undefined {
+  return (
+    getFirstToolString(item.rawOutput, ['redirect.id']) ||
+    getFirstToolString(item.args, ['input.source', 'input.sourceId', 'source', 'sourceId', 'input.id', 'id'])
+  )
+}
+
+function getWriteDestinationDocumentUrl(item: ChatToolPart): string | undefined {
+  return (
+    getFirstToolString(item.rawOutput, ['destination', 'ref.id', 'target']) ||
+    getFirstToolString(item.args, [
+      'input.destination',
+      'input.destinationId',
+      'destination',
+      'destinationId',
+      'input.to',
+      'to',
+      'input.target',
+      'target',
+    ])
+  )
+}
+
+function getCommentLinks(item: ChatToolPart) {
+  const output = item.rawOutput
+  const targetUrl = getFirstToolString(output, ['targetUrl', 'target'])
+  const commentRecordId = [
+    getFirstToolString(output, ['commentUrl']),
+    getFirstToolString(output, ['commentRecordId', 'commentId']),
+    getFirstToolString(item.args, ['input.comment', 'input.commentId', 'comment', 'commentId']),
+  ]
+  const rawCommentUrl = isCommentUrlForRecordId(commentRecordId[0]) ? commentRecordId[0] : undefined
+  const fallbackRecord = commentInfoFromRecordId(commentRecordId[1]) || commentInfoFromRecordId(commentRecordId[2])
+  const commentUrl =
+    rawCommentUrl ||
+    (targetUrl && isCommentRecordId(commentRecordId[1])
+      ? buildCommentUrl(targetUrl, commentRecordId[1])
+      : fallbackRecord?.commentUrl)
+  const resolvedTargetUrl = targetUrl || fallbackRecord?.targetUrl
+  return {commentUrl, targetUrl: resolvedTargetUrl}
+}
+
+function ToolDetailSection({label, children}: {label: string; children: React.ReactNode}) {
+  return (
+    <div className="space-y-1.5">
+      <div className="text-muted-foreground text-[10px] font-medium tracking-[0.18em] uppercase">{label}</div>
+      {children}
+    </div>
+  )
+}
+
+function ToolDetailCard({children}: {children: React.ReactNode}) {
+  return <div className="bg-background/60 text-foreground rounded-md border px-2.5 py-2">{children}</div>
+}
+
+function ToolDetailList({children}: {children: React.ReactNode}) {
+  return <div className="grid gap-1.5 sm:grid-cols-2">{children}</div>
+}
+
+function ToolDetailItem({label, children}: {label: string; children: React.ReactNode}) {
+  return (
+    <div className="min-w-0 space-y-0.5">
+      <div className="text-muted-foreground text-[10px]">{label}</div>
+      <div className="min-w-0 text-[12px] break-words">{children}</div>
+    </div>
+  )
+}
+
+function ToolEntityText({url, label}: {url?: string; label: string}) {
+  return url ? <ToolTextLink url={url}>{label}</ToolTextLink> : <span>{label}</span>
+}
+
+function ToolRenderedContent({content}: {content: {markdown?: string; blocks?: HMBlockNode[]}}) {
+  if (content.blocks?.length) {
+    return (
+      <div className="text-foreground rounded-md bg-transparent px-1 py-0.5 [&_.ProseMirror]:!bg-transparent [&_.bn-container]:!bg-transparent [&_.bn-editor]:!bg-transparent [&_.hm-prose]:!font-sans [&_.hm-prose]:!text-base">
+        <Suspense fallback={<pre className="text-[11px] whitespace-pre-wrap">Loading rich content…</pre>}>
+          <RichMessageBlocks blocks={content.blocks} />
+        </Suspense>
+      </div>
+    )
+  }
+
+  return <Markdown>{content.markdown || ''}</Markdown>
+}
+
+function ReadToolSummary({item}: {item: ChatToolPart}) {
+  const output = item.rawOutput
+  const resourceUrl = getFirstToolString(output, ['resourceUrl', 'id']) || getFirstToolString(item.args, ['id'])
+  const title =
+    getFirstToolString(output, ['title', 'displayLabel']) ||
+    getFirstToolString(item.args, ['id']) ||
+    labelFromUrl(resourceUrl, 'Document')
 
   return (
     <span className="text-foreground/80 min-w-0 truncate">
-      {commentUrl ? (
-        <ToolTextLink url={commentUrl}>New Comment</ToolTextLink>
-      ) : (
-        <span className="font-medium">New Comment</span>
-      )}{' '}
-      by {authorUrl ? <ToolTextLink url={authorUrl}>{authorName}</ToolTextLink> : <span>{authorName}</span>} on{' '}
-      {targetUrl ? <ToolTextLink url={targetUrl}>{targetName}</ToolTextLink> : <span>{targetName}</span>}
+      <span className="font-medium">Read document:</span> <ToolEntityText url={resourceUrl} label={title} />
     </span>
   )
 }
 
-function NewCommentDetails({item}: {item: ChatToolPart}) {
-  const markdown =
-    getToolString(item.rawOutput, 'markdown') ||
-    getToolString(item.args, 'input.body') ||
-    getToolString(item.args, 'input.content') ||
-    getToolString(item.args, 'body') ||
-    getToolString(item.args, 'content')
+function ReadToolDetails({item}: {item: ChatToolPart}) {
+  const output = item.rawOutput
+  const resourceUrl = getFirstToolString(output, ['resourceUrl', 'id']) || getFirstToolString(item.args, ['id'])
+  const requestedUrl = getFirstToolString(output, ['requestedId']) || getFirstToolString(item.args, ['id'])
+  const title = getFirstToolString(output, ['title', 'displayLabel']) || labelFromUrl(resourceUrl, 'Document')
+  const server = getFirstToolString(output, ['server'])
+  const markdown = getFirstToolString(output, ['markdown'])
 
   return (
-    <div className="space-y-1">
-      <div className="text-muted-foreground text-[10px] font-medium tracking-[0.18em] uppercase">Comment</div>
-      <div className="bg-background/60 text-foreground max-h-72 overflow-auto rounded-md border px-2.5 py-2">
-        <Markdown>{markdown || item.result || ''}</Markdown>
-      </div>
+    <div className="space-y-3">
+      <ToolDetailSection label="Document">
+        <ToolDetailCard>
+          <ToolDetailList>
+            <ToolDetailItem label="Title">
+              <ToolEntityText url={resourceUrl} label={title} />
+            </ToolDetailItem>
+            {server ? <ToolDetailItem label="Server">{server}</ToolDetailItem> : null}
+            {requestedUrl && requestedUrl !== resourceUrl ? (
+              <ToolDetailItem label="Requested">{requestedUrl}</ToolDetailItem>
+            ) : null}
+          </ToolDetailList>
+        </ToolDetailCard>
+      </ToolDetailSection>
+      {markdown ? (
+        <ToolDetailSection label="Content">
+          <ToolDetailCard>
+            <div className="max-h-72 overflow-auto">
+              <Markdown>{markdown}</Markdown>
+            </div>
+          </ToolDetailCard>
+        </ToolDetailSection>
+      ) : null}
+    </div>
+  )
+}
+
+function WriteCommandSummary({item}: {item: ChatToolPart}) {
+  const command = getWriteCommand(item)
+  const output = item.rawOutput
+  const documentUrl = getWritePrimaryDocumentUrl(item)
+  const documentName = getWriteDocumentName(item, labelFromUrl(documentUrl, 'Untitled'))
+  const sourceUrl = getWriteSourceDocumentUrl(item)
+  const destinationUrl = getWriteDestinationDocumentUrl(item)
+  const sourceName = labelFromUrl(sourceUrl, 'source')
+  const destinationName = labelFromUrl(destinationUrl, 'destination')
+  const draftTitle =
+    getFirstToolString(output, ['title']) || getFirstToolString(item.args, ['input.name', 'name']) || 'Untitled'
+  const draftId =
+    getFirstToolString(output, ['draftId']) ||
+    getFirstToolString(item.args, ['input.draftId', 'draftId', 'input.draft', 'draft'])
+  const profileName =
+    getFirstToolString(output, ['profile.name', 'signer.profileName']) ||
+    getFirstToolString(item.args, ['input.name', 'name']) ||
+    'Profile'
+  const profilePublicKey = getFirstToolString(output, ['profile.publicKey', 'signer.publicKey'])
+  const profileUrl = buildProfileUrl(profilePublicKey)
+  const alias =
+    getFirstToolString(output, ['alias']) || getFirstToolString(item.args, ['input.alias', 'alias']) || 'alias'
+  const contactName =
+    getFirstToolString(output, ['name']) || getFirstToolString(item.args, ['input.name', 'name']) || 'Contact'
+  const contactSubject =
+    getFirstToolString(output, ['subject']) || getFirstToolString(item.args, ['input.subject', 'subject'])
+  const contactSubjectUrl = buildProfileUrl(contactSubject)
+  const capabilityRole =
+    getFirstToolString(output, ['role']) || getFirstToolString(item.args, ['input.role', 'role']) || 'Capability'
+  const capabilityDelegate =
+    getFirstToolString(output, ['delegate']) ||
+    getFirstToolString(item.args, ['input.delegate', 'delegate', 'input.delegateUid', 'delegateUid'])
+  const capabilityDelegateUrl = buildProfileUrl(capabilityDelegate)
+  const {commentUrl, targetUrl} = getCommentLinks(item)
+  const authorPublicKey = getFirstToolString(output, ['authorUrl', 'signer.publicKey'])
+  const authorUrl = authorPublicKey?.startsWith('hm://') ? authorPublicKey : buildProfileUrl(authorPublicKey)
+  const authorName = getFirstToolString(output, ['authorName', 'signer.profileName']) || authorPublicKey || 'Author'
+  const targetName = getFirstToolString(output, ['targetName']) || labelFromUrl(targetUrl, 'document')
+
+  switch (command) {
+    case 'comment.create':
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          {commentUrl ? (
+            <ToolTextLink url={commentUrl}>New Comment</ToolTextLink>
+          ) : (
+            <span className="font-medium">New Comment</span>
+          )}{' '}
+          by <ToolEntityText url={authorUrl} label={authorName} /> on{' '}
+          <ToolEntityText url={targetUrl} label={targetName} />
+        </span>
+      )
+    case 'comment.update':
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          <span className="font-medium">Update comment</span>
+          {targetUrl ? (
+            <>
+              {' '}
+              on <ToolEntityText url={targetUrl} label={targetName} />
+            </>
+          ) : null}
+        </span>
+      )
+    case 'comment.delete':
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          <span className="font-medium">Delete comment</span>
+          {targetUrl ? (
+            <>
+              {' '}
+              on <ToolEntityText url={targetUrl} label={targetName} />
+            </>
+          ) : null}
+        </span>
+      )
+    case 'document.create':
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          <span className="font-medium">Create document:</span>{' '}
+          <ToolEntityText url={documentUrl} label={documentName} />
+        </span>
+      )
+    case 'document.update':
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          <span className="font-medium">Update document:</span>{' '}
+          <ToolEntityText url={documentUrl} label={documentName} />
+        </span>
+      )
+    case 'document.delete':
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          <span className="font-medium">Delete document:</span>{' '}
+          <ToolEntityText url={documentUrl} label={documentName} />
+        </span>
+      )
+    case 'document.fork':
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          <span className="font-medium">Copy document:</span>{' '}
+          <ToolEntityText url={destinationUrl || documentUrl} label={destinationName} />
+        </span>
+      )
+    case 'document.ref':
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          <span className="font-medium">Reference document:</span>{' '}
+          <ToolEntityText url={destinationUrl || documentUrl} label={destinationName} />
+        </span>
+      )
+    case 'document.move':
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          <span className="font-medium">Move document:</span> <ToolEntityText url={sourceUrl} label={sourceName} /> →{' '}
+          <ToolEntityText url={destinationUrl} label={destinationName} />
+        </span>
+      )
+    case 'document.redirect':
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          <span className="font-medium">Redirect document:</span> <ToolEntityText url={sourceUrl} label={sourceName} />{' '}
+          → <ToolEntityText url={destinationUrl} label={destinationName} />
+        </span>
+      )
+    case 'draft.create':
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          <span className="font-medium">Create draft:</span> {draftTitle}
+        </span>
+      )
+    case 'draft.update':
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          <span className="font-medium">Update draft:</span> {draftTitle}
+        </span>
+      )
+    case 'draft.get':
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          <span className="font-medium">Open draft:</span> {draftTitle}
+        </span>
+      )
+    case 'draft.list':
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          <span className="font-medium">List drafts</span>
+        </span>
+      )
+    case 'draft.delete':
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          <span className="font-medium">Delete draft:</span> {draftTitle || draftId || 'Draft'}
+        </span>
+      )
+    case 'draft.publish':
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          <span className="font-medium">Publish draft:</span> {draftTitle}
+          {documentUrl ? (
+            <>
+              {' '}
+              → <ToolEntityText url={documentUrl} label={documentName} />
+            </>
+          ) : null}
+        </span>
+      )
+    case 'profile.update':
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          <span className="font-medium">Update profile:</span> <ToolEntityText url={profileUrl} label={profileName} />
+        </span>
+      )
+    case 'profile.alias':
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          <span className="font-medium">Alias profile:</span> {alias}
+        </span>
+      )
+    case 'contact.create':
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          <span className="font-medium">Create contact:</span>{' '}
+          <ToolEntityText url={contactSubjectUrl} label={contactName} />
+        </span>
+      )
+    case 'contact.delete':
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          <span className="font-medium">Delete contact:</span> {contactName}
+        </span>
+      )
+    case 'capability.create':
+    case 'capability.grant':
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          <span className="font-medium">Grant {capabilityRole} capability</span>
+          {capabilityDelegate ? (
+            <>
+              {' '}
+              to <ToolEntityText url={capabilityDelegateUrl} label={capabilityDelegate} />
+            </>
+          ) : null}
+        </span>
+      )
+    default:
+      return (
+        <span className="text-foreground/80 min-w-0 truncate">
+          <span className="font-medium">{command || 'Write'}</span>
+          {documentUrl ? (
+            <>
+              : <ToolEntityText url={documentUrl} label={documentName} />
+            </>
+          ) : null}
+        </span>
+      )
+  }
+}
+
+function WriteCommandDetails({item}: {item: ChatToolPart}) {
+  const command = getWriteCommand(item)
+  const content = getWriteContent(item)
+  const metadata = getWriteMetadata(item)
+  const output = item.rawOutput
+  const warning = getFirstToolString(output, ['warning'])
+  const dryRun = getFirstToolValue(output, ['dryRun']) === true
+  const documentUrl = getWritePrimaryDocumentUrl(item)
+  const documentName = getWriteDocumentName(item, labelFromUrl(documentUrl, 'Untitled'))
+  const sourceUrl = getWriteSourceDocumentUrl(item)
+  const destinationUrl = getWriteDestinationDocumentUrl(item)
+  const sourceName = labelFromUrl(sourceUrl, 'source')
+  const destinationName = labelFromUrl(destinationUrl, 'destination')
+  const draftId =
+    getFirstToolString(output, ['draftId']) ||
+    getFirstToolString(item.args, ['input.draftId', 'draftId', 'input.draft', 'draft'])
+  const draftTitle =
+    getFirstToolString(output, ['title']) || getFirstToolString(item.args, ['input.name', 'name']) || 'Untitled'
+  const profileName =
+    getFirstToolString(output, ['profile.name', 'signer.profileName']) ||
+    getFirstToolString(item.args, ['input.name', 'name']) ||
+    'Profile'
+  const profilePublicKey = getFirstToolString(output, ['profile.publicKey', 'signer.publicKey'])
+  const profileUrl = buildProfileUrl(profilePublicKey)
+  const alias = getFirstToolString(output, ['alias']) || getFirstToolString(item.args, ['input.alias', 'alias'])
+  const contactId =
+    getFirstToolString(output, ['contactId']) || getFirstToolString(item.args, ['input.contactId', 'contactId'])
+  const contactName =
+    getFirstToolString(output, ['name']) || getFirstToolString(item.args, ['input.name', 'name']) || 'Contact'
+  const contactSubject =
+    getFirstToolString(output, ['subject']) || getFirstToolString(item.args, ['input.subject', 'subject'])
+  const contactSubjectUrl = buildProfileUrl(contactSubject)
+  const capabilityRole = getFirstToolString(output, ['role']) || getFirstToolString(item.args, ['input.role', 'role'])
+  const capabilityDelegate =
+    getFirstToolString(item.args, ['input.delegate', 'delegate', 'input.delegateUid', 'delegateUid']) ||
+    getFirstToolString(output, ['delegate'])
+  const capabilityDelegateUrl = buildProfileUrl(capabilityDelegate)
+  const capabilityPath = getFirstToolString(output, ['path']) || getFirstToolString(item.args, ['input.path', 'path'])
+  const capabilityLabel =
+    getFirstToolString(output, ['label']) || getFirstToolString(item.args, ['input.label', 'label'])
+  const version = getFirstToolString(output, ['version'])
+  const status = getFirstToolString(output, ['status'])
+  const {commentUrl, targetUrl} = getCommentLinks(item)
+  const targetName = getFirstToolString(output, ['targetName']) || labelFromUrl(targetUrl, 'document')
+  const authorPublicKey = getFirstToolString(output, ['authorUrl', 'signer.publicKey'])
+  const authorUrl = authorPublicKey?.startsWith('hm://') ? authorPublicKey : buildProfileUrl(authorPublicKey)
+  const authorName = getFirstToolString(output, ['authorName', 'signer.profileName']) || authorPublicKey || 'Author'
+  const drafts = getPathValues(output, 'drafts[]').filter((draft) => isRecord(draft)) as Record<string, unknown>[]
+
+  return (
+    <div className="space-y-3">
+      {dryRun || warning ? (
+        <ToolDetailSection label="Status">
+          <ToolDetailCard>
+            <div className="flex flex-wrap items-center gap-2 text-[12px]">
+              {dryRun ? <ToolChip>Dry run</ToolChip> : null}
+              {status ? <ToolChip>{status}</ToolChip> : null}
+              {warning ? <span className="text-amber-700 dark:text-amber-300">{warning}</span> : null}
+            </div>
+          </ToolDetailCard>
+        </ToolDetailSection>
+      ) : null}
+
+      {command === 'comment.create' || command === 'comment.update' || command === 'comment.delete' ? (
+        <ToolDetailSection label="Comment">
+          <ToolDetailCard>
+            <ToolDetailList>
+              <ToolDetailItem label="Comment">
+                {commentUrl ? <ToolTextLink url={commentUrl}>{commentUrl}</ToolTextLink> : 'Comment thread'}
+              </ToolDetailItem>
+              <ToolDetailItem label="Document">
+                <ToolEntityText url={targetUrl} label={targetName} />
+              </ToolDetailItem>
+              {command === 'comment.create' ? (
+                <ToolDetailItem label="Author">
+                  <ToolEntityText url={authorUrl} label={authorName} />
+                </ToolDetailItem>
+              ) : null}
+            </ToolDetailList>
+          </ToolDetailCard>
+        </ToolDetailSection>
+      ) : null}
+
+      {command === 'document.create' || command === 'document.update' || command === 'document.delete' ? (
+        <ToolDetailSection label="Document">
+          <ToolDetailCard>
+            <ToolDetailList>
+              <ToolDetailItem label="Document">
+                <ToolEntityText url={documentUrl} label={documentName} />
+              </ToolDetailItem>
+              {version ? <ToolDetailItem label="Version">{version}</ToolDetailItem> : null}
+            </ToolDetailList>
+          </ToolDetailCard>
+        </ToolDetailSection>
+      ) : null}
+
+      {command === 'document.fork' ||
+      command === 'document.ref' ||
+      command === 'document.move' ||
+      command === 'document.redirect' ? (
+        <ToolDetailSection label="Document change">
+          <ToolDetailCard>
+            <ToolDetailList>
+              {sourceUrl ? (
+                <ToolDetailItem label="Source">
+                  <ToolEntityText url={sourceUrl} label={sourceName} />
+                </ToolDetailItem>
+              ) : null}
+              {destinationUrl ? (
+                <ToolDetailItem label={command === 'document.redirect' ? 'Target' : 'Destination'}>
+                  <ToolEntityText url={destinationUrl} label={destinationName} />
+                </ToolDetailItem>
+              ) : null}
+              {version ? <ToolDetailItem label="Version">{version}</ToolDetailItem> : null}
+            </ToolDetailList>
+          </ToolDetailCard>
+        </ToolDetailSection>
+      ) : null}
+
+      {command === 'draft.create' ||
+      command === 'draft.update' ||
+      command === 'draft.get' ||
+      command === 'draft.delete' ||
+      command === 'draft.publish' ? (
+        <ToolDetailSection label="Draft">
+          <ToolDetailCard>
+            <ToolDetailList>
+              <ToolDetailItem label="Title">{draftTitle}</ToolDetailItem>
+              {draftId ? <ToolDetailItem label="Draft ID">{draftId}</ToolDetailItem> : null}
+              {documentUrl && command === 'draft.publish' ? (
+                <ToolDetailItem label="Published document">
+                  <ToolEntityText url={documentUrl} label={documentName} />
+                </ToolDetailItem>
+              ) : null}
+              {status ? <ToolDetailItem label="Status">{status}</ToolDetailItem> : null}
+            </ToolDetailList>
+          </ToolDetailCard>
+        </ToolDetailSection>
+      ) : null}
+
+      {command === 'draft.list' && drafts.length ? (
+        <ToolDetailSection label="Drafts">
+          <div className="space-y-2">
+            {drafts.map((draft) => (
+              <ToolDetailCard key={String(draft.id || draft.title || Math.random())}>
+                <ToolDetailList>
+                  <ToolDetailItem label="Title">
+                    {typeof draft.title === 'string' && draft.title ? draft.title : 'Untitled draft'}
+                  </ToolDetailItem>
+                  <ToolDetailItem label="Status">
+                    {typeof draft.status === 'string' ? draft.status : 'idle'}
+                  </ToolDetailItem>
+                  {typeof draft.edit_target === 'string' && draft.edit_target ? (
+                    <ToolDetailItem label="Edit target">{draft.edit_target}</ToolDetailItem>
+                  ) : null}
+                  {typeof draft.location_target === 'string' && draft.location_target ? (
+                    <ToolDetailItem label="Location">{draft.location_target}</ToolDetailItem>
+                  ) : null}
+                </ToolDetailList>
+              </ToolDetailCard>
+            ))}
+          </div>
+        </ToolDetailSection>
+      ) : null}
+
+      {command === 'profile.update' || command === 'profile.alias' ? (
+        <ToolDetailSection label="Profile">
+          <ToolDetailCard>
+            <ToolDetailList>
+              <ToolDetailItem label="Profile">
+                <ToolEntityText url={profileUrl} label={profileName} />
+              </ToolDetailItem>
+              {alias ? <ToolDetailItem label="Alias">{alias}</ToolDetailItem> : null}
+            </ToolDetailList>
+          </ToolDetailCard>
+        </ToolDetailSection>
+      ) : null}
+
+      {command === 'contact.create' || command === 'contact.delete' ? (
+        <ToolDetailSection label="Contact">
+          <ToolDetailCard>
+            <ToolDetailList>
+              <ToolDetailItem label="Contact">{contactName}</ToolDetailItem>
+              {contactSubject ? (
+                <ToolDetailItem label="Profile">
+                  <ToolEntityText url={contactSubjectUrl} label={contactSubject} />
+                </ToolDetailItem>
+              ) : null}
+              {contactId ? <ToolDetailItem label="Contact ID">{contactId}</ToolDetailItem> : null}
+            </ToolDetailList>
+          </ToolDetailCard>
+        </ToolDetailSection>
+      ) : null}
+
+      {command === 'capability.create' || command === 'capability.grant' ? (
+        <ToolDetailSection label="Capability">
+          <ToolDetailCard>
+            <ToolDetailList>
+              {capabilityRole ? <ToolDetailItem label="Role">{capabilityRole}</ToolDetailItem> : null}
+              {capabilityDelegate ? (
+                <ToolDetailItem label="Delegate">
+                  <ToolEntityText url={capabilityDelegateUrl} label={capabilityDelegate} />
+                </ToolDetailItem>
+              ) : null}
+              {capabilityPath ? <ToolDetailItem label="Path">{capabilityPath}</ToolDetailItem> : null}
+              {capabilityLabel ? <ToolDetailItem label="Label">{capabilityLabel}</ToolDetailItem> : null}
+            </ToolDetailList>
+          </ToolDetailCard>
+        </ToolDetailSection>
+      ) : null}
+
+      {content ? (
+        <ToolDetailSection label={content.label}>
+          <ToolDetailCard>
+            <div className="max-h-72 overflow-auto">
+              <ToolRenderedContent content={content} />
+            </div>
+          </ToolDetailCard>
+        </ToolDetailSection>
+      ) : null}
+
+      {metadata && isRecord(metadata) && Object.keys(metadata).length > 0 ? (
+        <ToolDetailSection label="Metadata">
+          <pre className="bg-background/60 text-foreground max-h-72 overflow-auto rounded-md border p-2 text-[11px] whitespace-pre-wrap">
+            {formatToolDebugValue(metadata)}
+          </pre>
+        </ToolDetailSection>
+      ) : null}
     </div>
   )
 }
@@ -490,8 +1142,10 @@ function ToolCallLine({item}: {item: ChatToolPart}) {
             {expanded ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
           </button>
           {isPending ? <Loader2 className="size-3 shrink-0 animate-spin" /> : <Icon className="size-3 shrink-0" />}
-          {customView?.kind === 'new-comment' ? (
-            <NewCommentSummary item={item} />
+          {item.name === 'read' ? (
+            <ReadToolSummary item={item} />
+          ) : customView?.kind === 'write-command' ? (
+            <WriteCommandSummary item={item} />
           ) : (
             <>
               <span className="shrink-0 font-medium">{render?.label || item.name}</span>
@@ -504,6 +1158,7 @@ function ToolCallLine({item}: {item: ChatToolPart}) {
             </>
           )}
           {isPending ? <ToolChip>{render?.pendingLabel || 'Running'}</ToolChip> : null}
+          {getFirstToolValue(item.rawOutput, ['dryRun']) === true ? <ToolChip>Dry run</ToolChip> : null}
           <button
             type="button"
             title="View raw tool input/output"
@@ -515,8 +1170,10 @@ function ToolCallLine({item}: {item: ChatToolPart}) {
         </div>
         {expanded ? (
           <div className="mt-2 space-y-2 border-t pt-2">
-            {customView?.kind === 'new-comment' ? (
-              <NewCommentDetails item={item} />
+            {item.name === 'read' ? (
+              <ReadToolDetails item={item} />
+            ) : customView?.kind === 'write-command' ? (
+              <WriteCommandDetails item={item} />
             ) : (
               details.map((detail) => (
                 <div key={`${detail.label}:${detail.path || detail.source}`} className="space-y-1">

--- a/frontend/apps/desktop/src/models/agents.ts
+++ b/frontend/apps/desktop/src/models/agents.ts
@@ -8,6 +8,8 @@ import {
   type AgentDefinition,
   type AgentInfo,
   type AgentMessageBlock,
+  type AgentRunActivity,
+  type AgentRunUsage,
   type AgentTriggerInput,
   type AgentTriggerPatch,
   type AgentWSEvent,
@@ -653,14 +655,26 @@ export function useStopAgentSession(serverUrl: string | undefined, accountUid: s
   })
 }
 
+/** Live, in-flight state for one agent session streamed over the WebSocket. */
+export type AgentSessionLiveState = {
+  /** Assistant text streamed so far for the current (uncommitted) partial. */
+  text: string
+  /** Cumulative token usage for the current run, if reported. */
+  usage?: AgentRunUsage
+  /** What the agent is doing right now, if reported. */
+  activity?: AgentRunActivity
+}
+
+const EMPTY_SESSION_LIVE_STATE: AgentSessionLiveState = {text: ''}
+
 /** Subscribes to signed agent-server WebSocket updates and refreshes cached data. */
 export function useAgentWebSocketSubscription(
   serverUrl: string | undefined,
   accountUid: string | null | undefined,
   key: `account/${string}` | `agents/${string}` | `sessions/${string}` | undefined,
   afterSeq?: number,
-) {
-  const [partials, setPartials] = useState<Record<string, string>>({})
+): AgentSessionLiveState {
+  const [partials, setPartials] = useState<Record<string, AgentSessionLiveState>>({})
 
   useEffect(() => {
     if (!serverUrl || !accountUid || !key) return
@@ -713,10 +727,12 @@ export function useAgentWebSocketSubscription(
               log('append event', {sessionId: event.event.sessionId, seq: event.event.seq})
               const eventPayload = event.event.event as {type?: string; role?: string; content?: string}
               if (eventPayload.type === 'message' && eventPayload.role === 'assistant') {
+                // The streamed text is now a durable message, but the run may continue
+                // (more turns after tool calls), so keep usage/activity until idle.
                 setPartials((current) => {
-                  const next = {...current}
-                  delete next[event.event.sessionId]
-                  return next
+                  const existing = current[event.event.sessionId]
+                  if (!existing) return current
+                  return {...current, [event.event.sessionId]: {...existing, text: ''}}
                 })
               }
               const sessionId = event.event.sessionId
@@ -748,20 +764,28 @@ export function useAgentWebSocketSubscription(
                 partialId: event.partialId,
                 textDeltaLength,
                 done: event.patch.done === true,
+                activity: event.patch.activity?.phase,
+                totalTokens: event.patch.usage?.total,
               })
               setPartials((current) => {
-                const existing = current[sessionId] || ''
+                const existing = current[sessionId] ?? EMPTY_SESSION_LIVE_STATE
+                // Usage and activity updates always apply, even on the `done` patch.
+                const next: AgentSessionLiveState = {
+                  ...existing,
+                  ...(event.patch.usage ? {usage: event.patch.usage} : {}),
+                  ...(event.patch.activity ? {activity: event.patch.activity} : {}),
+                }
                 if (event.patch.done) {
                   log('partial marked done; keeping visible until durable append', {
                     sessionId,
                     partialId: event.partialId,
-                    totalLength: existing.length,
+                    totalLength: existing.text.length,
                   })
-                  return current
+                  return {...current, [sessionId]: next}
                 }
-                const nextText = existing + (event.patch.textDelta || '')
-                log('partial state updated', {sessionId, partialId: event.partialId, totalLength: nextText.length})
-                return {...current, [sessionId]: nextText}
+                next.text = existing.text + (event.patch.textDelta || '')
+                log('partial state updated', {sessionId, partialId: event.partialId, totalLength: next.text.length})
+                return {...current, [sessionId]: next}
               })
             } else if (event._ === 'error') {
               log('server error event', {message: event.message})
@@ -800,8 +824,8 @@ export function useAgentWebSocketSubscription(
     }
   }, [serverUrl, accountUid, key])
 
-  if (!key?.startsWith('sessions/')) return ''
-  return partials[key.slice('sessions/'.length)] || ''
+  if (!key?.startsWith('sessions/')) return EMPTY_SESSION_LIVE_STATE
+  return partials[key.slice('sessions/'.length)] ?? EMPTY_SESSION_LIVE_STATE
 }
 
 /** Adds an optimistic user message to the cached session while the signed request is in flight. */

--- a/frontend/apps/desktop/src/models/agents.ts
+++ b/frontend/apps/desktop/src/models/agents.ts
@@ -225,7 +225,11 @@ export function useProviderModels(
       return res.models
     },
     enabled: !!serverUrl && !!accountUid && !!provider,
-    staleTime: 5 * 60 * 1000,
+    // Provider model catalogs change rarely, so keep them fresh for a while and
+    // retain them in cache across dialog open/close so reopening a model
+    // dropdown is instant instead of re-fetching the full list every time.
+    staleTime: 60 * 60 * 1000,
+    cacheTime: 24 * 60 * 60 * 1000,
     retry: false,
     useErrorBoundary: false,
   })

--- a/frontend/apps/desktop/src/models/agents.ts
+++ b/frontend/apps/desktop/src/models/agents.ts
@@ -63,6 +63,13 @@ export function useAgentServerUrls() {
         const normalized = tryNormalizeAgentServerUrl(storedDefault)
         if (normalized) urls.add(normalized)
       }
+      // In local development, seed the list with the built-in default the first
+      // time the app runs so there is a server to connect to out of the box.
+      // Once the list has been configured (even to empty), respect that choice
+      // so removing the last server still sticks.
+      if (urls.size === 0 && !Array.isArray(storedList) && process.env.NODE_ENV === 'development') {
+        urls.add(DEFAULT_AGENT_SERVER_URL)
+      }
       return Array.from(urls)
     },
     useErrorBoundary: false,

--- a/frontend/apps/desktop/src/pages/agents/__tests__/model-utils.test.ts
+++ b/frontend/apps/desktop/src/pages/agents/__tests__/model-utils.test.ts
@@ -1,0 +1,83 @@
+import {describe, expect, it} from 'vitest'
+import {canonicalModelId, curateProviderModels, isChatModel} from '../model-utils'
+
+const m = (id: string, name?: string) => ({id, name: name ?? id})
+
+describe('isChatModel', () => {
+  it('keeps text generation models', () => {
+    expect(isChatModel('gpt-4o')).toBe(true)
+    expect(isChatModel('claude-sonnet-4-5')).toBe(true)
+    expect(isChatModel('gemini-2.0-flash')).toBe(true)
+    expect(isChatModel('o3-mini')).toBe(true)
+  })
+
+  it('drops embedding, audio, image, and other non-chat models', () => {
+    expect(isChatModel('text-embedding-3-small')).toBe(false)
+    expect(isChatModel('text-embedding-ada-002')).toBe(false)
+    expect(isChatModel('whisper-1')).toBe(false)
+    expect(isChatModel('tts-1-hd')).toBe(false)
+    expect(isChatModel('dall-e-3')).toBe(false)
+    expect(isChatModel('gpt-image-1')).toBe(false)
+    expect(isChatModel('gpt-4o-realtime-preview')).toBe(false)
+    expect(isChatModel('omni-moderation-latest')).toBe(false)
+    expect(isChatModel('gpt-3.5-turbo-instruct')).toBe(false)
+    expect(isChatModel('davinci-002')).toBe(false)
+  })
+})
+
+describe('canonicalModelId', () => {
+  it('collapses dated snapshots onto their stable alias', () => {
+    expect(canonicalModelId('gpt-4o-2024-08-06')).toBe('gpt-4o')
+    expect(canonicalModelId('gpt-4o-mini-2024-07-18')).toBe('gpt-4o-mini')
+    expect(canonicalModelId('claude-3-5-sonnet-20241022')).toBe('claude-3-5-sonnet')
+    expect(canonicalModelId('gpt-4-0125-preview')).toBe('gpt-4')
+    expect(canonicalModelId('gpt-3.5-turbo-0125')).toBe('gpt-3.5-turbo')
+    expect(canonicalModelId('chatgpt-4o-latest')).toBe('chatgpt-4o')
+  })
+
+  it('does not strip semantic suffixes that mark distinct models', () => {
+    expect(canonicalModelId('gpt-4o-mini')).toBe('gpt-4o-mini')
+    expect(canonicalModelId('o1-mini')).toBe('o1-mini')
+    expect(canonicalModelId('claude-3-5-sonnet')).toBe('claude-3-5-sonnet')
+  })
+})
+
+describe('curateProviderModels', () => {
+  it('removes non-chat models, dedupes snapshots, and floats flagships', () => {
+    const models = [
+      m('text-embedding-3-small'),
+      m('dall-e-3'),
+      m('gpt-3.5-turbo'),
+      m('gpt-3.5-turbo-0125'),
+      m('gpt-4o', 'GPT-4o'),
+      m('gpt-4o-2024-08-06'),
+      m('gpt-4o-2024-11-20'),
+      m('gpt-4o-mini'),
+      m('o3'),
+    ]
+    const {recommended, all, hasMore} = curateProviderModels(models, 'openai')
+
+    // Embeddings/images are gone from both lists.
+    expect(all.some((model) => model.id === 'text-embedding-3-small')).toBe(false)
+    expect(all.some((model) => model.id === 'dall-e-3')).toBe(false)
+
+    // Recommended collapses the three gpt-4o entries to the stable alias.
+    const recommendedIds = recommended.map((model) => model.id)
+    expect(recommendedIds.filter((id) => id.startsWith('gpt-4o') && !id.includes('mini'))).toEqual(['gpt-4o'])
+    expect(recommendedIds).toContain('gpt-4o-mini')
+    expect(recommendedIds).toContain('gpt-3.5-turbo')
+    expect(recommendedIds).not.toContain('gpt-3.5-turbo-0125')
+
+    // Flagships sort ahead of older families.
+    expect(recommendedIds.indexOf('gpt-4o')).toBeLessThan(recommendedIds.indexOf('gpt-3.5-turbo'))
+
+    // The full list still contains snapshots, so "show all" is meaningful.
+    expect(all.some((model) => model.id === 'gpt-4o-2024-08-06')).toBe(true)
+    expect(hasMore).toBe(true)
+  })
+
+  it('handles an empty or missing model list', () => {
+    expect(curateProviderModels(undefined, 'openai')).toEqual({recommended: [], all: [], hasMore: false})
+    expect(curateProviderModels([], undefined)).toEqual({recommended: [], all: [], hasMore: false})
+  })
+})

--- a/frontend/apps/desktop/src/pages/agents/agent-tools.ts
+++ b/frontend/apps/desktop/src/pages/agents/agent-tools.ts
@@ -1,0 +1,17 @@
+import {seedToolRegistry} from '../../../../../../agents/protocol/src/tool-registry'
+
+/** Tools that let an agent find and read Seed content. */
+export const AGENT_READ_TOOL_GROUP = [
+  seedToolRegistry.read.name,
+  seedToolRegistry.search.name,
+  seedToolRegistry.list_activity_feed.name,
+]
+
+/** Tool that lets an agent create, sign, and publish Seed content. */
+export const AGENT_WRITE_TOOL = seedToolRegistry.write.name
+
+/**
+ * Tools granted to a newly created agent: full read access plus write, so the
+ * agent can publish as its own auto-created account without extra setup.
+ */
+export const DEFAULT_AGENT_TOOLS = [...AGENT_READ_TOOL_GROUP, AGENT_WRITE_TOOL]

--- a/frontend/apps/desktop/src/pages/agents/detail.tsx
+++ b/frontend/apps/desktop/src/pages/agents/detail.tsx
@@ -864,7 +864,6 @@ function AgentTriggersTab({
   const nameSaveIdRef = useRef(0)
   const [enabled, setEnabled] = useState(true)
   const [prompt, setPrompt] = useState<HMBlockNode[]>([])
-  const [cooldownMinutes, setCooldownMinutes] = useState('')
   const [source, setSource] = useState<AgentTriggerSource>({ type: 'document-comment', resource: '' })
   const [detailsDirty, setDetailsDirty] = useState(false)
   const [detailsSaveState, setDetailsSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
@@ -872,10 +871,8 @@ function AgentTriggersTab({
   const selectedTriggerRef = useRef<string | null>(null)
   const lastSavedDetailsKeyRef = useRef('')
   const currentDetailsKey = useMemo(() => {
-    const cooldownMs =
-      source.type === 'schedule' ? null : cooldownMinutes.trim() ? Number(cooldownMinutes) * 60_000 : null
-    return JSON.stringify({ prompt, source, cooldownMs })
-  }, [cooldownMinutes, prompt, source])
+    return JSON.stringify({ prompt, source })
+  }, [prompt, source])
   const currentDetailsKeyRef = useRef(currentDetailsKey)
   currentDetailsKeyRef.current = currentDetailsKey
   const nextScheduledFire = useMemo(
@@ -894,15 +891,12 @@ function AgentTriggersTab({
     if (!triggerChanged) return
     const nextPrompt = agentPromptToBlocks(selected.prompt)
     const nextSource = selected.source
-    const nextCooldownMinutes = selected.cooldownMs ? String(Math.round(selected.cooldownMs / 60_000)) : ''
     setEnabled(selected.enabled)
     setPrompt(nextPrompt)
-    setCooldownMinutes(nextCooldownMinutes)
     setSource(nextSource)
     lastSavedDetailsKeyRef.current = JSON.stringify({
       prompt: nextPrompt,
       source: nextSource,
-      cooldownMs: nextSource.type === 'schedule' ? null : selected.cooldownMs ?? null,
     })
     setDetailsDirty(false)
     setDetailsSaveState('idle')
@@ -957,8 +951,6 @@ function AgentTriggersTab({
 
   useEffect(() => {
     if (!selectedTriggerId || !selected || !detailsDirty || detailsSaveState === 'saving') return
-    const cooldownMs =
-      source.type === 'schedule' ? null : cooldownMinutes.trim() ? Number(cooldownMinutes) * 60_000 : null
     const detailsKey = currentDetailsKey
     if (detailsKey === lastSavedDetailsKeyRef.current) {
       setDetailsDirty(false)
@@ -972,7 +964,7 @@ function AgentTriggersTab({
       void updateTrigger
         .mutateAsync({
           triggerId: selectedTriggerId,
-          patch: { prompt: promptBlocksToMarkdown(prompt), source, cooldownMs },
+          patch: { prompt: promptBlocksToMarkdown(prompt), source },
         })
         .then((result) => {
           if (detailsSaveIdRef.current !== saveId) return
@@ -996,7 +988,7 @@ function AgentTriggersTab({
         })
     }, 800)
     return () => clearTimeout(timer)
-  }, [cooldownMinutes, currentDetailsKey, detailsDirty, detailsSaveState, prompt, selected, selectedTriggerId, source])
+  }, [currentDetailsKey, detailsDirty, detailsSaveState, prompt, selected, selectedTriggerId, source])
 
   async function handleDeleteTrigger() {
     if (!selectedTriggerId) return
@@ -1070,23 +1062,6 @@ function AgentTriggersTab({
                     setDetailsDirty(true)
                   }}
                 />
-                {source.type !== 'schedule' ? (
-                  <label className="flex flex-col gap-1">
-                    <SizableText size="sm" weight="bold">
-                      Cooldown minutes
-                    </SizableText>
-                    <Input
-                      type="number"
-                      min="1"
-                      value={cooldownMinutes}
-                      onChange={(event) => {
-                        setCooldownMinutes(event.target.value)
-                        setDetailsDirty(true)
-                      }}
-                      placeholder="optional"
-                    />
-                  </label>
-                ) : null}
                 <div className="flex flex-col gap-1">
                   <SizableText size="sm" weight="bold">
                     Prompt
@@ -1175,7 +1150,6 @@ function AgentTriggersTab({
           </SizableText>
           <SizableText size="xs" color="muted">
             Updated {new Date(item.updatedAt).toLocaleString()}
-            {item.cooldownMs ? ` · ${Math.round(item.cooldownMs / 60_000)}m cooldown` : ''}
           </SizableText>
         </button>
       ))}
@@ -1210,7 +1184,6 @@ function CreateAgentTriggerDialog({
   const [prompt, setPrompt] = useState<HMBlockNode[]>(() =>
     agentPromptToBlocks('Read the related Seed context and summarize what needs attention.'),
   )
-  const [cooldownMinutes, setCooldownMinutes] = useState('')
 
   async function handleCreateTrigger() {
     try {
@@ -1219,7 +1192,6 @@ function CreateAgentTriggerDialog({
         enabled,
         source,
         prompt: promptBlocksToMarkdown(prompt),
-        ...(source.type !== 'schedule' && cooldownMinutes.trim() ? { cooldownMs: Number(cooldownMinutes) * 60_000 } : {}),
       }
       const result = await createTrigger.mutateAsync({ agentId: input.agentId, trigger })
       if (result._ !== 'CreateAgentTriggerResponse') throw new Error('Unexpected trigger create response')
@@ -1247,20 +1219,6 @@ function CreateAgentTriggerDialog({
         <Input value={name} onChange={(event) => setName(event.target.value)} />
       </label>
       <TriggerSourceFields source={source} onChange={setSource} />
-      {source.type !== 'schedule' ? (
-        <label className="flex flex-col gap-1">
-          <SizableText size="sm" weight="bold">
-            Cooldown minutes
-          </SizableText>
-          <Input
-            type="number"
-            min="1"
-            value={cooldownMinutes}
-            onChange={(event) => setCooldownMinutes(event.target.value)}
-            placeholder="optional"
-          />
-        </label>
-      ) : null}
       <div className="flex flex-col gap-1">
         <SizableText size="sm" weight="bold">
           Prompt

--- a/frontend/apps/desktop/src/pages/agents/detail.tsx
+++ b/frontend/apps/desktop/src/pages/agents/detail.tsx
@@ -19,6 +19,7 @@ import {
   useCreateSigningIdentity,
   useDeleteAgent,
   useDeleteAgentTrigger,
+  useModelProviders,
   useProviderModels,
   useSigningIdentities,
   useUpdateAgent,
@@ -51,6 +52,7 @@ import {useAppDialog} from '@shm/ui/universal-dialog'
 import {KeyRound, Trash2} from 'lucide-react'
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {AgentHeader, AgentSubpageHeader, type AgentPageTab} from './header'
+import {ModelSelect} from './model-select'
 import {AgentPromptEditor, promptBlocksToMarkdown} from './prompt-editor'
 
 function AgentDetailPage({
@@ -78,7 +80,10 @@ function AgentDetailPage({
   const signingIdentities = useSigningIdentities(serverUrl, selectedAccountId)
   const createSigningIdentity = useCreateSigningIdentity(serverUrl, selectedAccountId)
   const createTriggerDialog = useAppDialog(CreateAgentTriggerDialog)
-  const providerModels = useProviderModels(serverUrl, selectedAccountId, agent.data?.agent.definition.modelProvider)
+  const modelProviderName = agent.data?.agent.definition.modelProvider
+  const providerModels = useProviderModels(serverUrl, selectedAccountId, modelProviderName)
+  const modelProviders = useModelProviders(serverUrl, selectedAccountId)
+  const selectedProviderType = modelProviders.data?.find((provider) => provider.name === modelProviderName)?.type
   useAgentWebSocketSubscription(serverUrl, selectedAccountId, `agents/${agentId}`)
   const [name, setName] = useState('')
   const [model, setModel] = useState('')
@@ -370,35 +375,18 @@ function AgentDetailPage({
                       <SizableText size="sm" weight="bold">
                         Model
                       </SizableText>
-                      <select
-                        className="border-input bg-background rounded-md border px-3 py-2 text-sm"
+                      <ModelSelect
+                        models={providerModels.data}
+                        providerType={selectedProviderType}
                         value={model}
-                        onChange={(event) => {
-                          setModel(event.target.value)
+                        onChange={(nextModel) => {
+                          setModel(nextModel)
                           setNameModelDirty(true)
                         }}
-                        disabled={providerModels.isLoading || !providerModels.data?.length}
-                      >
-                        {providerModels.isLoading ? <option value="">Loading models…</option> : null}
-                        {!providerModels.isLoading &&
-                        !providerModels.data?.some((providerModel) => providerModel.id === model) ? (
-                          <option value={model}>{model || 'No model selected'}</option>
-                        ) : null}
-                        {(providerModels.data || []).map((providerModel) => (
-                          <option key={providerModel.id} value={providerModel.id}>
-                            {providerModel.name === providerModel.id
-                              ? providerModel.id
-                              : `${providerModel.name} (${providerModel.id})`}
-                          </option>
-                        ))}
-                      </select>
-                      {providerModels.isError ? (
-                        <SizableText size="xs" className="text-destructive">
-                          {providerModels.error instanceof Error
-                            ? providerModels.error.message
-                            : 'Could not load models'}
-                        </SizableText>
-                      ) : null}
+                        isLoading={providerModels.isLoading}
+                        isError={providerModels.isError}
+                        error={providerModels.error}
+                      />
                     </label>
                   </div>
                   <div className="grid gap-3 text-sm md:grid-cols-2">

--- a/frontend/apps/desktop/src/pages/agents/detail.tsx
+++ b/frontend/apps/desktop/src/pages/agents/detail.tsx
@@ -51,9 +51,12 @@ import {toast} from '@shm/ui/toast'
 import {useAppDialog} from '@shm/ui/universal-dialog'
 import {KeyRound, Trash2} from 'lucide-react'
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {AddModelProviderDialog} from './dialogs'
 import {AgentHeader, AgentSubpageHeader, type AgentPageTab} from './header'
 import {ModelSelect} from './model-select'
+import {curateProviderModels} from './model-utils'
 import {AgentPromptEditor, promptBlocksToMarkdown} from './prompt-editor'
+import {ProviderSelect} from './provider-select'
 
 function AgentDetailPage({
   agentId,
@@ -80,13 +83,14 @@ function AgentDetailPage({
   const signingIdentities = useSigningIdentities(serverUrl, selectedAccountId)
   const createSigningIdentity = useCreateSigningIdentity(serverUrl, selectedAccountId)
   const createTriggerDialog = useAppDialog(CreateAgentTriggerDialog)
-  const modelProviderName = agent.data?.agent.definition.modelProvider
-  const providerModels = useProviderModels(serverUrl, selectedAccountId, modelProviderName)
   const modelProviders = useModelProviders(serverUrl, selectedAccountId)
-  const selectedProviderType = modelProviders.data?.find((provider) => provider.name === modelProviderName)?.type
+  const addProviderDialog = useAppDialog(AddModelProviderDialog)
   useAgentWebSocketSubscription(serverUrl, selectedAccountId, `agents/${agentId}`)
   const [name, setName] = useState('')
+  const [modelProvider, setModelProvider] = useState('')
   const [model, setModel] = useState('')
+  const providerModels = useProviderModels(serverUrl, selectedAccountId, modelProvider)
+  const selectedProviderType = modelProviders.data?.find((provider) => provider.name === modelProvider)?.type
   const [systemPrompt, setSystemPrompt] = useState<HMBlockNode[]>([])
   const [promptEditorKey, setPromptEditorKey] = useState(0)
   const [nameModelDirty, setNameModelDirty] = useState(false)
@@ -102,6 +106,7 @@ function AgentDetailPage({
     if (!nameModelDirty) {
       setName(agent.data.agent.definition.name)
       setModel(agent.data.agent.definition.model)
+      setModelProvider(agent.data.agent.definition.modelProvider)
     }
     if (!promptDirty) {
       const nextPromptKey = agentPromptStableKey(agent.data.agent.definition.systemPrompt)
@@ -112,6 +117,22 @@ function AgentDetailPage({
       }
     }
   }, [agent.data, nameModelDirty, promptDirty])
+
+  // After the user switches provider (which clears the model), pick a sensible
+  // default from the new provider's curated list once it loads.
+  useEffect(() => {
+    if (!nameModelDirty || model || !providerModels.data?.length) return
+    const {recommended, all} = curateProviderModels(providerModels.data, selectedProviderType)
+    const nextModel = recommended[0]?.id || all[0]?.id
+    if (nextModel) setModel(nextModel)
+  }, [nameModelDirty, model, providerModels.data, selectedProviderType])
+
+  function handleProviderChange(nextProvider: string) {
+    if (nextProvider === modelProvider) return
+    setModelProvider(nextProvider)
+    setModel('') // belongs to the previous provider; the effect above picks a new default
+    setNameModelDirty(true)
+  }
 
   async function handleCreateSession() {
     try {
@@ -127,11 +148,12 @@ function AgentDetailPage({
   useEffect(() => {
     if (!agent.data) return
     const draftName = name.trim()
-    if (!draftName || !model) return
+    if (!draftName || !model || !modelProvider) return
     const currentDefinition = agent.data.agent.definition
     const persistedName = currentDefinition.name
     const persistedModel = currentDefinition.model
-    if (draftName === persistedName && model === persistedModel) {
+    const persistedProvider = currentDefinition.modelProvider
+    if (draftName === persistedName && model === persistedModel && modelProvider === persistedProvider) {
       setSettingsSaveState('idle')
       return
     }
@@ -144,13 +166,14 @@ function AgentDetailPage({
         void updateAgent
           .mutateAsync({
             agentId,
-            definition: {...currentDefinition, name: draftName, model},
+            definition: {...currentDefinition, name: draftName, model, modelProvider},
           })
           .then((result) => {
             if (settingsSaveIdRef.current !== saveId) return
             if (result._ !== 'GetAgentResponse') throw new Error('Unexpected update response')
             setName(result.agent.definition.name)
             setModel(result.agent.definition.model)
+            setModelProvider(result.agent.definition.modelProvider)
             if (!promptDirty) {
               loadedPromptKeyRef.current = agentPromptStableKey(result.agent.definition.systemPrompt)
               setSystemPrompt(agentPromptToBlocks(result.agent.definition.systemPrompt))
@@ -171,7 +194,7 @@ function AgentDetailPage({
       model === persistedModel ? 600 : 0,
     )
     return () => clearTimeout(timer)
-  }, [agent.data, agentId, model, name, promptDirty, updateAgent.mutateAsync])
+  }, [agent.data, agentId, model, modelProvider, name, promptDirty, updateAgent.mutateAsync])
 
   const promptEditorDisabled = !selectedAccountId || serverHealth.isError || agent.isError
 
@@ -264,6 +287,7 @@ function AgentDetailPage({
 
               {createTriggerDialog.content}
               {deleteAgentDialog.content}
+              {addProviderDialog.content}
 
               {tab === 'sessions' ? (
                 <section className="flex min-h-0 flex-1 flex-col">
@@ -373,31 +397,34 @@ function AgentDetailPage({
                     </label>
                     <label className="flex flex-col gap-1">
                       <SizableText size="sm" weight="bold">
-                        Model
+                        Provider
                       </SizableText>
-                      <ModelSelect
-                        models={providerModels.data}
-                        providerType={selectedProviderType}
-                        value={model}
-                        onChange={(nextModel) => {
-                          setModel(nextModel)
-                          setNameModelDirty(true)
-                        }}
-                        isLoading={providerModels.isLoading}
-                        isError={providerModels.isError}
-                        error={providerModels.error}
+                      <ProviderSelect
+                        providers={modelProviders.data}
+                        value={modelProvider}
+                        onChange={handleProviderChange}
+                        onAddProvider={() => addProviderDialog.open({serverUrl, selectedAccountId})}
                       />
                     </label>
                   </div>
+                  <label className="flex flex-col gap-1">
+                    <SizableText size="sm" weight="bold">
+                      Model
+                    </SizableText>
+                    <ModelSelect
+                      models={providerModels.data}
+                      providerType={selectedProviderType}
+                      value={model}
+                      onChange={(nextModel) => {
+                        setModel(nextModel)
+                        setNameModelDirty(true)
+                      }}
+                      isLoading={providerModels.isLoading}
+                      isError={providerModels.isError}
+                      error={providerModels.error}
+                    />
+                  </label>
                   <div className="grid gap-3 text-sm md:grid-cols-2">
-                    <div>
-                      <SizableText size="sm" weight="bold">
-                        Provider
-                      </SizableText>
-                      <SizableText size="sm" color="muted">
-                        {agent.data.agent.definition.modelProvider}
-                      </SizableText>
-                    </div>
                     <div>
                       <SizableText size="sm" weight="bold">
                         Status

--- a/frontend/apps/desktop/src/pages/agents/detail.tsx
+++ b/frontend/apps/desktop/src/pages/agents/detail.tsx
@@ -27,16 +27,15 @@ import {
   useUpdateAgentTrigger,
   useUpdateSigningIdentity,
 } from '@/models/agents'
-import {useSelectedAccountId} from '@/selected-account'
-import {useClickNavigate, useNavigate} from '@/utils/useNavigate'
-import {markdownBlockNodesToHMBlockNodes, parseMarkdown} from '@seed-hypermedia/client'
-import {seedToolRegistry} from '../../../../../../agents/protocol/src/tool-registry'
-import type {HMBlockNode} from '@seed-hypermedia/client/hm-types'
-import {useSearch} from '@shm/shared/models/search'
-import {formattedDateMedium} from '@shm/shared/utils/date'
-import {packHmId} from '@shm/shared/utils/entity-id-url'
-import {useNavRoute} from '@shm/shared/utils/navigation'
-import {Button} from '@shm/ui/button'
+import { useSelectedAccountId } from '@/selected-account'
+import { useClickNavigate, useNavigate } from '@/utils/useNavigate'
+import { markdownBlockNodesToHMBlockNodes, parseMarkdown } from '@seed-hypermedia/client'
+import type { HMBlockNode } from '@seed-hypermedia/client/hm-types'
+import { useSearch } from '@shm/shared/models/search'
+import { formattedDateMedium } from '@shm/shared/utils/date'
+import { packHmId } from '@shm/shared/utils/entity-id-url'
+import { useNavRoute } from '@shm/shared/utils/navigation'
+import { Button } from '@shm/ui/button'
 import {
   AlertDialogAction,
   AlertDialogCancel,
@@ -44,22 +43,23 @@ import {
   AlertDialogFooter,
   AlertDialogTitle,
 } from '@shm/ui/components/alert-dialog'
-import {DialogDescription, DialogTitle} from '@shm/ui/components/dialog'
-import {Input} from '@shm/ui/components/input'
-import {Container, PanelContainer} from '@shm/ui/container'
-import {OptionsDropdown} from '@shm/ui/options-dropdown'
-import {SizableText} from '@shm/ui/text'
-import {toast} from '@shm/ui/toast'
-import {useAppDialog} from '@shm/ui/universal-dialog'
-import {KeyRound, Trash2} from 'lucide-react'
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
-import {AGENT_READ_TOOL_GROUP} from './agent-tools'
-import {AddModelProviderDialog, EditAgentNameDialog, type AgentAccountRenameStatus} from './dialogs'
-import {AgentHeader, AgentSubpageHeader, type AgentPageTab} from './header'
-import {ModelSelect} from './model-select'
-import {curateProviderModels} from './model-utils'
-import {AgentPromptEditor, promptBlocksToMarkdown} from './prompt-editor'
-import {ProviderSelect} from './provider-select'
+import { DialogDescription, DialogTitle } from '@shm/ui/components/dialog'
+import { Input } from '@shm/ui/components/input'
+import { Container, PanelContainer } from '@shm/ui/container'
+import { OptionsDropdown } from '@shm/ui/options-dropdown'
+import { SizableText } from '@shm/ui/text'
+import { toast } from '@shm/ui/toast'
+import { useAppDialog } from '@shm/ui/universal-dialog'
+import { KeyRound, Plus, Trash2 } from 'lucide-react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { seedToolRegistry } from '../../../../../../agents/protocol/src/tool-registry'
+import { AGENT_READ_TOOL_GROUP } from './agent-tools'
+import { AddModelProviderDialog, EditAgentNameDialog, type AgentAccountRenameStatus } from './dialogs'
+import { AgentHeader, AgentSubpageHeader, type AgentPageTab } from './header'
+import { ModelSelect } from './model-select'
+import { curateProviderModels } from './model-utils'
+import { AgentPromptEditor, promptBlocksToMarkdown } from './prompt-editor'
+import { ProviderSelect } from './provider-select'
 
 function AgentDetailPage({
   agentId,
@@ -83,7 +83,7 @@ function AgentDetailPage({
   const createSession = useCreateAgentSession(serverUrl, selectedAccountId)
   const updateAgent = useUpdateAgent(serverUrl, selectedAccountId)
   const updateSigningIdentity = useUpdateSigningIdentity(serverUrl, selectedAccountId)
-  const deleteAgentDialog = useAppDialog(DeleteAgentDialog, {isAlert: true})
+  const deleteAgentDialog = useAppDialog(DeleteAgentDialog, { isAlert: true })
   const signingIdentities = useSigningIdentities(serverUrl, selectedAccountId)
   const createSigningIdentity = useCreateSigningIdentity(serverUrl, selectedAccountId)
   const createTriggerDialog = useAppDialog(CreateAgentTriggerDialog)
@@ -128,7 +128,7 @@ function AgentDetailPage({
   // default from the new provider's curated list once it loads.
   useEffect(() => {
     if (!nameModelDirty || model || !providerModels.data?.length) return
-    const {recommended, all} = curateProviderModels(providerModels.data, selectedProviderType)
+    const { recommended, all } = curateProviderModels(providerModels.data, selectedProviderType)
     const nextModel = recommended[0]?.id || all[0]?.id
     if (nextModel) setModel(nextModel)
   }, [nameModelDirty, model, providerModels.data, selectedProviderType])
@@ -152,30 +152,30 @@ function AgentDetailPage({
       return otherKeys.includes(agentSigningKey)
     })
   const agentAccountStatus: AgentAccountRenameStatus = !agentSigningKey
-    ? {kind: 'none'}
+    ? { kind: 'none' }
     : isAccountShared
-      ? {kind: 'shared'}
-      : {kind: 'own'}
+      ? { kind: 'shared' }
+      : { kind: 'own' }
 
   async function handleRenameAgent(nextName: string) {
     if (!agent.data) throw new Error('Agent not loaded')
     const trimmed = nextName.trim()
     if (!trimmed) throw new Error('Agent name is required')
     const definition = agent.data.agent.definition
-    const result = await updateAgent.mutateAsync({agentId, definition: {...definition, name: trimmed}})
+    const result = await updateAgent.mutateAsync({ agentId, definition: { ...definition, name: trimmed } })
     if (result._ !== 'GetAgentResponse') throw new Error('Unexpected update response')
     // Keep the dedicated account's profile name in sync; leave shared accounts alone.
     if (agentSigningKey && !isAccountShared) {
-      await updateSigningIdentity.mutateAsync({name: agentSigningKey, label: trimmed})
+      await updateSigningIdentity.mutateAsync({ name: agentSigningKey, label: trimmed })
     }
     if (!nameModelDirty) setName(trimmed)
   }
 
   async function handleCreateSession() {
     try {
-      const result = await createSession.mutateAsync({agentId, title: 'Untitled session'})
+      const result = await createSession.mutateAsync({ agentId, title: 'Untitled session' })
       if (result._ !== 'CreateSessionResponse') throw new Error('Unexpected session response')
-      navigate({key: 'agent-session', agentId, sessionId: result.sessionId, serverUrl})
+      navigate({ key: 'agent-session', agentId, sessionId: result.sessionId, serverUrl })
       // toast.success('Session created')
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Could not create session')
@@ -203,7 +203,7 @@ function AgentDetailPage({
         void updateAgent
           .mutateAsync({
             agentId,
-            definition: {...currentDefinition, name: draftName, model, modelProvider},
+            definition: { ...currentDefinition, name: draftName, model, modelProvider },
           })
           .then((result) => {
             if (settingsSaveIdRef.current !== saveId) return
@@ -257,7 +257,7 @@ function AgentDetailPage({
       void updateAgent
         .mutateAsync({
           agentId,
-          definition: {...currentDefinition, systemPrompt: promptBlocksToMarkdown(systemPrompt)},
+          definition: { ...currentDefinition, systemPrompt: promptBlocksToMarkdown(systemPrompt) },
         })
         .then((result) => {
           if (promptSaveIdRef.current !== saveId) return
@@ -283,16 +283,16 @@ function AgentDetailPage({
   const isTriggerDetail = tab === 'triggers' && !!triggerId
   const breadcrumbItems = isTriggerDetail
     ? [
-        {label: 'Triggers', route: {key: 'agent' as const, agentId, serverUrl, tab: 'triggers' as const}},
-        {label: selectedTriggerName || 'Trigger'},
-      ]
+      { label: 'Triggers', route: { key: 'agent' as const, agentId, serverUrl, tab: 'triggers' as const } },
+      { label: selectedTriggerName || 'Trigger' },
+    ]
     : undefined
 
   return (
-    <PanelContainer className="flex flex-col overflow-hidden">
-      <div className={isTriggerDetail ? 'border-border flex-none border-b' : 'contents'}>
+    <PanelContainer className="flex overflow-hidden flex-col">
+      <div className={isTriggerDetail ? 'flex-none border-b border-border' : 'contents'}>
         <Container
-          className={isTriggerDetail ? 'max-w-4xl gap-4 pt-4 pb-4' : 'min-h-0 max-w-4xl flex-1 gap-4 pt-4 pb-0'}
+          className={isTriggerDetail ? 'gap-4 pt-4 pb-4 max-w-4xl' : 'flex-1 gap-4 pt-4 pb-0 max-w-4xl min-h-0'}
         >
           {agent.isLoading ? <SizableText color="muted">Loading agent…</SizableText> : null}
           {agent.isError ? (
@@ -319,7 +319,7 @@ function AgentDetailPage({
                 triggersCount={triggers.data?.length}
                 onCreateSession={() => void handleCreateSession()}
                 creatingSession={createSession.isLoading}
-                onCreateTrigger={() => createTriggerDialog.open({serverUrl, selectedAccountId, agentId})}
+                onCreateTrigger={() => createTriggerDialog.open({ serverUrl, selectedAccountId, agentId })}
                 canCreateTrigger={!!selectedAccountId}
                 breadcrumbItems={breadcrumbItems}
               />
@@ -330,8 +330,8 @@ function AgentDetailPage({
               {editNameDialog.content}
 
               {tab === 'sessions' ? (
-                <section className="flex min-h-0 flex-1 flex-col">
-                  <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto pr-1">
+                <section className="flex flex-col flex-1 min-h-0">
+                  <div className="flex overflow-y-auto flex-col flex-1 gap-2 pr-1 min-h-0">
                     {!agent.data.sessions.length ? <SizableText color="muted">No sessions yet.</SizableText> : null}
                     {agent.data.sessions.map((session) => (
                       <SessionListItem
@@ -339,17 +339,17 @@ function AgentDetailPage({
                         session={session}
                         serverUrl={serverUrl}
                         onOpen={(event) =>
-                          clickNavigate({key: 'agent-session', agentId, sessionId: session.id, serverUrl}, event)
+                          clickNavigate({ key: 'agent-session', agentId, sessionId: session.id, serverUrl }, event)
                         }
                         onOpenTrigger={() =>
                           session.startedByTrigger
                             ? navigate({
-                                key: 'agent',
-                                agentId,
-                                serverUrl,
-                                tab: 'triggers',
-                                triggerId: session.startedByTrigger.triggerId,
-                              })
+                              key: 'agent',
+                              agentId,
+                              serverUrl,
+                              tab: 'triggers',
+                              triggerId: session.startedByTrigger.triggerId,
+                            })
                             : undefined
                         }
                       />
@@ -379,14 +379,14 @@ function AgentDetailPage({
                   definition={agent.data.agent.definition}
                   identities={signingIdentities.data || []}
                   identitiesLoading={signingIdentities.isLoading}
-                  onSave={(definition) => updateAgent.mutateAsync({agentId, definition})}
+                  onSave={(definition) => updateAgent.mutateAsync({ agentId, definition })}
                   onCreateIdentity={(label) => createSigningIdentity.mutateAsync(label)}
                   saving={updateAgent.isLoading || createSigningIdentity.isLoading}
                 />
               ) : null}
 
               {tab === 'prompt' ? (
-                <section className="flex min-h-0 flex-1 flex-col gap-3">
+                <section className="flex flex-col flex-1 gap-3 min-h-0">
                   <div>
                     <SizableText weight="bold">System prompt</SizableText>
                     <SizableText size="sm" color="muted" className="block">
@@ -404,7 +404,7 @@ function AgentDetailPage({
                     </SizableText>
                   </div>
                   {promptEditorDisabled ? (
-                    <div className="border-input bg-muted/40 text-muted-foreground min-h-80 rounded-lg border p-4 text-sm">
+                    <div className="p-4 text-sm rounded-lg border border-input bg-muted/40 text-muted-foreground min-h-80">
                       Connect to the agent server to edit this prompt.
                     </div>
                   ) : (
@@ -421,7 +421,7 @@ function AgentDetailPage({
               ) : null}
 
               {tab === 'settings' ? (
-                <section className="flex max-w-2xl flex-col gap-4">
+                <section className="flex flex-col gap-4 max-w-2xl">
                   <div className="grid gap-3 md:grid-cols-2">
                     <label className="flex flex-col gap-1">
                       <SizableText size="sm" weight="bold">
@@ -431,7 +431,7 @@ function AgentDetailPage({
                         providers={modelProviders.data}
                         value={modelProvider}
                         onChange={handleProviderChange}
-                        onAddProvider={() => addProviderDialog.open({serverUrl, selectedAccountId})}
+                        onAddProvider={() => addProviderDialog.open({ serverUrl, selectedAccountId })}
                       />
                     </label>
                     <label className="flex flex-col gap-1">
@@ -465,7 +465,7 @@ function AgentDetailPage({
                   <SizableText size="xs" color="muted" className="font-mono">
                     {agent.data.agent.id}
                   </SizableText>
-                  <div className="flex flex-wrap items-center gap-2">
+                  <div className="flex flex-wrap gap-2 items-center">
                     {settingsSaveState !== 'idle' ? (
                       <SizableText
                         size="xs"
@@ -488,7 +488,7 @@ function AgentDetailPage({
                           selectedAccountId: selectedAccountId ?? null,
                           agentId,
                           agentName: name,
-                          onDeleted: () => navigate({key: 'agents'}),
+                          onDeleted: () => navigate({ key: 'agents' }),
                         })
                       }
                       disabled={!selectedAccountId}
@@ -528,7 +528,7 @@ function agentPromptStableKey(prompt: AgentDefinition['systemPrompt']): string {
 
 function hasPromptContent(blocks: HMBlockNode[]): boolean {
   return blocks.some((node) => {
-    const block = node.block as {text?: unknown; type?: unknown; link?: unknown; url?: unknown}
+    const block = node.block as { text?: unknown; type?: unknown; link?: unknown; url?: unknown }
     const type = typeof block.type === 'string' ? block.type.toLowerCase() : ''
     if (typeof block.text === 'string' && block.text.trim()) return true
     if (typeof block.link === 'string' && block.link.trim()) return true
@@ -567,7 +567,7 @@ function DeleteAgentDialog({
   }
 
   return (
-    <div className="flex flex-col gap-4 rounded-lg p-4">
+    <div className="flex flex-col gap-4 p-4 rounded-lg">
       <AlertDialogTitle>Delete agent?</AlertDialogTitle>
       <AlertDialogDescription>
         This will permanently delete “{input.agentName}” and its sessions, triggers, and drafts from the agent server.
@@ -661,7 +661,7 @@ function AgentToolsTab({
         '_' in response &&
         response._ === 'CreateSigningIdentityResponse'
       ) {
-        const identityName = (response as unknown as {identity: SigningIdentity}).identity.name
+        const identityName = (response as unknown as { identity: SigningIdentity }).identity.name
         await saveTools(enabledTools, Array.from(new Set([...signingKeys, identityName])))
       }
       setNewIdentityName('Agent publisher')
@@ -675,7 +675,7 @@ function AgentToolsTab({
   const writeEnabled = enabledTools.includes(seedToolRegistry.write.name)
 
   return (
-    <section className="flex min-h-0 max-w-3xl flex-1 flex-col gap-5 overflow-y-auto pr-1">
+    <section className="flex overflow-y-auto flex-col flex-1 gap-5 pr-1 max-w-3xl min-h-0">
       <div>
         <SizableText weight="bold">Tools</SizableText>
       </div>
@@ -686,7 +686,7 @@ function AgentToolsTab({
           return (
             <label
               key={tool.names.join('|')}
-              className="border-border bg-card flex items-start gap-3 rounded-xl border p-4"
+              className="flex gap-3 items-start p-4 rounded-xl border border-border bg-card"
             >
               <input
                 type="checkbox"
@@ -700,8 +700,8 @@ function AgentToolsTab({
                   void saveTools(nextTools, signingKeys)
                 }}
               />
-              <div className="flex min-w-0 flex-1 flex-col gap-1">
-                <div className="flex items-center gap-2">
+              <div className="flex flex-col flex-1 gap-1 min-w-0">
+                <div className="flex gap-2 items-center">
                   <SizableText size="sm" weight="bold">
                     {tool.title}
                   </SizableText>
@@ -721,18 +721,14 @@ function AgentToolsTab({
       </div>
 
       {writeEnabled ? (
-        <div className="border-border bg-card flex flex-col gap-3 rounded-xl border p-4">
-          <div className="flex items-start gap-3">
-            <div className="bg-primary/10 text-primary flex size-9 items-center justify-center rounded-lg">
+        <div className="flex flex-col gap-3 p-4 rounded-xl border border-border bg-card">
+          <div className="flex gap-3 items-start">
+            <div className="flex justify-center items-center rounded-lg bg-primary/10 text-primary size-9">
               <KeyRound className="size-5" />
             </div>
-            <div className="min-w-0 flex-1">
+            <div className="flex-1 min-w-0">
               <SizableText size="sm" weight="bold">
                 Signing identity
-              </SizableText>
-              <SizableText size="sm" color="muted">
-                Select uploaded HM account keys this agent may use to create, sign, and publish Seed content. The agent
-                is told both each profile name and public key ID.
               </SizableText>
             </div>
           </div>
@@ -742,7 +738,7 @@ function AgentToolsTab({
               return (
                 <label
                   key={identity.id}
-                  className="border-border bg-background flex items-start gap-3 rounded-lg border px-3 py-2"
+                  className="flex gap-3 items-start px-3 py-2 rounded-lg border border-border bg-background"
                 >
                   <input
                     type="checkbox"
@@ -756,12 +752,9 @@ function AgentToolsTab({
                       void saveTools(enabledTools, nextSigningKeys)
                     }}
                   />
-                  <div className="min-w-0 flex-1">
+                  <div className="flex-1 min-w-0">
                     <SizableText size="sm" weight="bold" className="block truncate">
                       {identity.label || identity.accountId || identity.name}
-                    </SizableText>
-                    <SizableText size="xs" color="muted" className="block truncate font-mono">
-                      {identity.accountId || identity.name}
                     </SizableText>
                   </div>
                 </label>
@@ -769,7 +762,7 @@ function AgentToolsTab({
             })}
           </div>
           {!identitiesLoading && identities.length === 0 ? (
-            <div className="border-border bg-background flex flex-col gap-3 rounded-lg border border-dashed p-3">
+            <div className="flex flex-col gap-3 p-3 rounded-lg border border-dashed border-border bg-background">
               <SizableText size="sm" color="muted">
                 No agent accounts are available on this server yet. Create a new server-side HM account key, then enable
                 it for this agent.
@@ -791,7 +784,8 @@ function AgentToolsTab({
             />
           ) : (
             <Button className="w-fit" variant="ghost" onClick={() => setShowNewIdentityPanel(true)} disabled={saving}>
-              New account
+              <Plus className="size-4" />
+              New Agent Account
             </Button>
           )}
         </div>
@@ -820,7 +814,7 @@ function NewAgentAccountPanel({
   disabled: boolean
 }) {
   return (
-    <div className="border-border bg-background flex flex-col gap-3 rounded-lg border p-3">
+    <div className="flex flex-col gap-3 p-3 rounded-lg border border-border bg-background">
       <div>
         <SizableText size="sm" weight="bold">
           New agent account
@@ -830,7 +824,7 @@ function NewAgentAccountPanel({
         </SizableText>
       </div>
       <Input value={name} onChange={(event) => onNameChange(event.target.value)} placeholder="Profile name" />
-      <div className="flex justify-end gap-2">
+      <div className="flex gap-2 justify-end">
         {onCancel ? (
           <Button variant="ghost" onClick={onCancel} disabled={disabled}>
             Cancel
@@ -871,7 +865,7 @@ function AgentTriggersTab({
   const [enabled, setEnabled] = useState(true)
   const [prompt, setPrompt] = useState<HMBlockNode[]>([])
   const [cooldownMinutes, setCooldownMinutes] = useState('')
-  const [source, setSource] = useState<AgentTriggerSource>({type: 'document-comment', resource: ''})
+  const [source, setSource] = useState<AgentTriggerSource>({ type: 'document-comment', resource: '' })
   const [detailsDirty, setDetailsDirty] = useState(false)
   const [detailsSaveState, setDetailsSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
   const detailsSaveIdRef = useRef(0)
@@ -880,14 +874,14 @@ function AgentTriggersTab({
   const currentDetailsKey = useMemo(() => {
     const cooldownMs =
       source.type === 'schedule' ? null : cooldownMinutes.trim() ? Number(cooldownMinutes) * 60_000 : null
-    return JSON.stringify({prompt, source, cooldownMs})
+    return JSON.stringify({ prompt, source, cooldownMs })
   }, [cooldownMinutes, prompt, source])
   const currentDetailsKeyRef = useRef(currentDetailsKey)
   currentDetailsKeyRef.current = currentDetailsKey
   const nextScheduledFire = useMemo(
     () =>
       selected
-        ? nextScheduleFire({source, createdAt: selected.createdAt, lastFiredAt: selected.lastFiredAt, enabled})
+        ? nextScheduleFire({ source, createdAt: selected.createdAt, lastFiredAt: selected.lastFiredAt, enabled })
         : null,
     [enabled, selected, source],
   )
@@ -928,7 +922,7 @@ function AgentTriggersTab({
     const timer = setTimeout(() => {
       setNameSaveState('saving')
       void updateTrigger
-        .mutateAsync({triggerId: selectedTriggerId, patch: {name: draftName}})
+        .mutateAsync({ triggerId: selectedTriggerId, patch: { name: draftName } })
         .then((result) => {
           if (nameSaveIdRef.current !== saveId) return
           if (result._ !== 'UpdateAgentTriggerResponse') throw new Error('Unexpected trigger update response')
@@ -953,7 +947,7 @@ function AgentTriggersTab({
     const previousEnabled = enabled
     setEnabled(nextEnabled)
     try {
-      const result = await updateTrigger.mutateAsync({triggerId: selectedTriggerId, patch: {enabled: nextEnabled}})
+      const result = await updateTrigger.mutateAsync({ triggerId: selectedTriggerId, patch: { enabled: nextEnabled } })
       if (result._ !== 'UpdateAgentTriggerResponse') throw new Error('Unexpected trigger update response')
     } catch (error) {
       setEnabled(previousEnabled)
@@ -978,7 +972,7 @@ function AgentTriggersTab({
       void updateTrigger
         .mutateAsync({
           triggerId: selectedTriggerId,
-          patch: {prompt: promptBlocksToMarkdown(prompt), source, cooldownMs},
+          patch: { prompt: promptBlocksToMarkdown(prompt), source, cooldownMs },
         })
         .then((result) => {
           if (detailsSaveIdRef.current !== saveId) return
@@ -1010,7 +1004,7 @@ function AgentTriggersTab({
       const result = await deleteTrigger.mutateAsync(selectedTriggerId)
       if (result._ !== 'DeleteAgentTriggerResponse') throw new Error('Unexpected trigger delete response')
       toast.success('Trigger deleted')
-      navigate({key: 'agent', agentId, serverUrl, tab: 'triggers'})
+      navigate({ key: 'agent', agentId, serverUrl, tab: 'triggers' })
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Could not delete trigger')
     }
@@ -1029,7 +1023,7 @@ function AgentTriggersTab({
           saveState={nameSaveState}
           disabled={!selected}
           backLabel="Back to agent triggers"
-          onBack={() => navigate({key: 'agent', agentId, serverUrl, tab: 'triggers'})}
+          onBack={() => navigate({ key: 'agent', agentId, serverUrl, tab: 'triggers' })}
           actions={
             <OptionsDropdown
               align="end"
@@ -1045,7 +1039,7 @@ function AgentTriggersTab({
             />
           }
         />
-        <div className="mx-auto flex min-h-0 w-full max-w-4xl flex-1 flex-col gap-5 overflow-y-auto px-4 py-4">
+        <div className="flex overflow-y-auto flex-col flex-1 gap-5 px-4 py-4 mx-auto w-full max-w-4xl min-h-0">
           {trigger.isLoading ? <SizableText color="muted">Loading trigger…</SizableText> : null}
           {trigger.isError ? (
             <SizableText className="text-destructive">
@@ -1054,12 +1048,12 @@ function AgentTriggersTab({
           ) : null}
           {selected ? (
             <>
-              <div className="border-border grid gap-4 rounded-xl border p-4">
-                <div className="flex items-center justify-between gap-3">
+              <div className="grid gap-4 p-4 rounded-xl border border-border">
+                <div className="flex gap-3 justify-between items-center">
                   <div>
                     <SizableText weight="bold">Trigger details</SizableText>
                   </div>
-                  <label className="flex items-center gap-2 text-sm">
+                  <label className="flex gap-2 items-center text-sm">
                     <input
                       type="checkbox"
                       checked={enabled}
@@ -1139,9 +1133,9 @@ function AgentTriggersTab({
                     key={session.id}
                     session={session}
                     serverUrl={serverUrl}
-                    onOpen={() => navigate({key: 'agent-session', agentId, sessionId: session.id, serverUrl})}
+                    onOpen={() => navigate({ key: 'agent-session', agentId, sessionId: session.id, serverUrl })}
                     onOpenTrigger={() =>
-                      navigate({key: 'agent', agentId, serverUrl, tab: 'triggers', triggerId: selected.id})
+                      navigate({ key: 'agent', agentId, serverUrl, tab: 'triggers', triggerId: selected.id })
                     }
                   />
                 ))}
@@ -1157,7 +1151,7 @@ function AgentTriggersTab({
     <section className="flex flex-col gap-2">
       {isLoading ? <SizableText color="muted">Loading triggers…</SizableText> : null}
       {!isLoading && !triggers.length ? (
-        <div className="border-border flex flex-col gap-2 rounded-xl border border-dashed p-6">
+        <div className="flex flex-col gap-2 p-6 rounded-xl border border-dashed border-border">
           <SizableText weight="bold">No triggers yet.</SizableText>
           <SizableText size="sm" color="muted">
             Create a trigger to start sessions when matching Seed activity appears.
@@ -1167,10 +1161,10 @@ function AgentTriggersTab({
       {triggers.map((item) => (
         <button
           key={item.id}
-          className="hover:bg-muted/60 flex cursor-pointer flex-col items-start rounded-lg px-3 py-2 text-left transition-colors"
-          onClick={() => navigate({key: 'agent', agentId, serverUrl, tab: 'triggers', triggerId: item.id})}
+          className="flex flex-col items-start px-3 py-2 text-left rounded-lg transition-colors cursor-pointer hover:bg-muted/60"
+          onClick={() => navigate({ key: 'agent', agentId, serverUrl, tab: 'triggers', triggerId: item.id })}
         >
-          <div className="flex w-full items-center justify-between gap-3">
+          <div className="flex gap-3 justify-between items-center w-full">
             <SizableText weight="bold">{item.name}</SizableText>
             <SizableText size="xs" color={item.enabled ? undefined : 'muted'}>
               {item.enabled ? 'Enabled' : 'Disabled'}
@@ -1189,7 +1183,7 @@ function AgentTriggersTab({
   )
 }
 
-function TriggerMeta({label, value}: {label: string; value?: number | string | null}) {
+function TriggerMeta({ label, value }: { label: string; value?: number | string | null }) {
   return (
     <div>
       <SizableText size="sm" weight="bold">
@@ -1206,13 +1200,13 @@ function CreateAgentTriggerDialog({
   input,
   onClose,
 }: {
-  input: {serverUrl: string; selectedAccountId: string | null | undefined; agentId: string}
+  input: { serverUrl: string; selectedAccountId: string | null | undefined; agentId: string }
   onClose: () => void
 }) {
   const createTrigger = useCreateAgentTrigger(input.serverUrl, input.selectedAccountId)
   const [name, setName] = useState('New activity trigger')
   const [enabled, setEnabled] = useState(true)
-  const [source, setSource] = useState<AgentTriggerSource>({type: 'document-comment', resource: ''})
+  const [source, setSource] = useState<AgentTriggerSource>({ type: 'document-comment', resource: '' })
   const [prompt, setPrompt] = useState<HMBlockNode[]>(() =>
     agentPromptToBlocks('Read the related Seed context and summarize what needs attention.'),
   )
@@ -1225,9 +1219,9 @@ function CreateAgentTriggerDialog({
         enabled,
         source,
         prompt: promptBlocksToMarkdown(prompt),
-        ...(source.type !== 'schedule' && cooldownMinutes.trim() ? {cooldownMs: Number(cooldownMinutes) * 60_000} : {}),
+        ...(source.type !== 'schedule' && cooldownMinutes.trim() ? { cooldownMs: Number(cooldownMinutes) * 60_000 } : {}),
       }
-      const result = await createTrigger.mutateAsync({agentId: input.agentId, trigger})
+      const result = await createTrigger.mutateAsync({ agentId: input.agentId, trigger })
       if (result._ !== 'CreateAgentTriggerResponse') throw new Error('Unexpected trigger create response')
       toast.success('Trigger created')
       onClose()
@@ -1242,7 +1236,7 @@ function CreateAgentTriggerDialog({
         <DialogTitle>New trigger</DialogTitle>
         <DialogDescription>Start a new agent session when matching Seed activity appears.</DialogDescription>
       </div>
-      <label className="flex items-center gap-2 text-sm">
+      <label className="flex gap-2 items-center text-sm">
         <input type="checkbox" checked={enabled} onChange={(event) => setEnabled(event.target.checked)} />
         Enabled
       </label>
@@ -1273,7 +1267,7 @@ function CreateAgentTriggerDialog({
         </SizableText>
         <AgentPromptEditor initialBlocks={prompt} onChange={setPrompt} />
       </div>
-      <div className="flex justify-end gap-2">
+      <div className="flex gap-2 justify-end">
         <Button variant="ghost" onClick={onClose}>
           Cancel
         </Button>
@@ -1299,7 +1293,7 @@ function TriggerSourceFields({
           Trigger Session on:
         </SizableText>
         <select
-          className="border-input bg-background rounded-md border px-3 py-2 text-sm"
+          className="px-3 py-2 text-sm rounded-md border border-input bg-background"
           value={source.type}
           onChange={(event) => onChange(defaultSourceForType(event.target.value as AgentTriggerSource['type']))}
         >
@@ -1314,7 +1308,7 @@ function TriggerSourceFields({
           <DocumentAutocompleteField
             label="Document"
             value={source.resource}
-            onChange={(value) => onChange({...source, resource: value})}
+            onChange={(value) => onChange({ ...source, resource: value })}
             placeholder="Search documents or enter hm:// URL"
           />
           <label className="flex flex-col gap-1">
@@ -1323,7 +1317,7 @@ function TriggerSourceFields({
             </SizableText>
             <Input
               value={source.author || ''}
-              onChange={(event) => onChange({...source, author: event.target.value || undefined})}
+              onChange={(event) => onChange({ ...source, author: event.target.value || undefined })}
               placeholder="optional account ID"
             />
           </label>
@@ -1334,14 +1328,14 @@ function TriggerSourceFields({
           <AccountAutocompleteField
             label="Mentioned account"
             value={source.mentionedAccount}
-            onChange={(value) => onChange({...source, mentionedAccount: value})}
+            onChange={(value) => onChange({ ...source, mentionedAccount: value })}
             placeholder="Search users or enter account ID"
             valueFormat="uid"
           />
           <AccountAutocompleteField
             label="Resource/site prefix"
             value={source.resourcePrefix || ''}
-            onChange={(value) => onChange({...source, resourcePrefix: value || undefined})}
+            onChange={(value) => onChange({ ...source, resourcePrefix: value || undefined })}
             placeholder="Search site/account or enter hm:// prefix"
             valueFormat="hm-url"
           />
@@ -1352,7 +1346,7 @@ function TriggerSourceFields({
           <AccountAutocompleteField
             label="Resource/site prefix"
             value={source.resourcePrefix}
-            onChange={(value) => onChange({...source, resourcePrefix: value})}
+            onChange={(value) => onChange({ ...source, resourcePrefix: value })}
             placeholder="Search site/account or enter hm:// prefix"
             valueFormat="hm-url"
           />
@@ -1385,13 +1379,13 @@ function ScheduleTriggerFields({
   source,
   onChange,
 }: {
-  source: Extract<AgentTriggerSource, {type: 'schedule'}>
+  source: Extract<AgentTriggerSource, { type: 'schedule' }>
   onChange: (source: AgentTriggerSource) => void
 }) {
   const schedule = source.schedule
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
-  const setSchedule = (next: Extract<AgentTriggerSource, {type: 'schedule'}>['schedule']) =>
-    onChange({type: 'schedule', schedule: next})
+  const setSchedule = (next: Extract<AgentTriggerSource, { type: 'schedule' }>['schedule']) =>
+    onChange({ type: 'schedule', schedule: next })
   return (
     <div className="grid gap-3">
       <label className="flex flex-col gap-1">
@@ -1399,13 +1393,13 @@ function ScheduleTriggerFields({
           Schedule mode
         </SizableText>
         <select
-          className="border-input bg-background rounded-md border px-3 py-2 text-sm"
+          className="px-3 py-2 text-sm rounded-md border border-input bg-background"
           value={schedule.kind}
           onChange={(event) => {
             const kind = event.target.value
-            if (kind === 'weekly') setSchedule({kind, daysOfWeek: [1, 2, 3, 4, 5], timeOfDay: '09:00', timezone})
-            else if (kind === 'once') setSchedule({kind, runAt: Date.now() + 60 * 60 * 1000, timezone})
-            else setSchedule({kind: 'interval', every: 1, unit: 'hours'})
+            if (kind === 'weekly') setSchedule({ kind, daysOfWeek: [1, 2, 3, 4, 5], timeOfDay: '09:00', timezone })
+            else if (kind === 'once') setSchedule({ kind, runAt: Date.now() + 60 * 60 * 1000, timezone })
+            else setSchedule({ kind: 'interval', every: 1, unit: 'hours' })
           }}
         >
           <option value="interval">Every interval</option>
@@ -1423,7 +1417,7 @@ function ScheduleTriggerFields({
               type="number"
               min={1}
               value={schedule.every}
-              onChange={(event) => setSchedule({...schedule, every: Number(event.target.value) || 1})}
+              onChange={(event) => setSchedule({ ...schedule, every: Number(event.target.value) || 1 })}
             />
           </label>
           <label className="flex flex-col gap-1">
@@ -1431,9 +1425,9 @@ function ScheduleTriggerFields({
               Unit
             </SizableText>
             <select
-              className="border-input bg-background rounded-md border px-3 py-2 text-sm"
+              className="px-3 py-2 text-sm rounded-md border border-input bg-background"
               value={schedule.unit}
-              onChange={(event) => setSchedule({...schedule, unit: event.target.value as 'minutes' | 'hours'})}
+              onChange={(event) => setSchedule({ ...schedule, unit: event.target.value as 'minutes' | 'hours' })}
             >
               <option value="minutes">Minutes</option>
               <option value="hours">Hours</option>
@@ -1453,7 +1447,7 @@ function ScheduleTriggerFields({
               ['Sat', 6],
               ['Sun', 0],
             ].map(([day, dayIndex]) => (
-              <label key={day} className="border-border flex items-center gap-2 rounded-md border px-3 py-2 text-sm">
+              <label key={day} className="flex gap-2 items-center px-3 py-2 text-sm rounded-md border border-border">
                 <input
                   type="checkbox"
                   checked={schedule.daysOfWeek.includes(dayIndex as number)}
@@ -1462,7 +1456,7 @@ function ScheduleTriggerFields({
                     const daysOfWeek = event.target.checked
                       ? [...schedule.daysOfWeek, dayNumber].sort()
                       : schedule.daysOfWeek.filter((item) => item !== dayNumber)
-                    setSchedule({...schedule, daysOfWeek})
+                    setSchedule({ ...schedule, daysOfWeek })
                   }}
                 />
                 {day}
@@ -1477,7 +1471,7 @@ function ScheduleTriggerFields({
               <Input
                 type="time"
                 value={schedule.timeOfDay}
-                onChange={(event) => setSchedule({...schedule, timeOfDay: event.target.value})}
+                onChange={(event) => setSchedule({ ...schedule, timeOfDay: event.target.value })}
               />
             </label>
             <label className="flex flex-col gap-1">
@@ -1486,7 +1480,7 @@ function ScheduleTriggerFields({
               </SizableText>
               <Input
                 value={schedule.timezone}
-                onChange={(event) => setSchedule({...schedule, timezone: event.target.value})}
+                onChange={(event) => setSchedule({ ...schedule, timezone: event.target.value })}
               />
             </label>
           </div>
@@ -1501,7 +1495,7 @@ function ScheduleTriggerFields({
             <Input
               type="datetime-local"
               value={dateTimeLocalValue(schedule.runAt)}
-              onChange={(event) => setSchedule({...schedule, runAt: new Date(event.target.value).getTime(), timezone})}
+              onChange={(event) => setSchedule({ ...schedule, runAt: new Date(event.target.value).getTime(), timezone })}
             />
           </label>
           <label className="flex flex-col gap-1">
@@ -1510,7 +1504,7 @@ function ScheduleTriggerFields({
             </SizableText>
             <Input
               value={schedule.timezone || timezone}
-              onChange={(event) => setSchedule({...schedule, timezone: event.target.value})}
+              onChange={(event) => setSchedule({ ...schedule, timezone: event.target.value })}
             />
           </label>
         </div>
@@ -1541,7 +1535,7 @@ function DocumentAutocompleteField({
   )
 
   return (
-    <label className="relative flex flex-col gap-1">
+    <label className="flex relative flex-col gap-1">
       <SizableText size="sm" weight="bold">
         {label}
       </SizableText>
@@ -1553,14 +1547,14 @@ function DocumentAutocompleteField({
         placeholder={placeholder}
       />
       {focused && documents.length ? (
-        <div className="border-border bg-popover absolute top-full right-0 left-0 z-20 mt-1 max-h-64 overflow-auto rounded-md border p-1 shadow-lg">
+        <div className="overflow-auto absolute right-0 left-0 top-full z-20 p-1 mt-1 max-h-64 rounded-md border shadow-lg border-border bg-popover">
           {documents.map((document) => {
             const nextValue = packHmId(document.id)
             return (
               <button
                 key={document.id.id}
                 type="button"
-                className="hover:bg-muted flex w-full flex-col rounded px-2 py-2 text-left"
+                className="flex flex-col px-2 py-2 w-full text-left rounded hover:bg-muted"
                 onMouseDown={(event) => event.preventDefault()}
                 onClick={() => {
                   onChange(nextValue)
@@ -1570,7 +1564,7 @@ function DocumentAutocompleteField({
                 <SizableText size="sm" weight="bold" className="truncate">
                   {document.title || nextValue}
                 </SizableText>
-                <SizableText size="xs" color="muted" className="truncate font-mono">
+                <SizableText size="xs" color="muted" className="font-mono truncate">
                   {nextValue}
                 </SizableText>
               </button>
@@ -1606,7 +1600,7 @@ function AccountAutocompleteField({
   )
 
   return (
-    <label className="relative flex flex-col gap-1">
+    <label className="flex relative flex-col gap-1">
       <SizableText size="sm" weight="bold">
         {label}
       </SizableText>
@@ -1618,14 +1612,14 @@ function AccountAutocompleteField({
         placeholder={placeholder}
       />
       {focused && accounts.length ? (
-        <div className="border-border bg-popover absolute top-full right-0 left-0 z-20 mt-1 max-h-64 overflow-auto rounded-md border p-1 shadow-lg">
+        <div className="overflow-auto absolute right-0 left-0 top-full z-20 p-1 mt-1 max-h-64 rounded-md border shadow-lg border-border bg-popover">
           {accounts.map((account) => {
             const nextValue = valueFormat === 'hm-url' ? `hm://${account.id.uid}` : account.id.uid
             return (
               <button
                 key={`${account.id.id}:${account.type}`}
                 type="button"
-                className="hover:bg-muted flex w-full flex-col rounded px-2 py-2 text-left"
+                className="flex flex-col px-2 py-2 w-full text-left rounded hover:bg-muted"
                 onMouseDown={(event) => event.preventDefault()}
                 onClick={() => {
                   onChange(nextValue)
@@ -1635,7 +1629,7 @@ function AccountAutocompleteField({
                 <SizableText size="sm" weight="bold" className="truncate">
                   {account.title || account.id.uid}
                 </SizableText>
-                <SizableText size="xs" color="muted" className="truncate font-mono">
+                <SizableText size="xs" color="muted" className="font-mono truncate">
                   {nextValue}
                 </SizableText>
               </button>
@@ -1648,10 +1642,10 @@ function AccountAutocompleteField({
 }
 
 function defaultSourceForType(type: AgentTriggerSource['type']): AgentTriggerSource {
-  if (type === 'user-mention') return {type, mentionedAccount: ''}
-  if (type === 'site-update') return {type, resourcePrefix: '', eventTypes: ['doc-update', 'comment']}
-  if (type === 'schedule') return {type, schedule: {kind: 'interval', every: 1, unit: 'hours'}}
-  return {type: 'document-comment', resource: ''}
+  if (type === 'user-mention') return { type, mentionedAccount: '' }
+  if (type === 'site-update') return { type, resourcePrefix: '', eventTypes: ['doc-update', 'comment'] }
+  if (type === 'schedule') return { type, schedule: { kind: 'interval', every: 1, unit: 'hours' } }
+  return { type: 'document-comment', resource: '' }
 }
 
 function triggerSourceSummary(source: AgentTriggerSource): string {
@@ -1666,9 +1660,8 @@ function triggerSourceSummary(source: AgentTriggerSource): string {
   }
   if (source.schedule.kind === 'interval') return `Every ${source.schedule.every} ${source.schedule.unit}`
   if (source.schedule.kind === 'once') return `Once at ${formattedDateMedium(new Date(source.schedule.runAt))}`
-  return `${source.schedule.daysOfWeek.map(dayName).join(', ')} at ${source.schedule.timeOfDay} ${
-    source.schedule.timezone
-  }`
+  return `${source.schedule.daysOfWeek.map(dayName).join(', ')} at ${source.schedule.timeOfDay} ${source.schedule.timezone
+    }`
 }
 
 function nextScheduleFire(input: {
@@ -1691,7 +1684,7 @@ function nextScheduleFire(input: {
 }
 
 function nextWeeklyScheduleFire(
-  schedule: Extract<Extract<AgentTriggerSource, {type: 'schedule'}>['schedule'], {kind: 'weekly'}>,
+  schedule: Extract<Extract<AgentTriggerSource, { type: 'schedule' }>['schedule'], { kind: 'weekly' }>,
   now: number,
   after: number,
 ): number | null {
@@ -1735,7 +1728,7 @@ function zonedTimeToUtcMs(
 function zonedParts(
   ms: number,
   timeZone: string,
-): {year: number; month: number; day: number; hour: number; minute: number; weekday: number} {
+): { year: number; month: number; day: number; hour: number; minute: number; weekday: number } {
   const formatter = new Intl.DateTimeFormat('en-US', {
     timeZone,
     weekday: 'short',
@@ -1810,10 +1803,10 @@ function SessionListItem({
   onOpenTrigger?: () => void
 }) {
   return (
-    <div className="hover:bg-muted flex flex-col items-start rounded-lg px-3 py-2 transition-colors">
-      <button type="button" className="flex w-full items-center gap-3 text-left" onClick={onOpen}>
+    <div className="flex flex-col items-start px-3 py-2 rounded-lg transition-colors hover:bg-muted">
+      <button type="button" className="flex gap-3 items-center w-full text-left" onClick={onOpen}>
         <SessionStatusDot status={session.status} />
-        <SizableText weight="bold" className="min-w-0 flex-1 truncate">
+        <SizableText weight="bold" className="flex-1 min-w-0 truncate">
           {session.title || 'Untitled session'}
         </SizableText>
         <SizableText size="sm" color="muted" className="flex-none whitespace-nowrap">
@@ -1836,7 +1829,7 @@ function SessionListItem({
   )
 }
 
-function SessionStatusDot({status}: {status: SessionInfo['status']}) {
+function SessionStatusDot({ status }: { status: SessionInfo['status'] }) {
   const className =
     status === 'error'
       ? 'bg-destructive'

--- a/frontend/apps/desktop/src/pages/agents/detail.tsx
+++ b/frontend/apps/desktop/src/pages/agents/detail.tsx
@@ -9,6 +9,7 @@ import {
 import {
   DEFAULT_AGENT_SERVER_URL,
   useAgentDetail,
+  useAgentList,
   useAgentServerHealth,
   useAgentServerUrl,
   useAgentTrigger,
@@ -24,6 +25,7 @@ import {
   useSigningIdentities,
   useUpdateAgent,
   useUpdateAgentTrigger,
+  useUpdateSigningIdentity,
 } from '@/models/agents'
 import {useSelectedAccountId} from '@/selected-account'
 import {useClickNavigate, useNavigate} from '@/utils/useNavigate'
@@ -51,7 +53,8 @@ import {toast} from '@shm/ui/toast'
 import {useAppDialog} from '@shm/ui/universal-dialog'
 import {KeyRound, Trash2} from 'lucide-react'
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
-import {AddModelProviderDialog} from './dialogs'
+import {AGENT_READ_TOOL_GROUP} from './agent-tools'
+import {AddModelProviderDialog, EditAgentNameDialog, type AgentAccountRenameStatus} from './dialogs'
 import {AgentHeader, AgentSubpageHeader, type AgentPageTab} from './header'
 import {ModelSelect} from './model-select'
 import {curateProviderModels} from './model-utils'
@@ -79,11 +82,14 @@ function AgentDetailPage({
   const triggers = useAgentTriggers(serverUrl, selectedAccountId, agentId)
   const createSession = useCreateAgentSession(serverUrl, selectedAccountId)
   const updateAgent = useUpdateAgent(serverUrl, selectedAccountId)
+  const updateSigningIdentity = useUpdateSigningIdentity(serverUrl, selectedAccountId)
   const deleteAgentDialog = useAppDialog(DeleteAgentDialog, {isAlert: true})
   const signingIdentities = useSigningIdentities(serverUrl, selectedAccountId)
   const createSigningIdentity = useCreateSigningIdentity(serverUrl, selectedAccountId)
   const createTriggerDialog = useAppDialog(CreateAgentTriggerDialog)
+  const editNameDialog = useAppDialog(EditAgentNameDialog)
   const modelProviders = useModelProviders(serverUrl, selectedAccountId)
+  const allAgents = useAgentList(serverUrl, selectedAccountId)
   const addProviderDialog = useAppDialog(AddModelProviderDialog)
   useAgentWebSocketSubscription(serverUrl, selectedAccountId, `agents/${agentId}`)
   const [name, setName] = useState('')
@@ -132,6 +138,37 @@ function AgentDetailPage({
     setModelProvider(nextProvider)
     setModel('') // belongs to the previous provider; the effect above picks a new default
     setNameModelDirty(true)
+  }
+
+  // The agent's primary signing account, and whether other agents also use it.
+  const agentSigningKey =
+    agent.data?.agent.definition.signingKeys?.[0] || agent.data?.agent.definition.signingKey || undefined
+  const isAccountShared =
+    !!agentSigningKey &&
+    (allAgents.data || []).some((other) => {
+      if (other.id === agentId) return false
+      const otherKeys =
+        other.definition.signingKeys || (other.definition.signingKey ? [other.definition.signingKey] : [])
+      return otherKeys.includes(agentSigningKey)
+    })
+  const agentAccountStatus: AgentAccountRenameStatus = !agentSigningKey
+    ? {kind: 'none'}
+    : isAccountShared
+      ? {kind: 'shared'}
+      : {kind: 'own'}
+
+  async function handleRenameAgent(nextName: string) {
+    if (!agent.data) throw new Error('Agent not loaded')
+    const trimmed = nextName.trim()
+    if (!trimmed) throw new Error('Agent name is required')
+    const definition = agent.data.agent.definition
+    const result = await updateAgent.mutateAsync({agentId, definition: {...definition, name: trimmed}})
+    if (result._ !== 'GetAgentResponse') throw new Error('Unexpected update response')
+    // Keep the dedicated account's profile name in sync; leave shared accounts alone.
+    if (agentSigningKey && !isAccountShared) {
+      await updateSigningIdentity.mutateAsync({name: agentSigningKey, label: trimmed})
+    }
+    if (!nameModelDirty) setName(trimmed)
   }
 
   async function handleCreateSession() {
@@ -268,11 +305,13 @@ function AgentDetailPage({
               <AgentHeader
                 agent={agent.data.agent}
                 agentName={name}
-                agentNameSaveState={settingsSaveState}
-                onAgentNameChange={(value) => {
-                  setName(value)
-                  setNameModelDirty(true)
-                }}
+                onEditName={() =>
+                  editNameDialog.open({
+                    currentName: name,
+                    accountStatus: agentAccountStatus,
+                    onRename: handleRenameAgent,
+                  })
+                }
                 agentId={agentId}
                 serverUrl={serverUrl}
                 activeTab={tab}
@@ -288,6 +327,7 @@ function AgentDetailPage({
               {createTriggerDialog.content}
               {deleteAgentDialog.content}
               {addProviderDialog.content}
+              {editNameDialog.content}
 
               {tab === 'sessions' ? (
                 <section className="flex min-h-0 flex-1 flex-col">
@@ -385,18 +425,6 @@ function AgentDetailPage({
                   <div className="grid gap-3 md:grid-cols-2">
                     <label className="flex flex-col gap-1">
                       <SizableText size="sm" weight="bold">
-                        Name
-                      </SizableText>
-                      <Input
-                        value={name}
-                        onChange={(event) => {
-                          setName(event.target.value)
-                          setNameModelDirty(true)
-                        }}
-                      />
-                    </label>
-                    <label className="flex flex-col gap-1">
-                      <SizableText size="sm" weight="bold">
                         Provider
                       </SizableText>
                       <ProviderSelect
@@ -406,24 +434,24 @@ function AgentDetailPage({
                         onAddProvider={() => addProviderDialog.open({serverUrl, selectedAccountId})}
                       />
                     </label>
+                    <label className="flex flex-col gap-1">
+                      <SizableText size="sm" weight="bold">
+                        Model
+                      </SizableText>
+                      <ModelSelect
+                        models={providerModels.data}
+                        providerType={selectedProviderType}
+                        value={model}
+                        onChange={(nextModel) => {
+                          setModel(nextModel)
+                          setNameModelDirty(true)
+                        }}
+                        isLoading={providerModels.isLoading}
+                        isError={providerModels.isError}
+                        error={providerModels.error}
+                      />
+                    </label>
                   </div>
-                  <label className="flex flex-col gap-1">
-                    <SizableText size="sm" weight="bold">
-                      Model
-                    </SizableText>
-                    <ModelSelect
-                      models={providerModels.data}
-                      providerType={selectedProviderType}
-                      value={model}
-                      onChange={(nextModel) => {
-                        setModel(nextModel)
-                        setNameModelDirty(true)
-                      }}
-                      isLoading={providerModels.isLoading}
-                      isError={providerModels.isError}
-                      error={providerModels.error}
-                    />
-                  </label>
                   <div className="grid gap-3 text-sm md:grid-cols-2">
                     <div>
                       <SizableText size="sm" weight="bold">
@@ -561,12 +589,6 @@ function DeleteAgentDialog({
     </div>
   )
 }
-
-const AGENT_READ_TOOL_GROUP = [
-  seedToolRegistry.read.name,
-  seedToolRegistry.search.name,
-  seedToolRegistry.list_activity_feed.name,
-]
 
 const AGENT_TOOL_OPTIONS = [
   {

--- a/frontend/apps/desktop/src/pages/agents/dialogs.tsx
+++ b/frontend/apps/desktop/src/pages/agents/dialogs.tsx
@@ -27,6 +27,7 @@ import {ExternalLink, Trash2} from 'lucide-react'
 import {useEffect, useState} from 'react'
 import {ModelSelect} from './model-select'
 import {AgentPromptEditor, promptBlocksToMarkdown} from './prompt-editor'
+import {ProviderSelect} from './provider-select'
 
 export function ModelProvidersDialog({
   input,
@@ -91,7 +92,7 @@ export function ModelProvidersDialog({
   )
 }
 
-function AddModelProviderDialog({
+export function AddModelProviderDialog({
   input,
   onClose,
 }: {
@@ -388,6 +389,7 @@ export function CreateAgentDialog({
   const [providerName, setProviderName] = useState('')
   const providerModels = useProviderModels(selectedServerUrl, input.selectedAccountId, providerName)
   const selectedProviderType = providers.data?.find((provider) => provider.name === providerName)?.type
+  const addProviderDialog = useAppDialog(AddModelProviderDialog)
   const [name, setName] = useState('Desktop Test Agent')
   const [model, setModel] = useState('')
   const [systemPrompt, setSystemPrompt] = useState<HMBlockNode[]>(() =>
@@ -480,18 +482,16 @@ export function CreateAgentDialog({
         <SizableText size="sm" weight="bold">
           Model provider
         </SizableText>
-        <select
-          className="border-input bg-background rounded-md border px-3 py-2 text-sm"
+        <ProviderSelect
+          providers={providers.data}
           value={providerName}
-          onChange={(event) => setProviderName(event.target.value)}
-        >
-          {(providers.data || []).map((provider) => (
-            <option key={provider.id} value={provider.name}>
-              {provider.name} ({provider.type})
-            </option>
-          ))}
-        </select>
+          onChange={setProviderName}
+          onAddProvider={() =>
+            addProviderDialog.open({serverUrl: selectedServerUrl, selectedAccountId: input.selectedAccountId})
+          }
+        />
       </label>
+      {addProviderDialog.content}
       <div className="grid gap-3 md:grid-cols-2">
         <label className="flex flex-col gap-1">
           <SizableText size="sm" weight="bold">

--- a/frontend/apps/desktop/src/pages/agents/dialogs.tsx
+++ b/frontend/apps/desktop/src/pages/agents/dialogs.tsx
@@ -389,6 +389,7 @@ export function CreateAgentDialog({
   const createAgent = useCreateAgent(selectedServerUrl, input.selectedAccountId)
   const createSigningIdentity = useCreateSigningIdentity(selectedServerUrl, input.selectedAccountId)
   const deleteSigningIdentity = useDeleteSigningIdentity(selectedServerUrl, input.selectedAccountId)
+  const navigate = useNavigate()
   const [providerName, setProviderName] = useState('')
   const providerModels = useProviderModels(selectedServerUrl, input.selectedAccountId, providerName)
   const selectedProviderType = providers.data?.find((provider) => provider.name === providerName)?.type
@@ -446,6 +447,7 @@ export function CreateAgentDialog({
       if (result._ !== 'CreateAgentResponse') throw new Error('Unexpected create response')
       toast.success('Agent created')
       onClose()
+      navigate({key: 'agent', agentId: result.agentId, serverUrl: selectedServerUrl})
     } catch (error) {
       // Roll back the just-created account so a failed agent create doesn't leave an orphan.
       void deleteSigningIdentity.mutateAsync(signingKeyName).catch(() => {})

--- a/frontend/apps/desktop/src/pages/agents/dialogs.tsx
+++ b/frontend/apps/desktop/src/pages/agents/dialogs.tsx
@@ -97,7 +97,40 @@ function AddModelProviderDialog({
   input: {serverUrl: string; selectedAccountId: string | null | undefined}
   onClose: () => void
 }) {
-  const saveProvider = useSaveModelProvider(input.serverUrl, input.selectedAccountId)
+  return (
+    <div className="flex min-w-[420px] flex-col gap-5">
+      <div>
+        <DialogTitle>Add model provider</DialogTitle>
+        <DialogDescription>Save this API key as an encrypted server-side secret.</DialogDescription>
+      </div>
+      <AddModelProviderForm
+        serverUrl={input.serverUrl}
+        selectedAccountId={input.selectedAccountId}
+        onSaved={onClose}
+        onCancel={onClose}
+      />
+    </div>
+  )
+}
+
+/**
+ * Provider type/name/API-key fields plus save logic, shared by the standalone
+ * "Add model provider" dialog and the inline provider step of agent creation.
+ */
+function AddModelProviderForm({
+  serverUrl,
+  selectedAccountId,
+  onSaved,
+  onCancel,
+  submitLabel = 'Save provider',
+}: {
+  serverUrl: string
+  selectedAccountId: string | null | undefined
+  onSaved?: () => void
+  onCancel: () => void
+  submitLabel?: string
+}) {
+  const saveProvider = useSaveModelProvider(serverUrl, selectedAccountId)
   const [type, setType] = useState<ModelProviderType>('openai')
   const [name, setName] = useState('openai')
   const [apiKey, setApiKey] = useState('')
@@ -111,7 +144,7 @@ function AddModelProviderDialog({
       await saveProvider.mutateAsync({type, name, apiKey})
       setApiKey('')
       toast.success('Model provider saved')
-      onClose()
+      onSaved?.()
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Could not save model provider')
     }
@@ -119,17 +152,13 @@ function AddModelProviderDialog({
 
   return (
     <form
-      className="flex min-w-[420px] flex-col gap-5"
+      className="flex flex-col gap-5"
       onSubmit={(event) => {
         event.preventDefault()
         if (saveProvider.isLoading || !apiKey.trim()) return
         void handleSave()
       }}
     >
-      <div>
-        <DialogTitle>Add model provider</DialogTitle>
-        <DialogDescription>Save this API key as an encrypted server-side secret.</DialogDescription>
-      </div>
       <label className="flex flex-col gap-1">
         <SizableText size="sm" weight="bold">
           Provider type
@@ -157,11 +186,11 @@ function AddModelProviderDialog({
         <Input type="password" value={apiKey} onChange={(event) => setApiKey(event.target.value)} />
       </label>
       <div className="flex justify-end gap-2">
-        <Button type="button" variant="ghost" onClick={onClose}>
+        <Button type="button" variant="ghost" onClick={onCancel}>
           Cancel
         </Button>
         <Button type="submit" disabled={saveProvider.isLoading || !apiKey.trim()}>
-          Save provider
+          {submitLabel}
         </Button>
       </div>
     </form>
@@ -396,28 +425,57 @@ export function CreateAgentDialog({
     }
   }
 
+  const serverSelector = (
+    <label className="flex flex-col gap-1">
+      <SizableText size="sm" weight="bold">
+        Agent server
+      </SizableText>
+      <select
+        className="border-input bg-background rounded-md border px-3 py-2 text-sm"
+        value={selectedServerUrl}
+        onChange={(event) => setSelectedServerUrl(event.target.value)}
+      >
+        {input.serverUrls.map((serverUrl) => (
+          <option key={serverUrl} value={serverUrl}>
+            {serverUrl}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+
+  // Force provider setup before agent creation when the selected server has
+  // none configured. Saving one refetches `providers`, which transitions this
+  // dialog to the regular agent creation form automatically.
+  const needsProvider = !providers.isLoading && !providers.data?.length
+
+  if (needsProvider) {
+    return (
+      <div className="flex min-w-[520px] flex-col gap-5">
+        <div>
+          <DialogTitle>Create Agent</DialogTitle>
+          <DialogDescription>
+            Add a model provider on this server before creating an agent.
+          </DialogDescription>
+        </div>
+        {serverSelector}
+        <AddModelProviderForm
+          serverUrl={selectedServerUrl}
+          selectedAccountId={input.selectedAccountId}
+          onCancel={onClose}
+          submitLabel="Add provider"
+        />
+      </div>
+    )
+  }
+
   return (
     <div className="flex min-w-[520px] flex-col gap-5">
       <div>
         <DialogTitle>Create Agent</DialogTitle>
         <DialogDescription>Choose a model provider, model, and system prompt for the new agent.</DialogDescription>
       </div>
-      <label className="flex flex-col gap-1">
-        <SizableText size="sm" weight="bold">
-          Agent server
-        </SizableText>
-        <select
-          className="border-input bg-background rounded-md border px-3 py-2 text-sm"
-          value={selectedServerUrl}
-          onChange={(event) => setSelectedServerUrl(event.target.value)}
-        >
-          {input.serverUrls.map((serverUrl) => (
-            <option key={serverUrl} value={serverUrl}>
-              {serverUrl}
-            </option>
-          ))}
-        </select>
-      </label>
+      {serverSelector}
       <label className="flex flex-col gap-1">
         <SizableText size="sm" weight="bold">
           Model provider
@@ -433,11 +491,6 @@ export function CreateAgentDialog({
             </option>
           ))}
         </select>
-        {!providers.isLoading && !providers.data?.length ? (
-          <SizableText size="xs" color="muted">
-            Configure a model provider on this server before creating an agent.
-          </SizableText>
-        ) : null}
       </label>
       <div className="grid gap-3 md:grid-cols-2">
         <label className="flex flex-col gap-1">

--- a/frontend/apps/desktop/src/pages/agents/dialogs.tsx
+++ b/frontend/apps/desktop/src/pages/agents/dialogs.tsx
@@ -25,6 +25,7 @@ import {toast} from '@shm/ui/toast'
 import {useAppDialog} from '@shm/ui/universal-dialog'
 import {ExternalLink, Trash2} from 'lucide-react'
 import {useEffect, useState} from 'react'
+import {ModelSelect} from './model-select'
 import {AgentPromptEditor, promptBlocksToMarkdown} from './prompt-editor'
 
 export function ModelProvidersDialog({
@@ -386,6 +387,7 @@ export function CreateAgentDialog({
   const createAgent = useCreateAgent(selectedServerUrl, input.selectedAccountId)
   const [providerName, setProviderName] = useState('')
   const providerModels = useProviderModels(selectedServerUrl, input.selectedAccountId, providerName)
+  const selectedProviderType = providers.data?.find((provider) => provider.name === providerName)?.type
   const [name, setName] = useState('Desktop Test Agent')
   const [model, setModel] = useState('')
   const [systemPrompt, setSystemPrompt] = useState<HMBlockNode[]>(() =>
@@ -454,9 +456,7 @@ export function CreateAgentDialog({
       <div className="flex min-w-[520px] flex-col gap-5">
         <div>
           <DialogTitle>Create Agent</DialogTitle>
-          <DialogDescription>
-            Add a model provider on this server before creating an agent.
-          </DialogDescription>
+          <DialogDescription>Add a model provider on this server before creating an agent.</DialogDescription>
         </div>
         {serverSelector}
         <AddModelProviderForm
@@ -503,29 +503,16 @@ export function CreateAgentDialog({
           <SizableText size="sm" weight="bold">
             Model
           </SizableText>
-          <select
-            className="border-input bg-background rounded-md border px-3 py-2 text-sm"
+          <ModelSelect
+            models={providerModels.data}
+            providerType={selectedProviderType}
             value={model}
-            onChange={(event) => setModel(event.target.value)}
-            disabled={!providerName || providerModels.isLoading || !providerModels.data?.length}
-          >
-            {providerModels.isLoading ? <option value="">Loading models…</option> : null}
-            {!providerModels.isLoading && !providerModels.data?.length ? (
-              <option value="">No models found</option>
-            ) : null}
-            {(providerModels.data || []).map((providerModel) => (
-              <option key={providerModel.id} value={providerModel.id}>
-                {providerModel.name === providerModel.id
-                  ? providerModel.id
-                  : `${providerModel.name} (${providerModel.id})`}
-              </option>
-            ))}
-          </select>
-          {providerModels.isError ? (
-            <SizableText size="xs" className="text-destructive">
-              {providerModels.error instanceof Error ? providerModels.error.message : 'Could not load models'}
-            </SizableText>
-          ) : null}
+            onChange={setModel}
+            isLoading={providerModels.isLoading}
+            isError={providerModels.isError}
+            error={providerModels.error}
+            disabled={!providerName}
+          />
         </label>
       </div>
       <div className="flex flex-col gap-1">

--- a/frontend/apps/desktop/src/pages/agents/dialogs.tsx
+++ b/frontend/apps/desktop/src/pages/agents/dialogs.tsx
@@ -25,6 +25,7 @@ import {toast} from '@shm/ui/toast'
 import {useAppDialog} from '@shm/ui/universal-dialog'
 import {ExternalLink, Trash2} from 'lucide-react'
 import {useEffect, useState} from 'react'
+import {DEFAULT_AGENT_TOOLS} from './agent-tools'
 import {ModelSelect} from './model-select'
 import {AgentPromptEditor, promptBlocksToMarkdown} from './prompt-editor'
 import {ProviderSelect} from './provider-select'
@@ -386,6 +387,8 @@ export function CreateAgentDialog({
   const [selectedServerUrl, setSelectedServerUrl] = useState(input.serverUrls[0] || DEFAULT_AGENT_SERVER_URL)
   const providers = useModelProviders(selectedServerUrl, input.selectedAccountId)
   const createAgent = useCreateAgent(selectedServerUrl, input.selectedAccountId)
+  const createSigningIdentity = useCreateSigningIdentity(selectedServerUrl, input.selectedAccountId)
+  const deleteSigningIdentity = useDeleteSigningIdentity(selectedServerUrl, input.selectedAccountId)
   const [providerName, setProviderName] = useState('')
   const providerModels = useProviderModels(selectedServerUrl, input.selectedAccountId, providerName)
   const selectedProviderType = providers.data?.find((provider) => provider.name === providerName)?.type
@@ -411,13 +414,32 @@ export function CreateAgentDialog({
   }, [model, providerModels.data])
 
   async function handleCreateAgent() {
+    const agentName = name.trim()
+    if (!agentName) {
+      toast.error('Agent name is required')
+      return
+    }
+    // Auto-create a dedicated account for the agent so it can publish without the
+    // user setting up a signing identity by hand. The account is named after the
+    // agent and wired in as its signing key with write tooling enabled.
+    let signingKeyName: string | undefined
+    try {
+      const identityResult = await createSigningIdentity.mutateAsync(agentName)
+      if (identityResult._ !== 'CreateSigningIdentityResponse') throw new Error('Unexpected account response')
+      signingKeyName = identityResult.identity.name
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Could not create the agent account')
+      return
+    }
     try {
       const definition: AgentDefinition = {
-        name,
+        name: agentName,
         systemPrompt: promptBlocksToMarkdown(systemPrompt),
         modelProvider: providerName,
         model,
-        tools: ['read'],
+        tools: DEFAULT_AGENT_TOOLS,
+        signingKey: signingKeyName,
+        signingKeys: [signingKeyName],
         metadata: {createdFrom: 'desktop-agents-page'},
       }
       const result = await createAgent.mutateAsync(definition)
@@ -425,6 +447,8 @@ export function CreateAgentDialog({
       toast.success('Agent created')
       onClose()
     } catch (error) {
+      // Roll back the just-created account so a failed agent create doesn't leave an orphan.
+      void deleteSigningIdentity.mutateAsync(signingKeyName).catch(() => {})
       toast.error(error instanceof Error ? error.message : 'Could not create agent')
     }
   }
@@ -475,7 +499,10 @@ export function CreateAgentDialog({
     <div className="flex min-w-[520px] flex-col gap-5">
       <div>
         <DialogTitle>Create Agent</DialogTitle>
-        <DialogDescription>Choose a model provider, model, and system prompt for the new agent.</DialogDescription>
+        <DialogDescription>
+          Choose a model provider, model, and system prompt. An account named after the agent is created automatically
+          so it can publish Seed content.
+        </DialogDescription>
       </div>
       {serverSelector}
       <label className="flex flex-col gap-1">
@@ -525,10 +552,84 @@ export function CreateAgentDialog({
         <Button variant="ghost" onClick={onClose}>
           Cancel
         </Button>
-        <Button onClick={() => void handleCreateAgent()} disabled={createAgent.isLoading || !providerName || !model}>
+        <Button
+          onClick={() => void handleCreateAgent()}
+          disabled={createAgent.isLoading || createSigningIdentity.isLoading || !providerName || !model}
+        >
           Create Agent
         </Button>
       </div>
     </div>
+  )
+}
+
+/** Describes how the agent's account relates to the rename so the dialog can explain what happens. */
+export type AgentAccountRenameStatus =
+  | {kind: 'own'} // a dedicated account that will be renamed alongside the agent
+  | {kind: 'shared'} // an account used by other agents, left untouched
+  | {kind: 'none'} // no signing account linked
+
+export function EditAgentNameDialog({
+  input,
+  onClose,
+}: {
+  input: {currentName: string; accountStatus: AgentAccountRenameStatus; onRename: (name: string) => Promise<void>}
+  onClose: () => void
+}) {
+  const [name, setName] = useState(input.currentName)
+  const [saving, setSaving] = useState(false)
+
+  async function handleSave() {
+    const trimmed = name.trim()
+    if (!trimmed) {
+      toast.error('Agent name is required')
+      return
+    }
+    setSaving(true)
+    try {
+      await input.onRename(trimmed)
+      toast.success('Agent renamed')
+      onClose()
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Could not rename agent')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <form
+      className="flex min-w-[420px] flex-col gap-5"
+      onSubmit={(event) => {
+        event.preventDefault()
+        if (saving) return
+        void handleSave()
+      }}
+    >
+      <div>
+        <DialogTitle>Rename agent</DialogTitle>
+        <DialogDescription>
+          {input.accountStatus.kind === 'own'
+            ? "The agent's account is renamed to match."
+            : input.accountStatus.kind === 'shared'
+              ? 'This agent shares its account with other agents, so the account keeps its name. Rename it separately from Manage accounts.'
+              : 'This agent has no linked account to rename.'}
+        </DialogDescription>
+      </div>
+      <label className="flex flex-col gap-1">
+        <SizableText size="sm" weight="bold">
+          Name
+        </SizableText>
+        <Input autoFocus value={name} onChange={(event) => setName(event.target.value)} placeholder="Agent" />
+      </label>
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="ghost" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={saving || !name.trim()}>
+          Save
+        </Button>
+      </div>
+    </form>
   )
 }

--- a/frontend/apps/desktop/src/pages/agents/header.tsx
+++ b/frontend/apps/desktop/src/pages/agents/header.tsx
@@ -6,7 +6,16 @@ import {useIsomorphicLayoutEffect} from '@shm/shared/utils/use-isomorphic-layout
 import {Button} from '@shm/ui/button'
 import {PageTab} from '@shm/ui/page-tabs'
 import {SizableText} from '@shm/ui/text'
-import {ArrowLeft, GitBranch, MessageSquarePlus, MessagesSquare, ScrollText, Settings, Wrench} from 'lucide-react'
+import {
+  ArrowLeft,
+  GitBranch,
+  MessageSquarePlus,
+  MessagesSquare,
+  Pencil,
+  ScrollText,
+  Settings,
+  Wrench,
+} from 'lucide-react'
 import {Fragment, type ReactNode, useRef, useState} from 'react'
 
 export type AgentPageTab = 'sessions' | 'triggers' | 'tools' | 'prompt' | 'settings'
@@ -150,6 +159,7 @@ export function AgentHeader({
   agentName,
   agentNameSaveState = 'idle',
   onAgentNameChange,
+  onEditName,
   serverUrl,
   activeTab,
   sessionsCount,
@@ -165,6 +175,7 @@ export function AgentHeader({
   agentName?: string
   agentNameSaveState?: AgentTitleSaveState
   onAgentNameChange?: (value: string) => void
+  onEditName?: () => void
   serverUrl: string
   activeTab: AgentPageTab
   sessionsCount?: number
@@ -232,7 +243,19 @@ export function AgentHeader({
       <section className="flex flex-col gap-3">
         <div className="flex items-start justify-between gap-4">
           <div className="flex min-w-0 flex-col gap-1">
-            {onAgentNameChange ? (
+            {onEditName ? (
+              <button
+                type="button"
+                aria-label="Rename agent"
+                onClick={onEditName}
+                className="hover:bg-muted/60 group -mx-1 flex min-w-0 items-center gap-2 rounded-md px-1 py-0.5 text-left"
+              >
+                <SizableText size="2xl" weight="bold" className="min-w-0 truncate">
+                  {currentAgentName}
+                </SizableText>
+                <Pencil className="text-muted-foreground size-4 flex-none opacity-0 transition-opacity group-hover:opacity-100" />
+              </button>
+            ) : onAgentNameChange ? (
               <input
                 aria-label="Agent name"
                 className="focus:ring-primary/25 -mx-1 min-w-0 truncate rounded-md bg-transparent px-1 py-0.5 text-2xl font-bold outline-none focus:ring-2"

--- a/frontend/apps/desktop/src/pages/agents/list.tsx
+++ b/frontend/apps/desktop/src/pages/agents/list.tsx
@@ -3,7 +3,6 @@ import {
   useAgentServerHealths,
   useAgentServerUrls,
   useAgentWebSocketSubscription,
-  useModelProviderLists,
 } from '@/models/agents'
 import {useSelectedAccountId} from '@/selected-account'
 import {useNavigate} from '@/utils/useNavigate'
@@ -24,7 +23,6 @@ function AgentsListPage() {
   const serverUrls = serverUrlsQuery.data || []
   const agentQueries = useAgentLists(serverUrls, selectedAccountId)
   const healthQueries = useAgentServerHealths(serverUrls)
-  const providerQueries = useModelProviderLists(serverUrls, selectedAccountId)
   const providersDialog = useAppDialog(ModelProvidersDialog)
   const manageAccountsDialog = useAppDialog(ManageAgentAccountsDialog)
   const createAgentDialog = useAppDialog(CreateAgentDialog)
@@ -38,16 +36,11 @@ function AgentsListPage() {
   )
   const isLoadingAgents = !!selectedAccountId && agentQueries.some((query) => query.isFetching && !query.data)
   const agentError = agentQueries.find((query) => query.isError)?.error
-  const providersLoading = providerQueries.some((query) => query.isLoading)
-  const hasCreatableProvider = providerQueries.some((query) => !!query.data?.length)
-  const needsModelProvider = !!selectedAccountId && !!serverUrls.length && !providersLoading && !hasCreatableProvider
   const createAgentDisabledReason = !selectedAccountId
     ? 'Select an account before creating an agent.'
     : !serverUrls.length
       ? 'Configure an agent server before creating an agent.'
-      : providersLoading
-        ? 'Checking model providers…'
-        : null
+      : null
 
   return (
     <PanelContainer className="overflow-y-auto">
@@ -74,7 +67,6 @@ function AgentsListPage() {
           </div>
           {serverUrls.map((serverUrl, index) => {
             const health = healthQueries[index]
-            const providers = providerQueries[index]
             const status = health?.isLoading ? 'Checking…' : health?.isError ? 'Offline' : 'Online'
             return (
               <AgentServerSubscription key={serverUrl} serverUrl={serverUrl} selectedAccountId={selectedAccountId}>
@@ -138,25 +130,14 @@ function AgentsListPage() {
         <section className="flex flex-col gap-3">
           <div className="flex items-center justify-between gap-4">
             <SizableText weight="bold">All Agents</SizableText>
-            <Tooltip
-              content={
-                createAgentDisabledReason ||
-                (needsModelProvider ? 'Add a model provider before creating an agent.' : 'Create Agent')
-              }
-            >
+            <Tooltip content={createAgentDisabledReason || 'Create Agent'}>
               <span>
                 <Button
-                  onClick={() => {
-                    if (needsModelProvider) {
-                      providersDialog.open({serverUrl: serverUrls[0], selectedAccountId})
-                      return
-                    }
-                    createAgentDialog.open({serverUrls, selectedAccountId})
-                  }}
+                  onClick={() => createAgentDialog.open({serverUrls, selectedAccountId})}
                   disabled={!!createAgentDisabledReason}
                 >
-                  {needsModelProvider ? <Settings className="size-4" /> : <Bot className="size-4" />}
-                  {needsModelProvider ? 'Add Model Provider' : 'Create Agent'}
+                  <Bot className="size-4" />
+                  Create Agent
                 </Button>
               </span>
             </Tooltip>

--- a/frontend/apps/desktop/src/pages/agents/model-select.tsx
+++ b/frontend/apps/desktop/src/pages/agents/model-select.tsx
@@ -1,0 +1,142 @@
+import type {ProviderModelInfo} from '@/agents-client'
+import {Popover, PopoverContent, PopoverTrigger} from '@shm/ui/components/popover'
+import {Input} from '@shm/ui/components/input'
+import {SizableText} from '@shm/ui/text'
+import {cn} from '@shm/ui/utils'
+import {Check, ChevronsUpDown} from 'lucide-react'
+import {useMemo, useState} from 'react'
+import {curateProviderModels, modelLabel} from './model-utils'
+
+/**
+ * Searchable model picker shared by every agent model dropdown. Shows a short
+ * curated list by default (embeddings/audio/image models removed, dated
+ * snapshots collapsed) with a "show all" affordance and free-text search to
+ * reach the full provider list.
+ */
+export function ModelSelect({
+  models,
+  providerType,
+  value,
+  onChange,
+  isLoading,
+  isError,
+  error,
+  disabled,
+}: {
+  models: ProviderModelInfo[] | undefined
+  providerType: string | undefined
+  value: string
+  onChange: (id: string) => void
+  isLoading?: boolean
+  isError?: boolean
+  error?: unknown
+  disabled?: boolean
+}) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [showAll, setShowAll] = useState(false)
+
+  const curated = useMemo(() => curateProviderModels(models, providerType), [models, providerType])
+
+  const trimmedQuery = query.trim().toLowerCase()
+  const visibleModels = useMemo(() => {
+    if (trimmedQuery) {
+      return curated.all.filter(
+        (model) => model.id.toLowerCase().includes(trimmedQuery) || model.name.toLowerCase().includes(trimmedQuery),
+      )
+    }
+    return showAll ? curated.all : curated.recommended
+  }, [curated, showAll, trimmedQuery])
+
+  const selectedModel = useMemo(() => curated.all.find((model) => model.id === value), [curated.all, value])
+  const triggerLabel = isLoading
+    ? 'Loading models…'
+    : selectedModel
+      ? modelLabel(selectedModel)
+      : value || 'Select a model'
+
+  const isDisabled = disabled || isLoading
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next)
+        if (!next) {
+          setQuery('')
+          setShowAll(false)
+        }
+      }}
+    >
+      <PopoverTrigger
+        type="button"
+        disabled={isDisabled}
+        className={cn(
+          'border-input bg-background flex w-full items-center justify-between gap-2 rounded-md border px-3 py-2 text-left text-sm',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+        )}
+      >
+        <span className={cn('truncate', !selectedModel && !value && 'text-muted-foreground')}>{triggerLabel}</span>
+        <ChevronsUpDown className="text-muted-foreground size-4 shrink-0" />
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-[var(--radix-popover-trigger-width)] min-w-[280px] p-0"
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
+        <div className="border-border border-b p-2">
+          <Input
+            autoFocus
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search models…"
+          />
+        </div>
+        <div className="max-h-72 overflow-y-auto p-1">
+          {isError ? (
+            <div className="px-2 py-3">
+              <SizableText size="xs" className="text-destructive">
+                {error instanceof Error ? error.message : 'Could not load models'}
+              </SizableText>
+            </div>
+          ) : visibleModels.length === 0 ? (
+            <div className="px-2 py-3">
+              <SizableText size="sm" color="muted">
+                {isLoading ? 'Loading models…' : 'No models found.'}
+              </SizableText>
+            </div>
+          ) : (
+            visibleModels.map((model) => (
+              <button
+                key={model.id}
+                type="button"
+                className={cn(
+                  'hover:bg-muted flex w-full items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-left text-sm',
+                  model.id === value && 'bg-muted',
+                )}
+                onClick={() => {
+                  onChange(model.id)
+                  setOpen(false)
+                }}
+              >
+                <span className="min-w-0 truncate">{modelLabel(model)}</span>
+                {model.id === value ? <Check className="size-4 shrink-0" /> : null}
+              </button>
+            ))
+          )}
+        </div>
+        {!trimmedQuery && curated.hasMore ? (
+          <div className="border-border border-t p-1">
+            <button
+              type="button"
+              className="hover:bg-muted text-muted-foreground w-full rounded-sm px-2 py-1.5 text-left text-xs"
+              onClick={() => setShowAll((current) => !current)}
+            >
+              {showAll ? 'Show fewer models' : `Show all ${curated.all.length} models`}
+            </button>
+          </div>
+        ) : null}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/frontend/apps/desktop/src/pages/agents/model-utils.ts
+++ b/frontend/apps/desktop/src/pages/agents/model-utils.ts
@@ -1,0 +1,129 @@
+import type {ModelProviderType, ProviderModelInfo} from '@/agents-client'
+
+/**
+ * Provider model lists returned by OpenAI/Anthropic/Google are long and noisy:
+ * they mix in embedding/audio/image-only models and expose every dated snapshot
+ * alongside its stable alias (e.g. `gpt-4o` and `gpt-4o-2024-08-06`). These
+ * helpers trim the noise so the model dropdown can show a short curated list
+ * while still letting the user reach the full set.
+ */
+
+/** Substrings that mark a model as something other than a text-generating chat model. */
+const NON_CHAT_PATTERNS = [
+  'embedding',
+  'embed',
+  'text-similarity',
+  'text-search',
+  'whisper',
+  'transcribe',
+  'tts',
+  'audio',
+  'realtime',
+  'speech',
+  'dall-e',
+  'dalle',
+  'gpt-image',
+  'imagen',
+  '-image',
+  'image-',
+  'veo',
+  'moderation',
+  'davinci',
+  'babbage',
+  'curie',
+  '-instruct',
+  'aqa',
+]
+
+/** Returns true for models we never want to surface in the agent model dropdown. */
+export function isChatModel(id: string): boolean {
+  const lower = id.toLowerCase()
+  return !NON_CHAT_PATTERNS.some((pattern) => lower.includes(pattern))
+}
+
+/**
+ * Strips trailing date/snapshot suffixes so dated variants collapse onto their
+ * stable alias. Conservative on purpose: only numeric date-like suffixes and
+ * `-latest` are removed, never semantic suffixes like `-mini` or `-preview`
+ * that denote genuinely distinct models.
+ */
+export function canonicalModelId(id: string): string {
+  return id
+    .replace(/-latest$/i, '')
+    .replace(/-\d{4}-\d{2}-\d{2}$/, '') // 2024-08-06
+    .replace(/-\d{6,8}$/, '') // 20241022 / 240612
+    .replace(/-\d{3,4}-preview$/i, '') // 0125-preview / 125-preview
+    .replace(/-\d{4}$/, '') // 0613 / 1106 / 0125
+}
+
+/** Ordered family prefixes used to float flagship models to the top of the curated list. */
+const PRIORITY_PREFIXES: Record<ModelProviderType, string[]> = {
+  openai: ['gpt-5', 'gpt-4.1', 'gpt-4o', 'o4', 'o3', 'o1', 'gpt-4', 'gpt-3.5', 'chatgpt'],
+  anthropic: ['claude-opus', 'claude-sonnet', 'claude-haiku', 'claude-3-5', 'claude-3'],
+  google: ['gemini-2.5', 'gemini-2.0', 'gemini-1.5', 'gemini', 'gemma'],
+}
+
+function priorityIndex(id: string, providerType: string | undefined): number {
+  const prefixes =
+    providerType && providerType in PRIORITY_PREFIXES ? PRIORITY_PREFIXES[providerType as ModelProviderType] : undefined
+  if (!prefixes) return Number.MAX_SAFE_INTEGER
+  const lower = id.toLowerCase()
+  const index = prefixes.findIndex((prefix) => lower.startsWith(prefix))
+  return index === -1 ? Number.MAX_SAFE_INTEGER : index
+}
+
+export type CuratedModels = {
+  /** Short, de-duplicated, priority-sorted list of stable chat models. */
+  recommended: ProviderModelInfo[]
+  /** Every chat model (snapshots included), priority-sorted. */
+  all: ProviderModelInfo[]
+  /** Whether `all` contains models beyond `recommended` (snapshots worth revealing). */
+  hasMore: boolean
+}
+
+function comparator(providerType: string | undefined) {
+  return (a: ProviderModelInfo, b: ProviderModelInfo) => {
+    const priorityDiff = priorityIndex(a.id, providerType) - priorityIndex(b.id, providerType)
+    if (priorityDiff !== 0) return priorityDiff
+    return a.id.localeCompare(b.id)
+  }
+}
+
+/**
+ * Turns a raw provider model list into a curated short list plus the full
+ * chat-model list. Embedding/audio/image models are dropped entirely; dated
+ * snapshots are collapsed onto their stable alias for the `recommended` list
+ * but remain available in `all`.
+ */
+export function curateProviderModels(
+  models: ProviderModelInfo[] | undefined,
+  providerType: string | undefined,
+): CuratedModels {
+  const chatModels = (models || []).filter((model) => isChatModel(model.id))
+  const sort = comparator(providerType)
+  const all = [...chatModels].sort(sort)
+
+  // Collapse dated snapshots onto one entry per canonical family, preferring the
+  // stable alias (id === canonical) and otherwise the newest snapshot.
+  const byCanonical = new Map<string, ProviderModelInfo>()
+  for (const model of chatModels) {
+    const canonical = canonicalModelId(model.id)
+    const existing = byCanonical.get(canonical)
+    if (!existing) {
+      byCanonical.set(canonical, model)
+      continue
+    }
+    const existingIsAlias = canonicalModelId(existing.id) === existing.id
+    const candidateIsAlias = canonicalModelId(model.id) === model.id
+    if (candidateIsAlias && !existingIsAlias) byCanonical.set(canonical, model)
+    else if (candidateIsAlias === existingIsAlias && model.id > existing.id) byCanonical.set(canonical, model)
+  }
+  const recommended = Array.from(byCanonical.values()).sort(sort)
+
+  return {recommended, all, hasMore: all.length > recommended.length}
+}
+
+/** Human-friendly label for a model option. */
+export function modelLabel(model: ProviderModelInfo): string {
+  return model.name && model.name !== model.id ? `${model.name} (${model.id})` : model.id
+}

--- a/frontend/apps/desktop/src/pages/agents/provider-select.tsx
+++ b/frontend/apps/desktop/src/pages/agents/provider-select.tsx
@@ -1,0 +1,45 @@
+import type {ModelProviderInfo} from '@/agents-client'
+
+const ADD_PROVIDER_VALUE = '__add_provider__'
+
+/**
+ * Native select of configured model providers with a trailing "add provider"
+ * option. Shared by the create-agent dialog and the agent settings page so both
+ * can switch providers and add a new one in place.
+ */
+export function ProviderSelect({
+  providers,
+  value,
+  onChange,
+  onAddProvider,
+  disabled,
+}: {
+  providers: ModelProviderInfo[] | undefined
+  value: string
+  onChange: (name: string) => void
+  onAddProvider: () => void
+  disabled?: boolean
+}) {
+  const hasValueOption = !value || providers?.some((provider) => provider.name === value)
+  return (
+    <select
+      className="border-input bg-background rounded-md border px-3 py-2 text-sm"
+      value={value}
+      onChange={(event) => {
+        const next = event.target.value
+        if (next === ADD_PROVIDER_VALUE) onAddProvider()
+        else onChange(next)
+      }}
+      disabled={disabled}
+    >
+      {/* Keep a stranded value (e.g. a since-deleted provider) selectable rather than silently switching it. */}
+      {hasValueOption ? null : <option value={value}>{value}</option>}
+      {(providers || []).map((provider) => (
+        <option key={provider.id} value={provider.name}>
+          {provider.name} ({provider.type})
+        </option>
+      ))}
+      <option value={ADD_PROVIDER_VALUE}>+ Add provider…</option>
+    </select>
+  )
+}

--- a/frontend/apps/desktop/src/pages/agents/server.tsx
+++ b/frontend/apps/desktop/src/pages/agents/server.tsx
@@ -42,12 +42,7 @@ function AgentServerContent({routeServerUrl}: {routeServerUrl: string}) {
   )
 
   const status = health.isLoading ? 'Checking…' : health.isError ? 'Offline' : 'Online'
-  const needsModelProvider = !!selectedAccountId && !providers.isLoading && !providers.data?.length
-  const createAgentDisabledReason = !selectedAccountId
-    ? 'Select an account before creating an agent.'
-    : providers.isLoading
-      ? 'Checking model providers…'
-      : null
+  const createAgentDisabledReason = !selectedAccountId ? 'Select an account before creating an agent.' : null
 
   return (
     <PanelContainer className="overflow-y-auto">
@@ -73,25 +68,14 @@ function AgentServerContent({routeServerUrl}: {routeServerUrl: string}) {
             </div>
           </div>
           <div className="flex flex-wrap justify-end gap-2">
-            <Tooltip
-              content={
-                createAgentDisabledReason ||
-                (needsModelProvider ? 'Add a model provider before creating an agent.' : 'Create Agent')
-              }
-            >
+            <Tooltip content={createAgentDisabledReason || 'Create Agent'}>
               <span>
                 <Button
-                  onClick={() => {
-                    if (needsModelProvider) {
-                      providersDialog.open({serverUrl, selectedAccountId})
-                      return
-                    }
-                    createAgentDialog.open({serverUrls: [serverUrl], selectedAccountId})
-                  }}
+                  onClick={() => createAgentDialog.open({serverUrls: [serverUrl], selectedAccountId})}
                   disabled={!!createAgentDisabledReason}
                 >
-                  {needsModelProvider ? <Settings className="size-4" /> : <Bot className="size-4" />}
-                  {needsModelProvider ? 'Add Model Provider' : 'Create Agent'}
+                  <Bot className="size-4" />
+                  Create Agent
                 </Button>
               </span>
             </Tooltip>

--- a/frontend/apps/desktop/src/pages/agents/session.tsx
+++ b/frontend/apps/desktop/src/pages/agents/session.tsx
@@ -1,4 +1,6 @@
 import {
+  type AgentRunActivity,
+  type AgentRunUsage,
   type AgentSessionTriggerContext,
   type AgentTriggerSource,
   type SessionEvent,
@@ -48,7 +50,7 @@ import {OptionsDropdown} from '@shm/ui/options-dropdown'
 import {SizableText} from '@shm/ui/text'
 import {toast} from '@shm/ui/toast'
 import {useAppDialog} from '@shm/ui/universal-dialog'
-import {ArrowDown, ExternalLink, Info, ScrollText, Send, Square, Trash2} from 'lucide-react'
+import {ArrowDown, ExternalLink, Info, Loader2, ScrollText, Send, Square, Trash2} from 'lucide-react'
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {AgentHeader, AgentSubpageHeader} from './header'
 import {promptBlocksToMarkdown} from './prompt-editor'
@@ -238,12 +240,8 @@ function AgentSessionPage({
   const deleteSessionDialog = useAppDialog(DeleteAgentSessionDialog, {isAlert: true})
   const systemPromptDialog = useAppDialog(SystemPromptDialog)
   const lastSeq = session.data?.events.filter((event) => event.seq !== Number.MAX_SAFE_INTEGER).at(-1)?.seq
-  const partialAssistantText = useAgentWebSocketSubscription(
-    serverUrl,
-    selectedAccountId,
-    `sessions/${sessionId}`,
-    lastSeq,
-  )
+  const liveState = useAgentWebSocketSubscription(serverUrl, selectedAccountId, `sessions/${sessionId}`, lastSeq)
+  const partialAssistantText = liveState.text
   const [titleDraft, setTitleDraft] = useState('')
   const [titleSaveState, setTitleSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
   const [isNearBottom, setIsNearBottom] = useState(true)
@@ -261,7 +259,12 @@ function AgentSessionPage({
   )
   const isAgentStreaming = session.data?.session.status === 'streaming'
   const isAgentBusy = messageSession.isPending || isAgentStreaming
-  const showThinkingIndicator = Boolean(!partialAssistantText && isAgentBusy)
+  const [runStartedAt, setRunStartedAt] = useState<number | null>(null)
+  useEffect(() => {
+    // Start the elapsed timer when the agent begins working; clear it when it finishes.
+    if (isAgentBusy) setRunStartedAt((prev) => prev ?? Date.now())
+    else setRunStartedAt(null)
+  }, [isAgentBusy])
   const triggerActivityRoute = useMemo(
     () => (session.data?.triggerContext ? getTriggerActivityRoute(session.data.triggerContext) : null),
     [session.data?.triggerContext],
@@ -367,10 +370,10 @@ function AgentSessionPage({
     if (isNearBottom) {
       const container = messagesContainerRef.current
       if (container) container.scrollTop = container.scrollHeight
-    } else if (partialAssistantText || showThinkingIndicator || chatRows.length) {
+    } else if (partialAssistantText || isAgentBusy || chatRows.length) {
       setShowScrollButton(true)
     }
-  }, [chatRows.length, partialAssistantText, showThinkingIndicator, isNearBottom])
+  }, [chatRows.length, partialAssistantText, isAgentBusy, isNearBottom])
 
   useEffect(() => {
     const eventId = getSharedEventIdFromHash(window.location.hash)
@@ -544,7 +547,9 @@ function AgentSessionPage({
                   </div>
                 ))}
                 {partialAssistantText ? <PartialAssistantRow text={partialAssistantText} /> : null}
-                {showThinkingIndicator ? <AssistantThinkingIndicator /> : null}
+                {isAgentBusy ? (
+                  <AgentRunStatusBar startedAt={runStartedAt} activity={liveState.activity} usage={liveState.usage} />
+                ) : null}
                 <div ref={messagesEndRef} />
                 {showScrollButton ? (
                   <div className="pointer-events-none sticky bottom-2 flex justify-center">
@@ -720,10 +725,66 @@ const PartialAssistantRow = React.memo(function PartialAssistantRow({text}: {tex
   return <AssistantMessageParts parts={parts} isStreaming />
 })
 
-function AssistantThinkingIndicator() {
+/** Formats elapsed milliseconds as m:ss for the live run timer. */
+function formatElapsed(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`
+}
+
+/** Formats a token count compactly (e.g. 1234 → "1.2k"). */
+function formatTokenCount(count: number): string {
+  if (count >= 10_000) return `${Math.round(count / 1000)}k`
+  if (count >= 1_000) return `${(count / 1000).toFixed(1)}k`
+  return String(count)
+}
+
+/** Human-readable label for the agent's current activity phase. */
+function activityLabel(activity?: AgentRunActivity): string {
+  switch (activity?.phase) {
+    case 'starting':
+      return 'Starting…'
+    case 'responding':
+      return 'Responding…'
+    case 'tool':
+      return activity.toolName ? `Running ${activity.toolName}…` : 'Running tool…'
+    case 'finalizing':
+      return 'Finishing…'
+    case 'thinking':
+      return 'Thinking…'
+    default:
+      return 'Working…'
+  }
+}
+
+/** Live status row shown while the agent is working: activity, elapsed time, and token count. */
+function AgentRunStatusBar({
+  startedAt,
+  activity,
+  usage,
+}: {
+  startedAt: number | null
+  activity?: AgentRunActivity
+  usage?: AgentRunUsage
+}) {
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    if (startedAt === null) return
+    setNow(Date.now())
+    const interval = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(interval)
+  }, [startedAt])
+  const elapsed = startedAt === null ? 0 : Math.max(0, now - startedAt)
   return (
-    <div className="text-muted-foreground flex items-center gap-2 py-2" aria-label="Assistant is thinking">
-      <span className="bg-muted-foreground inline-block size-2 animate-pulse rounded-full" />
+    <div className="text-muted-foreground flex items-center gap-2 py-2 text-xs" aria-live="polite">
+      <Loader2 className="size-3.5 shrink-0 animate-spin" />
+      <span className="font-medium">{activityLabel(activity)}</span>
+      {activity?.detail ? <span className="max-w-64 min-w-0 truncate opacity-75">{activity.detail}</span> : null}
+      <span className="ml-auto flex shrink-0 items-center gap-3 tabular-nums">
+        <span aria-label="Elapsed time">{formatElapsed(elapsed)}</span>
+        {usage && usage.total > 0 ? <span aria-label="Tokens used">{formatTokenCount(usage.total)} tokens</span> : null}
+      </span>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

This branch builds out the desktop agent setup flow and trims an unused trigger feature.

- Set up the model provider inside the agent creation dialog, with a curated + cached model dropdown
- Seed a default agent server in local development
- Make the provider a dropdown on agent settings
- Auto-create an account for new agents and rename it alongside the agent
- Navigate to the newly created agent after creation
- Polish agent tool-call summaries
- Remove the "cooldown minutes" feature of agent triggers (protocol types, API create/update logic, debug server/UI, and the desktop trigger editor). The `cooldown_ms` column and its migration are retained since SQLite migrations are append-only and the column already exists in deployed databases — it is simply no longer read or written.

## Test plan

- `bun typecheck` passes for the agents package (incl. protocol + frontend)
- `tsc --noEmit` passes for the desktop app
- Agents `sqlite.test.ts` + `api-service.test.ts` pass (27 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)