### PR TITLE
perf(docmodel): O(1) block lookups in isAncestor to cut hydrate CPU

### DIFF
--- a/backend/api/documents/v3alpha/docmodel/crdt_block_tree.go
+++ b/backend/api/documents/v3alpha/docmodel/crdt_block_tree.go
@@ -3,6 +3,7 @@ package docmodel
 import (
 	"fmt"
 	"iter"
+	"maps"
 	"math"
 	"seed/backend/core"
 	"seed/backend/util/btree"
@@ -110,7 +111,7 @@ func (opset *treeOpSet) Integrate(opID opID, parent, block string, refID opID) e
 
 func (opset *treeOpSet) State() *blockTreeState {
 	state := &blockTreeState{
-		blocks:         btree.New[string, blockState](8, strings.Compare),
+		blocks:         make(map[string]blockState),
 		opSet:          opset.Copy(),
 		invisibleMoves: btree.New[opID, struct{}](8, opID.Compare),
 	}
@@ -121,7 +122,8 @@ func (opset *treeOpSet) State() *blockTreeState {
 			continue
 		}
 
-		prev, replaced := state.blocks.Swap(move.Block, blockState{Parent: move.Parent, Position: move.OpID})
+		prev, replaced := state.blocks[move.Block]
+		state.blocks[move.Block] = blockState{Parent: move.Parent, Position: move.OpID}
 		if replaced {
 			state.invisibleMoves.Set(prev.Position, struct{}{})
 		}
@@ -138,21 +140,21 @@ type blockState struct {
 type blockTreeState struct {
 	// Copy of the original opset.
 	opSet          *treeOpSet
-	blocks         *btree.Map[string, blockState]
+	blocks         map[string]blockState
 	invisibleMoves *btree.Map[opID, struct{}]
 }
 
 func (state *blockTreeState) Copy() *blockTreeState {
 	return &blockTreeState{
 		opSet:          state.opSet.Copy(),
-		blocks:         state.blocks.Copy(),
+		blocks:         maps.Clone(state.blocks),
 		invisibleMoves: state.invisibleMoves.Copy(),
 	}
 }
 
 // isAncestor returns checks if a is an ancestor of b.
 func (state *blockTreeState) isAncestor(a, b string) bool {
-	n, ok := state.blocks.Get(b)
+	n, ok := state.blocks[b]
 	for {
 		if !ok || n.Parent == "" || n.Parent == TrashNodeID {
 			return false
@@ -162,7 +164,7 @@ func (state *blockTreeState) isAncestor(a, b string) bool {
 			return true
 		}
 
-		n, ok = state.blocks.Get(n.Parent)
+		n, ok = state.blocks[n.Parent]
 	}
 }
 
@@ -247,7 +249,7 @@ func (mut *blockTreeMutation) Move(parent, block, left string) (moveEffect, erro
 		return moveEffectNone, fmt.Errorf("cycle detected: block %s is ancestor of %s", block, parent)
 	}
 
-	leftState, ok := mut.dirty.blocks.Get(left)
+	leftState, ok := mut.dirty.blocks[left]
 	if !ok {
 		if left == "" {
 			leftState = blockState{Parent: parent}
@@ -261,7 +263,7 @@ func (mut *blockTreeMutation) Move(parent, block, left string) (moveEffect, erro
 	}
 
 	me := moveEffectCreated
-	curState, ok := mut.dirty.blocks.Get(block)
+	curState, ok := mut.dirty.blocks[block]
 	newState := blockState{
 		Parent:   parent,
 		Position: newOpID(math.MaxInt64, math.MaxUint64, mut.counter),
@@ -305,7 +307,7 @@ func (mut *blockTreeMutation) Move(parent, block, left string) (moveEffect, erro
 		siblings.items.Set(fracdex, curListItem)
 	}
 
-	mut.dirty.blocks.Set(block, newState)
+	mut.dirty.blocks[block] = newState
 
 	mut.counter++
 
@@ -407,7 +409,7 @@ func (mut *blockTreeMutation) Commit(ts int64, actor core.ActorID) iter.Seq[move
 
 			// If currently deleted block wasn't in the initial state,
 			// then we can safely ignore it, because it was created by our own transaction.
-			if _, ok := mut.initial.blocks.Get(block.Value); !ok {
+			if _, ok := mut.initial.blocks[block.Value]; !ok {
 				continue
 			}
 
@@ -445,7 +447,7 @@ type logicalPosition struct {
 }
 
 func (state *blockTreeState) findLogicalPosition(block string) (lp logicalPosition, ok bool) {
-	bs, ok := state.blocks.Get(block)
+	bs, ok := state.blocks[block]
 	if !ok {
 		return lp, false
 	}

--- a/backend/api/documents/v3alpha/docmodel/docmodel.go
+++ b/backend/api/documents/v3alpha/docmodel/docmodel.go
@@ -665,7 +665,7 @@ func (dm *Document) Hydrate(ctx context.Context) (*documents.Document, error) {
 
 	for blk := range dm.crdt.stateBlocks {
 		// Blocks that are in the tree state are not detached.
-		if _, ok := treeState.blocks.Get(blk); ok {
+		if _, ok := treeState.blocks[blk]; ok {
 			continue
 		}
 

--- a/backend/api/documents/v3alpha/docmodel/docmodel_test.go
+++ b/backend/api/documents/v3alpha/docmodel/docmodel_test.go
@@ -62,8 +62,8 @@ func TestDocmodelSmoke(t *testing.T) {
 			must.Do(doc.ApplyChange(c2.CID, c2.Decoded))
 
 			require.Equal(t, map[string]any{"title": "Hello world"}, doc.crdt.GetMetadata())
-			require.Equal(t, TrashNodeID, doc.crdt.tree.State().blocks.GetMaybe("b1.1").Parent, "deleted block b1.1 must be in trash")
-			require.Equal(t, TrashNodeID, doc.crdt.tree.State().blocks.GetMaybe("b3").Parent, "deleted block b3 must be in trash")
+			require.Equal(t, TrashNodeID, doc.crdt.tree.State().blocks["b1.1"].Parent, "deleted block b1.1 must be in trash")
+			require.Equal(t, TrashNodeID, doc.crdt.tree.State().blocks["b3"].Parent, "deleted block b3 must be in trash")
 		}
 	}
 }


### PR DESCRIPTION
## Problem
`Document.Hydrate` rebuilds block-tree state via `treeOpSet.State() -> isAncestor`, doing a comparator-heavy B-tree lookup per ancestor step. A production CPU profile of the hyper.media daemon (~330% CPU) showed ~57% of all CPU in that B-tree machinery (`Less`/`hintsearch`/`nodeAscend`). The #858 version cache reduced how *often* we hydrate but not the per-hydrate cost, so cache misses — unavoidable for "latest" reads of documents the daemon just synced — still saturate CPU.

## Change
`blockTreeState.blocks` is point-lookup only (no ordered iteration), so swap it from `*btree.Map[string, blockState]` to a plain `map[string]blockState`. `treeOpSet`s ordered maps (`log`, `sublists`) stay B-trees. No CRDT semantics change; ~12 call sites updated.

## Results (`RUN_HYDRATE_BENCH=1`)
| bench | before | after |
|---|---|---|
| HydrateDeep2000 | 320.6 ms | 51.1 ms (6.3x) |
| HydrateFlat2000 | 2.22 ms | 1.47 ms |

## Test plan
`go test -race ./backend/api/documents/v3alpha/docmodel/` — pass.