### PR TITLE
feat(drafts): support moving unpublished drafts

### DIFF
--- a/frontend/apps/desktop/src/components/__tests__/document-destination-dialog.test.tsx
+++ b/frontend/apps/desktop/src/components/__tests__/document-destination-dialog.test.tsx
@@ -6,6 +6,7 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {hmId} from '@shm/shared/utils/entity-id-url'
 
 const {
+  moveDraftMutateAsyncMock,
   moveMutateAsyncMock,
   navigateMock,
   republishMutateAsyncMock,
@@ -15,6 +16,7 @@ const {
   useResourcesMock,
   writableDocumentsMock,
 } = vi.hoisted(() => ({
+  moveDraftMutateAsyncMock: vi.fn(),
   moveMutateAsyncMock: vi.fn(),
   navigateMock: vi.fn(),
   republishMutateAsyncMock: vi.fn(),
@@ -31,6 +33,7 @@ vi.mock('@/models/access-control', () => ({
 
 vi.mock('@/models/documents', () => ({
   useMoveDocument: () => ({mutateAsync: moveMutateAsyncMock, isLoading: false}),
+  useMoveDraft: () => ({mutateAsync: moveDraftMutateAsyncMock, isLoading: false}),
   useRepublishDocument: () => ({mutateAsync: republishMutateAsyncMock, isLoading: false}),
 }))
 
@@ -142,6 +145,7 @@ function findButtonExact(container: HTMLDivElement, label: string) {
 
 describe('DocumentDestinationDialog', () => {
   beforeEach(() => {
+    moveDraftMutateAsyncMock.mockReset()
     moveMutateAsyncMock.mockReset()
     navigateMock.mockReset()
     republishMutateAsyncMock.mockReset()

--- a/frontend/apps/desktop/src/components/desktop-draft-actions-provider.tsx
+++ b/frontend/apps/desktop/src/components/desktop-draft-actions-provider.tsx
@@ -1,12 +1,14 @@
 import {useDraft} from '@/models/accounts'
 import {client} from '@/trpc'
 import {useNavigate} from '@/utils/useNavigate'
+import {DocumentDestinationDialog} from '@/components/document-destination-dialog'
 import {DraftActions, DraftActionsContext} from '@shm/editor/draft-actions-context'
 import {invalidateQueries} from '@shm/shared/models/query-client'
 import {queryKeys} from '@shm/shared/models/query-keys'
 import {hmId} from '@shm/shared/utils/entity-id-url'
 import {buildInlineDraftWrite} from '@shm/shared/utils/inline-draft'
 import {nanoid} from 'nanoid'
+import {useAppDialog} from '@shm/ui/universal-dialog'
 import {PropsWithChildren, useMemo, useState} from 'react'
 
 /**
@@ -19,6 +21,7 @@ export function DesktopDraftActionsProvider({
   children,
 }: PropsWithChildren<{canCreateInlineDraft?: boolean}>) {
   const navigate = useNavigate()
+  const moveDraftDialog = useAppDialog(DocumentDestinationDialog, {className: 'w-full max-w-2xl'})
   const [lastCreatedInlineDraftId, setLastCreatedInlineDraftId] = useState<string | null>(null)
 
   const value = useMemo<DraftActions>(
@@ -56,6 +59,25 @@ export function DesktopDraftActionsProvider({
           navigate({key: 'document', id: hmId(editUid, {path: editPath})})
         })
       },
+      onMoveDraft: (draftId, origin) => {
+        client.drafts.get.query(draftId).then((draft) => {
+          if (!draft) return
+          const editUid = draft.editUid ?? draft.locationUid
+          if (!editUid) return
+          const editPath = draft.editPath?.length ? draft.editPath : [...(draft.locationPath ?? []), `-${draftId}`]
+          moveDraftDialog.open({
+            id: hmId(editUid, {path: editPath}),
+            mode: 'move',
+            origin: draft.locationUid
+              ? {
+                  parentDocumentId: hmId(draft.locationUid, {path: draft.locationPath ?? []}),
+                  embedBlockId: origin?.embedBlockId,
+                }
+              : undefined,
+            draft: {draftId, title: draft.metadata?.name, icon: draft.metadata?.icon},
+          })
+        })
+      },
       onUpdateDraftName: async (draftId, name) => {
         const draft = await client.drafts.get.query(draftId)
         if (!draft) throw new Error(`Draft ${draftId} not found`)
@@ -80,8 +102,13 @@ export function DesktopDraftActionsProvider({
         setLastCreatedInlineDraftId((current) => (current === draftId ? null : current))
       },
     }),
-    [navigate, canCreateInlineDraft, lastCreatedInlineDraftId],
+    [navigate, canCreateInlineDraft, lastCreatedInlineDraftId, moveDraftDialog],
   )
 
-  return <DraftActionsContext.Provider value={value}>{children}</DraftActionsContext.Provider>
+  return (
+    <DraftActionsContext.Provider value={value}>
+      {children}
+      {moveDraftDialog.content}
+    </DraftActionsContext.Provider>
+  )
 }

--- a/frontend/apps/desktop/src/components/desktop-query-block-draft-slot.tsx
+++ b/frontend/apps/desktop/src/components/desktop-query-block-draft-slot.tsx
@@ -1,13 +1,17 @@
+import {DocumentDestinationDialog} from '@/components/document-destination-dialog'
 import {draftDocumentRouteId} from '@/utils/draft-route'
 import {useChildDrafts, useCreateInlineDraft, useDeleteDraft, useUpdateDraftMetadata} from '@/models/documents'
 import {useNavigate} from '@/utils/useNavigate'
+import {hmId} from '@shm/shared/utils/entity-id-url'
 import {roleCanWrite, useSelectedAccountCapability} from '@shm/shared/models/capabilities'
 import {useResource} from '@shm/shared/models/entity'
 import {QueryBlockDraftSlotProps, useQueryBlockDrafts} from '@shm/shared/query-block-drafts-context'
+import {useAppDialog} from '@shm/ui/universal-dialog'
 import {useMemo} from 'react'
 
 export function DesktopQueryBlockDraftSlot({targetId, children}: QueryBlockDraftSlotProps) {
   const navigate = useNavigate()
+  const moveDraftDialog = useAppDialog(DocumentDestinationDialog, {className: 'w-full max-w-2xl'})
   const capability = useSelectedAccountCapability(targetId ?? undefined)
   const canEdit = roleCanWrite(capability?.role)
   const resource = useResource(targetId)
@@ -59,8 +63,23 @@ export function DesktopQueryBlockDraftSlot({targetId, children}: QueryBlockDraft
           })
         },
         onDeleteDraft: (draftId) => deleteDraft.mutate(draftId),
+        onMoveDraft: (draftId) => {
+          const draft = childDrafts.find((draft) => draft.id === draftId)
+          if (!draft) return
+          const sourceId = draftDocumentRouteId(draft)
+          if (!sourceId) return
+          moveDraftDialog.open({
+            id: sourceId,
+            mode: 'move',
+            origin: draft.locationUid
+              ? {parentDocumentId: hmId(draft.locationUid, {path: draft.locationPath ?? []})}
+              : undefined,
+            draft: {draftId, title: draft.metadata?.name, icon: draft.metadata?.icon},
+          })
+        },
         onUpdateDraftName: (draftId, name) => updateDraftMetadata.mutate({draftId, metadata: {name}}),
       })}
+      {moveDraftDialog.content}
     </>
   )
 }

--- a/frontend/apps/desktop/src/components/document-destination-dialog.tsx
+++ b/frontend/apps/desktop/src/components/document-destination-dialog.tsx
@@ -1,5 +1,5 @@
 import {useSelectedAccountWritableDocuments} from '@/models/access-control'
-import {useMoveDocument, useRepublishDocument} from '@/models/documents'
+import {useMoveDocument, useMoveDraft, useRepublishDocument} from '@/models/documents'
 import {useSelectedAccount} from '@/selected-account'
 import {useNavigate} from '@/utils/useNavigate'
 import type {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
@@ -25,10 +25,21 @@ export function DocumentDestinationDialog({
   const selectedAccountUid = selectedAccount?.id.uid
   const writableDocuments = useSelectedAccountWritableDocuments()
   const moveDocument = useMoveDocument()
+  const moveDraft = useMoveDraft()
   const republishDocument = useRepublishDocument()
   const navigate = useNavigate()
 
   async function onSubmit(submitInput: DocumentDestinationSubmitInput) {
+    if (submitInput.draft?.draftId) {
+      await moveDraft.mutateAsync({
+        draftId: submitInput.draft.draftId,
+        from: submitInput.from,
+        to: submitInput.to,
+        signingAccountId: submitInput.signingAccountId,
+        origin: submitInput.origin,
+      })
+      return
+    }
     const mutation = submitInput.mode === 'move' ? moveDocument : republishDocument
     await mutation.mutateAsync({
       from: submitInput.from,

--- a/frontend/apps/desktop/src/models/auto-link-parent.ts
+++ b/frontend/apps/desktop/src/models/auto-link-parent.ts
@@ -8,7 +8,12 @@ import {invalidateQueries, queryClient} from '@shm/shared/models/query-client'
 import {queryKeys} from '@shm/shared/models/query-keys'
 import {hmId, packHmId} from '@shm/shared/utils/entity-id-url'
 import type {DocumentCardActionOrigin} from '@shm/shared/utils/document-actions'
-import {hmLinkTargetsDocument, planDocumentCardRemoval} from '@shm/shared/utils/document-card-cleanup'
+import {
+  appendDraftCardToEditorBlocks,
+  hmLinkTargetsDocument,
+  planDocumentCardRemoval,
+  removeDraftCardFromEditorBlocks,
+} from '@shm/shared/utils/document-card-cleanup'
 import {hmIdPathToEntityQueryPath} from '@shm/shared/utils/path-api'
 import {nanoid} from 'nanoid'
 import {shouldAutoLinkParent} from '../utils/publish-utils'
@@ -536,4 +541,82 @@ export async function updateParentCardsAfterDocumentRelocation({
     signingAccountUid,
   })
   return {removed, added}
+}
+
+/** Result of moving unpublished draft-card embeds between parent drafts. */
+export type MoveDraftCardBetweenParentDraftsResult = {
+  removed?: {parentId: UnpackedHypermediaId; parentDraftId: string; removedBlockIds: string[]}
+  added?: {parentId: UnpackedHypermediaId; parentDraftId: string; addedBlockIds: string[]}
+}
+
+async function writeDraftContent(draft: any, content: any[]) {
+  await client.drafts.write.mutate({
+    id: draft.id,
+    locationUid: draft.locationUid,
+    locationPath: draft.locationPath,
+    editUid: draft.editUid,
+    editPath: draft.editPath,
+    metadata: draft.metadata,
+    content,
+    deps: draft.deps,
+    navigation: draft.navigation,
+    visibility: draft.visibility,
+  })
+  invalidateQueries([queryKeys.DRAFT, draft.id])
+}
+
+/** Moves an unpublished draft-card embed from the old parent draft to the new parent draft when those drafts exist. */
+export async function moveDraftCardBetweenParentDrafts({
+  draftId,
+  fromParentId,
+  toParentId,
+  sourceBlockId,
+}: {
+  draftId: string
+  fromParentId: UnpackedHypermediaId | null | undefined
+  toParentId: UnpackedHypermediaId
+  sourceBlockId?: string
+}): Promise<MoveDraftCardBetweenParentDraftsResult> {
+  const result: MoveDraftCardBetweenParentDraftsResult = {}
+  if (fromParentId) {
+    const oldParentDraft = await client.drafts.findByEdit.query({
+      editUid: fromParentId.uid,
+      editPath: fromParentId.path || [],
+    })
+    if (oldParentDraft?.id) {
+      const draft = await client.drafts.get.query(oldParentDraft.id)
+      if (draft) {
+        const removed = removeDraftCardFromEditorBlocks((draft.content || []) as any[], draftId, sourceBlockId)
+        if (removed.removedBlockIds.length) {
+          await writeDraftContent(draft, removed.content)
+          result.removed = {parentId: fromParentId, parentDraftId: draft.id, removedBlockIds: removed.removedBlockIds}
+        }
+      }
+    }
+  }
+
+  const newParentDraft = await client.drafts.findByEdit.query({
+    editUid: toParentId.uid,
+    editPath: toParentId.path || [],
+  })
+  if (newParentDraft?.id) {
+    const draft = await client.drafts.get.query(newParentDraft.id)
+    if (draft) {
+      const added = appendDraftCardToEditorBlocks((draft.content || []) as any[], draftId, nanoid(10))
+      if (added.addedBlockIds.length) {
+        await writeDraftContent(draft, added.content)
+        result.added = {parentId: toParentId, parentDraftId: draft.id, addedBlockIds: added.addedBlockIds}
+      }
+    }
+  }
+
+  if (fromParentId) {
+    invalidateQueries([queryKeys.DOC_LIST_DIRECTORY, fromParentId.id])
+    invalidateQueries([queryKeys.ENTITY, fromParentId.id])
+    invalidateQueries([queryKeys.RESOLVED_ENTITY, fromParentId.id])
+  }
+  invalidateQueries([queryKeys.DOC_LIST_DIRECTORY, toParentId.id])
+  invalidateQueries([queryKeys.ENTITY, toParentId.id])
+  invalidateQueries([queryKeys.RESOLVED_ENTITY, toParentId.id])
+  return result
 }

--- a/frontend/apps/desktop/src/models/documents.ts
+++ b/frontend/apps/desktop/src/models/documents.ts
@@ -58,7 +58,7 @@ import {pathNameify} from '../utils/path'
 import {computeNewDraftParams, resolvePublishPath} from '../utils/publish-utils'
 import {useNavigate} from '../utils/useNavigate'
 import {useBroadcastWindowEvent} from '../utils/window-events'
-import {updateParentCardsAfterDocumentRelocation} from './auto-link-parent'
+import {moveDraftCardBetweenParentDrafts, updateParentCardsAfterDocumentRelocation} from './auto-link-parent'
 import type {ParentCardsAfterRelocationResult} from './auto-link-parent'
 import {useMyAccountIds} from './daemon'
 import {useGatewayUrl} from './gateway-settings'
@@ -1254,6 +1254,50 @@ async function resolveWriteCapabilityId(signingAccountId: string, id: UnpackedHy
   return capability.id
 }
 
+function getDocumentParentId(id: UnpackedHypermediaId) {
+  const path = id.path || []
+  if (!path.length) return null
+  return hmId(id.uid, {path: path.slice(0, -1)})
+}
+
+function pathsEqual(left: string[] | null | undefined, right: string[] | null | undefined) {
+  const a = left || []
+  const b = right || []
+  return a.length === b.length && a.every((segment, index) => segment === b[index])
+}
+
+async function retargetDraftAfterPublishedMove(from: UnpackedHypermediaId, to: UnpackedHypermediaId) {
+  const existingDraft = await client.drafts.findByEdit.query({editUid: from.uid, editPath: from.path || []})
+  if (!existingDraft?.id) return null
+  const draft = await client.drafts.get.query(existingDraft.id)
+  if (!draft) return null
+  const fromParent = getDocumentParentId(from)
+  const toParent = getDocumentParentId(to)
+  const shouldMoveLocation =
+    !!fromParent &&
+    !!toParent &&
+    draft.locationUid === fromParent.uid &&
+    pathsEqual(draft.locationPath, fromParent.path || [])
+
+  await client.drafts.write.mutate({
+    id: draft.id,
+    locationUid: shouldMoveLocation ? toParent!.uid : draft.locationUid,
+    locationPath: shouldMoveLocation ? toParent!.path || [] : draft.locationPath,
+    editUid: to.uid,
+    editPath: to.path || [],
+    metadata: draft.metadata,
+    content: draft.content,
+    deps: draft.deps,
+    navigation: draft.navigation,
+    visibility: draft.visibility,
+  })
+  invalidateQueries([queryKeys.DRAFT, draft.id])
+  invalidateQueries([queryKeys.DRAFTS_LIST])
+  invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT, from.uid])
+  invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT, to.uid])
+  return draft.id
+}
+
 function broadcastRelocatedParentDraftChanges(
   broadcastWindowEvent: ReturnType<typeof useBroadcastWindowEvent>,
   result: ParentCardsAfterRelocationResult,
@@ -1275,6 +1319,65 @@ function broadcastRelocatedParentDraftChanges(
       source: 'document-card-cleanup',
     })
   }
+}
+
+export function useMoveDraft() {
+  return useMutation({
+    mutationFn: async ({
+      draftId,
+      from,
+      to,
+      origin,
+    }: {
+      draftId: string
+      from: UnpackedHypermediaId
+      to: UnpackedHypermediaId
+      signingAccountId: string
+      origin?: DocumentCardActionOrigin
+    }) => {
+      const draft = await client.drafts.get.query(draftId)
+      if (!draft) throw new Error(`Draft ${draftId} not found`)
+      const toParent = getDocumentParentId(to)
+      if (!toParent) throw new Error('Choose a destination location.')
+      const fromParent = draft.locationUid
+        ? hmId(draft.locationUid, {path: draft.locationPath || []})
+        : getDocumentParentId(from)
+
+      await client.drafts.write.mutate({
+        id: draft.id,
+        locationUid: toParent.uid,
+        locationPath: toParent.path || [],
+        editUid: to.uid,
+        editPath: to.path || [],
+        metadata: draft.metadata,
+        content: draft.content,
+        deps: draft.deps,
+        navigation: draft.navigation,
+        visibility: draft.visibility,
+      })
+
+      await moveDraftCardBetweenParentDrafts({
+        draftId,
+        fromParentId: fromParent,
+        toParentId: toParent,
+        sourceBlockId: origin?.embedBlockId,
+      })
+
+      return {draftId, from, to, fromParent, toParent}
+    },
+    onSuccess: ({draftId, from, to, fromParent, toParent}) => {
+      invalidateQueries([queryKeys.DRAFT, draftId])
+      invalidateQueries([queryKeys.DRAFTS_LIST])
+      invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT, from.uid])
+      invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT, to.uid])
+      if (fromParent) invalidateQueries([queryKeys.DOC_LIST_DIRECTORY, fromParent.id])
+      invalidateQueries([queryKeys.DOC_LIST_DIRECTORY, toParent.id])
+      invalidateQueries([queryKeys.ENTITY, from.id])
+      invalidateQueries([queryKeys.ENTITY, to.id])
+      invalidateQueries([queryKeys.RESOLVED_ENTITY, from.id])
+      invalidateQueries([queryKeys.RESOLVED_ENTITY, to.id])
+    },
+  })
 }
 
 export function useMoveDocument() {
@@ -1401,6 +1504,8 @@ export function useMoveDocument() {
         push(moveRefs.targetId)
         // console.groupEnd()
       }
+      await retargetDraftAfterPublishedMove(from, to)
+
       const reconciliationInputs = getDocumentCardReconciliationInputsForMove({
         from,
         to,

--- a/frontend/apps/desktop/src/pages/__tests__/desktop-resource-draft-move.test.ts
+++ b/frontend/apps/desktop/src/pages/__tests__/desktop-resource-draft-move.test.ts
@@ -1,0 +1,13 @@
+import {readFileSync} from 'node:fs'
+import {join} from 'node:path'
+import {describe, expect, it} from 'vitest'
+
+describe('DesktopResourcePage draft move action wiring', () => {
+  it('opens the move dialog with draft context for unpublished draft routes', () => {
+    const source = readFileSync(join(__dirname, '../desktop-resource.tsx'), 'utf8')
+
+    expect(source).toContain('const draftMoveId = currentDraftId || placeholderDraftId')
+    expect(source).toContain('draft: {draftId: draftMoveId')
+    expect(source).toContain('parentDocumentId: fallbackParent')
+  })
+})

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -726,7 +726,24 @@ export default function DesktopResourcePage() {
       key: 'move',
       label: 'Move',
       icon: <FileInput className="size-4" />,
-      onClick: () => destinationDialog.open({id: docId, mode: 'move'}),
+      onClick: () => {
+        const draftMoveId = currentDraftId || placeholderDraftId
+        if (draftMoveId) {
+          const fallbackParent = docId.path?.length ? hmId(docId.uid, {path: docId.path.slice(0, -1)}) : undefined
+          destinationDialog.open({
+            id: docId,
+            mode: 'move',
+            origin: draftData?.locationUid
+              ? {parentDocumentId: hmId(draftData.locationUid, {path: draftData.locationPath ?? []})}
+              : fallbackParent
+                ? {parentDocumentId: fallbackParent}
+                : undefined,
+            draft: {draftId: draftMoveId, title: draftData?.metadata?.name, icon: draftData?.metadata?.icon},
+          })
+          return
+        }
+        destinationDialog.open({id: docId, mode: 'move'})
+      },
     })
   }
 

--- a/frontend/apps/web/app/document-edit/web-draft-actions-provider.tsx
+++ b/frontend/apps/web/app/document-edit/web-draft-actions-provider.tsx
@@ -7,6 +7,7 @@ import {buildInlineDraftWrite} from '@shm/shared/utils/inline-draft'
 import {useQuery} from '@tanstack/react-query'
 import {nanoid} from 'nanoid'
 import {PropsWithChildren, useMemo, useState} from 'react'
+import {useWebDocumentDestinationDialog} from '../web-move-document-dialog'
 import {deleteWebDocDraft, getWebDocDraft, putWebDocDraft, webDraftToListedDraft} from './web-draft-db'
 
 /** Hook returning a reactive web draft, shaped as a HMListedDraftWithLocation
@@ -44,6 +45,11 @@ export function WebDraftActionsProvider({
   capabilityCid?: string
 }>) {
   const navigate = useNavigate()
+  const moveDraftDialog = useWebDocumentDestinationDialog({
+    signingAccountId,
+    capabilityId: capabilityCid,
+    canMove: !!signingAccountId,
+  })
   const [lastCreatedInlineDraftId, setLastCreatedInlineDraftId] = useState<string | null>(null)
 
   const value = useMemo<DraftActions>(
@@ -104,6 +110,25 @@ export function WebDraftActionsProvider({
           navigate({key: 'document', id: hmId(editUid, {path: editPath})})
         })
       },
+      onMoveDraft: (draftId, origin) => {
+        getWebDocDraft(draftId).then((draft) => {
+          if (!draft) return
+          const editUid = draft.editUid ?? draft.locationUid
+          if (!editUid) return
+          const editPath = draft.editPath?.length ? draft.editPath : [...(draft.locationPath ?? []), `-${draftId}`]
+          moveDraftDialog.open({
+            id: hmId(editUid, {path: editPath}),
+            mode: 'move',
+            origin: draft.locationUid
+              ? {
+                  parentDocumentId: hmId(draft.locationUid, {path: draft.locationPath ?? []}),
+                  embedBlockId: origin?.embedBlockId,
+                }
+              : undefined,
+            draft: {draftId, title: (draft.metadata as any)?.name, icon: (draft.metadata as any)?.icon},
+          })
+        })
+      },
       onUpdateDraftName: async (draftId, name) => {
         const draft = await getWebDocDraft(draftId)
         if (!draft) throw new Error(`Draft ${draftId} not found`)
@@ -120,8 +145,13 @@ export function WebDraftActionsProvider({
         setLastCreatedInlineDraftId((current) => (current === draftId ? null : current))
       },
     }),
-    [canCreateInlineDraft, signingAccountId, capabilityCid, navigate, lastCreatedInlineDraftId],
+    [canCreateInlineDraft, signingAccountId, capabilityCid, navigate, lastCreatedInlineDraftId, moveDraftDialog],
   )
 
-  return <DraftActionsContext.Provider value={value}>{children}</DraftActionsContext.Provider>
+  return (
+    <DraftActionsContext.Provider value={value}>
+      {children}
+      {moveDraftDialog.content}
+    </DraftActionsContext.Provider>
+  )
 }

--- a/frontend/apps/web/app/document-edit/web-query-block-draft-slot.tsx
+++ b/frontend/apps/web/app/document-edit/web-query-block-draft-slot.tsx
@@ -6,6 +6,7 @@ import {QueryBlockDraftSlotProps, useQueryBlockDrafts} from '@shm/shared/query-b
 import {useNavigate} from '@shm/shared/utils/navigation'
 import {hmId} from '@shm/shared/utils/entity-id-url'
 import {useQuery} from '@tanstack/react-query'
+import {useWebDocumentDestinationDialog} from '../web-move-document-dialog'
 import {useCallback, useMemo} from 'react'
 import {useLocalKeyPair} from '../auth'
 import {createWebDocumentDraft} from './web-create-draft'
@@ -26,6 +27,10 @@ export function WebQueryBlockDraftSlot({targetId, children}: QueryBlockDraftSlot
   const navigate = useNavigate()
   const userKeyPair = useLocalKeyPair()
   const signingAccountId = userKeyPair?.delegatedAccountUid ?? null
+  const moveDraftDialog = useWebDocumentDestinationDialog({
+    signingAccountId: signingAccountId ?? undefined,
+    canMove: !!signingAccountId,
+  })
   const capability = useSelectedAccountCapability(targetId ?? undefined)
   const canEdit = roleCanWrite(capability?.role)
 
@@ -108,8 +113,19 @@ export function WebQueryBlockDraftSlot({targetId, children}: QueryBlockDraftSlot
         onCreateDraft,
         onOpenDraft,
         onDeleteDraft,
+        onMoveDraft: (draftId) => {
+          const draft = childDraftsQuery.data?.find((draft) => draft.id === draftId)
+          if (!draft?.editId) return
+          moveDraftDialog.open({
+            id: draft.editId,
+            mode: 'move',
+            origin: draft.locationId ? {parentDocumentId: draft.locationId} : undefined,
+            draft: {draftId, title: draft.metadata?.name, icon: draft.metadata?.icon},
+          })
+        },
         onUpdateDraftName,
       })}
+      {moveDraftDialog.content}
     </>
   )
 }

--- a/frontend/apps/web/app/routes/hm.api.image.$.tsx
+++ b/frontend/apps/web/app/routes/hm.api.image.$.tsx
@@ -5,7 +5,7 @@ import {getDaemonAuthToken, withDaemonAuthToken} from '@/daemon-auth.server'
 import fs from 'fs/promises'
 import path from 'path'
 import sharp from 'sharp'
-import {fileTypeFromBuffer} from 'file-type'
+import {fromBuffer as fileTypeFromBuffer} from 'file-type'
 
 const CACHE_PATH = path.resolve(path.join(process.env.DATA_DIR || process.cwd(), 'image-cache'))
 const IMG_SIZE_WIDTHS: Record<OptimizedImageSize, number> = {

--- a/frontend/apps/web/app/routes/hm.api.image.$.tsx
+++ b/frontend/apps/web/app/routes/hm.api.image.$.tsx
@@ -5,7 +5,7 @@ import {getDaemonAuthToken, withDaemonAuthToken} from '@/daemon-auth.server'
 import fs from 'fs/promises'
 import path from 'path'
 import sharp from 'sharp'
-import {fromBuffer as fileTypeFromBuffer} from 'file-type'
+import {fileTypeFromBuffer} from 'file-type'
 
 const CACHE_PATH = path.resolve(path.join(process.env.DATA_DIR || process.cwd(), 'image-cache'))
 const IMG_SIZE_WIDTHS: Record<OptimizedImageSize, number> = {

--- a/frontend/apps/web/app/web-move-document-dialog.tsx
+++ b/frontend/apps/web/app/web-move-document-dialog.tsx
@@ -8,10 +8,15 @@ import {queryKeys} from '@shm/shared/models/query-keys'
 import type {UniversalClient} from '@shm/shared/universal-client'
 import {getParentPaths} from '@shm/shared/utils/breadcrumbs'
 import type {DocumentCardActionOrigin} from '@shm/shared/utils/document-actions'
-import {planDocumentCardMoveOperations} from '@shm/shared/utils/document-card-cleanup'
+import {
+  appendDraftCardToEditorBlocks,
+  planDocumentCardMoveOperations,
+  removeDraftCardFromEditorBlocks,
+} from '@shm/shared/utils/document-card-cleanup'
 import {hmIdPathToEntityQueryPath} from '@shm/shared/utils/path-api'
 import {
   DocumentDestinationDialog,
+  type DocumentDestinationDialogInput,
   type DocumentDestinationSubmitInput,
   type WritableDocumentDestination,
 } from '@shm/ui/document-destination-dialog'
@@ -20,12 +25,15 @@ import {useQuery} from '@tanstack/react-query'
 import {useMemo} from 'react'
 import {useNavigate} from '@shm/shared/utils/navigation'
 import {enqueueWebDocumentCardCleanup} from './document-edit/web-document-card-cleanup'
+import {
+  getLatestWebDocDraftForDoc,
+  getWebDocDraft,
+  listWebDocDraftsForAccount,
+  putWebDocDraft,
+  type WebDocDraft,
+} from './document-edit/web-draft-db'
 
-export type WebMoveDocumentDialogInput = {
-  id: UnpackedHypermediaId
-  mode: WebDocumentDestinationMode
-  origin?: DocumentCardActionOrigin
-}
+export type WebMoveDocumentDialogInput = DocumentDestinationDialogInput
 
 export type WebDocumentDestinationMode = 'move' | 'republish'
 
@@ -69,6 +77,15 @@ export function WebDocumentDestinationDialog({
   async function onSubmit(submitInput: DocumentDestinationSubmitInput) {
     if (submitInput.mode !== 'move') throw new Error('Republish is not available on web yet')
     if (!canMove) throw new Error('You are not allowed to move this document')
+    if (submitInput.draft?.draftId) {
+      await moveWebDraft({
+        draftId: submitInput.draft.draftId,
+        from: submitInput.from,
+        to: submitInput.to,
+        origin: submitInput.origin,
+      })
+      return
+    }
     await moveWebDocuments(client, {
       from: submitInput.from,
       to: submitInput.to,
@@ -177,6 +194,8 @@ export async function moveWebDocuments(
     )
   }
 
+  await retargetWebDraftAfterPublishedMove(input.from, input.to)
+
   for (const cleanupInput of getMoveCleanupInputs(input.from, input.to, input.signingAccountId, input.capabilityId)) {
     enqueuePostMoveCleanup(cleanupInput, client)
   }
@@ -237,6 +256,117 @@ function getParentId(id: UnpackedHypermediaId) {
   const path = id.path || []
   if (!path.length) return null
   return hmId(id.uid, {path: path.slice(0, -1)})
+}
+
+function pathsEqual(left: string[] | null | undefined, right: string[] | null | undefined) {
+  const a = left || []
+  const b = right || []
+  return a.length === b.length && a.every((segment, index) => segment === b[index])
+}
+
+async function findWebDraftEditing(parentId: UnpackedHypermediaId): Promise<WebDocDraft | null> {
+  const drafts = await listWebDocDraftsForAccount(parentId.uid)
+  return (
+    drafts.find((draft) => draft.docId === parentId.id) ||
+    drafts.find((draft) => draft.editUid === parentId.uid && pathsEqual(draft.editPath, parentId.path || [])) ||
+    null
+  )
+}
+
+async function writeWebDraftContent(draft: WebDocDraft, content: any[]) {
+  await putWebDocDraft({...draft, content, updatedAt: Date.now()})
+  invalidateQueries([queryKeys.DRAFT, draft.draftId])
+  invalidateQueries([queryKeys.DRAFTS_LIST])
+  invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT])
+}
+
+async function moveWebDraftCardBetweenParentDrafts({
+  draftId,
+  fromParentId,
+  toParentId,
+  sourceBlockId,
+}: {
+  draftId: string
+  fromParentId: UnpackedHypermediaId | null
+  toParentId: UnpackedHypermediaId
+  sourceBlockId?: string
+}) {
+  if (fromParentId) {
+    const oldParentDraft = await findWebDraftEditing(fromParentId)
+    if (oldParentDraft) {
+      const removed = removeDraftCardFromEditorBlocks((oldParentDraft.content || []) as any[], draftId, sourceBlockId)
+      if (removed.removedBlockIds.length) await writeWebDraftContent(oldParentDraft, removed.content)
+    }
+  }
+
+  const newParentDraft = await findWebDraftEditing(toParentId)
+  if (newParentDraft) {
+    const added = appendDraftCardToEditorBlocks((newParentDraft.content || []) as any[], draftId, `${draftId}-card`)
+    if (added.addedBlockIds.length) await writeWebDraftContent(newParentDraft, added.content)
+  }
+}
+
+export async function moveWebDraft(input: {
+  draftId: string
+  from: UnpackedHypermediaId
+  to: UnpackedHypermediaId
+  origin?: DocumentCardActionOrigin
+}) {
+  const draft = await getWebDocDraft(input.draftId)
+  if (!draft) throw new Error(`Draft ${input.draftId} not found`)
+  const toParent = getParentId(input.to)
+  if (!toParent) throw new Error('Choose a destination location.')
+  const fromParent = draft.locationUid
+    ? hmId(draft.locationUid, {path: draft.locationPath || []})
+    : getParentId(input.from)
+
+  await putWebDocDraft({
+    ...draft,
+    docId: input.to.id,
+    locationUid: toParent.uid,
+    locationPath: toParent.path || [],
+    editUid: input.to.uid,
+    editPath: input.to.path || [],
+    updatedAt: Date.now(),
+  })
+  await moveWebDraftCardBetweenParentDrafts({
+    draftId: input.draftId,
+    fromParentId: fromParent,
+    toParentId: toParent,
+    sourceBlockId: input.origin?.embedBlockId,
+  })
+  invalidateQueries([queryKeys.DRAFT, input.draftId])
+  invalidateQueries([queryKeys.DRAFTS_LIST])
+  invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT, input.from.uid])
+  invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT, input.to.uid])
+  if (fromParent) invalidateQueries([queryKeys.DOC_LIST_DIRECTORY, fromParent.id])
+  invalidateQueries([queryKeys.DOC_LIST_DIRECTORY, toParent.id])
+  return {draftId: input.draftId, from: input.from, to: input.to}
+}
+
+async function retargetWebDraftAfterPublishedMove(from: UnpackedHypermediaId, to: UnpackedHypermediaId) {
+  const draft = await getLatestWebDocDraftForDoc(from.id)
+  if (!draft) return
+  const fromParent = getParentId(from)
+  const toParent = getParentId(to)
+  const shouldMoveLocation =
+    !!fromParent &&
+    !!toParent &&
+    draft.locationUid === fromParent.uid &&
+    pathsEqual(draft.locationPath, fromParent.path || [])
+  await putWebDocDraft({
+    ...draft,
+    docId: to.id,
+    locationUid: shouldMoveLocation ? toParent!.uid : draft.locationUid,
+    locationPath: shouldMoveLocation ? toParent!.path || [] : draft.locationPath,
+    editUid: to.uid,
+    editPath: to.path || [],
+    updatedAt: Date.now(),
+  })
+  invalidateQueries([queryKeys.DRAFT, draft.draftId])
+  invalidateQueries([queryKeys.DRAFTS_LIST])
+  invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT, from.uid])
+  invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT, to.uid])
 }
 
 function getMoveCleanupInputs(

--- a/frontend/apps/web/app/web-resource-page.test.ts
+++ b/frontend/apps/web/app/web-resource-page.test.ts
@@ -10,4 +10,12 @@ describe('WebResourcePage restore action wiring', () => {
       'onRestoreDocumentVersion={effectiveCanEdit && signingAccountId ? onRestoreDocumentVersion : undefined}',
     )
   })
+
+  it('opens the move dialog with draft context for unpublished draft routes', () => {
+    const source = readFileSync(join(__dirname, 'web-resource-page.tsx'), 'utf8')
+
+    expect(source).toContain('const draftMoveId = draftData?.draftId || placeholderDraftId')
+    expect(source).toContain('draft: {')
+    expect(source).toContain('draftId: draftMoveId')
+  })
 })

--- a/frontend/apps/web/app/web-resource-page.tsx
+++ b/frontend/apps/web/app/web-resource-page.tsx
@@ -403,9 +403,30 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
       key: 'move',
       label: 'Move',
       icon: <FileInput className="size-4" />,
-      onClick: () => destinationDialog.open({id: docId, mode: 'move'}),
+      onClick: () => {
+        const draftMoveId = draftData?.draftId || placeholderDraftId
+        if (draftMoveId) {
+          const fallbackParent = docId.path?.length ? hmId(docId.uid, {path: docId.path.slice(0, -1)}) : undefined
+          destinationDialog.open({
+            id: docId,
+            mode: 'move',
+            origin: draftData?.locationUid
+              ? {parentDocumentId: hmId(draftData.locationUid, {path: draftData.locationPath ?? []})}
+              : fallbackParent
+                ? {parentDocumentId: fallbackParent}
+                : undefined,
+            draft: {
+              draftId: draftMoveId,
+              title: (draftData?.metadata as any)?.name,
+              icon: (draftData?.metadata as any)?.icon,
+            },
+          })
+          return
+        }
+        destinationDialog.open({id: docId, mode: 'move'})
+      },
     }
-  }, [destinationDialog, docId, effectiveCanEdit, signingAccountId])
+  }, [destinationDialog, docId, draftData, effectiveCanEdit, placeholderDraftId, signingAccountId])
   const deleteMenuItem = useMemo<MenuItemType | null>(() => {
     if (!effectiveCanEdit || !signingAccountId || !docId.path?.length) return null
     return {

--- a/frontend/packages/editor/src/draft-actions-context.tsx
+++ b/frontend/packages/editor/src/draft-actions-context.tsx
@@ -23,6 +23,7 @@ export type DraftActions = {
   useInlineDraft: (id: string | undefined) => {data?: HMListedDraft | null}
   onDeleteDraft: (id: string) => Promise<void>
   onOpenDraft: (draftId: string, draftPath: string[]) => void
+  onMoveDraft?: (draftId: string, origin?: {embedBlockId?: string}) => void
   onUpdateDraftName?: (draftId: string, name: string) => Promise<void> | void
   lastCreatedInlineDraftId?: string | null
   clearLastCreatedInlineDraftId?: (draftId: string) => void

--- a/frontend/packages/editor/src/embed-block.tsx
+++ b/frontend/packages/editor/src/embed-block.tsx
@@ -29,6 +29,7 @@ import {
   ExternalLink as ExternalLinkIcon,
   Link2,
   Pencil,
+  Forward,
   SquareMinus,
   SquarePen,
   Trash2,
@@ -269,6 +270,17 @@ function DraftEmbedPlaceholder({
             disabled: !draftActions?.onOpenDraft || !draft,
             onClick: () => void handleOpen(),
           },
+          ...(draftActions?.onMoveDraft
+            ? [
+                {
+                  key: 'move',
+                  label: 'Move',
+                  icon: <Forward className="size-4" />,
+                  disabled: !draft,
+                  onClick: () => draftActions.onMoveDraft?.(draftId, {embedBlockId: blockId}),
+                },
+              ]
+            : []),
           {
             key: 'remove',
             label: 'Remove card',

--- a/frontend/packages/editor/src/query-block-draft-items.tsx
+++ b/frontend/packages/editor/src/query-block-draft-items.tsx
@@ -13,7 +13,7 @@ export function buildSlotItems(
   hasQueryResults = false,
 ): {prependItems?: ReactNode[]; bannerContent?: ReactNode} {
   if (!slot) return {}
-  const {drafts, onCreateDraft, onOpenDraft, onDeleteDraft, onUpdateDraftName} = slot
+  const {drafts, onCreateDraft, onOpenDraft, onDeleteDraft, onMoveDraft, onUpdateDraftName} = slot
   const hasDrafts = drafts.length > 0 && !!onOpenDraft && !!onDeleteDraft && !!onUpdateDraftName
   const shouldHideCreateButton = style === 'Card' && banner && (hasDrafts || hasQueryResults)
 
@@ -38,6 +38,7 @@ export function buildSlotItems(
         autoFocus={autoFocus}
         onOpenDraft={onOpenDraft!}
         onDeleteDraft={onDeleteDraft!}
+        onMoveDraft={onMoveDraft}
         onUpdateDraftName={onUpdateDraftName!}
       />
     ))
@@ -51,6 +52,7 @@ export function buildSlotItems(
           banner
           onOpenDraft={onOpenDraft!}
           onDeleteDraft={onDeleteDraft!}
+          onMoveDraft={onMoveDraft}
           onUpdateDraftName={onUpdateDraftName!}
         />
       )
@@ -70,6 +72,7 @@ export function buildSlotItems(
       autoFocus={autoFocus}
       onOpenDraft={onOpenDraft!}
       onDeleteDraft={onDeleteDraft!}
+      onMoveDraft={onMoveDraft}
       onUpdateDraftName={onUpdateDraftName!}
     />
   ))

--- a/frontend/packages/shared/src/query-block-drafts-context.tsx
+++ b/frontend/packages/shared/src/query-block-drafts-context.tsx
@@ -11,6 +11,7 @@ export type QueryBlockDraftSlotData = {
   onCreateDraft?: () => void
   onOpenDraft?: (draftId: string) => void
   onDeleteDraft?: (draftId: string) => void
+  onMoveDraft?: (draftId: string) => void
   onUpdateDraftName?: (draftId: string, name: string) => void
 }
 

--- a/frontend/packages/shared/src/utils/document-actions.test.ts
+++ b/frontend/packages/shared/src/utils/document-actions.test.ts
@@ -5,6 +5,8 @@ import {
   canShowRepublishDocumentAction,
   canUseDocumentAsDestinationParent,
   isMoveTargetParentBlocked,
+  isMoveTargetSameSite,
+  canUseMoveTargetParent,
 } from './document-actions'
 
 describe('document action visibility', () => {
@@ -38,6 +40,16 @@ describe('move target validation', () => {
     expect(isMoveTargetParentBlocked(sourceId, hmId('site-a', {path: ['specs', 'api']}))).toBe(true)
     expect(isMoveTargetParentBlocked(sourceId, hmId('site-a', {path: ['design']}))).toBe(false)
     expect(isMoveTargetParentBlocked(sourceId, hmId('site-b', {path: ['specs', 'api']}))).toBe(false)
+  })
+
+  it('keeps move targets inside the source site', () => {
+    const sourceId = hmId('site-a', {path: ['docs', 'api']})
+
+    expect(isMoveTargetSameSite(sourceId, hmId('site-a', {path: ['docs']}))).toBe(true)
+    expect(isMoveTargetSameSite(sourceId, hmId('site-b', {path: ['docs']}))).toBe(false)
+    expect(canUseMoveTargetParent(sourceId, hmId('site-a', {path: ['docs']}))).toBe(true)
+    expect(canUseMoveTargetParent(sourceId, hmId('site-a', {path: ['docs', 'api']}))).toBe(false)
+    expect(canUseMoveTargetParent(sourceId, hmId('site-b', {path: ['docs']}))).toBe(false)
   })
 
   it('excludes private documents as destination parents', () => {

--- a/frontend/packages/shared/src/utils/document-actions.ts
+++ b/frontend/packages/shared/src/utils/document-actions.ts
@@ -47,3 +47,14 @@ export function isMoveTargetParentBlocked(sourceId: UnpackedHypermediaId, target
   if (!sourcePath.length) return true
   return sourcePath.length <= targetPath.length && sourcePath.every((segment, index) => targetPath[index] === segment)
 }
+
+/** Returns true when a Move target belongs to the same site as the source document. */
+export function isMoveTargetSameSite(sourceId: UnpackedHypermediaId, targetParentId: UnpackedHypermediaId | null) {
+  if (!targetParentId) return false
+  return sourceId.uid === targetParentId.uid
+}
+
+/** Returns true when a parent is a valid Move destination candidate for the source. */
+export function canUseMoveTargetParent(sourceId: UnpackedHypermediaId, targetParentId: UnpackedHypermediaId | null) {
+  return isMoveTargetSameSite(sourceId, targetParentId) && !isMoveTargetParentBlocked(sourceId, targetParentId)
+}

--- a/frontend/packages/shared/src/utils/document-card-cleanup.test.ts
+++ b/frontend/packages/shared/src/utils/document-card-cleanup.test.ts
@@ -1,12 +1,14 @@
 import type {HMBlockNode, HMDocument} from '@seed-hypermedia/client/hm-types'
 import {describe, expect, it} from 'vitest'
 import {
+  appendDraftCardToEditorBlocks,
   applyDocumentCardCleanupToBlockNodes,
   planDocumentCardMoveOperations,
   planDeletedDocumentCardEmbedCleanup,
   planDocumentCardAppend,
   planDocumentCardRemoval,
   planDocumentCardRewrite,
+  removeDraftCardFromEditorBlocks,
 } from './document-card-cleanup'
 
 function doc(content: HMBlockNode[]): Pick<HMDocument, 'content'> {
@@ -387,5 +389,54 @@ describe('planDocumentCardMoveOperations', () => {
         targetDocumentId: 'hm://site/new-parent/doc',
       },
     ])
+  })
+})
+
+describe('draft-card editor block helpers', () => {
+  it('removes only the matching draft card and preserves its children', () => {
+    const result = removeDraftCardFromEditorBlocks(
+      [
+        {
+          id: 'target-card',
+          type: 'embed',
+          props: {draftId: 'draft-1', view: 'Card'},
+          children: [{id: 'child', type: 'paragraph', children: []}],
+        },
+        {id: 'other-card', type: 'embed', props: {draftId: 'draft-1', view: 'Card'}, children: []},
+      ],
+      'draft-1',
+      'target-card',
+    )
+
+    expect(result.removedBlockIds).toEqual(['target-card'])
+    expect(result.content).toEqual([
+      {id: 'child', type: 'paragraph', children: []},
+      {id: 'other-card', type: 'embed', props: {draftId: 'draft-1', view: 'Card'}, children: []},
+    ])
+  })
+
+  it('appends a draft card unless the draft is already linked', () => {
+    const initial = [{id: 'paragraph', type: 'paragraph', children: []}]
+
+    expect(appendDraftCardToEditorBlocks(initial, 'draft-1', 'new-card')).toEqual({
+      content: [
+        {id: 'paragraph', type: 'paragraph', children: []},
+        {
+          id: 'new-card',
+          type: 'embed',
+          props: {url: '', draftId: 'draft-1', view: 'Card', defaultOpen: 'false'},
+          content: [],
+          children: [],
+        },
+      ],
+      addedBlockIds: ['new-card'],
+    })
+    expect(
+      appendDraftCardToEditorBlocks(
+        [{id: 'existing-card', type: 'embed', props: {draftId: 'draft-1'}, children: []}],
+        'draft-1',
+        'new-card',
+      ).addedBlockIds,
+    ).toEqual([])
   })
 })

