### PR TITLE
fix(web): refresh unmounted comment lists after posting a comment

### DIFF
--- a/frontend/apps/web/app/commenting.tsx
+++ b/frontend/apps/web/app/commenting.tsx
@@ -194,13 +194,17 @@ export default function WebCommenting({
         commentPayload: commentPayload,
         id: commentId,
       })
-      invalidateQueries([queryKeys.DOCUMENT_ACTIVITY])
-      invalidateQueries([queryKeys.DOCUMENT_DISCUSSION])
-      invalidateQueries([queryKeys.DOCUMENT_COMMENTS])
-      invalidateQueries([queryKeys.DOCUMENT_INTERACTION_SUMMARY])
-      invalidateQueries([queryKeys.DOC_CITATIONS])
-      invalidateQueries([queryKeys.BLOCK_DISCUSSIONS])
-      invalidateQueries([queryKeys.ACTIVITY_FEED])
+      // refetchType 'all': posting navigates to the focused-comment view, which
+      // unmounts the discussions list. With refetchOnMount disabled on web, an
+      // 'active'-only invalidation would leave that list rendering its stale
+      // cache (without the new comment) when the user tabs back to it (#812).
+      invalidateQueries([queryKeys.DOCUMENT_ACTIVITY], {refetchType: 'all'})
+      invalidateQueries([queryKeys.DOCUMENT_DISCUSSION], {refetchType: 'all'})
+      invalidateQueries([queryKeys.DOCUMENT_COMMENTS], {refetchType: 'all'})
+      invalidateQueries([queryKeys.DOCUMENT_INTERACTION_SUMMARY], {refetchType: 'all'})
+      invalidateQueries([queryKeys.DOC_CITATIONS], {refetchType: 'all'})
+      invalidateQueries([queryKeys.BLOCK_DISCUSSIONS], {refetchType: 'all'})
+      invalidateQueries([queryKeys.ACTIVITY_FEED], {refetchType: 'all'})
     },
   })
 

