### PR TITLE
feat(collaborators): add writer promotion for site members

### DIFF
--- a/docs/projects/immediate-capability-email-notifications.md
+++ b/docs/projects/immediate-capability-email-notifications.md
@@ -1,0 +1,113 @@
+# Immediate Capability Grant Email Notifications
+
+## Problem
+
+When a site owner grants writer access to another account, the recipient may not know they can now contribute unless
+they open the app or inspect the site collaborators list.
+
+This matters more with the new “Add as writer” action because it behaves like an invitation. The recipient should
+receive a timely email telling them they were granted access and where to go next.
+
+## Solution
+
+Add immediate email notifications for new `Capability` blob events.
+
+Assumptions:
+
+- Send only to accounts with a verified notification email configured in the notify service.
+- Respect unsubscribe and disabled-email state.
+- Treat this as an immediate notification, like mentions and replies.
+- First version sends email only for meaningful write access grants, especially `WRITER`.
+- Do not send an email to the issuer if they grant a capability to themselves.
+- Resolve delegate or alias accounts to the canonical root account before selecting the recipient.
+
+User stories:
+
+- As a newly promoted site member, I receive an email soon after someone grants me writer access.
+- As a site owner, I can click “Add as writer” and trust that the recipient will be notified.
+- As a user who disabled or did not verify email notifications, I do not receive capability emails.
+
+Implementation plan:
+
+- Extend the notify service event evaluator in `frontend/apps/notify/app/email-notifier.ts`.
+
+  - Today it handles `newMention` and `newBlob` events for `Ref` and `Comment`.
+  - Add handling for `newBlob` events where `blob.blobType === 'Capability'`.
+  - Load the capability with `grpcClient.accessControl.getCapability` using the event identity available on the blob
+    event.
+  - Resolve delegate account metadata, issuer/account metadata, and target site/document metadata.
+  - Find the notification subscription whose account ID matches the canonical capability delegate.
+  - Skip if no verified email config exists.
+  - Skip unsupported capability roles unless they are explicitly included.
+
+- Add a new notification reason: `capability-granted`.
+
+  - Delivery kind: `immediate`.
+
+- Add a new email template in `frontend/apps/emails/notifier.tsx`.
+
+  - Suggested subject: `You can now write on <site/document name>`.
+  - Body should include who granted access when available, what role was granted, what site or document it applies to, a
+    CTA to open the site/document, and notification management/unsubscribe links.
+
+- Decide whether capability grants should appear in the in-app notification inbox.
+
+  - Recommended: yes, if adding the new reason is low-cost.
+  - If inbox support expands scope too much, keep V1 email-only and do not persist this notification reason.
+
+- Add tests.
+  - Notify routing maps `capability-granted` to `immediate`.
+  - A capability event creates a queued notification for the delegate.
+  - No email is queued without verified config.
+  - No email is queued for self-grants.
+  - The email template renders subject, CTA, and unsubscribe/manage link.
+  - Existing mention/reply/comment notifications continue to work.
+
+## Scope
+
+Estimated implementation: 1–2 days.
+
+Phase 1: Event handling and routing, half day.
+
+- Add `Capability` event detection.
+- Load capability details.
+- Resolve delegate and target account metadata.
+- Route to the delegate subscription.
+
+Phase 2: Email template, half day.
+
+- Add `createCapabilityGrantedEmail`.
+- Add subject/text/html rendering tests.
+- Wire the template into the immediate email sender.
+
+Phase 3: Tests and hardening, half to one day.
+
+- Add notifier tests for capability events.
+- Add routing tests.
+- Verify unsubscribe behavior and verified-email gating.
+- Run notify package tests and frontend typecheck.
+
+Dependencies:
+
+- Activity feed must emit `newBlob` events for `Capability` blobs.
+- Notify service must be able to fetch capability details by event ID/CID.
+- Recipient must already have notification email configured and verified.
+
+## Rabbit Holes
+
+- Building a full invitation system with accept/decline flows.
+- Adding a new notification preference category UI.
+- Supporting demotion or removal emails.
+- Sending emails to people who have no verified notification email on file.
+- Guaranteeing real-time delivery from the write path instead of using the existing notify polling loop.
+- Reworking the notification inbox schema beyond adding the new reason.
+- Designing per-site email notification preferences.
+
+## No Gos
+
+- Do not send capability emails to unverified email addresses.
+- Do not bypass unsubscribe or notification config state.
+- Do not send historical backfill emails for old capability events.
+- Do not block capability creation on email delivery.
+- Do not make the frontend “Add as writer” mutation call an email API directly.
+- Do not send duplicate emails for duplicate/delegate capability rows that resolve to the same canonical account.

