### PR TITLE
fix(agents): multi-account user mentions + reliable trigger matching

### DIFF
--- a/agents/docs/desktop-ui.md
+++ b/agents/docs/desktop-ui.md
@@ -102,6 +102,10 @@ New agents include `read` in `tools`, but the server also offers that tool regar
 plan is to augment this existing read tool for domain-aware SHM reads before deciding whether to expose a new `query`
 alias.
 
+The dialog creates a dedicated signing identity (HM account) for the agent before `CreateAgent`. The server then
+auto-creates a default enabled `user-mention` trigger that follows that signing identity's account uid, so mentioning
+the agent's account immediately starts a session in which it responds. See `signed-api.md` for the server-side behavior.
+
 ## Agent detail page
 
 Features:
@@ -167,10 +171,10 @@ Features:
 - durable final assistant message rendering;
 - automatic scroll-follow while the user is at the bottom, with a scroll-to-latest pill when the user scrolls up;
 - visible tool call/result events rendered with the shared assistant chat bubbles;
-- the first message of a trigger-created session hides the raw `<trigger_context>` / `<trigger_instructions>`
-  text and renders a per-trigger-type `TriggerContextView` card (icon, headline, source summary, fired time, and a
-  collapsible activity payload) plus the human prompt; the exact model-facing markdown remains available through the
-  message's raw-markdown dialog;
+- the first message of a trigger-created session hides the raw `<trigger_context>` / `<trigger_instructions>` text and
+  renders a per-trigger-type `TriggerContextView` card (icon, headline, source summary, fired time, and a collapsible
+  activity payload) plus the human prompt; the exact model-facing markdown remains available through the message's
+  raw-markdown dialog;
 - small thinking indicator while a message request is in flight or the durable session is streaming before partial text
   arrives;
 - signed `StopSession` support from the stop button while streaming, including recovery for stale sessions stuck in

--- a/agents/docs/desktop-ui.md
+++ b/agents/docs/desktop-ui.md
@@ -134,6 +134,9 @@ Features:
 - trigger enabled state defaults on for new triggers and autosaves immediately when toggled;
 - document-comment trigger forms include document autocomplete/search while still allowing raw HM URLs;
 - user-mention and site-update trigger forms include account/site autocomplete search while still allowing raw IDs/URLs;
+- per-trigger-type frontend logic (option labels, defaults, source summaries, configuration forms, activity-route
+  derivation, and the triggered-session `TriggerContextView`) is co-located in `pages/agents/trigger-types.tsx` so each
+  trigger type stays in sync across the trigger forms and the session UI;
 - subscribe to `agents/<agentId>` for live updates.
 
 ## Session page
@@ -164,6 +167,10 @@ Features:
 - durable final assistant message rendering;
 - automatic scroll-follow while the user is at the bottom, with a scroll-to-latest pill when the user scrolls up;
 - visible tool call/result events rendered with the shared assistant chat bubbles;
+- the first message of a trigger-created session hides the raw `<trigger_context>` / `<trigger_instructions>`
+  text and renders a per-trigger-type `TriggerContextView` card (icon, headline, source summary, fired time, and a
+  collapsible activity payload) plus the human prompt; the exact model-facing markdown remains available through the
+  message's raw-markdown dialog;
 - small thinking indicator while a message request is in flight or the durable session is streaming before partial text
   arrives;
 - signed `StopSession` support from the stop button while streaming, including recovery for stale sessions stuck in

--- a/agents/docs/signed-api.md
+++ b/agents/docs/signed-api.md
@@ -140,6 +140,11 @@ Request:
 
 Creates a new agent. Validates referenced provider exists for the account. Creates a per-agent state directory.
 
+When the definition's primary `signingKey` resolves to an `hm-account-key` secret, the server also auto-creates a
+default enabled `user-mention` trigger that follows that signing identity's account uid (prompt: "Respond to the
+mention, performing the action requested."), so mentioning the agent's account starts a session in which it responds.
+This is best-effort and never blocks agent creation; agents without a signing key get no default trigger.
+
 Idempotent when `clientRequestId` is supplied.
 
 ### `ListModelProviders`

--- a/agents/protocol/src/index.ts
+++ b/agents/protocol/src/index.ts
@@ -245,7 +245,7 @@ export type AgentTriggerPatch = {
 /** Activity source/filter that decides when an agent trigger fires. */
 export type AgentTriggerSource =
   | {type: 'document-comment'; resource: string; author?: string}
-  | {type: 'user-mention'; mentionedAccount: string; resourcePrefix?: string}
+  | {type: 'user-mention'; mentionedAccounts: string[]; resourcePrefix?: string}
   | {type: 'site-update'; resourcePrefix: string; eventTypes?: string[]}
   | {type: 'schedule'; schedule: AgentScheduleTrigger}
 

--- a/agents/protocol/src/tool-registry.ts
+++ b/agents/protocol/src/tool-registry.ts
@@ -25,6 +25,9 @@ export type ToolRenderLink = {
   labelPath?: string
 }
 
+/** Input and output of a single tool call, passed to a tool's reference extractor. */
+export type ToolCallIO = {input?: unknown; output?: unknown}
+
 export type ToolRenderDetail = {
   label: string
   source: ToolRenderValueSource
@@ -58,6 +61,8 @@ export type SeedToolMetadata = {
   inputSchema: JsonSchema
   outputSchema?: JsonSchema
   render: ToolRenderMetadata
+  /** Returns the hm:// resource URLs this tool call references, so referenced content can be synced. */
+  getReferencedUrls?: (io: ToolCallIO) => string[]
   runtimes: ToolRuntime[]
   hidden?: boolean
   userConfigurable?: boolean
@@ -215,6 +220,10 @@ export const seedToolRegistry: SeedToolRegistry = {
         {label: 'Output', source: 'output'},
       ],
     },
+    getReferencedUrls: ({output}) => {
+      const results = record(output).results
+      return Array.isArray(results) ? urlList(...results.map((result) => record(result).url)) : []
+    },
     runtimes: ['assistant', 'agent-service'],
     userConfigurable: true,
   },
@@ -334,6 +343,7 @@ export const seedToolRegistry: SeedToolRegistry = {
         {label: 'Output', source: 'output'},
       ],
     },
+    getReferencedUrls: ({input, output}) => urlList(record(output).id, record(output).resourceUrl, record(input).id),
     runtimes: ['assistant', 'agent-service'],
     userConfigurable: true,
   },
@@ -386,6 +396,14 @@ export const seedToolRegistry: SeedToolRegistry = {
         {command: 'profile.alias', kind: 'write-command'},
       ],
     },
+    getReferencedUrls: ({output}) =>
+      urlList(
+        record(output).id,
+        record(output).commentUrl,
+        record(output).target,
+        record(output).targetUrl,
+        record(output).authorUrl,
+      ),
     runtimes: ['agent-service'],
     userConfigurable: true,
   },
@@ -423,4 +441,19 @@ export function getSeedToolMetadata(name: string): SeedToolMetadata | undefined 
 
 export function getSeedToolInputSchema(name: SeedToolName): JsonSchema {
   return seedToolRegistry[name].inputSchema
+}
+
+/** Coerces an unknown to a record so a tool extractor can read fields off it without casts. */
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
+}
+
+/** Keeps only the non-empty strings from a list of candidate URL values. */
+function urlList(...values: unknown[]): string[] {
+  return values.filter((value): value is string => typeof value === 'string' && value.length > 0)
+}
+
+/** Returns the resource URLs a tool call references, via the tool's own `getReferencedUrls` extractor. */
+export function getToolReferencedUrls(toolName: string, io: ToolCallIO): string[] {
+  return getSeedToolMetadata(toolName)?.getReferencedUrls?.(io) ?? []
 }