--- a/frontend/packages/shared/src/utils/document-card-cleanup.ts
+++ b/frontend/packages/shared/src/utils/document-card-cleanup.ts
@@ -455,3 +455,69 @@ export function applyDocumentCardCleanupToBlockNodes(
 
   return {content: rewrite(content), changedBlockIds}
 }
+
+type EditorDraftCardBlockLike = {
+  id?: string
+  type?: string
+  props?: {draftId?: string; url?: string; view?: string; defaultOpen?: string}
+  content?: unknown[]
+  children?: EditorDraftCardBlockLike[]
+  [key: string]: unknown
+}
+
+function isEditorDraftCardEmbed(block: EditorDraftCardBlockLike, draftId: string, targetBlockId?: string) {
+  if (block.type !== 'embed') return false
+  if (targetBlockId && block.id !== targetBlockId) return false
+  return block.props?.draftId === draftId
+}
+
+function editorBlocksContainDraftCard(blocks: EditorDraftCardBlockLike[], draftId: string): boolean {
+  return blocks.some((block) => {
+    if (isEditorDraftCardEmbed(block, draftId)) return true
+    return editorBlocksContainDraftCard(block.children || [], draftId)
+  })
+}
+
+/** Removes editor draft-card embeds that reference an unpublished draft id. */
+export function removeDraftCardFromEditorBlocks(
+  blocks: EditorDraftCardBlockLike[],
+  draftId: string,
+  targetBlockId?: string,
+): {content: EditorDraftCardBlockLike[]; removedBlockIds: string[]} {
+  const removedBlockIds: string[] = []
+
+  function expandBlock(block: EditorDraftCardBlockLike): EditorDraftCardBlockLike[] {
+    const children = Array.isArray(block.children) ? block.children : []
+    if (isEditorDraftCardEmbed(block, draftId, targetBlockId)) {
+      if (block.id) removedBlockIds.push(block.id)
+      return children.flatMap(expandBlock)
+    }
+    return [{...block, children: children.flatMap(expandBlock)}]
+  }
+
+  return {content: blocks.flatMap(expandBlock), removedBlockIds}
+}
+
+/** Appends an editor draft-card embed for an unpublished draft unless one already exists. */
+export function appendDraftCardToEditorBlocks(
+  blocks: EditorDraftCardBlockLike[],
+  draftId: string,
+  newBlockId: string,
+): {content: EditorDraftCardBlockLike[]; addedBlockIds: string[]} {
+  if (!draftId || !newBlockId || editorBlocksContainDraftCard(blocks, draftId)) {
+    return {content: blocks, addedBlockIds: []}
+  }
+  return {
+    content: [
+      ...blocks,
+      {
+        id: newBlockId,
+        type: 'embed',
+        props: {url: '', draftId, view: 'Card', defaultOpen: 'false'},
+        content: [],
+        children: [],
+      },
+    ],
+    addedBlockIds: [newBlockId],
+  }
+}