--- a/frontend/packages/shared/src/__tests__/api-document-collaborators.test.ts
+++ b/frontend/packages/shared/src/__tests__/api-document-collaborators.test.ts
@@ -1,0 +1,57 @@
+import type {HMCapability, HMListDocumentCollaboratorsOutput, HMSiteMember} from '@seed-hypermedia/client/hm-types'
+import {describe, expect, it} from 'vitest'
+import {dedupeSiteMembersByCanonicalAccount} from '../api-document-collaborators'
+import {hmId} from '../utils/entity-id-url'
+
+function account(rawUid: string, canonicalUid: string = rawUid): HMListDocumentCollaboratorsOutput['accounts'][string] {
+  return {
+    id: hmId(canonicalUid),
+    metadata: {name: canonicalUid},
+  }
+}
+
+function capability(accountUid: string): HMCapability {
+  return {
+    id: `cap-${accountUid}`,
+    accountUid,
+    role: 'writer',
+    grantId: hmId('site'),
+    createTime: {seconds: 0, nanos: 0},
+  }
+}
+
+function member(accountUid: string): HMSiteMember {
+  return {
+    account: hmId(accountUid),
+    role: 'member',
+  }
+}
+
+describe('dedupeSiteMembersByCanonicalAccount', () => {
+  it('keeps the writer row when the same account is also a regular member', () => {
+    const result = dedupeSiteMembersByCanonicalAccount({
+      accounts: {
+        writer: account('writer'),
+      },
+      capabilities: [capability('writer')],
+      members: [member('writer')],
+    })
+
+    expect(result.grantedMembers).toEqual([{account: hmId('writer'), role: 'writer'}])
+    expect(result.members).toEqual([])
+  })
+
+  it('collapses delegate accounts to the canonical root account', () => {
+    const result = dedupeSiteMembersByCanonicalAccount({
+      accounts: {
+        delegate: account('delegate', 'root'),
+        root: account('root'),
+      },
+      capabilities: [capability('delegate')],
+      members: [member('root')],
+    })
+
+    expect(result.grantedMembers).toEqual([{account: hmId('root'), role: 'writer'}])
+    expect(result.members).toEqual([])
+  })
+})

--- a/frontend/packages/shared/src/api-document-collaborators.ts
+++ b/frontend/packages/shared/src/api-document-collaborators.ts
@@ -13,6 +13,8 @@ import {hmIdPathToEntityQueryPath, entityQueryPathToHmIdPath} from './utils/path
 import {getErrorMessage, HMRedirectError} from './models/entity'
 import {toPlainMessage} from '@bufbuild/protobuf'
 
+type AccountsByUid = HMListDocumentCollaboratorsRequest['output']['accounts']
+
 function rawRoleToHMRole(role?: string): HMCapability['role'] {
   if (role === 'WRITER') return 'writer'
   if (role === 'AGENT') return 'agent'
@@ -36,6 +38,65 @@ function rawCapabilityToHMCapability(raw: any): HMCapability | null {
     }),
     label: raw.label,
     createTime: parseTimestamp(raw.createTime),
+  }
+}
+
+function getCanonicalAccountUid(accounts: AccountsByUid, uid: string) {
+  return accounts[uid]?.id.uid || uid
+}
+
+function addCanonicalAccountEntries(accounts: AccountsByUid) {
+  const out = {...accounts}
+  Object.values(accounts).forEach((account) => {
+    out[account.id.uid] = out[account.id.uid] || account
+  })
+  return out
+}
+
+function canonicalizeCapability(capability: HMCapability, accounts: AccountsByUid): HMCapability {
+  return {
+    ...capability,
+    accountUid: getCanonicalAccountUid(accounts, capability.accountUid),
+  }
+}
+
+/** Deduplicates site member rows by canonical/root account, keeping writer rows over member rows. */
+export function dedupeSiteMembersByCanonicalAccount({
+  accounts,
+  capabilities,
+  members,
+}: {
+  accounts: AccountsByUid
+  capabilities: HMCapability[]
+  members: HMSiteMember[]
+}) {
+  const seenMembers = new Set<string>()
+  const grantedMembers: HMSiteMember[] = []
+  const dedupedMembers: HMSiteMember[] = []
+
+  capabilities.forEach((capability) => {
+    const accountUid = getCanonicalAccountUid(accounts, capability.accountUid)
+    if (seenMembers.has(accountUid)) return
+    seenMembers.add(accountUid)
+    grantedMembers.push({
+      account: hmId(accountUid),
+      role: capability.role === 'writer' ? 'writer' : 'member',
+    })
+  })
+
+  members.forEach((member) => {
+    const accountUid = getCanonicalAccountUid(accounts, member.account.uid)
+    if (seenMembers.has(accountUid)) return
+    seenMembers.add(accountUid)
+    dedupedMembers.push({
+      account: hmId(accountUid),
+      role: 'member',
+    })
+  })
+
+  return {
+    grantedMembers,
+    members: dedupedMembers,
   }
 }
 
