### PR TITLE
feat(explore): view-term URL routing, Profile tab, and network discovery

### DIFF
--- a/frontend/apps/explore/src/components/HM.tsx
+++ b/frontend/apps/explore/src/components/HM.tsx
@@ -10,15 +10,16 @@ import {
   useChildrenList,
   useCitations,
   useComments,
-  useResource,
+  useRawResource,
 } from '@shm/shared'
 import {useCommentVersions} from '@shm/shared/models/comments'
 import {useMemo} from 'react'
 import {useNavigate, useParams, useSearchParams} from 'react-router-dom'
 import {useApiHost} from '../apiHostStore'
+import {exploreTabHref, parseHmRoutePath, tabToViewTerm, viewTermToExploreTab} from '../utils/exploreHref'
 import {CopyTextButton} from './CopyTextButton'
 import {ExternalOpenButton, OpenInAppButton} from './ExternalOpenButton'
-import Tabs, {getSafeCurrentTab, getTabSearchParams, getTabs, TabType} from './Tabs'
+import Tabs, {getSafeCurrentTab, getTabs, TabType} from './Tabs'
 import AuthoredCommentsTab from './tabs/AuthoredCommentsTab'
 import CapabilitiesTab from './tabs/CapabilitiesTab'
 import ChangesTab from './tabs/ChangesTab'
@@ -27,7 +28,12 @@ import CitationsTab from './tabs/CitationsTab'
 import CommentVersionsTab from './tabs/CommentVersionsTab'
 import CommentsTab from './tabs/CommentsTab'
 import DocumentTab from './tabs/DocumentTab'
+import ProfileTab from './tabs/ProfileTab'
+import {ResourceStatus} from './ResourceStatus'
 import {Title} from './Title'
