### PR TITLE
Desktop network selector: mainnet / testnet / custom

### DIFF
--- a/frontend/apps/desktop/src/app-api.ts
+++ b/frontend/apps/desktop/src/app-api.ts
@@ -13,7 +13,7 @@ import {writeFile} from 'fs-extra'
 import path from 'path'
 import z from 'zod'
 import {deleteAccount} from './app-account-management'
-import {getDaemonState, restartDaemonWithEmbedding, subscribeDaemonState} from './daemon'
+import {getDaemonState, restartDaemon, subscribeDaemonState} from './daemon'
 import {aiConfigApi} from './app-ai-config'
 import {chatApi} from './app-chat'
 import {commentsApi} from './app-comments'
@@ -33,7 +33,7 @@ import {promptingApi} from './app-prompting'
 import {recentSignersApi} from './app-recent-signers'
 import {recentsApi} from './app-recents'
 import {secureStorageApi} from './app-secure-storage'
-import {appSettingsApi} from './app-settings'
+import {appSettingsApi, getStoredNetworkConfig, networkConfigSchema, writeNetworkConfig} from './app-settings'
 import {sitesApi} from './app-sites'
 import {syncApi} from './app-sync'
 import {t} from './app-trpc'
@@ -474,7 +474,18 @@ export const router = t.router({
 
   restartDaemonWithEmbedding: t.procedure.input(z.object({embeddingEnabled: z.boolean()})).mutation(async ({input}) => {
     log.info('Restarting daemon with embedding setting:', input)
-    await restartDaemonWithEmbedding(input.embeddingEnabled)
+    await restartDaemon({embeddingEnabled: input.embeddingEnabled})
+    return {success: true}
+  }),
+
+  getDaemonNetworkConfig: t.procedure.query(() => {
+    return getStoredNetworkConfig()
+  }),
+
+  setDaemonNetworkConfig: t.procedure.input(networkConfigSchema).mutation(async ({input}) => {
+    log.info('Changing daemon network setting:', input)
+    writeNetworkConfig(input)
+    await restartDaemon({network: input})
     return {success: true}
   }),
 })

--- a/frontend/apps/desktop/src/app-settings.ts
+++ b/frontend/apps/desktop/src/app-settings.ts
@@ -4,6 +4,9 @@ import z from 'zod'
 import {appStore} from './app-store.mts'
 import {t} from './app-trpc'
 import {broadcastUseDarkColors} from './app-windows'
+import {DEFAULT_TESTNET_NAME, type DaemonNetworkConfig} from './daemon'
+
+declare const __SEED_P2P_TESTNET_NAME__: string
 
 const AutoUpdateTypes = z.literal('true').or(z.literal('false'))
 
@@ -23,6 +26,34 @@ function writeSettingsStore(newState: SettingsStore) {
 }
 
 var autoUpdatePreference: AutoUpdateValues = (appStore.get(APP_AUTO_UPDATE_PREFERENCE) as AutoUpdateValues) || 'true'