@@ -67,6 +128,27 @@ export const ListDocumentCollaborators: HMRequestImplementation<HMListDocumentCo
           (capability) => capability.role !== 'agent' && capability.role !== 'owner' && capability.role !== 'none',
         )
 
+      const contactMembers: HMSiteMember[] = []
+
+      contactsResult?.contacts.forEach((contact) => {
+        const plain = toPlainMessage(contact)
+        const metadata = contact.metadata?.toJson() as Record<string, unknown> | undefined
+        const subscribe = metadata?.subscribe as {site?: boolean} | undefined
+        if (!subscribe?.site) return
+        contactMembers.push({
+          account: hmId(plain.account),
+          role: 'member',
+        })
+      })
+
+      const rawAccountUids = new Set<string>([input.targetId.uid])
+      capabilities.forEach((capability) => rawAccountUids.add(capability.accountUid))
+      contactMembers.forEach((member) => rawAccountUids.add(member.account.uid))
+
+      const accounts = addCanonicalAccountEntries(await loadAccounts(grpcClient, Array.from(rawAccountUids)))
+
+      const canonicalCapabilities = capabilities.map((capability) => canonicalizeCapability(capability, accounts))
+
       const seenCapabilities = new Set<string>()
       const dedupeCapabilities = (list: HMCapability[]) =>
         list.filter((capability) => {
@@ -76,36 +158,16 @@ export const ListDocumentCollaborators: HMRequestImplementation<HMListDocumentCo
         })
 
       const parentCapabilities = dedupeCapabilities(
-        capabilities.filter((capability) => capability.grantId.id !== input.targetId.id),
+        canonicalCapabilities.filter((capability) => capability.grantId.id !== input.targetId.id),
       )
       const grantedCapabilities = dedupeCapabilities(
-        capabilities.filter((capability) => capability.grantId.id === input.targetId.id),
+        canonicalCapabilities.filter((capability) => capability.grantId.id === input.targetId.id),
       )
 