--- a/agents/src/activity-triggers.test.ts
+++ b/agents/src/activity-triggers.test.ts
@@ -59,47 +59,128 @@ describe('activity trigger matching', () => {
 
     expect(
       triggers.activityMatchesTriggerSource(
-        {type: 'user-mention', mentionedAccount: 'z6Mkmentioned', resourcePrefix: 'hm://z6Mksite'},
+        {type: 'user-mention', mentionedAccounts: ['z6Mkmentioned'], resourcePrefix: 'hm://z6Mksite'},
         event,
       ),
     ).toBe(true)
     expect(
       triggers.activityMatchesTriggerSource(
-        {type: 'user-mention', mentionedAccount: 'z6Mkmentioned', resourcePrefix: 'hm://z6Mkelse'},
+        {type: 'user-mention', mentionedAccounts: ['z6Mkmentioned'], resourcePrefix: 'hm://z6Mkelse'},
         event,
       ),
     ).toBe(false)
     expect(
-      triggers.activityMatchesTriggerSource({type: 'user-mention', mentionedAccount: 'z6Mkmentioned'}, event),
+      triggers.activityMatchesTriggerSource({type: 'user-mention', mentionedAccounts: ['z6Mkmentioned']}, event),
     ).toBe(true)
     expect(
       triggers.activityMatchesTriggerSource(
-        {type: 'user-mention', mentionedAccount: 'z6Mkmentioned', resourcePrefix: 'hm://z6Mksite'},
+        {type: 'user-mention', mentionedAccounts: ['z6Mkmentioned'], resourcePrefix: 'hm://z6Mksite'},
         {...event, newMention: {...event.newMention, target: 'hm://z6Mkmentioned/profile'}},
       ),
     ).toBe(true)
-    expect(triggers.activityMatchesTriggerSource({type: 'user-mention', mentionedAccount: 'z6Mkother'}, event)).toBe(
+    expect(triggers.activityMatchesTriggerSource({type: 'user-mention', mentionedAccounts: ['z6Mkother']}, event)).toBe(
       false,
     )
     expect(
       triggers.activityMatchesTriggerSource(
-        {type: 'user-mention', mentionedAccount: 'z6Mkmentioned', resourcePrefix: 'hm://z6Mksite'},
+        {type: 'user-mention', mentionedAccounts: ['z6Mkmentioned'], resourcePrefix: 'hm://z6Mksite'},
         {data: {case: 'newMention', value: event.newMention}},
       ),
     ).toBe(true)
 
     expect(
       triggers.activityMatchesTriggerSource(
-        {type: 'user-mention', mentionedAccount: 'z6Mkmentioned'},
+        {type: 'user-mention', mentionedAccounts: ['z6Mkmentioned']},
         {type: 'doc-update', targetAuthorUids: ['z6Mkmentioned'], id: 'update-1'},
       ),
     ).toBe(false)
     expect(
       triggers.activityMatchesTriggerSource(
-        {type: 'user-mention', mentionedAccount: 'z6Mkmentioned'},
-        {type: 'comment', comment: {content: [{block: {annotations: [{link: 'hm://z6Mkmentioned/:profile'}]}}]}},
+        {type: 'user-mention', mentionedAccounts: ['z6Mkmentioned']},
+        {
+          type: 'comment',
+          comment: {content: [{block: {annotations: [{type: 'Embed', link: 'hm://z6Mkmentioned/:profile'}]}}]},
+        },
       ),
     ).toBe(true)
+
+    // Matches when any account in the list is mentioned.
+    expect(
+      triggers.activityMatchesTriggerSource(
+        {type: 'user-mention', mentionedAccounts: ['z6Mkother', 'z6Mkmentioned']},
+        event,
+      ),
+    ).toBe(true)
+
+    // Legacy triggers that stored a single `mentionedAccount` still match.
+    expect(
+      triggers.activityMatchesTriggerSource({type: 'user-mention', mentionedAccount: 'z6Mkmentioned'} as any, event),
+    ).toBe(true)
+  })
+
+  test('matches resolved LoadedEvents precisely without firing on incidental account references', () => {
+    const source = {type: 'user-mention' as const, mentionedAccounts: ['z6Mkmentioned']}
+
+    // Comment that embeds a mention of the account (the shape /api/ListEvents returns).
+    const commentMention = {
+      type: 'comment',
+      author: {id: {uid: 'z6Mkauthor', id: 'hm://z6Mkauthor', path: []}},
+      comment: {
+        content: [
+          {block: {annotations: [{type: 'Embed', link: 'hm://z6Mkmentioned/:profile?v=bafyabc&l'}]}, children: []},
+        ],
+      },
+    }
+    expect(triggers.activityMatchesTriggerSource(source, commentMention)).toBe(true)
+
+    // Comment authored BY the account, mentioning someone else, must not match.
+    const commentByAccount = {
+      type: 'comment',
+      author: {id: {uid: 'z6Mkmentioned', id: 'hm://z6Mkmentioned', path: []}},
+      comment: {content: [{block: {annotations: [{type: 'Embed', link: 'hm://z6Mkother/:profile'}]}, children: []}]},
+    }
+    expect(triggers.activityMatchesTriggerSource(source, commentByAccount)).toBe(false)
+
+    // A document citation that targets the account profile is a genuine mention.
+    const documentMention = {
+      type: 'citation',
+      citationType: 'd',
+      source: {id: {uid: 'z6Mksite', id: 'hm://z6Mksite/notes', path: ['notes']}},
+      target: {id: {uid: 'z6Mkmentioned', id: 'hm://z6Mkmentioned/:profile', path: [':profile']}},
+    }
+    expect(triggers.activityMatchesTriggerSource(source, documentMention)).toBe(true)
+
+    // A comment-sourced citation is suppressed because its comment event already reports the mention.
+    expect(triggers.activityMatchesTriggerSource(source, {...documentMention, citationType: 'c'})).toBe(false)
+
+    // A citation that merely *cites a document owned by* the account is not an account mention.
+    const documentCitation = {
+      type: 'citation',
+      citationType: 'd',
+      source: {id: {uid: 'z6Mksite', id: 'hm://z6Mksite/notes', path: ['notes']}},
+      target: {
+        id: {uid: 'z6Mkmentioned', id: 'hm://z6Mkmentioned/weekly-review', path: ['weekly-review']},
+      },
+      targetAuthorUids: ['z6Mkmentioned'],
+    }
+    expect(triggers.activityMatchesTriggerSource(source, documentCitation)).toBe(false)
+
+    // A doc-update authored by the account is not a mention.
+    expect(
+      triggers.activityMatchesTriggerSource(source, {
+        type: 'doc-update',
+        author: {id: {uid: 'z6Mkmentioned', id: 'hm://z6Mkmentioned', path: []}},
+        docId: {uid: 'z6Mkmentioned', id: 'hm://z6Mkmentioned/post', path: ['post']},
+      }),
+    ).toBe(false)
+
+    // resourcePrefix still filters resolved mentions by where the mention occurred.
+    expect(
+      triggers.activityMatchesTriggerSource({...source, resourcePrefix: 'hm://z6Mksite'}, documentMention),
+    ).toBe(true)
+    expect(
+      triggers.activityMatchesTriggerSource({...source, resourcePrefix: 'hm://z6Mkelsewhere'}, documentMention),
+    ).toBe(false)
   })
 
   test('matches site updates by resource prefix and event type', () => {

--- a/agents/src/activity-triggers.test.ts
+++ b/agents/src/activity-triggers.test.ts
@@ -175,9 +175,9 @@ describe('activity trigger matching', () => {
     ).toBe(false)
 
     // resourcePrefix still filters resolved mentions by where the mention occurred.
-    expect(
-      triggers.activityMatchesTriggerSource({...source, resourcePrefix: 'hm://z6Mksite'}, documentMention),
-    ).toBe(true)
+    expect(triggers.activityMatchesTriggerSource({...source, resourcePrefix: 'hm://z6Mksite'}, documentMention)).toBe(
+      true,
+    )
     expect(
       triggers.activityMatchesTriggerSource({...source, resourcePrefix: 'hm://z6Mkelsewhere'}, documentMention),
     ).toBe(false)

--- a/agents/src/activity-triggers.ts
+++ b/agents/src/activity-triggers.ts
@@ -159,15 +159,45 @@ function activityCommentTarget(event: ActivityFeedEvent): string | null {
   return canonicalizeResourceId(`hm://${account}${targetPath ? `/${targetPath.replace(/^\/+/, '')}` : ''}`)
 }
 
+/** Reads the mentioned account list, tolerating legacy triggers that stored a single `mentionedAccount`. */
+export function mentionedAccountsOf(source: Extract<api.AgentTriggerSource, {type: 'user-mention'}>): string[] {
+  const legacy = (source as {mentionedAccount?: string}).mentionedAccount
+  const accounts = source.mentionedAccounts ?? (legacy ? [legacy] : [])
+  return accounts.filter((account) => !!account)
+}
+
 function matchesUserMention(
   source: Extract<api.AgentTriggerSource, {type: 'user-mention'}>,
   event: ActivityFeedEvent,
 ): boolean {
-  const accountTarget = `hm://${source.mentionedAccount}`
+  return mentionedAccountsOf(source).some((mentionedAccount) => matchesSingleMention(mentionedAccount, source, event))
+}
+
+/**
+ * Decides whether a single activity event is a genuine @mention of `mentionedAccount`.
+ *
+ * Two event shapes are supported:
+ *  - Raw ActivityFeed events (`newMention`), used by tests and any caller that bypasses the
+ *    resolving `/api/ListEvents` endpoint.
+ *  - Resolved `LoadedEvent`s (the shape `/api/ListEvents` actually returns), where mentions live in
+ *    comment-block `Embed` annotations (`type: 'comment'`) or in citation targets (`type: 'citation'`).
+ *
+ * Detection is structural (mirroring the notification classifier) rather than a substring scan, so a
+ * trigger fires only when the account is actually mentioned — not merely because its UID appears as an
+ * author, reply parent, or cited document. Comment-sourced citations are ignored because the same
+ * mention is already reported by the comment event, which avoids firing two sessions for one mention.
+ */
+function matchesSingleMention(
+  mentionedAccount: string,
+  source: Extract<api.AgentTriggerSource, {type: 'user-mention'}>,
+  event: ActivityFeedEvent,
+): boolean {
+  // Raw ActivityFeed `newMention` events.
   const mention = activityEventMention(event)
   if (mention) {
+    const accountTarget = `hm://${mentionedAccount}`
     const target = stringField(mention, 'target')
-    if (target !== source.mentionedAccount && target !== accountTarget && !target?.startsWith(`${accountTarget}/`)) {
+    if (target !== mentionedAccount && target !== accountTarget && !target?.startsWith(`${accountTarget}/`)) {
       return false
     }
     if (!source.resourcePrefix) return true
@@ -178,11 +208,86 @@ function matchesUserMention(
     ].some((value) => !!value && value.startsWith(source.resourcePrefix!))
   }
 
+  // Resolved LoadedEvents.
   const type = stringField(event, 'type')
-  if (type !== 'comment' && type !== 'citation') return false
-  if (!jsonContainsString(event, source.mentionedAccount) && !jsonContainsString(event, accountTarget)) return false
-  if (!source.resourcePrefix) return true
-  return jsonContainsString(event, source.resourcePrefix)
+  if (type === 'comment') {
+    if (!commentMentionsAccount(recordField(event, 'comment'), mentionedAccount)) return false
+    return mentionMatchesResourcePrefix(event, source.resourcePrefix)
+  }
+  if (type === 'citation') {
+    // Comment-sourced citations mirror their comment event; rely on the comment event so a single
+    // mention does not create two sessions.
+    if (stringField(event, 'citationType') === 'c') return false
+    const target = recordField(event, 'target')
+    const targetId = target ? recordField(target, 'id') : null
+    if (mentionedAccountFromIdRecord(targetId) !== mentionedAccount) return false
+    return mentionMatchesResourcePrefix(event, source.resourcePrefix)
+  }
+
+  return false
+}
+
+/** Resolves the account UID a mention link points at, when it targets an account root or `:profile`. */
+function mentionedAccountFromLink(link: unknown): string | null {
+  if (typeof link !== 'string') return null
+  const trimmed = link.trim()
+  if (!trimmed.startsWith('hm://')) return null
+  const withoutScheme = trimmed.slice('hm://'.length)
+  const pathOnly = withoutScheme.split('?')[0]?.split('#')[0] || ''
+  const segments = pathOnly.split('/').filter(Boolean)
+  const uid = segments[0]
+  if (!uid) return null
+  if (segments.length === 1) return uid // account root
+  if (segments[1] === ':profile') return uid // profile mention
+  return null // points at a document, not the account itself
+}
+
+/** Resolves the account UID from a resolved `UnpackedHypermediaId` record, when it names an account. */
+function mentionedAccountFromIdRecord(idRecord: Record<string, unknown> | null): string | null {
+  if (!idRecord) return null
+  const uid = stringField(idRecord, 'uid')
+  if (!uid) return null
+  const path = idRecord['path']
+  if (!Array.isArray(path) || path.length === 0) return uid // account root
+  if (path[0] === ':profile') return uid // profile mention
+  return null // points at a document, not the account itself
+}
+
+/** Returns true when a resolved comment's content embeds a mention of `mentionedAccount`. */
+function commentMentionsAccount(comment: Record<string, unknown> | null, mentionedAccount: string): boolean {
+  if (!comment) return false
+  return blockNodesMentionAccount(comment['content'], mentionedAccount)
+}
+
+function blockNodesMentionAccount(nodes: unknown, mentionedAccount: string): boolean {
+  if (!Array.isArray(nodes)) return false
+  return nodes.some((node) => {
+    if (!node || typeof node !== 'object') return false
+    const block = recordField(node as Record<string, unknown>, 'block')
+    const annotations = block ? block['annotations'] : undefined
+    if (Array.isArray(annotations)) {
+      for (const annotation of annotations) {
+        if (!annotation || typeof annotation !== 'object') continue
+        if ((annotation as Record<string, unknown>).type !== 'Embed') continue
+        if (mentionedAccountFromLink((annotation as Record<string, unknown>).link) === mentionedAccount) return true
+      }
+    }
+    return blockNodesMentionAccount((node as Record<string, unknown>).children, mentionedAccount)
+  })
+}
+
+/** Applies the optional resource/site prefix filter against the resources a mention event references. */
+function mentionMatchesResourcePrefix(event: ActivityFeedEvent, resourcePrefix: string | undefined): boolean {
+  if (!resourcePrefix) return true
+  const candidates: Array<string | undefined> = []
+  for (const field of ['source', 'target', 'commentId'] as const) {
+    const record = recordField(event, field)
+    const id = record ? recordField(record, 'id') : null
+    candidates.push(id ? stringField(id, 'id') : stringField(record || {}, 'id'))
+  }
+  if (candidates.some((value) => !!value && value.startsWith(resourcePrefix))) return true
+  // Fall back to a broad scan so unusual event shapes still honour an explicit prefix filter.
+  return jsonContainsString(event, resourcePrefix)
 }
 
 function matchesSiteUpdate(

--- a/agents/src/api-service.test.ts
+++ b/agents/src/api-service.test.ts
@@ -631,7 +631,11 @@ describe('api service', () => {
             triggerId: createdTrigger.trigger.id,
             patch: {
               enabled: false,
-              source: {type: 'user-mention', mentionedAccount: ' z6Mkmentioned ', resourcePrefix: ' hm://z6Mksite '},
+              source: {
+                type: 'user-mention',
+                mentionedAccounts: [' z6Mkmentioned ', 'z6Mksecond', ' z6Mkmentioned '],
+                resourcePrefix: ' hm://z6Mksite ',
+              },
             },
           },
         }),
@@ -640,7 +644,11 @@ describe('api service', () => {
       if (updated._ !== 'UpdateAgentTriggerResponse') throw new Error('unexpected response')
       expect(updated.trigger).toMatchObject({
         enabled: false,
-        source: {type: 'user-mention', mentionedAccount: 'z6Mkmentioned', resourcePrefix: 'hm://z6Mksite'},
+        source: {
+          type: 'user-mention',
+          mentionedAccounts: ['z6Mkmentioned', 'z6Mksecond'],
+          resourcePrefix: 'hm://z6Mksite',
+        },
       })
 
       const updatedPrompt = await svc.message(

--- a/agents/src/api-service.test.ts
+++ b/agents/src/api-service.test.ts
@@ -52,6 +52,81 @@ describe('api service', () => {
     }
   })
 
+  test('creates a default user-mention trigger for the agent signing identity', async () => {
+    const {db, dataDir, cleanup} = createTestState()
+    try {
+      const account = blobs.generateNobleKeyPair()
+      const svc = new apisvc.Service(db, dataDir)
+      await setDefaultProvider(svc, account)
+      await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {
+            _: 'SetSecret',
+            name: 'agent-account-key',
+            value: new TextEncoder().encode('mnemonic words'),
+            metadata: {kind: 'hm-account-key', accountId: 'z6MkAgentAccountUid', label: 'Agent account'},
+          },
+        }),
+      )
+      const create = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {
+            _: 'CreateAgent',
+            definition: {
+              name: 'Mentionable Agent',
+              systemPrompt: 'ok',
+              modelProvider: 'openai',
+              model: 'gpt',
+              signingKey: 'agent-account-key',
+            },
+          },
+        }),
+      )
+      if (create._ !== 'CreateAgentResponse') throw new Error('unexpected response')
+
+      const listed = await svc.message(
+        await apisvc.createSignedEnvelope(account, {action: {_: 'ListAgentTriggers', agentId: create.agentId}}),
+      )
+      expect(listed._).toBe('ListAgentTriggersResponse')
+      if (listed._ !== 'ListAgentTriggersResponse') throw new Error('unexpected response')
+      expect(listed.triggers).toHaveLength(1)
+      const trigger = listed.triggers[0]
+      expect(trigger?.enabled).toBe(true)
+      expect(trigger?.source).toEqual({type: 'user-mention', mentionedAccounts: ['z6MkAgentAccountUid']})
+      expect(agentPromptText(trigger?.prompt)).toBe('Respond to the mention, performing the action requested.')
+    } finally {
+      db.close()
+      cleanup()
+    }
+  })
+
+  test('does not create a default trigger when the agent has no signing identity', async () => {
+    const {db, dataDir, cleanup} = createTestState()
+    try {
+      const account = blobs.generateNobleKeyPair()
+      const svc = new apisvc.Service(db, dataDir)
+      await setDefaultProvider(svc, account)
+      const create = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {
+            _: 'CreateAgent',
+            definition: {name: 'No Account Agent', systemPrompt: 'ok', modelProvider: 'openai', model: 'gpt'},
+          },
+        }),
+      )
+      if (create._ !== 'CreateAgentResponse') throw new Error('unexpected response')
+
+      const listed = await svc.message(
+        await apisvc.createSignedEnvelope(account, {action: {_: 'ListAgentTriggers', agentId: create.agentId}}),
+      )
+      if (listed._ !== 'ListAgentTriggersResponse') throw new Error('unexpected response')
+      expect(listed.triggers).toHaveLength(0)
+    } finally {
+      db.close()
+      cleanup()
+    }
+  })
+
   test('rejects invalid definitions before writing', async () => {
     const {db, dataDir, cleanup} = createTestState()
     try {

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -2317,9 +2317,19 @@ function normalizeAgentTriggerSource(raw: api.AgentTriggerSource): api.AgentTrig
     }
   }
   if (raw.type === 'user-mention') {
+    const legacy = (raw as {mentionedAccount?: unknown}).mentionedAccount
+    const rawAccounts = raw.mentionedAccounts ?? (legacy === undefined ? undefined : [legacy])
+    if (!Array.isArray(rawAccounts)) throw new APIError(400, 'Trigger mentioned accounts must be an array')
+    if (rawAccounts.length > MAX_TOOL_COUNT) throw new APIError(400, 'Too many trigger mentioned accounts')
+    const mentionedAccounts: string[] = []
+    for (const account of rawAccounts) {
+      const normalized = normalizeBoundedString(account, 'Trigger mentioned account', MAX_NAME_BYTES)
+      if (!mentionedAccounts.includes(normalized)) mentionedAccounts.push(normalized)
+    }
+    if (mentionedAccounts.length === 0) throw new APIError(400, 'Trigger mentioned account is required')
     return {
       type: 'user-mention',
-      mentionedAccount: normalizeBoundedString(raw.mentionedAccount, 'Trigger mentioned account', MAX_NAME_BYTES),
+      mentionedAccounts,
       ...(raw.resourcePrefix === undefined
         ? {}
         : {resourcePrefix: normalizeBoundedString(raw.resourcePrefix, 'Trigger resource prefix', 2048)}),

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -268,6 +268,7 @@ export class Service {
       [agentId, accountId, cbor.encode(definition), stateDir, 'idle', now, now],
     )
     fs.mkdirSync(stateDir, {recursive: true})
+    this.#createDefaultMentionTrigger(accountId, agentId, definition)
     const agentInfo = this.#getAgentInfo(accountId, agentId)
     if (agentInfo) {
       this.#emit({type: 'agent-change', accountId, agent: agentInfo})
@@ -275,6 +276,41 @@ export class Service {
     }
 
     return {_: 'CreateAgentResponse', agentId}
+  }
+
+  /**
+   * Gives a new agent a default trigger so that mentioning the agent's own HM account starts a
+   * session in which it responds. The mention target is the agent's signing-identity account uid,
+   * resolved from its primary signing key. Best-effort: a failure here never blocks agent creation.
+   */
+  #createDefaultMentionTrigger(accountId: string, agentId: string, definition: api.AgentDefinition): void {
+    const signingKey = definition.signingKey ?? definition.signingKeys?.[0]
+    if (!signingKey) return
+    const mentionAccountId = this.#signingIdentityAccountId(accountId, signingKey)
+    if (!mentionAccountId) return
+    try {
+      this.#createAgentTriggerOnce(accountId, agentId, {
+        name: `Mentions of ${definition.name}`,
+        enabled: true,
+        source: {type: 'user-mention', mentionedAccounts: [mentionAccountId]},
+        prompt: 'Respond to the mention, performing the action requested.',
+      })
+    } catch (error) {
+      console.warn('[agents] failed to create default mention trigger', {agentId, error: errorMessage(error)})
+    }
+  }
+
+  /** Resolves the HM account uid behind a signing-key secret name, or null if it is not an account key. */
+  #signingIdentityAccountId(accountId: string, signingKey: string): string | null {
+    const row = this.#db
+      .query<{metadata_cbor: Uint8Array | null}, [string, string]>(
+        `SELECT metadata_cbor FROM secrets WHERE account_id = ? AND name = ?`,
+      )
+      .get(accountId, signingKey)
+    if (!row?.metadata_cbor) return null
+    const metadata = cbor.decode<Record<string, unknown>>(row.metadata_cbor)
+    if (metadata.kind !== 'hm-account-key') return null
+    return typeof metadata.accountId === 'string' ? metadata.accountId : null
   }
 
   #listModelProviders(accountId: string): api.ListModelProvidersResponse {

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -125,6 +125,12 @@ export class Service {
     this.#hmServerUrl = options.hmServerUrl || 'https://hyper.media'
   }
 
+  /** The Seed HM server this agent publishes to and reads from. Surfaced via health so desktop clients can
+   * connect their local node to it for discovery. */
+  get hmServerUrl(): string {
+    return this.#hmServerUrl
+  }
+
   /** Verifies and dispatches a signed action envelope. */
   async message(envelope: api.SignedActionEnvelope): Promise<api.AgentResponse> {
     let verified: auth.VerifiedEnvelope

--- a/agents/src/main.ts
+++ b/agents/src/main.ts
@@ -142,10 +142,12 @@ export function createAPIRoutes(svc: apisvc.Service): Bun.Serve.Routes<undefined
     '/api/message': {OPTIONS: options, POST: message},
     '/agents/api/message': {OPTIONS: options, POST: message},
     '/api/health': {
-      GET: () => Response.json({status: 'ok', uptime: process.uptime()}, {headers: corsHeaders()}),
+      GET: () =>
+        Response.json({status: 'ok', uptime: process.uptime(), hmServerUrl: svc.hmServerUrl}, {headers: corsHeaders()}),
     },
     '/agents/api/health': {
-      GET: () => Response.json({status: 'ok', uptime: process.uptime()}, {headers: corsHeaders()}),
+      GET: () =>
+        Response.json({status: 'ok', uptime: process.uptime(), hmServerUrl: svc.hmServerUrl}, {headers: corsHeaders()}),
     },
   }
 }

--- a/frontend/apps/desktop/src/agents-client.ts
+++ b/frontend/apps/desktop/src/agents-client.ts
@@ -52,6 +52,8 @@ type AgentsResponse = AgentsProtocol.AgentResponse
 export type AgentServerHealth = {
   status: string
   uptime: number
+  /** The Seed HM server the agent publishes to; desktop connects its local node to this for discovery. */
+  hmServerUrl?: string
 }
 
 /** Normalizes an agent server URL for storage and fetch calls. */

--- a/frontend/apps/desktop/src/app-sync.ts
+++ b/frontend/apps/desktop/src/app-sync.ts
@@ -67,6 +67,25 @@ async function timeAsync<T>(label: string, fn: () => Promise<T>): Promise<T> {
   }
 }
 
