### PR TITLE
fix(activity): stop ListEvents pagination from silently skipping feed windows

### DIFF
--- a/backend/api/activity/v1alpha/activity.go
+++ b/backend/api/activity/v1alpha/activity.go
@@ -266,6 +266,11 @@ func (srv *Server) ListEvents(ctx context.Context, req *activity.ListEventsReque
 	// Count rows returned by the main DB fetch (pre-filter). Used to decide whether to
 	// emit a next-page token even if the deleted/dedup filters shorten the visible page.
 	var mainRawCount int
+	// Smallest cursor value returned by the main DB fetch (rows stream in
+	// cursor-descending order, so the last row sets it). Together with
+	// mentionsScanFloor this bounds how deep the merged page may reach — see
+	// the coverageFloor clamp below.
+	var mainScanFloor int64
 	if err := srv.db.WithSave(ctx, func(conn *sqlite.Conn) error {
 		err := sqlitex.ExecTransient(conn, getEventsStr, func(stmt *sqlite.Stmt) error {
 			mainRawCount++
@@ -318,6 +323,7 @@ func (srv *Server) ListEvents(ctx context.Context, req *activity.ListEventsReque
 			if orderByObserved {
 				cursor = id
 			}
+			mainScanFloor = cursor
 			eventCursors = append(eventCursors, feedCursor{
 				cursorValue: cursor,
 				blobID:      id,
@@ -407,6 +413,9 @@ func (srv *Server) ListEvents(ctx context.Context, req *activity.ListEventsReque
 	// Count rows returned by the mentions DB fetch (pre-filter). Used together with
 	// mainRawCount to decide whether more pages exist after post-fetch filtering.
 	var mentionsRawCount int
+	// Smallest cursor value returned by the mentions DB fetch (same contract
+	// as mainScanFloor).
+	var mentionsScanFloor int64
 
 	// Add mentions to the events list
 	if err := srv.db.WithSave(ctx, func(conn *sqlite.Conn) error {
@@ -526,6 +535,7 @@ func (srv *Server) ListEvents(ctx context.Context, req *activity.ListEventsReque
 			if orderByObserved {
 				cursor = blobID
 			}
+			mentionsScanFloor = cursor
 			eventCursors = append(eventCursors, feedCursor{
 				cursorValue: cursor,
 				blobID:      blobID,
@@ -574,7 +584,36 @@ func (srv *Server) ListEvents(ctx context.Context, req *activity.ListEventsReque
 	}
 	events, eventCursors = filterDeletedAndDedupEvents(events, eventCursors, deletedList, movedResources, orderByObserved)
 
-	// Apply page size to both arrays.
+	// Each DB fetch above is limited to PageSize rows, so a fetch that filled
+	// its limit only covered cursors down to its scan floor. The merged page
+	// must not emit anything below the deepest such floor: the other fetch
+	// hasn't scanned that far yet, and the next-page token (the minimum cursor
+	// of the page) would skip everything in between — events lost on every
+	// subsequent page. Clamped events are re-fetched by the next page.
+	var coverageFloor int64
+	if mainRawCount >= int(req.PageSize) && mainScanFloor > coverageFloor {
+		coverageFloor = mainScanFloor
+	}
+	if mentionsRawCount >= int(req.PageSize) && mentionsScanFloor > coverageFloor {
+		coverageFloor = mentionsScanFloor
+	}
+	if coverageFloor > 0 {
+		kept := events[:0]
+		keptCursors := eventCursors[:0]
+		for i, cursor := range eventCursors {
+			if cursor.cursorValue != 0 && cursor.cursorValue < coverageFloor {
+				continue
+			}
+			kept = append(kept, events[i])
+			keptCursors = append(keptCursors, cursor)
+		}
+		events = kept
+		eventCursors = keptCursors
+	}
+
+	// Apply page size to both arrays. If truncation cuts events, more pages
+	// exist even when both DB fetches came back under-full.
+	truncated := len(events) > int(req.PageSize)
 	pageLen := int(math.Min(float64(len(events)), float64(req.PageSize)))
 	events = events[:pageLen]
 	eventCursors = eventCursors[:pageLen]
@@ -608,7 +647,7 @@ func (srv *Server) ListEvents(ctx context.Context, req *activity.ListEventsReque
 	// Emit a token whenever either DB fetch returned a full batch, because the
 	// deleted/dedup filters above can shorten the visible page below req.PageSize
 	// while older rows remain in the database.
-	rawHasMore := mainRawCount >= int(req.PageSize) || mentionsRawCount >= int(req.PageSize)
+	rawHasMore := mainRawCount >= int(req.PageSize) || mentionsRawCount >= int(req.PageSize) || truncated
 	var nextPageToken string
 	if pageLen > 0 && rawHasMore {
 		minCursor := eventCursors[0].cursorValue
@@ -620,6 +659,11 @@ func (srv *Server) ListEvents(ctx context.Context, req *activity.ListEventsReque
 		if minCursor != 0 {
 			nextPageToken = apiutil.EncodePageToken(minCursor-1, nil)
 		}
+	} else if pageLen == 0 && rawHasMore && coverageFloor > 0 {
+		// Everything on this page was clamped or filtered out, but the DB has
+		// more rows. Emit a token at the coverage boundary so the client can
+		// keep paging instead of dead-ending on an empty page.
+		nextPageToken = apiutil.EncodePageToken(coverageFloor-1, nil)
 	}
 
 	return &activity.ListEventsResponse{

--- a/backend/api/activity/v1alpha/activity_test.go
+++ b/backend/api/activity/v1alpha/activity_test.go
@@ -346,6 +346,170 @@ func TestListEventsEmitsNextTokenWhenTruncationCutsUnderFullFetches(t *testing.T
 	require.Equal(t, 2, gotMentions, "both mentions must be delivered even when truncation cuts the first page")
 }
 
+func TestListEventsObservedOrderDoesNotSkipWindowWhenOldMentionEntersPage(t *testing.T) {
+	alice := newTestServer(t, "alice")
+	ctx := context.Background()
+
+	author, err := core.DecodePrincipal("z6Mkv1LjkRosErBhmqrkmb5sDxXNs6EzBDSD8ktywpYLLGuC")
+	require.NoError(t, err)
+
+	// Observed-order counterpart of
+	// TestListEventsPaginationDoesNotSkipWindowWhenOldMentionEntersPage. Here
+	// the pagination cursor is the blob id (not the structural ts), and
+	// sortFeedEvents takes a different branch, so the coverage clamp must be
+	// exercised in this ordering too. The old mention therefore needs the
+	// *lowest* blob id (oldest in observed order): comment blob 1, seven
+	// Profile blobs 2..8 (blobs 7 and 8 share a resource so dedup drops one).
+	// The main scan (LIMIT 5) only reaches blob id 4, so without the clamp the
+	// deduped page lets the comment's cursor (id 1) poison the token and skips
+	// blobs 2 and 3 forever.
+	commentTime := time.UnixMilli(500).UTC().Round(blob.ClockPrecision)
+	commentTSID := blob.NewTSID(commentTime, []byte("old comment"))
+	commentAttrs := fmt.Sprintf(`{"tsid":%q}`, commentTSID.String())
+	commentHash, err := multihash.Sum([]byte("old comment"), multihash.SHA2_256, -1)
+	require.NoError(t, err)
+
+	require.NoError(t, alice.db.WithTx(ctx, func(conn *sqlite.Conn) error {
+		if err := sqlitex.Exec(conn, `INSERT INTO public_keys (id, principal) VALUES (1, ?);`, nil, []byte(author)); err != nil {
+			return err
+		}
+		if err := insertActivityProfileEvent(conn, 2, 2, author.String()+"/p2", 2_000); err != nil {
+			return err
+		}
+		if err := insertActivityProfileEvent(conn, 3, 3, author.String()+"/p3", 3_000); err != nil {
+			return err
+		}
+		if err := insertActivityProfileEvent(conn, 4, 4, author.String()+"/p4", 4_000); err != nil {
+			return err
+		}
+		if err := insertActivityProfileEvent(conn, 5, 5, author.String()+"/p5", 5_000); err != nil {
+			return err
+		}
+		if err := insertActivityProfileEvent(conn, 6, 6, author.String()+"/p6", 6_000); err != nil {
+			return err
+		}
+		if err := insertActivityProfileEvent(conn, 7, 7, author.String()+"/p7", 7_000); err != nil {
+			return err
+		}
+		// blob 8 shares resource 7 + ts with blob 7 so dedup drops one on page 1.
+		if err := insertActivityProfileEventForResource(conn, 8, 7, 7_000); err != nil {
+			return err
+		}
+		if err := sqlitex.Exec(conn, `INSERT INTO blobs (id, multihash, codec, data, size, insert_time) VALUES (1, ?, ?, ?, 1, 1);`, nil, []byte(commentHash), int64(0x71), []byte{1}); err != nil {
+			return err
+		}
+		if err := sqlitex.Exec(conn, `INSERT INTO structural_blobs (id, type, ts, author, resource, extra_attrs) VALUES (1, 'Comment', ?, 1, 2, ?);`, nil, commentTime.UnixMilli(), commentAttrs); err != nil {
+			return err
+		}
+		return sqlitex.Exec(conn, `INSERT INTO resource_links (source, target, type, is_pinned, extra_attrs) VALUES (1, 2, 'comment/Embed', 0, '{}');`, nil)
+	}))
+
+	var gotBlobIDs []int64
+	var gotMention bool
+	var token string
+	for range 10 {
+		page, err := alice.ListEvents(ctx, &activity.ListEventsRequest{
+			PageSize:        5,
+			PageToken:       token,
+			FilterEventType: []string{"Profile", "comment/Embed"},
+			Order:           activity.FeedOrder_FEED_ORDER_OBSERVED_TIME,
+		})
+		require.NoError(t, err)
+		for _, e := range page.Events {
+			if nb := e.GetNewBlob(); nb != nil {
+				gotBlobIDs = append(gotBlobIDs, nb.GetBlobId())
+			} else if e.GetNewMention() != nil {
+				gotMention = true
+			}
+		}
+		if page.NextPageToken == "" {
+			break
+		}
+		token = page.NextPageToken
+	}
+
+	// blob 7 is dropped by dedup; every other Profile blob must survive
+	// pagination, including the 2 and 3 the poisoned token used to skip.
+	for _, id := range []int64{2, 3, 4, 5, 6} {
+		require.Contains(t, gotBlobIDs, id, "blob %d must be delivered by pagination", id)
+	}
+	require.True(t, gotMention, "the old mention must eventually be delivered")
+}
+
+func TestListEventsEmitsNextTokenWhenClampEmptiesPage(t *testing.T) {
+	alice := newTestServer(t, "alice")
+	ctx := context.Background()
+
+	author, err := core.DecodePrincipal("z6Mkv1LjkRosErBhmqrkmb5sDxXNs6EzBDSD8ktywpYLLGuC")
+	require.NoError(t, err)
+
+	// Regression guard for the empty-page dead-end: the main scan fills its
+	// limit with 5 Profile events that all live on one resource, and a comment
+	// mention marks that resource deleted, so the deleted/dedup filter wipes
+	// every above-floor event. The only survivor is the deleted-marker comment
+	// itself, which sits below the coverage floor and is therefore clamped —
+	// emptying the page. Because the main fetch was full, more rows remain, so
+	// ListEvents must still emit a next-page token instead of dead-ending; the
+	// comment is then delivered on the following page.
+	commentTime := time.UnixMilli(500).UTC().Round(blob.ClockPrecision)
+	commentTSID := blob.NewTSID(commentTime, []byte("marker comment"))
+	commentAttrs := fmt.Sprintf(`{"tsid":%q,"deleted":"1"}`, commentTSID.String())
+	commentHash, err := multihash.Sum([]byte("marker comment"), multihash.SHA2_256, -1)
+	require.NoError(t, err)
+
+	require.NoError(t, alice.db.WithTx(ctx, func(conn *sqlite.Conn) error {
+		if err := sqlitex.Exec(conn, `INSERT INTO public_keys (id, principal) VALUES (1, ?);`, nil, []byte(author)); err != nil {
+			return err
+		}
+		// Five Profile events (blob ids 2..6) all on resource 100, distinct ts
+		// so they do not dedup among themselves.
+		if err := insertActivityProfileEvent(conn, 2, 100, author.String()+"/dead", 2_000); err != nil {
+			return err
+		}
+		for i, millis := range []int64{3_000, 4_000, 5_000, 6_000} {
+			if err := insertActivityProfileEventForResource(conn, int64(i+3), 100, millis); err != nil {
+				return err
+			}
+		}
+		// Comment mention (blob id 1) targets resource 100 and is flagged
+		// deleted, so filterDeletedAndDedupEvents drops all five Profile events.
+		if err := sqlitex.Exec(conn, `INSERT INTO blobs (id, multihash, codec, data, size, insert_time) VALUES (1, ?, ?, ?, 1, 1);`, nil, []byte(commentHash), int64(0x71), []byte{1}); err != nil {
+			return err
+		}
+		if err := sqlitex.Exec(conn, `INSERT INTO structural_blobs (id, type, ts, author, resource, extra_attrs) VALUES (1, 'Comment', ?, 1, 100, ?);`, nil, commentTime.UnixMilli(), commentAttrs); err != nil {
+			return err
+		}
+		return sqlitex.Exec(conn, `INSERT INTO resource_links (source, target, type, is_pinned, extra_attrs) VALUES (1, 100, 'comment/Embed', 0, '{}');`, nil)
+	}))
+
+	var gotMention bool
+	var pages int
+	var token string
+	for range 10 {
+		page, err := alice.ListEvents(ctx, &activity.ListEventsRequest{
+			PageSize:        5,
+			PageToken:       token,
+			FilterEventType: []string{"Profile", "comment/Embed"},
+			Order:           activity.FeedOrder_FEED_ORDER_OBSERVED_TIME,
+		})
+		require.NoError(t, err)
+		pages++
+		for _, e := range page.Events {
+			if e.GetNewMention() != nil {
+				gotMention = true
+			}
+		}
+		if page.NextPageToken == "" {
+			break
+		}
+		token = page.NextPageToken
+	}
+
+	require.True(t, gotMention,
+		"the clamped comment must still be delivered: an emptied page must emit a token, not dead-end")
+	require.Greater(t, pages, 1, "the first page is emptied by the clamp, so a second page must be requested")
+}
+
 func TestListEventsCommentMentionSourceDocumentUsesCommentTarget(t *testing.T) {
 	alice := newTestServer(t, "alice")
 	ctx := context.Background()

--- a/backend/api/activity/v1alpha/activity_test.go
+++ b/backend/api/activity/v1alpha/activity_test.go
@@ -186,6 +186,166 @@ func TestListEventsEmitsNextTokenWhenDedupShortensPage(t *testing.T) {
 		"id=1 must be reachable via pagination after dedup shortens page 1")
 }
 
+func TestListEventsPaginationDoesNotSkipWindowWhenOldMentionEntersPage(t *testing.T) {
+	alice := newTestServer(t, "alice")
+	ctx := context.Background()
+
+	author, err := core.DecodePrincipal("z6Mkv1LjkRosErBhmqrkmb5sDxXNs6EzBDSD8ktywpYLLGuC")
+	require.NoError(t, err)
+
+	// Fixture mirroring the production incident (seed-hypermedia/seed#863):
+	// the main (blobs) query and the mentions query are each limited to
+	// PageSize, but the mentions scan reaches much deeper in time. When the
+	// in-memory dedup drops one of the main events from the first page, an
+	// old mention slips into the page, and the next-page token — the minimum
+	// cursor of the page — jumps below every not-yet-emitted main event,
+	// silently skipping them on all subsequent pages.
+	//
+	// Timeline: seven Profile events at ts 6000..1000; blobs 2 and 3 share a
+	// resource and timestamp so dedup drops one; a single comment/Embed
+	// mention sits far in the past at ts=500.
+	commentTime := time.UnixMilli(500).UTC().Round(blob.ClockPrecision)
+	commentTSID := blob.NewTSID(commentTime, []byte("old comment"))
+	commentAttrs := fmt.Sprintf(`{"tsid":%q}`, commentTSID.String())
+	commentHash, err := multihash.Sum([]byte("old comment"), multihash.SHA2_256, -1)
+	require.NoError(t, err)
+
+	require.NoError(t, alice.db.WithTx(ctx, func(conn *sqlite.Conn) error {
+		if err := sqlitex.Exec(conn, `INSERT INTO public_keys (id, principal) VALUES (1, ?);`, nil, []byte(author)); err != nil {
+			return err
+		}
+		if err := insertActivityProfileEvent(conn, 1, 1, author.String()+"/p1", 6_000); err != nil {
+			return err
+		}
+		if err := insertActivityProfileEvent(conn, 2, 2, author.String()+"/p2", 5_000); err != nil {
+			return err
+		}
+		if err := insertActivityProfileEventForResource(conn, 3, 2, 5_000); err != nil {
+			return err
+		}
+		if err := insertActivityProfileEvent(conn, 4, 4, author.String()+"/p4", 4_000); err != nil {
+			return err
+		}
+		if err := insertActivityProfileEvent(conn, 5, 5, author.String()+"/p5", 3_000); err != nil {
+			return err
+		}
+		if err := insertActivityProfileEvent(conn, 6, 6, author.String()+"/p6", 2_000); err != nil {
+			return err
+		}
+		if err := insertActivityProfileEvent(conn, 7, 7, author.String()+"/p7", 1_000); err != nil {
+			return err
+		}
+		if err := sqlitex.Exec(conn, `INSERT INTO blobs (id, multihash, codec, data, size, insert_time) VALUES (10, ?, ?, ?, 1, 10);`, nil, []byte(commentHash), int64(0x71), []byte{1}); err != nil {
+			return err
+		}
+		if err := sqlitex.Exec(conn, `INSERT INTO structural_blobs (id, type, ts, author, resource, extra_attrs) VALUES (10, 'Comment', ?, 1, 1, ?);`, nil, commentTime.UnixMilli(), commentAttrs); err != nil {
+			return err
+		}
+		return sqlitex.Exec(conn, `INSERT INTO resource_links (source, target, type, is_pinned, extra_attrs) VALUES (10, 4, 'comment/Embed', 0, '{}');`, nil)
+	}))
+
+	// Page through the feed exactly like the frontend does (PageSize 5,
+	// claimed-time order) and collect every delivered main blob id.
+	var gotBlobIDs []int64
+	var gotMention bool
+	var token string
+	for range 10 {
+		page, err := alice.ListEvents(ctx, &activity.ListEventsRequest{
+			PageSize:        5,
+			PageToken:       token,
+			FilterEventType: []string{"Profile", "comment/Embed"},
+		})
+		require.NoError(t, err)
+		for _, e := range page.Events {
+			if nb := e.GetNewBlob(); nb != nil {
+				gotBlobIDs = append(gotBlobIDs, nb.GetBlobId())
+			} else if e.GetNewMention() != nil {
+				gotMention = true
+			}
+		}
+		if page.NextPageToken == "" {
+			break
+		}
+		token = page.NextPageToken
+	}
+
+	for _, id := range []int64{1, 4, 5, 6, 7} {
+		require.Contains(t, gotBlobIDs, id, "blob %d must be delivered by pagination", id)
+	}
+	require.True(t, gotMention, "the old mention must eventually be delivered")
+}
+
+func TestListEventsEmitsNextTokenWhenTruncationCutsUnderFullFetches(t *testing.T) {
+	alice := newTestServer(t, "alice")
+	ctx := context.Background()
+
+	author, err := core.DecodePrincipal("z6Mkv1LjkRosErBhmqrkmb5sDxXNs6EzBDSD8ktywpYLLGuC")
+	require.NoError(t, err)
+
+	// Both DB fetches return fewer rows than PageSize (4 main events, 2
+	// mentions), but the merged list (6) still exceeds PageSize (5). The
+	// truncated tail must stay reachable via a next-page token instead of
+	// dead-ending.
+	mkComment := func(conn *sqlite.Conn, blobID int64, millis int64) error {
+		commentTime := time.UnixMilli(millis).UTC().Round(blob.ClockPrecision)
+		tsid := blob.NewTSID(commentTime, []byte(fmt.Sprintf("comment-%d", blobID)))
+		attrs := fmt.Sprintf(`{"tsid":%q}`, tsid.String())
+		hash, err := multihash.Sum([]byte(fmt.Sprintf("comment-%d", blobID)), multihash.SHA2_256, -1)
+		if err != nil {
+			return err
+		}
+		if err := sqlitex.Exec(conn, `INSERT INTO blobs (id, multihash, codec, data, size, insert_time) VALUES (?, ?, ?, ?, 1, ?);`, nil, blobID, []byte(hash), int64(0x71), []byte{1}, blobID); err != nil {
+			return err
+		}
+		if err := sqlitex.Exec(conn, `INSERT INTO structural_blobs (id, type, ts, author, resource, extra_attrs) VALUES (?, 'Comment', ?, 1, 1, ?);`, nil, blobID, commentTime.UnixMilli(), attrs); err != nil {
+			return err
+		}
+		return sqlitex.Exec(conn, `INSERT INTO resource_links (source, target, type, is_pinned, extra_attrs) VALUES (?, 2, 'comment/Embed', 0, '{}');`, nil, blobID)
+	}
+
+	require.NoError(t, alice.db.WithTx(ctx, func(conn *sqlite.Conn) error {
+		if err := sqlitex.Exec(conn, `INSERT INTO public_keys (id, principal) VALUES (1, ?);`, nil, []byte(author)); err != nil {
+			return err
+		}
+		for i, millis := range []int64{6_000, 5_000, 4_000, 3_000} {
+			id := int64(i + 1)
+			if err := insertActivityProfileEvent(conn, id, id, author.String()+"/p"+strconv.FormatInt(id, 10), millis); err != nil {
+				return err
+			}
+		}
+		if err := mkComment(conn, 10, 2_000); err != nil {
+			return err
+		}
+		return mkComment(conn, 11, 1_000)
+	}))
+
+	var gotMentions int
+	var gotBlobs int
+	var token string
+	for range 10 {
+		page, err := alice.ListEvents(ctx, &activity.ListEventsRequest{
+			PageSize:        5,
+			PageToken:       token,
+			FilterEventType: []string{"Profile", "comment/Embed"},
+		})
+		require.NoError(t, err)
+		for _, e := range page.Events {
+			if e.GetNewBlob() != nil {
+				gotBlobs++
+			} else if e.GetNewMention() != nil {
+				gotMentions++
+			}
+		}
+		if page.NextPageToken == "" {
+			break
+		}
+		token = page.NextPageToken
+	}
+
+	require.Equal(t, 4, gotBlobs, "all main events must be delivered")
+	require.Equal(t, 2, gotMentions, "both mentions must be delivered even when truncation cuts the first page")
+}
+
 func TestListEventsCommentMentionSourceDocumentUsesCommentTarget(t *testing.T) {
 	alice := newTestServer(t, "alice")
 	ctx := context.Background()


### PR DESCRIPTION
Fixes #863 — *New comments are not showing up in the Activity Feed.*

## TL;DR

- **Symptom** — comments (and doc updates, contacts, citations…) randomly vanish from the Activity Feed, even though they're fully indexed and visible in the document's Comments tab.
- **Cause** — `ListEvents` merges two independently-limited queries (blobs + mentions) and pages on the *minimum cursor of the returned page*. When an event is dropped from a page by the deleted/dedup filter, an **old mention slips in and poisons the next-page token**, silently skipping every event in between — hours of feed history at a time.
- **Fix** — clamp each page to the depth both queries actually scanned, so the token can never jump past unscanned rows. Two adjacent pagination dead-ends fixed along the way. Reproduced live on `seedteamtalks.hyper.media` and locally with a failing test before the fix.

## The symptom

Bea commented at 15:17 CET on the *"manage my account on the desktop app"* design story. The comment is on the server — it renders in the Comments tab and in a `pageSize=100` feed query — but the Activity Feed at `/:feed` never shows it. In the issue screenshot the feed jumps straight from **17:37 today** to **Jul 12, 11:27**, swallowing ~35 events from every author and event type in between.

## Root cause

`ListEvents` (`backend/api/activity/v1alpha/activity.go`) builds a page like this:

1. Fetch up to `PageSize` newest **blob events** (comments, doc updates, …) — `ORDER BY ts DESC LIMIT PageSize`.
2. Fetch up to `PageSize` newest **mention events** (citations, embeds) — same limit, **independent scan**.
3. Merge, drop deleted/moved/duplicate events, sort by event time, truncate to `PageSize`.
4. `nextPageToken = min(cursor in returned page) − 1`.

The two scans reach very different depths in time. The web UI requests `pageSize=5` with a link-type filter that matches few mentions, so the blobs scan covers the last ~20 minutes while the mentions scan reaches back **days**. That's fine while truncation cuts the old mentions off the page — but the moment step 3 drops a blob event (tombstoned comment, moved resource, dedup), an old mention rises into the page:

```
blobs scan (LIMIT 5):     15:56  15:51  15:50  15:37  [15:27 ← dropped by filter]
mentions scan (LIMIT 5):  Jul-12 11:27  …                    (sparse, reaches days back)

page returned:            15:56  15:51  15:50  15:37  Jul-12 11:27
nextPageToken:            min(page) − 1  =  Jul-12 11:26         ⟵ poisoned
                                    │
              everything in (Jul-12 11:27 … 15:27] is *never emitted on any page*
```

The blobs scan only covered down to 15:27; the token jumps to Jul 12. Every event in the gap — Bea's comment included — is unreachable forever. The window shifts as new events arrive, which is why the feed "randomly" loses different stretches of history.

## Smoking gun

Replaying the exact frontend request (`pageSize=5`, the UI's `filterEventType` list, site `filterResource`) against the live server and following `nextPageToken`:

```
page 0:  doc-update 16:03 · comment 15:56 · comment 15:51 · doc-update 15:50 · citation 10:06
         next token → 10:06:29.843                       ⟵ jumped past 5½ hours
page 1:  citation 10:06:26 · comment 09:52 · …           ⟵ resumes below the gap
…
15 pages walked: Bea's 13:17 UTC comment never appears.
```

The same query with `pageSize=100` returns the comment at its correct position — the data was always there; pagination was skipping over it.

## The fix

Track each query's **scan floor** (the smallest cursor it returned). A query that filled its `LIMIT` only covered rows down to its floor, so:

1. **Coverage clamp** — before truncation, drop merged events below the deepest floor among the fetches that filled their limit. They fall inside territory the other query hasn't scanned yet and will be re-fetched by the next page. The token now can never skip past unscanned rows.
2. **No empty-page dead-end** — if filtering empties a page while rows remain, emit a token at the coverage boundary instead of terminating the feed.
3. **Truncation counts as "has more"** — when both fetches come back under-full but the merged list still exceeds `PageSize` (feed tail), the truncated remainder previously vanished with no token; now it's reachable.

## Verification

- **`TestListEventsPaginationDoesNotSkipWindowWhenOldMentionEntersPage`** — recreates the incident against the real SQLite schema (5 fresh blob events, one dedup-dropped, one ancient mention) and pages exactly like the frontend. **Fails before the fix** (`[]int64{1, 3, 4, 5} does not contain 6`), passes after.
- **`TestListEventsEmitsNextTokenWhenTruncationCutsUnderFullFetches`** — covers dead-end (3); confirmed to fail with the new condition neutralized.
- Full `./backend/api/...` suite passes; `go vet` / `gofmt` clean. Applies identically to claimed-time and observed-time ordering (cursors are `ts` / blob id respectively).

**Follow-up worth considering:** the frontend defaults to `pageSize: 5` in `listEventsImpl`, which makes pages tiny and maximizes exposure to this class of bug (any single dropped event lets a stale mention into the page). The backend is now correct at any page size, but raising that default would cut round-trips and add margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