-      const seenMembers = new Set<string>()
-      const grantedMembers: HMSiteMember[] = []
-      const members: HMSiteMember[] = []
-
-      capabilities.forEach((capability) => {
-        if (seenMembers.has(capability.accountUid)) return
-        seenMembers.add(capability.accountUid)
-        grantedMembers.push({
-          account: hmId(capability.accountUid),
-          role: capability.role === 'writer' ? 'writer' : 'member',
-        })
-      })
-
-      contactsResult?.contacts.forEach((contact) => {
-        const plain = toPlainMessage(contact)
-        const metadata = contact.metadata?.toJson() as Record<string, unknown> | undefined
-        const subscribe = metadata?.subscribe as {site?: boolean} | undefined
-        if (!subscribe?.site) return
-        if (seenMembers.has(plain.account)) return
-        seenMembers.add(plain.account)
-        members.push({
-          account: hmId(plain.account),
-          role: 'member',
-        })
+      const {grantedMembers, members} = dedupeSiteMembersByCanonicalAccount({
+        accounts,
+        capabilities: canonicalCapabilities,
+        members: contactMembers,
       })
 
       const accountUids = new Set<string>([input.targetId.uid])
@@ -113,8 +175,9 @@ export const ListDocumentCollaborators: HMRequestImplementation<HMListDocumentCo
       grantedCapabilities.forEach((capability) => accountUids.add(capability.accountUid))
       grantedMembers.forEach((member) => accountUids.add(member.account.uid))
       members.forEach((member) => accountUids.add(member.account.uid))
-
-      const accounts = await loadAccounts(grpcClient, Array.from(accountUids))
+      accountUids.forEach((uid) => {
+        if (!accounts[uid]) accounts[uid] = {id: hmId(uid), metadata: null}
+      })
 
       return {
         publisherUid: input.targetId.uid,

--- a/frontend/packages/ui/src/__tests__/collaborators-page.test.ts
+++ b/frontend/packages/ui/src/__tests__/collaborators-page.test.ts
@@ -1,11 +1,110 @@
+// @vitest-environment jsdom
+import React from 'react'
 import type {
   HMCapability,
   HMListDocumentCollaboratorsOutput,
   HMSiteMember,
   UnpackedHypermediaId,
 } from '@seed-hypermedia/client/hm-types'
-import {describe, expect, it} from 'vitest'
-import {getRenderedCollaboratorsCount} from '../collaborators-page'
+import {act} from 'react-dom/test-utils'
+import {createRoot, type Root} from 'react-dom/client'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  errorToast: vi.fn(),
+  mutate: vi.fn(),
+  successToast: vi.fn(),
+}))
+
+const siteMembersState = vi.hoisted(() => ({
+  value: {
+    accounts: {} as HMListDocumentCollaboratorsOutput['accounts'],
+    grantedMembers: [] as HMSiteMember[],
+    isInitialLoading: false,
+    members: [] as HMSiteMember[],
+  },
+}))
+
+const selectedCapabilityState = vi.hoisted(() => ({
+  value: null as HMCapability | null,
+}))
+
+vi.mock('@shm/shared', () => ({
+  useUniversalAppContext: () => ({
+    getOptimizedImageUrl: () => null,
+    ipfsFileUrl: '',
+  }),
+  useRouteLink: () => ({href: '#profile'}),
+}))
+
+vi.mock('@shm/shared/models/capabilities', () => ({
+  useAddCapabilities: () => ({
+    isLoading: false,
+    mutate: mocks.mutate,
+  }),
+  useSelectedAccountCapability: () => selectedCapabilityState.value,
+}))
+
+vi.mock('@shm/shared/models/entity', () => ({
+  useAccount: () => ({data: null}),
+  useCapabilities: () => ({data: []}),
+  useCollaborators: () => ({
+    accounts: {},
+    parentCapabilities: [],
+    grantedCapabilities: [],
+    publisherUid: 'publisher',
+    isInitialLoading: false,
+  }),
+  useResource: () => ({data: null}),
+  useSelectedAccountId: () => 'publisher',
+  useSiteMembers: () => siteMembersState.value,
+}))
+
+vi.mock('@shm/shared/models/search', () => ({
+  useSearch: () => ({data: {entities: []}}),
+}))
+
+vi.mock('../hm-icon', () => ({
+  HMIcon: () => null,
+  LoadedHMIcon: () => null,
+}))
+
+vi.mock('../toast', () => ({
+  toast: {
+    error: mocks.errorToast,
+    success: mocks.successToast,
+  },
+}))
+
+import {CollaboratorsPage, getRenderedCollaboratorsCount} from '../collaborators-page'
+;(globalThis as typeof globalThis & {React?: typeof React; IS_REACT_ACT_ENVIRONMENT?: boolean}).React = React
+;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  mocks.mutate.mockReset()
+  mocks.successToast.mockReset()
+  mocks.errorToast.mockReset()
+  selectedCapabilityState.value = null
+  siteMembersState.value = {
+    accounts: {},
+    grantedMembers: [],
+    isInitialLoading: false,
+    members: [],
+  }
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
 
 function id(uid: string, path: string[] | null = null): UnpackedHypermediaId {
   return {
@@ -129,5 +228,132 @@ describe('getRenderedCollaboratorsCount', () => {
         false,
       ),
     ).toBe(3)
+  })
+})
+
+describe('site member writer promotion', () => {
+  it('renders a visible owner-only Add as writer button for regular site members', () => {
+    selectedCapabilityState.value = capability('publisher', id('publisher'))
+    siteMembersState.value = {
+      accounts: {
+        publisher: account('publisher'),
+        member: account('member'),
+        writer: account('writer'),
+      },
+      grantedMembers: [{account: id('writer'), role: 'writer'}],
+      isInitialLoading: false,
+      members: [{account: id('member'), role: 'member'}],
+    }
+
+    act(() => {
+      root.render(React.createElement(CollaboratorsPage, {docId: id('publisher')}))
+    })
+
+    expect(container.textContent).toContain('member')
+    expect(container.textContent).toContain('writer')
+    expect(container.querySelector('button')?.textContent).toContain('Add as writer')
+    expect(container.textContent?.match(/Add as writer/g)).toHaveLength(1)
+  })
+
+  it('does not render Add as writer for non-owners', () => {
+    selectedCapabilityState.value = null
+    siteMembersState.value = {
+      accounts: {
+        publisher: account('publisher'),
+        member: account('member'),
+      },
+      grantedMembers: [],
+      isInitialLoading: false,
+      members: [{account: id('member'), role: 'member'}],
+    }
+
+    act(() => {
+      root.render(React.createElement(CollaboratorsPage, {docId: id('publisher')}))
+    })
+
+    expect(container.textContent).toContain('member')
+    expect(container.textContent).not.toContain('Add as writer')
+  })
+
+  it('promotes the member to writer and shows a success toast after capability creation succeeds', () => {
+    selectedCapabilityState.value = capability('publisher', id('publisher'))
+    siteMembersState.value = {
+      accounts: {
+        publisher: account('publisher'),
+        member: account('member'),
+      },
+      grantedMembers: [],
+      isInitialLoading: false,
+      members: [{account: id('member'), role: 'member'}],
+    }
+    mocks.mutate.mockImplementation((_vars, options) => options?.onSuccess?.())
+
+    act(() => {
+      root.render(React.createElement(CollaboratorsPage, {docId: id('publisher')}))
+    })
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('button')?.click()
+    })
+
+    expect(mocks.mutate).toHaveBeenCalledWith(
+      {
+        myCapability: selectedCapabilityState.value,
+        collaboratorAccountIds: ['member'],
+        role: 'WRITER',
+      },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+      }),
+    )
+    expect(mocks.successToast).toHaveBeenCalledWith('Writer access granted')
+  })
+
+  it('keeps the row link on the profile name instead of wrapping the whole row', () => {
+    selectedCapabilityState.value = capability('publisher', id('publisher'))
+    siteMembersState.value = {
+      accounts: {
+        publisher: account('publisher'),
+        member: account('member'),
+      },
+      grantedMembers: [],
+      isInitialLoading: false,
+      members: [{account: id('member'), role: 'member'}],
+    }
+
+    act(() => {
+      root.render(React.createElement(CollaboratorsPage, {docId: id('publisher')}))
+    })
+
+    const profileLink = Array.from(container.querySelectorAll('a')).find((link) => link.textContent === 'member')
+    expect(profileLink).toBeTruthy()
+    expect(profileLink?.querySelector('button')).toBeNull()
+  })
+
+  it('places the Add as writer button before the capability label and keeps the profile name truncatable', () => {
+    selectedCapabilityState.value = capability('publisher', id('publisher'))
+    siteMembersState.value = {
+      accounts: {
+        publisher: account('publisher'),
+        member: account('member'),
+      },
+      grantedMembers: [],
+      isInitialLoading: false,
+      members: [{account: id('member'), role: 'member'}],
+    }
+
+    act(() => {
+      root.render(React.createElement(CollaboratorsPage, {docId: id('publisher')}))
+    })
+
+    const button = Array.from(container.querySelectorAll('button')).find(
+      (item) => item.textContent?.includes('Add as writer'),
+    )
+    const profileLink = Array.from(container.querySelectorAll('a')).find((link) => link.textContent === 'member')
+
+    expect(button?.nextElementSibling?.textContent).toBe('Member')
+    expect(profileLink?.className).toContain('min-w-0')
+    expect(profileLink?.className).toContain('flex-1')
+    expect(profileLink?.className).toContain('truncate')
   })
 })

