### PR TITLE
fix(desktop): show un-onboarded keys in account list and switcher

### DIFF
--- a/frontend/apps/desktop/src/components/titlebar-common.tsx
+++ b/frontend/apps/desktop/src/components/titlebar-common.tsx
@@ -199,13 +199,13 @@ export function AccountProfileButton() {
     },
   })
 
-  const accountOptions = myAccountIds.data
-    ?.map((uid, index) => {
-      const accountData = accountQueries[index]?.data
-      if (!accountData) return null
-      return accountData
-    })
-    .filter((d) => !!d)
+  const accountOptions = myAccountIds.data?.map((uid, index) => {
+    const accountData = accountQueries[index]?.data
+    // Fall back to a bare id-only entry so un-onboarded keys (no profile
+    // metadata yet) still appear and remain selectable in the switcher,
+    // instead of being filtered out and stranding a valid daemon key.
+    return accountData ?? {id: hmId(uid), metadata: null}
+  })
   const hasAccounts = !!myAccountIds.data?.length
 
   useEffect(() => {

--- a/frontend/apps/desktop/src/pages/account-settings.tsx
+++ b/frontend/apps/desktop/src/pages/account-settings.tsx
@@ -140,12 +140,14 @@ export default function AccountSettingsPage() {
     replace,
   ])
 
-  const accountOptions = accountIds
-    .map((uid, index) => {
-      const data = accountQueries[index]?.data
-      return data ? {uid, data} : null
-    })
-    .filter((o) => !!o)
+  // Keep every key the daemon reports, even if its profile document hasn't
+  // resolved (unnamed / un-onboarded accounts return null metadata). The row
+  // renderer already falls back to an abbreviated key id, so a valid key must
+  // never be filtered out just because it has no published profile yet.
+  const accountOptions = accountIds.map((uid, index) => ({
+    uid,
+    data: accountQueries[index]?.data ?? null,
+  }))
 
   function selectAccount(uid: string) {
     replace({key: 'account-settings', accountUid: uid, tab: accountSettingsRoute?.tab})
@@ -156,12 +158,12 @@ export default function AccountSettingsPage() {
       <AccountSettingsLayout
         accounts={accountOptions.map((option) => ({
           id: option.uid,
-          name: option.data.metadata?.name || `?${option.uid.slice(-8)}`,
+          name: option.data?.metadata?.name || `?${option.uid.slice(-8)}`,
           icon: (
             <HMIcon
               id={hmId(option.uid)}
-              name={option.data.metadata?.name}
-              icon={option.data.metadata?.icon}
+              name={option.data?.metadata?.name}
+              icon={option.data?.metadata?.icon}
               size={28}
             />
           ),
@@ -258,7 +260,7 @@ export default function AccountSettingsPage() {
         onOpenChange={(open) => {
           if (!open) setDeleteTargetUid(null)
         }}
-        accountName={accountOptions.find((o) => o.uid === deleteTargetUid)?.data.metadata?.name || 'Account'}
+        accountName={accountOptions.find((o) => o.uid === deleteTargetUid)?.data?.metadata?.name || 'Account'}
         busy={deleteKey.isPending}
         onDelete={() => {
           if (!deleteTargetUid) return


### PR DESCRIPTION
A daemon key that exists but has no published profile document resolves to null via queryAccount ('account-not-found'). Both the Account Settings list and the account switcher were built with `.filter(Boolean)` over that resolved profile data, so a valid-but-un-onboarded key was silently dropped from the UI — leaving the app "half logged in": no login/signup (a key exists) yet no way to see or select the account.

Drive both lists from the daemon's key list instead of resolved profiles, falling back to the existing abbreviated-key-id renderer when metadata is absent. Named accounts are unchanged.