### PR TITLE
feat(inspector): add document version graph tab

### DIFF
--- a/frontend/packages/shared/src/__tests__/routes.test.ts
+++ b/frontend/packages/shared/src/__tests__/routes.test.ts
@@ -354,11 +354,28 @@ describe('navRouteSchema', () => {
   test('parses the api inspector route', () => {
     expect(navRouteSchema.parse({key: 'api-inspector'})).toEqual({key: 'api-inspector'})
   })
+
+  test('parses the graph inspector tab', () => {
+    expect(navRouteSchema.parse({key: 'inspect', id: testDocId, inspectTab: 'graph'})).toEqual({
+      key: 'inspect',
+      id: testDocId,
+      inspectTab: 'graph',
+    })
+  })
 })
 
 describe('createRouteFromInspectNavRoute', () => {
   test('opens document changes via the activity route', () => {
     expect(createRouteFromInspectNavRoute({key: 'inspect', id: testDocId}, 'changes')).toEqual({
+      key: 'activity',
+      id: testDocId,
+      filterEventType: ['Ref'],
+      panel: null,
+    })
+  })
+
+  test('opens document graph via the versions activity route', () => {
+    expect(createRouteFromInspectNavRoute({key: 'inspect', id: testDocId}, 'graph')).toEqual({
       key: 'activity',
       id: testDocId,
       filterEventType: ['Ref'],
@@ -549,6 +566,11 @@ describe('routeToHref', () => {
     test('inspect route supports explorer parity tabs in query params', () => {
       const href = routeToHref({key: 'inspect', id: hmId('uid1'), inspectTab: 'versions'}, {originHomeId: originHome})
       expect(href).toBe('/inspect?tab=versions')
+    })
+
+    test('inspect route supports graph tabs in query params', () => {
+      const href = routeToHref({key: 'inspect', id: hmId('uid1'), inspectTab: 'graph'}, {originHomeId: originHome})
+      expect(href).toBe('/inspect?tab=graph')
     })
 
     test('inspect ipfs route generates inspect ipfs href', () => {

--- a/frontend/packages/shared/src/routes.ts
+++ b/frontend/packages/shared/src/routes.ts
@@ -59,6 +59,7 @@ const inspectTargetViewSchema = z.enum(INSPECT_TARGET_VIEW_KEYS).optional()
 export const INSPECT_TABS = [
   'document',
   'changes',
+  'graph',
   'versions',
   'comments',
   'citations',
@@ -610,6 +611,7 @@ export function createInspectIpfsNavRoute(ipfsPath: string): InspectIpfsRoute {
 export function createRouteFromInspectNavRoute(route: InspectRoute, inspectTab?: InspectTab | null): NavRoute {
   switch (inspectTab) {
     case 'changes':
+    case 'graph':
       return {
         key: 'activity',
         id: route.id,

--- a/frontend/packages/shared/src/utils/__tests__/entity-id-url.test.ts
+++ b/frontend/packages/shared/src/utils/__tests__/entity-id-url.test.ts
@@ -720,6 +720,18 @@ describe('routeToUrl', () => {
     expect(url).toBe('https://gw.com/hm/inspect/uid1/docs?tab=capabilities')
   })
 
+  test('inspect route preserves graph inspector tab query params', () => {
+    const url = routeToUrl(
+      {
+        key: 'inspect',
+        id: hmId('uid1', {path: ['docs']}),
+        inspectTab: 'graph',
+      },
+      {hostname: 'https://gw.com'},
+    )
+    expect(url).toBe('https://gw.com/hm/inspect/uid1/docs?tab=graph')
+  })
+
   test('inspect ipfs route produces inspect ipfs url', () => {
     const url = routeToUrl(
       {
@@ -777,6 +789,15 @@ describe('routeToHmUrl', () => {
       inspectTab: 'contacts',
     })
     expect(url).toBe('hm://inspect/uid1?tab=contacts')
+  })
+
+  test('inspect route preserves graph inspector tab in hm urls', () => {
+    const url = routeToHmUrl({
+      key: 'inspect',
+      id: hmId('uid1'),
+      inspectTab: 'graph',
+    })
+    expect(url).toBe('hm://inspect/uid1?tab=graph')
   })
 
   test('inspect ipfs route produces hm inspect ipfs urls', () => {

--- a/frontend/packages/shared/src/utils/url-to-route.test.ts
+++ b/frontend/packages/shared/src/utils/url-to-route.test.ts
@@ -130,6 +130,14 @@ describe('hypermediaUrlToRoute', () => {
     })
   })
 
+  test('converts graph inspector tabs from URL query params', () => {
+    expect(hypermediaUrlToRoute('hm://inspect/uid1?tab=graph')).toEqual({
+      key: 'inspect',
+      id: unpackHmId('hm://uid1'),
+      inspectTab: 'graph',
+    })
+  })
+
   test('converts an inspect ipfs URL into an inspect ipfs route', () => {
     expect(hypermediaUrlToRoute('hm://inspect/ipfs/bafy123/path/to/node')).toEqual({
       key: 'inspect-ipfs',

--- a/frontend/packages/ui/src/__tests__/document-version-graph-view.test.tsx
+++ b/frontend/packages/ui/src/__tests__/document-version-graph-view.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import React from 'react'
+import {hmId} from '@shm/shared/utils/entity-id-url'
+import {UniversalAppProvider} from '@shm/shared/routing'
+import {createRoot, type Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {DocumentVersionGraphView} from '../document-version-graph-view'
+;(globalThis as typeof globalThis & {React?: typeof React; IS_REACT_ACT_ENVIRONMENT?: boolean}).React = React
+;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+function renderGraph() {
+  act(() => {
+    root.render(
+      <UniversalAppProvider openRoute={vi.fn()} openUrl={vi.fn()} universalClient={{request: vi.fn()} as any}>
+        <DocumentVersionGraphView
+          docId={hmId('z6Mkfm8befyW32tingJymhfqjX6nhLwoBkQxdSmqg9DnqmiH', {path: ['demo-67']})}
+          latestVersion="bafy2bzacedezxtfo7mezppdmjfijpzmj72zgnjnbgrx5exprimzuwzxfwsq2g.bafy2bzaceaejob735npr3aweouk2rumqajhi4okuqucpayknnhvng6t276ei2"
+          changes={[
+            {
+              id: 'bafyreiecjrjf2hb7yhopf2lqua4xtd5fxz4ivxvay2rb6a5lu7kwgeubyq',
+              deps: [],
+              author: 'z6Mkfm8befyW32tingJymhfqjX6nhLwoBkQxdSmqg9DnqmiH',
+              createTime: '2026-04-27T21:40:00Z',
+            },
+            {
+              id: 'bafy2bzacedezxtfo7mezppdmjfijpzmj72zgnjnbgrx5exprimzuwzxfwsq2g',
+              deps: ['bafyreiecjrjf2hb7yhopf2lqua4xtd5fxz4ivxvay2rb6a5lu7kwgeubyq'],
+              author: 'z6Mkfm8befyW32tingJymhfqjX6nhLwoBkQxdSmqg9DnqmiH',
+              createTime: '2026-04-27T21:40:00Z',
+            },
+            {
+              id: 'bafy2bzaceaejob735npr3aweouk2rumqajhi4okuqucpayknnhvng6t276ei2',
+              deps: ['bafyreiecjrjf2hb7yhopf2lqua4xtd5fxz4ivxvay2rb6a5lu7kwgeubyq'],
+              author: 'z6MkQzh9W6yCrGp11fppNWCoDrKYoxkk7ooGQ4HrSdnEX8ukP',
+              createTime: '2026-04-27T21:41:00Z',
+            },
+          ]}
+        />
+      </UniversalAppProvider>,
+    )
+  })
+}
+
+describe('DocumentVersionGraphView layout', () => {
+  it('keeps graph marks visible above selected rows and wraps long detail values', () => {
+    renderGraph()
+
+    const selectedRow = container.querySelector('button[aria-pressed="true"]')
+    expect(selectedRow?.className).toContain('bg-accent')
+    expect(container.querySelector('svg')?.getAttribute('class')).toContain('z-20')
+    expect(container.querySelector('aside')?.className).toContain('overflow-hidden')
+
+    const detailRows = Array.from(container.querySelectorAll('dt')).map((label) => ({
+      label: label.textContent,
+      value: label.nextElementSibling,
+    }))
+    expect(detailRows.find((row) => row.label === 'Author')?.value?.className).toContain('break-all')
+    expect(detailRows.find((row) => row.label === 'Dependencies')?.value?.className).toContain('break-all')
+  })
+})

--- a/frontend/packages/ui/src/__tests__/document-version-graph.test.ts
+++ b/frontend/packages/ui/src/__tests__/document-version-graph.test.ts
@@ -1,0 +1,76 @@
+import {describe, expect, it} from 'vitest'
+import {buildDocumentVersionGraph} from '../document-version-graph'
+
+describe('buildDocumentVersionGraph', () => {
+  it('lays out a linear change history from newest to genesis', () => {
+    const graph = buildDocumentVersionGraph({
+      changes: [
+        {id: 'bafy-a', deps: [], author: 'alice', createTime: '2024-01-01T00:00:00Z'},
+        {id: 'bafy-b', deps: ['bafy-a'], author: 'alice', createTime: '2024-01-02T00:00:00Z'},
+        {id: 'bafy-c', deps: ['bafy-b'], author: 'bob', createTime: '2024-01-03T00:00:00Z'},
+      ],
+      latestVersion: 'bafy-c',
+    })
+
+    expect(graph.nodes.map((node) => ({id: node.id, depth: node.depth, lane: node.lane, isHead: node.isHead}))).toEqual(
+      [
+        {id: 'bafy-c', depth: 2, lane: 0, isHead: true},
+        {id: 'bafy-b', depth: 1, lane: 0, isHead: false},
+        {id: 'bafy-a', depth: 0, lane: 0, isHead: false},
+      ],
+    )
+    expect(graph.edges).toEqual([
+      {from: 'bafy-b', to: 'bafy-c'},
+      {from: 'bafy-a', to: 'bafy-b'},
+    ])
+    expect(graph.heads).toEqual(['bafy-c'])
+    expect(graph.maxLane).toBe(0)
+  })
+
+  it('assigns branch lanes and marks merge changes', () => {
+    const graph = buildDocumentVersionGraph({
+      changes: [
+        {id: 'root', deps: [], author: 'alice'},
+        {id: 'left', deps: ['root'], author: 'alice'},
+        {id: 'right', deps: ['root'], author: 'bob'},
+        {id: 'merge', deps: ['left', 'right'], author: 'carol'},
+      ],
+      latestVersion: 'merge',
+    })
+
+    expect(graph.nodes.map((node) => ({id: node.id, lane: node.lane, isMerge: node.isMerge}))).toEqual([
+      {id: 'merge', lane: 0, isMerge: true},
+      {id: 'left', lane: 0, isMerge: false},
+      {id: 'right', lane: 1, isMerge: false},
+      {id: 'root', lane: 0, isMerge: false},
+    ])
+    expect(graph.maxLane).toBe(1)
+  })
+
+  it('uses dot-separated latest versions as concurrent heads', () => {
+    const graph = buildDocumentVersionGraph({
+      changes: [
+        {id: 'root', deps: []},
+        {id: 'left', deps: ['root']},
+        {id: 'right', deps: ['root']},
+      ],
+      latestVersion: 'left.right',
+    })
+
+    expect(graph.heads).toEqual(['left', 'right'])
+    expect(graph.nodes.filter((node) => node.isHead).map((node) => node.id)).toEqual(['left', 'right'])
+  })
+
+  it('creates placeholder nodes for missing dependencies', () => {
+    const graph = buildDocumentVersionGraph({
+      changes: [{id: 'child', deps: ['missing-parent']}],
+      latestVersion: 'child',
+    })
+
+    expect(graph.nodes.map((node) => ({id: node.id, isMissing: node.isMissing}))).toEqual([
+      {id: 'child', isMissing: false},
+      {id: 'missing-parent', isMissing: true},
+    ])
+    expect(graph.edges).toEqual([{from: 'missing-parent', to: 'child'}])
+  })
+})

--- a/frontend/packages/ui/src/document-tools.tsx
+++ b/frontend/packages/ui/src/document-tools.tsx
@@ -12,6 +12,7 @@ import {useIsomorphicLayoutEffect} from '@shm/shared/utils/use-isomorphic-layout
 import {
   FileText,
   Folder,
+  GitGraph,
   History,
   LucideIcon,
   MessageSquare,
@@ -141,6 +142,12 @@ export function DocumentTools({
               label: 'Changes',
               tooltip: 'Inspect Document Changes',
               icon: History,
+            },
+            {
+              tab: 'graph' as const,
+              label: 'Graph',
+              tooltip: 'Inspect Document Version Graph',
+              icon: GitGraph,
             },
             {
               tab: 'comments' as const,

--- a/frontend/packages/ui/src/document-version-graph-view.tsx
+++ b/frontend/packages/ui/src/document-version-graph-view.tsx
@@ -1,0 +1,304 @@
+import type {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {createInspectIpfsNavRoute, createInspectNavRoute} from '@shm/shared'
+import {useRouteLink} from '@shm/shared/routing'
+import {GitBranch, GitCommitHorizontal, GitMerge, GitPullRequestArrow, LinkIcon} from 'lucide-react'
+import type {CSSProperties, ReactNode} from 'react'
+import {useEffect, useMemo, useState} from 'react'
+import {Button} from './button'
+import {
+  buildDocumentVersionGraph,
+  type DocumentVersionGraphChange,
+  type DocumentVersionGraphNode,
+} from './document-version-graph'
+import {cn} from './utils'
+
+const ROW_HEIGHT = 62
+const LANE_WIDTH = 30
+const GRAPH_LEFT_PADDING = 22
+const GRAPH_TOP_PADDING = 30
+const DETAIL_DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+})
+
+/** Renders a Git-tree-style dependency graph for document versions. */
+export function DocumentVersionGraphView({
+  changes,
+  latestVersion,
+  docId,
+}: {
+  changes: DocumentVersionGraphChange[] | undefined
+  latestVersion?: string | null
+  docId: UnpackedHypermediaId
+}) {
+  const graph = useMemo(() => buildDocumentVersionGraph({changes, latestVersion}), [changes, latestVersion])
+  const [selectedId, setSelectedId] = useState<string | null>(graph.heads[0] || graph.nodes[0]?.id || null)
+  const selectedNode = selectedId ? graph.nodesById[selectedId] || null : null
+  const graphWidth = Math.max(96, GRAPH_LEFT_PADDING * 2 + (graph.maxLane + 1) * LANE_WIDTH)
+  const graphHeight = Math.max(120, graph.nodes.length * ROW_HEIGHT + GRAPH_TOP_PADDING)
+
+  useEffect(() => {
+    if (selectedId && graph.nodesById[selectedId]) return
+    setSelectedId(graph.heads[0] || graph.nodes[0]?.id || null)
+  }, [graph, selectedId])
+
+  if (!graph.nodes.length) {
+    return (
+      <div className="text-muted-foreground border-border bg-background rounded-xl border p-4 text-sm">
+        No changes found.
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-0 flex-col gap-4 xl:flex-row">
+      <div className="border-border bg-background min-w-0 flex-1 overflow-auto rounded-xl border shadow-xs">
+        <div className="relative" style={{height: graphHeight, minWidth: 680}}>
+          <svg
+            className="text-muted-foreground pointer-events-none absolute top-0 left-0 z-20"
+            width={graphWidth}
+            height={graphHeight}
+            aria-hidden="true"
+          >
+            {graph.edges.map((edge) => {
+              const from = graph.nodesById[edge.from]
+              const to = graph.nodesById[edge.to]
+              if (!from || !to) return null
+
+              return (
+                <path
+                  key={`${edge.from}->${edge.to}`}
+                  d={edgePath(from, to)}
+                  className={cn(
+                    'fill-none stroke-current',
+                    selectedNode && (selectedNode.id === from.id || selectedNode.id === to.id)
+                      ? 'text-foreground'
+                      : 'text-muted-foreground/35',
+                  )}
+                  strokeWidth={selectedNode && (selectedNode.id === from.id || selectedNode.id === to.id) ? 2.5 : 1.75}
+                  strokeLinecap="round"
+                />
+              )
+            })}
+            {graph.nodes.map((node) => (
+              <g
+                key={node.id}
+                className={cn(
+                  selectedNode?.id === node.id ? 'text-foreground' : laneColorClass(node.lane),
+                  node.isMissing && 'text-muted-foreground',
+                )}
+              >
+                <circle
+                  cx={nodeX(node)}
+                  cy={nodeY(node)}
+                  r={node.isMerge ? 7 : 6}
+                  className={cn(
+                    'fill-current',
+                    selectedNode?.id === node.id && 'stroke-background',
+                    node.isMissing && 'fill-background stroke-current',
+                  )}
+                  strokeWidth={node.isMissing ? 2 : selectedNode?.id === node.id ? 3 : 0}
+                />
+                {node.isHead ? (
+                  <circle
+                    cx={nodeX(node)}
+                    cy={nodeY(node)}
+                    r={12}
+                    className="fill-none stroke-current"
+                    strokeWidth={2}
+                  />
+                ) : null}
+              </g>
+            ))}
+          </svg>
+
+          <div className="relative z-10">
+            {graph.nodes.map((node) => (
+              <button
+                key={node.id}
+                type="button"
+                className={cn(
+                  'border-border/60 hover:bg-accent/60 focus-visible:ring-ring grid w-full grid-cols-[var(--graph-width)_minmax(0,1fr)] items-center border-b text-left transition-colors last:border-b-0 focus-visible:ring-2 focus-visible:outline-none',
+                  selectedNode?.id === node.id && 'bg-accent hover:bg-accent',
+                )}
+                style={
+                  {
+                    height: ROW_HEIGHT,
+                    '--graph-width': `${graphWidth}px`,
+                  } as CSSProperties
+                }
+                aria-pressed={selectedNode?.id === node.id}
+                aria-label={`Inspect version ${node.id}`}
+                onClick={() => setSelectedId(node.id)}
+              >
+                <span />
+                <span className="flex min-w-0 items-center gap-3 pr-4">
+                  <VersionNodeIcon node={node} />
+                  <span className="min-w-0 flex-1">
+                    <span className="flex min-w-0 flex-wrap items-center gap-2">
+                      <span className="text-foreground font-mono text-sm font-semibold">{node.shortId}</span>
+                      {node.isHead ? <Badge>HEAD</Badge> : null}
+                      {node.isGenesis ? <Badge>genesis</Badge> : null}
+                      {node.isMerge ? <Badge>merge</Badge> : null}
+                      {node.isMissing ? <Badge>missing</Badge> : null}
+                    </span>
+                    <span className="text-muted-foreground mt-1 flex min-w-0 flex-wrap items-center gap-2 text-xs">
+                      {node.author ? <span className="max-w-full min-w-0 break-all">hm://{node.author}</span> : null}
+                      {node.author && node.createTime ? <span>•</span> : null}
+                      {node.createTime ? <span>{formatDate(node.createTime)}</span> : null}
+                      {!node.author && !node.createTime ? <span>Dependency placeholder</span> : null}
+                    </span>
+                  </span>
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <VersionDetails node={selectedNode} docId={docId} />
+    </div>
+  )
+}
+
+function VersionNodeIcon({node}: {node: DocumentVersionGraphNode}) {
+  const Icon = node.isMerge
+    ? GitMerge
+    : node.isHead
+      ? GitPullRequestArrow
+      : node.isGenesis
+        ? GitBranch
+        : GitCommitHorizontal
+
+  return (
+    <span
+      className={cn(
+        'border-border bg-background text-muted-foreground flex size-8 shrink-0 items-center justify-center rounded-full border shadow-xs',
+        node.isHead && 'text-foreground',
+        node.isMissing && 'border-dashed',
+      )}
+    >
+      <Icon className="size-4" />
+    </span>
+  )
+}
+
+function VersionDetails({node, docId}: {node: DocumentVersionGraphNode | null; docId: UnpackedHypermediaId}) {
+  if (!node) {
+    return (
+      <aside className="border-border bg-background text-muted-foreground min-w-0 overflow-hidden rounded-xl border p-4 text-sm shadow-xs xl:w-80 xl:shrink-0">
+        Select a version to inspect its dependencies.
+      </aside>
+    )
+  }
+
+  return (
+    <aside className="border-border bg-background h-fit min-w-0 overflow-hidden rounded-xl border p-4 shadow-xs xl:w-80 xl:shrink-0">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1 overflow-hidden">
+          <h2 className="text-foreground text-sm font-semibold">Version details</h2>
+          <p className="text-muted-foreground mt-1 font-mono text-xs break-all">{node.id}</p>
+        </div>
+        {node.isHead ? <Badge>HEAD</Badge> : null}
+      </div>
+
+      <dl className="mt-4 space-y-3 text-sm">
+        <DetailRow label="Author">{node.author ? `hm://${node.author}` : 'Unknown'}</DetailRow>
+        <DetailRow label="Created">{node.createTime ? formatDate(node.createTime) : 'Unknown'}</DetailRow>
+        <DetailRow label="Depth">{node.depth}</DetailRow>
+        <DetailRow label="Lane">{node.lane + 1}</DetailRow>
+        <DetailRow label="Dependencies">
+          {node.deps.length ? (
+            <span className="block min-w-0 space-y-1">
+              {node.deps.map((dep) => (
+                <span key={dep} className="block max-w-full overflow-hidden font-mono text-xs break-all">
+                  {dep}
+                </span>
+              ))}
+            </span>
+          ) : (
+            'None'
+          )}
+        </DetailRow>
+      </dl>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {node.isMissing ? null : <ExactVersionLink docId={docId} version={node.id} />}
+        <IpfsLink cid={node.id} />
+      </div>
+    </aside>
+  )
+}
+
+function ExactVersionLink({docId, version}: {docId: UnpackedHypermediaId; version: string}) {
+  const linkProps = useRouteLink(
+    createInspectNavRoute({...docId, version, latest: null, blockRef: null, blockRange: null}, null, null, null, null),
+  )
+
+  return (
+    <Button asChild size="sm" variant="outline">
+      <a {...linkProps}>
+        <LinkIcon className="size-4" />
+        Exact version
+      </a>
+    </Button>
+  )
+}
+
+function IpfsLink({cid}: {cid: string}) {
+  const linkProps = useRouteLink(createInspectIpfsNavRoute(cid))
+
+  return (
+    <Button asChild size="sm" variant="outline">
+      <a {...linkProps}>IPFS object</a>
+    </Button>
+  )
+}
+
+function DetailRow({label, children}: {label: string; children: ReactNode}) {
+  return (
+    <div className="flex min-w-0 gap-3">
+      <dt className="text-muted-foreground w-24 shrink-0 text-xs font-medium">{label}</dt>
+      <dd className="text-foreground min-w-0 flex-1 overflow-hidden break-all">{children}</dd>
+    </div>
+  )
+}
+
+function Badge({children}: {children: ReactNode}) {
+  return (
+    <span className="border-border bg-background text-muted-foreground rounded-full border px-2 py-0.5 text-xs font-semibold tracking-wide uppercase">
+      {children}
+    </span>
+  )
+}
+
+function nodeX(node: DocumentVersionGraphNode): number {
+  return GRAPH_LEFT_PADDING + node.lane * LANE_WIDTH
+}
+
+function nodeY(node: DocumentVersionGraphNode): number {
+  return GRAPH_TOP_PADDING + node.row * ROW_HEIGHT
+}
+
+function edgePath(from: DocumentVersionGraphNode, to: DocumentVersionGraphNode): string {
+  const startX = nodeX(from)
+  const startY = nodeY(from)
+  const endX = nodeX(to)
+  const endY = nodeY(to)
+  const midY = startY + (endY - startY) / 2
+
+  return `M ${startX} ${startY} C ${startX} ${midY}, ${endX} ${midY}, ${endX} ${endY}`
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return DETAIL_DATE_FORMAT.format(date)
+}
+
+function laneColorClass(lane: number): string {
+  return (
+    ['text-blue-600', 'text-amber-500', 'text-pink-600', 'text-emerald-600', 'text-violet-600'][lane % 5] ||
+    'text-blue-600'
+  )
+}

--- a/frontend/packages/ui/src/document-version-graph.ts
+++ b/frontend/packages/ui/src/document-version-graph.ts
@@ -1,0 +1,216 @@
+import {getVersionHeads} from '@shm/shared/utils/entity-id-url'
+
+/** Raw document change data needed to build a version dependency graph. */
+export type DocumentVersionGraphChange = {
+  id?: string
+  deps?: string[]
+  author?: string
+  createTime?: string
+}
+
+/** A rendered node in the document version dependency graph. */
+export type DocumentVersionGraphNode = {
+  id: string
+  shortId: string
+  deps: string[]
+  dependents: string[]
+  author?: string
+  createTime?: string
+  depth: number
+  lane: number
+  row: number
+  isHead: boolean
+  isGenesis: boolean
+  isMerge: boolean
+  isMissing: boolean
+}
+
+/** A dependency edge from one document version to a later version. */
+export type DocumentVersionGraphEdge = {
+  from: string
+  to: string
+}
+
+/** Prepared graph model for rendering a document version dependency DAG. */
+export type DocumentVersionGraphModel = {
+  nodes: DocumentVersionGraphNode[]
+  edges: DocumentVersionGraphEdge[]
+  nodesById: Record<string, DocumentVersionGraphNode>
+  heads: string[]
+  maxLane: number
+}
+
+type InternalGraphNode = {
+  id: string
+  deps: string[]
+  dependents: string[]
+  author?: string
+  createTime?: string
+  originalIndex: number
+  isMissing: boolean
+}
+
+/** Converts raw ListChanges output into a deterministic document version dependency graph. */
+export function buildDocumentVersionGraph({
+  changes,
+  latestVersion,
+}: {
+  changes: DocumentVersionGraphChange[] | undefined
+  latestVersion?: string | null
+}): DocumentVersionGraphModel {
+  const internalNodes = new Map<string, InternalGraphNode>()
+
+  ;(changes || []).forEach((change, index) => {
+    if (!change.id || internalNodes.has(change.id)) return
+
+    internalNodes.set(change.id, {
+      id: change.id,
+      deps: uniqueStrings(change.deps),
+      dependents: [],
+      author: change.author,
+      createTime: change.createTime,
+      originalIndex: index,
+      isMissing: false,
+    })
+  })
+
+  for (const node of Array.from(internalNodes.values())) {
+    for (const dep of node.deps) {
+      if (!internalNodes.has(dep)) {
+        internalNodes.set(dep, {
+          id: dep,
+          deps: [],
+          dependents: [],
+          originalIndex: Number.MAX_SAFE_INTEGER,
+          isMissing: true,
+        })
+      }
+      internalNodes.get(dep)?.dependents.push(node.id)
+    }
+  }
+
+  const depths = computeDepths(internalNodes)
+  const edges = Array.from(internalNodes.values())
+    .flatMap((node) => node.deps.map((dep) => ({from: dep, to: node.id})))
+    .sort((a, b) => compareByDisplayOrder(a.to, b.to, internalNodes, depths) || a.from.localeCompare(b.from))
+  const inferredHeads = Array.from(internalNodes.values())
+    .filter((node) => !node.isMissing && node.dependents.length === 0)
+    .map((node) => node.id)
+  const explicitHeads = getVersionHeads(latestVersion).filter((head) => internalNodes.has(head))
+  const heads = (explicitHeads.length ? explicitHeads : inferredHeads).sort(
+    (a, b) => compareByDisplayOrder(a, b, internalNodes, depths) || a.localeCompare(b),
+  )
+
+  const displayNodes = Array.from(internalNodes.values()).sort(
+    (a, b) => compareByDisplayOrder(a.id, b.id, internalNodes, depths) || a.id.localeCompare(b.id),
+  )
+  const lanes = assignLanes(displayNodes, heads)
+  const headSet = new Set(heads)
+  const nodes = displayNodes.map((node, row) => ({
+    id: node.id,
+    shortId: abbreviateChangeId(node.id),
+    deps: node.deps,
+    dependents: node.dependents.sort(),
+    author: node.author,
+    createTime: node.createTime,
+    depth: depths.get(node.id) || 0,
+    lane: lanes.get(node.id) || 0,
+    row,
+    isHead: headSet.has(node.id),
+    isGenesis: node.deps.length === 0 && !node.isMissing,
+    isMerge: node.deps.length > 1,
+    isMissing: node.isMissing,
+  }))
+  const nodesById = Object.fromEntries(nodes.map((node) => [node.id, node]))
+
+  return {
+    nodes,
+    edges,
+    nodesById,
+    heads,
+    maxLane: nodes.reduce((maxLane, node) => Math.max(maxLane, node.lane), 0),
+  }
+}
+
+function uniqueStrings(values: string[] | undefined): string[] {
+  return Array.from(new Set((values || []).filter(Boolean)))
+}
+
+function abbreviateChangeId(id: string): string {
+  if (id.length <= 14) return id
+  return `${id.slice(0, 7)}…${id.slice(-5)}`
+}
+
+function computeDepths(nodes: Map<string, InternalGraphNode>): Map<string, number> {
+  const depths = new Map<string, number>()
+  const visiting = new Set<string>()
+
+  const resolveDepth = (id: string): number => {
+    const cachedDepth = depths.get(id)
+    if (cachedDepth !== undefined) return cachedDepth
+    const node = nodes.get(id)
+    if (!node || visiting.has(id)) return 0
+
+    visiting.add(id)
+    const depth = node.deps.length ? Math.max(...node.deps.map((dep) => resolveDepth(dep))) + 1 : 0
+    visiting.delete(id)
+    depths.set(id, depth)
+    return depth
+  }
+
+  for (const id of Array.from(nodes.keys())) {
+    resolveDepth(id)
+  }
+
+  return depths
+}
+
+function compareByDisplayOrder(
+  a: string,
+  b: string,
+  nodes: Map<string, InternalGraphNode>,
+  depths: Map<string, number>,
+): number {
+  const nodeA = nodes.get(a)
+  const nodeB = nodes.get(b)
+  const depthDiff = (depths.get(b) || 0) - (depths.get(a) || 0)
+  if (depthDiff) return depthDiff
+
+  const timeA = Date.parse(nodeA?.createTime || '')
+  const timeB = Date.parse(nodeB?.createTime || '')
+  if (!Number.isNaN(timeA) && !Number.isNaN(timeB) && timeA !== timeB) {
+    return timeB - timeA
+  }
+
+  return (nodeA?.originalIndex || 0) - (nodeB?.originalIndex || 0)
+}
+
+function assignLanes(displayNodes: InternalGraphNode[], heads: string[]): Map<string, number> {
+  const lanes = new Map<string, number>()
+  let nextLane = 0
+
+  for (const head of heads) {
+    if (!lanes.has(head)) {
+      lanes.set(head, nextLane)
+      nextLane += 1
+    }
+  }
+
+  for (const node of displayNodes) {
+    if (!lanes.has(node.id)) {
+      lanes.set(node.id, nextLane)
+      nextLane += 1
+    }
+
+    const nodeLane = lanes.get(node.id) || 0
+    node.deps.forEach((dep, depIndex) => {
+      if (lanes.has(dep)) return
+      lanes.set(dep, depIndex === 0 ? nodeLane : nextLane)
+      if (depIndex !== 0) {
+        nextLane += 1
+      }
+    })
+  }
+
+  return lanes
+}

--- a/frontend/packages/ui/src/inspector-page.tsx
+++ b/frontend/packages/ui/src/inspector-page.tsx
@@ -32,11 +32,23 @@ import {activityFilterToSlug, getCommentTargetId} from '@shm/shared/utils/entity
 import {useNavRoute} from '@shm/shared/utils/navigation'
 import {Button} from './button'
 import {DataViewer} from './data-viewer'
+import {DocumentVersionGraphView} from './document-version-graph-view'
 import {DocumentTools} from './document-tools'
 import {InspectorShell} from './inspector-shell'
 import {PageDeleted, PageDiscovery, PageNotFound, PagePrivate} from './page-message-states'
 import {Spinner} from './spinner'
-import {FileText, Folder, History, LucideIcon, MessageSquare, MessagesSquare, Quote, Shield, Users} from 'lucide-react'
+import {
+  FileText,
+  Folder,
+  GitGraph,
+  History,
+  LucideIcon,
+  MessageSquare,
+  MessagesSquare,
+  Quote,
+  Shield,
+  Users,
+} from 'lucide-react'
 import {ReactNode, useCallback, useMemo} from 'react'
 import type {InspectTab} from '@shm/shared/routes'
 
@@ -170,6 +182,7 @@ function InspectorContent({
 
   const isLoading =
     (resource.type === 'document' && inspectTab === 'changes' && inspectData.changes.isLoading) ||
+    (resource.type === 'document' && inspectTab === 'graph' && inspectData.changes.isLoading) ||
     (inspectTab === 'versions' && inspectData.commentVersions.isLoading) ||
     (inspectTab === 'comments' && inspectData.commentsQuery.isLoading) ||
     (inspectTab === 'citations' && inspectData.citations.isLoading) ||
@@ -196,6 +209,12 @@ function InspectorContent({
         <div className="flex items-center justify-center py-8">
           <Spinner />
         </div>
+      ) : resource.type === 'document' && inspectTab === 'graph' ? (
+        <DocumentVersionGraphView
+          changes={inspectData.changes.data?.changes}
+          latestVersion={inspectData.changes.data?.latestVersion}
+          docId={docId}
+        />
       ) : Array.isArray(inspectPayload) && inspectPayload.length === 0 ? (
         <div className="text-muted-foreground text-sm">{emptyMessage}</div>
       ) : (
@@ -328,6 +347,13 @@ function getInspectToolTabs(
       icon: History,
       count: inspectData.changes.data?.changes?.length,
     })
+    tabs.push({
+      tab: 'graph',
+      label: 'Graph',
+      tooltip: 'Inspect document version graph',
+      icon: GitGraph,
+      count: inspectData.changes.data?.changes?.length,
+    })
   }
 
   if (isComment || route.targetOpenComment) {
@@ -428,6 +454,8 @@ function getInspectPayload(
     switch (inspectTab) {
       case 'changes':
         return prepareInspectChangesData(inspectData.changes.data?.changes, docId)
+      case 'graph':
+        return prepareInspectChangesData(inspectData.changes.data?.changes, docId)
       case 'versions':
         return prepareInspectCommentVersionsData(inspectData.commentVersions.data?.versions)
       case 'comments':
@@ -470,6 +498,8 @@ function getInspectEmptyMessage(
   switch (inspectTab) {
     case 'changes':
       return 'No changes found.'
+    case 'graph':
+      return 'No changes found.'
     case 'versions':
       return 'No comment versions found.'
     case 'comments':
@@ -511,7 +541,7 @@ function getInspectorOpenTarget(
 
   const openRoute = createRouteFromInspectNavRoute(route, route.inspectTab)
 
-  if (route.inspectTab === 'changes') {
+  if (route.inspectTab === 'changes' || route.inspectTab === 'graph') {
     return {label: 'Open Document Versions', route: openRoute}
   }
   if (route.inspectTab === 'citations') {


### PR DESCRIPTION
## Summary
- Add a Graph inspector tab for documents to visualize version history as a dependency graph.
- Support `tab=graph` across inspect route parsing, hrefs, hm URLs, and URL-to-route conversion.
- Add focused tests for graph layout behavior, graph model construction, and route serialization.