+/**
+ * Discovery diagnostics. Always logs key transitions/errors with a `[discovery]` prefix so an operator can
+ * trace why a clicked hm:// resource does or doesn't resolve. These run in the desktop MAIN process, so the
+ * output appears in the terminal running the app (e.g. `./dev run-desktop`), not the renderer DevTools console.
+ * Set SEED_DEBUG_DISCOVERY=1 to also log every per-poll discoverEntity response (verbose).
+ */
+const DISCOVERY_VERBOSE = process.env.SEED_DEBUG_DISCOVERY === '1' || process.env.SEED_DEBUG_DISCOVERY === 'true'
+// Generic per-resource discovery logging is OFF unless SEED_DEBUG_DISCOVERY is set — it fires for every
+// subscribed resource on every poll and is far too noisy for normal use. Agent-referenced discovery has its
+// own always-on `[agents-discovery]` log (see models/agents.ts).
+function discoveryLog(message: string, fields?: Record<string, unknown>): void {
+  if (!DISCOVERY_VERBOSE) return
+  console.info(`[discovery] ${message}`, fields ?? {})
+}
+function discoveryWarn(message: string, fields?: Record<string, unknown>): void {
+  if (!DISCOVERY_VERBOSE) return
+  console.warn(`[discovery] ${message}`, fields ?? {})
+}
+
 // Polling intervals (base values, multiplied by getPollingMultiplier())
 const DISCOVERY_POLL_INTERVAL_MS = 14_000
 const ACTIVITY_POLL_INTERVAL_MS = 1_000
@@ -719,9 +738,28 @@ export async function discoverDocument(
     return false
   }
 
