### PR TITLE
feat(deploy): support custom web and site images

### DIFF
--- a/.github/workflows/custom-ghcr-images.yml
+++ b/.github/workflows/custom-ghcr-images.yml
@@ -1,0 +1,213 @@
+name: Custom - GHCR Images
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  WEB_IMAGE: ghcr.io/horacioh/seed-web
+  SITE_IMAGE: ghcr.io/horacioh/seed-site
+
+jobs:
+  web-check:
+    name: Web checks and build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install native build dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Run web tests
+        run: pnpm web:test
+
+      - name: Build web app
+        run: pnpm web:prod
+
+      - name: Upload web build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: custom-web-build
+          path: frontend/apps/web/build/
+          retention-days: 1
+
+  daemon-check:
+    name: Site daemon checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.2'
+
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake g++
+
+      - name: Compute llama-go submodule sha
+        id: llama-sha
+        run: echo "sha=$(git -C backend/util/llama-go rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache llama.cpp build
+        id: llama-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            backend/util/llama-go/libbinding.a
+            backend/util/llama-go/libllama.a
+            backend/util/llama-go/libggml*.a
+            backend/util/llama-go/libcommon.a
+            backend/util/llama-go/build
+          key: llama-cpu-linux-${{ runner.arch }}-${{ steps.llama-sha.outputs.sha }}
+
+      - name: Build llama.cpp
+        if: steps.llama-cache.outputs.cache-hit != 'true'
+        run: |
+          cd backend/util/llama-go
+          CMAKE_ARGS="-DBUILD_SHARED_LIBS=OFF -DGGML_VULKAN=OFF -DGGML_METAL=OFF -DGGML_CUDA=OFF -DGGML_HIP=OFF -DGGML_SYCL=OFF -DGGML_BLAS=OFF" make libbinding.a
+
+      - name: Run daemon package tests
+        run: go test --count 1 ./backend/cmd/seed-daemon
+        env:
+          CGO_ENABLED: '1'
+          LIBRARY_PATH: ${{ github.workspace }}/backend/util/llama-go
+          C_INCLUDE_PATH: ${{ github.workspace }}/backend/util/llama-go
+          LLAMA_LOG: error
+
+      - name: Build daemon binary
+        run: go build -tags cpu ./backend/cmd/seed-daemon
+        env:
+          CGO_ENABLED: '1'
+          LIBRARY_PATH: ${{ github.workspace }}/backend/util/llama-go
+          C_INCLUDE_PATH: ${{ github.workspace }}/backend/util/llama-go
+          LLAMA_LOG: error
+
+  docker-web:
+    name: Publish web image
+    runs-on: ubuntu-latest
+    needs: [web-check]
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get commit date
+        run: echo "COMMIT_DATE=$(git show -s --format='%cd' ${{ github.sha }})" >> "$GITHUB_ENV"
+
+      - name: Download web build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: custom-web-build
+          path: frontend/apps/web/build/
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push web image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: frontend/apps/web/Dockerfile
+          push: true
+          tags: |
+            ${{ env.WEB_IMAGE }}:main
+            ${{ env.WEB_IMAGE }}:sha-${{ github.sha }}
+          build-args: |
+            PREBUILT=true
+            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+            SITE_SENTRY_DSN=${{ secrets.SITE_SENTRY_DSN }}
+            COMMIT_HASH=${{ github.sha }}
+            BRANCH=${{ github.ref }}
+            DATE=${{ env.COMMIT_DATE }}
+          cache-from: type=gha,scope=custom-ghcr-web
+          cache-to: type=gha,mode=max,scope=custom-ghcr-web
+
+  docker-site:
+    name: Publish site daemon image
+    runs-on: ubuntu-latest
+    needs: [daemon-check]
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Get commit date
+        run: echo "COMMIT_DATE=$(git show -s --format='%cd' ${{ github.sha }})" >> "$GITHUB_ENV"
+
+      - name: Cache GGUF model
+        uses: actions/cache@v4
+        with:
+          path: backend/llm/backends/llamacpp/models/*.gguf
+          key: gguf-model-granite-v2
+          enableCrossOsArchive: true
+
+      - name: Download GGUF model
+        run: |
+          if [ ! -f backend/llm/backends/llamacpp/models/granite-embedding-107m-multilingual-Q8_0.gguf ]; then
+            mkdir -p backend/llm/backends/llamacpp/models
+            curl -fSL -o backend/llm/backends/llamacpp/models/granite-embedding-107m-multilingual-Q8_0.gguf \
+              "https://huggingface.co/keisuke-miyako/granite-embedding-107m-multilingual-gguf-q8_0/resolve/main/granite-embedding-107m-multilingual-Q8_0.gguf?download=true"
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push site daemon image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: backend/cmd/seed-daemon/Dockerfile
+          push: true
+          tags: |
+            ${{ env.SITE_IMAGE }}:main
+            ${{ env.SITE_IMAGE }}:sha-${{ github.sha }}
+          build-args: |
+            COMMIT_HASH=${{ github.sha }}
+            BRANCH=${{ github.ref }}
+            DATE=${{ env.COMMIT_DATE }}
+          cache-from: type=gha,scope=custom-ghcr-site
+          cache-to: type=gha,mode=max,scope=custom-ghcr-site

--- a/.github/workflows/custom-rebase-main.yml
+++ b/.github/workflows/custom-rebase-main.yml
@@ -1,0 +1,63 @@
+name: Custom - Rebase Main from Upstream
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Keep Horacio's fork close to upstream once per day.
+    - cron: '17 5 * * *'
+
+permissions:
+  actions: write
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-main
+  cancel-in-progress: false
+
+jobs:
+  rebase-main:
+    name: Rebase horacioh/seed:main on upstream/main
+    runs-on: ubuntu-latest
+    if: github.repository == 'horacioh/seed'
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure actions bot identity
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Record starting HEAD
+        id: before
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Add and fetch upstream
+        run: |
+          git remote add upstream https://github.com/seed-hypermedia/seed.git
+          git fetch --prune upstream main
+
+      - name: Rebase main on upstream/main
+        run: git rebase upstream/main
+
+      - name: Record rebased HEAD
+        id: after
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Push rebased main
+        if: steps.after.outputs.sha != steps.before.outputs.sha
+        run: git push --force-with-lease origin HEAD:main
+
+      - name: Dispatch custom image workflow
+        if: steps.after.outputs.sha != steps.before.outputs.sha
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run custom-ghcr-images.yml --ref main
+
+      - name: Branch protection note
+        run: |
+          echo 'If this workflow cannot push to main, update branch protection to allow this GitHub Actions workflow/bot to bypass or satisfy the rule.'

--- a/docs/custom-docker-web-deploy.md
+++ b/docs/custom-docker-web-deploy.md
@@ -1,0 +1,189 @@
+# Custom Docker Web Deploy Runbook
+
+Operator notes for running the Horacio fork deployment while tracking upstream Seed.
+
+## Model
+
+- Fork remote: `origin` = `horacioh/seed`.
+- Deployment branch: `origin/main`.
+- Upstream: `seed-hypermedia/seed:main`.
+- Server deploy source: `https://raw.githubusercontent.com/horacioh/seed/main/ops`.
+- Custom images:
+  - Web: `ghcr.io/horacioh/seed-web:main` and `ghcr.io/horacioh/seed-web:sha-<sha>`.
+  - Daemon/site: `ghcr.io/horacioh/seed-site:main` and `ghcr.io/horacioh/seed-site:sha-<sha>`.
+
+`main` is the moving deployment channel. `sha-<sha>` tags are immutable rollback targets.
+
+## Daily upstream rebase
+
+Run from a clean local checkout of the fork:
+
+```sh
+git fetch upstream main
+git fetch origin main
+git switch main
+git rebase upstream/main
+git push --force-with-lease origin main
+```
+
+If rebase conflicts occur, stop and resolve them manually. Do not push a conflicted or unverified rebase. After the push,
+confirm the image build workflow publishes fresh `main` and SHA tags before expecting servers to update.
+
+Caveat: branch protection that blocks force pushes is incompatible with this exact rebase model. Either allow
+administrator/maintainer force-with-lease pushes for `main`, or use a separate deployment branch with matching build and
+server configuration.
+
+## Server bootstrap or migration
+
+Use the Horacio fork as the deploy source, not the upstream hosted installer:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/horacioh/seed/main/ops/deploy.sh | \
+  SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/main/ops sh
+```
+
+For an existing install, first take a backup, then re-run the fork bootstrap. The deploy script stores state under the
+seed directory, installs/updates `/usr/local/bin/seed-deploy` when allowed, detects legacy installs, writes
+`config.json`, and runs the deploy wizard when configuration is missing or `--reconfigure` is requested.
+
+```sh
+seed-deploy backup
+SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/main/ops seed-deploy deploy --reconfigure
+```
+
+When prompted for a custom Docker image tag, use `main` for the normal moving channel. Full GHCR image refs are
+stored in `config.json` as shown below.
+
+## Custom image references
+
+The server compose file must run the GHCR images, not the upstream defaults. Using the fork deploy source alone is not
+enough if that branch's `ops/docker-compose.yml` still references `seedhypermedia/*`; verify the raw compose file before
+rollout.
+
+Required image refs:
+
+```text
+ghcr.io/horacioh/seed-web:main
+ghcr.io/horacioh/seed-site:main
+```
+
+For rollback or pinned deploys, use matching SHA tags:
+
+```text
+ghcr.io/horacioh/seed-web:sha-<sha>
+ghcr.io/horacioh/seed-site:sha-<sha>
+```
+
+Persist these refs in the server config. After bootstrap or reconfigure, inspect and edit `config.json` if needed:
+
+```sh
+seed-deploy config
+sudo ${EDITOR:-vi} /opt/seed/config.json
+```
+
+The relevant fields should be:
+
+```json
+{
+  "deploy_url": "https://raw.githubusercontent.com/horacioh/seed/main/ops",
+  "compose_url": "https://raw.githubusercontent.com/horacioh/seed/main/ops/docker-compose.yml",
+  "release_channel": "main",
+  "web_image": "ghcr.io/horacioh/seed-web:main",
+  "site_image": "ghcr.io/horacioh/seed-site:main"
+}
+```
+
+Keep web and site on the same tag. Mixing SHAs can produce API or data compatibility surprises.
+
+Private registry caveat: if the GHCR packages are private, the server must authenticate before pulling:
+
+```sh
+echo "$GHCR_TOKEN" | docker login ghcr.io -u horacioh --password-stdin
+```
+
+Use a token with package read permission. Public GHCR packages do not need this step.
+
+## Automatic and manual deploys
+
+Install cron after bootstrap if it is not already present:
+
+```sh
+seed-deploy cron
+```
+
+Current deploy tooling installs a `# seed-deploy` cron entry that runs `upgrade` and `deploy` every 10 minutes, plus a
+`# seed-cleanup` entry that prunes old Docker images hourly. Check the exact schedule on the server with:
+
+```sh
+crontab -l | grep 'seed-'
+```
+
+Manual deploy:
+
+```sh
+SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/main/ops seed-deploy deploy
+```
+
+Reconfigure deploy settings:
+
+```sh
+SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/main/ops seed-deploy deploy --reconfigure
+```
+
+Start, stop, restart, and logs:
+
+```sh
+seed-deploy start
+seed-deploy stop
+seed-deploy restart
+seed-deploy logs web
+seed-deploy logs daemon
+seed-deploy logs proxy
+```
+
+## Rollback to a SHA tag
+
+1. Pick a known-good image SHA tag that exists for both images.
+2. Reconfigure the server to that tag:
+
+   ```sh
+   SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/main/ops seed-deploy deploy --reconfigure
+   ```
+
+3. Edit `/opt/seed/config.json` so `web_image` and `site_image` point at matching `sha-<sha>` tags.
+4. Deploy and verify:
+
+   ```sh
+   seed-deploy deploy
+   seed-deploy doctor
+   docker inspect seed-web --format '{{.Config.Image}}'
+   docker inspect seed-daemon --format '{{.Config.Image}}'
+   ```
+
+Return to the moving channel by reconfiguring back to `main`.
+
+## Verification
+
+After bootstrap, rebase, deploy, or rollback:
+
+```sh
+seed-deploy doctor
+seed-deploy config
+docker inspect seed-web --format '{{.State.Status}} {{.Config.Image}} {{.State.StartedAt}}'
+docker inspect seed-daemon --format '{{.State.Status}} {{.Config.Image}} {{.State.StartedAt}}'
+docker inspect seed-proxy --format '{{.State.Status}} {{.Config.Image}} {{.State.StartedAt}}'
+seed-deploy logs web
+seed-deploy logs daemon
+seed-deploy logs proxy
+```
+
+Expected:
+
+- `seed-web`, `seed-daemon`, and `seed-proxy` are `running`.
+- `seed-web` uses `ghcr.io/horacioh/seed-web:<tag>`.
+- `seed-daemon` uses `ghcr.io/horacioh/seed-site:<tag>`.
+- `seed-deploy doctor` has no unexpected env, disk, network, image, or cron failures.
+- Logs show normal startup and no repeated crash/restart loop.
+
+If `docker inspect` reports upstream `seedhypermedia/*` images, the server is not using the intended custom image refs;
+fix the deploy source/configuration and redeploy before considering the rollout complete.

--- a/ops/deploy.test.ts
+++ b/ops/deploy.test.ts
@@ -31,12 +31,16 @@ import {
   checkContainersHealthy,
   getContainerImages,
   checkForNewImages,
+  expectedServiceImages,
+  rollbackImageTargets,
+  rollbackTagRefs,
   checkGpuAcceleration,
   ensureSeedDir,
   environmentPresets,
   configWarnings,
   DEFAULT_RELEASE_CHANNEL,
   validateDockerImageTag,
+  validateDockerImageRef,
   buildCrontab,
   parseArgs,
   extractSeedCronLines,
@@ -311,6 +315,22 @@ describe('validateDockerImageTag', () => {
   })
 })
 
+describe('validateDockerImageRef', () => {
+  test('accepts full image refs with registries and tags', () => {
+    expect(validateDockerImageRef('ghcr.io/horacioh/seed-web:main')).toBeUndefined()
+    expect(validateDockerImageRef('ghcr.io/horacioh/seed-site:sha-abcdef123456')).toBeUndefined()
+    expect(validateDockerImageRef('registry.example.com:5000/ns/image:v1.2.3')).toBeUndefined()
+  })
+
+  test('rejects invalid full image refs', () => {
+    expect(validateDockerImageRef('')).toBeUndefined()
+    expect(validateDockerImageRef(' ghcr.io/horacioh/seed-web:main')).toContain('spaces')
+    expect(validateDockerImageRef('ghcr.io/horacioh/seed-web')).toContain('tag')
+    expect(validateDockerImageRef('ghcr.io/horacioh/seed-web:bad tag')).toContain('spaces')
+    expect(validateDockerImageRef('ghcr.io/horacioh/seed-web:-bad')).toContain('tag')
+  })
+})
+
 // ---------------------------------------------------------------------------
 // generateCaddyfile
 // ---------------------------------------------------------------------------
@@ -569,6 +589,25 @@ describe('buildComposeEnv', () => {
     )
   })
 
+  test('reflects configured full image references', () => {
+    const env = buildComposeEnv(
+      makeTestConfig({
+        web_image: 'ghcr.io/horacioh/seed-web:main',
+        site_image: 'ghcr.io/horacioh/seed-site:main',
+      }),
+      makePaths(),
+    )
+
+    expect(env).toContain('SEED_WEB_IMAGE="ghcr.io/horacioh/seed-web:main"')
+    expect(env).toContain('SEED_SITE_IMAGE="ghcr.io/horacioh/seed-site:main"')
+  })
+
+  test('omits full image references when official defaults are used', () => {
+    const env = buildComposeEnv(makeTestConfig(), makePaths())
+    expect(env).not.toContain('SEED_WEB_IMAGE=')
+    expect(env).not.toContain('SEED_SITE_IMAGE=')
+  })
+
   test('reflects log level', () => {
     expect(
       buildComposeEnv(
@@ -686,16 +725,26 @@ describe('config read/write/exists', () => {
   })
 
   test('config preserves all SeedConfig fields', async () => {
-    await writeConfig(makeTestConfig(), paths)
+    await writeConfig(
+      makeTestConfig({
+        deploy_url: 'https://raw.githubusercontent.com/horacioh/seed/main/ops',
+        web_image: 'ghcr.io/horacioh/seed-web:main',
+        site_image: 'ghcr.io/horacioh/seed-site:main',
+      }),
+      paths,
+    )
     const loaded = await readConfig(paths)
     const expectedKeys: (keyof SeedConfig)[] = [
       'domain',
       'email',
+      'deploy_url',
       'compose_url',
       'compose_sha',
       'compose_envs',
       'environment',
       'release_channel',
+      'web_image',
+      'site_image',
       'testnet',
       'link_secret',
       'analytics',
@@ -705,6 +754,91 @@ describe('config read/write/exists', () => {
     for (const key of expectedKeys) {
       expect(loaded).toHaveProperty(key)
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// docker-compose image refs
+// ---------------------------------------------------------------------------
+
+describe('docker-compose image refs', () => {
+  test('web and site images can be overridden by full image refs while preserving defaults', async () => {
+    const compose = await readFile(join(import.meta.dir, 'docker-compose.yml'), 'utf-8')
+
+    expect(compose).toContain('image: ${SEED_WEB_IMAGE:-seedhypermedia/web:${SEED_SITE_TAG:-latest}}')
+    expect(compose).toContain('image: ${SEED_SITE_IMAGE:-seedhypermedia/site:${SEED_SITE_TAG:-latest}}')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// expectedServiceImages
+// ---------------------------------------------------------------------------
+
+describe('expectedServiceImages', () => {
+  test('uses official image refs for default channels', () => {
+    expect(expectedServiceImages(makeTestConfig({release_channel: 'dev'}))).toEqual([
+      {container: 'seed-web', expectedImage: 'seedhypermedia/web:dev'},
+      {container: 'seed-daemon', expectedImage: 'seedhypermedia/site:dev'},
+    ])
+  })
+
+  test('uses configured full image refs when present', () => {
+    expect(
+      expectedServiceImages(
+        makeTestConfig({
+          web_image: 'ghcr.io/horacioh/seed-web:main',
+          site_image: 'ghcr.io/horacioh/seed-site:main',
+        }),
+      ),
+    ).toEqual([
+      {container: 'seed-web', expectedImage: 'ghcr.io/horacioh/seed-web:main'},
+      {container: 'seed-daemon', expectedImage: 'ghcr.io/horacioh/seed-site:main'},
+    ])
+  })
+})
+
+describe('rollbackImageTargets', () => {
+  test('retags official rollback images to the configured release channel', () => {
+    expect(rollbackImageTargets(makeTestConfig({release_channel: 'dev'}))).toEqual([
+      {base: 'seedhypermedia/web', target: 'seedhypermedia/web:dev'},
+      {base: 'seedhypermedia/site', target: 'seedhypermedia/site:dev'},
+    ])
+  })
+
+  test('retags custom rollback images to the exact full image refs compose uses', () => {
+    expect(
+      rollbackImageTargets(
+        makeTestConfig({
+          web_image: 'ghcr.io/horacioh/seed-web:sha-abcdef123456',
+          site_image: 'ghcr.io/horacioh/seed-site:sha-abcdef123456',
+        }),
+      ),
+    ).toEqual([
+      {base: 'ghcr.io/horacioh/seed-web', target: 'ghcr.io/horacioh/seed-web:sha-abcdef123456'},
+      {base: 'ghcr.io/horacioh/seed-site', target: 'ghcr.io/horacioh/seed-site:sha-abcdef123456'},
+    ])
+  })
+})
+
+describe('rollbackTagRefs', () => {
+  test('tags current and configured image bases when migrating to custom refs', () => {
+    expect(
+      rollbackTagRefs(
+        'seed-web',
+        'seedhypermedia/web:latest',
+        makeTestConfig({web_image: 'ghcr.io/horacioh/seed-web:main'}),
+      ),
+    ).toEqual(['seedhypermedia/web:rollback', 'ghcr.io/horacioh/seed-web:rollback'])
+  })
+
+  test('dedupes rollback tags when image base is unchanged', () => {
+    expect(rollbackTagRefs('seed-web', 'seedhypermedia/web:dev', makeTestConfig({release_channel: 'dev'}))).toEqual([
+      'seedhypermedia/web:rollback',
+    ])
+  })
+
+  test('only tags current base for unmanaged containers', () => {
+    expect(rollbackTagRefs('seed-proxy', 'caddy:2', makeTestConfig())).toEqual(['caddy:rollback'])
   })
 })
 
@@ -895,6 +1029,32 @@ describe('checkForNewImages', () => {
       "image inspect seedhypermedia/site:feature-branch --format '{{.Id}}'": 'sha256:ccc',
     })
     const result = await checkForNewImages({...config, release_channel: 'feature-branch'}, paths, shell)
+    expect(result).toBe(false)
+  })
+
+  test('uses configured full image refs when cron checks for updates', async () => {
+    const shell = makeMockShell({
+      "inspect seed-proxy --format '{{.Image}}'": 'sha256:aaa',
+      "inspect seed-web --format '{{.Image}}'": 'sha256:bbb',
+      "inspect seed-daemon --format '{{.Image}}'": 'sha256:ccc',
+      'docker compose': '',
+      "inspect seed-proxy --format '{{.Config.Image}}'": 'caddy:2',
+      "inspect seed-web --format '{{.Config.Image}}'": 'ghcr.io/horacioh/seed-web:main',
+      "inspect seed-daemon --format '{{.Config.Image}}'": 'ghcr.io/horacioh/seed-site:main',
+      "image inspect caddy:2 --format '{{.Id}}'": 'sha256:aaa',
+      "image inspect ghcr.io/horacioh/seed-web:main --format '{{.Id}}'": 'sha256:bbb',
+      "image inspect ghcr.io/horacioh/seed-site:main --format '{{.Id}}'": 'sha256:ccc',
+    })
+
+    const result = await checkForNewImages(
+      {
+        ...config,
+        web_image: 'ghcr.io/horacioh/seed-web:main',
+        site_image: 'ghcr.io/horacioh/seed-site:main',
+      },
+      paths,
+      shell,
+    )
     expect(result).toBe(false)
   })
 })
@@ -1721,6 +1881,12 @@ describe('getDeployScriptUrl', () => {
     const url = await getDeployScriptUrl('latest')
     // Should be either a GitHub release asset URL or the legacy fallback
     expect(url).toContain('deploy.js')
+  })
+
+  test('uses configured deploy source before official release channels', async () => {
+    const url = await getDeployScriptUrl('main', 'https://raw.githubusercontent.com/horacioh/seed/main/ops')
+
+    expect(url).toBe('https://raw.githubusercontent.com/horacioh/seed/main/ops/dist/deploy.js')
   })
 
   test('returns constants with expected values', () => {

--- a/ops/deploy.ts
+++ b/ops/deploy.ts
@@ -48,6 +48,27 @@ export const NOTIFY_SERVICE_HOST = 'https://notify.seed.hyper.media'
 export const LIGHTNING_URL_MAINNET = 'https://ln.seed.hyper.media'
 export const LIGHTNING_URL_TESTNET = 'https://ln.testnet.seed.hyper.media'
 
+function currentDeployUrl(): string {
+  return getOpsBaseUrl().replace(/\/+$/, '')
+}
+
+function currentComposeUrl(): string {
+  return `${currentDeployUrl()}/docker-compose.yml`
+}
+
+function configuredDeployUrl(existing?: SeedConfig): string {
+  if (process.env.SEED_DEPLOY_URL || process.env.SEED_REPO_URL) return currentDeployUrl()
+  if (existing?.deploy_url) return existing.deploy_url.replace(/\/+$/, '')
+  return currentDeployUrl()
+}
+
+function configuredComposeUrl(existing?: SeedConfig): string {
+  if (process.env.SEED_DEPLOY_URL || process.env.SEED_REPO_URL) return currentComposeUrl()
+  if (existing?.deploy_url) return `${existing.deploy_url.replace(/\/+$/, '')}/docker-compose.yml`
+  if (existing?.compose_url) return existing.compose_url
+  return currentComposeUrl()
+}
+
 // deploy.js distribution URLs.
 // Production: attached as a GitHub Release asset on each tagged release.
 // Dev: uploaded to S3 alongside dev Docker images on each main push.
@@ -60,7 +81,11 @@ export const DEV_DEPLOY_SCRIPT_URL = 'https://seedappdev.s3.eu-west-2.amazonaws.
  * - "dev": fetches from S3 dev bucket.
  * - Falls back to ops/dist/deploy.js via raw GitHub if release has no asset.
  */