+
+/** Resource states rendered as a status panel instead of the tabbed document view. */
+const STATUS_RESOURCE_TYPES = ['redirect', 'tombstone', 'not-found', 'error'] as const
 
 /** Returns all descendant replies for a comment in the same order they were loaded. */
 export function getReplyComments(comments: HMComment[] | undefined, commentId: string | null | undefined): HMComment[] {
@@ -57,10 +63,10 @@ export function getReplyComments(comments: HMComment[] | undefined, commentId: s
 
 export default function HM() {
   const {'*': path} = useParams()
-  const [searchParams, setSearchParams] = useSearchParams()
-  const pathParts = path ? path.split('/') : []
-  const uid = pathParts[0]
-  const hmPath = pathParts.slice(1)
+  const [searchParams] = useSearchParams()
+  // Strip any trailing view term (e.g. /:profile, /:comments) so it doesn't
+  // leak into the entity path, and remember which tab it implies.
+  const {uid, path: hmPath, viewTerm} = parseHmRoutePath(path)
 
   const apiHost = useApiHost()
   const navigate = useNavigate()
@@ -68,7 +74,9 @@ export default function HM() {
     path: hmPath,
     version: searchParams.get('v') ? searchParams.get('v') : undefined,
   })
-  const {data} = useResource(id)
+  // Use the redirect-preserving fetch so the explorer can display redirects,
+  // tombstones, and not-found states instead of silently following them.
+  const {data} = useRawResource(id)
   const resourceType = data?.type
   const commentsTargetId = useMemo(() => {
     if (data?.type !== 'comment') {
@@ -119,12 +127,16 @@ export default function HM() {
     ],
   )
 
-  // Get current tab from URL or default to "document"
-  const currentTab = getSafeCurrentTab(searchParams.get('tab'), tabs)
+  // A view term in the path (e.g. /:comments) is the canonical tab selector;
+  // `?tab=` is only consulted for explore-only tabs that have no view term.
+  const viewTermTab = viewTermToExploreTab(viewTerm)
+  const currentTab = getSafeCurrentTab(viewTermTab ?? searchParams.get('tab'), tabs)
 
-  // Function to change tabs
+  // Function to change tabs. Always navigate via the clean base path so any
+  // current view term is dropped: tabs backed by a view term encode it in the
+  // path (/:comments), explore-only tabs fall back to a `?tab=` query param.
   const handleTabChange = (tab: TabType) => {
-    setSearchParams(getTabSearchParams(searchParams, tab))
+    navigate(exploreTabHref(id, tab, searchParams))
   }
 
   const preparedData = useMemo(() => {
@@ -161,24 +173,17 @@ export default function HM() {
       return {type: 'comment', comment: data.comment}
     }
 
-    if (data.type === 'redirect') {
-      return {type: 'redirect', redirectTarget: data.redirectTarget}
-    }
-
-    if (data.type === 'not-found') {
-      return {type: 'not-found'}
-    }
-
-    if (data.type === 'tombstone') {
-      return {type: 'tombstone'}
-    }
-
+    // Redirect / tombstone / not-found / error are rendered by <ResourceStatus />.
     return null
   }, [data, id])
 
   // Render tab content based on current tab
   const renderTabContent = () => {
     switch (currentTab) {
+      case 'profile':
+        return (
+          <ProfileTab metadata={data?.type === 'document' ? data.document.metadata : undefined} onNavigate={navigate} />
+        )
       case 'document':
         return <DocumentTab data={preparedData} onNavigate={navigate} />
       case 'changes':
@@ -205,6 +210,8 @@ export default function HM() {
     webUrl += `?v=${id.version}`
   }
 
+  const isStatusResource = !!data && STATUS_RESOURCE_TYPES.includes(data.type as (typeof STATUS_RESOURCE_TYPES)[number])
+
   return (
     <div className="container mx-auto max-w-full overflow-hidden p-4">
       <Title
@@ -219,20 +226,26 @@ export default function HM() {
         title={url}
       />
 
-      <Tabs
-        id={id}
-        resourceType={resourceType}
-        currentTab={currentTab}
-        onTabChange={handleTabChange}
-        changeCount={changes?.changes?.length}
-        versionCount={commentVersions?.versions?.length}
-        commentCount={comments?.length}
-        citationCount={citations?.citations?.length}
-        capabilityCount={capabilities?.length}
-        childrenCount={childrenDocs?.length}
-        authoredCommentCount={authoredComments?.comments?.length}
-      />
-      <div className="tab-content">{renderTabContent()}</div>
+      {isStatusResource ? (
+        <ResourceStatus data={data} />
+      ) : (
+        <>
+          <Tabs
+            id={id}
+            resourceType={resourceType}
+            currentTab={currentTab}
+            onTabChange={handleTabChange}
+            changeCount={changes?.changes?.length}
+            versionCount={commentVersions?.versions?.length}
+            commentCount={comments?.length}
+            citationCount={citations?.citations?.length}
+            capabilityCount={capabilities?.length}
+            childrenCount={childrenDocs?.length}
+            authoredCommentCount={authoredComments?.comments?.length}
+          />
+          <div className="tab-content">{renderTabContent()}</div>
+        </>
+      )}
     </div>
   )
 }

--- a/frontend/apps/explore/src/components/HM.tsx
+++ b/frontend/apps/explore/src/components/HM.tsx
@@ -65,8 +65,9 @@ export default function HM() {
   const {'*': path} = useParams()
   const [searchParams] = useSearchParams()
   // Strip any trailing view term (e.g. /:profile, /:comments) so it doesn't
-  // leak into the entity path, and remember which tab it implies.
-  const {uid, path: hmPath, viewTerm} = parseHmRoutePath(path)
+  // leak into the entity path, and remember which tab it implies. A
+  // /:comments/<commentId> tail resolves `uid`/`hmPath` to the comment itself.
+  const {uid, path: hmPath, viewTerm, commentId: routeCommentId} = parseHmRoutePath(path)
 
   const apiHost = useApiHost()
   const navigate = useNavigate()
@@ -129,7 +130,9 @@ export default function HM() {
 
   // A view term in the path (e.g. /:comments) is the canonical tab selector;
   // `?tab=` is only consulted for explore-only tabs that have no view term.
-  const viewTermTab = viewTermToExploreTab(viewTerm)
+  // When a commentId resolved the resource, :comments was the locator (not a
+  // tab), so let the comment open on its default document view.
+  const viewTermTab = routeCommentId ? null : viewTermToExploreTab(viewTerm)
   const currentTab = getSafeCurrentTab(viewTermTab ?? searchParams.get('tab'), tabs)
 
   // Function to change tabs. Always navigate via the clean base path so any

--- a/frontend/apps/explore/src/components/ResourceStatus.tsx
+++ b/frontend/apps/explore/src/components/ResourceStatus.tsx
@@ -1,0 +1,127 @@
+import {HMResource, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {packHmId} from '@shm/shared'
+import {ArrowRight, Ban, FileQuestion, Loader, Radar, SignpostBig, TriangleAlert} from 'lucide-react'
+import {Link} from 'react-router-dom'
+import {exploreHref, isProfileId} from '../utils/exploreHref'
+import {useDiscoverResource} from '../utils/useDiscoverResource'
+import {CopyTextButton} from './CopyTextButton'
+import {OpenInAppButton} from './ExternalOpenButton'
+
+const panelClass = 'rounded-xl border border-gray-200 bg-white p-6'
+
+/**
+ * Renders resource states that are not a document or comment: redirects,
+ * tombstones, not-found, and errors. Redirects are shown (not followed) with a
+ * link to the destination so the user can choose to navigate there.
+ */
+export function ResourceStatus({data}: {data: HMResource}) {
+  if (data.type === 'redirect') {
+    return <RedirectStatus id={data.id} target={data.redirectTarget} republish={data.republish} />
+  }
+
+  if (data.type === 'tombstone') {
+    return (
+      <div className={panelClass}>
+        <div className="mb-2 flex items-center gap-2 text-lg font-bold text-gray-800">
+          <Ban className="size-5 text-red-500" />
+          Deleted
+        </div>
+        <p className="text-gray-600">
+          This {isProfileId(data.id) ? 'profile' : 'resource'} has been deleted (tombstoned).
+        </p>
+      </div>
+    )
+  }
+
+  if (data.type === 'not-found') {
+    return <NotFoundStatus id={data.id} />
+  }
+
+  if (data.type === 'error') {
+    return (
+      <div className={panelClass}>
+        <div className="mb-2 flex items-center gap-2 text-lg font-bold text-gray-800">
+          <TriangleAlert className="size-5 text-amber-500" />
+          Error
+        </div>
+        <p className="font-mono text-sm break-words text-red-600">{data.message}</p>
+      </div>
+    )
+  }
+
+  return null
+}
+
+/**
+ * Not-found panel with a Discover action. The configured host doesn't have the
+ * resource locally, so this pokes the daemon's network discovery and refetches
+ * once the content arrives.
+ */
+function NotFoundStatus({id}: {id: UnpackedHypermediaId}) {
+  const kind = isProfileId(id) ? 'profile' : 'resource'
+  const {state, discover} = useDiscoverResource(id)
+  const isDiscovering = state.status === 'discovering'
+
+  return (
+    <div className={panelClass}>
+      <div className="mb-2 flex items-center gap-2 text-lg font-bold text-gray-800">
+        <FileQuestion className="size-5 text-gray-500" />
+        Not Found
+      </div>
+      <p className="mb-4 text-gray-600">
+        No {kind} was found at this address on the configured host. Try discovering it on the network.
+      </p>
+
+      <button
+        onClick={discover}
+        disabled={isDiscovering}
+        className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+      >
+        {isDiscovering ? <Loader className="size-4 animate-spin" /> : <Radar className="size-4" />}
+        {isDiscovering ? 'Discovering…' : 'Discover on the network'}
+      </button>
+
+      {state.status === 'failed' && (
+        <p className="mt-3 text-sm text-red-600">{state.error || 'Discovery failed.'}</p>
+      )}
+    </div>
+  )
+}
+
+function RedirectStatus({
+  id,
+  target,
+  republish,
+}: {
+  id: UnpackedHypermediaId
+  target: UnpackedHypermediaId
+  republish: boolean
+}) {
+  const targetUrl = packHmId(target)
+  const kind = isProfileId(id) ? 'profile' : 'document'
+
+  return (
+    <div className={panelClass}>
+      <div className="mb-2 flex items-center gap-2 text-lg font-bold text-gray-800">
+        <SignpostBig className="size-5 text-blue-600" />
+        Redirect
+      </div>
+      <p className="mb-4 text-gray-600">
+        This {kind} redirects to another {republish ? 'resource (republished content)' : kind}. The explorer does not
+        follow redirects automatically.
+      </p>
+
+      <div className="mb-1 text-sm font-bold text-gray-700">Destination</div>
+      <div className="flex flex-wrap items-center gap-2 overflow-hidden">
+        <ArrowRight className="size-4 flex-shrink-0 text-gray-400" />
+        <Link to={exploreHref(target)} className="font-mono break-all text-blue-600 underline hover:underline">
+          {targetUrl}
+        </Link>
+        <CopyTextButton text={targetUrl} />
+        <OpenInAppButton url={targetUrl} />
+      </div>
+    </div>
+  )
+}
+
+export default ResourceStatus

--- a/frontend/apps/explore/src/components/Tabs.tsx
+++ b/frontend/apps/explore/src/components/Tabs.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 
 /** Supported Explore tabs for a resource page. */
 export type TabType =
+  | 'profile'
   | 'document'
   | 'changes'
   | 'versions'
@@ -43,12 +44,19 @@ export function getTabs({
   childrenCount = 0,
   authoredCommentCount = 0,
 }: {id: UnpackedHypermediaId; resourceType?: ResourceType} & TabCounts): TabDefinition[] {
-  const tabs: TabDefinition[] = [
-    {
-      id: 'document',
-      label: `Document State${id.version ? ` (Exact Version)` : ''}`,
-    },
-  ]
+  const isAccountRoot = !id.path?.filter((p) => !!p).length
+  const tabs: TabDefinition[] = []
+
+  // Accounts expose a Profile view (their home document as a profile); the raw
+  // Document State stays available alongside it.
+  if (isAccountRoot && resourceType === 'document') {
+    tabs.push({id: 'profile', label: 'Profile'})
+  }
+
+  tabs.push({
+    id: 'document',
+    label: `Document State${id.version ? ` (Exact Version)` : ''}`,
+  })
 
   if (resourceType === 'document') {
     tabs.push({
@@ -83,7 +91,7 @@ export function getTabs({
     label: `${childrenCount} ${pluralS(childrenCount, 'Child', 'Children')}`,
   })
 
-  if (!id.path?.filter((p) => !!p).length) {
+  if (isAccountRoot) {
     tabs.push({
       id: 'authored-comments',
       label: `${authoredCommentCount} ${pluralS(authoredCommentCount, 'Authored Comment', 'Authored Comments')}`,

--- a/frontend/apps/explore/src/components/tabs/ProfileTab.tsx
+++ b/frontend/apps/explore/src/components/tabs/ProfileTab.tsx
@@ -1,0 +1,21 @@
+import {UserCircle} from 'lucide-react'
+import React from 'react'
+import {NavigateFunction} from 'react-router-dom'
+import {DataViewer} from '../DataViewer'
+import EmptyState from '../EmptyState'
+
+interface ProfileTabProps {
+  /** The account home document's metadata — its profile fields (name, icon, …). */
+  metadata: Record<string, any> | undefined
+  onNavigate: NavigateFunction
+}
+
+/** Renders an account's profile (its home document metadata), distinct from the raw Document State. */
+const ProfileTab: React.FC<ProfileTabProps> = ({metadata, onNavigate}) => {
+  if (!metadata || Object.keys(metadata).length === 0) {
+    return <EmptyState message="This account has no profile metadata" icon={UserCircle} />
+  }
+  return <DataViewer data={metadata} onNavigate={onNavigate} />
+}
+
+export default ProfileTab

--- a/frontend/apps/explore/src/utils/exploreHref.test.ts
+++ b/frontend/apps/explore/src/utils/exploreHref.test.ts
@@ -1,0 +1,134 @@
+import {hmId} from '@shm/shared'
+import {describe, expect, it} from 'vitest'
+import {exploreHref, exploreTabHref, isProfileId, parseHmRoutePath, tabToViewTerm, viewTermToExploreTab} from './exploreHref'
+
+describe('exploreHref', () => {
+  it('links to a profile (root document) with no path', () => {
+    expect(exploreHref(hmId('zAccount'))).toBe('/hm/zAccount')
+  })
+
+  it('includes the path segments for a document', () => {
+    expect(exploreHref(hmId('zAccount', {path: ['notes', 'thread']}))).toBe('/hm/zAccount/notes/thread')
+  })
+
+  it('appends the version as a query param', () => {
+    expect(exploreHref(hmId('zAccount', {path: ['notes'], version: 'bafyVersion'}))).toBe(
+      '/hm/zAccount/notes?v=bafyVersion',
+    )
+  })
+})
+
+describe('isProfileId', () => {
+  it('is true for an account home doc (empty path)', () => {
+    expect(isProfileId(hmId('zAccount'))).toBe(true)
+    expect(isProfileId(hmId('zAccount', {path: []}))).toBe(true)
+  })
+
+  it('is false for a document with a path', () => {
+    expect(isProfileId(hmId('zAccount', {path: ['notes']}))).toBe(false)
+  })
+})
+
+describe('parseHmRoutePath', () => {
+  it('parses a bare uid', () => {
+    expect(parseHmRoutePath('zAccount')).toEqual({
+      uid: 'zAccount',
+      path: [],
+      viewTerm: null,
+      defaultTab: null,
+    })
+  })
+
+  it('parses uid + path segments', () => {
+    expect(parseHmRoutePath('zAccount/notes/thread')).toEqual({
+      uid: 'zAccount',
+      path: ['notes', 'thread'],
+      viewTerm: null,
+      defaultTab: null,
+    })
+  })
+
+  it('strips a /:profile view term back to the account home doc', () => {
+    expect(parseHmRoutePath('zAccount/:profile')).toEqual({
+      uid: 'zAccount',
+      path: [],
+      viewTerm: ':profile',
+      defaultTab: 'profile',
+    })
+  })
+
+  it('maps a /:comments view term to the comments tab and keeps the path', () => {
+    expect(parseHmRoutePath('zAccount/notes/:comments')).toEqual({
+      uid: 'zAccount',
+      path: ['notes'],
+      viewTerm: ':comments',
+      defaultTab: 'comments',
+    })
+  })
+
+  it('handles an empty route tail', () => {
+    expect(parseHmRoutePath(undefined)).toEqual({uid: '', path: [], viewTerm: null, defaultTab: null})
+  })
+})
+
+describe('viewTermToExploreTab', () => {
+  it('maps :profile to the profile tab', () => {
+    expect(viewTermToExploreTab(':profile')).toBe('profile')
+  })
+
+  it('maps comment-family terms to the comments tab', () => {
+    expect(viewTermToExploreTab(':comments')).toBe('comments')
+    expect(viewTermToExploreTab(':discussions')).toBe('comments')
+  })
+
+  it('maps directory terms to the children tab and collaborators to capabilities', () => {
+    expect(viewTermToExploreTab(':directory')).toBe('children')
+    expect(viewTermToExploreTab(':all-documents')).toBe('children')
+    expect(viewTermToExploreTab(':collaborators')).toBe('capabilities')
+  })
+
+  it('has no distinct tab for the remaining profile-family or feed terms', () => {
+    expect(viewTermToExploreTab(':followers')).toBeNull()
+    expect(viewTermToExploreTab(':feed')).toBeNull()
+    expect(viewTermToExploreTab(null)).toBeNull()
+  })
+})
+
+describe('tabToViewTerm', () => {
+  it('round-trips view-term tabs', () => {
+    expect(tabToViewTerm('profile')).toBe(':profile')
+    expect(tabToViewTerm('comments')).toBe(':comments')
+    expect(tabToViewTerm('capabilities')).toBe(':collaborators')
+    expect(tabToViewTerm('children')).toBe(':directory')
+  })
+
+  it('returns null for explore-only tabs', () => {
+    expect(tabToViewTerm('document')).toBeNull()
+    expect(tabToViewTerm('changes')).toBeNull()
+    expect(tabToViewTerm('versions')).toBeNull()
+    expect(tabToViewTerm('citations')).toBeNull()
+    expect(tabToViewTerm('authored-comments')).toBeNull()
+  })
+})
+
+describe('exploreTabHref', () => {
+  const id = hmId('zAccount', {path: ['notes']})
+
+  it('encodes a view-term tab in the path and drops ?tab', () => {
+    expect(exploreTabHref(id, 'comments', new URLSearchParams('tab=document'))).toBe('/hm/zAccount/notes/:comments')
+  })
+
+  it('uses /:profile for the profile tab on an account root', () => {
+    expect(exploreTabHref(hmId('zAccount'), 'profile', new URLSearchParams())).toBe('/hm/zAccount/:profile')
+  })
+
+  it('preserves the version param on view-term tabs', () => {
+    expect(exploreTabHref(id, 'comments', new URLSearchParams('v=bafyVersion'))).toBe(
+      '/hm/zAccount/notes/:comments?v=bafyVersion',
+    )
+  })
+
+  it('uses ?tab= for explore-only tabs', () => {
+    expect(exploreTabHref(id, 'citations', new URLSearchParams())).toBe('/hm/zAccount/notes?tab=citations')
+  })
+})

--- a/frontend/apps/explore/src/utils/exploreHref.test.ts
+++ b/frontend/apps/explore/src/utils/exploreHref.test.ts
@@ -69,6 +69,16 @@ describe('parseHmRoutePath', () => {
   it('handles an empty route tail', () => {
     expect(parseHmRoutePath(undefined)).toEqual({uid: '', path: [], viewTerm: null, defaultTab: null})
   })
+
+  it('resolves a /:comments/<commentId> tail to the comment resource', () => {
+    expect(parseHmRoutePath('zDocAccount/mydoc/:comments/zCommentAccount/ts-abc123')).toEqual({
+      uid: 'zCommentAccount',
+      path: ['ts-abc123'],
+      viewTerm: ':comments',
+      defaultTab: null,
+      commentId: 'zCommentAccount/ts-abc123',
+    })
+  })
 })
 
 describe('viewTermToExploreTab', () => {

--- a/frontend/apps/explore/src/utils/exploreHref.ts
+++ b/frontend/apps/explore/src/utils/exploreHref.ts
@@ -1,5 +1,5 @@
 import {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
-import {extractViewTermFromUrl, hmIdPathToEntityQueryPath, ViewTerm} from '@shm/shared'
+import {commentIdToHmId, extractViewTermFromUrl, hmIdPathToEntityQueryPath, ViewTerm} from '@shm/shared'
 import type {TabType} from '../components/Tabs'
 
 /** True when the id points at an account's home/profile (no path segments). */
@@ -80,8 +80,22 @@ export function parseHmRoutePath(routePath: string | undefined): {
   path: string[]
   viewTerm: ViewTerm | null
   defaultTab: TabType | null
+  commentId?: string
 } {
-  const {url: cleanedPath, viewTerm} = extractViewTermFromUrl(`/${routePath ?? ''}`)
+  const {url: cleanedPath, viewTerm, commentId} = extractViewTermFromUrl(`/${routePath ?? ''}`)
+  // `/:comments/<commentId>` locates a specific comment resource. Resolve it to
+  // that comment's id (uid/tsid) so the explorer opens the comment itself —
+  // here :comments is the comment locator, not a tab selector.
+  if (commentId) {
+    const commentResourceId = commentIdToHmId(commentId)
+    return {
+      uid: commentResourceId.uid,
+      path: commentResourceId.path?.filter(Boolean) ?? [],
+      viewTerm,
+      defaultTab: null,
+      commentId,
+    }
+  }
   const parts = cleanedPath.split('/').filter(Boolean)
   return {
     uid: parts[0] ?? '',

--- a/frontend/apps/explore/src/utils/exploreHref.ts
+++ b/frontend/apps/explore/src/utils/exploreHref.ts
@@ -1,0 +1,101 @@
+import {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {extractViewTermFromUrl, hmIdPathToEntityQueryPath, ViewTerm} from '@shm/shared'
+import type {TabType} from '../components/Tabs'
+
+/** True when the id points at an account's home/profile (no path segments). */
+export function isProfileId(id: UnpackedHypermediaId): boolean {
+  return !id.path?.filter((segment) => !!segment).length
+}
+
+/**
+ * Maps a site view term (e.g. `/:comments`) to the Explore tab that represents
+ * it. View terms without a distinct Explore tab — the remaining profile family
+ * (`:membership`, `:followers`, `:following`) and `:feed`/`:activity` — resolve
+ * to the resource's default document view.
+ */
+export function viewTermToExploreTab(viewTerm: ViewTerm | null): TabType | null {
+  switch (viewTerm) {
+    case ':profile':
+      return 'profile'
+    case ':comments':
+    case ':comment':
+    case ':discussions':
+      return 'comments'
+    case ':collaborators':
+      return 'capabilities'
+    case ':directory':
+    case ':all-documents':
+      return 'children'
+    default:
+      return null
+  }
+}
+
+/**
+ * Inverse of {@link viewTermToExploreTab}: the canonical view term for an
+ * Explore tab, or null for explore-only tabs (Document State, Changes,
+ * Versions, Citations, Authored Comments) that have no hypermedia view term and
+ * are therefore selected via `?tab=` instead of a path segment.
+ */
+export function tabToViewTerm(tab: TabType): ViewTerm | null {
+  switch (tab) {
+    case 'profile':
+      return ':profile'
+    case 'comments':
+      return ':comments'
+    case 'capabilities':
+      return ':collaborators'
+    case 'children':
+      return ':directory'
+    default:
+      return null
+  }
+}
+
+/**
+ * Builds the Explore route for selecting a tab on a resource. Tabs backed by a
+ * view term encode it in the path (`/hm/uid/path/:comments`); explore-only tabs
+ * fall back to `?tab=`. Existing query params (e.g. the `v` version) are kept.
+ */
+export function exploreTabHref(id: UnpackedHypermediaId, tab: TabType, searchParams: URLSearchParams): string {
+  const base = `/hm/${id.uid}${hmIdPathToEntityQueryPath(id.path)}`
+  const params = new URLSearchParams(searchParams)
+  params.delete('tab')
+  const viewTerm = tabToViewTerm(tab)
+  if (viewTerm) {
+    const query = params.toString()
+    return `${base}/${viewTerm}${query ? `?${query}` : ''}`
+  }
+  params.set('tab', tab)
+  return `${base}?${params.toString()}`
+}
+
+/**
+ * Parses an Explore `/hm/*` route tail (the segment after `/hm/`) into its id
+ * parts plus the tab implied by any trailing view term. Keeps view terms like
+ * `/:profile` from leaking into the entity path, where they'd break resolution.
+ */
+export function parseHmRoutePath(routePath: string | undefined): {
+  uid: string
+  path: string[]
+  viewTerm: ViewTerm | null
+  defaultTab: TabType | null
+} {
+  const {url: cleanedPath, viewTerm} = extractViewTermFromUrl(`/${routePath ?? ''}`)
+  const parts = cleanedPath.split('/').filter(Boolean)
+  return {
+    uid: parts[0] ?? '',
+    path: parts.slice(1),
+    viewTerm,
+    defaultTab: viewTermToExploreTab(viewTerm),
+  }
+}
+
+/** Builds the in-app Explore route (`/hm/...`) for a hypermedia id. */
+export function exploreHref(id: UnpackedHypermediaId): string {
+  let href = `/hm/${id.uid}${hmIdPathToEntityQueryPath(id.path)}`
+  if (id.version) {
+    href += `?v=${encodeURIComponent(id.version)}`
+  }
+  return href
+}

--- a/frontend/apps/explore/src/utils/useDiscoverResource.ts
+++ b/frontend/apps/explore/src/utils/useDiscoverResource.ts
@@ -1,0 +1,68 @@
+import {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {queryKeys, useUniversalClient} from '@shm/shared'
+import {invalidateQueries} from '@shm/shared/models/query-client'
+import {useCallback, useRef, useState} from 'react'
+
+export type DiscoverState =
+  | {status: 'idle'}
+  | {status: 'discovering'}
+  | {status: 'found'}
+  | {status: 'failed'; error?: string}
+
+const POLL_INTERVAL_MS = 1500
+const DISCOVERY_TIMEOUT_MS = 60_000
+
+/**
+ * Triggers the daemon's async discovery for a resource that isn't available on
+ * the configured host, then polls until it is found (or fails/times out). On
+ * success it invalidates the entity queries so the resource view refetches and
+ * renders the now-available content.
+ *
+ * The daemon's `DiscoverEntity` call returns immediately with the current task
+ * state (starting one if none exists), so each poll re-pokes discovery — this
+ * is the same mechanism the gateway's not-found shim page uses.
+ */
+export function useDiscoverResource(id: UnpackedHypermediaId) {
+  const client = useUniversalClient()
+  const [state, setState] = useState<DiscoverState>({status: 'idle'})
+  // Guards against overlapping runs when the button is clicked repeatedly.
+  const activeRef = useRef(false)
+
+  const discover = useCallback(async () => {
+    if (activeRef.current) return
+    activeRef.current = true
+    setState({status: 'discovering'})
+
+    const input = {
+      uid: id.uid,
+      path: id.path?.filter(Boolean) ?? [],
+      version: id.version || undefined,
+      // With no explicit version, accept any discovered version as success.
+      latest: id.latest || !id.version,
+    }
+    const deadline = Date.now() + DISCOVERY_TIMEOUT_MS
+
+    try {
+      while (Date.now() < deadline) {
+        const res = await client.request('DiscoveryStatus', input)
+        if (res.state === 'found') {
+          invalidateQueries([queryKeys.ENTITY])
+          setState({status: 'found'})
+          return
+        }
+        if (res.state === 'failed') {
+          setState({status: 'failed', error: res.error})
+          return
+        }
+        await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS))
+      }
+      setState({status: 'failed', error: 'Discovery timed out. The content may be unavailable on the network.'})
+    } catch (e) {
+      setState({status: 'failed', error: e instanceof Error ? e.message : String(e)})
+    } finally {
+      activeRef.current = false
+    }
+  }, [client, id.uid, id.path, id.version, id.latest])
+
+  return {state, discover}
+}

--- a/frontend/packages/shared/src/models/entity.ts
+++ b/frontend/packages/shared/src/models/entity.ts
@@ -26,7 +26,7 @@ import {DocumentInfo, RedirectErrorDetails} from '../client'
 import {DISCOVERY_TIMEOUT_MS} from '../constants'
 import {useUniversalAppContext, useUniversalClient} from '../routing'
 import {useStream} from '../use-stream'
-import {createWebHMUrl, entityQueryPathToHmIdPath, hmId, latestId, unpackHmId} from '../utils'
+import {createWebHMUrl, entityQueryPathToHmIdPath, extractViewTermFromUrl, hmId, latestId, unpackHmId} from '../utils'
 import {
   queryAccount,
   queryCapabilities,
@@ -36,6 +36,7 @@ import {
   queryDirectory,
   queryDocumentCollaborators,
   queryDomain,
+  queryRawResource,
   queryResource,
 } from './queries'
 import {queryKeys} from './query-keys'
@@ -196,6 +197,27 @@ export function useResource(
     isDiscovering,
     isTombstone,
   }
+}
+
+/**
+ * Fetches a resource WITHOUT following redirects.
+ *
+ * `useResource` auto-follows redirects, so its `data.type` is never 'redirect' —
+ * a redirected profile/document resolves straight to its target. This hook
+ * instead returns the raw resource, so `data.type` can be 'redirect',
+ * 'tombstone', 'not-found', or 'error'. Inspector UIs (e.g. the Explore app)
+ * use it to display the redirect itself and link to the destination rather than
+ * navigating there automatically.
+ */
+export function useRawResource(
+  id: UnpackedHypermediaId | null | undefined,
+  options?: UseQueryOptions<HMResource | null>,
+) {
+  const client = useUniversalClient()
+  return useQuery({
+    ...queryRawResource(client, id),
+    ...options,
+  })
 }
 
 /**
@@ -776,7 +798,26 @@ export async function search(input: string): Promise<HypermediaSearchResult> {
     return {destination: `/ipfs/${cid}`}
   }
 
-  const unpackedId = unpackHmId(normalizedInput)
+  // Strip any trailing site view term (e.g. /:comments, /:profile) so the
+  // underlying resource resolves cleanly, then re-attach it to the destination
+  // so the explorer opens the matching view. `unpackHmId` already resolves the
+  // `/:comments/<id>` form into the comment resource, so keep the raw input in
+  // that case and don't append a redundant view term.
+  const {url: cleanedInput, viewTerm, commentId, accountUid} = extractViewTermFromUrl(normalizedInput)
+  const idInput = commentId ? normalizedInput : cleanedInput
+  const passViewTerm = commentId ? null : viewTerm
+
+  // A profile-family view term can name the account it applies to
+  // (e.g. site.com/:profile/<accountUid>). That targets the named account's
+  // profile directly — not the site host it happened to be viewed on — so it
+  // must win over resolving the hostname below.
+  if (accountUid) {
+    return {
+      destination: createWebHMUrl(accountUid, {hostname: null, viewTerm: passViewTerm}),
+    }
+  }
+
+  const unpackedId = unpackHmId(idInput)
   if (unpackedId) {
     return {
       destination: createWebHMUrl(unpackedId.uid, {
@@ -786,14 +827,15 @@ export async function search(input: string): Promise<HypermediaSearchResult> {
         blockRef: unpackedId.blockRef,
         blockRange: unpackedId.blockRange,
         hostname: null,
+        viewTerm: passViewTerm,
       }),
     }
   }
 
-  if (normalizedInput.match(/\./)) {
+  if (cleanedInput.match(/\./)) {
     // it might be a url
-    const hasProtocol = normalizedInput.match(/^https?:\/\//)
-    const searchUrl = hasProtocol ? normalizedInput : `https://${normalizedInput}`
+    const hasProtocol = cleanedInput.match(/^https?:\/\//)
+    const searchUrl = hasProtocol ? cleanedInput : `https://${cleanedInput}`
 
     try {
       const resolved = await resolveHypermediaUrl(searchUrl)
@@ -806,6 +848,7 @@ export async function search(input: string): Promise<HypermediaSearchResult> {
             blockRef: resolved.hmId.blockRef,
             blockRange: resolved.hmId.blockRange,
             hostname: null,
+            viewTerm: passViewTerm,
           }),
         }
       }

--- a/frontend/packages/shared/src/models/queries.ts
+++ b/frontend/packages/shared/src/models/queries.ts
@@ -112,6 +112,35 @@ export function queryResource(client: UniversalClient, id: UnpackedHypermediaId 
 }
 
 /**
+ * Query options for fetching a resource WITHOUT following redirects.
+ *
+ * Unlike queryResource (which auto-follows redirects so callers never see
+ * {type: 'redirect'}), this returns the raw resource exactly as the server
+ * reports it — including redirect, tombstone, and not-found. Inspector tools
+ * like the Explore app use this so they can display the redirect itself and
+ * link to the destination instead of silently navigating there.
+ */
+export function queryRawResource(client: UniversalClient, id: UnpackedHypermediaId | null | undefined) {
+  const version = id?.version || undefined
+  const latest = id?.latest || false
+  return {
+    queryKey: [queryKeys.ENTITY, 'raw', id?.id, version, latest] as const,
+    queryFn: async ({signal}: {signal?: AbortSignal} = {}): Promise<HMResource | null> => {
+      if (!id) return null
+      try {
+        const res = await client.request('Resource', id, {signal})
+        return HMResourceSchema.parse(res)
+      } catch (e) {
+        if (isAbortError(e)) throw e
+        const message = e instanceof Error ? e.message : 'Unknown error'
+        return {type: 'error', id, message}
+      }
+    },
+    enabled: !!id,
+  }
+}
+
+/**
  * Query options for fetching account metadata.
  * Returns HMMetadataPayload or null (handles not-found internally).
  */

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -35,6 +35,12 @@ procs:
     shell: 'pnpm web'
     autostart: true
 
+  # Hypermedia Explorer (Vite :5173). Browses network data; defaults its API host
+  # to the web app above (VITE_PUBLIC_EXPLORE_API_HOST, http://localhost:3000).
+  explore:
+    shell: 'pnpm explore'
+    autostart: true
+
   # Notify server (Remix/Vite :3060). Backs the vault's email/notification flow.
   notify:
     shell: 'pnpm notify'


### PR DESCRIPTION
Make the Explore app understand the hypermedia view-term URL forms and recover from not-found resources, and run it as part of `./dev up`.

- Routing: `/hm/<uid>/:profile`, `/:comments`, `/:directory`, `/:collaborators` select the matching tab via the path (the canonical selector); `?tab=` is now only used for explore-only tabs (Document State, Changes, Versions, Citations, Authored Comments). Tab clicks rebuild from the clean base path so stale view terms are dropped.
- New Profile tab (account roots) renders the home document's profile metadata, distinct from the raw Document State tab.
- search(): strip the trailing view term before resolving so hostnames and hm ids resolve cleanly, then re-attach it to the destination. The profile-family `/:profile/<accountUid>` form now targets the named account directly instead of the site host it was viewed on.
- Not-found state gains a "Discover on the network" button that pokes the daemon's DiscoveryStatus API, polls, and refetches once found.
- mprocs.yaml: add an `explore` pane so `./dev up` launches it (:5173).


Claude-Session: https://claude.ai/code/session_01QBsCNKq3EvZu9Be7P2iHoD