--- a/frontend/packages/ui/src/collaborators-page.tsx
+++ b/frontend/packages/ui/src/collaborators-page.tsx
@@ -322,6 +322,9 @@ export function CollaboratorsPage({
 
 function SiteMembers({docId, domainResolver}: {docId: UnpackedHypermediaId; domainResolver?: DomainResolverFn}) {
   const {accounts, grantedMembers, isInitialLoading, members} = useSiteMembers(docId)
+  const myCapability = useSelectedAccountCapability(docId, 'owner')
+  const addCapabilities = useAddCapabilities(docId)
+  const [promotingAccountUid, setPromotingAccountUid] = useState<string | null>(null)
   if (isInitialLoading) {
     return (
       <div className="flex items-center justify-center py-8">
@@ -330,6 +333,29 @@ function SiteMembers({docId, domainResolver}: {docId: UnpackedHypermediaId; doma
     )
   }
   const hasNoMembers = grantedMembers.length === 0 && members.length === 0
+  const promoteMember = (accountUid: string) => {
+    if (!myCapability) return
+    setPromotingAccountUid(accountUid)
+    addCapabilities.mutate(
+      {
+        myCapability,
+        collaboratorAccountIds: [accountUid],
+        role: 'WRITER',
+      },
+      {
+        onSuccess: () => {
+          toast.success('Writer access granted')
+        },
+        onError: () => {
+          toast.error('Failed to grant writer access')
+        },
+        onSettled: () => {
+          setPromotingAccountUid(null)
+        },
+      },
+    )
+  }
+
   return (
     <div className="flex flex-col gap-4">
       <AddCollaboratorForm id={docId} domainResolver={domainResolver} />
@@ -342,6 +368,7 @@ function SiteMembers({docId, domainResolver}: {docId: UnpackedHypermediaId; doma
               siteUid={docId.uid}
               account={accounts[member.account.uid]}
               key={member.account.uid}
+              canAddAsWriter={false}
             />
           ))}
         </div>
@@ -354,6 +381,9 @@ function SiteMembers({docId, domainResolver}: {docId: UnpackedHypermediaId; doma
               siteUid={docId.uid}
               account={accounts[member.account.uid]}
               key={member.account.uid}
+              canAddAsWriter={!!myCapability}
+              isPromoting={promotingAccountUid === member.account.uid && addCapabilities.isLoading}
+              onAddAsWriter={promoteMember}
             />
           ))}
         </div>
@@ -371,10 +401,16 @@ function MemberListItem({
   member,
   siteUid,
   account,
+  canAddAsWriter,
+  isPromoting,
+  onAddAsWriter,
 }: {
   member: HMSiteMember
   siteUid: string
   account?: HMMetadataPayload
+  canAddAsWriter?: boolean
+  isPromoting?: boolean
+  onAddAsWriter?: (accountUid: string) => void
 }) {
   const linkProps = useRouteLink({
     key: 'site-profile',
@@ -384,19 +420,39 @@ function MemberListItem({
   })
 
   const metadata = account?.metadata
+  const showAddAsWriter = canAddAsWriter && member.role === 'member'
 
   return (
-    <a {...linkProps} className="hover:bg-muted flex items-center gap-3 rounded-md p-3 transition-colors">
+    <div className="group hover:bg-muted flex items-center gap-3 rounded-md p-3 transition-colors">
       <HMIcon id={member.account} name={metadata?.name} icon={metadata?.icon} size={32} />
-      <div className="flex flex-1 items-center gap-2 overflow-hidden">
-        <SizableText size="sm" className={`truncate ${metadata?.name ? '' : 'text-muted-foreground'}`}>
-          {metadata?.name || abbreviateUid(member.account.uid)}
-        </SizableText>
-        <SizableText size="xs" color="muted" className="ml-auto shrink-0">
+      <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
+        <a
+          {...linkProps}
+          className={`focus-visible:ring-ring min-w-0 flex-1 truncate rounded-sm outline-none hover:underline focus-visible:ring-2 ${
+            metadata?.name ? '' : 'text-muted-foreground'
+          }`}
+        >
+          <SizableText size="sm" className="truncate">
+            {metadata?.name || abbreviateUid(member.account.uid)}
+          </SizableText>
+        </a>
+        {showAddAsWriter ? (
+          <Button
+            type="button"
+            size="xs"
+            variant="outline"
+            loading={isPromoting}
+            className="[@media(hover:hover)_and_(pointer:fine)]:opacity-0 [@media(hover:hover)_and_(pointer:fine)]:transition-opacity [@media(hover:hover)_and_(pointer:fine)]:group-focus-within:opacity-100 [@media(hover:hover)_and_(pointer:fine)]:group-hover:opacity-100"
+            onClick={() => onAddAsWriter?.(member.account.uid)}
+          >
+            Add as writer
+          </Button>
+        ) : null}
+        <SizableText size="xs" color="muted" className="shrink-0">
           {getRoleDisplayName(member.role)}
         </SizableText>
       </div>
-    </a>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- Add an owner-only `Add as writer` action for regular site members on the collaborators page.
- Promote selected site members by granting writer capability and show success/error feedback.
- Deduplicate members by canonical account so delegate/root accounts do not appear twice, with tests for collaborator counts and promotion behavior.
- Add a project plan for immediate email notifications when writer access is granted.