--- a/frontend/packages/ui/src/__tests__/document-destination-dialog.test.tsx
+++ b/frontend/packages/ui/src/__tests__/document-destination-dialog.test.tsx
@@ -5,11 +5,17 @@ import {act} from 'react-dom/test-utils'
 import {UniversalAppProvider} from '@shm/shared/routing'
 import {hmId} from '@shm/shared/utils/entity-id-url'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
-import {DocumentDestinationDialog, type WritableDocumentDestination} from '../document-destination-dialog'
+import {
+  DocumentDestinationDialog,
+  type DocumentDestinationDialogInput,
+  type WritableDocumentDestination,
+} from '../document-destination-dialog'
 ;(globalThis as typeof globalThis & {React?: typeof React; IS_REACT_ACT_ENVIRONMENT?: boolean}).React = React
 ;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
 
+const hmIconMock = vi.hoisted(() => vi.fn(() => <span data-testid="hm-icon" />))
 const siteId = hmId('site')
+const otherSiteId = hmId('other')
 const sourceId = hmId('site', {path: ['old-parent', 'move-me']})
 
 vi.mock('@shm/shared/models/entity', () => ({
@@ -54,7 +60,7 @@ vi.mock('../tooltip', () => ({
 }))
 
 vi.mock('../hm-icon', () => ({
-  HMIcon: () => <span data-testid="hm-icon" />,
+  HMIcon: hmIconMock,
 }))
 
 let container: HTMLDivElement
@@ -71,9 +77,24 @@ afterEach(() => {
     root.unmount()
   })
   container.remove()
+  hmIconMock.mockClear()
 })
 
-function renderDialog(props: {onSubmit?: ReturnType<typeof vi.fn>; writableDocuments?: WritableDocumentDestination[]}) {
+async function clearToWritableRoots() {
+  for (let index = 0; index < 2; index++) {
+    const backButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Back')
+    if (!backButton) return
+    await act(async () => {
+      backButton.click()
+    })
+  }
+}
+
+function renderDialog(props: {
+  input?: DocumentDestinationDialogInput
+  onSubmit?: ReturnType<typeof vi.fn>
+  writableDocuments?: WritableDocumentDestination[]
+}) {
   const onSubmit = (props.onSubmit || vi.fn(async () => undefined)) as any
   act(() => {
     root.render(
@@ -84,11 +105,13 @@ function renderDialog(props: {onSubmit?: ReturnType<typeof vi.fn>; writableDocum
         universalClient={{request: vi.fn()} as any}
       >
         <DocumentDestinationDialog
-          input={{id: sourceId, mode: 'move'}}
+          input={props.input || {id: sourceId, mode: 'move'}}
           onClose={vi.fn()}
           selectedAccountUid="site"
           writableDocuments={
-            props.writableDocuments || [{id: siteId, title: 'Docs', document: {metadata: {name: 'Docs'}} as any}]
+            props.writableDocuments || [
+              {id: siteId, title: 'Docs', document: {metadata: {name: 'Docs', icon: 'site-icon'}} as any},
+            ]
           }
           onSubmit={onSubmit}
         />
@@ -124,5 +147,49 @@ describe('DocumentDestinationDialog', () => {
       mode: 'move',
       signingAccountId: 'site',
     })
+  })
+  it('passes destination metadata icons into location rows', async () => {
+    renderDialog({})
+    await clearToWritableRoots()
+
+    expect(hmIconMock).toHaveBeenCalledWith(
+      expect.objectContaining({id: siteId, name: 'Docs', icon: 'site-icon', size: 28}),
+      expect.anything(),
+    )
+  })
+
+  it('filters writable roots to the source site for moves but not republish', async () => {
+    renderDialog({
+      input: {id: sourceId, mode: 'move'},
+      writableDocuments: [
+        {id: siteId, title: 'Docs', document: {metadata: {name: 'Docs'}} as any},
+        {id: otherSiteId, title: 'Other Site', document: {metadata: {name: 'Other Site'}} as any},
+      ],
+    })
+
+    await clearToWritableRoots()
+
+    expect(container.textContent).toContain('Docs')
+    expect(container.textContent).not.toContain('Other Site')
+
+    act(() => {
+      root.unmount()
+      container.remove()
+      container = document.createElement('div')
+      document.body.appendChild(container)
+      root = createRoot(container)
+    })
+
+    renderDialog({
+      input: {id: sourceId, mode: 'republish'},
+      writableDocuments: [
+        {id: siteId, title: 'Docs', document: {metadata: {name: 'Docs'}} as any},
+        {id: otherSiteId, title: 'Other Site', document: {metadata: {name: 'Other Site'}} as any},
+      ],
+    })
+    await clearToWritableRoots()
+
+    expect(container.textContent).toContain('Docs')
+    expect(container.textContent).toContain('Other Site')
   })
 })

--- a/frontend/packages/ui/src/document-destination-dialog.tsx
+++ b/frontend/packages/ui/src/document-destination-dialog.tsx
@@ -1,4 +1,4 @@
-import type {HMDocument, HMMetadataPayload, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import type {HMDocument, HMMetadata, HMMetadataPayload, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {
   createSiteUrl,
   createWebHMUrl,
@@ -13,7 +13,9 @@ import {getMetadataName} from '@shm/shared/content'
 import {useDirectory, useResource, useResources} from '@shm/shared/models/entity'
 import {
   canUseDocumentAsDestinationParent,
+  canUseMoveTargetParent,
   isMoveTargetParentBlocked,
+  isMoveTargetSameSite,
   type DocumentCardActionOrigin,
 } from '@shm/shared/utils/document-actions'
 import {validatePath} from '@shm/shared/utils/document-path'
@@ -39,6 +41,11 @@ export type DocumentDestinationDialogInput = {
   id: UnpackedHypermediaId
   mode: DocumentDestinationMode
   origin?: DocumentCardActionOrigin
+  draft?: {
+    draftId: string
+    title?: string | null
+    icon?: HMMetadata['icon'] | null
+  }
 }
 
 /** Writable location root that can be selected or browsed in the destination dialog. */
@@ -56,6 +63,7 @@ export type DocumentDestinationSubmitInput = {
   mode: DocumentDestinationMode
   signingAccountId: string
   origin?: DocumentCardActionOrigin
+  draft?: DocumentDestinationDialogInput['draft']
 }
 
 const modeCopy: Record<DocumentDestinationMode, {eyebrow: string; action: string; success: string}> = {
@@ -81,12 +89,18 @@ export function DocumentDestinationDialog({
   onSubmit: (input: DocumentDestinationSubmitInput) => Promise<void>
   onSuccess?: (input: DocumentDestinationSubmitInput) => void
 }) {
-  const {data: resource, isLoading, isError, error} = useResource(input.id)
+  const isDraftSource = !!input.draft
+  const {data: resource, isLoading, isError, error} = useResource(isDraftSource ? null : input.id)
   const document = resource?.type === 'document' ? resource.document : undefined
-  const sourceId = resource?.type === 'document' ? resource.id : input.id
-  const sourceTitle = document ? getMetadataName(document.metadata) : 'Untitled'
-  const initialTargetParent = useMemo(() => getSourceParentId(input.id), [input.id.id])
-  const initialSlug = input.id.path?.at(-1) || ''
+  const sourceId = input.id
+  const sourceTitle = isDraftSource
+    ? input.draft?.title || 'Untitled draft'
+    : document
+      ? getMetadataName(document.metadata)
+      : 'Untitled'
+  const sourceIcon = isDraftSource ? input.draft?.icon : document?.metadata.icon
+  const initialTargetParent = useMemo(() => getSourceParentId(sourceId), [sourceId.id])
+  const initialSlug = sourceId.path?.at(-1) || ''
   const [targetParent, setTargetParent] = useState<UnpackedHypermediaId | null>(initialTargetParent)
   const [slug, setSlug] = useState(initialSlug)
   const [searchQuery, setSearchQuery] = useState('')
@@ -115,6 +129,7 @@ export function DocumentDestinationDialog({
     [destinationId?.id],
   )
   const modeDisabled = !enabledModes.includes(input.mode)
+  const moveTargetWrongSite = input.mode === 'move' && !!targetParent && !isMoveTargetSameSite(sourceId, targetParent)
   const moveTargetBlocked = input.mode === 'move' && isMoveTargetParentBlocked(sourceId, targetParent)
   const sourceIsHomeDocument = !sourceId.path?.length
   const destinationExists = destinationResource.data?.type === 'document'
@@ -130,30 +145,32 @@ export function DocumentDestinationDialog({
             ? 'Private documents cannot contain child documents.'
             : !slug
               ? 'Enter a URL path.'
-              : moveTargetBlocked
-                ? 'Choose a location outside this document subtree.'
-                : pathInvalid
-                  ? pathInvalid.error
-                  : destinationId?.id === sourceId.id
-                    ? 'Choose a new location or URL path.'
-                    : destinationResource.isLoading
-                      ? 'Checking destination availability…'
-                      : destinationExists
-                        ? 'A document already exists at this URL. Choose a different path.'
-                        : null
+              : moveTargetWrongSite
+                ? 'Moves must stay inside the current site.'
+                : moveTargetBlocked
+                  ? 'Choose a location outside this document subtree.'
+                  : pathInvalid
+                    ? pathInvalid.error
+                    : destinationId?.id === sourceId.id
+                      ? 'Choose a new location or URL path.'
+                      : destinationResource.isLoading
+                        ? 'Checking destination availability…'
+                        : destinationExists
+                          ? 'A document already exists at this URL. Choose a different path.'
+                          : null
   const canSubmit = !!destinationId && !validationMessage && !isSubmitting
 
   if (!selectedAccountUid) {
     return <DialogError message="Select an account before moving or republishing documents." />
   }
-  if (isLoading || !document) {
+  if (!isDraftSource && (isLoading || !document)) {
     return (
       <div className="flex min-h-48 items-center justify-center">
         <Spinner />
       </div>
     )
   }
-  if (isError || resource?.type !== 'document') {
+  if (!isDraftSource && (isError || resource?.type !== 'document')) {
     return <DialogError message={error ? String(error) : 'Could not load document.'} />
   }
 
@@ -165,6 +182,7 @@ export function DocumentDestinationDialog({
       mode: input.mode,
       signingAccountId: selectedAccountUid,
       origin: input.origin,
+      draft: input.draft,
     }
     setIsSubmitting(true)
     try {
@@ -186,7 +204,7 @@ export function DocumentDestinationDialog({
           {modeCopy[input.mode].eyebrow}
         </SizableText>
         <DialogTitle className="flex items-center gap-2 text-2xl leading-tight font-semibold">
-          <HMIcon id={sourceId} name={sourceTitle} icon={document.metadata.icon} size={30} />
+          <HMIcon id={sourceId} name={sourceTitle} icon={sourceIcon} size={30} />
           <span className="min-w-0 truncate">{sourceTitle}</span>
         </DialogTitle>
       </div>
@@ -235,12 +253,18 @@ export function DocumentDestinationDialog({
             <Help className="text-muted-foreground size-4" />
           </Tooltip>
         </div>
-        <Input
-          className="h-11 rounded-xl text-base"
-          value={slug}
-          onChange={(event) => setSlug(pathNameify(event.target.value))}
-          placeholder="url-path"
-        />
+        {isDraftSource ? (
+          <SizableText className="text-muted-foreground text-sm">
+            Draft moves keep the draft placeholder path until publish.
+          </SizableText>
+        ) : (
+          <Input
+            className="h-11 rounded-xl text-base"
+            value={slug}
+            onChange={(event) => setSlug(pathNameify(event.target.value))}
+            placeholder="url-path"
+          />
+        )}
         {destinationUrl ? (
           <SizableText
             className={cn('text-sm break-all', validationMessage ? 'text-muted-foreground' : 'text-primary')}
@@ -296,9 +320,16 @@ function DestinationBrowser({
     )
   }
   if (!targetParent) {
-    return <WritableRoots roots={getWritableRoots(writableDocuments, selectedAccountUid)} onSelect={onSelect} />
+    return (
+      <WritableRoots
+        mode={mode}
+        sourceId={sourceId}
+        roots={getWritableRoots(writableDocuments, selectedAccountUid)}
+        onSelect={onSelect}
+      />
+    )
   }
-  return <ChildLocations parent={targetParent} onSelect={onSelect} onClear={onClear} />
+  return <ChildLocations mode={mode} sourceId={sourceId} parent={targetParent} onSelect={onSelect} onClear={onClear} />
 }
 
 function SearchResults({
@@ -320,14 +351,18 @@ function SearchResults({
   const writableResults =
     search.data?.entities
       .filter((item) => canWriteLocation(writableDocuments, item.id, selectedAccountUid))
-      .filter((item) => mode !== 'move' || !isMoveTargetParentBlocked(sourceId, item.id)) || []
+      .filter((item) => mode !== 'move' || canUseMoveTargetParent(sourceId, item.id)) || []
   const resultResources = useResources(writableResults.map((item) => item.id))
   const results: HMMetadataPayload[] = writableResults
     .filter((_, index) => {
       const resource = resultResources[index]?.data
       return resource?.type === 'document' && canUseDocumentAsDestinationParent(resource.document)
     })
-    .map((item) => ({id: item.id, metadata: {name: item.title}}))
+    .map((item, index) => {
+      const resource = resultResources[index]?.data
+      const document = resource?.type === 'document' ? resource.document : null
+      return {id: item.id, metadata: {name: item.title, icon: document?.metadata.icon || (item as any).icon}}
+    })
   const loadingLabel =
     search.isLoading || resultResources.some((result) => result.isLoading)
       ? 'Loading locations…'
@@ -335,34 +370,59 @@ function SearchResults({
   return (
     <LocationList emptyLabel={loadingLabel}>
       {results.map((item) => (
-        <LocationRow key={item.id.id} id={item.id} title={item.metadata?.name || 'Untitled'} onSelect={onSelect} />
+        <LocationRow
+          key={item.id.id}
+          id={item.id}
+          title={item.metadata?.name || 'Untitled'}
+          icon={item.metadata?.icon}
+          onSelect={onSelect}
+        />
       ))}
     </LocationList>
   )
 }
 
 function WritableRoots({
+  mode,
+  sourceId,
   roots,
   onSelect,
 }: {
+  mode: DocumentDestinationMode
+  sourceId: UnpackedHypermediaId
   roots: WritableDocumentDestination[]
   onSelect: (location: UnpackedHypermediaId) => void
 }) {
   return (
     <LocationList emptyLabel="No writable destinations available for the selected account.">
-      {roots.filter(isPublicWritableDocument).map((item) => {
-        const title = item.title || (item.document ? getMetadataName(item.document.metadata) : item.id.uid)
-        return <LocationRow key={item.id.id} id={item.id} title={title} onSelect={onSelect} />
-      })}
+      {roots
+        .filter((item) => mode !== 'move' || canUseMoveTargetParent(sourceId, item.id))
+        .filter(isPublicWritableDocument)
+        .map((item) => {
+          const title = item.title || (item.document ? getMetadataName(item.document.metadata) : item.id.uid)
+          return (
+            <LocationRow
+              key={item.id.id}
+              id={item.id}
+              title={title}
+              icon={item.document?.metadata.icon}
+              onSelect={onSelect}
+            />
+          )
+        })}
     </LocationList>
   )
 }
 
 function ChildLocations({
+  mode,
+  sourceId,
   parent,
   onSelect,
   onClear,
 }: {
+  mode: DocumentDestinationMode
+  sourceId: UnpackedHypermediaId
   parent: UnpackedHypermediaId
   onSelect: (location: UnpackedHypermediaId) => void
   onClear: () => void
@@ -378,12 +438,14 @@ function ChildLocations({
         </Button>
       </div>
       {directory
-        ?.filter(canUseDocumentAsDestinationParent)
+        ?.filter((item) => mode !== 'move' || canUseMoveTargetParent(sourceId, item.id))
+        .filter(canUseDocumentAsDestinationParent)
         .map((item) => (
           <LocationRow
             key={item.id.id}
             id={item.id}
             title={getMetadataName(item.metadata)}
+            icon={item.metadata.icon}
             suffix={item.path?.at(-1)}
             onSelect={onSelect}
           />
@@ -406,11 +468,13 @@ function LocationList({children, emptyLabel}: {children: React.ReactNode; emptyL
 function LocationRow({
   id,
   title,
+  icon,
   suffix,
   onSelect,
 }: {
   id: UnpackedHypermediaId
   title: string
+  icon?: HMMetadata['icon'] | null
   suffix?: string
   onSelect: (location: UnpackedHypermediaId) => void
 }) {
@@ -420,7 +484,7 @@ function LocationRow({
       onClick={() => onSelect(id)}
       className="hover:bg-muted/70 focus-visible:ring-ring border-border flex min-h-14 items-center gap-3 border-b px-5 text-left transition-colors focus-visible:ring-2 focus-visible:outline-none"
     >
-      <HMIcon id={id} name={title} size={28} />
+      <HMIcon id={id} name={title} icon={icon} size={28} />
       <div className="flex min-w-0 flex-1 items-baseline gap-2 overflow-hidden">
         <SizableText className="truncate text-base font-medium">{title}</SizableText>
         {suffix ? <SizableText className="text-muted-foreground truncate text-xs">{suffix}</SizableText> : null}

--- a/frontend/packages/ui/src/inline-draft-card.tsx
+++ b/frontend/packages/ui/src/inline-draft-card.tsx
@@ -1,5 +1,5 @@
 import {HMListedDraft} from '@seed-hypermedia/client/hm-types'
-import {ImageIcon, MoreVertical, Pencil, Trash2} from 'lucide-react'
+import {ImageIcon, MoreVertical, Forward, Pencil, Trash2} from 'lucide-react'
 import {useCallback, useEffect, useRef, useState} from 'react'
 import {Button} from './button'
 import {DraftBadge} from './draft-badge'
@@ -12,6 +12,7 @@ export interface InlineDraftCardProps {
   banner?: boolean
   onOpenDraft: (draftId: string) => void
   onDeleteDraft: (draftId: string) => void
+  onMoveDraft?: (draftId: string) => void
   onUpdateDraftName: (draftId: string, name: string) => void
 }
 
@@ -21,6 +22,7 @@ export function InlineDraftCard({
   banner,
   onOpenDraft,
   onDeleteDraft,
+  onMoveDraft,
   onUpdateDraftName,
 }: InlineDraftCardProps) {
   const [title, setTitle] = useState(draft.metadata?.name || '')
@@ -145,6 +147,16 @@ export function InlineDraftCard({
                   icon: <Pencil className="size-4" />,
                   onClick: openDraft,
                 },
+                ...(onMoveDraft
+                  ? [
+                      {
+                        key: 'move',
+                        label: 'Move',
+                        icon: <Forward className="size-4" />,
+                        onClick: () => onMoveDraft(draft.id),
+                      },
+                    ]
+                  : []),
                 {
                   key: 'delete',
                   label: 'Delete Draft',

--- a/frontend/packages/ui/src/inline-draft-list-item.tsx
+++ b/frontend/packages/ui/src/inline-draft-list-item.tsx
@@ -1,5 +1,5 @@
 import {HMListedDraft} from '@seed-hypermedia/client/hm-types'
-import {FileText, MoreVertical, Pencil, Trash2} from 'lucide-react'
+import {FileText, MoreVertical, Forward, Pencil, Trash2} from 'lucide-react'
 import {useCallback, useEffect, useRef, useState} from 'react'
 import {Button} from './button'
 import {DraftBadge} from './draft-badge'
@@ -10,6 +10,7 @@ export interface InlineDraftListItemProps {
   autoFocus?: boolean
   onOpenDraft: (draftId: string) => void
   onDeleteDraft: (draftId: string) => void
+  onMoveDraft?: (draftId: string) => void
   onUpdateDraftName: (draftId: string, name: string) => void
 }
 
@@ -18,6 +19,7 @@ export function InlineDraftListItem({
   autoFocus,
   onOpenDraft,
   onDeleteDraft,
+  onMoveDraft,
   onUpdateDraftName,
 }: InlineDraftListItemProps) {
   const [title, setTitle] = useState(draft.metadata?.name || '')
@@ -122,6 +124,16 @@ export function InlineDraftListItem({
                 icon: <Pencil className="size-4" />,
                 onClick: openDraft,
               },
+              ...(onMoveDraft
+                ? [
+                    {
+                      key: 'move',
+                      label: 'Move',
+                      icon: <Forward className="size-4" />,
+                      onClick: () => onMoveDraft(draft.id),
+                    },
+                  ]
+                : []),
               {
                 key: 'delete',
                 label: 'Delete Draft',


### PR DESCRIPTION
## Summary
- Add Move actions for unpublished draft cards and draft route menus on desktop and web.
- Route draft moves through the destination picker while preserving draft metadata and parent card placement.
- Keep published-document moves aligned with any existing local draft edits.
- Restrict move destinations to the source site and surface destination icons in location rows.
- Add focused tests for draft move wiring, destination validation, and draft card cleanup helpers.

Fixes #829