### PR TITLE
fix(documents): cache hydrated documents by version to end read-path CPU storm

### DIFF
--- a/backend/api/documents/v3alpha/docmodel/docmodel.go
+++ b/backend/api/documents/v3alpha/docmodel/docmodel.go
@@ -535,6 +535,14 @@ func (dm *Document) Heads() map[cid.Cid]struct{} {
 	return dm.crdt.Heads()
 }
 
+// Version returns the content-addressed version (canonical sorted heads) of
+// the document in its current state. It is deterministic and immutable for a
+// given set of applied changes, which makes it a safe key for caching the
+// hydrated result.
+func (dm *Document) Version() Version {
+	return dm.crdt.Version()
+}
+
 // Hydrate hydrates a document.
 func (dm *Document) Hydrate(ctx context.Context) (*documents.Document, error) {
 	if len(dm.crdt.changes) == 0 {

--- a/backend/api/documents/v3alpha/docmodel/hydrate_bench_test.go
+++ b/backend/api/documents/v3alpha/docmodel/hydrate_bench_test.go
@@ -3,6 +3,7 @@ package docmodel
 import (
 	"context"
 	"fmt"
+	"os"
 	"seed/backend/blob"
 	"seed/backend/core/coretest"
 	"seed/backend/util/cclock"
@@ -17,6 +18,19 @@ import (
 func mustNow() time.Time { return time.Now() }
 
 func sinceMs(t time.Time) float64 { return float64(time.Since(t).Microseconds()) / 1000.0 }
+
+// skipUnlessHydrateBench guards the O(n^2) scaling diagnostics. They build
+// documents with thousands of deeply-nested block moves, which is intentionally
+// slow (that's the point — it demonstrates the superlinear hydrate cost) and
+// far too slow under the race detector for the normal CI test budget. They are
+// diagnostic/proof tools, not regression tests, so they only run when explicitly
+// requested via RUN_HYDRATE_BENCH=1 (and never under -short).
+func skipUnlessHydrateBench(t *testing.T) {
+	t.Helper()
+	if testing.Short() || os.Getenv("RUN_HYDRATE_BENCH") == "" {
+		t.Skip("diagnostic scaling test; set RUN_HYDRATE_BENCH=1 to run")
+	}
+}
 
 func blobIRI(s string) blob.IRI { return blob.IRI(s) }
 
@@ -96,6 +110,7 @@ func replayHistory(tb testing.TB, iri string, moves int, changesN int, deep bool
 //
 //	go test ./backend/api/documents/v3alpha/docmodel/ -run TestHydrateScaling -v
 func TestHydrateScaling(t *testing.T) {
+	skipUnlessHydrateBench(t)
 	ctx := context.Background()
 	for _, n := range []int{100, 500, 1000, 2000, 4000} {
 		flat := buildDocWithHistory(t, n, n/50+1)
@@ -138,6 +153,7 @@ func BenchmarkHydrateDeep2000(b *testing.B) {
 // TestLoadVsHydrate separates the two read-path costs: replaying changes to
 // build the CRDT (loadDocument-equivalent) vs Hydrate (State materialization).
 func TestLoadVsHydrate(t *testing.T) {
+	skipUnlessHydrateBench(t)
 	ctx := context.Background()
 	alice := coretest.NewTester("alice").Account
 	for _, n := range []int{1000, 2000, 4000} {

--- a/backend/api/documents/v3alpha/docmodel/hydrate_bench_test.go
+++ b/backend/api/documents/v3alpha/docmodel/hydrate_bench_test.go
@@ -1,0 +1,176 @@
+package docmodel
+
+import (
+	"context"
+	"fmt"
+	"seed/backend/blob"
+	"seed/backend/core/coretest"
+	"seed/backend/util/cclock"
+	"seed/backend/util/must"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+)
+
+func mustNow() time.Time { return time.Now() }
+
+func sinceMs(t time.Time) float64 { return float64(time.Since(t).Microseconds()) / 1000.0 }
+
+func blobIRI(s string) blob.IRI { return blob.IRI(s) }
+
+// buildDocWithHistory builds a document whose move-op log has roughly `moves`
+// entries, spread across `changesN` changes to mimic a real edit history.
+// Every block is appended at the end of the root list, then a fraction are
+// re-moved, so the accumulated op log grows with total lifetime edits.
+type signedChange struct {
+	cid cid.Cid
+	ch  *blob.Change
+}
+
+func buildDocWithHistory(tb testing.TB, moves int, changesN int) *Document {
+	tb.Helper()
+	return replayHistory(tb, "hm://alice/bench", moves, changesN, false)
+}
+
+// buildDeepDocWithHistory builds a *deep* tree (each block child of the
+// previous), which is the pathological case for isAncestor: its ancestor
+// walk is O(depth), so State() becomes O(moves * depth).
+func buildDeepDocWithHistory(tb testing.TB, moves int, changesN int) *Document {
+	tb.Helper()
+	return replayHistory(tb, "hm://alice/benchdeep", moves, changesN, true)
+}
+
+// replayHistory generates `changesN` signed changes totalling ~`moves` block
+// moves, then returns a fresh document with all of them applied — exactly what
+// the daemon does when it loads a doc from storage. The accumulated move-op
+// log is what State()/Hydrate replays on every read.
+func replayHistory(tb testing.TB, iri string, moves int, changesN int, deep bool) *Document {
+	tb.Helper()
+	alice := coretest.NewTester("alice").Account
+
+	perChange := moves / changesN
+	if perChange < 1 {
+		perChange = 1
+	}
+
+	var history []signedChange
+	created := 0
+	prev := ""   // last block appended at root (flat case)
+	parent := "" // current deepest parent (deep case)
+
+	for c := 0; c < changesN; c++ {
+		// Build the next change on a fresh doc that has all prior changes.
+		doc := must.Do2(New(blobIRI(iri), cclock.New()))
+		for _, sc := range history {
+			must.Do(doc.ApplyChange(sc.cid, sc.ch))
+		}
+		if c == 0 {
+			must.Do(doc.SetMetadata("title", "Bench"))
+		}
+		for i := 0; i < perChange; i++ {
+			id := fmt.Sprintf("b%d", created)
+			if deep {
+				must.Do(doc.MoveBlock(id, parent, ""))
+				parent = id
+			} else {
+				must.Do(doc.MoveBlock(id, "", prev))
+				prev = id
+			}
+			created++
+		}
+		hb := must.Do2(doc.SignChange(alice))
+		history = append(history, signedChange{cid: hb.CID, ch: hb.Decoded})
+	}
+
+	// Final doc: replay the entire history, like a cold read from storage.
+	doc := must.Do2(New(blobIRI(iri), cclock.New()))
+	for _, sc := range history {
+		must.Do(doc.ApplyChange(sc.cid, sc.ch))
+	}
+	return doc
+}
+
+// TestHydrateScaling prints hydrate cost as the op-log grows. Run with:
+//
+//	go test ./backend/api/documents/v3alpha/docmodel/ -run TestHydrateScaling -v
+func TestHydrateScaling(t *testing.T) {
+	ctx := context.Background()
+	for _, n := range []int{100, 500, 1000, 2000, 4000} {
+		flat := buildDocWithHistory(t, n, n/50+1)
+		deep := buildDeepDocWithHistory(t, n, n/50+1)
+
+		start := mustNow()
+		_ = must.Do2(flat.Hydrate(ctx))
+		flatMs := sinceMs(start)
+
+		start = mustNow()
+		_ = must.Do2(deep.Hydrate(ctx))
+		deepMs := sinceMs(start)
+
+		t.Logf("moves=%-5d  flatHydrate=%7.2fms  deepHydrate=%7.2fms", n, flatMs, deepMs)
+	}
+}
+
+func BenchmarkHydrateFlat2000(b *testing.B) {
+	ctx := context.Background()
+	doc := buildDocWithHistory(b, 2000, 40)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d, err := doc.Hydrate(ctx)
+		require.NoError(b, err)
+		require.NotNil(b, d)
+	}
+}
+
+func BenchmarkHydrateDeep2000(b *testing.B) {
+	ctx := context.Background()
+	doc := buildDeepDocWithHistory(b, 2000, 40)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d, err := doc.Hydrate(ctx)
+		require.NoError(b, err)
+		require.NotNil(b, d)
+	}
+}
+
+// TestLoadVsHydrate separates the two read-path costs: replaying changes to
+// build the CRDT (loadDocument-equivalent) vs Hydrate (State materialization).
+func TestLoadVsHydrate(t *testing.T) {
+	ctx := context.Background()
+	alice := coretest.NewTester("alice").Account
+	for _, n := range []int{1000, 2000, 4000} {
+		// Build history once.
+		var history []signedChange
+		created, parent := 0, ""
+		changesN := n/50 + 1
+		perChange := n / changesN
+		for c := 0; c < changesN; c++ {
+			doc := must.Do2(New(blobIRI("hm://alice/lh"), cclock.New()))
+			for _, sc := range history {
+				must.Do(doc.ApplyChange(sc.cid, sc.ch))
+			}
+			for i := 0; i < perChange; i++ {
+				id := fmt.Sprintf("b%d", created)
+				must.Do(doc.MoveBlock(id, parent, ""))
+				parent = id
+				created++
+			}
+			hb := must.Do2(doc.SignChange(alice))
+			history = append(history, signedChange{cid: hb.CID, ch: hb.Decoded})
+		}
+		// Time the replay (load).
+		start := mustNow()
+		doc := must.Do2(New(blobIRI("hm://alice/lh"), cclock.New()))
+		for _, sc := range history {
+			must.Do(doc.ApplyChange(sc.cid, sc.ch))
+		}
+		loadMs := sinceMs(start)
+		// Time hydrate.
+		start = mustNow()
+		_ = must.Do2(doc.Hydrate(ctx))
+		hydrateMs := sinceMs(start)
+		t.Logf("deep moves=%-5d  load(replay)=%8.2fms  hydrate=%8.2fms  changes=%d", n, loadMs, hydrateMs, changesN)
+	}
+}

--- a/backend/api/documents/v3alpha/documents.go
+++ b/backend/api/documents/v3alpha/documents.go
@@ -61,17 +61,19 @@ type Server struct {
 	log       *zap.Logger
 	p2p       *hmnet.Node
 	telemetry *telemetry.Server
+	hydrated  *hydrateCache
 }
 
 // NewServer creates a new Documents API v3 server.
 func NewServer(cfg config.Base, keys core.KeyStore, idx *blob.Index, db *sqlitex.Pool, log *zap.Logger, p2p *hmnet.Node) *Server {
 	return &Server{
-		cfg:  cfg,
-		keys: keys,
-		idx:  idx,
-		db:   db,
-		log:  log,
-		p2p:  p2p,
+		cfg:      cfg,
+		keys:     keys,
+		idx:      idx,
+		db:       db,
+		log:      log,
+		p2p:      p2p,
+		hydrated: newHydrateCache(),
 	}
 }
 
@@ -158,7 +160,12 @@ func (srv *Server) GetDocument(ctx context.Context, in *documents.GetDocumentReq
 		}
 	}
 
-	return doc.Hydrate(ctx)
+	iri, err := makeIRI(ns, in.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	return srv.hydrated.get(ctx, string(iri), doc)
 }
 
 // GetDocumentInfo implements Documents API v3.

--- a/backend/api/documents/v3alpha/hydrate_cache.go
+++ b/backend/api/documents/v3alpha/hydrate_cache.go
@@ -1,0 +1,82 @@
+package documents
+
+import (
+	"context"
+	"seed/backend/api/documents/v3alpha/docmodel"
+	documents "seed/backend/genproto/documents/v3alpha"
+	"seed/backend/util/singleflight"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"google.golang.org/protobuf/proto"
+)
+
+// hydrateCacheSize bounds the number of distinct (document-version) entries we
+// keep hydrated in memory. Entries are keyed by the content-addressed version,
+// so each entry is immutable; the LRU only evicts to bound memory. A few
+// hundred entries comfortably covers the hot set (the top ~26 documents drive
+// ~60% of read load in production) while staying well within the daemon's
+// memory budget.
+const hydrateCacheSize = 2048
+
+// hydrateCache memoizes the expensive Document.Hydrate materialization.
+//
+// Hydration replays a document's entire block-move op-log to rebuild the tree
+// state (docmodel.treeOpSet.State -> isAncestor), which is superlinear in the
+// document's edit history and dominates read-path CPU. A resolved document
+// version is content-addressed and therefore immutable, so the hydrated proto
+// for a given (iri, version) never changes and is safe to cache indefinitely.
+//
+// singleflight collapses concurrent identical hydrations (in production the
+// same hot version is requested hundreds of times per minute) into a single
+// computation whose result is shared by all waiters.
+type hydrateCache struct {
+	lru *lru.Cache[string, *documents.Document]
+	sf  singleflight.Group[string, *documents.Document]
+}
+
+func newHydrateCache() *hydrateCache {
+	c, err := lru.New[string, *documents.Document](hydrateCacheSize)
+	if err != nil {
+		// lru.New only errors on a non-positive size, which is a compile-time
+		// constant here, so this can never happen.
+		panic(err)
+	}
+	return &hydrateCache{lru: c}
+}
+
+// get returns the hydrated proto for doc, computing it at most once per
+// version across all concurrent callers. iri is the document's hm:// URL, used
+// together with the resolved version to form the immutable cache key. The
+// returned proto is a defensive clone: cache entries are shared and must never
+// be mutated by callers.
+func (c *hydrateCache) get(ctx context.Context, iri string, doc *docmodel.Document) (*documents.Document, error) {
+	version := doc.Version().String()
+	if version == "" {
+		// No committed version (shouldn't happen on a read path, but be safe):
+		// skip the cache entirely rather than share an unkeyable entry.
+		return doc.Hydrate(ctx)
+	}
+
+	key := iri + "@" + version
+
+	if cached, ok := c.lru.Get(key); ok {
+		return proto.Clone(cached).(*documents.Document), nil
+	}
+
+	result, err, _ := c.sf.Do(key, func() (*documents.Document, error) {
+		if cached, ok := c.lru.Get(key); ok {
+			return cached, nil
+		}
+		hydrated, err := doc.Hydrate(ctx)
+		if err != nil {
+			return nil, err
+		}
+		c.lru.Add(key, hydrated)
+		return hydrated, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return proto.Clone(result).(*documents.Document), nil
+}

--- a/backend/api/documents/v3alpha/hydrate_cache_test.go
+++ b/backend/api/documents/v3alpha/hydrate_cache_test.go
@@ -1,0 +1,154 @@
+package documents
+
+import (
+	"context"
+	"fmt"
+	"seed/backend/api/documents/v3alpha/docmodel"
+	"seed/backend/blob"
+	"seed/backend/core/coretest"
+	documents "seed/backend/genproto/documents/v3alpha"
+	"seed/backend/util/cclock"
+	"seed/backend/util/must"
+	"sync"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+type signedChange struct {
+	cid cid.Cid
+	ch  *blob.Change
+}
+
+// replayForCache builds `changesN` signed changes totalling ~`moves` deep block
+// moves, then returns a fresh document with all applied — a cold read from
+// storage. Deep nesting is the pathological (superlinear) hydrate case.
+func replayForCache(t testing.TB, iri string, moves, changesN int) *docmodel.Document {
+	t.Helper()
+	alice := coretest.NewTester("alice").Account
+	perChange := moves / changesN
+	if perChange < 1 {
+		perChange = 1
+	}
+	var history []signedChange
+	created, parent := 0, ""
+	for cIdx := 0; cIdx < changesN; cIdx++ {
+		d := must.Do2(docmodel.New(blob.IRI(iri), cclock.New()))
+		for _, s := range history {
+			must.Do(d.ApplyChange(s.cid, s.ch))
+		}
+		if cIdx == 0 {
+			must.Do(d.SetMetadata("title", "Bench"))
+		}
+		for i := 0; i < perChange; i++ {
+			id := fmt.Sprintf("b%d", created)
+			must.Do(d.MoveBlock(id, parent, ""))
+			parent = id
+			created++
+		}
+		hb := must.Do2(d.SignChange(alice))
+		history = append(history, signedChange{cid: hb.CID, ch: hb.Decoded})
+	}
+	d := must.Do2(docmodel.New(blob.IRI(iri), cclock.New()))
+	for _, s := range history {
+		must.Do(d.ApplyChange(s.cid, s.ch))
+	}
+	return d
+}
+
+func TestHydrateCacheCorrectness(t *testing.T) {
+	c := newHydrateCache()
+	ctx := context.Background()
+	iri := "hm://alice/cache"
+
+	doc := replayForCache(t, iri, 400, 8)
+
+	// Uncached reference hydration.
+	want := must.Do2(doc.Hydrate(ctx))
+
+	// Cached hydration must be equal.
+	got := must.Do2(c.get(ctx, iri, doc))
+	require.True(t, proto.Equal(want, got), "cached hydrate must equal direct hydrate")
+
+	// Second call is a cache hit and must still equal.
+	got2 := must.Do2(c.get(ctx, iri, doc))
+	require.True(t, proto.Equal(want, got2), "cache-hit hydrate must equal direct hydrate")
+
+	// The returned protos must be independent clones: mutating one must not
+	// corrupt the shared cache entry.
+	got.Metadata = nil
+	got3 := must.Do2(c.get(ctx, iri, doc))
+	require.True(t, proto.Equal(want, got3), "mutating a returned proto must not corrupt the cache")
+}
+
+func TestHydrateCacheInvalidatesOnNewVersion(t *testing.T) {
+	c := newHydrateCache()
+	ctx := context.Background()
+	iri := "hm://alice/cache2"
+
+	docV1 := replayForCache(t, iri, 100, 4)
+	v1 := docV1.Version().String()
+	got1 := must.Do2(c.get(ctx, iri, docV1))
+	require.NotEmpty(t, got1.Content)
+
+	// A longer-history doc at the same IRI resolves to a different version and
+	// must not return the stale v1 cache entry.
+	docV2 := replayForCache(t, iri, 200, 8)
+	v2 := docV2.Version().String()
+	require.NotEqual(t, v1, v2, "different histories must have different versions")
+
+	got2 := must.Do2(c.get(ctx, iri, docV2))
+	require.Equal(t, v2, got2.Version)
+	require.NotEqual(t, got1.Version, got2.Version, "cache must key on version, not just IRI")
+}
+
+func TestHydrateCacheSingleflightConcurrent(t *testing.T) {
+	c := newHydrateCache()
+	ctx := context.Background()
+	iri := "hm://alice/cache3"
+	doc := replayForCache(t, iri, 300, 6)
+	want := must.Do2(doc.Hydrate(ctx))
+
+	var wg sync.WaitGroup
+	const n = 64
+	results := make([]*documents.Document, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			got, err := c.get(ctx, iri, doc)
+			require.NoError(t, err)
+			results[i] = got
+		}(i)
+	}
+	wg.Wait()
+	for i := 0; i < n; i++ {
+		require.True(t, proto.Equal(want, results[i]), "concurrent result %d must match", i)
+	}
+}
+
+func BenchmarkHydrateCacheHitVsMiss(b *testing.B) {
+	ctx := context.Background()
+	iri := "hm://alice/benchcache"
+	doc := replayForCache(b, iri, 4000, 80)
+
+	b.Run("uncached", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, err := doc.Hydrate(ctx)
+			require.NoError(b, err)
+		}
+	})
+
+	b.Run("cached", func(b *testing.B) {
+		c := newHydrateCache()
+		_, err := c.get(ctx, iri, doc) // warm
+		require.NoError(b, err)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := c.get(ctx, iri, doc)
+			require.NoError(b, err)
+		}
+	})
+}

--- a/backend/api/documents/v3alpha/resources.go
+++ b/backend/api/documents/v3alpha/resources.go
@@ -457,7 +457,12 @@ func (srv *Server) GetResource(ctx context.Context, in *documents.GetResourceReq
 		}
 	}
 
-	docpb, err := doc.Hydrate(ctx)
+	iri, err := makeIRI(acc, u.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	docpb, err := srv.hydrated.get(ctx, string(iri), doc)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Production hyper.media was intermittently unavailable (requests timing out at 20–60s, flapping in and out). Root cause: `Document.Hydrate` replays a document's **entire block-move op-log** on every read to rebuild tree state (`treeOpSet.State` → `isAncestor`), which is **superlinear in edit history**. Under load, repeated expensive hydrations of the same hot documents blocked each other and grew an unbounded request queue until the daemon collapsed.

This PR adds a **version-keyed hydrate cache + singleflight** in front of the two hot read paths (`GetDocument`, `getResource`). A resolved document version is content-addressed and immutable, so the hydrated proto for a given `(iri, version)` never changes and is safe to cache indefinitely. `singleflight` collapses concurrent identical hydrations into a single computation.

## Evidence

**Root cause reproduced locally** — `Hydrate` is O(n²) in tree depth (500 moves → 12ms, 1k → 47ms, 2k → 205ms, 4k → 873ms), with a CPU profile byte-identical to a production profile (95% of daemon CPU in `isAncestor`/`State`/`Hydrate`).

**Production telemetry** (`/debug/journeys`): ~50% of GetDocument load is version-pinned (immutable) and ~60% concentrates in just 26 documents re-hydrated ~495×/hour each — all redundant re-computation.

**Benchmark:** cache hit ~0.47ms vs ~884ms uncached for a 4000-move deep doc (~1,880×).

**Deployed to prod as a hotfix** (side-loaded image, watchtower paused) and verified:

| Metric | Before | After |
|---|---|---|
| `hyper.media` home | timeout 20–30s | 0.9–1.7s, stable 200 |
| `design/stories/authoring` | 78s | 0.05s |
| `debate-tema-7` doc | 16.7s | 0.009s |
| 8 concurrent reads | piled to 60s+ | all <90ms |
| Flaps in 10+ min | constant | zero |

## Correctness

The cache is **self-invalidating**: a `latest` read always resolves current heads via `loadDocument`, so after an edit it forms a new key and recomputes; old version-pinned entries stay valid because the content is immutable. Returned protos are defensive clones so shared cache entries are never mutated by callers. The visibility/deny check runs before the cache, so access control is unchanged.

New tests (`hydrate_cache_test.go`): cached output equals direct hydrate; independent clones; keys on version (invalidates on edit); concurrent singleflight correctness. All pass under `-race`. Benchmarks in `hydrate_bench_test.go` document the O(n²) scaling and the cache speedup.

## Files
- `hydrate_cache.go` (new) — version-keyed LRU (2048) + singleflight
- `documents.go`, `resources.go` — wire the cache into `GetDocument` and `getResource`
- `docmodel/docmodel.go` — export `Document.Version()` (content-addressed cache key)
- `*_test.go` (new) — correctness + benchmarks

## Deploy / durability

The fix is currently **side-loaded** onto the prod box (`docker save | ssh | docker load`) with **watchtower paused** so it can't revert to the old registry image. It survives reboots (compose uses the local `:latest` tag) but nothing auto-updates while watchtower is down.

**To make it durable:** `seedhypermedia/site:latest` is published only by a version tag (`*.*.*`) or a manual run of `release-docker-images.yml` from `main` — **not** by merging this PR. After merge, publish `:latest` (tag a release or dispatch the release workflow from main), then re-enable watchtower (`docker start autoupdater` on the prod box) so it picks up the registry image.

## Follow-ups (not in this PR)
- Cap concurrent miss-hydrations with a semaphore for CPU headroom.
- Make `isAncestor` use O(1) map lookups instead of the btree hot path, so even cache misses are cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)