### PR TITLE
Site owner email subscribers list (web + desktop)

### DIFF
--- a/frontend/apps/desktop/src/app-notifications.ts
+++ b/frontend/apps/desktop/src/app-notifications.ts
@@ -84,7 +84,8 @@ function normalizeHost(host: string) {
   return host.replace(/\/$/, '')
 }
 
-function getNotifyServiceHostDefault(): string | null {
+/** Returns the app-wide notify service host: the stored override, or the built-in default. */
+export function getNotifyServiceHostDefault(): string | null {
   const stored = appStore.get(NOTIFY_SERVICE_HOST_KEY) as string | undefined
   const host = stored !== undefined ? stored : NOTIFY_SERVICE_HOST
   if (!host) return null
@@ -100,7 +101,8 @@ function resolveNotifyHost(notifyServiceHost: string | undefined): string {
   return host
 }
 
-function buildDesktopSigner(accountUid: string): NotificationSigner {
+/** Builds a NotificationSigner that signs with a local account key via the daemon. */
+export function buildDesktopSigner(accountUid: string): NotificationSigner {
   return {
     publicKey: Uint8Array.from(base58btc.decode(accountUid)),
     sign: async (data: Uint8Array) => {

--- a/frontend/apps/desktop/src/app-sites.ts
+++ b/frontend/apps/desktop/src/app-sites.ts
@@ -1,5 +1,22 @@
+import {getSiteEmailSubscribers} from '@shm/shared/models/notification-service'
 import {z} from 'zod'
+import {buildDesktopSigner, getNotifyServiceHostDefault} from './app-notifications'
 import {t} from './app-trpc'
+
+/** Reads the notifyServiceHost that a site advertises via its /hm/api/config. */
+async function getSiteNotifyServiceHost(siteUrl: string): Promise<string | null> {
+  const resp = await fetch(`${siteUrl.replace(/\/$/, '')}/hm/api/config`, {})
+  if (resp.status !== 200) {
+    throw new Error(`Site returned status ${resp.status}`)
+  }
+  let config
+  try {
+    config = await resp.json()
+  } catch {
+    throw new Error('Site returned invalid response')
+  }
+  return typeof config?.notifyServiceHost === 'string' ? config.notifyServiceHost : null
+}
 
 const registerInputSchema = z.object({
   url: z.string(),
@@ -50,4 +67,24 @@ export const sitesApi = t.router({
     }
     return result
   }),
+  // Discovers the site's notify service through its /hm/api/config (falling
+  // back to the app default host for sites without a published siteUrl), then
+  // requests the site account's subscriber emails. The request is signed with
+  // the signAs key (the selected identity), delegated to the site account —
+  // the notify service verifies the AGENT capability when they differ.
+  getEmailSubscribers: t.procedure
+    .input(z.object({siteUrl: z.string().optional(), accountUid: z.string(), signAs: z.string().optional()}))
+    .query(async ({input}) => {
+      const notifyServiceHost =
+        (input.siteUrl ? await getSiteNotifyServiceHost(input.siteUrl) : null) ?? getNotifyServiceHostDefault()
+      if (!notifyServiceHost) {
+        throw new Error('No notification service is configured for this site')
+      }
+      const signAs = input.signAs ?? input.accountUid
+      const signer = buildDesktopSigner(signAs)
+      if (signAs !== input.accountUid) {
+        signer.accountUid = input.accountUid
+      }
+      return getSiteEmailSubscribers(notifyServiceHost, signer)
+    }),
 })

--- a/frontend/apps/desktop/src/components/titlebar-common.tsx
+++ b/frontend/apps/desktop/src/components/titlebar-common.tsx
@@ -811,6 +811,9 @@ function getRouteId(route: NavRoute): UnpackedHypermediaId | null {
   ) {
     return route.id
   }
+  if (route.key === 'site-settings-emails') {
+    return route.accountUid ? hmId(route.accountUid) : null
+  }
   return null
 }
 
@@ -828,7 +831,8 @@ function isUrlDisplayableRoute(route: NavRoute): boolean {
     route.key === 'collaborators' ||
     route.key === 'comments' ||
     route.key === 'all-documents' ||
-    route.key === 'site-profile'
+    route.key === 'site-profile' ||
+    route.key === 'site-settings-emails'
   )
 }
 

--- a/frontend/apps/desktop/src/models/access-control.ts
+++ b/frontend/apps/desktop/src/models/access-control.ts
@@ -19,7 +19,8 @@ export function getRoleCapabilityType(role: Role): HMRole | null {
   return null
 }
 
-const CapabilityInheritance: Readonly<HMRole[]> = ['owner', 'writer', 'none']
+// AGENT is a full delegation of the account (it can act as the account), so it ranks highest.
+const CapabilityInheritance: Readonly<HMRole[]> = ['agent', 'owner', 'writer', 'none']
 
 function isGreaterOrEqualRole(referenceRole: HMRole, role: HMRole) {
   const referenceRoleIndex = CapabilityInheritance.indexOf(referenceRole)

--- a/frontend/apps/desktop/src/omnibar-url.ts
+++ b/frontend/apps/desktop/src/omnibar-url.ts
@@ -57,6 +57,9 @@ export function selectValidatedOmnibarSiteUrl(params: {
  * Resolves a URL using the same routing rules as the desktop omnibar.
  */
 export async function resolveOmnibarUrlToRoute(url: string, opts?: ResolveOptions): Promise<NavRoute | null> {
+  const siteSettingsEmailsRoute = await siteSettingsEmailsUrlToRoute(url, opts)
+  if (siteSettingsEmailsRoute) return siteSettingsEmailsRoute
+
   const directRoute = hypermediaUrlToRoute(url)
   if (directRoute) return directRoute
 
@@ -102,6 +105,36 @@ export function agentSessionUrl(serverUrl: string, agentId: string, sessionId: s
 
 export function agentTriggerUrl(serverUrl: string, agentId: string, triggerId: string): string {
   return `${agentUrl(serverUrl, agentId)}/triggers/${encodeURIComponent(triggerId)}`
+}
+
+/**
+ * Resolves <siteUrl>/:settings/email-subscribers (or the gateway form
+ * <gatewayUrl>/hm/<uid>/:settings/email-subscribers) to the
+ * site-settings-emails route.
+ */
+async function siteSettingsEmailsUrlToRoute(input: string, opts?: ResolveOptions): Promise<NavRoute | null> {
+  try {
+    const url = new URL(input.trim())
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null
+    const segments = url.pathname.split('/').filter(Boolean).map(decodeURIComponent)
+    if (
+      segments.length === 4 &&
+      segments[0] === 'hm' &&
+      segments[2] === ':settings' &&
+      segments[3] === 'email-subscribers'
+    ) {
+      return {key: 'site-settings-emails', accountUid: segments[1]}
+    }
+    if (segments.length !== 2 || segments[0] !== ':settings' || segments[1] !== 'email-subscribers') return null
+    url.pathname = '/'
+    url.search = ''
+    url.hash = ''
+    const result = await resolveHypermediaUrl(url.toString(), opts)
+    if (!result?.hmId) return null
+    return {key: 'site-settings-emails', accountUid: result.hmId.uid}
+  } catch {
+    return null
+  }
 }
 
 function agentUrlToRoute(input: string): NavRoute | null {

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -19,6 +19,8 @@ import {usePublishSite, useRemoveSiteDialog} from '@/components/publish-site'
 import {SearchInput} from '@/components/search-input'
 import {domainResolver, grpcClient} from '@/grpc-client'
 import {roleCanWrite, useSelectedAccountCapability} from '@/models/access-control'
+import {useIsSiteOwner} from '@shm/shared/models/capabilities'
+import {createEmailSubscribersMenuItem} from '@shm/ui/site-email-subscribers'
 import {useDraft} from '@/models/accounts'
 import {useMyAccountIds} from '@/models/daemon'
 import {
@@ -239,6 +241,8 @@ export default function DesktopResourcePage() {
   const capability = useSelectedAccountCapability(capabilityId)
   const canEdit = roleCanWrite(capability?.role)
   const myAccountIds = useMyAccountIds()
+  // Email subscribers is offered on the home document for the site owner.
+  const {isSiteOwner} = useIsSiteOwner(docId.path?.length ? undefined : docId.uid)
 
   // Fetch draft content early so the editor can be initialized with draft blocks
   // instead of published blocks (avoids the flash + replaceBlocks race condition)
@@ -909,6 +913,9 @@ export default function DesktopResourcePage() {
           publishSite.open({id: docId})
         },
       })
+    }
+    if (isSiteOwner) {
+      menuItems.push(createEmailSubscribersMenuItem({navigate, accountUid: docId.uid}))
     }
   }
 

--- a/frontend/apps/desktop/src/pages/main.tsx
+++ b/frontend/apps/desktop/src/pages/main.tsx
@@ -57,6 +57,7 @@ var AgentSession = lazy(() => import('./agents/session'))
 var Drafts = lazy(() => import('./drafts'))
 var Profile = lazy(() => import('./profile'))
 var Notifications = lazy(() => import('./notifications'))
+var SiteSettingsEmails = lazy(() => import('./site-settings-emails'))
 
 /**
  * Redirect persisted `key: 'draft'` routes (from before draft-route removal)
@@ -471,6 +472,11 @@ function getPageComponent(navRoute: NavRoute) {
     case 'notifications':
       return {
         PageComponent: Notifications,
+        Fallback: BaseLoading,
+      }
+    case 'site-settings-emails':
+      return {
+        PageComponent: SiteSettingsEmails,
         Fallback: BaseLoading,
       }
     default:

--- a/frontend/apps/desktop/src/pages/site-settings-emails.tsx
+++ b/frontend/apps/desktop/src/pages/site-settings-emails.tsx
@@ -1,0 +1,72 @@
+import {MainWrapper} from '@/components/main-wrapper'
+import {useSelectedAccountId} from '@/selected-account'
+import {client} from '@/trpc'
+import {useIsSiteOwner} from '@shm/shared/models/capabilities'
+import {useAccount} from '@shm/shared/models/entity'
+import {queryKeys} from '@shm/shared/models/query-keys'
+import {useNavRoute} from '@shm/shared/utils/navigation'
+import {PanelContainer} from '@shm/ui/container'
+import {GeneralPageSurface} from '@shm/ui/general-page'
+import {SiteEmailSubscribersPanel} from '@shm/ui/site-email-subscribers'
+import {useQuery} from '@tanstack/react-query'
+import {ReactNode} from 'react'
+
+/**
+ * Site owner's email subscribers page. The list lives on the notify service
+ * that the site advertises via its /hm/api/config, so the request goes
+ * through the main process which resolves that host and signs with the
+ * selected identity's key, delegated to the site account.
+ */
+export default function SiteSettingsEmailsPage() {
+  const route = useNavRoute()
+  const routeAccountUid = route.key === 'site-settings-emails' ? route.accountUid : undefined
+  const selectedAccountUid = useSelectedAccountId()
+  const siteAccountUid = routeAccountUid ?? selectedAccountUid ?? undefined
+  const {isSiteOwner, isLoading: isOwnershipLoading} = useIsSiteOwner(siteAccountUid)
+  const account = useAccount(siteAccountUid)
+  const siteUrl: string | undefined = account.data?.metadata?.siteUrl
+
+  let content: ReactNode
+  if (!selectedAccountUid || !siteAccountUid) {
+    content = <SiteEmailSubscribersPanel message="Select an account to view its email subscribers." />
+  } else if (isOwnershipLoading || account.isLoading) {
+    content = <SiteEmailSubscribersPanel isLoading />
+  } else if (!isSiteOwner) {
+    content = (
+      <SiteEmailSubscribersPanel message="Only the site owner can view email subscribers. Switch to the site's account to see this list." />
+    )
+  } else {
+    content = <SiteEmailSubscribers siteUrl={siteUrl} siteAccountUid={siteAccountUid} signAs={selectedAccountUid} />
+  }
+
+  return (
+    <PanelContainer className="dark:bg-background bg-white">
+      <MainWrapper scrollable>
+        <GeneralPageSurface>{content}</GeneralPageSurface>
+      </MainWrapper>
+    </PanelContainer>
+  )
+}
+
+function SiteEmailSubscribers({
+  siteUrl,
+  siteAccountUid,
+  signAs,
+}: {
+  siteUrl: string | undefined
+  siteAccountUid: string
+  signAs: string
+}) {
+  const subscribers = useQuery({
+    queryKey: [queryKeys.SITE_EMAIL_SUBSCRIBERS, siteUrl ?? null, siteAccountUid, signAs],
+    queryFn: () => client.sites.getEmailSubscribers.query({siteUrl, accountUid: siteAccountUid, signAs}),
+  })
+
+  return (
+    <SiteEmailSubscribersPanel
+      subscribers={subscribers.data?.subscribers}
+      isLoading={subscribers.isLoading}
+      errorMessage={subscribers.error instanceof Error ? subscribers.error.message : null}
+    />
+  )
+}

--- a/frontend/apps/notify/app/db.test.ts
+++ b/frontend/apps/notify/app/db.test.ts
@@ -12,6 +12,7 @@ import {
   getNotificationConfigsForEmail,
   getNotificationEmailVerificationByToken,
   getNotificationEmailVerificationForAccount,
+  getEmailSubscribersForAccount,
   getNotificationReadState,
   getNotifierLastProcessedEventId,
   getSubscription,
@@ -165,6 +166,52 @@ describe('Database', () => {
 
     it('should return null for non-existent subscription', () => {
       expect(getSubscription('non-existent-id', 'non-existent@example.com')).toBeNull()
+    })
+
+    it('should list email subscribers for an account without leaking admin tokens', () => {
+      createSubscription({
+        id: 'site-account',
+        email: 'subscriber1@example.com',
+        notifyOwnedDocChange: true,
+        notifySiteDiscussions: false,
+      })
+      createSubscription({
+        id: 'site-account',
+        email: 'subscriber2@example.com',
+        notifySiteDiscussions: true,
+      })
+      createSubscription({
+        id: 'other-account',
+        email: 'other@example.com',
+      })
+
+      const db = new Database(join(tmpDir, 'web-db.sqlite'))
+      const adminToken = db.prepare('SELECT adminToken FROM emails WHERE email = ?').get('subscriber2@example.com') as {
+        adminToken: string
+      }
+      db.close()
+      setEmailUnsubscribed(adminToken.adminToken, true)
+
+      const subscribers = getEmailSubscribersForAccount('site-account')
+      expect(subscribers).toHaveLength(2)
+      expect(subscribers.map((s) => s.email).sort()).toEqual(['subscriber1@example.com', 'subscriber2@example.com'])
+
+      const first = subscribers.find((s) => s.email === 'subscriber1@example.com')
+      expect(first).toMatchObject({
+        notifyOwnedDocChange: true,
+        notifySiteDiscussions: false,
+        isUnsubscribed: false,
+      })
+      // createdAt is normalized to an ISO UTC timestamp for clients.
+      expect(new Date(first!.createdAt).getTime()).not.toBeNaN()
+      expect(first!.createdAt.endsWith('Z')).toBe(true)
+
+      expect(subscribers.find((s) => s.email === 'subscriber2@example.com')?.isUnsubscribed).toBe(true)
+      for (const subscriber of subscribers) {
+        expect(subscriber).not.toHaveProperty('adminToken')
+      }
+
+      expect(getEmailSubscribersForAccount('account-with-no-subscribers')).toEqual([])
     })
   })
 

--- a/frontend/apps/notify/app/db.ts
+++ b/frontend/apps/notify/app/db.ts
@@ -22,6 +22,14 @@ export type Email = BaseEmail & {
   subscriptions: BaseSubscription[]
 }
 
+export type EmailSubscriber = {
+  email: string
+  createdAt: string
+  notifyOwnedDocChange: boolean
+  notifySiteDiscussions: boolean
+  isUnsubscribed: boolean
+}
+
 type DBSubscription = {
   id: string
   email: string
@@ -64,6 +72,7 @@ let stmtInsertEmail: Database.Statement
 let stmtInsertSubscription: Database.Statement
 let stmtGetSubscription: Database.Statement
 let stmtGetSubscriptionsForAccount: Database.Statement
+let stmtGetEmailSubscribersForAccount: Database.Statement
 let stmtSetNotifierStatus: Database.Statement
 let stmtGetNotifierStatus: Database.Statement
 let stmtUpdateSubscription: Database.Statement
@@ -333,6 +342,13 @@ export async function initDatabase(): Promise<void> {
     FROM email_subscriptions es
     WHERE es.id = ?
   `)
+  stmtGetEmailSubscribersForAccount = db.prepare(`
+    SELECT es.email, es.createdAt, es.notifyOwnedDocChange, es.notifySiteDiscussions, emails.isUnsubscribed
+    FROM email_subscriptions es
+    JOIN emails ON emails.email = es.email
+    WHERE es.id = ?
+    ORDER BY es.createdAt DESC
+  `)
   stmtSetNotifierStatus = db.prepare(`
     INSERT OR REPLACE INTO notifier_status (field, value) VALUES (?, ?)
   `)
@@ -539,6 +555,26 @@ export function getSubscriptionsForAccount(id: string): BaseSubscription[] {
     ...r,
     notifyOwnedDocChange: Boolean(r.notifyOwnedDocChange),
     notifySiteDiscussions: Boolean(r.notifySiteDiscussions),
+  }))
+}
+
+/** Lists every email subscribed to an account's site, without exposing admin tokens. */
+export function getEmailSubscribersForAccount(id: string): EmailSubscriber[] {
+  const rows = stmtGetEmailSubscribersForAccount.all(id) as Array<{
+    email: string
+    createdAt: string
+    notifyOwnedDocChange: number
+    notifySiteDiscussions: number
+    isUnsubscribed: number
+  }>
+
+  return rows.map((r) => ({
+    email: r.email,
+    // SQLite CURRENT_TIMESTAMP is UTC without a timezone marker; normalize to ISO.
+    createdAt: r.createdAt.includes('T') ? r.createdAt : `${r.createdAt.replace(' ', 'T')}Z`,
+    notifyOwnedDocChange: Boolean(r.notifyOwnedDocChange),
+    notifySiteDiscussions: Boolean(r.notifySiteDiscussions),
+    isUnsubscribed: Boolean(r.isUnsubscribed),
   }))
 }
 

--- a/frontend/apps/notify/app/routes/hm.api.notifications.tsx
+++ b/frontend/apps/notify/app/routes/hm.api.notifications.tsx
@@ -1,4 +1,5 @@
 import {BadRequestError, cborApiAction} from '@/server-api'
+import {getEmailSubscribersForAccount} from '@/db'
 import {applyNotificationActionsForAccount, getNotificationStateSnapshot} from '@/notification-state'
 import {apiActionOnlyLoader} from '@/utils/cors'
 import {validateSignature} from '@/validate-signature'
@@ -68,6 +69,13 @@ const notificationAction = z.discriminatedUnion('action', [
     siteUid: z.string().optional(),
     actions: z.array(notificationMutationActionSchema),
   }),
+  z.object({
+    action: z.literal('get-email-subscribers'),
+    signer: z.instanceof(Uint8Array),
+    time: z.number(),
+    sig: z.instanceof(Uint8Array),
+    accountUid: z.string().optional(),
+  }),
 ])
 
 export type NotificationAction = z.infer<typeof notificationAction>
@@ -101,6 +109,13 @@ export const action = cborApiAction<NotificationAction, any>(async (signedPayloa
   }
 
   const accountId = await resolveAccountId(signedPayload.signer, signedPayload.accountUid)
+
+  if (restPayload.action === 'get-email-subscribers') {
+    // The resolved accountId scopes the query, so a signer can only list
+    // subscribers of the site they own (or are a delegated agent of).
+    return {subscribers: getEmailSubscribersForAccount(accountId)}
+  }
+
   const page = {
     beforeMs: restPayload.beforeMs,
     limit: restPayload.limit,

--- a/frontend/apps/notify/app/verify-delegation.ts
+++ b/frontend/apps/notify/app/verify-delegation.ts
@@ -6,12 +6,24 @@ import {grpcClient} from './notify-request'
 import {base58btc} from 'multiformats/bases/base58'
 import {BIG_INT} from '@shm/shared/constants'
 
+/** Returns the accounts that granted the delegate an AGENT capability. */
+async function listAgentGrantorAccounts(delegateUid: string): Promise<Set<string>> {
+  const result = await grpcClient.accessControl.listCapabilitiesForDelegate({
+    delegate: delegateUid,
+    pageSize: BIG_INT,
+  })
+  return new Set(result.capabilities.filter((cap) => cap.role === 3 /* AGENT */).map((cap) => cap.account))
+}
+
 /**
  * Resolves the effective account ID for a notification request.
  *
  * When `accountUid` is provided (delegation), verifies that the signer holds
- * an AGENT capability for that account via the daemon. Returns `accountUid`
- * on success.
+ * an AGENT capability for that account via the daemon. One level of chaining
+ * is supported: a web session key delegated by a user account (AGENT) may act
+ * for any account that granted that user account an AGENT capability — e.g.
+ * a site account whose owner is signed in through the vault. Returns
+ * `accountUid` on success.
  *
  * When `accountUid` is absent, derives the account ID from the signer's
  * public key (the traditional path).
@@ -23,17 +35,20 @@ export async function resolveAccountId(signerPublicKey: Uint8Array, accountUid: 
     return signerUid
   }
 
-  // Delegation: verify the signer has a capability for the claimed account
-  const result = await grpcClient.accessControl.listCapabilitiesForDelegate({
-    delegate: signerUid,
-    pageSize: BIG_INT,
-  })
-
-  const hasCapability = result.capabilities.some((cap) => cap.account === accountUid && cap.role === 3 /* AGENT */)
-
-  if (!hasCapability) {
-    throw new Error(`Signer ${signerUid} is not authorized to act on behalf of account ${accountUid}`)
+  // Direct delegation: the target account granted the signer key an AGENT capability.
+  const grantors = await listAgentGrantorAccounts(signerUid)
+  if (grantors.has(accountUid)) {
+    return accountUid
   }
 
-  return accountUid
+  // Chained delegation: the signer key acts for an intermediate account
+  // (e.g. the signed-in user), which in turn is an AGENT of the target account.
+  for (const intermediate of grantors) {
+    const intermediateGrantors = await listAgentGrantorAccounts(intermediate)
+    if (intermediateGrantors.has(accountUid)) {
+      return accountUid
+    }
+  }
+
+  throw new Error(`Signer ${signerUid} is not authorized to act on behalf of account ${accountUid}`)
 }

--- a/frontend/apps/web/app/routes/$.tsx
+++ b/frontend/apps/web/app/routes/$.tsx
@@ -6,7 +6,15 @@ import {
   setRequestInstrumentationContext,
 } from '@/instrumentation.server'
 import {createResourceMetadata, metadataToPageMeta} from '@/hypermedia-metadata'
-import {GRPCError, loadSiteResource, loadWebDraftPlaceholderResource, SiteDocumentPayload} from '@/loaders'
+import {
+  GRPCError,
+  loadSiteHeaderData,
+  loadSiteResource,
+  loadWebDraftPlaceholderResource,
+  SiteDocumentPayload,
+} from '@/loaders'
+import {SiteSettingsEmailsScreen, type SiteSettingsEmailsPayload} from '@/site-settings-emails-content'
+import {NOTIFY_SERVICE_HOST} from '@shm/shared/constants'
 import {defaultPageMeta} from '@/meta'
 import {NoSitePage, NotRegisteredPage} from '@/not-registered'
 import {WebSiteProvider} from '@/providers'
@@ -61,7 +69,7 @@ type InspectIpfsPayload = {
   siteHost: string
 }
 
-type DocumentPayload = ExtendedSitePayload | InspectIpfsPayload | 'unregistered' | 'no-site'
+type DocumentPayload = ExtendedSitePayload | InspectIpfsPayload | SiteSettingsEmailsPayload | 'unregistered' | 'no-site'
 
 /**
  * Extract view term from path parts and return cleaned path + view term
@@ -199,6 +207,9 @@ export const meta: MetaFunction<typeof loader> = (args) => {
   if ('kind' in payload && payload.kind === 'inspect-ipfs') {
     return [{title: `ipfs://${payload.ipfsPath}`}]
   }
+  if ('kind' in payload && payload.kind === 'site-settings-emails') {
+    return [{title: 'Email Subscribers'}]
+  }
   return documentPageMeta({
     // @ts-ignore
     data: args.data,
@@ -262,6 +273,33 @@ async function loadRoute({params, request}: {params: Params; request: Request}) 
       printInstrumentationSummary(ctx)
     }
     return wrapJSON('unregistered', {status: 404})
+  }
+
+  // Site settings pages use a `:settings` view term: /:settings/email-subscribers
+  // on the site's own origin, or /hm/<uid>/:settings/email-subscribers on the gateway.
+  const rawSitePath = params['*'] ? params['*'].split('/').filter(Boolean) : []
+  let settingsSiteAccountUid: string | null = null
+  if (rawSitePath.length === 2 && rawSitePath[0] === ':settings' && rawSitePath[1] === 'email-subscribers') {
+    settingsSiteAccountUid = registeredAccountUid
+  } else if (
+    rawSitePath.length === 4 &&
+    rawSitePath[0] === 'hm' &&
+    rawSitePath[2] === ':settings' &&
+    rawSitePath[3] === 'email-subscribers'
+  ) {
+    settingsSiteAccountUid = rawSitePath[1] || null
+  }
+  if (settingsSiteAccountUid) {
+    const headerData = await instrument(ctx, 'loadSiteHeaderData', () => loadSiteHeaderData(parsedRequest))
+    if (isDataRequest && ctx.enabled) {
+      printInstrumentationSummary(ctx)
+    }
+    return wrapJSON({
+      kind: 'site-settings-emails',
+      ...headerData,
+      siteAccountUid: settingsSiteAccountUid,
+      notifyServiceHost: NOTIFY_SERVICE_HOST || null,
+    } satisfies SiteSettingsEmailsPayload)
   }
 
   const gatewayInspectIpfsPath = pathParts[0] === 'hm' ? extractInspectIpfsPathFromPath(pathParts, true) : null
@@ -380,6 +418,9 @@ export default function UnifiedDocumentPage() {
   }
   if (data === 'no-site') {
     return <NoSitePage />
+  }
+  if ('kind' in data && data.kind === 'site-settings-emails') {
+    return <SiteSettingsEmailsScreen payload={data} />
   }
   if ('kind' in data && data.kind === 'inspect-ipfs') {
     return (

--- a/frontend/apps/web/app/routes/hm.api.config.tsx
+++ b/frontend/apps/web/app/routes/hm.api.config.tsx
@@ -4,7 +4,7 @@ import {getOrCreateServerSignerAccountUid} from '@/server-signing'
 import {getConfig} from '@/site-config.server'
 import type {LoaderFunction} from '@remix-run/node'
 import {json} from '@remix-run/node'
-import {SITE_BASE_URL, WEB_IS_GATEWAY} from '@shm/shared/constants'
+import {NOTIFY_SERVICE_HOST, SITE_BASE_URL, WEB_IS_GATEWAY} from '@shm/shared/constants'
 
 const corsHeaders = {'Access-Control-Allow-Origin': '*'}
 
@@ -27,6 +27,7 @@ export const loader: LoaderFunction = async ({request}) => {
         addrs: peerInfo.addrs,
         hostname: SITE_BASE_URL,
         isGateway: WEB_IS_GATEWAY,
+        notifyServiceHost: NOTIFY_SERVICE_HOST || null,
       },
       {headers: corsHeaders},
     )

--- a/frontend/apps/web/app/site-settings-emails-content.tsx
+++ b/frontend/apps/web/app/site-settings-emails-content.tsx
@@ -1,0 +1,118 @@
+import {useLocalKeyPair} from '@/auth'
+import {ClientOnly} from '@/client-lazy'
+import type {SiteHeaderPayload} from '@/loaders'
+import {PageFooter} from '@/page-footer'
+import {NavigationLoadingContent, WebSiteProvider} from '@/providers'
+import {WebSiteHeader} from '@/web-site-header'
+import {useWebNotificationSigner} from '@/web-notifications'
+import {WebHeaderActions} from '@/web-utils'
+import {useIsSiteOwner} from '@shm/shared/models/capabilities'
+import {getSiteEmailSubscribers, type NotificationSigner} from '@shm/shared/models/notification-service'
+import {queryKeys} from '@shm/shared/models/query-keys'
+import {GeneralPageSurface} from '@shm/ui/general-page'
+import {SiteEmailSubscribersPanel} from '@shm/ui/site-email-subscribers'
+import {Spinner} from '@shm/ui/spinner'
+import {useQuery} from '@tanstack/react-query'
+import {Suspense} from 'react'
+
+/** Loader payload for the email subscribers page, served at /:settings/email-subscribers. */
+export type SiteSettingsEmailsPayload = SiteHeaderPayload & {
+  kind: 'site-settings-emails'
+  // The account whose subscribers are shown: the registered site account, or
+  // the uid from the /hm/<uid>/:settings/email-subscribers gateway path.
+  siteAccountUid: string | undefined
+  // Matches the notifyServiceHost exposed by this site's /hm/api/config.
+  notifyServiceHost: string | null
+}
+
+/** Full email subscribers page (site chrome + owner-gated list). */
+export function SiteSettingsEmailsScreen({payload}: {payload: SiteSettingsEmailsPayload}) {
+  const {originHomeId, siteHost, origin, homeMetadata, dehydratedState, siteAccountUid, notifyServiceHost} = payload
+  if (!originHomeId) {
+    return <h2>Invalid origin home id</h2>
+  }
+  return (
+    <WebSiteProvider origin={origin} originHomeId={originHomeId} siteHost={siteHost} dehydratedState={dehydratedState}>
+      <GeneralPageSurface className="min-h-screen items-center">
+        <WebSiteHeader
+          homeMetadata={homeMetadata}
+          originHomeId={originHomeId}
+          siteHomeId={originHomeId}
+          docId={null}
+          origin={origin}
+          rightActions={<WebHeaderActions siteUid={originHomeId.uid} />}
+        />
+        <NavigationLoadingContent className="flex w-full flex-1 flex-col gap-4 pt-[var(--site-header-h)] sm:pt-0">
+          <ClientOnly>
+            <Suspense fallback={<Spinner />}>
+              <WebSiteSettingsEmailsPage siteAccountUid={siteAccountUid} notifyServiceHost={notifyServiceHost} />
+            </Suspense>
+          </ClientOnly>
+        </NavigationLoadingContent>
+        <PageFooter className="w-full" />
+      </GeneralPageSurface>
+    </WebSiteProvider>
+  )
+}
+
+/**
+ * Client-only content for the email subscribers page. The list is fetched
+ * from the site's notify service (the one exposed via /hm/api/config) with a
+ * request signed by the web session key, delegated to the site account.
+ */
+export function WebSiteSettingsEmailsPage({
+  siteAccountUid,
+  notifyServiceHost,
+}: {
+  siteAccountUid: string | undefined
+  notifyServiceHost: string | null
+}) {
+  const keyPair = useLocalKeyPair()
+  const signer = useWebNotificationSigner()
+  const {isSiteOwner, isLoading: isOwnershipLoading} = useIsSiteOwner(siteAccountUid)
+
+  if (!siteAccountUid) {
+    return <SiteEmailSubscribersPanel message="This site does not have a registered owner account." />
+  }
+  if (!notifyServiceHost) {
+    return <SiteEmailSubscribersPanel message="This site does not have a notification service configured." />
+  }
+  if (!keyPair) {
+    return <SiteEmailSubscribersPanel message="Sign in as the site owner to view email subscribers." />
+  }
+  if (isOwnershipLoading) {
+    return <SiteEmailSubscribersPanel isLoading />
+  }
+  if (!isSiteOwner) {
+    return <SiteEmailSubscribersPanel message="Only the site owner can view email subscribers." />
+  }
+  return <SiteEmailSubscribers notifyServiceHost={notifyServiceHost} siteAccountUid={siteAccountUid} signer={signer} />
+}
+
+function SiteEmailSubscribers({
+  notifyServiceHost,
+  siteAccountUid,
+  signer,
+}: {
+  notifyServiceHost: string
+  siteAccountUid: string
+  signer: NotificationSigner | undefined
+}) {
+  // Ask for the SITE account's subscribers: the web session key signs the
+  // request and the notify server verifies the AGENT capability chain from
+  // the site account down to the session key.
+  const siteSigner = signer ? {...signer, accountUid: siteAccountUid} : undefined
+  const subscribers = useQuery({
+    queryKey: [queryKeys.SITE_EMAIL_SUBSCRIBERS, notifyServiceHost, siteAccountUid],
+    enabled: !!siteSigner,
+    queryFn: () => getSiteEmailSubscribers(notifyServiceHost, siteSigner!),
+  })
+
+  return (
+    <SiteEmailSubscribersPanel
+      subscribers={subscribers.data?.subscribers}
+      isLoading={!signer || subscribers.isLoading}
+      errorMessage={subscribers.error instanceof Error ? subscribers.error.message : null}
+    />
+  )
+}

--- a/frontend/apps/web/app/web-notifications.ts
+++ b/frontend/apps/web/app/web-notifications.ts
@@ -37,7 +37,7 @@ function useWebNotifyServiceHost() {
  * Builds a NotificationSigner from the web's local CryptoKeyPair.
  * Returns undefined until the async public key export resolves.
  */
-function useWebNotificationSigner(): NotificationSigner | undefined {
+export function useWebNotificationSigner(): NotificationSigner | undefined {
   const keyPair = useLocalKeyPair()
   const [signer, setSigner] = useState<NotificationSigner | undefined>(undefined)
 

--- a/frontend/apps/web/app/web-utils.tsx
+++ b/frontend/apps/web/app/web-utils.tsx
@@ -8,7 +8,9 @@ import {
   useUniversalAppContext,
 } from '@shm/shared'
 import {DEFAULT_GATEWAY_URL} from '@shm/shared/constants'
+import {useIsSiteOwner} from '@shm/shared/models/capabilities'
 import {useAccount} from '@shm/shared/models/entity'
+import {createEmailSubscribersMenuItem} from '@shm/ui/site-email-subscribers'
 import {isNotificationEventRead} from '@shm/shared/models/notification-read-logic'
 import {hmIdToURL} from '@shm/shared/utils/entity-id-url'
 import {useNavigate, useNavRoute} from '@shm/shared/utils/navigation'
@@ -58,6 +60,9 @@ export function useWebMenuItems(docId: UnpackedHypermediaId, options?: {includeI
   const navigate = useNavigate()
   const {onCopyReference, onPushReference, origin, originHomeId, experiments} = useUniversalAppContext()
   const includeInspect = options?.includeInspect !== false
+  // Email subscribers is offered on the home document for the site owner,
+  // matching the desktop document options menu.
+  const {isSiteOwner} = useIsSiteOwner(docId.path?.length ? undefined : docId.uid)
   const inspectRoute = useMemo(() => {
     if (!includeInspect) return null
     const wrappedRoute = createInspectNavRouteFromRoute(route)
@@ -109,6 +114,7 @@ export function useWebMenuItems(docId: UnpackedHypermediaId, options?: {includeI
         icon: <LayoutList className="size-4" />,
         onClick: () => navigate({key: 'all-documents', id: allDocumentsId}),
       },
+      ...(isSiteOwner ? [createEmailSubscribersMenuItem({navigate})] : []),
       ...(inspectRoute
         ? [
             {
@@ -126,6 +132,7 @@ export function useWebMenuItems(docId: UnpackedHypermediaId, options?: {includeI
       allDocumentsId,
       docId,
       inspectRoute,
+      isSiteOwner,
       navigate,
       onCopyReference,
       onPushReference,

--- a/frontend/packages/shared/src/models/capabilities.ts
+++ b/frontend/packages/shared/src/models/capabilities.ts
@@ -2,7 +2,8 @@ import type {CapabilityRole} from '@seed-hypermedia/client'
 import {createCapability as createCapabilityBlob} from '@seed-hypermedia/client'
 import type {HMCapability, HMRole, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {useMutation} from '@tanstack/react-query'
-import {useUniversalClient} from '../routing'
+import {useUniversalAppContext, useUniversalClient} from '../routing'
+import {useStream} from '../use-stream'
 import {hmId} from '../utils/entity-id-url'
 import {hmIdPathToEntityQueryPath} from '../utils/path-api'
 import {useCapabilities, useSelectedAccountId} from './entity'
@@ -10,8 +11,9 @@ import {invalidateQueries} from './query-client'
 import {queryKeys} from './query-keys'
 
 const CapabilityInheritance: Readonly<HMRole[]> =
-  // used to determine when one capability can be used in place of another. all owners are writers, for example
-  ['owner', 'writer', 'none']
+  // used to determine when one capability can be used in place of another. all owners are writers, for example.
+  // AGENT is a full delegation of the account (it can act as the account), so it ranks highest.
+  ['agent', 'owner', 'writer', 'none']
 
 export function roleCanWrite(role?: HMRole | null | undefined) {
   if (!role) return false
@@ -96,6 +98,28 @@ export function useSelectedAccountCapability(
       return selectedAccountUid === cap.accountUid
     })
   return myCapability || null
+}
+
+/**
+ * Whether the current identity can act as the site owner: the site account
+ * is the current user, or an AGENT capability on the site account was
+ * granted to the current user. Like useIsCurrentUser, both the selected
+ * identity (vault/account UID) and the signing identity (web session key
+ * UID) are checked, because web sign-in delegates an AGENT capability to
+ * the session key itself.
+ */
+export function useIsSiteOwner(siteUid: string | undefined): {isSiteOwner: boolean; isLoading: boolean} {
+  const {selectedIdentity, signingIdentity} = useUniversalAppContext()
+  const selectedId = useStream(selectedIdentity) ?? null
+  const signingId = useStream(signingIdentity) ?? null
+  const capabilities = useCapabilities(siteUid ? hmId(siteUid) : undefined)
+  const identityUids = [selectedId, signingId].filter((uid): uid is string => !!uid)
+  const isDirectOwner = Boolean(siteUid && identityUids.includes(siteUid))
+  const hasAgentCapability = (capabilities.data ?? []).some(
+    (cap) => cap.role === 'agent' && identityUids.includes(cap.accountUid),
+  )
+  const isSiteOwner = Boolean(siteUid) && (isDirectOwner || hasAgentCapability)
+  return {isSiteOwner, isLoading: !isSiteOwner && Boolean(siteUid) && capabilities.isLoading}
 }
 
 /**

--- a/frontend/packages/shared/src/models/notification-service.ts
+++ b/frontend/packages/shared/src/models/notification-service.ts
@@ -61,6 +61,26 @@ export async function getNotificationState(
   }) as Promise<NotificationStateSnapshot>
 }
 
+/** One email subscribed to a site via the public subscribe form. */
+export type SiteEmailSubscriber = {
+  email: string
+  createdAt: string
+  notifyOwnedDocChange: boolean
+  notifySiteDiscussions: boolean
+  isUnsubscribed: boolean
+}
+
+/**
+ * Fetches the emails subscribed to the signer's site. The notify service
+ * only returns subscribers for the account resolved from the signature,
+ * so this is available exclusively to the site owner (or their agent).
+ */
+export async function getSiteEmailSubscribers(notifyServiceHost: string, signer: NotificationSigner) {
+  return signedNotifPost(notifyServiceHost, signer, {
+    action: 'get-email-subscribers',
+  }) as Promise<{subscribers: SiteEmailSubscriber[]}>
+}
+
 /** Applies one or more notification actions on the notify service and returns canonical state. */
 export async function applyNotificationActions(
   notifyServiceHost: string,

--- a/frontend/packages/shared/src/models/query-keys.ts
+++ b/frontend/packages/shared/src/models/query-keys.ts
@@ -140,6 +140,7 @@ export const queryKeys = {
   NOTIFICATION_INBOX: 'NOTIFICATION_INBOX', // accountUid
   NOTIFICATION_READ_STATE: 'NOTIFICATION_READ_STATE', // notifyServiceHost, accountUid
   NOTIFICATION_SYNC_STATUS: 'NOTIFICATION_SYNC_STATUS', // accountUid
+  SITE_EMAIL_SUBSCRIBERS: 'SITE_EMAIL_SUBSCRIBERS', // notifyServiceHost, accountUid
 
   // ai config
   AI_CONFIG: 'AI_CONFIG',

--- a/frontend/packages/shared/src/routes.ts
+++ b/frontend/packages/shared/src/routes.ts
@@ -264,6 +264,16 @@ export const notificationsRouteSchema = z.object({
 })
 export type NotificationsRoute = z.infer<typeof notificationsRouteSchema>
 
+/**
+ * Route for the site owner's email subscribers page. On web this is the
+ * current site; on desktop accountUid selects which owned site to show.
+ */
+export const siteSettingsEmailsRouteSchema = z.object({
+  key: z.literal('site-settings-emails'),
+  accountUid: z.string().optional(),
+})
+export type SiteSettingsEmailsRoute = z.infer<typeof siteSettingsEmailsRouteSchema>
+
 export const deletedContentRouteSchema = z.object({
   key: z.literal('deleted-content'),
 })
@@ -336,6 +346,7 @@ export const navRouteSchema = z.discriminatedUnion('key', [
   contactRouteSchema,
   settingsRouteSchema,
   notificationsRouteSchema,
+  siteSettingsEmailsRouteSchema,
   documentRouteSchema,
   draftRouteSchema,
   draftRebaseRouteSchema,

--- a/frontend/packages/shared/src/routing.tsx
+++ b/frontend/packages/shared/src/routing.tsx
@@ -212,6 +212,11 @@ export function routeToHref(
     const viewParam = route.view ? `?view=${route.view}` : ''
     return `/hm/notifications${viewParam}`
   }
+  if (typeof route !== 'string' && route.key === 'site-settings-emails') {
+    const siteBase =
+      !route.accountUid || options?.originHomeId?.uid === route.accountUid ? '' : `/hm/${route.accountUid}`
+    return `${siteBase}/:settings/email-subscribers`
+  }
 
   if (typeof route !== 'string' && route.key === 'inspect') {
     if (options?.hmUrlHref) {

--- a/frontend/packages/shared/src/utils/entity-id-url.ts
+++ b/frontend/packages/shared/src/utils/entity-id-url.ts
@@ -605,6 +605,12 @@ export function routeToUrl(
     const tab = route.tab || 'profile'
     return `${urlHost}${siteBase}/:${tab}`
   }
+  if (route.key === 'site-settings-emails') {
+    if (!route.accountUid) return null
+    const urlHost = opts?.hostname === undefined ? DEFAULT_GATEWAY_URL : opts?.hostname === null ? '' : opts.hostname
+    const siteBase = opts?.originHomeId?.uid === route.accountUid ? '' : `/hm/${route.accountUid}`
+    return `${urlHost}${siteBase}/:settings/email-subscribers`
+  }
   if (route.key === 'contact') {
     const urlHost = opts?.hostname ?? DEFAULT_GATEWAY_URL
     return `${urlHost}/hm/contact/${route.id.uid}`

--- a/frontend/packages/ui/src/site-email-subscribers.tsx
+++ b/frontend/packages/ui/src/site-email-subscribers.tsx
@@ -1,0 +1,140 @@
+import type {SiteEmailSubscriber} from '@shm/shared/models/notification-service'
+import type {NavRoute} from '@shm/shared/routes'
+import {useTxString} from '@shm/shared/translation'
+import {formattedDateShort} from '@shm/shared/utils/date'
+import {Mail} from 'lucide-react'
+import type {MenuItemType} from './options-dropdown'
+import {Spinner} from './spinner'
+import {SizableText} from './text'
+import {cn} from './utils'
+
+/**
+ * Document-options menu entry that opens the site's email subscribers page.
+ * Shared between the web and desktop document options menus.
+ */
+export function createEmailSubscribersMenuItem({
+  navigate,
+  accountUid,
+}: {
+  navigate: (route: NavRoute) => void
+  accountUid?: string
+}): MenuItemType {
+  return {
+    key: 'email-subscribers',
+    label: 'Email Subscribers',
+    icon: <Mail className="size-4" />,
+    onClick: () => navigate({key: 'site-settings-emails', accountUid}),
+  }
+}
+
+/**
+ * Page body for the email subscribers page: heading, description, and either
+ * a status message or the subscriber list. Shared between web and desktop;
+ * the platform pages provide their own chrome and data fetching.
+ */
+export function SiteEmailSubscribersPanel({
+  message,
+  subscribers,
+  isLoading,
+  errorMessage,
+}: {
+  /** When set, shown instead of the list (sign-in / not-owner / unavailable states). */
+  message?: string | null
+  subscribers?: SiteEmailSubscriber[] | undefined
+  isLoading?: boolean
+  errorMessage?: string | null
+}) {
+  const tx = useTxString()
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 px-4 py-8">
+      <SizableText size="2xl" weight="bold" asChild>
+        <h1>{tx('Email Subscribers')}</h1>
+      </SizableText>
+      <SizableText size="sm" className="text-muted-foreground">
+        {tx('People who subscribed to receive updates from this site.')}
+      </SizableText>
+      {message ? (
+        <SizableText className="text-muted-foreground">{message}</SizableText>
+      ) : (
+        <SiteEmailSubscribersList subscribers={subscribers} isLoading={!!isLoading} errorMessage={errorMessage} />
+      )}
+    </div>
+  )
+}
+
+/**
+ * Renders the list of emails subscribed to a site. Shared between the web
+ * and desktop email subscribers pages.
+ */
+export function SiteEmailSubscribersList({
+  subscribers,
+  isLoading,
+  errorMessage,
+}: {
+  subscribers: SiteEmailSubscriber[] | undefined
+  isLoading: boolean
+  errorMessage?: string | null
+}) {
+  const tx = useTxString()
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Spinner />
+      </div>
+    )
+  }
+
+  if (errorMessage) {
+    return <SizableText className="text-red-500">{errorMessage}</SizableText>
+  }
+
+  if (!subscribers?.length) {
+    return <SizableText className="text-muted-foreground">{tx('No one has subscribed to this site yet.')}</SizableText>
+  }
+
+  const activeCount = subscribers.filter((s) => !s.isUnsubscribed).length
+
+  return (
+    <div className="flex flex-col gap-3">
+      <SizableText size="sm" className="text-muted-foreground">
+        {activeCount === 1 ? tx('1 subscriber') : `${activeCount} ${tx('subscribers')}`}
+      </SizableText>
+      <div className="border-border flex flex-col divide-y rounded-md border">
+        {subscribers.map((subscriber) => (
+          <div key={subscriber.email} className="flex flex-wrap items-center justify-between gap-2 px-4 py-3">
+            <div className="flex flex-col">
+              <SizableText
+                weight="medium"
+                className={cn(subscriber.isUnsubscribed && 'text-muted-foreground line-through')}
+              >
+                {subscriber.email}
+              </SizableText>
+              <SizableText size="xs" className="text-muted-foreground">
+                {tx('Subscribed')} {formattedDateShort(subscriber.createdAt)}
+              </SizableText>
+            </div>
+            <div className="flex items-center gap-2">
+              {subscriber.isUnsubscribed ? (
+                <SubscriberTag label={tx('Unsubscribed')} />
+              ) : (
+                <>
+                  {subscriber.notifyOwnedDocChange && <SubscriberTag label={tx('Document Changes')} />}
+                  {subscriber.notifySiteDiscussions && <SubscriberTag label={tx('Discussions')} />}
+                </>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function SubscriberTag({label}: {label: string}) {
+  return (
+    <SizableText size="xs" className="bg-muted text-muted-foreground rounded-full px-2 py-0.5">
+      {label}
+    </SizableText>
+  )
+}


### PR DESCRIPTION
## What

Site owners can now see the list of emails that subscribed to their site through the "Subscribe to receive updates" form. The list lives on the notification server and is only accessible to the site owner via the standard signed notify-message flow.

## How it works

**Notify service**
- New `get-email-subscribers` action on the signed `/hm/api/notifications` endpoint. Authorization is structural: the query is scoped to the account resolved from the request signature (signature + 20s timestamp window + delegation check), so a signer can only list subscribers of the account they control.
- Delegation supports the web session-key model: the notify service accepts a request signed by a key holding an AGENT capability from the site account, including one level of chaining (site account → user account → session key).
- The db helper returns email, subscribe date (ISO UTC), notification preferences, and unsubscribed status — never the admin token.

**Discovery**
- The site's `/hm/api/config` now exposes `notifyServiceHost`, so clients know which notify server holds a site's subscribers. Desktop discovers the host through the target site's config (falling back to the app default for sites without a published `siteUrl`).

**Pages**
- Web: `<SiteURL>/:settings/email-subscribers` (gateway form `/hm/<uid>/:settings/email-subscribers`), served by the catch-all route alongside the other `:view` terms.
- Desktop: new `site-settings-emails` route; the omnibar shows/copies the page URL and resolves pasted URLs back to the page.
- Entry point on both platforms: the home document's options menu, shown only to the site owner.

**Shared code**
- `useIsSiteOwner` in `@shm/shared/models/capabilities` checks both the selected identity and the web session key against the site account (direct match or AGENT capability) — used by both platforms for gating.
- `SiteEmailSubscribersPanel` + `createEmailSubscribersMenuItem` in `@shm/ui` — one page body and one menu entry shared by web and desktop.
- `'agent'` is now ranked explicitly (highest) in the capability inheritance lattice instead of passing role checks by accident of `indexOf(-1)`; all existing role-check outcomes are preserved.
- Both platforms authenticate identically: sign with the current identity's key, delegate to the site account via the notify `accountUid` field.

## Security audit

Traced every path to the subscriber data: the only read path is the signed action; the signature covers the full payload (action, time, target account); capability issuance is enforced by the daemon (a capability only indexes if signed by the space key, and AGENT capabilities cannot be path-scoped); role check is AGENT-only (writers don't qualify); all other email-touching notify routes are signature- or secret-token-gated and scoped to a single email. Client-side gating is cosmetic; the server is authoritative.

## Testing

- `pnpm typecheck` clean across the monorepo.
- Test suites pass: notify (94, incl. a new db test asserting subscriber listing excludes admin tokens), shared (957), desktop (532), web (126).
- Verified end-to-end on a local dev site (localhost:3000) with a vault-delegated session key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)