+  if (DISCOVERY_VERBOSE) {
+    discoveryLog('discoverDocument start', {id: discoverRequest.id, version: version || undefined, recursive, scope})
+  }
+
   return await tryUntilSuccess(
     async () => {
       const discoverResp = await grpcClient.entities.discoverEntity(discoverRequest)
+      const progress = discoverResp.progress
+      if (DISCOVERY_VERBOSE || discoverResp.lastError) {
+        discoveryLog('discoverEntity response', {
+          id: discoverRequest.id,
+          state: discoverResp.state,
+          version: discoverResp.version || '(empty)',
+          lastError: discoverResp.lastError || undefined,
+          peersFound: progress?.peersFound,
+          peersSyncedOk: progress?.peersSyncedOk,
+          peersFailed: progress?.peersFailed,
+          blobsDiscovered: progress?.blobsDiscovered,
+          blobsDownloaded: progress?.blobsDownloaded,
+          blobsFailed: progress?.blobsFailed,
+        })
+      }
       if (discoverResp.progress && onProgress) {
         onProgress({
           blobsDiscovered: discoverResp.progress.blobsDiscovered,
@@ -784,14 +822,23 @@ async function runDiscovery(sub: ResourceSubscription): Promise<DiscoveryResult 
     )
   } catch (e) {
     // Discovery failed (timeout, network error, etc.)
-    // Check resource status anyway - data may have been synced
-    // console.log(`[Discovery] ${id.id}: discovery error, checking resource status`)
+    // Check resource status anyway - data may have been synced.
+    discoveryWarn('discoverDocument failed (will still check resource status)', {
+      id: id.id,
+      recursive: getEffectiveRecursive(),
+      error: getErrorMessage(e),
+    })
   }
 
   updateAggregatedDiscoveryState()
 
   // After discovery, check resource status via GetResource
   const status = await checkResourceStatus(id)
+  discoveryLog('resource status after discovery', {
+    id: id.id,
+    status,
+    discoveredVersion: discoveryResult?.version || undefined,
+  })
   // if (!PROFILE_ENABLED) {
   //   console.log(`[Discovery] ${id.id}: status=${status}`)
   // }
@@ -866,6 +913,7 @@ function isEntityCoveredByRecursive(id: UnpackedHypermediaId): boolean {
 function createSubscription(sub: ResourceSubscription): SubscriptionState {
   const {id, recursive} = sub
   const key = getSubscriptionKey(sub)
+  discoveryLog('subscribe', {id: id.id, recursive: !!recursive, scope: sub.scope ?? 'all'})
 
   // Track recursive subscriptions
   if (recursive) {
@@ -926,9 +974,14 @@ function createSubscription(sub: ResourceSubscription): SubscriptionState {
         updateAggregatedDiscoveryState()
         discoveryTimer = setTimeout(discoveryLoop, getAdaptiveInterval(DISCOVERY_POLL_INTERVAL_MS))
       })
-      .catch(() => {
+      .catch((error) => {
         if (cancelled) return
-        // Keep discovering state and retry on errors
+        // Keep discovering state and retry on errors — this is the path that keeps a resource stuck on a
+        // loading spinner indefinitely, so surface it loudly.
+        discoveryWarn('runDiscovery threw — keeping discovering state and retrying', {
+          id: id.id,
+          error: getErrorMessage(error),
+        })
         discoveryTimer = setTimeout(discoveryLoop, getAdaptiveInterval(DISCOVERY_POLL_INTERVAL_MS))
       })
   }

--- a/frontend/apps/desktop/src/models/agents.ts
+++ b/frontend/apps/desktop/src/models/agents.ts
@@ -237,18 +237,51 @@ export function useConnectLocalNodeToAgentHmServer(serverUrl: string | undefined
     useErrorBoundary: false,
     queryFn: async () => {
       if (!hmServerUrl) return null
-      const config = await client.web.configOfHost.query({host: hmServerUrl})
-      if (config.addrs?.length) {
-        await grpcClient.networking.connect({addrs: config.addrs})
-        console.info('[agents] connected local node to agent HM server', {
-          hmServerUrl,
-          peerId: config.peerId,
-          addrs: config.addrs.length,
-        })
-      }
-      return {peerId: config.peerId, addrs: config.addrs}
+      return connectLocalNodeToAgentHmServer(hmServerUrl)
     },
   })
+}
+
+/** Peers the local node with an agent HM server so discovery can sync content directly from it. */
+async function connectLocalNodeToAgentHmServer(hmServerUrl: string): Promise<{peerId: string; addrs: string[]} | null> {
+  const config = await client.web.configOfHost.query({host: hmServerUrl})
+  if (config.addrs?.length) {
+    await grpcClient.networking.connect({addrs: config.addrs})
+    console.info('[agents] connected local node to agent HM server', {
+      hmServerUrl,
+      peerId: config.peerId,
+      addrs: config.addrs.length,
+    })
+  }
+  return {peerId: config.peerId, addrs: config.addrs}
+}
+
+/**
+ * Syncs a newly created agent's HM account onto the local node so it can immediately be searched and
+ * @mentioned. The agent account profile/home is published to the agent server's HM node, so we first peer the
+ * local node with that HM node (same logic as {@link useConnectLocalNodeToAgentHmServer}) and then discover the
+ * account recursively — its profile lives in the account subtree. Best-effort and fire-and-forget; failures
+ * are non-fatal and logged under `[agents-discovery]`.
+ */
+export async function syncAgentAccountToLocalNode(serverUrl: string | undefined, accountUid: string): Promise<void> {
+  const discoveryId = `hm://${accountUid}/**`
+  try {
+    const health = await getAgentServerHealth(serverUrl || DEFAULT_AGENT_SERVER_URL)
+    if (health.hmServerUrl) await connectLocalNodeToAgentHmServer(health.hmServerUrl)
+    discoveredAgentRefs.add(discoveryId)
+    console.info('[agents-discovery] syncing new agent account to local node', {id: discoveryId})
+    const resp = await grpcClient.entities.discoverEntity({id: discoveryId})
+    console.info('[agents-discovery] agent account discovery scheduled', {
+      id: discoveryId,
+      state: resp.state,
+      version: resp.version || '(pending)',
+    })
+  } catch (error) {
+    console.warn('[agents-discovery] failed to sync agent account to local node', {
+      id: discoveryId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
 }
 
 /** Lists agents for the selected account on the configured server. */
@@ -376,8 +409,14 @@ export function useCreateSigningIdentity(serverUrl: string | undefined, accountU
         action: {_: 'CreateSigningIdentity', label, clientRequestId: crypto.randomUUID()},
       })
     },
-    onSuccess() {
+    onSuccess(result) {
       invalidateQueries(['agents'])
+      // The new agent account profile/home was just published to the server's HM node. Sync it onto the
+      // local node so it can be searched and @mentioned right away (covers both the create-agent flow and
+      // the Tools-tab "New account" workflow).
+      if (result._ === 'CreateSigningIdentityResponse' && result.identity.accountId) {
+        void syncAgentAccountToLocalNode(serverUrl, result.identity.accountId)
+      }
     },
   })
 }

--- a/frontend/apps/desktop/src/models/agents.ts
+++ b/frontend/apps/desktop/src/models/agents.ts
@@ -19,6 +19,8 @@ import {
   type SigningIdentity,
 } from '@/agents-client'
 import {client} from '@/trpc'
+import {grpcClient} from '@/grpc-client'
+import {getToolReferencedUrls} from '@seed-hypermedia/agents-protocol'
 import * as cbor from '@shm/shared/cbor'
 import {invalidateQueries, queryClient} from '@shm/shared/models/query-client'
 import {useMutation, useQueries, useQuery} from '@tanstack/react-query'
@@ -35,6 +37,78 @@ export function getDefaultAgentServerUrl() {
 /** The built-in default agent server URL for the current desktop runtime. */
 export const DEFAULT_AGENT_SERVER_URL = getDefaultAgentServerUrl()
 const AGENT_BACKGROUND_REFETCH_INTERVAL_MS = 5_000
+
+// ─── Agent-referenced content discovery ─────────────────────────────────────
+// When an agent session event arrives over the WebSocket it may reference hm:// content the local node
+// hasn't synced. We detect those references centrally at the ingestion point — reading tool-result URLs from
+// the tool registry's structured `references` metadata (getToolReferencedUrls), and assistant-message URLs
+// from the markdown prose — then ask the local daemon to discover/sync each, so the document is available by
+// the time the user clicks. The agent publishes to a different node (its HM server), so this only works once
+// the local node is peered with it (see useConnectLocalNodeToAgentHmServer).
+
+const HM_REF_REGEX = /hm:\/\/[^\s)"'`\]<>]+/g
+/** Canonical discovery URLs already requested this process, to avoid re-discovering the same resource. */
+const discoveredAgentRefs = new Set<string>()
+
+/** Normalize an hm:// URL to a bare resource URL (drop version/query, block ref, and any `:view` marker). */
+function canonicalAgentRef(raw: string): string | null {
+  if (!raw.startsWith('hm://')) return null
+  const withoutScheme = (raw.slice('hm://'.length).split('#')[0] ?? '').split('?')[0] ?? ''
+  const segments = withoutScheme.split('/').filter((segment) => segment.length > 0)
+  const uid = segments[0]
+  if (!uid) return null
+  const pathSegments: string[] = []
+  for (const segment of segments.slice(1)) {
+    if (segment.startsWith(':')) break
+    pathSegments.push(segment)
+  }
+  return `hm://${uid}${pathSegments.length ? `/${pathSegments.join('/')}` : ''}`
+}
+
+/** Pull hm:// references out of free-form text (assistant prose / markdown links). */
+function extractHmUrlsFromText(text: string): string[] {
+  return (text.match(HM_REF_REGEX) ?? []).map((match) => match.replace(/[.,;]+$/, ''))
+}
+
+/**
+ * Triggers local-daemon discovery for any referenced resource not already seen this process. Best-effort and
+ * fire-and-forget; logs under `[agents-discovery]` so the agent-content discovery path is visible without the
+ * noise of generic per-resource discovery.
+ *
+ * A comment URL (`hm://target/path/:comments/<author>/<tsid>`) canonicalizes to its target document, but a
+ * comment is only synced as part of that document's subtree — so comment references are discovered
+ * recursively (`/**`), the same way the document page subscribes (`recursive: true`). Plain document
+ * references stay non-recursive.
+ */
+function discoverReferences(urls: string[]): void {
+  // Group by canonical resource id, marking a target recursive if any reference to it is a comment.
+  const recursiveById = new Map<string, boolean>()
+  for (const rawUrl of urls) {
+    const id = canonicalAgentRef(rawUrl)
+    if (!id) continue
+    const recursive = rawUrl.includes('/:comments/') || (recursiveById.get(id) ?? false)
+    recursiveById.set(id, recursive)
+  }
+  for (const [id, recursive] of Array.from(recursiveById.entries())) {
+    const discoveryId = recursive ? `${id}/**` : id
+    if (discoveredAgentRefs.has(discoveryId)) continue
+    discoveredAgentRefs.add(discoveryId)
+    console.info('[agents-discovery] agent referenced content — discovering on local node', {id: discoveryId})
+    void grpcClient.entities.discoverEntity({id: discoveryId}).then(
+      (resp) =>
+        console.info('[agents-discovery] discovery scheduled', {
+          id: discoveryId,
+          state: resp.state,
+          version: resp.version || '(pending)',
+        }),
+      (error) =>
+        console.warn('[agents-discovery] discovery request failed', {
+          id: discoveryId,
+          error: error instanceof Error ? error.message : String(error),
+        }),
+    )
+  }
+}
 
 function tryNormalizeAgentServerUrl(input: string): string | null {
   try {
@@ -138,6 +212,42 @@ export function useAgentServerHealth(serverUrl: string | undefined) {
     refetchIntervalInBackground: true,
     retry: false,
     useErrorBoundary: false,
+  })
+}
+
+/**
+ * Ensures the desktop's local Seed node is peered with the agent server's HM node.
+ *
+ * Agents publish documents/comments to their configured `hmServerUrl` — a different node than the desktop's
+ * local embedded daemon. Discovery only queries the node's current set of connected peers, so unless the
+ * local node is peered with the HM node that actually holds the content, discovery has nowhere to fetch it
+ * from and clicked links stay stuck on a loading spinner. Connecting the local node to the HM server adds it
+ * to that peer set so discovery can sync agent-created content directly from it. Best-effort and periodic;
+ * failures are non-fatal.
+ */
+export function useConnectLocalNodeToAgentHmServer(serverUrl: string | undefined) {
+  const health = useAgentServerHealth(serverUrl)
+  const hmServerUrl = health.data?.hmServerUrl
+  return useQuery({
+    queryKey: ['agents', 'hm-server-connect', hmServerUrl],
+    enabled: !!hmServerUrl,
+    refetchInterval: AGENT_BACKGROUND_REFETCH_INTERVAL_MS,
+    refetchIntervalInBackground: true,
+    retry: false,
+    useErrorBoundary: false,
+    queryFn: async () => {
+      if (!hmServerUrl) return null
+      const config = await client.web.configOfHost.query({host: hmServerUrl})
+      if (config.addrs?.length) {
+        await grpcClient.networking.connect({addrs: config.addrs})
+        console.info('[agents] connected local node to agent HM server', {
+          hmServerUrl,
+          peerId: config.peerId,
+          addrs: config.addrs.length,
+        })
+      }
+      return {peerId: config.peerId, addrs: config.addrs}
+    },
   })
 }
 
@@ -676,6 +786,9 @@ export function useAgentWebSocketSubscription(
 ): AgentSessionLiveState {
   const [partials, setPartials] = useState<Record<string, AgentSessionLiveState>>({})
 
+  // Keep the local node peered with this server's HM node so agent-created content can be discovered locally.
+  useConnectLocalNodeToAgentHmServer(serverUrl)
+
   useEffect(() => {
     if (!serverUrl || !accountUid || !key) return
     let cancelled = false
@@ -725,7 +838,21 @@ export function useAgentWebSocketSubscription(
               log('subscribed event', {subscribedKey: event.key, accountId: event.accountId})
             } else if (event._ === 'append') {
               log('append event', {sessionId: event.event.sessionId, seq: event.event.seq})
-              const eventPayload = event.event.event as {type?: string; role?: string; content?: string}
+              const eventPayload = event.event.event as {
+                type?: string
+                role?: string
+                content?: string
+                name?: string
+                output?: unknown
+              }
+              // Central detection point: sync any hm:// content this agent event references onto the local
+              // node — tool-result URLs come from the registry's structured reference metadata, message URLs
+              // from the markdown prose.
+              if (eventPayload.type === 'tool_result' && typeof eventPayload.name === 'string') {
+                discoverReferences(getToolReferencedUrls(eventPayload.name, {output: eventPayload.output}))
+              } else if (eventPayload.type === 'message' && typeof eventPayload.content === 'string') {
+                discoverReferences(extractHmUrlsFromText(eventPayload.content))
+              }
               if (eventPayload.type === 'message' && eventPayload.role === 'assistant') {
                 // The streamed text is now a durable message, but the run may continue
                 // (more turns after tool calls), so keep usage/activity until idle.

--- a/frontend/apps/desktop/src/pages/agents/__tests__/model-utils.test.ts
+++ b/frontend/apps/desktop/src/pages/agents/__tests__/model-utils.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest'
-import {canonicalModelId, curateProviderModels, isChatModel} from '../model-utils'
+import {canonicalModelId, curateProviderModels, isChatModel, pickDefaultProviderModel} from '../model-utils'
 
 const m = (id: string, name?: string) => ({id, name: name ?? id})
 
@@ -39,6 +39,23 @@ describe('canonicalModelId', () => {
     expect(canonicalModelId('gpt-4o-mini')).toBe('gpt-4o-mini')
     expect(canonicalModelId('o1-mini')).toBe('o1-mini')
     expect(canonicalModelId('claude-3-5-sonnet')).toBe('claude-3-5-sonnet')
+  })
+})
+
+describe('pickDefaultProviderModel', () => {
+  it('prefers gpt-5-mini for OpenAI when available and skips embedding models', () => {
+    const models = [m('text-embedding-3-large'), m('gpt-5'), m('gpt-5-mini'), m('gpt-4o')]
+
+    expect(pickDefaultProviderModel(models, 'openai')?.id).toBe('gpt-5-mini')
+  })
+
+  it('prefers claude-sonnet-4.6 for Anthropic when available via alias or snapshot', () => {
+    expect(pickDefaultProviderModel([m('claude-opus-4'), m('claude-sonnet-4.6')], 'anthropic')?.id).toBe(
+      'claude-sonnet-4.6',
+    )
+    expect(pickDefaultProviderModel([m('claude-opus-4'), m('claude-sonnet-4-6-20260115')], 'anthropic')?.id).toBe(
+      'claude-sonnet-4-6-20260115',
+    )
   })
 })
 

--- a/frontend/apps/desktop/src/pages/agents/detail.tsx
+++ b/frontend/apps/desktop/src/pages/agents/detail.tsx
@@ -1289,13 +1289,6 @@ function TriggerSourceFields({
             accounts={mentionedAccountsOf(source)}
             onChange={(accounts) => onChange({...source, mentionedAccounts: accounts})}
           />
-          <AccountAutocompleteField
-            label="Resource/site prefix"
-            value={source.resourcePrefix || ''}
-            onChange={(value) => onChange({...source, resourcePrefix: value || undefined})}
-            placeholder="Search site/account or enter hm:// prefix"
-            valueFormat="hm-url"
-          />
         </div>
       ) : null}
       {source.type === 'site-update' ? (

--- a/frontend/apps/desktop/src/pages/agents/detail.tsx
+++ b/frontend/apps/desktop/src/pages/agents/detail.tsx
@@ -31,13 +31,9 @@ import {useSelectedAccountId} from '@/selected-account'
 import {useClickNavigate, useNavigate} from '@/utils/useNavigate'
 import {markdownBlockNodesToHMBlockNodes, parseMarkdown} from '@seed-hypermedia/client'
 import type {HMBlockNode} from '@seed-hypermedia/client/hm-types'
-import {useSearch} from '@shm/shared/models/search'
-import {abbreviateUid} from '@shm/shared/utils/abbreviate'
 import {formattedDateMedium} from '@shm/shared/utils/date'
-import {hmId, packHmId} from '@shm/shared/utils/entity-id-url'
 import {useNavRoute} from '@shm/shared/utils/navigation'
 import {Button} from '@shm/ui/button'
-import {AccountSearchInput, type SearchResult} from '@shm/ui/collaborators-page'
 import {
   AlertDialogAction,
   AlertDialogCancel,
@@ -56,6 +52,7 @@ import {KeyRound, Plus, Trash2} from 'lucide-react'
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {seedToolRegistry} from '../../../../../../agents/protocol/src/tool-registry'
 import {AGENT_READ_TOOL_GROUP} from './agent-tools'
+import {TriggerSourceFields, summarizeTriggerSource} from './trigger-types'
 import {AddModelProviderDialog, EditAgentNameDialog, type AgentAccountRenameStatus} from './dialogs'
 import {AgentHeader, AgentSubpageHeader, type AgentPageTab} from './header'
 import {ModelSelect} from './model-select'
@@ -1148,7 +1145,7 @@ function AgentTriggersTab({
             </SizableText>
           </div>
           <SizableText size="sm" color="muted">
-            {triggerSourceSummary(item.source)}
+            {summarizeTriggerSource(item.source)}
           </SizableText>
           <SizableText size="xs" color="muted">
             Updated {new Date(item.updatedAt).toLocaleString()}
@@ -1184,7 +1181,7 @@ function CreateAgentTriggerDialog({
   const [enabled, setEnabled] = useState(true)
   const [source, setSource] = useState<AgentTriggerSource>({type: 'document-comment', resource: ''})
   const [prompt, setPrompt] = useState<HMBlockNode[]>(() =>
-    agentPromptToBlocks('Read the related Seed context and summarize what needs attention.'),
+    agentPromptToBlocks('Respond to the mention, performing the action requested.'),
   )
 
   async function handleCreateTrigger() {
@@ -1237,420 +1234,6 @@ function CreateAgentTriggerDialog({
       </div>
     </div>
   )
-}
-
-function TriggerSourceFields({
-  source,
-  onChange,
-}: {
-  source: AgentTriggerSource
-  onChange: (source: AgentTriggerSource) => void
-}) {
-  return (
-    <div className="grid gap-3">
-      <label className="flex flex-col gap-1">
-        <SizableText size="sm" weight="bold">
-          Trigger Session on:
-        </SizableText>
-        <select
-          className="border-border bg-input rounded-md border px-3 py-2 text-sm"
-          value={source.type}
-          onChange={(event) => onChange(defaultSourceForType(event.target.value as AgentTriggerSource['type']))}
-        >
-          <option value="document-comment">Comment in a document</option>
-          <option value="user-mention">User mention</option>
-          <option value="site-update">Site update</option>
-          <option value="schedule">Schedule</option>
-        </select>
-      </label>
-      {source.type === 'document-comment' ? (
-        <div className="grid gap-3 md:grid-cols-2">
-          <DocumentAutocompleteField
-            label="Document"
-            value={source.resource}
-            onChange={(value) => onChange({...source, resource: value})}
-            placeholder="Search documents or enter hm:// URL"
-          />
-          <label className="flex flex-col gap-1">
-            <SizableText size="sm" weight="bold">
-              Author filter
-            </SizableText>
-            <Input
-              value={source.author || ''}
-              onChange={(event) => onChange({...source, author: event.target.value || undefined})}
-              placeholder="optional account ID"
-            />
-          </label>
-        </div>
-      ) : null}
-      {source.type === 'user-mention' ? (
-        <div className="grid gap-3">
-          <MentionedAccountsField
-            accounts={mentionedAccountsOf(source)}
-            onChange={(accounts) => onChange({...source, mentionedAccounts: accounts})}
-          />
-        </div>
-      ) : null}
-      {source.type === 'site-update' ? (
-        <div className="grid gap-3 md:grid-cols-2">
-          <AccountAutocompleteField
-            label="Resource/site prefix"
-            value={source.resourcePrefix}
-            onChange={(value) => onChange({...source, resourcePrefix: value})}
-            placeholder="Search site/account or enter hm:// prefix"
-            valueFormat="hm-url"
-          />
-          <label className="flex flex-col gap-1">
-            <SizableText size="sm" weight="bold">
-              Event types
-            </SizableText>
-            <Input
-              value={(source.eventTypes || []).join(', ')}
-              onChange={(event) =>
-                onChange({
-                  ...source,
-                  eventTypes: event.target.value
-                    .split(',')
-                    .map((value) => value.trim())
-                    .filter(Boolean),
-                })
-              }
-              placeholder="doc-update, comment"
-            />
-          </label>
-        </div>
-      ) : null}
-      {source.type === 'schedule' ? <ScheduleTriggerFields source={source} onChange={onChange} /> : null}
-    </div>
-  )
-}
-
-function ScheduleTriggerFields({
-  source,
-  onChange,
-}: {
-  source: Extract<AgentTriggerSource, {type: 'schedule'}>
-  onChange: (source: AgentTriggerSource) => void
-}) {
-  const schedule = source.schedule
-  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
-  const setSchedule = (next: Extract<AgentTriggerSource, {type: 'schedule'}>['schedule']) =>
-    onChange({type: 'schedule', schedule: next})
-  return (
-    <div className="grid gap-3">
-      <label className="flex flex-col gap-1">
-        <SizableText size="sm" weight="bold">
-          Schedule mode
-        </SizableText>
-        <select
-          className="border-border bg-input rounded-md border px-3 py-2 text-sm"
-          value={schedule.kind}
-          onChange={(event) => {
-            const kind = event.target.value
-            if (kind === 'weekly') setSchedule({kind, daysOfWeek: [1, 2, 3, 4, 5], timeOfDay: '09:00', timezone})
-            else if (kind === 'once') setSchedule({kind, runAt: Date.now() + 60 * 60 * 1000, timezone})
-            else setSchedule({kind: 'interval', every: 1, unit: 'hours'})
-          }}
-        >
-          <option value="interval">Every interval</option>
-          <option value="weekly">Days of week</option>
-          <option value="once">One time</option>
-        </select>
-      </label>
-      {schedule.kind === 'interval' ? (
-        <div className="grid gap-3 md:grid-cols-2">
-          <label className="flex flex-col gap-1">
-            <SizableText size="sm" weight="bold">
-              Every
-            </SizableText>
-            <Input
-              type="number"
-              min={1}
-              value={schedule.every}
-              onChange={(event) => setSchedule({...schedule, every: Number(event.target.value) || 1})}
-            />
-          </label>
-          <label className="flex flex-col gap-1">
-            <SizableText size="sm" weight="bold">
-              Unit
-            </SizableText>
-            <select
-              className="border-border bg-input rounded-md border px-3 py-2 text-sm"
-              value={schedule.unit}
-              onChange={(event) => setSchedule({...schedule, unit: event.target.value as 'minutes' | 'hours'})}
-            >
-              <option value="minutes">Minutes</option>
-              <option value="hours">Hours</option>
-            </select>
-          </label>
-        </div>
-      ) : null}
-      {schedule.kind === 'weekly' ? (
-        <div className="grid gap-3">
-          <div className="flex flex-wrap gap-2">
-            {[
-              ['Mon', 1],
-              ['Tue', 2],
-              ['Wed', 3],
-              ['Thu', 4],
-              ['Fri', 5],
-              ['Sat', 6],
-              ['Sun', 0],
-            ].map(([day, dayIndex]) => (
-              <label key={day} className="border-border flex items-center gap-2 rounded-md border px-3 py-2 text-sm">
-                <input
-                  type="checkbox"
-                  checked={schedule.daysOfWeek.includes(dayIndex as number)}
-                  onChange={(event) => {
-                    const dayNumber = dayIndex as number
-                    const daysOfWeek = event.target.checked
-                      ? [...schedule.daysOfWeek, dayNumber].sort()
-                      : schedule.daysOfWeek.filter((item) => item !== dayNumber)
-                    setSchedule({...schedule, daysOfWeek})
-                  }}
-                />
-                {day}
-              </label>
-            ))}
-          </div>
-          <div className="grid gap-3 md:grid-cols-2">
-            <label className="flex flex-col gap-1">
-              <SizableText size="sm" weight="bold">
-                Time of day
-              </SizableText>
-              <Input
-                type="time"
-                value={schedule.timeOfDay}
-                onChange={(event) => setSchedule({...schedule, timeOfDay: event.target.value})}
-              />
-            </label>
-            <label className="flex flex-col gap-1">
-              <SizableText size="sm" weight="bold">
-                Timezone
-              </SizableText>
-              <Input
-                value={schedule.timezone}
-                onChange={(event) => setSchedule({...schedule, timezone: event.target.value})}
-              />
-            </label>
-          </div>
-        </div>
-      ) : null}
-      {schedule.kind === 'once' ? (
-        <div className="grid gap-3 md:grid-cols-2">
-          <label className="flex flex-col gap-1">
-            <SizableText size="sm" weight="bold">
-              Date and time
-            </SizableText>
-            <Input
-              type="datetime-local"
-              value={dateTimeLocalValue(schedule.runAt)}
-              onChange={(event) => setSchedule({...schedule, runAt: new Date(event.target.value).getTime(), timezone})}
-            />
-          </label>
-          <label className="flex flex-col gap-1">
-            <SizableText size="sm" weight="bold">
-              Timezone
-            </SizableText>
-            <Input
-              value={schedule.timezone || timezone}
-              onChange={(event) => setSchedule({...schedule, timezone: event.target.value})}
-            />
-          </label>
-        </div>
-      ) : null}
-    </div>
-  )
-}
-
-function DocumentAutocompleteField({
-  label,
-  value,
-  onChange,
-  placeholder,
-}: {
-  label: string
-  value: string
-  onChange: (value: string) => void
-  placeholder: string
-}) {
-  const [focused, setFocused] = useState(false)
-  const search = useSearch(value, {
-    enabled: focused && value.trim().length > 0,
-    pageSize: 12,
-  })
-  const documents = useMemo(
-    () => (search.data?.entities || []).filter((item) => item.type === 'document').slice(0, 8),
-    [search.data?.entities],
-  )
-
-  return (
-    <label className="relative flex flex-col gap-1">
-      <SizableText size="sm" weight="bold">
-        {label}
-      </SizableText>
-      <Input
-        value={value}
-        onFocus={() => setFocused(true)}
-        onBlur={() => window.setTimeout(() => setFocused(false), 120)}
-        onChange={(event) => onChange(event.target.value)}
-        placeholder={placeholder}
-      />
-      {focused && documents.length ? (
-        <div className="border-border bg-popover absolute top-full right-0 left-0 z-20 mt-1 max-h-64 overflow-auto rounded-md border p-1 shadow-lg">
-          {documents.map((document) => {
-            const nextValue = packHmId(document.id)
-            return (
-              <button
-                key={document.id.id}
-                type="button"
-                className="hover:bg-muted flex w-full flex-col rounded px-2 py-2 text-left"
-                onMouseDown={(event) => event.preventDefault()}
-                onClick={() => {
-                  onChange(nextValue)
-                  setFocused(false)
-                }}
-              >
-                <SizableText size="sm" weight="bold" className="truncate">
-                  {document.title || nextValue}
-                </SizableText>
-                <SizableText size="xs" color="muted" className="truncate font-mono">
-                  {nextValue}
-                </SizableText>
-              </button>
-            )
-          })}
-        </div>
-      ) : null}
-    </label>
-  )
-}
-
-function AccountAutocompleteField({
-  label,
-  value,
-  onChange,
-  placeholder,
-  valueFormat,
-}: {
-  label: string
-  value: string
-  onChange: (value: string) => void
-  placeholder: string
-  valueFormat: 'uid' | 'hm-url'
-}) {
-  const [focused, setFocused] = useState(false)
-  const search = useSearch(value, {
-    enabled: focused && value.trim().length > 0,
-    pageSize: 12,
-  })
-  const accounts = useMemo(
-    () => (search.data?.entities || []).filter((item) => item.type === 'contact' || !item.id.path?.length).slice(0, 8),
-    [search.data?.entities],
-  )
-
-  return (
-    <label className="relative flex flex-col gap-1">
-      <SizableText size="sm" weight="bold">
-        {label}
-      </SizableText>
-      <Input
-        value={value}
-        onFocus={() => setFocused(true)}
-        onBlur={() => window.setTimeout(() => setFocused(false), 120)}
-        onChange={(event) => onChange(event.target.value)}
-        placeholder={placeholder}
-      />
-      {focused && accounts.length ? (
-        <div className="border-border bg-popover absolute top-full right-0 left-0 z-20 mt-1 max-h-64 overflow-auto rounded-md border p-1 shadow-lg">
-          {accounts.map((account) => {
-            const nextValue = valueFormat === 'hm-url' ? `hm://${account.id.uid}` : account.id.uid
-            return (
-              <button
-                key={`${account.id.id}:${account.type}`}
-                type="button"
-                className="hover:bg-muted flex w-full flex-col rounded px-2 py-2 text-left"
-                onMouseDown={(event) => event.preventDefault()}
-                onClick={() => {
-                  onChange(nextValue)
-                  setFocused(false)
-                }}
-              >
-                <SizableText size="sm" weight="bold" className="truncate">
-                  {account.title || account.id.uid}
-                </SizableText>
-                <SizableText size="xs" color="muted" className="truncate font-mono">
-                  {nextValue}
-                </SizableText>
-              </button>
-            )
-          })}
-        </div>
-      ) : null}
-    </label>
-  )
-}
-
-/** Reads the mentioned account list, tolerating legacy triggers that stored a single `mentionedAccount`. */
-function mentionedAccountsOf(source: Extract<AgentTriggerSource, {type: 'user-mention'}>): string[] {
-  const legacy = (source as {mentionedAccount?: string}).mentionedAccount
-  return source.mentionedAccounts ?? (legacy ? [legacy] : [])
-}
-
-function MentionedAccountsField({
-  accounts,
-  onChange,
-}: {
-  accounts: string[]
-  onChange: (accounts: string[]) => void
-}) {
-  const accountsKey = accounts.join('|')
-  const values = useMemo<SearchResult[]>(
-    () => accounts.map((uid) => ({id: hmId(uid), label: abbreviateUid(uid), unresolved: true})),
-    // accountsKey captures the contents of `accounts` for memoization
-    [accountsKey],
-  )
-  return (
-    <div className="flex flex-col gap-1">
-      <SizableText size="sm" weight="bold">
-        Mentioned accounts
-      </SizableText>
-      <div className="border-border bg-input flex min-h-9 items-center overflow-hidden rounded-md border">
-        <AccountSearchInput
-          label="Mentioned accounts"
-          placeholder="Search or paste accounts"
-          values={values}
-          onValuesChange={(next) => onChange(next.map((value) => value.id.uid))}
-        />
-      </div>
-    </div>
-  )
-}
-
-function defaultSourceForType(type: AgentTriggerSource['type']): AgentTriggerSource {
-  if (type === 'user-mention') return {type, mentionedAccounts: []}
-  if (type === 'site-update') return {type, resourcePrefix: '', eventTypes: ['doc-update', 'comment']}
-  if (type === 'schedule') return {type, schedule: {kind: 'interval', every: 1, unit: 'hours'}}
-  return {type: 'document-comment', resource: ''}
-}
-
-function triggerSourceSummary(source: AgentTriggerSource): string {
-  if (source.type === 'document-comment') {
-    return `Comment in ${source.resource}${source.author ? ` by ${source.author}` : ''}`
-  }
-  if (source.type === 'user-mention') {
-    const accounts = mentionedAccountsOf(source)
-    const mention = accounts.length ? accounts.map(abbreviateUid).join(', ') : 'anyone'
-    return `Mention of ${mention}${source.resourcePrefix ? ` in ${source.resourcePrefix}` : ''}`
-  }
-  if (source.type === 'site-update') {
-    return `Update in ${source.resourcePrefix}${source.eventTypes?.length ? ` (${source.eventTypes.join(', ')})` : ''}`
-  }
-  if (source.schedule.kind === 'interval') return `Every ${source.schedule.every} ${source.schedule.unit}`
-  if (source.schedule.kind === 'once') return `Once at ${formattedDateMedium(new Date(source.schedule.runAt))}`
-  return `${source.schedule.daysOfWeek.map(dayName).join(', ')} at ${source.schedule.timeOfDay} ${
-    source.schedule.timezone
-  }`
 }
 
 function nextScheduleFire(input: {
@@ -1737,17 +1320,6 @@ function zonedParts(
     minute: Number(values.minute),
     weekday: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].indexOf((values.weekday || 'Sun').slice(0, 3)),
   }
-}
-
-function dateTimeLocalValue(ms: number): string {
-  if (!Number.isFinite(ms)) return ''
-  const date = new Date(ms)
-  const offsetMs = date.getTimezoneOffset() * 60 * 1000
-  return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16)
-}
-
-function dayName(day: number): string {
-  return ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][day] || String(day)
 }
 
 function StartSessionInput({

--- a/frontend/apps/desktop/src/pages/agents/detail.tsx
+++ b/frontend/apps/desktop/src/pages/agents/detail.tsx
@@ -1284,7 +1284,7 @@ function TriggerSourceFields({
         </div>
       ) : null}
       {source.type === 'user-mention' ? (
-        <div className="grid gap-3 md:grid-cols-2">
+        <div className="grid gap-3">
           <MentionedAccountsField
             accounts={mentionedAccountsOf(source)}
             onChange={(accounts) => onChange({...source, mentionedAccounts: accounts})}
@@ -1622,10 +1622,10 @@ function MentionedAccountsField({
       <SizableText size="sm" weight="bold">
         Mentioned accounts
       </SizableText>
-      <div className="border-input flex overflow-hidden rounded-md border">
+      <div className="border-border bg-input flex min-h-9 items-center overflow-hidden rounded-md border">
         <AccountSearchInput
           label="Mentioned accounts"
-          placeholder="Search users or paste account ID"
+          placeholder="Search or paste accounts"
           values={values}
           onValuesChange={(next) => onChange(next.map((value) => value.id.uid))}
         />

--- a/frontend/apps/desktop/src/pages/agents/detail.tsx
+++ b/frontend/apps/desktop/src/pages/agents/detail.tsx
@@ -1205,7 +1205,7 @@ function CreateAgentTriggerDialog({
   }
 
   return (
-    <div className="flex min-w-[560px] flex-col gap-5">
+    <div className="flex w-full max-w-full min-w-0 flex-col gap-5">
       <div>
         <DialogTitle>New trigger</DialogTitle>
         <DialogDescription>Start a new agent session when matching Seed activity appears.</DialogDescription>

--- a/frontend/apps/desktop/src/pages/agents/detail.tsx
+++ b/frontend/apps/desktop/src/pages/agents/detail.tsx
@@ -1253,7 +1253,7 @@ function TriggerSourceFields({
           Trigger Session on:
         </SizableText>
         <select
-          className="border-input bg-background rounded-md border px-3 py-2 text-sm"
+          className="border-border bg-input rounded-md border px-3 py-2 text-sm"
           value={source.type}
           onChange={(event) => onChange(defaultSourceForType(event.target.value as AgentTriggerSource['type']))}
         >
@@ -1350,7 +1350,7 @@ function ScheduleTriggerFields({
           Schedule mode
         </SizableText>
         <select
-          className="border-input bg-background rounded-md border px-3 py-2 text-sm"
+          className="border-border bg-input rounded-md border px-3 py-2 text-sm"
           value={schedule.kind}
           onChange={(event) => {
             const kind = event.target.value
@@ -1382,7 +1382,7 @@ function ScheduleTriggerFields({
               Unit
             </SizableText>
             <select
-              className="border-input bg-background rounded-md border px-3 py-2 text-sm"
+              className="border-border bg-input rounded-md border px-3 py-2 text-sm"
               value={schedule.unit}
               onChange={(event) => setSchedule({...schedule, unit: event.target.value as 'minutes' | 'hours'})}
             >

--- a/frontend/apps/desktop/src/pages/agents/detail.tsx
+++ b/frontend/apps/desktop/src/pages/agents/detail.tsx
@@ -56,7 +56,7 @@ import {TriggerSourceFields, summarizeTriggerSource} from './trigger-types'
 import {AddModelProviderDialog, EditAgentNameDialog, type AgentAccountRenameStatus} from './dialogs'
 import {AgentHeader, AgentSubpageHeader, type AgentPageTab} from './header'
 import {ModelSelect} from './model-select'
-import {curateProviderModels} from './model-utils'
+import {curateProviderModels, pickDefaultProviderModel} from './model-utils'
 import {AgentPromptEditor, promptBlocksToMarkdown} from './prompt-editor'
 import {ProviderSelect} from './provider-select'
 
@@ -127,8 +127,7 @@ function AgentDetailPage({
   // default from the new provider's curated list once it loads.
   useEffect(() => {
     if (!nameModelDirty || model || !providerModels.data?.length) return
-    const {recommended, all} = curateProviderModels(providerModels.data, selectedProviderType)
-    const nextModel = recommended[0]?.id || all[0]?.id
+    const nextModel = pickDefaultProviderModel(providerModels.data, selectedProviderType)?.id
     if (nextModel) setModel(nextModel)
   }, [nameModelDirty, model, providerModels.data, selectedProviderType])
 

--- a/frontend/apps/desktop/src/pages/agents/detail.tsx
+++ b/frontend/apps/desktop/src/pages/agents/detail.tsx
@@ -32,10 +32,12 @@ import {useClickNavigate, useNavigate} from '@/utils/useNavigate'
 import {markdownBlockNodesToHMBlockNodes, parseMarkdown} from '@seed-hypermedia/client'
 import type {HMBlockNode} from '@seed-hypermedia/client/hm-types'
 import {useSearch} from '@shm/shared/models/search'
+import {abbreviateUid} from '@shm/shared/utils/abbreviate'
 import {formattedDateMedium} from '@shm/shared/utils/date'
-import {packHmId} from '@shm/shared/utils/entity-id-url'
+import {hmId, packHmId} from '@shm/shared/utils/entity-id-url'
 import {useNavRoute} from '@shm/shared/utils/navigation'
 import {Button} from '@shm/ui/button'
+import {AccountSearchInput, type SearchResult} from '@shm/ui/collaborators-page'
 import {
   AlertDialogAction,
   AlertDialogCancel,
@@ -1283,12 +1285,9 @@ function TriggerSourceFields({
       ) : null}
       {source.type === 'user-mention' ? (
         <div className="grid gap-3 md:grid-cols-2">
-          <AccountAutocompleteField
-            label="Mentioned account"
-            value={source.mentionedAccount}
-            onChange={(value) => onChange({...source, mentionedAccount: value})}
-            placeholder="Search users or enter account ID"
-            valueFormat="uid"
+          <MentionedAccountsField
+            accounts={mentionedAccountsOf(source)}
+            onChange={(accounts) => onChange({...source, mentionedAccounts: accounts})}
           />
           <AccountAutocompleteField
             label="Resource/site prefix"
@@ -1599,8 +1598,44 @@ function AccountAutocompleteField({
   )
 }
 
+/** Reads the mentioned account list, tolerating legacy triggers that stored a single `mentionedAccount`. */
+function mentionedAccountsOf(source: Extract<AgentTriggerSource, {type: 'user-mention'}>): string[] {
+  const legacy = (source as {mentionedAccount?: string}).mentionedAccount
+  return source.mentionedAccounts ?? (legacy ? [legacy] : [])
+}
+
+function MentionedAccountsField({
+  accounts,
+  onChange,
+}: {
+  accounts: string[]
+  onChange: (accounts: string[]) => void
+}) {
+  const accountsKey = accounts.join('|')
+  const values = useMemo<SearchResult[]>(
+    () => accounts.map((uid) => ({id: hmId(uid), label: abbreviateUid(uid), unresolved: true})),
+    // accountsKey captures the contents of `accounts` for memoization
+    [accountsKey],
+  )
+  return (
+    <div className="flex flex-col gap-1">
+      <SizableText size="sm" weight="bold">
+        Mentioned accounts
+      </SizableText>
+      <div className="border-input flex overflow-hidden rounded-md border">
+        <AccountSearchInput
+          label="Mentioned accounts"
+          placeholder="Search users or paste account ID"
+          values={values}
+          onValuesChange={(next) => onChange(next.map((value) => value.id.uid))}
+        />
+      </div>
+    </div>
+  )
+}
+
 function defaultSourceForType(type: AgentTriggerSource['type']): AgentTriggerSource {
-  if (type === 'user-mention') return {type, mentionedAccount: ''}
+  if (type === 'user-mention') return {type, mentionedAccounts: []}
   if (type === 'site-update') return {type, resourcePrefix: '', eventTypes: ['doc-update', 'comment']}
   if (type === 'schedule') return {type, schedule: {kind: 'interval', every: 1, unit: 'hours'}}
   return {type: 'document-comment', resource: ''}
@@ -1611,7 +1646,9 @@ function triggerSourceSummary(source: AgentTriggerSource): string {
     return `Comment in ${source.resource}${source.author ? ` by ${source.author}` : ''}`
   }
   if (source.type === 'user-mention') {
-    return `Mention of ${source.mentionedAccount}${source.resourcePrefix ? ` in ${source.resourcePrefix}` : ''}`
+    const accounts = mentionedAccountsOf(source)
+    const mention = accounts.length ? accounts.map(abbreviateUid).join(', ') : 'anyone'
+    return `Mention of ${mention}${source.resourcePrefix ? ` in ${source.resourcePrefix}` : ''}`
   }
   if (source.type === 'site-update') {
     return `Update in ${source.resourcePrefix}${source.eventTypes?.length ? ` (${source.eventTypes.join(', ')})` : ''}`

--- a/frontend/apps/desktop/src/pages/agents/dialogs.tsx
+++ b/frontend/apps/desktop/src/pages/agents/dialogs.tsx
@@ -26,6 +26,7 @@ import {useAppDialog} from '@shm/ui/universal-dialog'
 import {ExternalLink, Trash2} from 'lucide-react'
 import {useEffect, useState} from 'react'
 import {DEFAULT_AGENT_TOOLS} from './agent-tools'
+import {pickDefaultProviderModel} from './model-utils'
 import {ModelSelect} from './model-select'
 import {AgentPromptEditor, promptBlocksToMarkdown} from './prompt-editor'
 import {ProviderSelect} from './provider-select'
@@ -410,9 +411,9 @@ export function CreateAgentDialog({
   }, [providerName, providers.data])
 
   useEffect(() => {
-    const firstModel = providerModels.data?.[0]?.id || ''
-    if (!providerModels.data?.some((providerModel) => providerModel.id === model)) setModel(firstModel)
-  }, [model, providerModels.data])
+    const defaultModel = pickDefaultProviderModel(providerModels.data, selectedProviderType)?.id || ''
+    if (!providerModels.data?.some((providerModel) => providerModel.id === model)) setModel(defaultModel)
+  }, [model, providerModels.data, selectedProviderType])
 
   async function handleCreateAgent() {
     const agentName = name.trim()

--- a/frontend/apps/desktop/src/pages/agents/header.tsx
+++ b/frontend/apps/desktop/src/pages/agents/header.tsx
@@ -4,6 +4,7 @@ import type {NavRoute} from '@shm/shared/routes'
 import {hostnameStripProtocol} from '@shm/shared'
 import {useIsomorphicLayoutEffect} from '@shm/shared/utils/use-isomorphic-layout-effect'
 import {Button} from '@shm/ui/button'
+import {Badge} from '@shm/ui/components/badge'
 import {PageTab} from '@shm/ui/page-tabs'
 import {SizableText} from '@shm/ui/text'
 import {
@@ -268,29 +269,41 @@ export function AgentHeader({
                 {agent?.definition.name || 'Agent'}
               </SizableText>
             )}
-            <SizableText color="muted" className="block">
-              {agent
-                ? `${agent.definition.modelProvider} · ${agent.definition.model} · ${agent.status}`
-                : 'Loading agent…'}
-              {agentNameSaveState === 'saving'
-                ? ' · Saving…'
-                : agentNameSaveState === 'saved'
-                  ? ' · Saved'
-                  : agentNameSaveState === 'error'
-                    ? ' · Save failed'
-                    : ''}
-            </SizableText>
+            {!agent ? (
+              <SizableText color="muted" className="block">
+                Loading agent…
+              </SizableText>
+            ) : agentNameSaveState === 'saving' ? (
+              <SizableText color="muted" className="block">
+                Saving…
+              </SizableText>
+            ) : agentNameSaveState === 'saved' ? (
+              <SizableText color="muted" className="block">
+                Saved
+              </SizableText>
+            ) : agentNameSaveState === 'error' ? (
+              <SizableText color="muted" className="block">
+                Save failed
+              </SizableText>
+            ) : null}
           </div>
-          {activeTab === 'sessions' && onCreateSession ? (
-            <Button onClick={onCreateSession} disabled={creatingSession}>
-              <MessageSquarePlus className="mr-2 size-4" /> New session
-            </Button>
-          ) : null}
-          {activeTab === 'triggers' && onCreateTrigger ? (
-            <Button onClick={onCreateTrigger} disabled={!canCreateTrigger}>
-              <GitBranch className="mr-2 size-4" /> New trigger
-            </Button>
-          ) : null}
+          <div className="flex flex-none items-center gap-2">
+            {agent ? (
+              <Badge variant="secondary" className="flex-none">
+                {agent.definition.model}
+              </Badge>
+            ) : null}
+            {activeTab === 'sessions' && onCreateSession ? (
+              <Button onClick={onCreateSession} disabled={creatingSession}>
+                <MessageSquarePlus className="mr-2 size-4" /> New session
+              </Button>
+            ) : null}
+            {activeTab === 'triggers' && onCreateTrigger ? (
+              <Button onClick={onCreateTrigger} disabled={!canCreateTrigger}>
+                <GitBranch className="mr-2 size-4" /> New trigger
+              </Button>
+            ) : null}
+          </div>
         </div>
 
         {agentId ? (

--- a/frontend/apps/desktop/src/pages/agents/model-utils.ts
+++ b/frontend/apps/desktop/src/pages/agents/model-utils.ts
@@ -63,6 +63,12 @@ const PRIORITY_PREFIXES: Record<ModelProviderType, string[]> = {
   google: ['gemini-2.5', 'gemini-2.0', 'gemini-1.5', 'gemini', 'gemma'],
 }
 
+/** Provider-specific models we prefer as the initial default in agent creation/edit flows. */
+const PREFERRED_DEFAULT_MODEL_IDS: Partial<Record<ModelProviderType, string[]>> = {
+  openai: ['gpt-5-mini'],
+  anthropic: ['claude-sonnet-4.6', 'claude-sonnet-4-6'],
+}
+
 function priorityIndex(id: string, providerType: string | undefined): number {
   const prefixes =
     providerType && providerType in PRIORITY_PREFIXES ? PRIORITY_PREFIXES[providerType as ModelProviderType] : undefined
@@ -124,6 +130,34 @@ export function curateProviderModels(
 }
 
 /** Human-friendly label for a model option. */
+function normalizePreferredModelId(id: string): string {
+  return canonicalModelId(id).toLowerCase().replace(/\./g, '-')
+}
+
+function matchesPreferredModelId(candidate: string, preferred: string): boolean {
+  return normalizePreferredModelId(candidate) === normalizePreferredModelId(preferred)
+}
+
+/** Picks the best default model for a provider, honoring product defaults when available. */
+export function pickDefaultProviderModel(
+  models: ProviderModelInfo[] | undefined,
+  providerType: string | undefined,
+): ProviderModelInfo | undefined {
+  const curated = curateProviderModels(models, providerType)
+  const preferredIds =
+    providerType && providerType in PREFERRED_DEFAULT_MODEL_IDS
+      ? PREFERRED_DEFAULT_MODEL_IDS[providerType as ModelProviderType]
+      : undefined
+
+  return (
+    curated.recommended.find(
+      (model) => preferredIds?.some((preferredId) => matchesPreferredModelId(model.id, preferredId)),
+    ) ||
+    curated.recommended[0] ||
+    curated.all[0]
+  )
+}
+
 export function modelLabel(model: ProviderModelInfo): string {
   return model.name && model.name !== model.id ? `${model.name} (${model.id})` : model.id
 }

--- a/frontend/apps/desktop/src/pages/agents/session.tsx
+++ b/frontend/apps/desktop/src/pages/agents/session.tsx
@@ -2,7 +2,6 @@ import {
   type AgentRunActivity,
   type AgentRunUsage,
   type AgentSessionTriggerContext,
-  type AgentTriggerSource,
   type SessionEvent,
   type SessionInfo,
 } from '@/agents-client'
@@ -32,9 +31,6 @@ import {useNavigate} from '@/utils/useNavigate'
 import {trimTrailingEmptyBlocks} from '@seed-hypermedia/client'
 import type {HMBlockNode} from '@seed-hypermedia/client/hm-types'
 import {CommentEditor, type CommentEditorSubmitHandle} from '@shm/editor/comment-editor'
-import type {NavRoute} from '@shm/shared/routes'
-import {abbreviateUid} from '@shm/shared/utils/abbreviate'
-import {unpackHmId} from '@shm/shared/utils/entity-id-url'
 import {useNavRoute} from '@shm/shared/utils/navigation'
 import {Button} from '@shm/ui/button'
 import {
@@ -55,26 +51,7 @@ import {ArrowDown, ExternalLink, Info, Loader2, ScrollText, Send, Square, Trash2
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {AgentHeader, AgentSubpageHeader} from './header'
 import {promptBlocksToMarkdown} from './prompt-editor'
-
-function triggerSourceSummary(source: AgentTriggerSource): string {
-  if (source.type === 'document-comment') {
-    return `Comment in ${source.resource}${source.author ? ` by ${source.author}` : ''}`
-  }
-  if (source.type === 'user-mention') {
-    const legacy = (source as {mentionedAccount?: string}).mentionedAccount
-    const accounts = source.mentionedAccounts ?? (legacy ? [legacy] : [])
-    const mention = accounts.length ? accounts.map(abbreviateUid).join(', ') : 'anyone'
-    return `Mention of ${mention}${source.resourcePrefix ? ` in ${source.resourcePrefix}` : ''}`
-  }
-  if (source.type === 'site-update') {
-    return `Update in ${source.resourcePrefix}${source.eventTypes?.length ? ` (${source.eventTypes.join(', ')})` : ''}`
-  }
-  if (source.schedule.kind === 'interval') return `Every ${source.schedule.every} ${source.schedule.unit}`
-  if (source.schedule.kind === 'once') return `Once at ${new Date(source.schedule.runAt).toLocaleString()}`
-  return `${source.schedule.daysOfWeek
-    .map((day) => ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][day])
-    .join(', ')} at ${source.schedule.timeOfDay} ${source.schedule.timezone}`
-}
+import {getTriggerActivityRoute, summarizeTriggerSource, TriggerContextView} from './trigger-types'
 
 function SessionListItem({
   session,
@@ -141,7 +118,7 @@ function TriggerContextPopover({
             </Button>
           </div>
           <div className="grid gap-3 text-sm md:grid-cols-2">
-            <TriggerDetail label="Source" value={triggerSourceSummary(context.source)} />
+            <TriggerDetail label="Source" value={summarizeTriggerSource(context.source)} />
             <TriggerDetail label="Activity key" value={context.activityKey} mono />
             <TriggerDetail label="Firing ID" value={context.firingId} mono />
             <TriggerDetail label="Fired at" value={new Date(context.firedAt).toLocaleString()} />
@@ -185,42 +162,6 @@ function TriggerDetail({label, value, mono}: {label: string; value: string; mono
   )
 }
 
-function getTriggerActivityRoute(context: AgentSessionTriggerContext): NavRoute | null {
-  const blob = recordField(context.activity, 'newBlob')
-  if (blob) {
-    const blobType = stringField(blob, 'blobType') || stringField(blob, 'blob_type')
-    const resource = stringField(blob, 'resource')
-    const resourceId = resource ? unpackHmId(resource) : null
-    if (blobType === 'Comment' && resourceId) {
-      return {key: 'comments', id: resourceId, openComment: stringField(blob, 'blobId') || stringField(blob, 'blob_id')}
-    }
-    if ((blobType === 'Ref' || blobType === 'Change') && resourceId) {
-      return {key: 'document', id: resourceId}
-    }
-  }
-
-  if (context.source.type === 'document-comment') {
-    const id = unpackHmId(context.source.resource)
-    return id ? {key: 'comments', id} : null
-  }
-  if (context.source.type === 'site-update') {
-    const id = unpackHmId(context.source.resourcePrefix)
-    return id ? {key: 'activity', id} : null
-  }
-  return null
-}
-
-function recordField(value: unknown, key: string): Record<string, unknown> | null {
-  if (!value || typeof value !== 'object') return null
-  const field = (value as Record<string, unknown>)[key]
-  return field && typeof field === 'object' ? (field as Record<string, unknown>) : null
-}
-
-function stringField(value: Record<string, unknown>, key: string): string | undefined {
-  const field = value[key]
-  return typeof field === 'string' && field ? field : undefined
-}
-
 function AgentSessionPage({
   sessionId,
   routeServerUrl,
@@ -258,8 +199,14 @@ function AgentSessionPage({
   const loadedSessionId = session.data?.session.id
   const persistedTitle = session.data?.session.title || 'Untitled session'
   const chatRows = useMemo(
-    () => buildAgentSessionChatRows(session.data?.events || [], {serverUrl, agentId, sessionId}),
-    [agentId, serverUrl, session.data?.events, sessionId],
+    () =>
+      buildAgentSessionChatRows(session.data?.events || [], {
+        serverUrl,
+        agentId,
+        sessionId,
+        triggerContext: session.data?.triggerContext ?? null,
+      }),
+    [agentId, serverUrl, session.data?.events, session.data?.triggerContext, sessionId],
   )
   const isAgentStreaming = session.data?.session.status === 'streaming'
   const isAgentBusy = messageSession.isPending || isAgentStreaming
@@ -547,7 +494,7 @@ function AgentSessionPage({
                     id={`event-${row.key}`}
                     className="target:ring-primary/40 scroll-mt-24 rounded-lg target:ring-2"
                   >
-                    <AgentSessionChatRow row={row} />
+                    <AgentSessionChatRow row={row} serverUrl={serverUrl} agentId={agentId} />
                   </div>
                 ))}
                 {partialAssistantText ? <PartialAssistantRow text={partialAssistantText} /> : null}
@@ -794,12 +741,45 @@ function AgentRunStatusBar({
 }
 
 type AgentSessionChatRow =
-  | {key: string; kind: 'message'; message: ChatBubbleMessage}
+  | {
+      key: string
+      kind: 'message'
+      message: ChatBubbleMessage
+      triggerContext?: AgentSessionTriggerContext
+      triggerInstructions?: string
+    }
   | {key: string; kind: 'error'; message: string}
   | {key: string; kind: 'raw'; event: SessionEvent}
 
-const AgentSessionChatRow = React.memo(function AgentSessionChatRow({row}: {row: AgentSessionChatRow}) {
-  if (row.kind === 'message') return <ChatMessageBubble message={row.message} />
+const AgentSessionChatRow = React.memo(function AgentSessionChatRow({
+  row,
+  serverUrl,
+  agentId,
+}: {
+  row: AgentSessionChatRow
+  serverUrl: string
+  agentId?: string
+}) {
+  if (row.kind === 'message') {
+    if (row.triggerContext) {
+      // First message of a triggered session: render the human prompt (if any) and a friendly
+      // trigger card instead of the raw <trigger_context> text that is sent to the model.
+      return (
+        <div className="flex flex-col gap-1.5">
+          {row.message.content?.trim() || row.message.blocks?.length ? (
+            <ChatMessageBubble message={row.message} />
+          ) : null}
+          <TriggerContextView
+            context={row.triggerContext}
+            instructions={row.triggerInstructions}
+            serverUrl={serverUrl}
+            agentId={agentId}
+          />
+        </div>
+      )
+    }
+    return <ChatMessageBubble message={row.message} />
+  }
 
   if (row.kind === 'error') {
     return (
@@ -819,10 +799,16 @@ const AgentSessionChatRow = React.memo(function AgentSessionChatRow({row}: {row:
 
 function buildAgentSessionChatRows(
   events: SessionEvent[],
-  context: {serverUrl: string; agentId?: string; sessionId: string},
+  context: {
+    serverUrl: string
+    agentId?: string
+    sessionId: string
+    triggerContext?: AgentSessionTriggerContext | null
+  },
 ): AgentSessionChatRow[] {
   const rows: AgentSessionChatRow[] = []
   const toolRowsById = new Map<string, Extract<AgentSessionChatRow, {kind: 'message'}>>()
+  let triggerCardAttached = false
 
   for (const event of events) {
     const payload = event.event as {
@@ -841,12 +827,20 @@ function buildAgentSessionChatRows(
     }
 
     if (payload.type === 'message' && typeof payload.content === 'string') {
+      // The first user message of a triggered session embeds a <trigger_context> block for the model.
+      // Hide it from the bubble and surface a friendly trigger card instead; the full text stays
+      // available through the raw-markdown dialog.
+      const hasTriggerBlock = payload.role === 'user' && payload.content.includes('<trigger_context>')
+      const attachTriggerCard = hasTriggerBlock && !triggerCardAttached
+      if (attachTriggerCard) triggerCardAttached = true
+      const displayContent = hasTriggerBlock ? stripTriggerContextBlock(payload.content) : payload.content
+      const triggerInstructions = attachTriggerCard ? extractTriggerInstructions(payload.content) : undefined
       rows.push({
         key: event.id,
         kind: 'message',
         message: {
           role: payload.role,
-          content: payload.content,
+          content: displayContent,
           rawMarkdown: typeof payload.rawMarkdown === 'string' ? payload.rawMarkdown : payload.content,
           blocks: Array.isArray(payload.blocks) ? payload.blocks : undefined,
           eventId: event.id,
@@ -854,6 +848,9 @@ function buildAgentSessionChatRows(
           seq: event.seq,
           shareUrl: buildAgentSessionEventUrl(context.serverUrl, context.agentId, context.sessionId, event.id),
         },
+        ...(attachTriggerCard && context.triggerContext
+          ? {triggerContext: context.triggerContext, triggerInstructions}
+          : {}),
       })
       continue
     }
@@ -928,6 +925,20 @@ function buildAgentSessionChatRows(
   }
 
   return rows
+}
+
+/** Removes the `<trigger_context>` / `<trigger_instructions>` blocks appended to a trigger's first message. */
+function stripTriggerContextBlock(content: string): string {
+  const index = content.indexOf('<trigger_context>')
+  if (index === -1) return content
+  return content.slice(0, index).trimEnd()
+}
+
+/** Pulls the model-facing `<trigger_instructions>` text out of a trigger's first message, if present. */
+function extractTriggerInstructions(content: string): string | undefined {
+  const match = content.match(/<trigger_instructions>\n?([\s\S]*?)\n?<\/trigger_instructions>/)
+  const text = match?.[1]?.trim()
+  return text ? text : undefined
 }
 
 function buildAgentSessionEventUrl(

--- a/frontend/apps/desktop/src/pages/agents/session.tsx
+++ b/frontend/apps/desktop/src/pages/agents/session.tsx
@@ -33,6 +33,7 @@ import {trimTrailingEmptyBlocks} from '@seed-hypermedia/client'
 import type {HMBlockNode} from '@seed-hypermedia/client/hm-types'
 import {CommentEditor, type CommentEditorSubmitHandle} from '@shm/editor/comment-editor'
 import type {NavRoute} from '@shm/shared/routes'
+import {abbreviateUid} from '@shm/shared/utils/abbreviate'
 import {unpackHmId} from '@shm/shared/utils/entity-id-url'
 import {useNavRoute} from '@shm/shared/utils/navigation'
 import {Button} from '@shm/ui/button'
@@ -60,7 +61,10 @@ function triggerSourceSummary(source: AgentTriggerSource): string {
     return `Comment in ${source.resource}${source.author ? ` by ${source.author}` : ''}`
   }
   if (source.type === 'user-mention') {
-    return `Mention of ${source.mentionedAccount}${source.resourcePrefix ? ` in ${source.resourcePrefix}` : ''}`
+    const legacy = (source as {mentionedAccount?: string}).mentionedAccount
+    const accounts = source.mentionedAccounts ?? (legacy ? [legacy] : [])
+    const mention = accounts.length ? accounts.map(abbreviateUid).join(', ') : 'anyone'
+    return `Mention of ${mention}${source.resourcePrefix ? ` in ${source.resourcePrefix}` : ''}`
   }
   if (source.type === 'site-update') {
     return `Update in ${source.resourcePrefix}${source.eventTypes?.length ? ` (${source.eventTypes.join(', ')})` : ''}`

--- a/frontend/apps/desktop/src/pages/agents/trigger-types.tsx
+++ b/frontend/apps/desktop/src/pages/agents/trigger-types.tsx
@@ -1,0 +1,624 @@
+import {type AgentSessionTriggerContext, type AgentTriggerSource} from '@/agents-client'
+import {useNavigate} from '@/utils/useNavigate'
+import {AccountSearchInput, type SearchResult} from '@shm/ui/collaborators-page'
+import {Input} from '@shm/ui/components/input'
+import {SizableText} from '@shm/ui/text'
+import type {LoadedEvent} from '@shm/shared/models/activity-service'
+import {useSearch} from '@shm/shared/models/search'
+import type {NavRoute} from '@shm/shared/routes'
+import {getEventRoute} from '@shm/ui/feed'
+import {abbreviateUid} from '@shm/shared/utils/abbreviate'
+import {formattedDateMedium} from '@shm/shared/utils/date'
+import {hmId, packHmId, unpackHmId} from '@shm/shared/utils/entity-id-url'
+import {AtSign, CalendarClock, ChevronDown, ChevronRight, FileText, MessageSquare} from 'lucide-react'
+import React, {useMemo, useState} from 'react'
+
+/**
+ * Canonical per-trigger-type frontend definitions.
+ *
+ * Each trigger type (`AgentTriggerSource['type']`) keeps its option label, default config, summary,
+ * configuration form, and triggered-session context rendering in one place so the four trigger types
+ * stay in sync. The session UI renders {@link TriggerContextView} instead of the raw `<trigger_context>`
+ * block that is sent to the model.
+ */
+
+export const TRIGGER_TYPE_OPTIONS: {value: AgentTriggerSource['type']; label: string}[] = [
+  {value: 'document-comment', label: 'Comment in a document'},
+  {value: 'user-mention', label: 'User mention'},
+  {value: 'site-update', label: 'Site update'},
+  {value: 'schedule', label: 'Schedule'},
+]
+
+export function defaultSourceForType(type: AgentTriggerSource['type']): AgentTriggerSource {
+  if (type === 'user-mention') return {type, mentionedAccounts: []}
+  if (type === 'site-update') return {type, resourcePrefix: '', eventTypes: ['doc-update', 'comment']}
+  if (type === 'schedule') return {type, schedule: {kind: 'interval', every: 1, unit: 'hours'}}
+  return {type: 'document-comment', resource: ''}
+}
+
+/** Reads the mentioned account list, tolerating legacy triggers that stored a single `mentionedAccount`. */
+export function mentionedAccountsOf(source: Extract<AgentTriggerSource, {type: 'user-mention'}>): string[] {
+  const legacy = (source as {mentionedAccount?: string}).mentionedAccount
+  return source.mentionedAccounts ?? (legacy ? [legacy] : [])
+}
+
+/** Compact human-readable description of how a trigger is configured. */
+export function summarizeTriggerSource(source: AgentTriggerSource): string {
+  if (source.type === 'document-comment') {
+    return `Comment in ${source.resource}${source.author ? ` by ${source.author}` : ''}`
+  }
+  if (source.type === 'user-mention') {
+    const accounts = mentionedAccountsOf(source)
+    const mention = accounts.length ? accounts.map(abbreviateUid).join(', ') : 'anyone'
+    return `Mention of ${mention}${source.resourcePrefix ? ` in ${source.resourcePrefix}` : ''}`
+  }
+  if (source.type === 'site-update') {
+    return `Update in ${source.resourcePrefix}${source.eventTypes?.length ? ` (${source.eventTypes.join(', ')})` : ''}`
+  }
+  if (source.schedule.kind === 'interval') return `Every ${source.schedule.every} ${source.schedule.unit}`
+  if (source.schedule.kind === 'once') return `Once at ${formattedDateMedium(new Date(source.schedule.runAt))}`
+  return `${source.schedule.daysOfWeek.map(dayName).join(', ')} at ${source.schedule.timeOfDay} ${
+    source.schedule.timezone
+  }`
+}
+
+// ---------------------------------------------------------------------------
+// Configuration form
+// ---------------------------------------------------------------------------
+
+export function TriggerSourceFields({
+  source,
+  onChange,
+}: {
+  source: AgentTriggerSource
+  onChange: (source: AgentTriggerSource) => void
+}) {
+  return (
+    <div className="grid gap-3">
+      <label className="flex flex-col gap-1">
+        <SizableText size="sm" weight="bold">
+          Trigger Session on:
+        </SizableText>
+        <select
+          className="border-border bg-input rounded-md border px-3 py-2 text-sm"
+          value={source.type}
+          onChange={(event) => onChange(defaultSourceForType(event.target.value as AgentTriggerSource['type']))}
+        >
+          {TRIGGER_TYPE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      {source.type === 'document-comment' ? (
+        <div className="grid gap-3 md:grid-cols-2">
+          <DocumentAutocompleteField
+            label="Document"
+            value={source.resource}
+            onChange={(value) => onChange({...source, resource: value})}
+            placeholder="Search documents or enter hm:// URL"
+          />
+          <label className="flex flex-col gap-1">
+            <SizableText size="sm" weight="bold">
+              Author filter
+            </SizableText>
+            <Input
+              value={source.author || ''}
+              onChange={(event) => onChange({...source, author: event.target.value || undefined})}
+              placeholder="optional account ID"
+            />
+          </label>
+        </div>
+      ) : null}
+      {source.type === 'user-mention' ? (
+        <div className="grid gap-3">
+          <MentionedAccountsField
+            accounts={mentionedAccountsOf(source)}
+            onChange={(accounts) => onChange({...source, mentionedAccounts: accounts})}
+          />
+        </div>
+      ) : null}
+      {source.type === 'site-update' ? (
+        <div className="grid gap-3 md:grid-cols-2">
+          <AccountAutocompleteField
+            label="Resource/site prefix"
+            value={source.resourcePrefix}
+            onChange={(value) => onChange({...source, resourcePrefix: value})}
+            placeholder="Search site/account or enter hm:// prefix"
+            valueFormat="hm-url"
+          />
+          <label className="flex flex-col gap-1">
+            <SizableText size="sm" weight="bold">
+              Event types
+            </SizableText>
+            <Input
+              value={(source.eventTypes || []).join(', ')}
+              onChange={(event) =>
+                onChange({
+                  ...source,
+                  eventTypes: event.target.value
+                    .split(',')
+                    .map((value) => value.trim())
+                    .filter(Boolean),
+                })
+              }
+              placeholder="doc-update, comment"
+            />
+          </label>
+        </div>
+      ) : null}
+      {source.type === 'schedule' ? <ScheduleTriggerFields source={source} onChange={onChange} /> : null}
+    </div>
+  )
+}
+
+function ScheduleTriggerFields({
+  source,
+  onChange,
+}: {
+  source: Extract<AgentTriggerSource, {type: 'schedule'}>
+  onChange: (source: AgentTriggerSource) => void
+}) {
+  const schedule = source.schedule
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+  const setSchedule = (next: Extract<AgentTriggerSource, {type: 'schedule'}>['schedule']) =>
+    onChange({type: 'schedule', schedule: next})
+  return (
+    <div className="grid gap-3">
+      <label className="flex flex-col gap-1">
+        <SizableText size="sm" weight="bold">
+          Schedule mode
+        </SizableText>
+        <select
+          className="border-border bg-input rounded-md border px-3 py-2 text-sm"
+          value={schedule.kind}
+          onChange={(event) => {
+            const kind = event.target.value
+            if (kind === 'weekly') setSchedule({kind, daysOfWeek: [1, 2, 3, 4, 5], timeOfDay: '09:00', timezone})
+            else if (kind === 'once') setSchedule({kind, runAt: Date.now() + 60 * 60 * 1000, timezone})
+            else setSchedule({kind: 'interval', every: 1, unit: 'hours'})
+          }}
+        >
+          <option value="interval">Every interval</option>
+          <option value="weekly">Days of week</option>
+          <option value="once">One time</option>
+        </select>
+      </label>
+      {schedule.kind === 'interval' ? (
+        <div className="grid gap-3 md:grid-cols-2">
+          <label className="flex flex-col gap-1">
+            <SizableText size="sm" weight="bold">
+              Every
+            </SizableText>
+            <Input
+              type="number"
+              min={1}
+              value={schedule.every}
+              onChange={(event) => setSchedule({...schedule, every: Number(event.target.value) || 1})}
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <SizableText size="sm" weight="bold">
+              Unit
+            </SizableText>
+            <select
+              className="border-border bg-input rounded-md border px-3 py-2 text-sm"
+              value={schedule.unit}
+              onChange={(event) => setSchedule({...schedule, unit: event.target.value as 'minutes' | 'hours'})}
+            >
+              <option value="minutes">Minutes</option>
+              <option value="hours">Hours</option>
+            </select>
+          </label>
+        </div>
+      ) : null}
+      {schedule.kind === 'weekly' ? (
+        <div className="grid gap-3">
+          <div className="flex flex-wrap gap-2">
+            {[
+              ['Mon', 1],
+              ['Tue', 2],
+              ['Wed', 3],
+              ['Thu', 4],
+              ['Fri', 5],
+              ['Sat', 6],
+              ['Sun', 0],
+            ].map(([day, dayIndex]) => (
+              <label key={day} className="border-border flex items-center gap-2 rounded-md border px-3 py-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={schedule.daysOfWeek.includes(dayIndex as number)}
+                  onChange={(event) => {
+                    const dayNumber = dayIndex as number
+                    const daysOfWeek = event.target.checked
+                      ? [...schedule.daysOfWeek, dayNumber].sort()
+                      : schedule.daysOfWeek.filter((item) => item !== dayNumber)
+                    setSchedule({...schedule, daysOfWeek})
+                  }}
+                />
+                {day}
+              </label>
+            ))}
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            <label className="flex flex-col gap-1">
+              <SizableText size="sm" weight="bold">
+                Time of day
+              </SizableText>
+              <Input
+                type="time"
+                value={schedule.timeOfDay}
+                onChange={(event) => setSchedule({...schedule, timeOfDay: event.target.value})}
+              />
+            </label>
+            <label className="flex flex-col gap-1">
+              <SizableText size="sm" weight="bold">
+                Timezone
+              </SizableText>
+              <Input
+                value={schedule.timezone}
+                onChange={(event) => setSchedule({...schedule, timezone: event.target.value})}
+              />
+            </label>
+          </div>
+        </div>
+      ) : null}
+      {schedule.kind === 'once' ? (
+        <div className="grid gap-3 md:grid-cols-2">
+          <label className="flex flex-col gap-1">
+            <SizableText size="sm" weight="bold">
+              Date and time
+            </SizableText>
+            <Input
+              type="datetime-local"
+              value={dateTimeLocalValue(schedule.runAt)}
+              onChange={(event) => setSchedule({...schedule, runAt: new Date(event.target.value).getTime(), timezone})}
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <SizableText size="sm" weight="bold">
+              Timezone
+            </SizableText>
+            <Input
+              value={schedule.timezone || timezone}
+              onChange={(event) => setSchedule({...schedule, timezone: event.target.value})}
+            />
+          </label>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function DocumentAutocompleteField({
+  label,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  placeholder: string
+}) {
+  const [focused, setFocused] = useState(false)
+  const search = useSearch(value, {
+    enabled: focused && value.trim().length > 0,
+    pageSize: 12,
+  })
+  const documents = useMemo(
+    () => (search.data?.entities || []).filter((item) => item.type === 'document').slice(0, 8),
+    [search.data?.entities],
+  )
+
+  return (
+    <label className="relative flex flex-col gap-1">
+      <SizableText size="sm" weight="bold">
+        {label}
+      </SizableText>
+      <Input
+        value={value}
+        onFocus={() => setFocused(true)}
+        onBlur={() => window.setTimeout(() => setFocused(false), 120)}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+      />
+      {focused && documents.length ? (
+        <div className="border-border bg-popover absolute top-full right-0 left-0 z-20 mt-1 max-h-64 overflow-auto rounded-md border p-1 shadow-lg">
+          {documents.map((document) => {
+            const nextValue = packHmId(document.id)
+            return (
+              <button
+                key={document.id.id}
+                type="button"
+                className="hover:bg-muted flex w-full flex-col rounded px-2 py-2 text-left"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => {
+                  onChange(nextValue)
+                  setFocused(false)
+                }}
+              >
+                <SizableText size="sm" weight="bold" className="truncate">
+                  {document.title || nextValue}
+                </SizableText>
+                <SizableText size="xs" color="muted" className="truncate font-mono">
+                  {nextValue}
+                </SizableText>
+              </button>
+            )
+          })}
+        </div>
+      ) : null}
+    </label>
+  )
+}
+
+function AccountAutocompleteField({
+  label,
+  value,
+  onChange,
+  placeholder,
+  valueFormat,
+}: {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  placeholder: string
+  valueFormat: 'uid' | 'hm-url'
+}) {
+  const [focused, setFocused] = useState(false)
+  const search = useSearch(value, {
+    enabled: focused && value.trim().length > 0,
+    pageSize: 12,
+  })
+  const accounts = useMemo(
+    () => (search.data?.entities || []).filter((item) => item.type === 'contact' || !item.id.path?.length).slice(0, 8),
+    [search.data?.entities],
+  )
+
+  return (
+    <label className="relative flex flex-col gap-1">
+      <SizableText size="sm" weight="bold">
+        {label}
+      </SizableText>
+      <Input
+        value={value}
+        onFocus={() => setFocused(true)}
+        onBlur={() => window.setTimeout(() => setFocused(false), 120)}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+      />
+      {focused && accounts.length ? (
+        <div className="border-border bg-popover absolute top-full right-0 left-0 z-20 mt-1 max-h-64 overflow-auto rounded-md border p-1 shadow-lg">
+          {accounts.map((account) => {
+            const nextValue = valueFormat === 'hm-url' ? `hm://${account.id.uid}` : account.id.uid
+            return (
+              <button
+                key={`${account.id.id}:${account.type}`}
+                type="button"
+                className="hover:bg-muted flex w-full flex-col rounded px-2 py-2 text-left"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => {
+                  onChange(nextValue)
+                  setFocused(false)
+                }}
+              >
+                <SizableText size="sm" weight="bold" className="truncate">
+                  {account.title || account.id.uid}
+                </SizableText>
+                <SizableText size="xs" color="muted" className="truncate font-mono">
+                  {nextValue}
+                </SizableText>
+              </button>
+            )
+          })}
+        </div>
+      ) : null}
+    </label>
+  )
+}
+
+function MentionedAccountsField({accounts, onChange}: {accounts: string[]; onChange: (accounts: string[]) => void}) {
+  const accountsKey = accounts.join('|')
+  const values = useMemo<SearchResult[]>(
+    () => accounts.map((uid) => ({id: hmId(uid), label: abbreviateUid(uid), unresolved: true})),
+    // accountsKey captures the contents of `accounts` for memoization
+    [accountsKey],
+  )
+  return (
+    <div className="flex flex-col gap-1">
+      <SizableText size="sm" weight="bold">
+        Mentioned accounts
+      </SizableText>
+      <div className="border-border bg-input flex min-h-9 items-center overflow-hidden rounded-md border">
+        <AccountSearchInput
+          label="Mentioned accounts"
+          placeholder="Search or paste accounts"
+          values={values}
+          onValuesChange={(next) => onChange(next.map((value) => value.id.uid))}
+        />
+      </div>
+    </div>
+  )
+}
+
+function dateTimeLocalValue(ms: number): string {
+  if (!Number.isFinite(ms)) return ''
+  const date = new Date(ms)
+  const offsetMs = date.getTimezoneOffset() * 60 * 1000
+  return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16)
+}
+
+function dayName(day: number): string {
+  return ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][day] || String(day)
+}
+
+// ---------------------------------------------------------------------------
+// Triggered-session context rendering
+// ---------------------------------------------------------------------------
+
+/** Resolves the in-app route that opens the comment, document, or activity that fired a trigger. */
+export function getTriggerActivityRoute(context: AgentSessionTriggerContext): NavRoute | null {
+  // The stored activity is a resolved LoadedEvent (the shape `/api/ListEvents` returns), so reuse the
+  // activity feed's own routing. This links to the exact comment, the document where a mention was made,
+  // or the document at the specific version that fired the trigger.
+  const resolvedRoute = getEventRoute(context.activity as unknown as LoadedEvent)
+  if (resolvedRoute) return resolvedRoute
+
+  // Raw ActivityFeed events (`newBlob`) used by tests and callers that bypass the resolving endpoint.
+  const blob = recordField(context.activity, 'newBlob')
+  if (blob) {
+    const blobType = stringField(blob, 'blobType') || stringField(blob, 'blob_type')
+    const resource = stringField(blob, 'resource')
+    const resourceId = resource ? unpackHmId(resource) : null
+    if (blobType === 'Comment' && resourceId) {
+      return {key: 'comments', id: resourceId, openComment: stringField(blob, 'blobId') || stringField(blob, 'blob_id')}
+    }
+    if ((blobType === 'Ref' || blobType === 'Change') && resourceId) {
+      return {key: 'document', id: resourceId}
+    }
+  }
+
+  // Last resort: fall back to the configured trigger source location.
+  if (context.source.type === 'document-comment') {
+    const id = unpackHmId(context.source.resource)
+    return id ? {key: 'comments', id} : null
+  }
+  if (context.source.type === 'site-update') {
+    const id = unpackHmId(context.source.resourcePrefix)
+    return id ? {key: 'activity', id} : null
+  }
+  return null
+}
+
+const TRIGGER_TYPE_ICONS: Record<AgentTriggerSource['type'], React.ComponentType<{className?: string}>> = {
+  'document-comment': MessageSquare,
+  'user-mention': AtSign,
+  'site-update': FileText,
+  schedule: CalendarClock,
+}
+
+/**
+ * Friendly card shown at the top of a triggered session in place of the raw `<trigger_context>` /
+ * `<trigger_instructions>` text. The headline and icon depend on the trigger type; the full activity
+ * payload that was sent to the model stays available behind the collapsible details.
+ */
+export function TriggerContextView({
+  context,
+  instructions,
+  serverUrl,
+  agentId,
+}: {
+  context: AgentSessionTriggerContext
+  instructions?: string
+  serverUrl: string
+  agentId?: string
+}) {
+  const navigate = useNavigate()
+  const Icon = TRIGGER_TYPE_ICONS[context.source.type]
+  const activityRoute = useMemo(() => getTriggerActivityRoute(context), [context])
+  const triggerRoute: NavRoute | null = agentId
+    ? {key: 'agent', agentId, serverUrl, tab: 'triggers', triggerId: context.triggerId}
+    : null
+
+  return (
+    <div className="bg-muted/40 mr-6 ml-6 rounded-lg border px-3 py-2 text-xs">
+      <div className="flex min-w-0 flex-wrap items-center gap-x-1.5">
+        <Icon className="size-3.5 shrink-0 opacity-70" />
+        <span className="shrink-0">Triggered by</span>
+        <ContextLink
+          route={triggerRoute}
+          onNavigate={navigate}
+          title="Open this trigger"
+          className="shrink-0 font-medium"
+        >
+          {context.triggerName}
+        </ContextLink>
+        <ContextLink
+          route={activityRoute}
+          onNavigate={navigate}
+          title="Open the comment, document, or update that started this session"
+          className="text-muted-foreground min-w-0 truncate"
+        >
+          {context.activitySummary}
+        </ContextLink>
+      </div>
+      <div className="text-muted-foreground mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5">
+        <span>{summarizeTriggerSource(context.source)}</span>
+        <span>Fired {formattedDateMedium(new Date(context.firedAt))}</span>
+        {context.status && context.status !== 'fired' ? <span>Status: {context.status}</span> : null}
+      </div>
+      {context.error ? <div className="text-destructive mt-1">{context.error}</div> : null}
+      <TriggerDisclosure label="Activity details">
+        <pre className="bg-background/60 text-foreground max-h-72 overflow-auto rounded-md border p-2 text-[11px] whitespace-pre-wrap">
+          {JSON.stringify(context.activity, null, 2)}
+        </pre>
+      </TriggerDisclosure>
+      {instructions ? (
+        <TriggerDisclosure label="Trigger instructions">
+          <p className="bg-background/60 text-foreground rounded-md border p-2 text-[11px] whitespace-pre-wrap">
+            {instructions}
+          </p>
+        </TriggerDisclosure>
+      ) : null}
+    </div>
+  )
+}
+
+/** Renders text that navigates to `route` when present, or plain text when there is nowhere to link. */
+function ContextLink({
+  route,
+  onNavigate,
+  title,
+  className,
+  children,
+}: {
+  route: NavRoute | null
+  onNavigate: (route: NavRoute) => void
+  title: string
+  className?: string
+  children: React.ReactNode
+}) {
+  if (!route) return <span className={className}>{children}</span>
+  return (
+    <button
+      type="button"
+      title={title}
+      onClick={() => onNavigate(route)}
+      className={`hover:text-foreground text-left hover:underline ${className ?? ''}`}
+    >
+      {children}
+    </button>
+  )
+}
+
+/** Inline collapsible row used for the trigger card's "Activity details" / "Trigger instructions" sections. */
+function TriggerDisclosure({label, children}: {label: string; children: React.ReactNode}) {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((current) => !current)}
+        className="text-muted-foreground hover:text-foreground mt-1.5 flex items-center gap-1"
+      >
+        {open ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+        {label}
+      </button>
+      {open ? <div className="mt-1.5">{children}</div> : null}
+    </>
+  )
+}
+
+function recordField(value: unknown, key: string): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object') return null
+  const field = (value as Record<string, unknown>)[key]
+  return field && typeof field === 'object' ? (field as Record<string, unknown>) : null
+}
+
+function stringField(value: Record<string, unknown>, key: string): string | undefined {
+  const field = value[key]
+  return typeof field === 'string' && field ? field : undefined
+}

--- a/frontend/packages/ui/src/collaborators-page.tsx
+++ b/frontend/packages/ui/src/collaborators-page.tsx
@@ -32,7 +32,7 @@ import {Spinner} from './spinner'
 import {SizableText} from './text'
 import {toast} from './toast'
 
-type SearchResult = {
+export type SearchResult = {
   id: UnpackedHypermediaId
   label: string
   unresolved?: boolean
@@ -67,6 +67,73 @@ function AddCollaboratorForm({id, domainResolver}: {id: UnpackedHypermediaId; do
   const addCapabilities = useAddCapabilities(id)
   const [selectedCollaborators, setSelectedCollaborators] = useState<SearchResult[]>([])
   const capabilities = useCapabilities(id)
+
+  const excludeUids = useMemo(() => {
+    // The owner cannot be added, and accounts that already have a capability are filtered out.
+    return [id.uid, ...(capabilities.data?.map((capability) => capability.grantId.uid) ?? [])]
+  }, [id.uid, capabilities.data])
+
+  if (!myCapability) return null
+  return (
+    <div className="flex flex-col gap-2 px-4 pt-4">
+      <div className="border-border flex overflow-hidden rounded-md border-1">
+        <AccountSearchInput
+          label="Members"
+          placeholder="Invite members"
+          values={selectedCollaborators}
+          onValuesChange={setSelectedCollaborators}
+          excludeUids={excludeUids}
+          domainResolver={domainResolver}
+        />
+        {selectedCollaborators.length ? (
+          <Button
+            size="sm"
+            className="h-auto rounded-tl-none rounded-bl-none"
+            onClick={() => {
+              addCapabilities.mutate(
+                {
+                  myCapability: myCapability,
+                  collaboratorAccountIds: selectedCollaborators.map((collab) => collab.id.uid),
+                  role: 'WRITER',
+                },
+                {
+                  onSuccess: (_, {collaboratorAccountIds: count}) => {
+                    toast.success(`Capabilit${count?.length > 1 ? 'ies' : 'y'} added`)
+                  },
+                },
+              )
+              setSelectedCollaborators([])
+            }}
+            variant="default"
+          >
+            <ArrowRight className="size-4" />
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Reusable multi-select account search. Renders selected accounts as pills (resolving raw account
+ * IDs to account names/icons) and accepts free-text search, pasted hm:// IDs, and full URLs.
+ */
+export function AccountSearchInput({
+  label,
+  placeholder,
+  values,
+  onValuesChange,
+  excludeUids,
+  domainResolver,
+}: {
+  label: string
+  placeholder?: string
+  values: SearchResult[]
+  onValuesChange: (values: SearchResult[]) => void
+  /** Account UIDs to omit from search matches (e.g. the owner or already-added accounts). */
+  excludeUids?: string[]
+  domainResolver?: DomainResolverFn
+}) {
   const [search, setSearch] = useState('')
   const selectedAccountId = useSelectedAccountId()
   const searchResults = useSearch(search, {
@@ -81,7 +148,7 @@ function AddCollaboratorForm({id, domainResolver}: {id: UnpackedHypermediaId; do
       if (hmUrl) {
         const label = hmIdToURL(hmId(hmUrl.uid))
         if (label) {
-          setSelectedCollaborators((v) => [...v, {id: hmUrl, label, unresolved: true}])
+          onValuesChange([...values, {id: hmUrl, label, unresolved: true}])
           setSearch('')
           return
         }
@@ -97,25 +164,25 @@ function AddCollaboratorForm({id, domainResolver}: {id: UnpackedHypermediaId; do
             if (!resolved?.hmId) return
             const resolvedId = hmId(resolved.hmId.uid)
             const label = resolved.title || hmIdToURL(resolvedId) || resolved.hmId.uid
-            setSelectedCollaborators((v) => [...v, {id: resolvedId, label, unresolved: true}])
+            onValuesChange([...values, {id: resolvedId, label, unresolved: true}])
             setSearch('')
           })
           .catch(() => {})
       }
     },
-    [domainResolver],
+    [values, onValuesChange, domainResolver],
   )
 
   const matches = useMemo(() => {
     const matchesByAccountUid = new Map<string, SearchResult & {type: string}>()
     const orderedAccountUids: string[] = []
+    const excluded = new Set(excludeUids ?? [])
 
     for (const result of search ? searchResults.data?.entities || [] : []) {
       if (!result) continue // probably id was not parsed correctly
       if (result.id.path?.length) continue // this is a directory document, not an account
-      if (result.id.uid === id.uid) continue // this account is already the owner, cannot be added
-      if (capabilities.data?.find((capability) => capability.grantId.uid === result.id.uid)) continue // already added
-      if (selectedCollaborators.find((collab) => collab.id.uid === result.id.uid)) continue // already added
+      if (excluded.has(result.id.uid)) continue // owner or already-added account
+      if (values.find((value) => value.id.uid === result.id.uid)) continue // already selected
       if (result.type !== 'contact' && result.type !== 'document') continue
 
       const match = {
@@ -135,88 +202,56 @@ function AddCollaboratorForm({id, domainResolver}: {id: UnpackedHypermediaId; do
     }
 
     return orderedAccountUids.map((uid) => matchesByAccountUid.get(uid)!).filter(Boolean)
-  }, [search, searchResults.data?.entities, selectedCollaborators, capabilities.data, id.uid])
+  }, [search, searchResults.data?.entities, values, excludeUids])
 
-  if (!myCapability) return null
   return (
-    <div className="flex flex-col gap-2 px-4 pt-4">
-      <div className="border-border flex overflow-hidden rounded-md border-1">
-        <div className="flex flex-1">
-          <TagInput
-            label="Members"
-            value={search}
-            onChange={handleSearchChange}
-            values={selectedCollaborators}
-            onValuesChange={(collabs) => {
-              setSelectedCollaborators(collabs)
-            }}
-            placeholder="Invite members"
-          >
-            {matches.map(
-              (result) =>
-                result && (
-                  <TagInputItem
-                    key={result.id.id}
-                    onClick={() => {
-                      setSelectedCollaborators((vals) => [...vals, result])
-                    }}
-                    member={result}
-                  >
-                    Add &quot;{result?.label}&quot;
-                  </TagInputItem>
-                ),
-            )}
-            {search && matches.length == 0 ? (
+    <div className="flex flex-1">
+      <TagInput
+        label={label}
+        value={search}
+        onChange={handleSearchChange}
+        values={values}
+        onValuesChange={onValuesChange}
+        placeholder={placeholder}
+      >
+        {matches.map(
+          (result) =>
+            result && (
               <TagInputItem
-                onClick={async () => {
-                  // Try resolving bare domains (e.g. "gabo.es")
-                  if (search.includes('.')) {
-                    const url = search.startsWith('http') ? search : `https://${search}`
-                    try {
-                      const resolved = await resolveHypermediaUrl(url, {domainResolver})
-                      if (resolved?.hmId) {
-                        const resolvedId = hmId(resolved.hmId.uid)
-                        const label = resolved.title || hmIdToURL(resolvedId) || resolved.hmId.uid
-                        setSelectedCollaborators((v) => [...v, {id: resolvedId, label, unresolved: true}])
-                        setSearch('')
-                        return
-                      }
-                    } catch {}
-                  }
-                  toast.error('Invalid Collaborator Input')
+                key={result.id.id}
+                onClick={() => {
+                  onValuesChange([...values, result])
                 }}
+                member={result}
               >
-                Add &quot;{search}&quot;
+                Add &quot;{result?.label}&quot;
               </TagInputItem>
-            ) : null}
-          </TagInput>
-        </div>
-        {selectedCollaborators.length ? (
-          <Button
-            size="sm"
-            className="h-auto rounded-tl-none rounded-bl-none"
-            onClick={() => {
-              addCapabilities.mutate(
-                {
-                  myCapability: myCapability,
-                  collaboratorAccountIds: selectedCollaborators.map((collab) => collab.id.uid),
-                  role: 'WRITER',
-                },
-                {
-                  onSuccess: (_, {collaboratorAccountIds: count}) => {
-                    toast.success(`Capabilit${count?.length > 1 ? 'ies' : 'y'} added`)
-                  },
-                },
-              )
-              setSearch('')
-              setSelectedCollaborators([])
+            ),
+        )}
+        {search && matches.length == 0 ? (
+          <TagInputItem
+            onClick={async () => {
+              // Try resolving bare domains (e.g. "gabo.es")
+              if (search.includes('.')) {
+                const url = search.startsWith('http') ? search : `https://${search}`
+                try {
+                  const resolved = await resolveHypermediaUrl(url, {domainResolver})
+                  if (resolved?.hmId) {
+                    const resolvedId = hmId(resolved.hmId.uid)
+                    const label = resolved.title || hmIdToURL(resolvedId) || resolved.hmId.uid
+                    onValuesChange([...values, {id: resolvedId, label, unresolved: true}])
+                    setSearch('')
+                    return
+                  }
+                } catch {}
+              }
+              toast.error('Invalid account input')
             }}
-            variant="default"
           >
-            <ArrowRight className="size-4" />
-          </Button>
+            Add &quot;{search}&quot;
+          </TagInputItem>
         ) : null}
-      </div>
+      </TagInput>
     </div>
   )
 }

--- a/frontend/packages/ui/src/collaborators-page.tsx
+++ b/frontend/packages/ui/src/collaborators-page.tsx
@@ -575,6 +575,16 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>(function TagInput(p
   const defaultComboboxId = useId()
   const comboboxId = comboboxProps.id || defaultComboboxId
 
+  // When this combobox is rendered inside a modal dialog (e.g. Radix Dialog), the dialog disables
+  // pointer events outside its content and dismisses itself on an outside pointerdown. Because the
+  // popover is portalled to the body it counts as "outside", so mouse clicks on options are swallowed
+  // (keyboard selection still works). Re-enable pointer events on the popover and stop its pointerdown
+  // from bubbling to the dialog's document-level dismiss listener. A native listener is used so it runs
+  // regardless of React's synthetic event root.
+  const popoverRef = useCallback((node: HTMLElement | null) => {
+    node?.addEventListener('pointerdown', (event) => event.stopPropagation())
+  }, [])
+
   const combobox = Ariakit.useComboboxStore({
     value,
     defaultValue,
@@ -682,10 +692,12 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>(function TagInput(p
           />
         </div>
         <Ariakit.ComboboxPopover
+          ref={popoverRef}
           store={combobox}
           portal
           sameWidth
           gutter={8}
+          className="pointer-events-auto"
           render={
             <Ariakit.SelectList
               // @ts-expect-error

--- a/frontend/packages/ui/src/feed.tsx
+++ b/frontend/packages/ui/src/feed.tsx
@@ -929,7 +929,7 @@ function CitationSourceBlock({sourceId}: {sourceId: UnpackedHypermediaId}) {
   return <Viewer blocks={[blockNode]} resourceId={sourceId} textUnit={14} layoutUnit={16} />
 }
 
-function getEventRoute(event: LoadedEvent): NavRoute | null {
+export function getEventRoute(event: LoadedEvent): NavRoute | null {
   if (event.type == 'comment') {
     // Navigate to the full comments page with the comment focused in the main panel
     if (!event.target?.id || !event.comment) return null


### PR DESCRIPTION
## Summary
Two related improvements to **user-mention agent triggers**, addressing reports that mentions sometimes don't trigger a session, and sometimes trigger several.

### 1. Multi-account mentions + consistent UI
- `AgentTriggerSource` user-mention changes from `mentionedAccount: string` → `mentionedAccounts: string[]` (protocol + `normalizeAgentTriggerSource`, dedup, with legacy single-account fallback so existing triggers keep working).
- The "New trigger" dialog's mentioned-account field now uses the **same** account-search autocomplete as the People-tab *Add collaborator* form. Extracted a shared, exported `AccountSearchInput` from `collaborators-page.tsx` — multi-select **pills that resolve account names/icons** (no more raw IDs) and accept pasted account IDs / `hm://` URLs.

### 2. Reliable trigger matching (root-cause fix)
`/api/ListEvents` returns **resolved `LoadedEvent`s** (`type:'comment'|'citation'|…`), not raw `newBlob`/`newMention`. The old matcher fell back to a broad `jsonContainsString(event, uid)`, so a user-mention trigger fired on **any** comment/citation that merely *contained* the account UID — as the author, reply-parent, or a cited document.

**Measured against the live `hyper.media` feed:** an account genuinely @mentioned **7 times** matched **32 events → 32 sessions** (16 comments + 16 citations).

The matcher now detects mentions **structurally**, mirroring the notification classifier:
- comment events → an `Embed` annotation whose link resolves to the account;
- citation events → a `target` that resolves to the account root/`:profile`;
- **suppress comment-sourced (`citationType:'c'`) citations** — they mirror the comment event, so one mention yields one session.

Re-verified against 344 real events: the 32→ case now matches exactly **7**, with **zero** spurious matches across all 10 mentioned accounts.

## Tests
- New resolved-`LoadedEvent` test: comment mention ✓, comment authored-by-account (no match) ✓, document-citation mention ✓, `c`-citation suppression ✓, cite-a-doc-owned-by-account (no match) ✓, doc-update (no match) ✓, resourcePrefix filtering ✓.
- Updated backend normalize/matcher tests for the array shape + legacy fallback.
- `bun test` → 48 pass / 0 fail. `tsgo --noEmit`, desktop + ui `tsc --noEmit` → 0 errors. `collaborators-page` vitest → 9 pass.

## Not covered
Verified the matching logic against real data, but not the full live loop (running agents server + real new mention + model provider). Suggest an end-to-end check: @mention an account once in a comment and once in a document → expect one session each.

> Note: this branch stacks on two prior unpushed `main` commits (`Auto discover referenced content of agent`, `Visual tweak agent page header`) because they share `api-service.ts`; they appear in this PR's diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)