### PR TITLE
fix(explore): comment resource view — target link, replies, and hm:// navigation

### DIFF
--- a/frontend/apps/explore/src/components/Feed.tsx
+++ b/frontend/apps/explore/src/components/Feed.tsx
@@ -1,13 +1,13 @@
 import {useInfiniteFeed, useLatestEvent} from '@shm/shared'
 import {invalidateQueries} from '@shm/shared/models/query-client'
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
-import {useNavigate} from 'react-router-dom'
+import {useHmNavigate} from '../utils/useHmNavigate'
 import DataViewer from './DataViewer'
 
 export default function Feed() {
   const {data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, error} = useInfiniteFeed(10)
   const {data: latestEvent} = useLatestEvent()
-  const navigate = useNavigate()
+  const navigate = useHmNavigate()
   const observerRef = useRef<IntersectionObserver>()
   const [showNewContentPill, setShowNewContentPill] = useState(false)
   const [isAtTop, setIsAtTop] = useState(true)

--- a/frontend/apps/explore/src/components/HM.tsx
+++ b/frontend/apps/explore/src/components/HM.tsx
@@ -11,12 +11,15 @@ import {
   useCitations,
   useComments,
   useRawResource,
+  useResource,
 } from '@shm/shared'
 import {useCommentVersions} from '@shm/shared/models/comments'
+import {MessageCircle} from 'lucide-react'
 import {useMemo} from 'react'
-import {useNavigate, useParams, useSearchParams} from 'react-router-dom'
+import {Link, useParams, useSearchParams} from 'react-router-dom'
 import {useApiHost} from '../apiHostStore'
-import {exploreTabHref, parseHmRoutePath, tabToViewTerm, viewTermToExploreTab} from '../utils/exploreHref'
+import {exploreHref, exploreTabHref, parseHmRoutePath, tabToViewTerm, viewTermToExploreTab} from '../utils/exploreHref'
+import {useHmNavigate} from '../utils/useHmNavigate'
 import {CopyTextButton} from './CopyTextButton'
 import {ExternalOpenButton, OpenInAppButton} from './ExternalOpenButton'
 import Tabs, {getSafeCurrentTab, getTabs, TabType} from './Tabs'
@@ -70,7 +73,7 @@ export default function HM() {
   const {uid, path: hmPath, viewTerm, commentId: routeCommentId} = parseHmRoutePath(path)
 
   const apiHost = useApiHost()
-  const navigate = useNavigate()
+  const navigate = useHmNavigate()
   const id = hmId(uid, {
     path: hmPath,
     version: searchParams.get('v') ? searchParams.get('v') : undefined,
@@ -79,12 +82,16 @@ export default function HM() {
   // tombstones, and not-found states instead of silently following them.
   const {data} = useRawResource(id)
   const resourceType = data?.type
-  const commentsTargetId = useMemo(() => {
-    if (data?.type !== 'comment') {
-      return id
-    }
-    return getCommentTargetId(data.comment)
-  }, [data, id])
+  // The document a comment is attached to. Non-null only when viewing a comment,
+  // so the comment page can link back to what it's commenting on.
+  const commentTargetId = useMemo(() => {
+    if (data?.type !== 'comment') return null
+    return getCommentTargetId(data.comment) ?? null
+  }, [data])
+  const commentsTargetId = commentTargetId ?? id
+  const {data: commentTargetResource} = useResource(commentTargetId)
+  const commentTargetName =
+    commentTargetResource?.type === 'document' ? commentTargetResource.document.metadata?.name : undefined
   const {data: commentsResponse} = useComments(commentsTargetId)
   const comments = useMemo(() => {
     if (data?.type !== 'comment') {
@@ -194,7 +201,12 @@ export default function HM() {
       case 'versions':
         return <CommentVersionsTab versions={commentVersions?.versions} />
       case 'comments':
-        return <CommentsTab comments={comments} />
+        return (
+          <CommentsTab
+            comments={comments}
+            emptyMessage={resourceType === 'comment' ? 'No replies yet' : 'No comments available'}
+          />
+        )
       case 'citations':
         return <CitationsTab citations={citations?.citations} />
       case 'capabilities':
@@ -228,6 +240,19 @@ export default function HM() {
         }
         title={url}
       />
+
+      {commentTargetId && (
+        <Link
+          to={exploreHref(commentTargetId)}
+          className="mb-4 flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 p-3 text-sm text-blue-700 transition-colors hover:bg-blue-100"
+        >
+          <MessageCircle className="size-4 flex-shrink-0" />
+          <span className="flex-shrink-0 font-medium">Comment on</span>
+          <span className="min-w-0 truncate font-semibold">
+            {commentTargetName || `${commentTargetId.uid}${hmIdPathToEntityQueryPath(commentTargetId.path)}`}
+          </span>
+        </Link>
+      )}
 
       {isStatusResource ? (
         <ResourceStatus data={data} />

--- a/frontend/apps/explore/src/components/IPFS.tsx
+++ b/frontend/apps/explore/src/components/IPFS.tsx
@@ -1,7 +1,8 @@
 import {useCID} from '@shm/shared'
 import {base58btc} from 'multiformats/bases/base58'
 import React, {useMemo} from 'react'
-import {useNavigate, useParams} from 'react-router-dom'
+import {useParams} from 'react-router-dom'
+import {useHmNavigate} from '../utils/useHmNavigate'
 import {useApiHost} from '../apiHostStore'
 import {CopyTextButton} from './CopyTextButton'
 import {DataViewer} from './DataViewer'
@@ -12,7 +13,7 @@ const IPFS: React.FC = () => {
   const {cid} = useParams()
   const apiHost = useApiHost()
   const {data} = useCID(cid)
-  const navigate = useNavigate()
+  const navigate = useHmNavigate()
   const revisedData = useMemo(() => {
     if (!data?.value) return null
 

--- a/frontend/apps/explore/src/components/Tabs.test.ts
+++ b/frontend/apps/explore/src/components/Tabs.test.ts
@@ -3,7 +3,7 @@ import {describe, expect, it} from 'vitest'
 import {getSafeCurrentTab, getTabs} from './Tabs'
 
 describe('getTabs', () => {
-  it('shows comment versions and citations instead of document changes for comment resources', () => {
+  it('shows comment versions and citations instead of document changes for comment resources, and hides capabilities/children', () => {
     const tabs = getTabs({
       id: hmId('zComment', {path: ['zCommentId']}),
       resourceType: 'comment',
@@ -11,14 +11,20 @@ describe('getTabs', () => {
       citationCount: 2,
     })
 
-    expect(tabs.map((tab) => tab.id)).toEqual([
-      'document',
-      'versions',
-      'comments',
-      'citations',
-      'capabilities',
-      'children',
-    ])
+    // Comments have no capabilities or children; their comments tab lists replies.
+    expect(tabs.map((tab) => tab.id)).toEqual(['document', 'versions', 'comments', 'citations'])
+  })
+
+  it('labels the state tab "Comment State" and the comments tab "Replies" for comments', () => {
+    const tabs = getTabs({
+      id: hmId('zComment', {path: ['zCommentId']}),
+      resourceType: 'comment',
+      commentCount: 2,
+    })
+
+    const byId = Object.fromEntries(tabs.map((tab) => [tab.id, tab.label]))
+    expect(byId.document).toBe('Comment State')
+    expect(byId.comments).toBe('2 Replies')
   })
 
   it('keeps the changes tab for documents', () => {

--- a/frontend/apps/explore/src/components/Tabs.tsx
+++ b/frontend/apps/explore/src/components/Tabs.tsx
@@ -55,7 +55,7 @@ export function getTabs({
 
   tabs.push({
     id: 'document',
-    label: `Document State${id.version ? ` (Exact Version)` : ''}`,
+    label: `${resourceType === 'comment' ? 'Comment' : 'Document'} State${id.version ? ` (Exact Version)` : ''}`,
   })
 
   if (resourceType === 'document') {
@@ -72,9 +72,14 @@ export function getTabs({
     })
   }
 
+  // On a comment this tab lists the comment's replies; on a document it lists
+  // top-level comments.
   tabs.push({
     id: 'comments',
-    label: `${commentCount} ${pluralS(commentCount, 'Comment')}`,
+    label:
+      resourceType === 'comment'
+        ? `${commentCount} ${pluralS(commentCount, 'Reply', 'Replies')}`
+        : `${commentCount} ${pluralS(commentCount, 'Comment')}`,
   })
   if (resourceType === 'document' || resourceType === 'comment') {
     tabs.push({
@@ -82,14 +87,17 @@ export function getTabs({
       label: `${citationCount} ${pluralS(citationCount, 'Citation')}`,
     })
   }
-  tabs.push({
-    id: 'capabilities',
-    label: `${capabilityCount} ${pluralS(capabilityCount, 'Capability', 'Capabilities')}`,
-  })
-  tabs.push({
-    id: 'children',
-    label: `${childrenCount} ${pluralS(childrenCount, 'Child', 'Children')}`,
-  })
+  // Capabilities and children are document-only concepts; comments have neither.
+  if (resourceType !== 'comment') {
+    tabs.push({
+      id: 'capabilities',
+      label: `${capabilityCount} ${pluralS(capabilityCount, 'Capability', 'Capabilities')}`,
+    })
+    tabs.push({
+      id: 'children',
+      label: `${childrenCount} ${pluralS(childrenCount, 'Child', 'Children')}`,
+    })
+  }
 
   if (isAccountRoot) {
     tabs.push({

--- a/frontend/apps/explore/src/components/tabs/AuthoredCommentsTab.tsx
+++ b/frontend/apps/explore/src/components/tabs/AuthoredCommentsTab.tsx
@@ -1,12 +1,12 @@
 import {commentIdToHmId, entityQueryPathToHmIdPath, hmId, packHmId} from '@shm/shared'
 import {MessageCircle} from 'lucide-react'
 import React, {useMemo} from 'react'
-import {useNavigate} from 'react-router-dom'
+import {useHmNavigate} from '../../utils/useHmNavigate'
 import DataViewer from '../DataViewer'
 import EmptyState from '../EmptyState'
 
 const AuthoredCommentsTab: React.FC<{comments: any[] | undefined}> = ({comments}) => {
-  const navigate = useNavigate()
+  const navigate = useHmNavigate()
   const preparedComments = useMemo(() => {
     if (!Array.isArray(comments)) {
       console.warn('Comments is not an array:', comments)

--- a/frontend/apps/explore/src/components/tabs/CapabilitiesTab.tsx
+++ b/frontend/apps/explore/src/components/tabs/CapabilitiesTab.tsx
@@ -1,6 +1,6 @@
 import {Shield} from "lucide-react";
 import React, {useMemo} from "react";
-import {useNavigate} from "react-router-dom";
+import {useHmNavigate} from "../../utils/useHmNavigate";
 import DataViewer from "../DataViewer";
 import EmptyState from "../EmptyState";
 
@@ -9,7 +9,7 @@ interface CapabilitiesTabProps {
 }
 
 const CapabilitiesTab: React.FC<CapabilitiesTabProps> = ({capabilities}) => {
-  const navigate = useNavigate();
+  const navigate = useHmNavigate();
   const preparedCapabilities = useMemo(() => {
     if (!Array.isArray(capabilities)) {
       console.warn("Capabilities is not an array:", capabilities);

--- a/frontend/apps/explore/src/components/tabs/ChangesTab.tsx
+++ b/frontend/apps/explore/src/components/tabs/ChangesTab.tsx
@@ -1,13 +1,13 @@
 import {packHmId, type UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {History} from 'lucide-react'
 import React, {useMemo} from 'react'
-import {useNavigate} from 'react-router-dom'
+import {useHmNavigate} from '../../utils/useHmNavigate'
 import DataViewer from '../DataViewer'
 import EmptyState from '../EmptyState'
 
 /** Renders document changes with hypermedia-friendly IDs and links. */
 const ChangesTab: React.FC<{changes: any[] | undefined; docId: UnpackedHypermediaId}> = ({changes, docId}) => {
-  const navigate = useNavigate()
+  const navigate = useHmNavigate()
   const preparedChanges = useMemo(() => {
     if (!Array.isArray(changes)) {
       console.warn('Changes is not an array:', changes)

--- a/frontend/apps/explore/src/components/tabs/CitationsTab.tsx
+++ b/frontend/apps/explore/src/components/tabs/CitationsTab.tsx
@@ -1,11 +1,11 @@
 import {Quote} from "lucide-react";
 import React, {useMemo} from "react";
-import {useNavigate} from "react-router-dom";
+import {useHmNavigate} from "../../utils/useHmNavigate";
 import DataViewer from "../DataViewer";
 import EmptyState from "../EmptyState";
 
 const CitationsTab: React.FC<{citations: any[] | undefined}> = ({citations}) => {
-  const navigate = useNavigate();
+  const navigate = useHmNavigate();
   const preparedCitations = useMemo(() => {
     if (!Array.isArray(citations)) {
       console.warn("Citations is not an array:", citations);

--- a/frontend/apps/explore/src/components/tabs/CommentVersionsTab.tsx
+++ b/frontend/apps/explore/src/components/tabs/CommentVersionsTab.tsx
@@ -1,13 +1,13 @@
 import {commentIdToHmId, packHmId} from '@shm/shared'
 import {History} from 'lucide-react'
 import React, {useMemo} from 'react'
-import {useNavigate} from 'react-router-dom'
+import {useHmNavigate} from '../../utils/useHmNavigate'
 import DataViewer from '../DataViewer'
 import EmptyState from '../EmptyState'
 
 /** Renders comment edit history with links to each exact comment version. */
 const CommentVersionsTab: React.FC<{versions: any[] | undefined}> = ({versions}) => {
-  const navigate = useNavigate()
+  const navigate = useHmNavigate()
   const preparedVersions = useMemo(() => {
     if (!Array.isArray(versions)) {
       console.warn('Comment versions is not an array:', versions)

--- a/frontend/apps/explore/src/components/tabs/CommentsTab.tsx
+++ b/frontend/apps/explore/src/components/tabs/CommentsTab.tsx
@@ -1,12 +1,15 @@
 import {commentIdToHmId, entityQueryPathToHmIdPath, hmId, packHmId} from '@shm/shared'
 import {MessageCircle} from 'lucide-react'
 import React, {useMemo} from 'react'
-import {useNavigate} from 'react-router-dom'
+import {useHmNavigate} from '../../utils/useHmNavigate'
 import DataViewer from '../DataViewer'
 import EmptyState from '../EmptyState'
 
-const CommentsTab: React.FC<{comments: any[] | undefined}> = ({comments}) => {
-  const navigate = useNavigate()
+const CommentsTab: React.FC<{comments: any[] | undefined; emptyMessage?: string}> = ({
+  comments,
+  emptyMessage = 'No comments available',
+}) => {
+  const navigate = useHmNavigate()
   const preparedComments = useMemo(() => {
     if (!Array.isArray(comments)) {
       console.warn('Comments is not an array:', comments)
@@ -34,7 +37,7 @@ const CommentsTab: React.FC<{comments: any[] | undefined}> = ({comments}) => {
   }, [comments])
 
   if (!Array.isArray(comments) || comments.length === 0) {
-    return <EmptyState message="No comments available" icon={MessageCircle} />
+    return <EmptyState message={emptyMessage} icon={MessageCircle} />
   }
 
   return (

--- a/frontend/apps/explore/src/components/tabs/DocumentTab.tsx
+++ b/frontend/apps/explore/src/components/tabs/DocumentTab.tsx
@@ -1,10 +1,9 @@
 import React from "react";
-import {NavigateFunction} from "react-router-dom";
 import {DataViewer} from "../DataViewer";
 
 interface DocumentTabProps {
   data: any;
-  onNavigate: NavigateFunction;
+  onNavigate: (url: string) => void;
 }
 
 const DocumentTab: React.FC<DocumentTabProps> = ({data, onNavigate}) => {

--- a/frontend/apps/explore/src/components/tabs/ProfileTab.tsx
+++ b/frontend/apps/explore/src/components/tabs/ProfileTab.tsx
@@ -1,13 +1,12 @@
 import {UserCircle} from 'lucide-react'
 import React from 'react'
-import {NavigateFunction} from 'react-router-dom'
 import {DataViewer} from '../DataViewer'
 import EmptyState from '../EmptyState'
 
 interface ProfileTabProps {
   /** The account home document's metadata — its profile fields (name, icon, …). */
   metadata: Record<string, any> | undefined
-  onNavigate: NavigateFunction
+  onNavigate: (url: string) => void
 }
 
 /** Renders an account's profile (its home document metadata), distinct from the raw Document State. */

--- a/frontend/apps/explore/src/utils/useHmNavigate.ts
+++ b/frontend/apps/explore/src/utils/useHmNavigate.ts
@@ -1,0 +1,35 @@
+import {extractIpfsUrlCid, unpackHmId} from '@shm/shared'
+import {useCallback} from 'react'
+import {useNavigate} from 'react-router-dom'
+import {exploreHref} from './exploreHref'
+
+/**
+ * Navigation callback for the JSON DataViewer. Values rendered there are raw
+ * hypermedia strings (`hm://…`, `ipfs://…`), not Explore route paths — handing
+ * them straight to react-router's `navigate` treats them as *relative* paths and
+ * appends them to the current URL (e.g. `…/:comments/hm:/…`). This converts them
+ * to the corresponding Explore route first; anything else is passed through.
+ */
+export function useHmNavigate() {
+  const navigate = useNavigate()
+  return useCallback(
+    (url: string) => {
+      if (typeof url === 'string') {
+        const cid = extractIpfsUrlCid(url)
+        if (cid) {
+          navigate(`/ipfs/${cid}`)
+          return
+        }
+        if (url.startsWith('hm://')) {
+          const id = unpackHmId(url)
+          if (id) {
+            navigate(exploreHref(id))
+            return
+          }
+        }
+      }
+      navigate(url)
+    },
+    [navigate],
+  )
+}


### PR DESCRIPTION
Improve how the Explore app renders comment resources and fix relative navigation from the JSON data viewer.

- Add a "Comment on <target doc>" link on comment pages (was computed for loading sibling comments but never surfaced).
- Label the state tab "Comment State" (not "Document State") for comments.
- On comments, hide the Capabilities and Children tabs (not applicable) and relabel the comments tab as "Replies"; replies render via the transitive reply tree.
- Convert hm://ipfs:// links clicked in the DataViewer to Explore routes before navigating. Passing the raw hm:// string to react-router's navigate treated it as a relative path and corrupted the URL (e.g. .../:comments/hm:/uid/path). New useHmNavigate() helper handles this for every DataViewer call site.