### PR TITLE
fix(comments): comment timestamp navigates to the copy-comment-link location

### DIFF
--- a/frontend/packages/shared/src/utils/__tests__/entity-id-url.test.ts
+++ b/frontend/packages/shared/src/utils/__tests__/entity-id-url.test.ts
@@ -612,6 +612,25 @@ describe('routeToUrl', () => {
     expect(url).toBe('https://gw.com/hm/uid1/:comments/comment123')
   })
 
+  test('comments route with openComment serializes to the same URL as the copied comment link', () => {
+    // The comment timestamp navigates to this route; the omnibar URL it
+    // produces must match what the "Copy Comment Link" button copies.
+    const url = routeToUrl(
+      {
+        key: 'comments',
+        id: hmId('z6MkOwner', {path: ['doc-path']}),
+        openComment: 'z6MkAuthor/tsid123',
+      },
+      {hostname: 'https://example.com', originHomeId: hmId('z6MkOwner')},
+    )
+    expect(url).toBe(
+      buildCopyLinkUrl({
+        id: hmId('z6MkOwner', {path: ['doc-path'], hostname: 'https://example.com'}),
+        commentId: hmId('z6MkAuthor', {path: ['tsid123']}),
+      }),
+    )
+  })
+
   test('comments route with openComment and blockRef includes fragment', () => {
     const url = routeToUrl(
       {

--- a/frontend/packages/ui/src/comments.tsx
+++ b/frontend/packages/ui/src/comments.tsx
@@ -897,16 +897,16 @@ export function CommentContent({
 
 function CommentDate({comment}: {comment: HMComment}) {
   const targetId = getCommentTargetId(comment)
-  const currentRoute = useNavRoute()
-  const useFullPageNavigation = currentRoute.key === 'activity' || currentRoute.key === 'comments'
-  const commentEntityId = commentIdToHmId(comment.id)
-  const destRoute: NavRoute = useFullPageNavigation
-    ? {key: 'document', id: commentEntityId}
-    : {
-        key: 'document',
-        id: targetId!,
-        panel: {key: 'comments', id: targetId!, openComment: comment.id},
+  // Same destination as "Copy Comment Link": the target document's comments
+  // view focused on this comment, staying within the site context. The id
+  // drops the comment's targetVersion so the URL matches the copied link.
+  const destRoute: NavRoute | null = targetId
+    ? {
+        key: 'comments',
+        id: hmId(targetId.uid, {path: targetId.path}),
+        openComment: comment.id,
       }
+    : null
   return <Timestamp time={comment.createTime} route={destRoute} />
 }
 


### PR DESCRIPTION
Fixes #865

## Problem

Clicking a comment's timestamp did not take you to the location that "Copy Comment Link" points at:

- From the activity or comments pages, it navigated to the comment entity as its own document (`hm://<author>/<tsid>`), leaving the context of the target document and site entirely.
- From a document page, it opened the comments panel, whose URL uses a `?panel=` param and therefore never matches the copied comment link.

## Fix

`CommentDate` now always routes to the target document's comments view focused on the comment (`{key: 'comments', id: <target doc>, openComment: <comment id>}`), the same pattern the feed already uses in `getEventRoute`. This route serializes to `<site>/<doc-path>/:comments/<uid>/<tsid>` — exactly the URL the "Copy Comment Link" button copies — so on desktop the omnibar URL after clicking a timestamp matches the copied link, and navigation stays within the target document and site context. The route id drops the comment's `targetVersion` (matching notification routing) so no stray `?v=` appears in the URL.

Added a test asserting that the timestamp's destination route serializes to the identical URL that `buildCopyLinkUrl` produces for the same comment.

## Testing

- `@shm/shared`: full vitest suite (958 passed, incl. the new test) and typecheck
- `@shm/ui`: full vitest suite (152 passed) and typecheck
- agent-ci local CI could not run in this environment (no Docker socket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)