--- a/frontend/packages/shared/src/comments-service-provider.tsx
+++ b/frontend/packages/shared/src/comments-service-provider.tsx
@@ -176,12 +176,15 @@ export function useDeleteComment() {
       await client.publish(publishInput)
     },
     onSuccess: (_result, params) => {
-      // Invalidate all comment-related queries to refresh the UI
-      invalidateQueries([queryKeys.DOCUMENT_DISCUSSION])
-      invalidateQueries([queryKeys.DOCUMENT_COMMENTS])
-      invalidateQueries([queryKeys.BLOCK_DISCUSSIONS])
-      invalidateQueries([queryKeys.ACTIVITY_FEED])
-      invalidateQueries([queryKeys.SEARCH])
+      // Invalidate all comment-related queries to refresh the UI.
+      // refetchType 'all' also refreshes comment views that are unmounted right
+      // now — web disables refetchOnMount, so they'd otherwise show stale data
+      // when remounted (#812).
+      invalidateQueries([queryKeys.DOCUMENT_DISCUSSION], {refetchType: 'all'})
+      invalidateQueries([queryKeys.DOCUMENT_COMMENTS], {refetchType: 'all'})
+      invalidateQueries([queryKeys.BLOCK_DISCUSSIONS], {refetchType: 'all'})
+      invalidateQueries([queryKeys.ACTIVITY_FEED], {refetchType: 'all'})
+      invalidateQueries([queryKeys.SEARCH], {refetchType: 'all'})
       pushAfterCommentPublish?.(
         hmId(params.comment.targetAccount, {path: entityQueryPathToHmIdPath(params.comment.targetPath || '')}),
       )
@@ -216,12 +219,13 @@ export function useUpdateComment() {
       await client.publish(publishInput)
     },
     onSuccess: (_result, params) => {
-      invalidateQueries([queryKeys.DOCUMENT_DISCUSSION])
-      invalidateQueries([queryKeys.DOCUMENT_COMMENTS])
-      invalidateQueries([queryKeys.BLOCK_DISCUSSIONS])
-      invalidateQueries([queryKeys.ACTIVITY_FEED])
-      invalidateQueries([queryKeys.COMMENT_VERSIONS])
-      invalidateQueries([queryKeys.SEARCH])
+      // refetchType 'all': see useDeleteComment above (#812).
+      invalidateQueries([queryKeys.DOCUMENT_DISCUSSION], {refetchType: 'all'})
+      invalidateQueries([queryKeys.DOCUMENT_COMMENTS], {refetchType: 'all'})
+      invalidateQueries([queryKeys.BLOCK_DISCUSSIONS], {refetchType: 'all'})
+      invalidateQueries([queryKeys.ACTIVITY_FEED], {refetchType: 'all'})
+      invalidateQueries([queryKeys.COMMENT_VERSIONS], {refetchType: 'all'})
+      invalidateQueries([queryKeys.SEARCH], {refetchType: 'all'})
       pushAfterCommentPublish?.(
         hmId(params.comment.targetAccount, {path: entityQueryPathToHmIdPath(params.comment.targetPath || '')}),
       )

--- a/frontend/packages/shared/src/models/__tests__/query-client-invalidation.test.ts
+++ b/frontend/packages/shared/src/models/__tests__/query-client-invalidation.test.ts
@@ -1,0 +1,63 @@
+import {QueryClient} from '@tanstack/react-query'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+import {invalidateQueries, registerQueryClient} from '../query-client'
+
+/**
+ * Regression test for #812: on web the query client disables `refetchOnMount`,
+ * so a query that is inactive when invalidated (e.g. the discussions list after
+ * posting a comment navigates to the focused-comment view) would keep rendering
+ * its stale cache forever when remounted. `refetchType: 'all'` makes the
+ * invalidation refetch inactive queries immediately.
+ */
+describe('invalidateQueries refetchType', () => {
+  // Mirror the web browser query client defaults (apps/web/app/providers.tsx)
+  function createWebLikeQueryClient() {
+    return new QueryClient({
+      defaultOptions: {
+        queries: {
+          staleTime: 30_000,
+          refetchOnMount: false,
+          refetchOnWindowFocus: false,
+          refetchOnReconnect: false,
+          retry: false,
+        },
+      },
+    })
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  async function setupInactiveQuery(client: QueryClient) {
+    registerQueryClient(client)
+    const queryFn = vi.fn(async () => ({comments: ['old']}))
+    const key = ['DOCUMENT_DISCUSSION', {uid: 'doc1'}]
+    // Fetch once, then leave the query with no observers (inactive), like an
+    // unmounted discussions list.
+    await client.fetchQuery({queryKey: key, queryFn})
+    expect(queryFn).toHaveBeenCalledTimes(1)
+    queryFn.mockResolvedValue({comments: ['old', 'new']})
+    return {queryFn, key}
+  }
+
+  it("default invalidation does not refetch inactive queries (why 'all' is needed)", async () => {
+    const client = createWebLikeQueryClient()
+    const {queryFn, key} = await setupInactiveQuery(client)
+
+    invalidateQueries(['DOCUMENT_DISCUSSION'])
+    await vi.waitFor(() => expect(client.isFetching()).toBe(0))
+
+    expect(queryFn).toHaveBeenCalledTimes(1)
+    expect(client.getQueryData(key)).toEqual({comments: ['old']})
+  })
+
+  it("refetchType 'all' refetches inactive queries so remounts see fresh data", async () => {
+    const client = createWebLikeQueryClient()
+    const {queryFn, key} = await setupInactiveQuery(client)
+
+    invalidateQueries(['DOCUMENT_DISCUSSION'], {refetchType: 'all'})
+    await vi.waitFor(() => expect(queryFn).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(client.getQueryData(key)).toEqual({comments: ['old', 'new']}))
+  })
+})

--- a/frontend/packages/shared/src/models/query-client.ts
+++ b/frontend/packages/shared/src/models/query-client.ts
@@ -47,10 +47,20 @@ export function registerQueryClient(client: QueryClient) {
   registeredClient = client
 }
 
-export function invalidateQueries(queryKey: QueryKey) {
+export type InvalidateQueriesOptions = {
+  /**
+   * Which matching queries to refetch (react-query `refetchType`, default 'active').
+   * Pass 'all' when the affected view may be unmounted at invalidation time: the web
+   * query client disables `refetchOnMount`, so an invalidated inactive query would
+   * otherwise render its stale cache forever when it remounts.
+   */
+  refetchType?: 'active' | 'inactive' | 'all' | 'none'
+}
+
+export function invalidateQueries(queryKey: QueryKey, options?: InvalidateQueriesOptions) {
   // Always invalidate the registered client directly
   if (registeredClient) {
-    registeredClient.invalidateQueries({queryKey})
+    registeredClient.invalidateQueries({queryKey, refetchType: options?.refetchType})
   }
   // Fire subscriptions for platform-specific behavior (IPC broadcast on desktop)
   queryInvalidationSubscriptions.forEach((handler) => handler(queryKey))


### PR DESCRIPTION
Fixes #812

## Problem

On web, posting a comment, clicking the Content tab, and returning to Comments made the new comment invisible.

Root cause (three client behaviors combining):

1. Posting navigates to the focused-comment view (`navigateToComment` sets `openComment`), which unmounts the discussions list backed by the `DOCUMENT_DISCUSSION` query. The optimistic comment is only written into `DOCUMENT_COMMENTS`, which the focused view reads — so the comment appears there at first.
2. The post-publish `invalidateQueries` uses react-query's default `refetchType: 'active'`, which only refetches mounted queries — the unmounted discussions list is merely marked invalidated.
3. The web query client sets `refetchOnMount: false`, so when the user tabs back to Comments, the remounted list query never refetches and renders its stale cache indefinitely. (Desktop is unaffected: it keeps the default `refetchOnMount: true`.)

## Fix

- `invalidateQueries()` in `@shm/shared` now accepts an optional `{refetchType}` passed through to react-query (the desktop IPC broadcast path is unchanged).
- The web post-comment `onSuccess` and the shared update/delete comment mutations invalidate with `refetchType: 'all'`, so matching inactive queries refetch immediately and remounted views see fresh data.
- Added a regression test reproducing the web client config: default invalidation leaves an inactive query stale; `refetchType: 'all'` refreshes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)