-export async function getDeployScriptUrl(releaseChannel: string): Promise<string> {
+export async function getDeployScriptUrl(releaseChannel: string, deployUrl?: string): Promise<string> {
+  if (deployUrl) {
+    return `${deployUrl.replace(/\/+$/, '')}/dist/deploy.js`
+  }
+
   if (releaseChannel === 'dev') {
     return DEV_DEPLOY_SCRIPT_URL
   }
@@ -191,6 +216,8 @@ export interface SeedConfig {
   domain: string
   /** Contact email — used to reach the operator about security updates */
   email: string
+  /** URL to fetch deploy assets from, usually the raw GitHub ops directory */
+  deploy_url?: string
   /** URL to fetch the docker-compose.yml from */
   compose_url: string
   /** SHA-256 of the last deployed docker-compose.yml — used to detect changes */
@@ -212,6 +239,10 @@ export interface SeedConfig {
    * Orthogonal to `testnet`: the image channel never changes the P2P network.
    */
   release_channel: 'latest' | 'dev' | string
+  /** Full Docker image ref for the web service; overrides release_channel when set */
+  web_image?: string
+  /** Full Docker image ref for the daemon/site service; overrides release_channel when set */
+  site_image?: string
   /**
    * Whether to connect to the testnet (devnet) P2P network instead of mainnet.
    * This is the sole source of truth for the network and is chosen explicitly
@@ -285,6 +316,26 @@ export function validateDockerImageTag(tag: string): string | undefined {
   if (!/^[A-Za-z0-9_][A-Za-z0-9_.-]*$/.test(tag)) {
     return 'Use a Docker image tag: letters, numbers, _, . or -; must start with a letter, number or _'
   }
+}
+
+/** Validate an optional full Docker image reference entered at the setup/reconfigure boundary. */
+export function validateDockerImageRef(ref: string): string | undefined {
+  if (!ref) return undefined
+  if (ref.trim() !== ref) return 'Remove leading or trailing spaces'
+  if (/\s/.test(ref)) return 'Docker image refs cannot contain spaces'
+
+  const lastSlash = ref.lastIndexOf('/')
+  const lastColon = ref.lastIndexOf(':')
+  if (lastColon <= lastSlash) return 'Include an explicit image tag, for example ghcr.io/horacioh/seed-web:main'
+
+  const name = ref.slice(0, lastColon)
+  const tag = ref.slice(lastColon + 1)
+  if (!name || !/^[A-Za-z0-9][A-Za-z0-9._:/-]*$/.test(name) || name.includes('://')) {
+    return 'Use a Docker image ref such as ghcr.io/horacioh/seed-web:main'
+  }
+
+  const tagError = validateDockerImageTag(tag)
+  if (tagError) return `Invalid image tag: ${tagError}`
 }
 
 async function promptReleaseChannel(options: {
@@ -766,6 +817,18 @@ async function runMigrationWizard(old: OldInstallInfo, paths: DeployPaths, shell
         promptReleaseChannel({
           initialTag: old.imageTag,
         }),
+      web_image: () =>
+        p.text({
+          message: 'Full web image ref (optional)',
+          placeholder: 'ghcr.io/horacioh/seed-web:main',
+          validate: validateDockerImageRef,
+        }),
+      site_image: () =>
+        p.text({
+          message: 'Full site/daemon image ref (optional)',
+          placeholder: 'ghcr.io/horacioh/seed-site:main',
+          validate: validateDockerImageRef,
+        }),
       log_level: () =>
         p.select({
           message: 'Log level',
@@ -823,7 +886,8 @@ async function runMigrationWizard(old: OldInstallInfo, paths: DeployPaths, shell
   const config: SeedConfig = {
     domain: answers.domain as string,
     email: (answers.email as string) || '',
-    compose_url: DEFAULT_COMPOSE_URL,
+    deploy_url: currentDeployUrl(),
+    compose_url: currentComposeUrl(),
     compose_sha: '',
     compose_env_sha: '',
     compose_envs: {
@@ -831,6 +895,8 @@ async function runMigrationWizard(old: OldInstallInfo, paths: DeployPaths, shell
     },
     environment: env,
     release_channel: answers.release_channel as string,
+    web_image: (answers.web_image as string) || undefined,
+    site_image: (answers.site_image as string) || undefined,
     testnet,
     link_secret: secret,
     analytics: old.trafficStats,
@@ -925,6 +991,20 @@ async function runFreshWizard(paths: DeployPaths, existing?: SeedConfig): Promis
         promptReleaseChannel({
           initialTag: existing?.release_channel,
         }),
+      web_image: () =>
+        p.text({
+          message: 'Full web image ref (optional)',
+          initialValue: existing?.web_image,
+          placeholder: 'ghcr.io/horacioh/seed-web:main',
+          validate: validateDockerImageRef,
+        }),
+      site_image: () =>
+        p.text({
+          message: 'Full site/daemon image ref (optional)',
+          initialValue: existing?.site_image,
+          placeholder: 'ghcr.io/horacioh/seed-site:main',
+          validate: validateDockerImageRef,
+        }),
       log_level: () =>
         p.select({
           message: 'Log level for Seed services',
@@ -975,7 +1055,8 @@ async function runFreshWizard(paths: DeployPaths, existing?: SeedConfig): Promis
   const config: SeedConfig = {
     domain: answers.domain as string,
     email: (answers.email as string) || '',
-    compose_url: DEFAULT_COMPOSE_URL,
+    deploy_url: configuredDeployUrl(existing),
+    compose_url: configuredComposeUrl(existing),
     compose_sha: existing?.compose_sha ?? '',
     compose_env_sha: existing?.compose_env_sha ?? '',
     compose_envs: {
@@ -983,6 +1064,8 @@ async function runFreshWizard(paths: DeployPaths, existing?: SeedConfig): Promis
     },
     environment: env,
     release_channel: answers.release_channel as string,
+    web_image: (answers.web_image as string) || undefined,
+    site_image: (answers.site_image as string) || undefined,
     testnet,
     link_secret: secret,
     // TODO: When re-enabling wizard analytics, publish a post/changelog
@@ -997,6 +1080,8 @@ async function runFreshWizard(paths: DeployPaths, existing?: SeedConfig): Promis
     ['email', config.email],
     ['network', config.testnet ? 'testnet (devnet)' : 'mainnet'],
     ['release_channel', config.release_channel],
+    ['web_image', config.web_image || '(default)'],
+    ['site_image', config.site_image || '(default)'],
     ['log_level', config.compose_envs.LOG_LEVEL],
     ['gateway', String(config.gateway)],
   ]
@@ -1006,6 +1091,8 @@ async function runFreshWizard(paths: DeployPaths, existing?: SeedConfig): Promis
         email: existing.email,
         network: existing.testnet ? 'testnet (devnet)' : 'mainnet',
         release_channel: existing.release_channel,
+        web_image: existing.web_image || '(default)',
+        site_image: existing.site_image || '(default)',
         log_level: existing.compose_envs?.LOG_LEVEL ?? 'info',
         gateway: String(existing.gateway),
       }
@@ -1083,6 +1170,40 @@ export async function getContainerImages(shell: ShellRunner): Promise<Map<string
     if (image) images.set(name, image)
   }
   return images
+}
+
+/** Return the expected Docker image refs for services managed by Seed compose. */
+export function expectedServiceImages(config: SeedConfig): Array<{container: string; expectedImage: string}> {
+  const tag = config.release_channel || DEFAULT_RELEASE_CHANNEL
+  return [
+    {container: 'seed-web', expectedImage: config.web_image || `seedhypermedia/web:${tag}`},
+    {container: 'seed-daemon', expectedImage: config.site_image || `seedhypermedia/site:${tag}`},
+  ]
+}
+
+function imageBase(ref: string): string {
+  const lastSlash = ref.lastIndexOf('/')
+  const lastColon = ref.lastIndexOf(':')
+  if (lastColon > lastSlash) return ref.slice(0, lastColon)
+  return ref
+}
+
+/** Return rollback tag sources and targets for the configured service image refs. */
+export function rollbackImageTargets(config: SeedConfig): Array<{base: string; target: string}> {
+  return expectedServiceImages(config).map(({expectedImage}) => ({
+    base: imageBase(expectedImage),
+    target: expectedImage,
+  }))
+}
+
+/** Return rollback tag refs to apply to a running image before deploying a new config. */
+export function rollbackTagRefs(container: string, runningImage: string, config: SeedConfig): string[] {
+  const tags = new Set<string>([`${imageBase(runningImage)}:rollback`])
+  const expected = expectedServiceImages(config).find((image) => image.container === container)
+  if (expected) {
+    tags.add(`${imageBase(expected.expectedImage)}:rollback`)
+  }
+  return [...tags]
 }
 
 /**
@@ -1172,6 +1293,13 @@ export function buildComposeEnv(config: SeedConfig, paths: DeployPaths): string 
     SEED_SITE_MONITORING_WORKDIR: join(paths.seedDir, 'monitoring'),
   }
 
+  if (config.web_image) {
+    vars.SEED_WEB_IMAGE = config.web_image
+  }
+  if (config.site_image) {
+    vars.SEED_SITE_IMAGE = config.site_image
+  }
+
   return Object.entries(vars)
     .map(([k, v]) => `${k}="${v}"`)
     .join(' ')
@@ -1219,14 +1347,13 @@ async function rollback(
   shell: ShellRunner,
 ): Promise<void> {
   log('Deployment failed — rolling back to previous images...')
-  const tag = config.release_channel || 'latest'
 
-  // Re-tag rollback images back to the release channel tag so compose uses them.
-  for (const base of ['seedhypermedia/site', 'seedhypermedia/web']) {
+  // Re-tag rollback images back to the exact image refs compose uses.
+  for (const {base, target} of rollbackImageTargets(config)) {
     const hasRollback = shell.runSafe(`docker image inspect ${base}:rollback >/dev/null 2>&1 && echo yes`)
     if (hasRollback === 'yes') {
-      shell.runSafe(`docker tag ${base}:rollback ${base}:${tag}`)
-      log(`  Restored ${base}:${tag} from rollback image`)
+      shell.runSafe(`docker tag ${base}:rollback ${target}`)
+      log(`  Restored ${target} from rollback image`)
     }
   }
 
@@ -1247,7 +1374,11 @@ async function rollback(
 // with the code already loaded in memory.
 // ---------------------------------------------------------------------------
 
-export async function selfUpdate(paths: DeployPaths, releaseChannel: string = 'latest'): Promise<void> {
+export async function selfUpdate(
+  paths: DeployPaths,
+  releaseChannel: string = 'latest',
+  deployUrl?: string,
+): Promise<void> {
   const scriptPath = join(paths.seedDir, 'deploy.js')
   const report = (msg: string) => {
     if (process.stdout.isTTY) {
@@ -1258,7 +1389,7 @@ export async function selfUpdate(paths: DeployPaths, releaseChannel: string = 'l
   }
 
   try {
-    const url = await getDeployScriptUrl(releaseChannel)
+    const url = await getDeployScriptUrl(releaseChannel, deployUrl)
     const response = await fetch(url)
     if (!response.ok) {
       report(`Upgrade: failed to fetch ${url}: ${response.status}`)
@@ -1310,7 +1441,11 @@ export async function deploy(config: SeedConfig, paths: DeployPaths, shell: Shel
   // Use env-based URL override when present (testing / branch builds),
   // otherwise fall back to the compose_url stored in config.json.
   const hasEnvOverride = process.env.SEED_DEPLOY_URL || process.env.SEED_REPO_URL
-  const composeUrl = hasEnvOverride ? `${getOpsBaseUrl()}/docker-compose.yml` : config.compose_url
+  const composeUrl = hasEnvOverride
+    ? `${getOpsBaseUrl()}/docker-compose.yml`
+    : config.deploy_url
+      ? `${config.deploy_url.replace(/\/+$/, '')}/docker-compose.yml`
+      : config.compose_url
   const composeResponse = await fetch(composeUrl)
   if (!composeResponse.ok) {
     spinner?.stop('Failed to fetch docker-compose.yml')
@@ -1419,8 +1554,9 @@ export async function deploy(config: SeedConfig, paths: DeployPaths, shell: Shel
   for (const [name, imageId] of previousImages) {
     const imageName = shell.runSafe(`docker inspect ${name} --format '{{.Config.Image}}' 2>/dev/null`)
     if (imageName) {
-      const base = imageName.split(':')[0]
-      shell.runSafe(`docker tag ${imageId} ${base}:rollback 2>/dev/null`)
+      for (const tagRef of rollbackTagRefs(name, imageName, config)) {
+        shell.runSafe(`docker tag ${imageId} ${tagRef} 2>/dev/null`)
+      }
     }
   }
 
@@ -1495,7 +1631,8 @@ export async function deploy(config: SeedConfig, paths: DeployPaths, shell: Shel
   await writeConfig(config, paths)
 
   // New images are healthy — remove rollback tags so old images can be pruned.
-  for (const base of ['seedhypermedia/site', 'seedhypermedia/web']) {
+  for (const {expectedImage} of expectedServiceImages(config)) {
+    const base = imageBase(expectedImage)
     shell.runSafe(`docker rmi ${base}:rollback 2>/dev/null`)
   }
 
@@ -1727,15 +1864,17 @@ async function cmdDeploy(paths: DeployPaths, shell: ShellRunner, reconfigure = f
 
 async function cmdUpgrade(paths: DeployPaths): Promise<void> {
   let releaseChannel = 'latest'
+  let deployUrl: string | undefined
   try {
     if (await configExists(paths)) {
       const config = await readConfig(paths)
       releaseChannel = config.release_channel
+      deployUrl = config.deploy_url
     }
   } catch {
     // If config can't be read, default to stable channel.
   }
-  await selfUpdate(paths, releaseChannel)
+  await selfUpdate(paths, releaseChannel, deployUrl)
 }
 
 async function cmdStop(paths: DeployPaths, shell: ShellRunner): Promise<void> {
@@ -1778,6 +1917,9 @@ async function cmdDoctor(paths: DeployPaths, shell: ShellRunner): Promise<void> 
     console.log(`  Domain:      ${config.domain}`)
     console.log(`  Network:     ${config.testnet ? 'Testnet (devnet)' : 'Mainnet'}`)
     console.log(`  Channel:     ${config.release_channel}`)
+    if (config.deploy_url) console.log(`  Deploy URL:  ${config.deploy_url}`)
+    if (config.web_image) console.log(`  Web image:   ${config.web_image}`)
+    if (config.site_image) console.log(`  Site image:  ${config.site_image}`)
     console.log(`  Gateway:     ${config.gateway ? 'Yes' : 'No'}`)
     console.log(`  Config:      ${paths.configPath}`)
     for (const warning of configWarnings(config)) {
@@ -1820,7 +1962,6 @@ async function cmdDoctor(paths: DeployPaths, shell: ShellRunner): Promise<void> 
 
   // Configuration sync — compare running container state against config
   if (config) {
-    const expectedTag = config.release_channel
     const expectedLightning = config.testnet ? LIGHTNING_URL_TESTNET : LIGHTNING_URL_MAINNET
     const expectedTestnetName = config.testnet ? 'dev' : ''
 
@@ -1842,10 +1983,7 @@ async function cmdDoctor(paths: DeployPaths, shell: ShellRunner): Promise<void> 
     }
 
     // Check image tags
-    const imageChecks: Array<{container: string; expectedImage: string}> = [
-      {container: 'seed-web', expectedImage: `seedhypermedia/web:${expectedTag}`},
-      {container: 'seed-daemon', expectedImage: `seedhypermedia/site:${expectedTag}`},
-    ]
+    const imageChecks = expectedServiceImages(config)
 
     let hasMismatch = false
     const mismatches: string[] = []

--- a/ops/dist/deploy.js
+++ b/ops/dist/deploy.js
@@ -833,9 +833,34 @@ var DEFAULT_COMPOSE_URL = `${OPS_BASE_URL}/docker-compose.yml`;
 var NOTIFY_SERVICE_HOST = "https://notify.seed.hyper.media";
 var LIGHTNING_URL_MAINNET = "https://ln.seed.hyper.media";
 var LIGHTNING_URL_TESTNET = "https://ln.testnet.seed.hyper.media";
+function currentDeployUrl() {
+  return getOpsBaseUrl().replace(/\/+$/, "");
+}
+function currentComposeUrl() {
+  return `${currentDeployUrl()}/docker-compose.yml`;
+}
+function configuredDeployUrl(existing) {
+  if (process.env.SEED_DEPLOY_URL || process.env.SEED_REPO_URL)
+    return currentDeployUrl();
+  if (existing?.deploy_url)
+    return existing.deploy_url.replace(/\/+$/, "");
+  return currentDeployUrl();
+}
+function configuredComposeUrl(existing) {
+  if (process.env.SEED_DEPLOY_URL || process.env.SEED_REPO_URL)
+    return currentComposeUrl();
+  if (existing?.deploy_url)
+    return `${existing.deploy_url.replace(/\/+$/, "")}/docker-compose.yml`;
+  if (existing?.compose_url)
+    return existing.compose_url;
+  return currentComposeUrl();
+}
 var GITHUB_RELEASES_API = "https://api.github.com/repos/seed-hypermedia/seed/releases/latest";
 var DEV_DEPLOY_SCRIPT_URL = "https://seedappdev.s3.eu-west-2.amazonaws.com/dev/latest/deploy.js";
-async function getDeployScriptUrl(releaseChannel) {
+async function getDeployScriptUrl(releaseChannel, deployUrl) {
+  if (deployUrl) {
+    return `${deployUrl.replace(/\/+$/, "")}/dist/deploy.js`;
+  }
   if (releaseChannel === "dev") {
     return DEV_DEPLOY_SCRIPT_URL;
   }
@@ -948,6 +973,26 @@ function validateDockerImageTag(tag) {
   if (!/^[A-Za-z0-9_][A-Za-z0-9_.-]*$/.test(tag)) {
     return "Use a Docker image tag: letters, numbers, _, . or -; must start with a letter, number or _";
   }
+}
+function validateDockerImageRef(ref) {
+  if (!ref)
+    return;
+  if (ref.trim() !== ref)
+    return "Remove leading or trailing spaces";
+  if (/\s/.test(ref))
+    return "Docker image refs cannot contain spaces";
+  const lastSlash = ref.lastIndexOf("/");
+  const lastColon = ref.lastIndexOf(":");
+  if (lastColon <= lastSlash)
+    return "Include an explicit image tag, for example ghcr.io/horacioh/seed-web:main";
+  const name = ref.slice(0, lastColon);
+  const tag = ref.slice(lastColon + 1);
+  if (!name || !/^[A-Za-z0-9][A-Za-z0-9._:/-]*$/.test(name) || name.includes("://")) {
+    return "Use a Docker image ref such as ghcr.io/horacioh/seed-web:main";
+  }
+  const tagError = validateDockerImageTag(tag);
+  if (tagError)
+    return `Invalid image tag: ${tagError}`;
 }
 async function promptReleaseChannel(options) {
   const initialTag = options.initialTag ?? DEFAULT_RELEASE_CHANNEL;
@@ -1279,6 +1324,16 @@ async function runMigrationWizard(old, paths, shell) {
     release_channel: () => promptReleaseChannel({
       initialTag: old.imageTag
     }),
+    web_image: () => ue({
+      message: "Full web image ref (optional)",
+      placeholder: "ghcr.io/horacioh/seed-web:main",
+      validate: validateDockerImageRef
+    }),
+    site_image: () => ue({
+      message: "Full site/daemon image ref (optional)",
+      placeholder: "ghcr.io/horacioh/seed-site:main",
+      validate: validateDockerImageRef
+    }),
     log_level: () => de({
       message: "Log level",
       initialValue: old.logLevel ?? "info",
@@ -1329,7 +1384,8 @@ async function runMigrationWizard(old, paths, shell) {
   const config = {
     domain: answers.domain,
     email: answers.email || "",
-    compose_url: DEFAULT_COMPOSE_URL,
+    deploy_url: currentDeployUrl(),
+    compose_url: currentComposeUrl(),
     compose_sha: "",
     compose_env_sha: "",
     compose_envs: {
@@ -1337,6 +1393,8 @@ async function runMigrationWizard(old, paths, shell) {
     },
     environment: env,
     release_channel: answers.release_channel,
+    web_image: answers.web_image || undefined,
+    site_image: answers.site_image || undefined,
     testnet,
     link_secret: secret,
     analytics: old.trafficStats,
@@ -1411,6 +1469,18 @@ async function runFreshWizard(paths, existing) {
     release_channel: () => promptReleaseChannel({
       initialTag: existing?.release_channel
     }),
+    web_image: () => ue({
+      message: "Full web image ref (optional)",
+      initialValue: existing?.web_image,
+      placeholder: "ghcr.io/horacioh/seed-web:main",
+      validate: validateDockerImageRef
+    }),
+    site_image: () => ue({
+      message: "Full site/daemon image ref (optional)",
+      initialValue: existing?.site_image,
+      placeholder: "ghcr.io/horacioh/seed-site:main",
+      validate: validateDockerImageRef
+    }),
     log_level: () => de({
       message: "Log level for Seed services",
       initialValue: existing?.compose_envs?.LOG_LEVEL ?? "info",
@@ -1454,7 +1524,8 @@ async function runFreshWizard(paths, existing) {
   const config = {
     domain: answers.domain,
     email: answers.email || "",
-    compose_url: DEFAULT_COMPOSE_URL,
+    deploy_url: configuredDeployUrl(existing),
+    compose_url: configuredComposeUrl(existing),
     compose_sha: existing?.compose_sha ?? "",
     compose_env_sha: existing?.compose_env_sha ?? "",
     compose_envs: {
@@ -1462,6 +1533,8 @@ async function runFreshWizard(paths, existing) {
     },
     environment: env,
     release_channel: answers.release_channel,
+    web_image: answers.web_image || undefined,
+    site_image: answers.site_image || undefined,
     testnet,
     link_secret: secret,
     analytics: existing?.analytics ?? false,
@@ -1473,6 +1546,8 @@ async function runFreshWizard(paths, existing) {
     ["email", config.email],
     ["network", config.testnet ? "testnet (devnet)" : "mainnet"],
     ["release_channel", config.release_channel],
+    ["web_image", config.web_image || "(default)"],
+    ["site_image", config.site_image || "(default)"],
     ["log_level", config.compose_envs.LOG_LEVEL],
     ["gateway", String(config.gateway)]
   ];
@@ -1481,6 +1556,8 @@ async function runFreshWizard(paths, existing) {
     email: existing.email,
     network: existing.testnet ? "testnet (devnet)" : "mainnet",
     release_channel: existing.release_channel,
+    web_image: existing.web_image || "(default)",
+    site_image: existing.site_image || "(default)",
     log_level: existing.compose_envs?.LOG_LEVEL ?? "info",
     gateway: String(existing.gateway)
   } : undefined;
@@ -1544,6 +1621,34 @@ async function getContainerImages(shell) {
       images.set(name, image);
   }
   return images;
+}
+function expectedServiceImages(config) {
+  const tag = config.release_channel || DEFAULT_RELEASE_CHANNEL;
+  return [
+    { container: "seed-web", expectedImage: config.web_image || `seedhypermedia/web:${tag}` },
+    { container: "seed-daemon", expectedImage: config.site_image || `seedhypermedia/site:${tag}` }
+  ];
+}
+function imageBase(ref) {
+  const lastSlash = ref.lastIndexOf("/");
+  const lastColon = ref.lastIndexOf(":");
+  if (lastColon > lastSlash)
+    return ref.slice(0, lastColon);
+  return ref;
+}
+function rollbackImageTargets(config) {
+  return expectedServiceImages(config).map(({ expectedImage }) => ({
+    base: imageBase(expectedImage),
+    target: expectedImage
+  }));
+}
+function rollbackTagRefs(container, runningImage, config) {
+  const tags = new Set([`${imageBase(runningImage)}:rollback`]);
+  const expected = expectedServiceImages(config).find((image) => image.container === container);
+  if (expected) {
+    tags.add(`${imageBase(expected.expectedImage)}:rollback`);
+  }
+  return [...tags];
 }
 async function checkForNewImages(config, paths, shell) {
   const env = buildComposeEnv(config, paths);
@@ -1614,6 +1719,12 @@ function buildComposeEnv(config, paths) {
     NOTIFY_SERVICE_HOST,
     SEED_SITE_MONITORING_WORKDIR: join(paths.seedDir, "monitoring")
   };
+  if (config.web_image) {
+    vars.SEED_WEB_IMAGE = config.web_image;
+  }
+  if (config.site_image) {
+    vars.SEED_SITE_IMAGE = config.site_image;
+  }
   return Object.entries(vars).map(([k3, v3]) => `${k3}="${v3}"`).join(" ");
 }
 function getWorkspaceDirs(paths) {
@@ -1643,12 +1754,11 @@ async function ensureSeedDir(paths, shell) {
 }
 async function rollback(previousImages, config, paths, shell) {
   log("Deployment failed \u2014 rolling back to previous images...");
-  const tag = config.release_channel || "latest";
-  for (const base of ["seedhypermedia/site", "seedhypermedia/web"]) {
+  for (const { base, target } of rollbackImageTargets(config)) {
     const hasRollback = shell.runSafe(`docker image inspect ${base}:rollback >/dev/null 2>&1 && echo yes`);
     if (hasRollback === "yes") {
-      shell.runSafe(`docker tag ${base}:rollback ${base}:${tag}`);
-      log(`  Restored ${base}:${tag} from rollback image`);
+      shell.runSafe(`docker tag ${base}:rollback ${target}`);
+      log(`  Restored ${target} from rollback image`);
     }
   }
   for (const [name] of previousImages) {
@@ -1660,7 +1770,7 @@ async function rollback(previousImages, config, paths, shell) {
   shell.runSafe(`${env} docker compose -f ${paths.composePath} up -d --quiet-pull 2>&1`);
   log("Rollback complete. Check container status with: docker ps");
 }
-async function selfUpdate(paths, releaseChannel = "latest") {
+async function selfUpdate(paths, releaseChannel = "latest", deployUrl) {
   const scriptPath = join(paths.seedDir, "deploy.js");
   const report = (msg) => {
     if (process.stdout.isTTY) {
@@ -1670,7 +1780,7 @@ async function selfUpdate(paths, releaseChannel = "latest") {
     }
   };
   try {
-    const url = await getDeployScriptUrl(releaseChannel);
+    const url = await getDeployScriptUrl(releaseChannel, deployUrl);
     const response = await fetch(url);
     if (!response.ok) {
       report(`Upgrade: failed to fetch ${url}: ${response.status}`);
@@ -1711,7 +1821,7 @@ async function deploy(config, paths, shell) {
   spinner?.start("Fetching docker-compose.yml...");
   step("Fetching docker-compose.yml...");
   const hasEnvOverride = process.env.SEED_DEPLOY_URL || process.env.SEED_REPO_URL;
-  const composeUrl = hasEnvOverride ? `${getOpsBaseUrl()}/docker-compose.yml` : config.compose_url;
+  const composeUrl = hasEnvOverride ? `${getOpsBaseUrl()}/docker-compose.yml` : config.deploy_url ? `${config.deploy_url.replace(/\/+$/, "")}/docker-compose.yml` : config.compose_url;
   const composeResponse = await fetch(composeUrl);
   if (!composeResponse.ok) {
     spinner?.stop("Failed to fetch docker-compose.yml");
@@ -1803,8 +1913,9 @@ async function deploy(config, paths, shell) {
   for (const [name, imageId] of previousImages) {
     const imageName = shell.runSafe(`docker inspect ${name} --format '{{.Config.Image}}' 2>/dev/null`);
     if (imageName) {
-      const base = imageName.split(":")[0];
-      shell.runSafe(`docker tag ${imageId} ${base}:rollback 2>/dev/null`);
+      for (const tagRef of rollbackTagRefs(name, imageName, config)) {
+        shell.runSafe(`docker tag ${imageId} ${tagRef} 2>/dev/null`);
+      }
     }
   }
   const env = buildComposeEnv(config, paths);
@@ -1857,7 +1968,8 @@ async function deploy(config, paths, shell) {
   config.compose_env_sha = envSha;
   config.last_script_run = new Date().toISOString();
   await writeConfig(config, paths);
-  for (const base of ["seedhypermedia/site", "seedhypermedia/web"]) {
+  for (const { expectedImage } of expectedServiceImages(config)) {
+    const base = imageBase(expectedImage);
     shell.runSafe(`docker rmi ${base}:rollback 2>/dev/null`);
   }
   step("Cleaning up unused images...");
@@ -2025,13 +2137,15 @@ ${MANAGE_HINT}`);
 }
 async function cmdUpgrade(paths) {
   let releaseChannel = "latest";
+  let deployUrl;
   try {
     if (await configExists(paths)) {
       const config = await readConfig(paths);
       releaseChannel = config.release_channel;
+      deployUrl = config.deploy_url;
     }
   } catch {}
-  await selfUpdate(paths, releaseChannel);
+  await selfUpdate(paths, releaseChannel, deployUrl);
 }
 async function cmdStop(paths, shell) {
   checkDockerAccess(shell);
@@ -2068,6 +2182,12 @@ Configuration:`);
     console.log(`  Domain:      ${config.domain}`);
     console.log(`  Network:     ${config.testnet ? "Testnet (devnet)" : "Mainnet"}`);
     console.log(`  Channel:     ${config.release_channel}`);
+    if (config.deploy_url)
+      console.log(`  Deploy URL:  ${config.deploy_url}`);
+    if (config.web_image)
+      console.log(`  Web image:   ${config.web_image}`);
+    if (config.site_image)
+      console.log(`  Site image:  ${config.site_image}`);
     console.log(`  Gateway:     ${config.gateway ? "Yes" : "No"}`);
     console.log(`  Config:      ${paths.configPath}`);
     for (const warning of configWarnings(config)) {
@@ -2104,7 +2224,6 @@ Containers:`);
   Tip: Check logs with '${cmd("logs daemon|web|proxy")}'`);
   }
   if (config) {
-    const expectedTag = config.release_channel;
     const expectedLightning = config.testnet ? LIGHTNING_URL_TESTNET : LIGHTNING_URL_MAINNET;
     const expectedTestnetName = config.testnet ? "dev" : "";
     const checks = [
@@ -2121,10 +2240,7 @@ Containers:`);
       "seed-daemon": daemonEnvs,
       "seed-web": webEnvs
     };
-    const imageChecks = [
-      { container: "seed-web", expectedImage: `seedhypermedia/web:${expectedTag}` },
-      { container: "seed-daemon", expectedImage: `seedhypermedia/site:${expectedTag}` }
-    ];
+    const imageChecks = expectedServiceImages(config);
     let hasMismatch = false;
     const mismatches = [];
     for (const { container, envVar, expected, label } of checks) {
@@ -2574,9 +2690,12 @@ if (import.meta.main) {
 export {
   writeConfig,
   validateDockerImageTag,
+  validateDockerImageRef,
   sha256,
   setupCron,
   selfUpdate,
+  rollbackTagRefs,
+  rollbackImageTargets,
   removeSeedCronLines,
   removeLegacyHostCronLines,
   removeLegacyHostCron,
@@ -2601,6 +2720,7 @@ export {
   freeConflictingPortBindings,
   extractSeedCronLines,
   extractDns,
+  expectedServiceImages,
   environmentPresets,
   ensureSeedDir,
   detectOldInstall,

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -27,7 +27,7 @@ services:
 
   seed-web:
     container_name: seed-web
-    image: seedhypermedia/web:${SEED_SITE_TAG:-latest}
+    image: ${SEED_WEB_IMAGE:-seedhypermedia/web:${SEED_SITE_TAG:-latest}}
     user: "${SEED_UID}:${SEED_GID}"
     depends_on:
       - seed-daemon
@@ -49,7 +49,7 @@ services:
 
   seed-daemon:
     container_name: seed-daemon
-    image: seedhypermedia/site:${SEED_SITE_TAG:-latest}
+    image: ${SEED_SITE_IMAGE:-seedhypermedia/site:${SEED_SITE_TAG:-latest}}
     user: "${SEED_UID}:${SEED_GID}"
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary
- Add deploy configuration for custom web and site Docker image references while preserving official image defaults.
- Update deploy, doctor, upgrade, rollback, and cron image checks to respect configured custom image refs.
- Add GHCR publishing and upstream rebase workflows for the custom fork deployment path.
- Document the custom Docker deployment, rollback, and verification runbook.