+
+export const networkConfigSchema = z.object({
+  mode: z.union([z.literal('mainnet'), z.literal('testnet'), z.literal('custom')]),
+  customName: z.string().optional(),
+})
+
+const NETWORK_CONFIG_SETTINGS_KEY = 'daemonNetwork'
+
+/** The network to use when the user has not picked one: the build-time testnet flag, or mainnet. */
+function defaultNetworkConfig(): DaemonNetworkConfig {
+  if (!__SEED_P2P_TESTNET_NAME__) return {mode: 'mainnet'}
+  if (__SEED_P2P_TESTNET_NAME__ === DEFAULT_TESTNET_NAME) return {mode: 'testnet'}
+  return {mode: 'custom', customName: __SEED_P2P_TESTNET_NAME__}
+}
+
+/**
+ * Returns the stored network setting.
+ * Used by main.ts to determine daemon startup flags before tRPC is ready.
+ */
+export function getStoredNetworkConfig(): DaemonNetworkConfig {
+  const parsed = networkConfigSchema.safeParse(settingsStore[NETWORK_CONFIG_SETTINGS_KEY])
+  if (parsed.success) return parsed.data
+  return defaultNetworkConfig()
+}
+
+export function writeNetworkConfig(config: DaemonNetworkConfig) {
+  writeSettingsStore({...settingsStore, [NETWORK_CONFIG_SETTINGS_KEY]: config})
+}
 
 export const appSettingsApi = t.router({
   getAutoUpdatePreference: t.procedure.query(async () => {

--- a/frontend/apps/desktop/src/daemon.ts
+++ b/frontend/apps/desktop/src/daemon.ts
@@ -16,22 +16,24 @@ let goDaemonExecutablePath = getDaemonBinaryPath()
 
 declare const __SEED_P2P_TESTNET_NAME__: string
 
-const lndhubFlags = !__SEED_P2P_TESTNET_NAME__ ? '-lndhub.mainnet=true' : '-lndhub.mainnet=false'
+/** Testnet name used by the "testnet" network option (matches the ./dev up-testnet stack). */
+export const DEFAULT_TESTNET_NAME = 'dev'
 
-// Base daemon arguments (without embedding flags)
-const baseDaemonArguments = [
-  `-http.port=${String(DAEMON_HTTP_PORT)}`,
-  `-grpc.port=${String(DAEMON_GRPC_PORT)}`,
-  `-p2p.port=${String(P2P_PORT)}`,
+export type DaemonNetworkConfig = {
+  mode: 'mainnet' | 'testnet' | 'custom'
+  customName?: string
+}
 
-  lndhubFlags,
+/** Maps the user-facing network config to the -p2p.testnet-name flag value ('' means mainnet). */
+export function resolveTestnetName(network: DaemonNetworkConfig): string {
+  if (network.mode === 'testnet') return DEFAULT_TESTNET_NAME
+  if (network.mode === 'custom') return network.customName?.trim() || ''
+  return ''
+}
 
-  ...(__SEED_P2P_TESTNET_NAME__ ? ['-p2p.testnet-name', __SEED_P2P_TESTNET_NAME__] : []),
-
-  // Daemon data is always at {userDataPath}/daemon.
-  // In fixture mode, userDataPath is set via SEED_FIXTURE_DATA_DIR.
-  `-data-dir=${userDataPath}/daemon`,
-]
+// Current daemon configuration, so a restart triggered by one setting keeps the others.
+let currentEmbeddingEnabled = false
+let currentTestnetName = __SEED_P2P_TESTNET_NAME__ || ''
 
 // Embedding-specific flags
 const embeddingFlags = [
@@ -41,9 +43,21 @@ const embeddingFlags = [
   '-llm.embedding.index-pass-size=100',
 ]
 
-// Build daemon arguments based on embedding setting
-function buildDaemonArguments(embeddingEnabled: boolean): string[] {
-  const args = [...baseDaemonArguments]
+// Build daemon arguments based on the current settings
+function buildDaemonArguments(embeddingEnabled: boolean, testnetName: string): string[] {
+  const args = [
+    `-http.port=${String(DAEMON_HTTP_PORT)}`,
+    `-grpc.port=${String(DAEMON_GRPC_PORT)}`,
+    `-p2p.port=${String(P2P_PORT)}`,
+
+    testnetName ? '-lndhub.mainnet=false' : '-lndhub.mainnet=true',
+
+    ...(testnetName ? ['-p2p.testnet-name', testnetName] : []),
+
+    // Daemon data is always at {userDataPath}/daemon.
+    // In fixture mode, userDataPath is set via SEED_FIXTURE_DATA_DIR.
+    `-data-dir=${userDataPath}/daemon`,
+  ]
 
   // Use file-based keystore in fixture mode.
   if (process.env.SEED_FIXTURE_DATA_DIR) {
@@ -86,24 +100,9 @@ export function updateGoDaemonState(state: GoDaemonState) {
   daemonStateHandlers.forEach((handler) => handler(state))
 }
 
-export async function startMainDaemon(embeddingEnabled: boolean = false): Promise<{
-  httpPort: string | undefined
-  grpcPort: string | undefined
-  p2pPort: string | undefined
-}> {
-  if (process.env.SEED_NO_DAEMON_SPAWN) {
-    log.debug('Go daemon spawn skipped')
-    updateGoDaemonState({t: 'ready'})
-    markGRPCReady()
-    return {
-      httpPort: process.env.VITE_DESKTOP_HTTP_PORT,
-      grpcPort: process.env.VITE_DESKTOP_GRPC_PORT,
-      p2pPort: process.env.VITE_DESKTOP_P2P_PORT,
-    }
-  }
-
-  const args = buildDaemonArguments(embeddingEnabled)
-  log.info('Starting daemon with arguments:', {args, embeddingEnabled})
+/** Spawns the daemon process, wires up log/close handling, and resolves once the process has spawned. */
+async function spawnDaemonProcess(args: string[]): Promise<void> {
+  log.info('Starting daemon with arguments:', {args})
 
   const daemonProcess = spawn(goDaemonExecutablePath, args, {
     // daemon env
@@ -138,7 +137,9 @@ export async function startMainDaemon(embeddingEnabled: boolean = false): Promis
       reject(err)
     })
     daemonProcess.on('close', (code, signal) => {
-      if (!expectingDaemonClose) {
+      // Only report an error if this process is still the current one — a
+      // stale process closing late after a restart should not flip the state.
+      if (!expectingDaemonClose && daemonProcess === currentDaemonProcess) {
         updateGoDaemonState({
           t: 'error',
           message: 'Service Error: !!!' + lastStderr,
@@ -151,19 +152,10 @@ export async function startMainDaemon(embeddingEnabled: boolean = false): Promis
       resolve()
     })
   })
+}
 
-  app.addListener('will-quit', () => {
-    log.debug('App will quit')
-    expectingDaemonClose = true
-    const daemon = currentDaemonProcess
-    if (!daemon || daemon.killed) return
-    if (process.platform === 'win32') {
-      forceKillChildProcess(daemon)
-    } else {
-      daemon.kill()
-    }
-  })
-
+/** Polls the daemon gRPC and HTTP endpoints until it is fully ready. */
+async function waitForDaemonReady(label: string): Promise<void> {
   await tryUntilSuccess(
     async () => {
       log.debug('Waiting for daemon to boot...')
@@ -186,7 +178,7 @@ export async function startMainDaemon(embeddingEnabled: boolean = false): Promis
       // Daemon is ACTIVE - update state so loading window can close
       updateGoDaemonState({t: 'ready'})
     },
-    'waiting for daemon gRPC to be ready',
+    `waiting for ${label} gRPC to be ready`,
     200, // try every 200ms
     10 * 60 * 1_000, // timeout after 10 minutes
   )
@@ -202,10 +194,85 @@ export async function startMainDaemon(embeddingEnabled: boolean = false): Promis
       const version = await response.text()
       log.info('HTTP endpoint is ready, version: ' + version)
     },
-    'waiting for daemon HTTP to be ready',
+    `waiting for ${label} HTTP to be ready`,
     200, // try every 200ms
     30_000, // timeout after 30s
   )
+}
+
+/** Kills the current daemon process (if any) and waits for it to close, with a 5s timeout. */
+async function killCurrentDaemon(): Promise<void> {
+  if (!currentDaemonProcess) return
+  expectingDaemonClose = true
+
+  if (process.platform === 'win32') {
+    forceKillChildProcess(currentDaemonProcess)
+  } else {
+    currentDaemonProcess.kill()
+  }
+
+  // Wait for the process to actually close
+  await new Promise<void>((resolve) => {
+    if (!currentDaemonProcess) {
+      resolve()
+      return
+    }
+    const proc = currentDaemonProcess
+    const onClose = () => {
+      proc.removeListener('close', onClose)
+      resolve()
+    }
+    proc.on('close', onClose)
+    // Timeout after 5 seconds
+    setTimeout(() => {
+      proc.removeListener('close', onClose)
+      resolve()
+    }, 5000)
+  })
+
+  currentDaemonProcess = null
+}
+
+export async function startMainDaemon(
+  embeddingEnabled: boolean = false,
+  network?: DaemonNetworkConfig,
+): Promise<{
+  httpPort: string | undefined
+  grpcPort: string | undefined
+  p2pPort: string | undefined
+}> {
+  if (process.env.SEED_NO_DAEMON_SPAWN) {
+    log.debug('Go daemon spawn skipped')
+    updateGoDaemonState({t: 'ready'})
+    markGRPCReady()
+    return {
+      httpPort: process.env.VITE_DESKTOP_HTTP_PORT,
+      grpcPort: process.env.VITE_DESKTOP_GRPC_PORT,
+      p2pPort: process.env.VITE_DESKTOP_P2P_PORT,
+    }
+  }
+
+  currentEmbeddingEnabled = embeddingEnabled
+  if (network) {
+    currentTestnetName = resolveTestnetName(network)
+  }
+
+  const args = buildDaemonArguments(currentEmbeddingEnabled, currentTestnetName)
+  await spawnDaemonProcess(args)
+
+  app.addListener('will-quit', () => {
+    log.debug('App will quit')
+    expectingDaemonClose = true
+    const daemon = currentDaemonProcess
+    if (!daemon || daemon.killed) return
+    if (process.platform === 'win32') {
+      forceKillChildProcess(daemon)
+    } else {
+      daemon.kill()
+    }
+  })
+
+  await waitForDaemonReady('daemon')
   markGRPCReady()
 
   const mainDaemon = {
@@ -243,145 +310,50 @@ async function tryUntilSuccess(
 }
 
 /**
- * Restarts the daemon with new embedding configuration.
+ * Restarts the daemon with updated configuration. Only the provided settings
+ * change; the rest keep their current values.
  * This will kill the current daemon process and start a new one with updated flags.
  */
-export async function restartDaemonWithEmbedding(embeddingEnabled: boolean): Promise<void> {
+export async function restartDaemon(changes: {
+  embeddingEnabled?: boolean
+  network?: DaemonNetworkConfig
+}): Promise<void> {
   if (process.env.SEED_NO_DAEMON_SPAWN) {
     log.debug('Daemon restart skipped (SEED_NO_DAEMON_SPAWN)')
     return
   }
 
-  log.info('Restarting daemon with embedding:', {embeddingEnabled})
+  if (changes.embeddingEnabled !== undefined) {
+    currentEmbeddingEnabled = changes.embeddingEnabled
+  }
+  if (changes.network) {
+    currentTestnetName = resolveTestnetName(changes.network)
+  }
+
+  log.info('Restarting daemon with changes:', {
+    changes,
+    embeddingEnabled: currentEmbeddingEnabled,
+    testnetName: currentTestnetName,
+  })
   updateGoDaemonState({t: 'startup'})
 
   // Kill the current daemon process
-  if (currentDaemonProcess) {
-    expectingDaemonClose = true
-
-    if (process.platform === 'win32') {
-      forceKillChildProcess(currentDaemonProcess)
-    } else {
-      currentDaemonProcess.kill()
-    }
-
-    // Wait for the process to actually close
-    await new Promise<void>((resolve) => {
-      if (!currentDaemonProcess) {
-        resolve()
-        return
-      }
-      const onClose = () => {
-        currentDaemonProcess?.removeListener('close', onClose)
-        resolve()
-      }
-      currentDaemonProcess.on('close', onClose)
-      // Timeout after 5 seconds
-      setTimeout(() => {
-        currentDaemonProcess?.removeListener('close', onClose)
-        resolve()
-      }, 5000)
-    })
-
-    currentDaemonProcess = null
-  }
+  await killCurrentDaemon()
 
   // Reset the close expectation flag
   expectingDaemonClose = false
 
   // Start new daemon with updated configuration
-  const daemonEnv = {
-    ...process.env,
-    SENTRY_RELEASE: VERSION,
-    SENTRY_DSN: __SENTRY_DSN__,
-  }
-
-  const args = buildDaemonArguments(embeddingEnabled)
-  log.info('Restarting daemon with arguments:', {args, embeddingEnabled})
-
-  const daemonProcess = spawn(goDaemonExecutablePath, args, {
-    cwd: path.join(process.cwd(), '../../..'),
-    env: daemonEnv,
-    stdio: 'pipe',
-  })
-
-  currentDaemonProcess = daemonProcess
-
-  let lastStderr = ''
-  const stderr = readline.createInterface({input: daemonProcess.stderr})
-  await new Promise<void>((resolve, reject) => {
-    stderr.on('line', (line: string) => {
-      lastStderr = line
-      if (line.includes('DaemonStarted')) {
-        updateGoDaemonState({t: 'ready'})
-      }
-      if (!quietNodeLogs) log.rawMessage(line)
-    })
-    const stdout = readline.createInterface({input: daemonProcess.stdout})
-    stdout.on('line', (line: string) => {
-      if (!quietNodeLogs) log.rawMessage(line)
-    })
-    daemonProcess.on('error', (err) => {
-      log.error('Go daemon restart spawn error', {error: err})
-      reject(err)
-    })
-    daemonProcess.on('close', (code, signal) => {
-      if (!expectingDaemonClose) {
-        updateGoDaemonState({
-          t: 'error',
-          message: 'Service Error: !!!' + lastStderr,
-        })
-        log.error('Go daemon closed after restart', {code, signal})
-      }
-    })
-    daemonProcess.on('spawn', () => {
-      log.debug('Go daemon respawned')
-      resolve()
-    })
-  })
+  const args = buildDaemonArguments(currentEmbeddingEnabled, currentTestnetName)
+  await spawnDaemonProcess(args)
 
   // Wait for daemon to be ready
-  await tryUntilSuccess(
-    async () => {
-      log.debug('Waiting for restarted daemon to boot...')
-      const info = await grpcClient.daemon.getInfo({})
-      if (info.state !== State.ACTIVE) {
-        if (info.state === State.MIGRATING && info.tasks.length === 1) {
-          const completed = Number(info.tasks[0].completed)
-          const total = Number(info.tasks[0].total)
-          log.info(`Daemon migrating after restart: ${completed}/${total}`)
-          updateGoDaemonState({
-            t: 'migrating',
-            completed,
-            total,
-          })
-        }
-        throw new Error(`Daemon not ready yet: ${info.state}`)
-      }
-      log.info('Restarted daemon is ready')
-      updateGoDaemonState({t: 'ready'})
-    },
-    'waiting for restarted daemon gRPC to be ready',
-    200,
-    10 * 60 * 1_000,
-  )
+  await waitForDaemonReady('restarted daemon')
 
-  // Also check HTTP endpoint
-  await tryUntilSuccess(
-    async () => {
-      log.debug('Checking HTTP endpoint health after restart...')
-      const response = await fetch(`http://localhost:${DAEMON_HTTP_PORT}/debug/version`)
-      if (!response.ok) {
-        throw new Error(`HTTP endpoint not ready: ${response.status}`)
-      }
-      log.info('HTTP endpoint is ready after restart')
-    },
-    'waiting for restarted daemon HTTP to be ready',
-    200,
-    30_000,
-  )
-
-  log.info('Daemon restart complete', {embeddingEnabled})
+  log.info('Daemon restart complete', {
+    embeddingEnabled: currentEmbeddingEnabled,
+    testnetName: currentTestnetName,
+  })
 }
 
 /**
@@ -396,33 +368,6 @@ export async function shutdownDaemonForUpdate(): Promise<void> {
   }
 
   log.info('[DAEMON] Shutting down daemon for update')
-  expectingDaemonClose = true
-
-  if (process.platform === 'win32') {
-    log.info('[DAEMON] Windows: force-killing daemon process tree')
-    await forceKillChildProcess(currentDaemonProcess)
-  } else {
-    currentDaemonProcess.kill()
-  }
-
-  await new Promise<void>((resolve) => {
-    if (!currentDaemonProcess) {
-      resolve()
-      return
-    }
-    const proc = currentDaemonProcess
-    const onClose = () => {
-      proc.removeListener('close', onClose)
-      log.info('[DAEMON] Daemon process closed after update shutdown')
-      resolve()
-    }
-    proc.on('close', onClose)
-    setTimeout(() => {
-      proc.removeListener('close', onClose)
-      log.warn('[DAEMON] Timeout waiting for daemon to close during update shutdown')
-      resolve()
-    }, 5000)
-  })
-
-  currentDaemonProcess = null
+  await killCurrentDaemon()
+  log.info('[DAEMON] Daemon process closed after update shutdown')
 }

--- a/frontend/apps/desktop/src/main.ts
+++ b/frontend/apps/desktop/src/main.ts
@@ -64,6 +64,7 @@ import {initDerivedSubscriptions} from './derived-subscriptions'
 import {initCommentDrafts} from './app-comments'
 import {initDrafts} from './app-drafts'
 import {getStoredEmbeddingEnabled} from './app-experiments'
+import {getStoredNetworkConfig} from './app-settings'
 import {setupOnboardingHandlers} from './app-onboarding-store'
 import {memoryMonitor, setupMemoryMonitorLifecycle} from './memory-monitor'
 import {getSubscriptionCount, getDiscoveryStreamCount} from './app-sync'
@@ -241,8 +242,9 @@ async function startDaemonWithLoadingWindow(): Promise<void> {
     // Start daemon - this spawns the process and polls until ACTIVE
     // Daemon will send state updates (startup, migrating, etc) to loading window
     const embeddingEnabled = getStoredEmbeddingEnabled()
-    logger.info('[MAIN]: Starting daemon with embedding:', {embeddingEnabled})
-    await startMainDaemon(embeddingEnabled)
+    const networkConfig = getStoredNetworkConfig()
+    logger.info('[MAIN]: Starting daemon with settings:', {embeddingEnabled, networkConfig})
+    await startMainDaemon(embeddingEnabled, networkConfig)
     logger.info('[MAIN]: Daemon is ACTIVE')
   } finally {
     // Cleanup: unsubscribe if still subscribed

--- a/frontend/apps/desktop/src/pages/settings.tsx
+++ b/frontend/apps/desktop/src/pages/settings.tsx
@@ -532,9 +532,9 @@ function GeneralSettings() {
 type NetworkMode = 'mainnet' | 'testnet' | 'custom'
 
 const NETWORK_MODE_LABELS: Record<NetworkMode, string> = {
-  mainnet: 'Mainnet',
-  testnet: 'Testnet',
-  custom: 'Custom',
+  mainnet: 'Main Network',
+  testnet: 'Test Network',
+  custom: 'Custom Network',
 }
 
 function NetworkSettings() {
@@ -578,6 +578,13 @@ function NetworkSettings() {
   }
 
   const canConfirm = pendingMode !== 'custom' || pendingCustomName.trim().length > 0
+  // The select item for 'custom' only exists when a custom network is already saved;
+  // a pending new custom network maps to the 'custom-new' item.
+  const selectValue = pendingMode
+    ? pendingMode === 'custom' && savedMode !== 'custom'
+      ? 'custom-new'
+      : pendingMode
+    : savedMode
   const pendingNetworkLabel =
     pendingMode === 'custom'
       ? pendingCustomName.trim()
@@ -601,17 +608,27 @@ function NetworkSettings() {
             <div className="flex items-center gap-2">
               {setNetwork.isLoading ? <Spinner size="small" /> : null}
               <Select
-                value={pendingMode ?? savedMode}
-                onValueChange={(value) => requestModeChange(value as NetworkMode)}
+                value={selectValue}
+                onValueChange={(value) => {
+                  if (value === 'custom-new') {
+                    setPendingMode('custom')
+                    setPendingCustomName('')
+                  } else {
+                    requestModeChange(value as NetworkMode)
+                  }
+                }}
                 disabled={networkConfig.isLoading || setNetwork.isLoading}
               >
                 <SelectTrigger className="w-[140px]">
                   <SelectValue placeholder="Select network" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="mainnet">Mainnet</SelectItem>
-                  <SelectItem value="testnet">Testnet</SelectItem>
-                  <SelectItem value="custom">Custom</SelectItem>
+                  <SelectItem value="mainnet">{NETWORK_MODE_LABELS.mainnet}</SelectItem>
+                  <SelectItem value="testnet">{NETWORK_MODE_LABELS.testnet}</SelectItem>
+                  {savedMode === 'custom' && savedCustomName ? (
+                    <SelectItem value="custom">{savedCustomName}</SelectItem>
+                  ) : null}
+                  <SelectItem value="custom-new">{NETWORK_MODE_LABELS.custom}</SelectItem>
                 </SelectContent>
               </Select>
               {savedMode === 'custom' ? (

--- a/frontend/apps/desktop/src/pages/settings.tsx
+++ b/frontend/apps/desktop/src/pages/settings.tsx
@@ -525,7 +525,6 @@ function GeneralSettings() {
           right={<ClearHistoryButton />}
         />
       </SettingsCard>
-      <NetworkSettings />
     </>
   )
 }
@@ -543,24 +542,17 @@ function NetworkSettings() {
     queryKey: ['daemonNetworkConfig'],
     queryFn: () => client.getDaemonNetworkConfig.query(),
   })
-  const [draftMode, setDraftMode] = useState<NetworkMode | null>(null)
-  const [draftCustomName, setDraftCustomName] = useState<string | null>(null)
-  const [showConfirm, setShowConfirm] = useState(false)
+  // While non-null, the confirmation dialog is open for switching to this mode.
+  const [pendingMode, setPendingMode] = useState<NetworkMode | null>(null)
+  const [pendingCustomName, setPendingCustomName] = useState('')
 
   const savedMode: NetworkMode = networkConfig.data?.mode ?? 'mainnet'
   const savedCustomName = networkConfig.data?.customName ?? ''
-  const mode = draftMode ?? savedMode
-  const customName = draftCustomName ?? savedCustomName
-
-  const isDirty = mode !== savedMode || (mode === 'custom' && customName.trim() !== savedCustomName)
-  const canApply = isDirty && (mode !== 'custom' || customName.trim().length > 0)
 
   const setNetwork = useMutation({
     mutationFn: (config: {mode: NetworkMode; customName?: string}) => client.setDaemonNetworkConfig.mutate(config),
     onSuccess: () => {
       toast.success('Network changed. Background service restarted.')
-      setDraftMode(null)
-      setDraftCustomName(null)
       networkConfig.refetch()
     },
     onError: (error: unknown) => {
@@ -572,95 +564,105 @@ function NetworkSettings() {
     },
   })
 
-  function confirmNetworkChange() {
-    setShowConfirm(false)
-    setNetwork.mutate(mode === 'custom' ? {mode, customName: customName.trim()} : {mode})
+  function requestModeChange(mode: NetworkMode) {
+    setPendingMode(mode)
+    setPendingCustomName(savedCustomName)
   }
 
+  function confirmNetworkChange() {
+    if (!pendingMode) return
+    setNetwork.mutate(
+      pendingMode === 'custom' ? {mode: pendingMode, customName: pendingCustomName.trim()} : {mode: pendingMode},
+    )
+    setPendingMode(null)
+  }
+
+  const canConfirm = pendingMode !== 'custom' || pendingCustomName.trim().length > 0
   const pendingNetworkLabel =
-    mode === 'custom' ? `the custom network "${customName.trim()}"` : NETWORK_MODE_LABELS[mode]
+    pendingMode === 'custom'
+      ? pendingCustomName.trim()
+        ? `the custom network "${pendingCustomName.trim()}"`
+        : 'a custom network'
+      : pendingMode
+        ? NETWORK_MODE_LABELS[pendingMode]
+        : ''
 
   return (
     <>
       <SettingsCard label="NETWORK">
         <SettingsRow
           label="P2P Network"
-          description="Choose which peer-to-peer network to connect to. Changing this restarts the background service."
+          description={
+            savedMode === 'custom' && savedCustomName
+              ? `Connected to the custom network "${savedCustomName}". Changing this restarts the background service.`
+              : 'Choose which peer-to-peer network to connect to. Changing this restarts the background service.'
+          }
           right={
-            <Select
-              value={mode}
-              onValueChange={(value) => setDraftMode(value as NetworkMode)}
-              disabled={networkConfig.isLoading || setNetwork.isLoading}
-            >
-              <SelectTrigger className="w-[140px]">
-                <SelectValue placeholder="Select network" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="mainnet">Mainnet</SelectItem>
-                <SelectItem value="testnet">Testnet</SelectItem>
-                <SelectItem value="custom">Custom</SelectItem>
-              </SelectContent>
-            </Select>
+            <div className="flex items-center gap-2">
+              {setNetwork.isLoading ? <Spinner size="small" /> : null}
+              <Select
+                value={pendingMode ?? savedMode}
+                onValueChange={(value) => requestModeChange(value as NetworkMode)}
+                disabled={networkConfig.isLoading || setNetwork.isLoading}
+              >
+                <SelectTrigger className="w-[140px]">
+                  <SelectValue placeholder="Select network" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="mainnet">Mainnet</SelectItem>
+                  <SelectItem value="testnet">Testnet</SelectItem>
+                  <SelectItem value="custom">Custom</SelectItem>
+                </SelectContent>
+              </Select>
+              {savedMode === 'custom' ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={networkConfig.isLoading || setNetwork.isLoading}
+                  onClick={() => requestModeChange('custom')}
+                >
+                  <Pencil className="size-3" />
+                </Button>
+              ) : null}
+            </div>
           }
         />
-        {mode === 'custom' ? (
-          <>
-            <Separator />
-            <SettingsRow
-              label="Custom Network Name"
-              description="Peers only connect to each other when they use the same network name."
-              right={
-                <Input
-                  value={customName}
-                  onChange={(e) => setDraftCustomName(e.target.value)}
-                  placeholder="network-name"
-                  className="w-[200px]"
-                  disabled={setNetwork.isLoading}
-                />
-              }
-            />
-          </>
-        ) : null}
-        {isDirty || setNetwork.isLoading ? (
-          <>
-            <Separator />
-            <SettingsRow
-              label={setNetwork.isLoading ? 'Restarting background service…' : `Switch to ${pendingNetworkLabel}?`}
-              right={
-                <div className="flex items-center gap-2">
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    disabled={setNetwork.isLoading}
-                    onClick={() => {
-                      setDraftMode(null)
-                      setDraftCustomName(null)
-                    }}
-                  >
-                    Revert
-                  </Button>
-                  <Button size="sm" disabled={!canApply || setNetwork.isLoading} onClick={() => setShowConfirm(true)}>
-                    {setNetwork.isLoading ? 'Restarting…' : 'Apply & Restart'}
-                  </Button>
-                </div>
-              }
-            />
-          </>
-        ) : null}
       </SettingsCard>
-      <AlertDialog open={showConfirm} onOpenChange={setShowConfirm}>
+      <AlertDialog
+        open={pendingMode !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingMode(null)
+        }}
+      >
         <AlertDialogPortal>
           <AlertDialogContent className="max-w-[500px] gap-4">
             <AlertDialogTitle className="text-xl font-bold">Change Network?</AlertDialogTitle>
             <AlertDialogDescription>
               {`This will restart the background service connected to ${pendingNetworkLabel}. Content from other networks will be unavailable until you switch back. The app may be briefly unresponsive during restart.`}
             </AlertDialogDescription>
+            {pendingMode === 'custom' ? (
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="custom-network-name">Network Name</Label>
+                <Input
+                  id="custom-network-name"
+                  value={pendingCustomName}
+                  onChange={(e) => setPendingCustomName(e.target.value)}
+                  placeholder="network-name"
+                  autoFocus
+                />
+                <SizableText size="xs" className="text-muted-foreground">
+                  Peers only connect to each other when they use the same network name.
+                </SizableText>
+              </div>
+            ) : null}
             <div className="flex justify-end gap-3">
               <AlertDialogCancel asChild>
                 <Button variant="ghost">Cancel</Button>
               </AlertDialogCancel>
               <AlertDialogAction asChild>
-                <Button onClick={confirmNetworkChange}>Change & Restart</Button>
+                <Button disabled={!canConfirm} onClick={confirmNetworkChange}>
+                  Change & Restart
+                </Button>
               </AlertDialogAction>
             </div>
           </AlertDialogContent>
@@ -1318,6 +1320,7 @@ function GatewaySettings() {
           }
         />
       </SettingsCard>
+      <NetworkSettings />
       <SettingsCard label="AUTO-PUSH TRIGGERS">
         <PushOnPublishSetting />
         <Separator />

--- a/frontend/apps/desktop/src/pages/settings.tsx
+++ b/frontend/apps/desktop/src/pages/settings.tsx
@@ -525,6 +525,147 @@ function GeneralSettings() {
           right={<ClearHistoryButton />}
         />
       </SettingsCard>
+      <NetworkSettings />
+    </>
+  )
+}
+
+type NetworkMode = 'mainnet' | 'testnet' | 'custom'
+
+const NETWORK_MODE_LABELS: Record<NetworkMode, string> = {
+  mainnet: 'Mainnet',
+  testnet: 'Testnet',
+  custom: 'Custom',
+}
+
+function NetworkSettings() {
+  const networkConfig = useQuery({
+    queryKey: ['daemonNetworkConfig'],
+    queryFn: () => client.getDaemonNetworkConfig.query(),
+  })
+  const [draftMode, setDraftMode] = useState<NetworkMode | null>(null)
+  const [draftCustomName, setDraftCustomName] = useState<string | null>(null)
+  const [showConfirm, setShowConfirm] = useState(false)
+
+  const savedMode: NetworkMode = networkConfig.data?.mode ?? 'mainnet'
+  const savedCustomName = networkConfig.data?.customName ?? ''
+  const mode = draftMode ?? savedMode
+  const customName = draftCustomName ?? savedCustomName
+
+  const isDirty = mode !== savedMode || (mode === 'custom' && customName.trim() !== savedCustomName)
+  const canApply = isDirty && (mode !== 'custom' || customName.trim().length > 0)
+
+  const setNetwork = useMutation({
+    mutationFn: (config: {mode: NetworkMode; customName?: string}) => client.setDaemonNetworkConfig.mutate(config),
+    onSuccess: () => {
+      toast.success('Network changed. Background service restarted.')
+      setDraftMode(null)
+      setDraftCustomName(null)
+      networkConfig.refetch()
+    },
+    onError: (error: unknown) => {
+      toast.error('Failed to change network: ' + String(error))
+      reportError(error, {
+        feature: 'settings',
+        operation: 'set-daemon-network',
+      })
+    },
+  })
+
+  function confirmNetworkChange() {
+    setShowConfirm(false)
+    setNetwork.mutate(mode === 'custom' ? {mode, customName: customName.trim()} : {mode})
+  }
+
+  const pendingNetworkLabel =
+    mode === 'custom' ? `the custom network "${customName.trim()}"` : NETWORK_MODE_LABELS[mode]
+
+  return (
+    <>
+      <SettingsCard label="NETWORK">
+        <SettingsRow
+          label="P2P Network"
+          description="Choose which peer-to-peer network to connect to. Changing this restarts the background service."
+          right={
+            <Select
+              value={mode}
+              onValueChange={(value) => setDraftMode(value as NetworkMode)}
+              disabled={networkConfig.isLoading || setNetwork.isLoading}
+            >
+              <SelectTrigger className="w-[140px]">
+                <SelectValue placeholder="Select network" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="mainnet">Mainnet</SelectItem>
+                <SelectItem value="testnet">Testnet</SelectItem>
+                <SelectItem value="custom">Custom</SelectItem>
+              </SelectContent>
+            </Select>
+          }
+        />
+        {mode === 'custom' ? (
+          <>
+            <Separator />
+            <SettingsRow
+              label="Custom Network Name"
+              description="Peers only connect to each other when they use the same network name."
+              right={
+                <Input
+                  value={customName}
+                  onChange={(e) => setDraftCustomName(e.target.value)}
+                  placeholder="network-name"
+                  className="w-[200px]"
+                  disabled={setNetwork.isLoading}
+                />
+              }
+            />
+          </>
+        ) : null}
+        {isDirty || setNetwork.isLoading ? (
+          <>
+            <Separator />
+            <SettingsRow
+              label={setNetwork.isLoading ? 'Restarting background service…' : `Switch to ${pendingNetworkLabel}?`}
+              right={
+                <div className="flex items-center gap-2">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={setNetwork.isLoading}
+                    onClick={() => {
+                      setDraftMode(null)
+                      setDraftCustomName(null)
+                    }}
+                  >
+                    Revert
+                  </Button>
+                  <Button size="sm" disabled={!canApply || setNetwork.isLoading} onClick={() => setShowConfirm(true)}>
+                    {setNetwork.isLoading ? 'Restarting…' : 'Apply & Restart'}
+                  </Button>
+                </div>
+              }
+            />
+          </>
+        ) : null}
+      </SettingsCard>
+      <AlertDialog open={showConfirm} onOpenChange={setShowConfirm}>
+        <AlertDialogPortal>
+          <AlertDialogContent className="max-w-[500px] gap-4">
+            <AlertDialogTitle className="text-xl font-bold">Change Network?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {`This will restart the background service connected to ${pendingNetworkLabel}. Content from other networks will be unavailable until you switch back. The app may be briefly unresponsive during restart.`}
+            </AlertDialogDescription>
+            <div className="flex justify-end gap-3">
+              <AlertDialogCancel asChild>
+                <Button variant="ghost">Cancel</Button>
+              </AlertDialogCancel>
+              <AlertDialogAction asChild>
+                <Button onClick={confirmNetworkChange}>Change & Restart</Button>
+              </AlertDialogAction>
+            </div>
+          </AlertDialogContent>
+        </AlertDialogPortal>
+      </AlertDialog>
     </>
   )
 }


### PR DESCRIPTION
## Summary

Adds a **Network** section to the desktop Settings → Sync Options panel, letting the user choose which P2P network the daemon connects to:

- **Main Network** — no `-p2p.testnet-name`, `-lndhub.mainnet=true`
- **Test Network** — `-p2p.testnet-name dev` (matches the `./dev up-testnet` stack)
- **Custom Network** — user-provided `-p2p.testnet-name`

Changing the selection opens a confirmation dialog (with the network-name input when Custom is chosen) before restarting the daemon with the new flags. A saved custom network shows up as its own dropdown item by name, with a pencil button to edit it.

## Implementation

- **Persistence**: stored as `daemonNetwork` under the `Settings-v001` key in `AppStore.json` (zod-validated). Default derives from the build-time `__SEED_P2P_TESTNET_NAME__` define, so testnet builds keep their existing behavior until the user picks something.
- **Boot**: `main.ts` reads the stored config and passes it to `startMainDaemon`.
- **Restart**: the old `restartDaemonWithEmbedding` became a general `restartDaemon({embeddingEnabled?, network?})` that preserves whichever settings aren't being changed. The ~90 lines of copy-pasted spawn/wait logic between start and restart were deduplicated into shared helpers, and a latent bug was fixed where a stale process closing late after a restart timeout could incorrectly flip the daemon state to error.
- **API**: new `getDaemonNetworkConfig` / `setDaemonNetworkConfig` tRPC procedures (set persists, then restarts the daemon).

## Notes

- The daemon data dir stays `{userData}/daemon` across networks (same as the existing build-time testnet behavior); keys are environment-scoped by testnet name in the Go daemon.

## Test plan

- [x] `pnpm typecheck` (desktop)
- [ ] Switch mainnet → testnet in Sync Options, confirm daemon restarts with `-p2p.testnet-name dev`
- [ ] Switch to a custom network name, confirm flag and persistence across app relaunch
- [ ] Toggle embedding after a network change, confirm the network flag is preserved on restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PcXpTnVq45xwRBUMgczVp