### PR TITLE
chore(pr): describe media multiselect support

### DIFF
--- a/frontend/packages/editor/src/media-container.test.tsx
+++ b/frontend/packages/editor/src/media-container.test.tsx
@@ -4,6 +4,7 @@ import {act} from 'react-dom/test-utils'
 import {Schema} from 'prosemirror-model'
 import {EditorState, NodeSelection} from 'prosemirror-state'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {MultipleNodeSelection} from './blocknote/core/extensions/SideMenu/MultipleNodeSelection'
 ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
 
 const editorGate = {canEdit: false, isEditing: false, beginEditIfNeeded: vi.fn()}
@@ -27,8 +28,8 @@ vi.mock('./blocknote/react/ReactBlockSpec', () => ({
 
 import {MediaContainer} from './media-container'
 
-function makeBlock() {
-  return {id: 'block-1', type: 'image', props: {}, content: [], children: []} as any
+function makeBlock(id = 'block-1') {
+  return {id, type: 'image', props: {}, content: [], children: []} as any
 }
 
 const schema = new Schema({
@@ -51,7 +52,11 @@ const schema = new Schema({
 })
 
 function createSelectableEditorState() {
-  const doc = schema.node('doc', null, [schema.node('blockNode', {id: 'block-1'}, [schema.node('image')])])
+  const doc = schema.node('doc', null, [
+    schema.node('blockNode', {id: 'block-1'}, [schema.node('image')]),
+    schema.node('blockNode', {id: 'block-2'}, [schema.node('image')]),
+    schema.node('blockNode', {id: 'block-3'}, [schema.node('image')]),
+  ])
   return EditorState.create({schema, doc})
 }
 
@@ -168,6 +173,36 @@ describe('MediaContainer image caption', () => {
     expect(editor.__view.dispatch).toHaveBeenCalledOnce()
     expect(editor.__view.focus).toHaveBeenCalledOnce()
     expect(editor.__view.state.selection instanceof NodeSelection).toBe(true)
+  })
+
+  it('selects a contiguous media block range when shift-clicking another media block', () => {
+    editorGate.canEdit = true
+    editorGate.isEditing = true
+    const editor = makeEditor(true, true)
+    act(() => {
+      root.render(
+        <>
+          <MediaContainer editor={editor} block={makeBlock('block-1')} mediaType="image" assign={() => {}}>
+            <div data-testid="media-child-1" />
+          </MediaContainer>
+          <MediaContainer editor={editor} block={makeBlock('block-3')} mediaType="image" assign={() => {}}>
+            <div data-testid="media-child-3" />
+          </MediaContainer>
+        </>,
+      )
+    })
+
+    const firstMediaChild = container.querySelector('[data-testid="media-child-1"]') as HTMLElement
+    const thirdMediaChild = container.querySelector('[data-testid="media-child-3"]') as HTMLElement
+
+    act(() => {
+      firstMediaChild.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))
+      thirdMediaChild.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true, shiftKey: true}))
+    })
+
+    expect(editor.__view.state.selection instanceof MultipleNodeSelection).toBe(true)
+    const selection = editor.__view.state.selection as MultipleNodeSelection
+    expect(selection.nodes.map((node) => node.attrs.id)).toEqual(['block-1', 'block-2', 'block-3'])
   })
 
   it('moves to the next block when Enter is pressed in the image caption', () => {

--- a/frontend/packages/editor/src/media-container.tsx
+++ b/frontend/packages/editor/src/media-container.tsx
@@ -12,6 +12,7 @@ import {BlockNoteEditor} from './blocknote/core/BlockNoteEditor'
 import {Block} from './blocknote/core/extensions/Blocks/api/blockTypes'
 import {getBlockInfoWithManualOffset} from './blocknote/core/extensions/Blocks/helpers/getBlockInfoFromPos'
 import {isInGridContainer} from './blocknote/core/extensions/Blocks/nodes/BlockChildren'
+import {MultipleNodeSelection} from './blocknote/core/extensions/SideMenu/MultipleNodeSelection'
 import {InlineContent} from './blocknote/react/ReactBlockSpec'
 import {markBlockUploaded, MediaType} from './media-render'
 import {MediaSelectionMenu} from './media-selection-menu'
@@ -35,6 +36,67 @@ interface ContainerProps {
   urlInputPlaceholder?: string
   deleteLabel?: string
   extraMenuContent?: React.ReactNode
+}
+
+type BlockRange = {
+  blockBeforePos: number
+  blockAfterPos: number
+  blockContentBeforePos: number
+}
+
+function findBlockRangeById(doc: PMNode, blockId: string): BlockRange | null {
+  let range: BlockRange | null = null
+
+  doc.descendants((node: PMNode, pos: number) => {
+    if (node.type.name !== 'blockNode' || node.attrs?.id !== blockId) return true
+
+    try {
+      const blockInfo = getBlockInfoWithManualOffset(node, pos)
+      range = {
+        blockBeforePos: blockInfo.block.beforePos,
+        blockAfterPos: blockInfo.block.afterPos,
+        blockContentBeforePos: blockInfo.blockContent.beforePos,
+      }
+    } catch {
+      range = {
+        blockBeforePos: pos,
+        blockAfterPos: pos + node.nodeSize,
+        blockContentBeforePos: pos,
+      }
+    }
+    return false
+  })
+
+  return range
+}
+
+function findBlockRangeContainingPos(doc: PMNode, targetPos: number): BlockRange | null {
+  let range: BlockRange | null = null
+
+  doc.descendants((node: PMNode, pos: number) => {
+    if (node.type.name !== 'blockNode') return true
+
+    const blockAfterPos = pos + node.nodeSize
+    if (targetPos < pos || targetPos >= blockAfterPos) return true
+
+    try {
+      const blockInfo = getBlockInfoWithManualOffset(node, pos)
+      range = {
+        blockBeforePos: blockInfo.block.beforePos,
+        blockAfterPos: blockInfo.block.afterPos,
+        blockContentBeforePos: blockInfo.blockContent.beforePos,
+      }
+    } catch {
+      range = {
+        blockBeforePos: pos,
+        blockAfterPos,
+        blockContentBeforePos: pos,
+      }
+    }
+    return false
+  })
+
+  return range
 }
 
 export const MediaContainer = ({
@@ -186,16 +248,8 @@ export const MediaContainer = ({
     const view = editor._tiptapEditor?.view
     if (!view) return
 
-    let blockContentPos: number | null = null
-    view.state.doc.descendants((node: PMNode, pos: number) => {
-      if (node.type.name !== 'blockNode' || node.attrs?.id !== block.id) return true
-      try {
-        blockContentPos = getBlockInfoWithManualOffset(node, pos).blockContent.beforePos
-      } catch {
-        blockContentPos = pos
-      }
-      return false
-    })
+    const targetRange = findBlockRangeById(view.state.doc, block.id)
+    const blockContentPos = targetRange?.blockContentBeforePos ?? null
 
     if (blockContentPos == null) return
 
@@ -204,6 +258,30 @@ export const MediaContainer = ({
     e.preventDefault()
     e.stopPropagation()
     beginEditIfNeeded()
+
+    if (e.shiftKey) {
+      const currentSelection = view.state.selection
+      const anchorRange =
+        currentSelection instanceof NodeSelection || currentSelection instanceof MultipleNodeSelection
+          ? findBlockRangeContainingPos(view.state.doc, currentSelection.anchor)
+          : null
+
+      if (anchorRange && targetRange) {
+        const from = Math.min(anchorRange.blockBeforePos, targetRange.blockBeforePos)
+        const to = Math.max(anchorRange.blockAfterPos, targetRange.blockAfterPos)
+        const $from = view.state.doc.resolve(from)
+        const $to = view.state.doc.resolve(to)
+
+        if ($from.depth === $to.depth && $from.node($from.depth).eq($to.node($to.depth))) {
+          view.dispatch(
+            view.state.tr.setSelection(MultipleNodeSelection.create(view.state.doc, from, to)).scrollIntoView(),
+          )
+          view.focus()
+          return
+        }
+      }
+    }
+
     view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, blockContentPos)).scrollIntoView())
     view.focus()
   }
@@ -264,6 +342,10 @@ export const MediaContainer = ({
       onClick={
         onPress
           ? (e) => {
+              if (canAuthor && e.shiftKey) {
+                selectBlock(e)
+                return
+              }
               e.preventDefault()
               e.stopPropagation()
               // @ts-expect-error


### PR DESCRIPTION
## Summary
- Add shift-click range selection for media blocks, including containers with custom press handlers.
- Preserve existing single-click media selection behavior and grid-container guardrails.
- Add coverage for contiguous media block range selection using `MultipleNodeSelection`.