### PR TITLE
feat: document Attributes editor

### DIFF
--- a/backend/api/documents/v3alpha/docmodel/crdt.go
+++ b/backend/api/documents/v3alpha/docmodel/crdt.go
@@ -154,29 +154,47 @@ func newCRDT(id blob.IRI, clock *cclock.Clock) *docCRDT {
 func (e *docCRDT) GetMetadata() map[string]any {
 	out := make(map[string]any, e.stateMetadata.Len())
 
-	var prevEntry struct {
-		Key   []string
-		ID    opID
-		Value any
+	// When a key is set to null it removes any nested map previously stored
+	// under it. Keys are stored flattened and iterated in prefix order (a
+	// parent immediately precedes all of its descendants), so we keep a stack
+	// of the "removal" ancestors currently in scope. A descendant is dropped
+	// when it lives under such a removal and is older than it; a newer value
+	// under the same prefix means the key was re-set and is kept.
+	// Search for "attrprefixhack" in the codebase.
+	type removal struct {
+		Key []string
+		ID  opID
 	}
+	var removals []removal
 	for k, v := range e.stateMetadata.Items() {
 		id, vv, ok := v.GetLatestWithID()
 
-		// If current key has prefix of the previous key and the value timestamp is lower, then skip this.
-		// TODO(burdiyan): There're other places in the code where this is done. DRY.
-		// Search for "attrprefixhack" in the codebase.
-		if !ok || vv == nil || (colx.HasPrefix(k, prevEntry.Key) && id.Compare(prevEntry.ID) < 0) {
-			prevEntry.Key = k
-			prevEntry.ID = id
-			prevEntry.Value = vv
+		// Pop removal ancestors we've iterated out of.
+		for len(removals) > 0 && !colx.HasPrefix(k, removals[len(removals)-1].Key) {
+			removals = removals[:len(removals)-1]
+		}
+
+		if !ok || vv == nil {
+			// A null value removes its subtree; remember it so every older
+			// descendant (not just the first one) is dropped.
+			if ok && vv == nil {
+				removals = append(removals, removal{Key: k, ID: id})
+			}
+			continue
+		}
+
+		dropped := false
+		for _, r := range removals {
+			if colx.HasPrefix(k, r.Key) && id.Compare(r.ID) < 0 {
+				dropped = true
+				break
+			}
+		}
+		if dropped {
 			continue
 		}
 
 		colx.ObjectSet(out, k, vv)
-
-		prevEntry.Key = k
-		prevEntry.ID = id
-		prevEntry.Value = vv
 	}
 
 	return out

--- a/backend/api/documents/v3alpha/documents_test.go
+++ b/backend/api/documents/v3alpha/documents_test.go
@@ -1214,6 +1214,38 @@ func TestDocumentAttributesFullJSONModel(t *testing.T) {
 	}
 }
 
+func TestDocumentAttributesRemoveMultiChildObject(t *testing.T) {
+	t.Parallel()
+
+	alice := newTestDocsAPI(t, "alice")
+	ctx := context.Background()
+
+	// An object with multiple children, plus an unrelated key.
+	doc, err := alice.PublishDocumentChangeForTest(ctx, apitest.NewChangeBuilder(alice.me.Account.Principal(), "", "", "main").
+		SetAttribute("", []string{"name"}, "Doc").
+		SetAttribute("", []string{"obj", "b"}, "beee").
+		SetAttribute("", []string{"obj", "number"}, 123).
+		SetAttribute("", []string{"obj", "toggle"}, true).
+		Build(),
+	)
+	require.NoError(t, err)
+	testutil.StructsEqual(map[string]any{
+		"name": "Doc",
+		"obj":  map[string]any{"b": "beee", "number": float64(123), "toggle": true},
+	}, docmodel.ProtoStructAsMap(doc.Metadata)).Compare(t, "object must have all children")
+
+	// Removing the object with a single parent-null must clear ALL children,
+	// not just the first one (regression: the object used to survive).
+	doc, err = alice.PublishDocumentChangeForTest(ctx, apitest.NewChangeBuilder(alice.me.Account.Principal(), "", doc.Version, "main").
+		SetAttribute("", []string{"obj"}, nil).
+		Build(),
+	)
+	require.NoError(t, err)
+	testutil.StructsEqual(map[string]any{
+		"name": "Doc",
+	}, docmodel.ProtoStructAsMap(doc.Metadata)).Compare(t, "object must be fully removed")
+}
+
 func TestRedirect(t *testing.T) {
 	t.Parallel()
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -27,7 +27,14 @@
   - make sure `pnpm typecheck` pass.
   - make sure all tests pass (`pnpm test`).
   - make sure `pnpm audit` pass.
-  - make sure run `pnpm format:write`
+  - Formatting (the CI `Lint` job runs `prettier --check` per package and fails on ANY unformatted file):
+    - Run `pnpm -r format:write` across the WHOLE workspace, then confirm with `pnpm -r format:check`.
+      Do NOT run prettier on only the files a CI log happens to name — turbo interleaves parallel package
+      output and `head`/grep truncation hides other offenders, so a per-file fix passes locally but CI still
+      fails on the files you missed. Always fix and re-check the whole workspace.
+    - Local `format:check` may flag gitignored build artifacts (e.g. `packages/editor/e2e/playwright-report/**`,
+      `test-results/**`) that do not exist on CI. Confirm with `git check-ignore <file>`; ignore those, but never
+      assume a warning is an artifact without checking — tracked source files must be formatted.
 - For full CI parity before pushing, validate locally via agent-ci:
   `npx @redwoodjs/agent-ci run -w .github/workflows/test-frontend-parallel.yml -p --github-token`.
   See `docs/local-ci-with-agent-ci.md` for setup, the fix-and-retry loop, and what to skip.

--- a/frontend/apps/desktop/src/components/sidebar-active.ts
+++ b/frontend/apps/desktop/src/components/sidebar-active.ts
@@ -10,6 +10,7 @@ export function isSiteDocumentsActiveRoute(route: NavRoute, siteId: UnpackedHype
     case 'activity':
     case 'directory':
     case 'collaborators':
+    case 'metadata':
     case 'feed':
       return route.id.uid === siteId.uid
     default:

--- a/frontend/apps/desktop/src/components/titlebar-common.tsx
+++ b/frontend/apps/desktop/src/components/titlebar-common.tsx
@@ -83,6 +83,7 @@ const DOC_OPTIONS_ROUTE_KEYS = [
   'collaborators',
   'inspect',
   'all-documents',
+  'metadata',
 ] as const
 
 type DocOptionsRouteKey = (typeof DOC_OPTIONS_ROUTE_KEYS)[number]
@@ -821,6 +822,7 @@ function getRouteId(route: NavRoute): UnpackedHypermediaId | null {
     route.key === 'collaborators' ||
     route.key === 'comments' ||
     route.key === 'all-documents' ||
+    route.key === 'metadata' ||
     route.key === 'profile' ||
     route.key === 'contact' ||
     route.key === 'site-profile' ||
@@ -848,6 +850,7 @@ function isUrlDisplayableRoute(route: NavRoute): boolean {
     route.key === 'collaborators' ||
     route.key === 'comments' ||
     route.key === 'all-documents' ||
+    route.key === 'metadata' ||
     route.key === 'site-profile' ||
     route.key === 'site-settings-emails' ||
     route.key === 'site-settings'

--- a/frontend/apps/desktop/src/hooks/route-breadcrumbs.ts
+++ b/frontend/apps/desktop/src/hooks/route-breadcrumbs.ts
@@ -97,6 +97,7 @@ export function getWindowTitle(routeKey: string, activeName?: string): string | 
     case 'collaborators':
     case 'activity':
     case 'comments':
+    case 'metadata':
     case 'inspect':
       return activeName || 'Document'
     default:

--- a/frontend/apps/desktop/src/models/documents.ts
+++ b/frontend/apps/desktop/src/models/documents.ts
@@ -40,6 +40,7 @@ import {
   compareBlocksWithMap,
   createBlocksMap,
   extractDeletes,
+  expandObjectRemovals,
   getDocAttributeChanges,
 } from '@shm/shared/utils/document-changes'
 import {filterChildDrafts} from '@shm/shared/utils/draft-children'
@@ -330,7 +331,7 @@ export function usePublishResource(
 
           const allChanges = [
             ...navigationChanges,
-            ...getDocAttributeChanges(draft.metadata),
+            ...getDocAttributeChanges(expandObjectRemovals(draft.metadata, editDocument?.metadata)),
             ...changes.changes,
             ...deleteChanges,
           ]

--- a/frontend/apps/desktop/src/models/drafts.ts
+++ b/frontend/apps/desktop/src/models/drafts.ts
@@ -57,5 +57,6 @@ function getRouteResourceId(route: NavRoute): UnpackedHypermediaId | null {
   if (route.key === 'comments') return route.id
   if (route.key === 'activity') return route.id
   if (route.key === 'collaborators') return route.id
+  if (route.key === 'metadata') return route.id
   return null
 }

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -404,9 +404,7 @@ export default function DesktopResourcePage() {
         // :metadata view), preserve the draft's existing content or the
         // published document's blocks — writing [] would publish the body as a
         // full delete.
-        const content = editor
-          ? editor.topLevelBlocks
-          : existingDraft?.content ?? lastPublishedContentRef.current ?? []
+        const content = editor ? editor.topLevelBlocks : existingDraft?.content ?? lastPublishedContentRef.current ?? []
         const cursorPosition = editor?._tiptapEditor?.view?.state?.selection?.$anchor?.pos ?? undefined
         const contentSummary = summarizeEditorBlocksForCleanup(content)
         cleanupInfo(`${CLEANUP_LOG_PREFIX} renderer writeDraft actor reading editor content`, {

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -318,6 +318,10 @@ export default function DesktopResourcePage() {
 
   // Editor ref for draft saving — captured via onEditorReady callback
   const editorRef = useRef<any>(null)
+  // Published document content (editor-block form); the content fallback when
+  // no editor is mounted (e.g. saving an attributes-only draft from the
+  // :metadata view) so we never clobber the body with an empty array.
+  const lastPublishedContentRef = useRef<any>(null)
   const selectedAccountId = useSelectedAccountId()
   const selectedAccount = useSelectedAccount()
   const handleEditorReady = useCallback((editor: any) => {
@@ -394,9 +398,16 @@ export default function DesktopResourcePage() {
     () =>
       fromPromise<WriteDraftOutput, WriteDraftInput>(async ({input}) => {
         const editor = editorRef.current
-        const content = editor ? editor.topLevelBlocks : []
-        const cursorPosition = editor?._tiptapEditor?.view?.state?.selection?.$anchor?.pos ?? undefined
         const draftId = input.draftId || nanoid(10)
+        const existingDraft = input.draftId ? await client.drafts.get.query(input.draftId) : null
+        // When no editor is mounted (e.g. an attributes-only edit from the
+        // :metadata view), preserve the draft's existing content or the
+        // published document's blocks — writing [] would publish the body as a
+        // full delete.
+        const content = editor
+          ? editor.topLevelBlocks
+          : existingDraft?.content ?? lastPublishedContentRef.current ?? []
+        const cursorPosition = editor?._tiptapEditor?.view?.state?.selection?.$anchor?.pos ?? undefined
         const contentSummary = summarizeEditorBlocksForCleanup(content)
         cleanupInfo(`${CLEANUP_LOG_PREFIX} renderer writeDraft actor reading editor content`, {
           draftId,
@@ -414,7 +425,6 @@ export default function DesktopResourcePage() {
         //   signingAccountId: input.signingAccountId,
         //   hasEditor: !!editor,
         // })
-        const existingDraft = input.draftId ? await client.drafts.get.query(input.draftId) : null
         const currentPath = docIdRef.current.path ?? []
         const routeDraftId = getDraftIdFromDraftPathSegment(currentPath.at(-1))
         const isReservedRouteDraft = !!routeDraftId && routeDraftId === draftId && !existingDraft
@@ -643,6 +653,10 @@ export default function DesktopResourcePage() {
   // Hooks for options dropdown
   const resource = useResource(documentResourceId)
   const doc = resource.data?.type === 'document' ? resource.data.document : undefined
+  lastPublishedContentRef.current = useMemo(
+    () => (doc?.content ? hmBlocksToEditorContent(doc.content, {childrenType: 'Group'}) : null),
+    [doc],
+  )
   const docIsInMyAccount = myAccountIds.data?.includes(docId.uid)
 
   // Key off the route's docId rather than the resolved doc.{account,path,version}
@@ -945,7 +959,7 @@ export default function DesktopResourcePage() {
     })
   }
 
-  const showPublishToolbar = route.key === 'document'
+  const showPublishToolbar = route.key === 'document' || route.key === 'metadata'
 
   // Walk the editor's blocks for embed blocks with a draftId.
   // Called at Publish click time so the popover always opens

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -213,6 +213,7 @@ export default function DesktopResourcePage() {
     'comments',
     'site-profile',
     'all-documents',
+    'metadata',
   ]
   if (!supportedKeys.includes(route.key)) {
     throw new Error(`DesktopResourcePage: unsupported route ${route.key}`)

--- a/frontend/apps/desktop/src/pages/main.tsx
+++ b/frontend/apps/desktop/src/pages/main.tsx
@@ -471,6 +471,11 @@ function getPageComponent(navRoute: NavRoute) {
         PageComponent: Document,
         Fallback: DocumentPlaceholder,
       }
+    case 'metadata':
+      return {
+        PageComponent: Document,
+        Fallback: DocumentPlaceholder,
+      }
     case 'profile':
       return {
         PageComponent: Profile,

--- a/frontend/apps/web/app/document-edit/web-document-actors.ts
+++ b/frontend/apps/web/app/document-edit/web-document-actors.ts
@@ -35,6 +35,7 @@ import {
   compareBlocksWithMap,
   createBlocksMap,
   extractDeletes,
+  expandObjectRemovals,
   getDocAttributeChanges,
 } from '@shm/shared/utils/document-changes'
 import {getNavigationChanges} from '@shm/shared/utils/navigation-changes'
@@ -204,7 +205,9 @@ export async function publishWebDocument(input: PublishInput, deps: CreateWebDoc
     editDocument?.detachedBlocks?.navigation ?? null,
   )
 
-  const metadataChanges = getDocAttributeChanges(draft.metadata as HMMetadata)
+  const metadataChanges = getDocAttributeChanges(
+    expandObjectRemovals(draft.metadata as HMMetadata, editDocument?.metadata),
+  )
 
   const allChanges = [...navChanges, ...metadataChanges, ...blockDiff.changes, ...deleteChanges]
 

--- a/frontend/apps/web/app/document-edit/web-document-actors.ts
+++ b/frontend/apps/web/app/document-edit/web-document-actors.ts
@@ -85,12 +85,15 @@ export function createWebDocumentMachine(deps: CreateWebDocumentMachineDeps) {
 function makeWriteDraftActor(deps: CreateWebDocumentMachineDeps) {
   return fromPromise<WriteDraftOutput, WriteDraftInput>(async ({input}) => {
     const editor = deps.getEditor()
-    const editorBlocks = editor?.getTopLevelBlocks() ?? []
     const cursorPosition = editor?.getCursorPosition?.() ?? null
-    const content = editorBlocksToHMBlockNodes(editorBlocks)
-
     const draftId = input.draftId ?? nanoid(10)
     const existingDraft = input.draftId ? await getWebDocDraft(input.draftId) : null
+    // No editor mounted (e.g. an attributes-only edit from the :metadata view):
+    // preserve the draft's existing content or the published blocks instead of
+    // clobbering the body with an empty array.
+    const content = editor
+      ? editorBlocksToHMBlockNodes(editor.getTopLevelBlocks() ?? [])
+      : existingDraft?.content ?? input.baseBlocks ?? []
     const currentPath = deps.docId.path ?? []
     const routeDraftId = getWebDraftPlaceholderId(currentPath)
     const isReservedRouteDraft = !!routeDraftId && routeDraftId === draftId && !existingDraft

--- a/frontend/apps/web/app/web-resource-page.tsx
+++ b/frontend/apps/web/app/web-resource-page.tsx
@@ -348,7 +348,7 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
     [origin, originHomeId, navigate, replaceRoute, docId, route],
   )
 
-  const showPublishToolbar = route.key === 'document'
+  const showPublishToolbar = route.key === 'document' || route.key === 'metadata'
 
   const editingFloatingActions =
     effectiveCanEdit && showPublishToolbar

--- a/frontend/packages/client/__tests__/metadata-passthrough.test.ts
+++ b/frontend/packages/client/__tests__/metadata-passthrough.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest'
-import {HMDocumentMetadataSchema} from '../src/hm-types'
+import {countCustomMetadataFields, HMDocumentMetadataSchema} from '../src/hm-types'
 
 describe('HMDocumentMetadataSchema preserves custom metadata (open attribute map)', () => {
   it('keeps unknown top-level keys through parse', () => {
@@ -32,5 +32,31 @@ describe('HMDocumentMetadataSchema preserves custom metadata (open attribute map
     const parsed = HMDocumentMetadataSchema.parse({name: 'Doc', showOutline: true})
     expect(parsed.name).toBe('Doc')
     expect(parsed.showOutline).toBe(true)
+  })
+})
+
+describe('countCustomMetadataFields', () => {
+  it('counts only custom keys, not built-in HMDocumentMetadataSchema fields', () => {
+    expect(
+      countCustomMetadataFields({
+        name: 'Doc',
+        summary: 'built-in',
+        cover: 'ipfs://x',
+        theme: {headerLayout: 'Center'},
+        customA: 'x',
+        customB: 3,
+      } as never),
+    ).toBe(2)
+  })
+
+  it('returns 0 with no custom fields (or no metadata)', () => {
+    expect(countCustomMetadataFields({name: 'Doc', showOutline: true} as never)).toBe(0)
+    expect(countCustomMetadataFields(null)).toBe(0)
+    expect(countCustomMetadataFields(undefined)).toBe(0)
+    expect(countCustomMetadataFields({} as never)).toBe(0)
+  })
+
+  it('ignores custom keys whose value is null/undefined (draft tombstones)', () => {
+    expect(countCustomMetadataFields({customA: 'x', removed: null, gone: undefined} as never)).toBe(1)
   })
 })

--- a/frontend/packages/client/__tests__/metadata-passthrough.test.ts
+++ b/frontend/packages/client/__tests__/metadata-passthrough.test.ts
@@ -1,0 +1,36 @@
+import {describe, expect, it} from 'vitest'
+import {HMDocumentMetadataSchema} from '../src/hm-types'
+
+describe('HMDocumentMetadataSchema preserves custom metadata (open attribute map)', () => {
+  it('keeps unknown top-level keys through parse', () => {
+    const parsed = HMDocumentMetadataSchema.parse({
+      name: 'Doc',
+      customField: 'hello',
+      anotherOne: 42,
+      enabled: true,
+    })
+    expect(parsed.name).toBe('Doc')
+    expect((parsed as Record<string, unknown>).customField).toBe('hello')
+    expect((parsed as Record<string, unknown>).anotherOne).toBe(42)
+    expect((parsed as Record<string, unknown>).enabled).toBe(true)
+  })
+
+  it('preserves the whole value of a schema-keyed (ipfs://) field, nested objects included', () => {
+    const schemaKey = 'ipfs://bafyreigu5vewjq63sy3t2spkkpmchine3vo3jnuuvntx7ig4oef7hafuka'
+    const parsed = HMDocumentMetadataSchema.parse({
+      name: 'Doc',
+      [schemaKey]: {headline: 'Hi', status: 'draft', nested: {deep: 1}},
+    })
+    expect((parsed as Record<string, unknown>)[schemaKey]).toEqual({
+      headline: 'Hi',
+      status: 'draft',
+      nested: {deep: 1},
+    })
+  })
+
+  it('still validates and keeps known fields', () => {
+    const parsed = HMDocumentMetadataSchema.parse({name: 'Doc', showOutline: true})
+    expect(parsed.name).toBe('Doc')
+    expect(parsed.showOutline).toBe(true)
+  })
+})

--- a/frontend/packages/client/src/hm-types.ts
+++ b/frontend/packages/client/src/hm-types.ts
@@ -568,6 +568,25 @@ export function hmMetadataJsonCorrection(metadata: any): any {
 
 export type HMMetadata = z.infer<typeof HMDocumentMetadataSchema>
 
+/** Keys declared by HMDocumentMetadataSchema — the built-in document metadata fields. */
+export const BUILTIN_METADATA_KEYS: ReadonlySet<string> = new Set(Object.keys(HMDocumentMetadataSchema.shape))
+
+/**
+ * Count of custom (user-authored) metadata fields on a document: keys not
+ * declared by HMDocumentMetadataSchema. Null/undefined values (e.g. removed
+ * fields staged as draft tombstones) are not counted.
+ */
+export function countCustomMetadataFields(metadata?: HMMetadata | null): number {
+  if (!metadata) return 0
+  let count = 0
+  for (const [key, value] of Object.entries(metadata)) {
+    if (BUILTIN_METADATA_KEYS.has(key)) continue
+    if (value === undefined || value === null) continue
+    count++
+  }
+  return count
+}
+
 export type HMResourceVisibility = 'PUBLIC' | 'PRIVATE'
 
 const visibilityMap: Record<string | number, HMResourceVisibility> = {

--- a/frontend/packages/client/src/hm-types.ts
+++ b/frontend/packages/client/src/hm-types.ts
@@ -525,31 +525,32 @@ export const HMBlockNodeSchema: z.ZodType<HMBlockNode> = z.lazy(() =>
   }),
 )
 
-export const HMDocumentMetadataSchema = z.object({
-  name: z.string().optional(),
-  summary: z.string().optional(),
-  icon: z.string().optional(),
-  thumbnail: z.string().optional(), // DEPRECATED
-  cover: z.string().optional(),
-  siteUrl: z.string().optional(),
-  layout: z.union([z.literal('Seed/Experimental/Newspaper'), z.literal('')]).optional(),
-  displayPublishTime: z.string().optional(),
-  displayAuthor: z.string().optional(),
-  seedExperimentalLogo: z.string().optional(),
-  seedExperimentalHomeOrder: z.union([z.literal('UpdatedFirst'), z.literal('CreatedFirst')]).optional(),
-  showOutline: z.boolean().optional(),
-  showActivity: z.boolean().optional(),
-  contentWidth: z.union([z.literal('S'), z.literal('M'), z.literal('L')]).optional(),
-  childrenType: HMBlockChildrenTypeSchema.optional(),
-  theme: z
-    .object({
-      headerLayout: z.union([z.literal('Center'), z.literal('')]).optional(),
-    })
-    .optional(),
-  // Import taxonomy fields (comma-separated values from external sources like WordPress)
-  importCategories: z.string().optional(),
-  importTags: z.string().optional(),
-})
+export const HMDocumentMetadataSchema = z
+  .object({
+    name: z.string().optional(),
+    summary: z.string().optional(),
+    icon: z.string().optional(),
+    thumbnail: z.string().optional(), // DEPRECATED
+    cover: z.string().optional(),
+    siteUrl: z.string().optional(),
+    layout: z.union([z.literal('Seed/Experimental/Newspaper'), z.literal('')]).optional(),
+    displayPublishTime: z.string().optional(),
+    displayAuthor: z.string().optional(),
+    seedExperimentalLogo: z.string().optional(),
+    seedExperimentalHomeOrder: z.union([z.literal('UpdatedFirst'), z.literal('CreatedFirst')]).optional(),
+    showOutline: z.boolean().optional(),
+    showActivity: z.boolean().optional(),
+    contentWidth: z.union([z.literal('S'), z.literal('M'), z.literal('L')]).optional(),
+    childrenType: HMBlockChildrenTypeSchema.optional(),
+    theme: z
+      .object({
+        headerLayout: z.union([z.literal('Center'), z.literal('')]).optional(),
+      })
+      .optional(),
+    // Import taxonomy fields (comma-separated values from external sources like WordPress)
+    importCategories: z.string().optional(),
+    importTags: z.string().optional(),
+  })
   // Metadata is an open/extensible attribute map: the document data model
   // supports arbitrary keys (custom fields authored in the metadata editor).
   // Preserve unknown keys instead of stripping them, so custom metadata

--- a/frontend/packages/client/src/hm-types.ts
+++ b/frontend/packages/client/src/hm-types.ts
@@ -550,6 +550,11 @@ export const HMDocumentMetadataSchema = z.object({
   importCategories: z.string().optional(),
   importTags: z.string().optional(),
 })
+  // Metadata is an open/extensible attribute map: the document data model
+  // supports arbitrary keys (custom fields authored in the metadata editor).
+  // Preserve unknown keys instead of stripping them, so custom metadata
+  // survives draft save/load and the published-document read-back.
+  .passthrough()
 
 export function hmMetadataJsonCorrection(metadata: any): any {
   if (typeof metadata.theme === 'string') {

--- a/frontend/packages/shared/src/__tests__/routes.test.ts
+++ b/frontend/packages/shared/src/__tests__/routes.test.ts
@@ -290,6 +290,11 @@ describe('createDocumentNavRoute', () => {
       expect(route).toEqual({key: 'collaborators', id: testDocId, panel: null})
     })
 
+    test('metadata viewTerm returns metadata route', () => {
+      const route = createDocumentNavRoute(testDocId, 'metadata', null)
+      expect(route).toEqual({key: 'metadata', id: testDocId, panel: null})
+    })
+
     test('feed viewTerm with panel preserves panel', () => {
       const route = createDocumentNavRoute(testDocId, 'feed', 'collaborators')
       expect(route).toEqual({

--- a/frontend/packages/shared/src/routes.ts
+++ b/frontend/packages/shared/src/routes.ts
@@ -219,6 +219,7 @@ const documentPanelRoute = z.discriminatedUnion('key', [
   directoryRouteSchema,
   collaboratorsRouteSchema,
   documentOptionsRouteSchema,
+  metadataRouteSchema,
 ])
 export type DocumentPanelRoute = z.infer<typeof documentPanelRoute>
 export type PanelSelectionOptions = DocumentPanelRoute['key']

--- a/frontend/packages/shared/src/routes.ts
+++ b/frontend/packages/shared/src/routes.ts
@@ -52,6 +52,7 @@ const INSPECT_TARGET_VIEW_KEYS = [
   'directory',
   'feed',
   'all-documents',
+  'metadata',
   ...SITE_PROFILE_TABS,
 ] as const
 const inspectTargetViewSchema = z.enum(INSPECT_TARGET_VIEW_KEYS).optional()
@@ -196,6 +197,21 @@ export const commentsRouteSchema = z.object({
   panel: commentsPagePanelSchema.nullable().optional(),
 })
 export type CommentsRoute = z.infer<typeof commentsRouteSchema>
+
+// Metadata page panel options
+const metadataPagePanelSchema = z.discriminatedUnion('key', [
+  activityPanelSchema,
+  commentsPanelSchema,
+  collaboratorsPanelSchema,
+  directoryPanelSchema,
+])
+
+export const metadataRouteSchema = z.object({
+  key: z.literal('metadata'),
+  id: unpackedHmIdSchema,
+  panel: metadataPagePanelSchema.nullable().optional(),
+})
+export type MetadataRoute = z.infer<typeof metadataRouteSchema>
 
 const documentPanelRoute = z.discriminatedUnion('key', [
   activityRouteSchema,
@@ -392,6 +408,7 @@ export const navRouteSchema = z.discriminatedUnion('key', [
   collaboratorsRouteSchema,
   activityRouteSchema,
   commentsRouteSchema,
+  metadataRouteSchema,
 ])
 export type NavRoute = z.infer<typeof navRouteSchema>
 
@@ -430,6 +447,9 @@ export function getRoutePanel(route: NavRoute): NavRoute | null {
     panel = route.panel as DocumentPanelRoute | null
     routeId = route.id
   } else if (route.key === 'comments') {
+    panel = route.panel as DocumentPanelRoute | null
+    routeId = route.id
+  } else if (route.key === 'metadata') {
     panel = route.panel as DocumentPanelRoute | null
     routeId = route.id
   }
@@ -479,6 +499,7 @@ export function replaceRouteDocumentId(route: NavRoute, targetId: UnpackedHyperm
     case 'collaborators':
     case 'activity':
     case 'comments':
+    case 'metadata':
       return {
         ...route,
         id: targetId,
@@ -605,6 +626,8 @@ export function createDocumentNavRoute(
       return {key: 'all-documents', id: docId}
     case 'site-settings':
       return {key: 'site-settings', id: docId}
+    case 'metadata':
+      return {key: 'metadata', id: docId, panel}
     default: {
       // ?panel=comments/COMMENT_ID (no viewTerm) → document main + comments right panel
       return {key: 'document', id: docId, panel}

--- a/frontend/packages/shared/src/routing.tsx
+++ b/frontend/packages/shared/src/routing.tsx
@@ -276,7 +276,7 @@ export function routeToHref(
     return `${basePath}/ipfs/${route.ipfsPath}`
   }
 
-  // Handle view routes (activity, comments, directory, collaborators, feed, all-documents)
+  // Handle view routes (activity, comments, directory, collaborators, feed, all-documents, metadata)
   if (
     typeof route !== 'string' &&
     (route.key === 'activity' ||
@@ -284,7 +284,8 @@ export function routeToHref(
       route.key === 'directory' ||
       route.key === 'collaborators' ||
       route.key === 'feed' ||
-      route.key === 'all-documents')
+      route.key === 'all-documents' ||
+      route.key === 'metadata')
   ) {
     const docId = route.id
     // Build path with view term

--- a/frontend/packages/shared/src/utils/__tests__/entity-id-url.test.ts
+++ b/frontend/packages/shared/src/utils/__tests__/entity-id-url.test.ts
@@ -600,6 +600,17 @@ describe('routeToUrl', () => {
     expect(url).toBe('https://gw.com/hm/uid1/:comments')
   })
 
+  test('metadata route includes :metadata viewTerm', () => {
+    const url = routeToUrl(
+      {
+        key: 'metadata',
+        id: hmId('uid1'),
+      },
+      {hostname: 'https://gw.com'},
+    )
+    expect(url).toBe('https://gw.com/hm/uid1/:metadata')
+  })
+
   test('comments route with openComment includes commentId in path', () => {
     const url = routeToUrl(
       {
@@ -855,6 +866,11 @@ describe('extractViewTermFromUrl', () => {
   test('extracts :comments view term', () => {
     const result = extractViewTermFromUrl('https://site.com/path/:comments')
     expect(result).toEqual({url: 'https://site.com/path', isInspect: false, viewTerm: ':comments'})
+  })
+
+  test('extracts :metadata view term', () => {
+    const result = extractViewTermFromUrl('https://site.com/path/:metadata')
+    expect(result).toEqual({url: 'https://site.com/path', isInspect: false, viewTerm: ':metadata'})
   })
 
   test('extracts :comments/UID/TSID pattern', () => {

--- a/frontend/packages/shared/src/utils/__tests__/entity-id-url.test.ts
+++ b/frontend/packages/shared/src/utils/__tests__/entity-id-url.test.ts
@@ -600,7 +600,7 @@ describe('routeToUrl', () => {
     expect(url).toBe('https://gw.com/hm/uid1/:comments')
   })
 
-  test('metadata route includes :metadata viewTerm', () => {
+  test('metadata route is surfaced as the :attributes viewTerm', () => {
     const url = routeToUrl(
       {
         key: 'metadata',
@@ -608,7 +608,7 @@ describe('routeToUrl', () => {
       },
       {hostname: 'https://gw.com'},
     )
-    expect(url).toBe('https://gw.com/hm/uid1/:metadata')
+    expect(url).toBe('https://gw.com/hm/uid1/:attributes')
   })
 
   test('comments route with openComment includes commentId in path', () => {

--- a/frontend/packages/shared/src/utils/document-changes.test.ts
+++ b/frontend/packages/shared/src/utils/document-changes.test.ts
@@ -1,7 +1,13 @@
 import type {EditorBlock} from '@seed-hypermedia/client/editor-types'
 import type {HMBlockNode} from '@seed-hypermedia/client/hm-types'
 import {describe, expect, it} from 'vitest'
-import {compareBlocksWithMap, createBlocksMap, deduplicateBlockIds, getDocAttributeChanges} from './document-changes'
+import {
+  compareBlocksWithMap,
+  createBlocksMap,
+  deduplicateBlockIds,
+  expandObjectRemovals,
+  getDocAttributeChanges,
+} from './document-changes'
 
 function para(id: string, children: EditorBlock[] = []): EditorBlock {
   return {
@@ -90,6 +96,27 @@ describe('getDocAttributeChanges', () => {
   it('removing object children emits per-leaf null removals', () => {
     const changes = getDocAttributeChanges({obj: {a: null, b: null}} as Record<string, unknown>)
     expect(nullKeys(changes)).toEqual(expect.arrayContaining(['obj.a', 'obj.b']))
+  })
+
+  it('expandObjectRemovals turns an object tombstone into a per-leaf null publish', () => {
+    // Draft removed the object (staged { test: null }); published doc has it.
+    const draft = {test: null} as never
+    const published = {name: 'Doc', test: {b: 'beee', number: 123, toggle: false}} as never
+    const expanded = expandObjectRemovals(draft, published) as Record<string, unknown>
+    // Every leaf is explicitly nulled (so publish doesn't rely on a parent-null).
+    expect(expanded.test).toEqual({b: null, number: null, toggle: null})
+    // Un-edited keys (e.g. name) are not introduced/touched.
+    expect('name' in expanded).toBe(false)
+    // Publishing yields a null op per leaf.
+    expect(nullKeys(getDocAttributeChanges(expanded as never))).toEqual(
+      expect.arrayContaining(['test.b', 'test.number', 'test.toggle']),
+    )
+  })
+
+  it('expandObjectRemovals leaves non-removal edits and scalar tombstones alone', () => {
+    const published = {a: 'x', obj: {k: 1}} as never
+    // scalar removal stays a plain null; a normal value passes through
+    expect(expandObjectRemovals({a: null, keep: 'v'} as never, published)).toEqual({a: null, keep: 'v'})
   })
 })
 

--- a/frontend/packages/shared/src/utils/document-changes.test.ts
+++ b/frontend/packages/shared/src/utils/document-changes.test.ts
@@ -48,6 +48,27 @@ describe('getDocAttributeChanges', () => {
     expect(changes[0]!.op.value.value.case).toBe('stringValue')
     expect(changes[0]!.op.value.value.value).toBe('Ordered')
   })
+
+  it('emits setAttribute ops for arbitrary custom metadata keys and nested objects', () => {
+    const changes = getDocAttributeChanges({
+      customText: 'hi',
+      customCount: 3,
+      customFlag: true,
+      nested: {inner: 'deep'},
+    } as Record<string, unknown>)
+
+    const byKey = new Map(
+      changes.map((change) => {
+        if (change.op.case !== 'setAttribute') throw new Error('expected setAttribute')
+        return [change.op.value.key.join('.'), change.op.value.value]
+      }),
+    )
+    expect(byKey.get('customText')).toMatchObject({case: 'stringValue', value: 'hi'})
+    expect(byKey.get('customCount')).toMatchObject({case: 'intValue', value: 3n})
+    expect(byKey.get('customFlag')).toMatchObject({case: 'boolValue', value: true})
+    // nested objects are flattened into keyed attribute paths
+    expect(byKey.get('nested.inner')).toMatchObject({case: 'stringValue', value: 'deep'})
+  })
 })
 
 describe('deduplicateBlockIds', () => {

--- a/frontend/packages/shared/src/utils/document-changes.test.ts
+++ b/frontend/packages/shared/src/utils/document-changes.test.ts
@@ -69,6 +69,28 @@ describe('getDocAttributeChanges', () => {
     // nested objects are flattened into keyed attribute paths
     expect(byKey.get('nested.inner')).toMatchObject({case: 'stringValue', value: 'deep'})
   })
+
+  const nullKeys = (changes: ReturnType<typeof getDocAttributeChanges>) =>
+    changes
+      .filter((c) => c.op.case === 'setAttribute' && c.op.value.value.case === 'nullValue')
+      .map((c) => (c.op.case === 'setAttribute' ? c.op.value.key.join('.') : ''))
+
+  it('deleting an object field emits a null removal for the key', () => {
+    // Row "Remove" stages { obj: null }.
+    const changes = getDocAttributeChanges({name: 'x', obj: null} as Record<string, unknown>)
+    expect(nullKeys(changes)).toContain('obj')
+  })
+
+  it('an emptied object (all children removed) emits a null removal instead of nothing', () => {
+    // With no leaves there is no attribute op to represent it, so it must clear.
+    expect(nullKeys(getDocAttributeChanges({obj: {}} as Record<string, unknown>))).toContain('obj')
+    expect(nullKeys(getDocAttributeChanges({obj: {nested: {}}} as Record<string, unknown>))).toContain('obj.nested')
+  })
+
+  it('removing object children emits per-leaf null removals', () => {
+    const changes = getDocAttributeChanges({obj: {a: null, b: null}} as Record<string, unknown>)
+    expect(nullKeys(changes)).toEqual(expect.arrayContaining(['obj.a', 'obj.b']))
+  })
 })
 
 describe('deduplicateBlockIds', () => {

--- a/frontend/packages/shared/src/utils/document-changes.ts
+++ b/frontend/packages/shared/src/utils/document-changes.ts
@@ -24,6 +24,47 @@ export function getDocAttributeChanges(metadata: HMMetadata, baseMetadata?: HMMe
   )
 }
 
+/** Recursively null every leaf of an object. */
+function deepNullObject(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(obj)) {
+    out[k] = isPlainObject(v) ? deepNullObject(v) : null
+  }
+  return out
+}
+
+/**
+ * Rewrite object-removal tombstones into per-leaf nulls before publishing.
+ *
+ * Removing an object stages `{key: null}`. Publishing that as a single
+ * parent-null attribute op is unreliable: the server only clears one child of
+ * a multi-child object, so the rest (and thus the object) survive. Where the
+ * published document holds `key` as an object, replace the null with a
+ * deeply-nulled copy so publish emits an explicit `nullValue` op per leaf.
+ *
+ * Only null-valued keys whose published value is an object are touched; every
+ * other key (including keys absent from a partial draft) passes through
+ * unchanged, so un-edited metadata is never affected.
+ */
+export function expandObjectRemovals(
+  metadata: HMMetadata,
+  publishedMetadata: HMMetadata | undefined | null,
+): HMMetadata {
+  if (!publishedMetadata) return metadata
+  const meta = metadata as Record<string, unknown>
+  const published = publishedMetadata as Record<string, unknown>
+  const out: Record<string, unknown> = {...meta}
+  for (const [key, value] of Object.entries(meta)) {
+    const pub = published[key]
+    if (value === null && isPlainObject(pub)) {
+      out[key] = deepNullObject(pub)
+    } else if (isPlainObject(value) && isPlainObject(pub)) {
+      out[key] = expandObjectRemovals(value as HMMetadata, pub as HMMetadata)
+    }
+  }
+  return out as HMMetadata
+}
+
 function getAttributeChangesForObject(
   metadata: Record<string, unknown>,
   baseMetadata: Record<string, unknown> | undefined,

--- a/frontend/packages/shared/src/utils/document-changes.ts
+++ b/frontend/packages/shared/src/utils/document-changes.ts
@@ -41,6 +41,13 @@ function pushAttributeChanges(changes: DocumentChange[], key: string[], value: u
     const valueObj = isPlainObject(value) ? value : undefined
     const baseObj = isPlainObject(baseValue) ? baseValue : undefined
     const keys = new Set([...Object.keys(baseObj ?? {}), ...Object.keys(valueObj ?? {})])
+    // An object with no leaves can't be represented in the attribute model
+    // (there's no "set empty object" op). Emit a removal so an emptied object
+    // is cleared on publish instead of silently persisting the old value.
+    if (keys.size === 0) {
+      changes.push(docAttributeChangeNull(key))
+      return
+    }
     for (const childKey of Array.from(keys)) {
       pushAttributeChanges(changes, [...key, childKey], valueObj?.[childKey], baseObj?.[childKey])
     }

--- a/frontend/packages/shared/src/utils/entity-id-url.ts
+++ b/frontend/packages/shared/src/utils/entity-id-url.ts
@@ -50,6 +50,7 @@ export const VIEW_TERMS = [
   ':feed',
   ':all-documents',
   ':settings',
+  ':metadata',
   ...SITE_PROFILE_VIEW_TERMS,
 ] as const
 export type ViewTerm = (typeof VIEW_TERMS)[number]
@@ -63,6 +64,7 @@ export type ViewRouteKey =
   | 'feed'
   | 'all-documents'
   | 'site-settings'
+  | 'metadata'
   | SiteProfileTab
 
 // Panel keys that can be encoded in URL query param
@@ -180,6 +182,7 @@ export function viewTermToRouteKey(viewTerm: ViewTerm | null): ViewRouteKey | nu
     ':feed': 'feed',
     ':all-documents': 'all-documents',
     ':settings': 'site-settings',
+    ':metadata': 'metadata',
     ':profile': 'profile',
     ':membership': 'membership',
     ':followers': 'followers',
@@ -527,6 +530,7 @@ export function getRoutePanelParam(route: NavRoute): string | null {
       route.key === 'comments' ||
       route.key === 'collaborators' ||
       route.key === 'directory' ||
+      route.key === 'metadata' ||
       route.key === 'feed') &&
     route.panel
   ) {
@@ -585,7 +589,8 @@ export function routeToUrl(
     route.key === 'directory' ||
     route.key === 'collaborators' ||
     route.key === 'comments' ||
-    route.key === 'all-documents'
+    route.key === 'all-documents' ||
+    route.key === 'metadata'
   ) {
     // View-term routes use /:viewTerm in the path
     let viewTermPath = `:${route.key}`
@@ -672,7 +677,8 @@ export function routeToHmUrl(route: NavRoute): string | null {
     route.key === 'directory' ||
     route.key === 'collaborators' ||
     route.key === 'comments' ||
-    route.key === 'all-documents'
+    route.key === 'all-documents' ||
+    route.key === 'metadata'
   ) {
     let viewTermPath = `:${route.key}`
     if (route.key === 'activity') {
@@ -730,7 +736,8 @@ export function bookmarkUrlFromRoute(route: NavRoute): string | null {
     route.key === 'directory' ||
     route.key === 'collaborators' ||
     route.key === 'comments' ||
-    route.key === 'all-documents'
+    route.key === 'all-documents' ||
+    route.key === 'metadata'
   ) {
     return `${packBaseId(route.id.uid, route.id.path)}/:${route.key}`
   }

--- a/frontend/packages/shared/src/utils/entity-id-url.ts
+++ b/frontend/packages/shared/src/utils/entity-id-url.ts
@@ -50,7 +50,8 @@ export const VIEW_TERMS = [
   ':feed',
   ':all-documents',
   ':settings',
-  ':metadata',
+  ':attributes',
+  ':metadata', // backward compat: the metadata view is now surfaced as :attributes
   ...SITE_PROFILE_VIEW_TERMS,
 ] as const
 export type ViewTerm = (typeof VIEW_TERMS)[number]
@@ -182,7 +183,8 @@ export function viewTermToRouteKey(viewTerm: ViewTerm | null): ViewRouteKey | nu
     ':feed': 'feed',
     ':all-documents': 'all-documents',
     ':settings': 'site-settings',
-    ':metadata': 'metadata',
+    ':attributes': 'metadata',
+    ':metadata': 'metadata', // backward compat
     ':profile': 'profile',
     ':membership': 'membership',
     ':followers': 'followers',
@@ -592,8 +594,9 @@ export function routeToUrl(
     route.key === 'all-documents' ||
     route.key === 'metadata'
   ) {
-    // View-term routes use /:viewTerm in the path
-    let viewTermPath = `:${route.key}`
+    // View-term routes use /:viewTerm in the path. The metadata view is
+    // surfaced in URLs as :attributes (the route key stays `metadata`).
+    let viewTermPath = route.key === 'metadata' ? ':attributes' : `:${route.key}`
     // Append activity filter slug to view term path
     if (route.key === 'activity') {
       const filterSlug = activityFilterToSlug(route.filterEventType)
@@ -680,7 +683,7 @@ export function routeToHmUrl(route: NavRoute): string | null {
     route.key === 'all-documents' ||
     route.key === 'metadata'
   ) {
-    let viewTermPath = `:${route.key}`
+    let viewTermPath = route.key === 'metadata' ? ':attributes' : `:${route.key}`
     if (route.key === 'activity') {
       const filterSlug = activityFilterToSlug(route.filterEventType)
       if (filterSlug) viewTermPath = `:activity/${filterSlug}`
@@ -739,7 +742,8 @@ export function bookmarkUrlFromRoute(route: NavRoute): string | null {
     route.key === 'all-documents' ||
     route.key === 'metadata'
   ) {
-    return `${packBaseId(route.id.uid, route.id.path)}/:${route.key}`
+    const term = route.key === 'metadata' ? 'attributes' : route.key
+    return `${packBaseId(route.id.uid, route.id.path)}/:${term}`
   }
   if (route.key === 'site-settings') {
     return `${packBaseId(route.id.uid, route.id.path)}/:settings`

--- a/frontend/packages/shared/src/utils/navigation.tsx
+++ b/frontend/packages/shared/src/utils/navigation.tsx
@@ -65,7 +65,8 @@ export function getRouteKey(route: NavRoute): string {
     route.key === 'comments' ||
     route.key === 'activity' ||
     route.key === 'collaborators' ||
-    route.key === 'directory'
+    route.key === 'directory' ||
+    route.key === 'metadata'
   )
     return route.key === 'inspect-ipfs'
       ? `inspect-ipfs:${route.ipfsPath}`

--- a/frontend/packages/ui/src/__tests__/document-metadata-view.test.ts
+++ b/frontend/packages/ui/src/__tests__/document-metadata-view.test.ts
@@ -1,0 +1,53 @@
+import {describe, expect, test} from 'vitest'
+import {diffMetadata} from '../document-metadata-view'
+import {dagCborKeyCompare} from '../value-editor'
+
+describe('dagCborKeyCompare', () => {
+  test('shorter keys sort first (length-first, per DAG-CBOR spec)', () => {
+    const keys = ['name', 'icon', 'seedExperimentalLogo', 'summary', 'theme', 'a']
+    const sorted = [...keys].sort(dagCborKeyCompare)
+    expect(sorted).toEqual(['a', 'icon', 'name', 'theme', 'summary', 'seedExperimentalLogo'])
+  })
+
+  test('equal-length keys compare bytewise', () => {
+    expect(['cover', 'aaaaa'].sort(dagCborKeyCompare)).toEqual(['aaaaa', 'cover'])
+    expect(['b', 'a'].sort(dagCborKeyCompare)).toEqual(['a', 'b'])
+  })
+
+  test('multi-byte UTF-8 keys sort by encoded length, not code-point count', () => {
+    // 'é' encodes to 2 bytes, so 'é' sorts after single-byte 2-char keys of equal char count
+    expect(['é', 'zz'].sort(dagCborKeyCompare)).toEqual(['zz', 'é'])
+    expect(['é', 'z'].sort(dagCborKeyCompare)).toEqual(['z', 'é'])
+  })
+})
+
+describe('diffMetadata', () => {
+  test('includes only changed keys', () => {
+    expect(diffMetadata({name: 'A', icon: 'x'}, {name: 'B', icon: 'x'})).toEqual({name: 'B'})
+  })
+
+  test('removed top-level keys become null tombstones', () => {
+    expect(diffMetadata({name: 'A', icon: 'x'}, {name: 'A'})).toEqual({icon: null})
+  })
+
+  test('removed nested keys become null tombstones inside the object', () => {
+    expect(diffMetadata({theme: {headerLayout: 'Center', extra: 'y'}}, {theme: {headerLayout: 'Center'}})).toEqual({
+      theme: {headerLayout: 'Center', extra: null},
+    })
+  })
+
+  test('existing nested tombstones survive unrelated edits to the same object', () => {
+    // 'extra' was already staged as deleted; editing headerLayout must not resurrect it
+    expect(diffMetadata({theme: {headerLayout: '', extra: null}}, {theme: {headerLayout: 'Center'}})).toEqual({
+      theme: {headerLayout: 'Center', extra: null},
+    })
+  })
+
+  test('added keys and unchanged objects produce a minimal patch', () => {
+    expect(diffMetadata({theme: {headerLayout: ''}}, {theme: {headerLayout: ''}, name: 'New'})).toEqual({name: 'New'})
+  })
+
+  test('lists replace wholesale', () => {
+    expect(diffMetadata({tags: ['a', 'b']}, {tags: ['b', 'a']})).toEqual({tags: ['b', 'a']})
+  })
+})

--- a/frontend/packages/ui/src/__tests__/value-editor-field-type.test.ts
+++ b/frontend/packages/ui/src/__tests__/value-editor-field-type.test.ts
@@ -1,0 +1,63 @@
+import {describe, expect, test} from 'vitest'
+import {CBOR_VALUE_RULES, METADATA_VALUE_RULES, coerceFieldValue, valueToFieldType} from '../value-editor'
+
+describe('valueToFieldType', () => {
+  test('maps each value shape to its field type', () => {
+    expect(valueToFieldType('hi')).toBe('text')
+    expect(valueToFieldType(3)).toBe('number')
+    expect(valueToFieldType(true)).toBe('toggle')
+    expect(valueToFieldType(null)).toBe('null')
+    expect(valueToFieldType(undefined)).toBe('null')
+    expect(valueToFieldType([])).toBe('list')
+    expect(valueToFieldType({a: 1})).toBe('object')
+  })
+
+  test('recognizes DAG-JSON link and bytes leaves before plain objects', () => {
+    expect(valueToFieldType({'/': 'bafyabc'})).toBe('link')
+    expect(valueToFieldType({'/': {bytes: 'AAAA'}})).toBe('bytes')
+  })
+})
+
+describe('coerceFieldValue (preserve when compatible, else reset)', () => {
+  test('same type is returned untouched', () => {
+    const obj = {a: 1}
+    expect(coerceFieldValue(obj, 'object', CBOR_VALUE_RULES)).toBe(obj)
+    expect(coerceFieldValue('x', 'text', CBOR_VALUE_RULES)).toBe('x')
+  })
+
+  test('number <-> text round-trips losslessly', () => {
+    expect(coerceFieldValue(42, 'text', CBOR_VALUE_RULES)).toBe('42')
+    expect(coerceFieldValue('42', 'number', CBOR_VALUE_RULES)).toBe(42)
+  })
+
+  test('non-numeric text falls back to 0 when retyped to number', () => {
+    expect(coerceFieldValue('hello', 'number', CBOR_VALUE_RULES)).toBe(0)
+  })
+
+  test('integer rules reject a fractional text; float rules keep it', () => {
+    expect(coerceFieldValue('1.5', 'number', METADATA_VALUE_RULES)).toBe(0)
+    expect(coerceFieldValue('1.5', 'number', CBOR_VALUE_RULES)).toBe(1.5)
+  })
+
+  test('boolean coerces across text and number', () => {
+    expect(coerceFieldValue(true, 'text', CBOR_VALUE_RULES)).toBe('true')
+    expect(coerceFieldValue('true', 'toggle', CBOR_VALUE_RULES)).toBe(true)
+    expect(coerceFieldValue('nope', 'toggle', CBOR_VALUE_RULES)).toBe(false)
+    expect(coerceFieldValue(0, 'toggle', CBOR_VALUE_RULES)).toBe(false)
+    expect(coerceFieldValue(2, 'toggle', CBOR_VALUE_RULES)).toBe(true)
+  })
+
+  test('a valid CID string becomes a link; otherwise an empty link', () => {
+    const cid = 'bafyreigu5vewjq63sy3t2spkkpmchine3vo3jnuuvntx7ig4oef7hafuka'
+    expect(coerceFieldValue(cid, 'link', CBOR_VALUE_RULES)).toEqual({'/': cid})
+    expect(coerceFieldValue(`ipfs://${cid}`, 'link', CBOR_VALUE_RULES)).toEqual({'/': cid})
+    expect(coerceFieldValue('not-a-cid', 'link', CBOR_VALUE_RULES)).toEqual({'/': ''})
+  })
+
+  test('incompatible container conversions reset to the target default', () => {
+    expect(coerceFieldValue({a: 1}, 'list', CBOR_VALUE_RULES)).toEqual([])
+    expect(coerceFieldValue([1, 2], 'object', CBOR_VALUE_RULES)).toEqual({})
+    expect(coerceFieldValue('x', 'null', CBOR_VALUE_RULES)).toBe(null)
+    expect(coerceFieldValue({a: 1}, 'bytes', CBOR_VALUE_RULES)).toEqual({'/': {bytes: ''}})
+  })
+})

--- a/frontend/packages/ui/src/__tests__/value-editor-keyboard.test.tsx
+++ b/frontend/packages/ui/src/__tests__/value-editor-keyboard.test.tsx
@@ -104,8 +104,7 @@ describe('value editor keyboard navigation', () => {
 
   it('only the selected row reveals its actions menu (not every nested field)', () => {
     render({obj: {inner: 'y'}})
-    const menu = (key: string) =>
-      document.querySelector(`[aria-label="Actions for ${key}"]`) as HTMLElement
+    const menu = (key: string) => document.querySelector(`[aria-label="Actions for ${key}"]`) as HTMLElement
     act(() => (rowFor('inner').querySelector('input') as HTMLInputElement).focus())
     // The reveal is the standalone `opacity-100` class (classList token, not the
     // base `data-[state=open]:opacity-100`). Only the focused (inner) field

--- a/frontend/packages/ui/src/__tests__/value-editor-keyboard.test.tsx
+++ b/frontend/packages/ui/src/__tests__/value-editor-keyboard.test.tsx
@@ -84,4 +84,21 @@ describe('value editor keyboard navigation', () => {
     press(rowFor('inner'), 'ArrowLeft')
     expect(activeKey()).toBe('obj')
   })
+
+  it("selection follows focus into a field's editor (no highlight left behind)", () => {
+    render({aa: 'x', bb: 'y'})
+    const bbInput = rowFor('bb').querySelector('input') as HTMLInputElement
+    act(() => bbInput.focus())
+    // The bb row is highlighted, not aa.
+    expect(rowFor('bb').getAttribute('aria-selected')).toBe('true')
+    expect(rowFor('aa').getAttribute('aria-selected')).toBe('false')
+  })
+
+  it('focusing a nested field selects the innermost row, not its ancestor', () => {
+    render({obj: {inner: 'y'}})
+    const innerInput = rowFor('inner').querySelector('input') as HTMLInputElement
+    act(() => innerInput.focus())
+    expect(rowFor('inner').getAttribute('aria-selected')).toBe('true')
+    expect(rowFor('obj').getAttribute('aria-selected')).toBe('false')
+  })
 })

--- a/frontend/packages/ui/src/__tests__/value-editor-keyboard.test.tsx
+++ b/frontend/packages/ui/src/__tests__/value-editor-keyboard.test.tsx
@@ -101,4 +101,16 @@ describe('value editor keyboard navigation', () => {
     expect(rowFor('inner').getAttribute('aria-selected')).toBe('true')
     expect(rowFor('obj').getAttribute('aria-selected')).toBe('false')
   })
+
+  it('only the selected row reveals its actions menu (not every nested field)', () => {
+    render({obj: {inner: 'y'}})
+    const menu = (key: string) =>
+      document.querySelector(`[aria-label="Actions for ${key}"]`) as HTMLElement
+    act(() => (rowFor('inner').querySelector('input') as HTMLInputElement).focus())
+    // The reveal is the standalone `opacity-100` class (classList token, not the
+    // base `data-[state=open]:opacity-100`). Only the focused (inner) field
+    // reveals its menu; the ancestor object's stays hidden.
+    expect(menu('inner').classList.contains('opacity-100')).toBe(true)
+    expect(menu('obj').classList.contains('opacity-100')).toBe(false)
+  })
 })

--- a/frontend/packages/ui/src/__tests__/value-editor-keyboard.test.tsx
+++ b/frontend/packages/ui/src/__tests__/value-editor-keyboard.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import {CBOR_VALUE_RULES, ObjectEditor, ValueEditorProvider} from '@shm/ui/value-editor'
+import {createRoot, Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, beforeEach, describe, expect, it} from 'vitest'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  ;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+function render(value: unknown) {
+  act(() => {
+    root.render(
+      <ValueEditorProvider>
+        <ObjectEditor value={value as Record<string, unknown>} onValue={() => {}} rules={CBOR_VALUE_RULES} path={[]} />
+      </ValueEditorProvider>,
+    )
+  })
+}
+
+/** The keyed rows, in DOM order, labeled by their field key text. */
+function rowKeys(): string[] {
+  return Array.from(container.querySelectorAll('[role="treeitem"]')).map(
+    (el) => el.querySelector('span')?.textContent?.trim() ?? '',
+  )
+}
+function rowFor(key: string): HTMLElement {
+  return Array.from(container.querySelectorAll('[role="treeitem"]')).find(
+    (el) => el.querySelector('span')?.textContent?.trim() === key,
+  ) as HTMLElement
+}
+function press(el: HTMLElement, key: string) {
+  act(() => el.focus())
+  act(() => {
+    el.dispatchEvent(new KeyboardEvent('keydown', {key, bubbles: true}))
+  })
+}
+function activeKey(): string {
+  return (document.activeElement as HTMLElement)?.querySelector('span')?.textContent?.trim() ?? ''
+}
+
+describe('value editor keyboard navigation', () => {
+  it('exposes rows as treeitems with a single roving tab-stop', () => {
+    render({alpha: 'x', beta: 'y'})
+    const items = Array.from(container.querySelectorAll('[role="treeitem"]'))
+    expect(items.length).toBe(2)
+    // exactly one tab-stop (tabIndex 0), the rest are -1
+    expect(items.filter((el) => (el as HTMLElement).tabIndex === 0).length).toBe(1)
+  })
+
+  it('ArrowDown / ArrowUp move focus between visible rows', () => {
+    // Equal-length keys so canonical DAG-CBOR order matches source order (aa, bb).
+    render({aa: 'x', bb: 'y'})
+    press(rowFor('aa'), 'ArrowDown')
+    expect(activeKey()).toBe('bb')
+    press(rowFor('bb'), 'ArrowUp')
+    expect(activeKey()).toBe('aa')
+  })
+
+  it('ArrowLeft collapses an expanded container; ArrowRight expands it', () => {
+    render({obj: {inner: 'y'}})
+    // expanded: the child row is present
+    expect(rowKeys()).toContain('inner')
+    press(rowFor('obj'), 'ArrowLeft')
+    expect(rowKeys()).not.toContain('inner') // collapsed
+    press(rowFor('obj'), 'ArrowRight')
+    expect(rowKeys()).toContain('inner') // expanded again
+  })
+
+  it('ArrowRight on an expanded container moves to its first child; ArrowLeft returns to parent', () => {
+    render({obj: {inner: 'y'}})
+    press(rowFor('obj'), 'ArrowRight')
+    expect(activeKey()).toBe('inner')
+    press(rowFor('inner'), 'ArrowLeft')
+    expect(activeKey()).toBe('obj')
+  })
+})

--- a/frontend/packages/ui/src/dag-json.ts
+++ b/frontend/packages/ui/src/dag-json.ts
@@ -1,0 +1,139 @@
+import {CID} from 'multiformats/cid'
+
+/**
+ * Helpers for the DAG-JSON representations of IPLD's two special kinds
+ * (see https://ipld.io/specs/codecs/dag-json/spec/):
+ *
+ * - Links (CIDs) encode as `{"/": "<cid string>"}`
+ * - Bytes encode as `{"/": {"bytes": "<base64>"}}`
+ *
+ * The daemon's /ipfs/{cid}.dagjson endpoint returns these forms, so the value
+ * editor works on them directly and converts to real CID / Uint8Array values
+ * only when encoding to DAG-CBOR for publishing.
+ */
+
+export type DagJsonLink = {'/': string}
+export type DagJsonBytes = {'/': {bytes: string}}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+/** True for the DAG-JSON link form `{"/": "cid"}`. */
+export function isDagJsonLink(value: unknown): value is DagJsonLink {
+  return isRecord(value) && Object.keys(value).length === 1 && typeof value['/'] === 'string'
+}
+
+/** True for the DAG-JSON bytes form `{"/": {"bytes": "base64"}}`. */
+export function isDagJsonBytes(value: unknown): value is DagJsonBytes {
+  if (!isRecord(value) || Object.keys(value).length !== 1) return false
+  const slash = value['/']
+  return isRecord(slash) && Object.keys(slash).length === 1 && typeof slash.bytes === 'string'
+}
+
+/** Parse a CID string, returning null when invalid. */
+export function parseCidString(text: string): CID | null {
+  try {
+    return CID.parse(text.trim())
+  } catch {
+    return null
+  }
+}
+
+/** Decode base64 (padded or unpadded — DAG-JSON uses unpadded) to bytes. Throws on invalid input. */
+export function base64ToBytes(b64: string): Uint8Array {
+  const normalized = b64.replace(/\s+/g, '')
+  const padded = normalized + '='.repeat((4 - (normalized.length % 4)) % 4)
+  const binary = atob(padded)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}
+
+/** Encode bytes as unpadded base64, per the DAG-JSON spec. */
+export function bytesToBase64(bytes: Uint8Array): string {
+  let binary = ''
+  const chunkSize = 0x8000
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode.apply(null, Array.from(bytes.subarray(i, i + chunkSize)))
+  }
+  return btoa(binary).replace(/=+$/, '')
+}
+
+/** Human-readable byte size. */
+export function formatByteSize(size: number): string {
+  if (size < 1024) return `${size} ${size === 1 ? 'byte' : 'bytes'}`
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`
+}
+
+// Blob type names the Seed daemon dispatches indexers on (backend/blob/
+// index_registry.go makeCBORTypeMatch): the raw blob bytes are scanned for
+// CBOR("type") immediately followed by CBOR(<name>), at any nesting depth.
+// A match triggers a strict decode + signature verification whose failure
+// aborts the entire StoreBlobs call with an opaque Internal error.
+const SEED_INDEXED_TYPE_NAMES = ['Comment', 'Change', 'Ref', 'Capability', 'Contact', 'Profile']
+
+const utf8Encoder = new TextEncoder()
+
+// CBOR text-string header for lengths < 24: major type 3, single byte 0x60+len.
+function cborShortText(text: string): Uint8Array {
+  const body = utf8Encoder.encode(text)
+  const bytes = new Uint8Array(body.length + 1)
+  bytes[0] = 0x60 + body.length
+  bytes.set(body, 1)
+  return bytes
+}
+
+function bytesContain(haystack: Uint8Array, needle: Uint8Array): boolean {
+  outer: for (let i = 0; i + needle.length <= haystack.length; i++) {
+    for (let j = 0; j < needle.length; j++) {
+      if (haystack[i + j] !== needle[j]) continue outer
+    }
+    return true
+  }
+  return false
+}
+
+/**
+ * Detect whether encoded DAG-CBOR bytes would be picked up by one of the Seed
+ * daemon's blob indexers (a `"type"` entry immediately followed by a known
+ * type name, at any depth). Returns the colliding type name or null. Used to
+ * turn the daemon's opaque store failure into an actionable message — never
+ * to block a publish attempt (a pasted genuine signed blob stores fine).
+ */
+export function findSeedIndexerCollision(data: Uint8Array): string | null {
+  const typeKey = cborShortText('type')
+  for (const name of SEED_INDEXED_TYPE_NAMES) {
+    const value = cborShortText(name)
+    const matcher = new Uint8Array(typeKey.length + value.length)
+    matcher.set(typeKey, 0)
+    matcher.set(value, typeKey.length)
+    if (bytesContain(data, matcher)) return name
+  }
+  return null
+}
+
+/**
+ * Convert a DAG-JSON-form value into real IPLD values for DAG-CBOR encoding:
+ * link forms become CID instances (encoded as tag 42), bytes forms become
+ * Uint8Array. Without this, republishing a blob would corrupt its links and
+ * bytes into plain maps. Throws on invalid CIDs or base64.
+ */
+export function dagJsonToIpld(value: unknown): unknown {
+  if (isDagJsonLink(value)) {
+    const cid = parseCidString(value['/'])
+    if (!cid) throw new Error(`Invalid CID link: ${value['/']}`)
+    return cid
+  }
+  if (isDagJsonBytes(value)) {
+    return base64ToBytes(value['/'].bytes)
+  }
+  if (Array.isArray(value)) return value.map(dagJsonToIpld)
+  if (isRecord(value)) {
+    return Object.fromEntries(Object.entries(value).map(([key, child]) => [key, dagJsonToIpld(child)]))
+  }
+  return value
+}

--- a/frontend/packages/ui/src/document-metadata-view.tsx
+++ b/frontend/packages/ui/src/document-metadata-view.tsx
@@ -1,10 +1,10 @@
-import type {HMMetadata} from '@seed-hypermedia/client/hm-types'
-import {Braces, Check} from 'lucide-react'
-import {useEffect, useMemo, useState} from 'react'
-import {Button} from './button'
-import {Textarea} from './components/textarea'
-import {Tooltip} from './tooltip'
-import {cn} from './utils'
+import type { HMMetadata } from '@seed-hypermedia/client/hm-types'
+import { Braces, Check } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { Button } from './button'
+import { Textarea } from './components/textarea'
+import { Tooltip } from './tooltip'
+import { cn } from './utils'
 import {
   AddFieldForm,
   canonicalEntries,
@@ -78,7 +78,7 @@ export function DocumentMetadataView({
 }) {
   const [jsonMode, setJsonMode] = useState(false)
   const current = useMemo(() => (metadata ?? {}) as Record<string, unknown>, [metadata])
-  const entries = canonicalEntries(current, {hideNull: true})
+  const entries = canonicalEntries(current, { hideNull: true })
   const editable = canEdit && !!onMetadata
 
   // Undo/redo over snapshots of the merged metadata: `record()` before each
@@ -103,7 +103,7 @@ export function DocumentMetadataView({
         {/* No title here — the tab/breadcrumb (main view) and the panel header
             already label this "Attributes". */}
         {editable && (
-          <div className="flex items-center justify-end">
+          <div className="flex justify-end items-center">
             <Tooltip content={jsonMode ? 'Edit as fields' : 'Edit as JSON'}>
               <Button
                 variant={jsonMode ? 'secondary' : 'ghost'}
@@ -121,7 +121,7 @@ export function DocumentMetadataView({
         ) : editable ? (
           <>
             {entries.length === 0 ? (
-              <p className="text-muted-foreground text-sm">This document has no attributes.</p>
+              <p className="text-sm text-muted-foreground">This document has no attributes.</p>
             ) : (
               <div className="flex flex-col">
                 {entries.map(([key, value]) => (
@@ -131,11 +131,11 @@ export function DocumentMetadataView({
                     fieldKey={key}
                     value={value}
                     siblingKeys={entries.map(([k]) => k).filter((k) => k !== key)}
-                    onValue={(newValue) => stage({[key]: newValue})}
+                    onValue={(newValue) => stage({ [key]: newValue })}
                     onEditField={(newKey, newValue) =>
-                      stage(newKey === key ? {[key]: newValue} : {[key]: null, [newKey]: newValue})
+                      stage(newKey === key ? { [key]: newValue } : { [key]: null, [newKey]: newValue })
                     }
-                    onRemove={() => stage({[key]: null})}
+                    onRemove={() => stage({ [key]: null })}
                     rules={METADATA_VALUE_RULES}
                     path={[key]}
                   />
@@ -145,11 +145,11 @@ export function DocumentMetadataView({
             <AddFieldForm
               rules={METADATA_VALUE_RULES}
               existingKeys={entries.map(([key]) => key)}
-              onAdd={(key, value) => stage({[key]: value})}
+              onAdd={(key, value) => stage({ [key]: value })}
             />
           </>
         ) : entries.length === 0 ? (
-          <p className="text-muted-foreground text-sm">This document has no attributes.</p>
+          <p className="text-sm text-muted-foreground">This document has no attributes.</p>
         ) : (
           <dl className="flex flex-col">
             {entries.map(([key, value]) => (
@@ -178,7 +178,7 @@ function MetadataJsonEditor({
   onMetadata?: (patch: MetadataPatch) => void
 }) {
   const currentVisible = useMemo(
-    () => toCanonicalOrder(metadata, {hideNull: true}) as Record<string, unknown>,
+    () => toCanonicalOrder(metadata, { hideNull: true }) as Record<string, unknown>,
     [metadata],
   )
   const serialized = useMemo(() => JSON.stringify(currentVisible, null, 2), [currentVisible])
@@ -186,20 +186,20 @@ function MetadataJsonEditor({
   useEffect(() => setText(serialized), [serialized])
 
   const validation = useMemo(() => {
-    if (text === serialized) return {dirty: false as const}
+    if (text === serialized) return { dirty: false as const }
     try {
       const parsed: unknown = JSON.parse(text)
-      if (!isPlainObject(parsed)) return {dirty: true as const, error: 'Attributes must be a JSON object'}
+      if (!isPlainObject(parsed)) return { dirty: true as const, error: 'Attributes must be a JSON object' }
       const problem = findInvalidValue(parsed, METADATA_VALUE_RULES)
-      if (problem) return {dirty: true as const, error: problem}
-      return {dirty: true as const, value: parsed}
+      if (problem) return { dirty: true as const, error: problem }
+      return { dirty: true as const, value: parsed }
     } catch (e) {
-      return {dirty: true as const, error: e instanceof Error ? e.message : 'Invalid JSON'}
+      return { dirty: true as const, error: e instanceof Error ? e.message : 'Invalid JSON' }
     }
   }, [text, serialized])
 
   if (!editable) {
-    return <pre className="bg-muted/50 overflow-x-auto rounded-md p-4 font-mono text-sm">{serialized}</pre>
+    return <pre className="overflow-x-auto p-4 font-mono text-sm rounded-md bg-muted/50">{serialized}</pre>
   }
 
   return (
@@ -211,10 +211,10 @@ function MetadataJsonEditor({
         className={cn('font-mono text-sm', validation.dirty && 'error' in validation && 'border-destructive')}
         onChange={(e) => setText(e.target.value)}
       />
-      <div className="flex min-h-8 items-center gap-2">
+      <div className="flex gap-2 items-center min-h-8">
         {validation.dirty ? (
           'error' in validation ? (
-            <p className="text-destructive text-xs">{validation.error}</p>
+            <p className="text-xs text-destructive">{validation.error}</p>
           ) : (
             <>
               <Button
@@ -232,9 +232,7 @@ function MetadataJsonEditor({
             </>
           )
         ) : (
-          <p className="text-muted-foreground text-xs">
-            Values may be text, whole numbers, true/false, or nested objects.
-          </p>
+          <></>
         )}
       </div>
     </div>

--- a/frontend/packages/ui/src/document-metadata-view.tsx
+++ b/frontend/packages/ui/src/document-metadata-view.tsx
@@ -1,0 +1,31 @@
+import type {HMMetadata} from '@seed-hypermedia/client/hm-types'
+
+function formatMetadataValue(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return JSON.stringify(value, null, 2)
+}
+
+/** Read-only listing of a document's metadata fields, shown on the `:metadata` view. */
+export function DocumentMetadataView({metadata}: {metadata?: HMMetadata | null}) {
+  const entries = Object.entries(metadata ?? {}).filter(
+    ([, value]) => value !== undefined && value !== null && value !== '',
+  )
+  return (
+    <div className="flex flex-col gap-4 py-6">
+      <h2 className="text-2xl font-bold">Metadata</h2>
+      {entries.length === 0 ? (
+        <p className="text-muted-foreground text-sm">This document has no metadata.</p>
+      ) : (
+        <dl className="flex flex-col gap-3">
+          {entries.map(([key, value]) => (
+            <div key={key} className="border-border flex flex-col gap-1 border-b pb-3 last:border-b-0">
+              <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">{key}</dt>
+              <dd className="font-mono text-sm break-words whitespace-pre-wrap">{formatMetadataValue(value)}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+    </div>
+  )
+}

--- a/frontend/packages/ui/src/document-metadata-view.tsx
+++ b/frontend/packages/ui/src/document-metadata-view.tsx
@@ -1,31 +1,241 @@
 import type {HMMetadata} from '@seed-hypermedia/client/hm-types'
+import {Braces, Check} from 'lucide-react'
+import {useEffect, useMemo, useState} from 'react'
+import {Button} from './button'
+import {Textarea} from './components/textarea'
+import {Tooltip} from './tooltip'
+import {cn} from './utils'
+import {
+  AddFieldForm,
+  canonicalEntries,
+  FIELD_LABEL_CLASS,
+  FieldRow,
+  findInvalidValue,
+  isPlainObject,
+  METADATA_VALUE_RULES,
+  toCanonicalOrder,
+  useValueHistory,
+  ValueDisplay,
+  ValueEditorProvider,
+} from './value-editor'
 
-function formatMetadataValue(value: unknown): string {
-  if (typeof value === 'string') return value
-  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
-  return JSON.stringify(value, null, 2)
+/**
+ * A staged partial update: top-level keys map to their new value, or `null`
+ * to remove the field (publishes a nullValue attribute op).
+ */
+export type MetadataPatch = Record<string, unknown>
+
+/**
+ * Publish ops are generated from the draft metadata without a base document,
+ * so a nested key that simply disappears emits no op and its old value would
+ * survive. Removed nested object keys therefore become explicit `null`
+ * tombstones, which publish as nullValue ops and clear the attribute.
+ */
+function withNestedTombstones(prev: unknown, next: unknown): unknown {
+  if (!isPlainObject(prev) || !isPlainObject(next)) return next
+  const result: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(next)) {
+    result[key] = withNestedTombstones(prev[key], value)
+  }
+  // Keys absent from `next` become (or remain) null tombstones.
+  for (const [key, value] of Object.entries(prev)) {
+    if (value !== undefined && !(key in next)) result[key] = null
+  }
+  return result
 }
 
-/** Read-only listing of a document's metadata fields, shown on the `:metadata` view. */
-export function DocumentMetadataView({metadata}: {metadata?: HMMetadata | null}) {
-  const entries = Object.entries(metadata ?? {}).filter(
-    ([, value]) => value !== undefined && value !== null && value !== '',
-  )
+/**
+ * Compute the staged patch that turns `prev` into `next` (removed keys → null
+ * tombstones). `prev` must be the raw draft metadata including existing null
+ * tombstones so they survive unrelated edits.
+ */
+export function diffMetadata(prev: Record<string, unknown>, next: Record<string, unknown>): MetadataPatch {
+  const patch: MetadataPatch = {}
+  for (const [key, value] of Object.entries(next)) {
+    const merged = withNestedTombstones(prev[key], value)
+    if (JSON.stringify(prev[key]) !== JSON.stringify(merged)) patch[key] = merged
+  }
+  for (const [key, value] of Object.entries(prev)) {
+    if (value !== undefined && !(key in next)) patch[key] = null
+  }
+  return patch
+}
+
+/**
+ * Metadata view for the `:metadata` document route. Read-only without edit
+ * permission; with `canEdit` + `onMetadata` it becomes a recursive editor
+ * where every change is staged as a draft patch and published via the
+ * standard publish flow. A raw JSON mode allows full editing in one place.
+ */
+export function DocumentMetadataView({
+  metadata,
+  canEdit = false,
+  onMetadata,
+}: {
+  metadata?: HMMetadata | null
+  canEdit?: boolean
+  onMetadata?: (patch: MetadataPatch) => void
+}) {
+  const [jsonMode, setJsonMode] = useState(false)
+  const current = useMemo(() => (metadata ?? {}) as Record<string, unknown>, [metadata])
+  const entries = canonicalEntries(current, {hideNull: true})
+  const editable = canEdit && !!onMetadata
+
+  // Undo/redo over snapshots of the merged metadata: `record()` before each
+  // staged patch; undo/redo apply the diff back to the snapshot.
+  const history = useValueHistory(current)
+  const stage = (patch: MetadataPatch) => {
+    history.record()
+    onMetadata!(patch)
+  }
+  const handleUndo = () => {
+    const snapshot = history.undo()
+    if (snapshot) onMetadata!(diffMetadata(current, snapshot.value))
+  }
+  const handleRedo = () => {
+    const snapshot = history.redo()
+    if (snapshot) onMetadata!(diffMetadata(current, snapshot.value))
+  }
+
   return (
-    <div className="flex flex-col gap-4 py-6">
-      <h2 className="text-2xl font-bold">Metadata</h2>
-      {entries.length === 0 ? (
-        <p className="text-muted-foreground text-sm">This document has no metadata.</p>
-      ) : (
-        <dl className="flex flex-col gap-3">
-          {entries.map(([key, value]) => (
-            <div key={key} className="border-border flex flex-col gap-1 border-b pb-3 last:border-b-0">
-              <dt className="text-muted-foreground text-xs font-medium tracking-wide uppercase">{key}</dt>
-              <dd className="font-mono text-sm break-words whitespace-pre-wrap">{formatMetadataValue(value)}</dd>
-            </div>
-          ))}
-        </dl>
-      )}
+    <ValueEditorProvider onUndo={editable ? handleUndo : undefined} onRedo={editable ? handleRedo : undefined}>
+      <div className="flex flex-col gap-4 py-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-bold">Metadata</h2>
+          {editable && (
+            <Tooltip content={jsonMode ? 'Edit as fields' : 'Edit as JSON'}>
+              <Button
+                variant={jsonMode ? 'secondary' : 'ghost'}
+                size="icon"
+                aria-label={jsonMode ? 'Edit as fields' : 'Edit as JSON'}
+                onClick={() => setJsonMode((mode) => !mode)}
+              >
+                <Braces className="size-4" />
+              </Button>
+            </Tooltip>
+          )}
+        </div>
+        {jsonMode ? (
+          <MetadataJsonEditor metadata={current} editable={editable} onMetadata={editable ? stage : undefined} />
+        ) : editable ? (
+          <>
+            {entries.length === 0 ? (
+              <p className="text-muted-foreground text-sm">This document has no metadata.</p>
+            ) : (
+              <div className="flex flex-col">
+                {entries.map(([key, value]) => (
+                  <FieldRow
+                    key={key}
+                    className="border-border border-b py-3 last:border-b-0"
+                    fieldKey={key}
+                    value={value}
+                    siblingKeys={entries.map(([k]) => k).filter((k) => k !== key)}
+                    onValue={(newValue) => stage({[key]: newValue})}
+                    onEditField={(newKey, newValue) =>
+                      stage(newKey === key ? {[key]: newValue} : {[key]: null, [newKey]: newValue})
+                    }
+                    onRemove={() => stage({[key]: null})}
+                    rules={METADATA_VALUE_RULES}
+                    path={[key]}
+                  />
+                ))}
+              </div>
+            )}
+            <AddFieldForm
+              rules={METADATA_VALUE_RULES}
+              existingKeys={entries.map(([key]) => key)}
+              onAdd={(key, value) => stage({[key]: value})}
+            />
+          </>
+        ) : entries.length === 0 ? (
+          <p className="text-muted-foreground text-sm">This document has no metadata.</p>
+        ) : (
+          <dl className="flex flex-col">
+            {entries.map(([key, value]) => (
+              <div key={key} className="border-border flex flex-col gap-1 border-b py-3 last:border-b-0">
+                <dt className={FIELD_LABEL_CLASS}>{key}</dt>
+                <dd>
+                  <ValueDisplay value={value} rules={METADATA_VALUE_RULES} />
+                </dd>
+              </div>
+            ))}
+          </dl>
+        )}
+      </div>
+    </ValueEditorProvider>
+  )
+}
+
+/** Whole-metadata JSON editor: full editing in one textarea, applied as a diff. */
+function MetadataJsonEditor({
+  metadata,
+  editable,
+  onMetadata,
+}: {
+  metadata: Record<string, unknown>
+  editable: boolean
+  onMetadata?: (patch: MetadataPatch) => void
+}) {
+  const currentVisible = useMemo(
+    () => toCanonicalOrder(metadata, {hideNull: true}) as Record<string, unknown>,
+    [metadata],
+  )
+  const serialized = useMemo(() => JSON.stringify(currentVisible, null, 2), [currentVisible])
+  const [text, setText] = useState(serialized)
+  useEffect(() => setText(serialized), [serialized])
+
+  const validation = useMemo(() => {
+    if (text === serialized) return {dirty: false as const}
+    try {
+      const parsed: unknown = JSON.parse(text)
+      if (!isPlainObject(parsed)) return {dirty: true as const, error: 'Metadata must be a JSON object'}
+      const problem = findInvalidValue(parsed, METADATA_VALUE_RULES)
+      if (problem) return {dirty: true as const, error: problem}
+      return {dirty: true as const, value: parsed}
+    } catch (e) {
+      return {dirty: true as const, error: e instanceof Error ? e.message : 'Invalid JSON'}
+    }
+  }, [text, serialized])
+
+  if (!editable) {
+    return <pre className="bg-muted/50 overflow-x-auto rounded-md p-4 font-mono text-sm">{serialized}</pre>
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Textarea
+        value={text}
+        rows={Math.max(8, Math.min(28, text.split('\n').length + 1))}
+        spellCheck={false}
+        className={cn('font-mono text-sm', validation.dirty && 'error' in validation && 'border-destructive')}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <div className="flex min-h-8 items-center gap-2">
+        {validation.dirty ? (
+          'error' in validation ? (
+            <p className="text-destructive text-xs">{validation.error}</p>
+          ) : (
+            <>
+              <Button
+                size="sm"
+                onClick={() => {
+                  onMetadata!(diffMetadata(metadata, validation.value!))
+                }}
+              >
+                <Check className="size-4" />
+                Apply changes
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => setText(serialized)}>
+                Reset
+              </Button>
+            </>
+          )
+        ) : (
+          <p className="text-muted-foreground text-xs">
+            Values may be text, whole numbers, true/false, or nested objects.
+          </p>
+        )}
+      </div>
     </div>
   )
 }

--- a/frontend/packages/ui/src/document-metadata-view.tsx
+++ b/frontend/packages/ui/src/document-metadata-view.tsx
@@ -100,9 +100,10 @@ export function DocumentMetadataView({
   return (
     <ValueEditorProvider onUndo={editable ? handleUndo : undefined} onRedo={editable ? handleRedo : undefined}>
       <div className="flex flex-col gap-4 py-6">
-        <div className="flex items-center justify-between">
-          <h2 className="text-2xl font-bold">Attributes</h2>
-          {editable && (
+        {/* No title here — the tab/breadcrumb (main view) and the panel header
+            already label this "Attributes". */}
+        {editable && (
+          <div className="flex items-center justify-end">
             <Tooltip content={jsonMode ? 'Edit as fields' : 'Edit as JSON'}>
               <Button
                 variant={jsonMode ? 'secondary' : 'ghost'}
@@ -113,8 +114,8 @@ export function DocumentMetadataView({
                 <Braces className="size-4" />
               </Button>
             </Tooltip>
-          )}
-        </div>
+          </div>
+        )}
         {jsonMode ? (
           <MetadataJsonEditor metadata={current} editable={editable} onMetadata={editable ? stage : undefined} />
         ) : editable ? (

--- a/frontend/packages/ui/src/document-metadata-view.tsx
+++ b/frontend/packages/ui/src/document-metadata-view.tsx
@@ -101,7 +101,7 @@ export function DocumentMetadataView({
     <ValueEditorProvider onUndo={editable ? handleUndo : undefined} onRedo={editable ? handleRedo : undefined}>
       <div className="flex flex-col gap-4 py-6">
         <div className="flex items-center justify-between">
-          <h2 className="text-2xl font-bold">Metadata</h2>
+          <h2 className="text-2xl font-bold">Attributes</h2>
           {editable && (
             <Tooltip content={jsonMode ? 'Edit as fields' : 'Edit as JSON'}>
               <Button
@@ -120,7 +120,7 @@ export function DocumentMetadataView({
         ) : editable ? (
           <>
             {entries.length === 0 ? (
-              <p className="text-muted-foreground text-sm">This document has no metadata.</p>
+              <p className="text-muted-foreground text-sm">This document has no attributes.</p>
             ) : (
               <div className="flex flex-col">
                 {entries.map(([key, value]) => (
@@ -148,7 +148,7 @@ export function DocumentMetadataView({
             />
           </>
         ) : entries.length === 0 ? (
-          <p className="text-muted-foreground text-sm">This document has no metadata.</p>
+          <p className="text-muted-foreground text-sm">This document has no attributes.</p>
         ) : (
           <dl className="flex flex-col">
             {entries.map(([key, value]) => (
@@ -188,7 +188,7 @@ function MetadataJsonEditor({
     if (text === serialized) return {dirty: false as const}
     try {
       const parsed: unknown = JSON.parse(text)
-      if (!isPlainObject(parsed)) return {dirty: true as const, error: 'Metadata must be a JSON object'}
+      if (!isPlainObject(parsed)) return {dirty: true as const, error: 'Attributes must be a JSON object'}
       const problem = findInvalidValue(parsed, METADATA_VALUE_RULES)
       if (problem) return {dirty: true as const, error: problem}
       return {dirty: true as const, value: parsed}

--- a/frontend/packages/ui/src/document-metadata-view.tsx
+++ b/frontend/packages/ui/src/document-metadata-view.tsx
@@ -127,7 +127,7 @@ export function DocumentMetadataView({
                 {entries.map(([key, value]) => (
                   <FieldRow
                     key={key}
-                    className="border-border border-b py-3 last:border-b-0"
+                    className="py-2"
                     fieldKey={key}
                     value={value}
                     siblingKeys={entries.map(([k]) => k).filter((k) => k !== key)}
@@ -153,7 +153,7 @@ export function DocumentMetadataView({
         ) : (
           <dl className="flex flex-col">
             {entries.map(([key, value]) => (
-              <div key={key} className="border-border flex flex-col gap-1 border-b py-3 last:border-b-0">
+              <div key={key} className="flex flex-col gap-1 py-2">
                 <dt className={FIELD_LABEL_CLASS}>{key}</dt>
                 <dd>
                   <ValueDisplay value={value} rules={METADATA_VALUE_RULES} />

--- a/frontend/packages/ui/src/document-metadata-view.tsx
+++ b/frontend/packages/ui/src/document-metadata-view.tsx
@@ -1,10 +1,10 @@
-import type { HMMetadata } from '@seed-hypermedia/client/hm-types'
-import { Braces, Check } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
-import { Button } from './button'
-import { Textarea } from './components/textarea'
-import { Tooltip } from './tooltip'
-import { cn } from './utils'
+import type {HMMetadata} from '@seed-hypermedia/client/hm-types'
+import {Braces, Check} from 'lucide-react'
+import {useEffect, useMemo, useState} from 'react'
+import {Button} from './button'
+import {Textarea} from './components/textarea'
+import {Tooltip} from './tooltip'
+import {cn} from './utils'
 import {
   AddFieldForm,
   canonicalEntries,
@@ -78,7 +78,7 @@ export function DocumentMetadataView({
 }) {
   const [jsonMode, setJsonMode] = useState(false)
   const current = useMemo(() => (metadata ?? {}) as Record<string, unknown>, [metadata])
-  const entries = canonicalEntries(current, { hideNull: true })
+  const entries = canonicalEntries(current, {hideNull: true})
   const editable = canEdit && !!onMetadata
 
   // Undo/redo over snapshots of the merged metadata: `record()` before each
@@ -103,7 +103,7 @@ export function DocumentMetadataView({
         {/* No title here — the tab/breadcrumb (main view) and the panel header
             already label this "Attributes". */}
         {editable && (
-          <div className="flex justify-end items-center">
+          <div className="flex items-center justify-end">
             <Tooltip content={jsonMode ? 'Edit as fields' : 'Edit as JSON'}>
               <Button
                 variant={jsonMode ? 'secondary' : 'ghost'}
@@ -121,7 +121,7 @@ export function DocumentMetadataView({
         ) : editable ? (
           <>
             {entries.length === 0 ? (
-              <p className="text-sm text-muted-foreground">This document has no attributes.</p>
+              <p className="text-muted-foreground text-sm">This document has no attributes.</p>
             ) : (
               <div className="flex flex-col">
                 {entries.map(([key, value]) => (
@@ -131,11 +131,11 @@ export function DocumentMetadataView({
                     fieldKey={key}
                     value={value}
                     siblingKeys={entries.map(([k]) => k).filter((k) => k !== key)}
-                    onValue={(newValue) => stage({ [key]: newValue })}
+                    onValue={(newValue) => stage({[key]: newValue})}
                     onEditField={(newKey, newValue) =>
-                      stage(newKey === key ? { [key]: newValue } : { [key]: null, [newKey]: newValue })
+                      stage(newKey === key ? {[key]: newValue} : {[key]: null, [newKey]: newValue})
                     }
-                    onRemove={() => stage({ [key]: null })}
+                    onRemove={() => stage({[key]: null})}
                     rules={METADATA_VALUE_RULES}
                     path={[key]}
                   />
@@ -145,11 +145,11 @@ export function DocumentMetadataView({
             <AddFieldForm
               rules={METADATA_VALUE_RULES}
               existingKeys={entries.map(([key]) => key)}
-              onAdd={(key, value) => stage({ [key]: value })}
+              onAdd={(key, value) => stage({[key]: value})}
             />
           </>
         ) : entries.length === 0 ? (
-          <p className="text-sm text-muted-foreground">This document has no attributes.</p>
+          <p className="text-muted-foreground text-sm">This document has no attributes.</p>
         ) : (
           <dl className="flex flex-col">
             {entries.map(([key, value]) => (
@@ -178,7 +178,7 @@ function MetadataJsonEditor({
   onMetadata?: (patch: MetadataPatch) => void
 }) {
   const currentVisible = useMemo(
-    () => toCanonicalOrder(metadata, { hideNull: true }) as Record<string, unknown>,
+    () => toCanonicalOrder(metadata, {hideNull: true}) as Record<string, unknown>,
     [metadata],
   )
   const serialized = useMemo(() => JSON.stringify(currentVisible, null, 2), [currentVisible])
@@ -186,20 +186,20 @@ function MetadataJsonEditor({
   useEffect(() => setText(serialized), [serialized])
 
   const validation = useMemo(() => {
-    if (text === serialized) return { dirty: false as const }
+    if (text === serialized) return {dirty: false as const}
     try {
       const parsed: unknown = JSON.parse(text)
-      if (!isPlainObject(parsed)) return { dirty: true as const, error: 'Attributes must be a JSON object' }
+      if (!isPlainObject(parsed)) return {dirty: true as const, error: 'Attributes must be a JSON object'}
       const problem = findInvalidValue(parsed, METADATA_VALUE_RULES)
-      if (problem) return { dirty: true as const, error: problem }
-      return { dirty: true as const, value: parsed }
+      if (problem) return {dirty: true as const, error: problem}
+      return {dirty: true as const, value: parsed}
     } catch (e) {
-      return { dirty: true as const, error: e instanceof Error ? e.message : 'Invalid JSON' }
+      return {dirty: true as const, error: e instanceof Error ? e.message : 'Invalid JSON'}
     }
   }, [text, serialized])
 
   if (!editable) {
-    return <pre className="overflow-x-auto p-4 font-mono text-sm rounded-md bg-muted/50">{serialized}</pre>
+    return <pre className="bg-muted/50 overflow-x-auto rounded-md p-4 font-mono text-sm">{serialized}</pre>
   }
 
   return (
@@ -211,10 +211,10 @@ function MetadataJsonEditor({
         className={cn('font-mono text-sm', validation.dirty && 'error' in validation && 'border-destructive')}
         onChange={(e) => setText(e.target.value)}
       />
-      <div className="flex gap-2 items-center min-h-8">
+      <div className="flex min-h-8 items-center gap-2">
         {validation.dirty ? (
           'error' in validation ? (
-            <p className="text-xs text-destructive">{validation.error}</p>
+            <p className="text-destructive text-xs">{validation.error}</p>
           ) : (
             <>
               <Button

--- a/frontend/packages/ui/src/document-tools.tsx
+++ b/frontend/packages/ui/src/document-tools.tsx
@@ -14,6 +14,7 @@ import {
   Folder,
   GitGraph,
   History,
+  Info,
   LucideIcon,
   MessageSquare,
   MessagesSquare,
@@ -42,7 +43,7 @@ export function DocumentTools({
   rightAction,
 }: {
   id: UnpackedHypermediaId
-  activeTab?: 'draft' | 'content' | 'comments' | 'collaborators' | 'citations'
+  activeTab?: 'draft' | 'content' | 'comments' | 'collaborators' | 'citations' | 'metadata'
   commentsCount?: number
   citationsCount?: number
   collabsCount?: number
@@ -248,6 +249,18 @@ export function DocumentTools({
               panel: panelFor(),
             },
           },
+          // Hidden tab: only shown while the metadata view is active (opened from the options menu)
+          ...(activeTab === 'metadata'
+            ? [
+                {
+                  label: 'Metadata',
+                  tooltip: 'Open Document Metadata',
+                  icon: Info,
+                  active: true,
+                  route: {key: 'metadata', id: idWithoutBlock, panel: panelFor()} as NavRoute,
+                },
+              ]
+            : []),
         ]
   const hasActive = buttons.some((b) => b.active)
   const standaloneAction =

--- a/frontend/packages/ui/src/document-tools.tsx
+++ b/frontend/packages/ui/src/document-tools.tsx
@@ -33,6 +33,7 @@ export function DocumentTools({
   commentsCount = 0,
   citationsCount = 0,
   collabsCount = 0,
+  metadataCount = 0,
   activeTabAction,
   existingDraft,
   currentPanel,
@@ -47,6 +48,8 @@ export function DocumentTools({
   commentsCount?: number
   citationsCount?: number
   collabsCount?: number
+  /** Number of custom (non-built-in) metadata fields; shows the Attributes tab with a count when > 0. */
+  metadataCount?: number
   /** Rendered immediately to the right of the active tab pill. When no tab is active, rendered as last sibling. */
   activeTabAction?: React.ReactNode
   /** Optional controls rendered on the right side of the tools row. */
@@ -249,14 +252,17 @@ export function DocumentTools({
               panel: panelFor(),
             },
           },
-          // Hidden tab: only shown while the metadata view is active (opened from the options menu)
-          ...(activeTab === 'metadata'
+          // Hidden by default; shown when the view is active (opened from the
+          // options menu) or once the document has custom attributes, with a
+          // count of those custom fields.
+          ...(activeTab === 'metadata' || metadataCount > 0
             ? [
                 {
-                  label: 'Metadata',
-                  tooltip: 'Open Document Metadata',
+                  label: 'Attributes',
+                  tooltip: 'Open Document Attributes',
                   icon: Info,
-                  active: true,
+                  active: activeTab === 'metadata',
+                  count: metadataCount,
                   route: {key: 'metadata', id: idWithoutBlock, panel: panelFor()} as NavRoute,
                 },
               ]

--- a/frontend/packages/ui/src/inline-descriptor.tsx
+++ b/frontend/packages/ui/src/inline-descriptor.tsx
@@ -47,6 +47,7 @@ function getSiteContextUid(route: NavRoute | null): string | null {
     case 'comments':
     case 'directory':
     case 'collaborators':
+    case 'metadata':
     case 'site-profile':
     case 'profile':
     case 'contact':

--- a/frontend/packages/ui/src/panel-layout.tsx
+++ b/frontend/packages/ui/src/panel-layout.tsx
@@ -53,6 +53,8 @@ function getPanelTitle(panelKey: PanelSelectionOptions | null): string {
       return 'Collaborators'
     case 'options':
       return 'Draft Options'
+    case 'metadata':
+      return 'Attributes'
     default:
       return ''
   }

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -2695,7 +2695,10 @@ function MainContent({
     case 'metadata':
       return (
         <PageLayout contentMaxWidth={contentMaxWidth}>
-          <DocumentMetadataPage document={document} />
+          {/* Extra left padding in the main view; the panel render keeps its own. */}
+          <div className="pl-4">
+            <DocumentMetadataPage document={document} />
+          </div>
         </PageLayout>
       )
 

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -74,7 +74,7 @@ import {activityFilterToSlug, getCommentTargetId, parseFragment} from '@shm/shar
 import {useNavigate, useNavRoute} from '@shm/shared/utils/navigation'
 import {getReservedLazyDraftBreadcrumbName} from '@shm/shared/utils/reserved-draft-ids'
 import {useIsomorphicLayoutEffect} from '@shm/shared/utils/use-isomorphic-layout-effect'
-import {FilePen, Search} from 'lucide-react'
+import {FilePen, Info, Search} from 'lucide-react'
 import {lazy, ReactNode, Suspense, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {AccountPage} from './account-page'
 import {AllDocumentsPage} from './all-documents-page'
@@ -83,6 +83,7 @@ import {ScrollArea} from './components/scroll-area'
 import {DirectoryPageContent} from './directory-page'
 import {DiscussionsPageContent} from './discussions-page'
 import {DocumentCover} from './document-cover'
+import {DocumentMetadataView} from './document-metadata-view'
 import {AuthorPayload, BreadcrumbEntry, Breadcrumbs, DocumentHeader} from './document-header'
 import {DocumentTools} from './document-tools'
 import {DocumentVersionsPanel, isDocumentVersionsPanelRoute} from './document-versions-panel'
@@ -160,6 +161,7 @@ export type ActiveView =
   | 'collaborators'
   | 'site-profile'
   | 'all-documents'
+  | 'metadata'
 
 /** Selects the action controls shown for document content. */
 export function getDocumentContentAction({
@@ -359,6 +361,8 @@ function getActiveView(routeKey: string): ActiveView {
       return 'all-documents'
     case 'site-profile':
       return 'site-profile'
+    case 'metadata':
+      return 'metadata'
     default:
       return 'content'
   }
@@ -1497,6 +1501,7 @@ function DocumentBody({
       directory: 'Sub documents',
       activity: 'Activity',
       'all-documents': 'All Documents',
+      metadata: 'Metadata',
     }
     if (activeView !== 'content' && panelLabels[activeView]) {
       items.push({label: panelLabels[activeView]})
@@ -1755,11 +1760,23 @@ function DocumentBody({
       },
     }
   }, [canEdit, panelKey, route, replaceRoute])
+  const metadataMenuItem = useMemo<MenuItemType | null>(() => {
+    if (route.key === 'inspect' || route.key === 'metadata') return null
+    return {
+      key: 'metadata',
+      label: 'Metadata',
+      icon: <Info className="size-4" />,
+      onClick: () => {
+        navigate({key: 'metadata', id: {...docId, blockRef: null, blockRange: null}})
+      },
+    }
+  }, [docId, navigate, route.key])
 
   const allMenuItems = useMemo(() => {
     let unorderedItems: MenuItemType[] = [...(optionsMenuItems ?? extraMenuItems ?? [])]
     if (inspectMenuItem) unorderedItems.push(inspectMenuItem)
     if (documentOptionsMenuItem) unorderedItems.push(documentOptionsMenuItem)
+    if (metadataMenuItem) unorderedItems.push(metadataMenuItem)
     // Drop share/copy-link entries while the doc is an unpublished draft —
     // its URL won't resolve for anyone else, so any "share" action is a footgun.
     if (isUnpublishedDraft) {
@@ -1771,6 +1788,7 @@ function DocumentBody({
       'new',
       'versions',
       'options',
+      'metadata',
       'copy-link',
       'link-site',
       'link',
@@ -1799,7 +1817,7 @@ function DocumentBody({
       if (item.variant === 'destructive') orderedItems.push(item)
     }
     return orderedItems
-  }, [optionsMenuItems, extraMenuItems, inspectMenuItem, documentOptionsMenuItem, isUnpublishedDraft])
+  }, [optionsMenuItems, extraMenuItems, inspectMenuItem, documentOptionsMenuItem, metadataMenuItem, isUnpublishedDraft])
 
   const hasOptions = allMenuItems.length > 0
   const actionButtons = hasOptions ? <OptionsDropdown menuItems={allMenuItems} align="end" side="bottom" /> : null
@@ -1862,6 +1880,7 @@ function DocumentBody({
                                   directory: 'Sub documents',
                                   'all-documents': 'All Documents',
                                   'site-profile': 'Profile',
+                                  metadata: 'Metadata',
                                 } as Record<string, string>
                               )[activeView] || '',
                           },
@@ -1923,6 +1942,7 @@ function DocumentBody({
                                 directory: 'Sub documents',
                                 'all-documents': 'All Documents',
                                 'site-profile': 'Profile',
+                                metadata: 'Metadata',
                               } as Record<string, string>
                             )[activeView] || '',
                         },
@@ -2000,14 +2020,20 @@ function DocumentBody({
                   }
             }
             activeTabAction={
-              activeView !== 'content' && activeView !== 'site-profile' && activeView !== 'all-documents' ? (
+              activeView !== 'content' &&
+              activeView !== 'site-profile' &&
+              activeView !== 'all-documents' &&
+              activeView !== 'metadata' ? (
                 <OpenInPanelButton
                   id={docId}
                   panelRoute={
                     route.key === activeView
                       ? extractPanelRoute(route)
                       : {
-                          key: activeView as Exclude<ActiveView, 'content' | 'site-profile' | 'all-documents'>,
+                          key: activeView as Exclude<
+                            ActiveView,
+                            'content' | 'site-profile' | 'all-documents' | 'metadata'
+                          >,
                           id: docId,
                         }
                   }
@@ -2634,6 +2660,13 @@ function MainContent({
       return (
         <PageLayout contentMaxWidth={contentMaxWidth}>
           <CollaboratorsPage docId={docId} />
+        </PageLayout>
+      )
+
+    case 'metadata':
+      return (
+        <PageLayout contentMaxWidth={contentMaxWidth}>
+          <DocumentMetadataView metadata={document.metadata} />
         </PageLayout>
       )
 

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -2541,6 +2541,28 @@ function DocumentOptionsPanel({
   )
 }
 
+/** Metadata view wired to the document machine: edits stage into the draft
+ * and publish through the standard publish flow. */
+function DocumentMetadataPage({document}: {document: HMDocument}) {
+  const ctx = useDocumentSelector(selectContext)
+  const send = useDocumentSend()
+  const {canEdit, beginEditIfNeeded} = useEditorGate()
+
+  // Draft metadata (partial) overrides published metadata, same as the options panel.
+  const metadata = {...(ctx.document?.metadata || document.metadata || {}), ...ctx.metadata}
+
+  return (
+    <DocumentMetadataView
+      metadata={metadata as any}
+      canEdit={canEdit}
+      onMetadata={(patch) => {
+        beginEditIfNeeded()
+        send({type: 'change', metadata: patch as any})
+      }}
+    />
+  )
+}
+
 function MainContent({
   docId,
   resourceId,
@@ -2666,7 +2688,7 @@ function MainContent({
     case 'metadata':
       return (
         <PageLayout contentMaxWidth={contentMaxWidth}>
-          <DocumentMetadataView metadata={document.metadata} />
+          <DocumentMetadataPage document={document} />
         </PageLayout>
       )
 

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -2024,18 +2024,14 @@ function DocumentBody({
             activeTabAction={
               activeView !== 'content' &&
               activeView !== 'site-profile' &&
-              activeView !== 'all-documents' &&
-              activeView !== 'metadata' ? (
+              activeView !== 'all-documents' ? (
                 <OpenInPanelButton
                   id={docId}
                   panelRoute={
                     route.key === activeView
                       ? extractPanelRoute(route)
                       : {
-                          key: activeView as Exclude<
-                            ActiveView,
-                            'content' | 'site-profile' | 'all-documents' | 'metadata'
-                          >,
+                          key: activeView as Exclude<ActiveView, 'content' | 'site-profile' | 'all-documents'>,
                           id: docId,
                         }
                   }
@@ -2170,6 +2166,7 @@ function DocumentBody({
       <PanelContentRenderer
         panelRoute={panelRoute!}
         docId={docId}
+        document={document}
         contentMaxWidth={contentMaxWidth}
         CommentEditor={CommentEditor}
         siteUrl={siteUrl}
@@ -2373,6 +2370,7 @@ function applyTitleResize(el: HTMLTextAreaElement) {
 function PanelContentRenderer({
   panelRoute,
   docId,
+  document,
   contentMaxWidth,
   CommentEditor,
   siteUrl,
@@ -2381,6 +2379,7 @@ function PanelContentRenderer({
 }: {
   panelRoute: DocumentPanelRoute
   docId: UnpackedHypermediaId
+  document: HMDocument
   contentMaxWidth: number
   CommentEditor?: React.ComponentType<CommentEditorProps>
   siteUrl?: string
@@ -2390,6 +2389,12 @@ function PanelContentRenderer({
   switch (panelRoute.key) {
     case 'options':
       return <DocumentOptionsPanel docId={docId} fileUpload={fileUpload} />
+    case 'metadata':
+      return (
+        <div className="px-4">
+          <DocumentMetadataPage document={document} />
+        </div>
+      )
     case 'activity':
       if (isDocumentVersionsPanelRoute(panelRoute)) {
         return (

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -182,7 +182,7 @@ export function getDocumentContentAction({
   actionButtons: ReactNode
   allMenuItems: MenuItemType[]
 }) {
-  if (activeView !== 'content') return null
+  if (activeView !== 'content' && activeView !== 'metadata') return null
   if (editingFloatingActions) return editingFloatingActions({menuItems: allMenuItems})
   if (!isEditing && hasDraft && draftActions) return draftActions({menuItems: allMenuItems})
   return actionButtons

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -1,5 +1,6 @@
 import {
   BlockRange,
+  countCustomMetadataFields,
   HMBlockNode,
   HMComment,
   HMDocument,
@@ -1501,7 +1502,7 @@ function DocumentBody({
       directory: 'Sub documents',
       activity: 'Activity',
       'all-documents': 'All Documents',
-      metadata: 'Metadata',
+      metadata: 'Attributes',
     }
     if (activeView !== 'content' && panelLabels[activeView]) {
       items.push({label: panelLabels[activeView]})
@@ -1764,7 +1765,7 @@ function DocumentBody({
     if (route.key === 'inspect' || route.key === 'metadata') return null
     return {
       key: 'metadata',
-      label: 'Metadata',
+      label: 'Attributes',
       icon: <Info className="size-4" />,
       onClick: () => {
         navigate({key: 'metadata', id: {...docId, blockRef: null, blockRange: null}})
@@ -1880,7 +1881,7 @@ function DocumentBody({
                                   directory: 'Sub documents',
                                   'all-documents': 'All Documents',
                                   'site-profile': 'Profile',
-                                  metadata: 'Metadata',
+                                  metadata: 'Attributes',
                                 } as Record<string, string>
                               )[activeView] || '',
                           },
@@ -1942,7 +1943,7 @@ function DocumentBody({
                                 directory: 'Sub documents',
                                 'all-documents': 'All Documents',
                                 'site-profile': 'Profile',
-                                metadata: 'Metadata',
+                                metadata: 'Attributes',
                               } as Record<string, string>
                             )[activeView] || '',
                         },
@@ -2008,6 +2009,7 @@ function DocumentBody({
             commentsCount={interactionSummary.data?.comments || 0}
             citationsCount={interactionSummary.data?.citations || 0}
             collabsCount={peopleCount}
+            metadataCount={countCustomMetadataFields(document.metadata)}
             rightAction={documentToolsRightAction}
             layoutProps={
               isMobile

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -2022,9 +2022,7 @@ function DocumentBody({
                   }
             }
             activeTabAction={
-              activeView !== 'content' &&
-              activeView !== 'site-profile' &&
-              activeView !== 'all-documents' ? (
+              activeView !== 'content' && activeView !== 'site-profile' && activeView !== 'all-documents' ? (
                 <OpenInPanelButton
                   id={docId}
                   panelRoute={

--- a/frontend/packages/ui/src/value-editor.tsx
+++ b/frontend/packages/ui/src/value-editor.tsx
@@ -914,7 +914,9 @@ export function FieldRow({
         <RowActionsMenu
           label={`Actions for ${fieldKey}`}
           getActions={getMenuActions}
-          className={cn('group-focus-within/row:opacity-100 group-hover/row:opacity-100', isSelected && 'opacity-100')}
+          // Only the selected row shows its actions (selection follows focus),
+          // so nested objects don't light up every ancestor's menu at once.
+          className={cn(isSelected && 'opacity-100')}
         />
       </div>
       <FieldDialog
@@ -1423,10 +1425,8 @@ function ListItemRow({
         <RowActionsMenu
           label={`Actions for item ${index + 1}`}
           getActions={getMenuActions}
-          className={cn(
-            'group-focus-within/item:opacity-100 group-hover/item:opacity-100',
-            isSelected && 'opacity-100',
-          )}
+          // Only the selected item shows its actions (selection follows focus).
+          className={cn(isSelected && 'opacity-100')}
         />
       </div>
       <FieldDialog

--- a/frontend/packages/ui/src/value-editor.tsx
+++ b/frontend/packages/ui/src/value-editor.tsx
@@ -1,0 +1,1570 @@
+import {
+  ArrowDown,
+  ArrowUp,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  ChevronsDownUp,
+  ChevronsUpDown,
+  ClipboardPaste,
+  Copy,
+  CopyPlus,
+  Download,
+  ExternalLink,
+  FileUp,
+  GripVertical,
+  Link2,
+  MoreHorizontal,
+  Pencil,
+  Plus,
+  X,
+} from 'lucide-react'
+import {createContext, useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react'
+import {Button} from './button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './components/dialog'
+import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from './components/dropdown-menu'
+import {Input} from './components/input'
+import {Switch} from './components/switch'
+import {base64ToBytes, bytesToBase64, formatByteSize, isDagJsonBytes, isDagJsonLink, parseCidString} from './dag-json'
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from './select-dropdown'
+import {toast} from './toast'
+import {Tooltip} from './tooltip'
+import {cn} from './utils'
+
+/**
+ * Behavior rules for the recursive value editor, so it can serve both the
+ * document metadata editor (attribute-publish constraints) and the raw
+ * DAG-CBOR blob editor (full CBOR data model).
+ */
+export type ValueEditorRules = {
+  /** Allow list values and the List add-type. */
+  lists: boolean
+  /** Allow non-integer numbers. */
+  floats: boolean
+  /**
+   * How removing an object key behaves. 'tombstone' sets it to null (metadata
+   * publish semantics — a missing key would never clear); 'delete' removes it.
+   */
+  removeKeys: 'tombstone' | 'delete'
+  /** Hide null-valued object entries (metadata treats null as deleted). */
+  hideNullEntries: boolean
+  /** Allow IPLD kinds in DAG-JSON form: links `{"/": cid}` and bytes `{"/": {bytes}}`. */
+  ipld: boolean
+}
+
+/** Rules for document metadata: what SetAttribute ops can publish. */
+export const METADATA_VALUE_RULES: ValueEditorRules = {
+  lists: false,
+  floats: false,
+  removeKeys: 'tombstone',
+  hideNullEntries: true,
+  ipld: false,
+}
+
+/** Rules for raw DAG-CBOR blobs: the full CBOR data model (as JSON types). */
+export const CBOR_VALUE_RULES: ValueEditorRules = {
+  lists: true,
+  floats: true,
+  removeKeys: 'delete',
+  hideNullEntries: false,
+  ipld: true,
+}
+
+/** Containers the editor recurses into — excludes the IPLD link/bytes leaf forms. */
+function isEditableContainer(value: unknown): boolean {
+  return (Array.isArray(value) || isPlainObject(value)) && !isDagJsonLink(value) && !isDagJsonBytes(value)
+}
+
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+const utf8 = new TextEncoder()
+
+/**
+ * Canonical map key order per the IPLD DAG-CBOR spec: shorter UTF-8 keys sort
+ * first; equal-length keys compare bytewise.
+ */
+export function dagCborKeyCompare(a: string, b: string): number {
+  const aBytes = utf8.encode(a)
+  const bBytes = utf8.encode(b)
+  if (aBytes.length !== bBytes.length) return aBytes.length - bBytes.length
+  for (let i = 0; i < aBytes.length; i++) {
+    if (aBytes[i] !== bBytes[i]) return aBytes[i]! - bBytes[i]!
+  }
+  return 0
+}
+
+/** Entries of an object in canonical DAG-CBOR key order. */
+export function canonicalEntries(value: Record<string, unknown>, opts?: {hideNull?: boolean}): [string, unknown][] {
+  return Object.entries(value)
+    .filter(([, v]) => v !== undefined && (!opts?.hideNull || v !== null))
+    .sort(([a], [b]) => dagCborKeyCompare(a, b))
+}
+
+/** Rebuild a value with all nested object keys in canonical order (for JSON display). */
+export function toCanonicalOrder(value: unknown, opts?: {hideNull?: boolean}): unknown {
+  if (Array.isArray(value)) return value.map((item) => toCanonicalOrder(item, opts))
+  if (isPlainObject(value)) {
+    return Object.fromEntries(canonicalEntries(value, opts).map(([k, v]) => [k, toCanonicalOrder(v, opts)]))
+  }
+  return value
+}
+
+/** Validate a value against the rules. Returns an error message or null. */
+export function findInvalidValue(value: unknown, rules: ValueEditorRules, path: string[] = []): string | null {
+  if (value === null || value === undefined) return null
+  if (typeof value === 'string' || typeof value === 'boolean') return null
+  if (typeof value === 'number') {
+    if (rules.floats) return Number.isFinite(value) ? null : `"${path.join('.')}" must be a finite number`
+    return Number.isInteger(value) ? null : `"${path.join('.')}" must be a whole number`
+  }
+  if (isDagJsonLink(value)) {
+    if (!rules.ipld) return `"${path.join('.')}" is an IPLD link — links cannot be published in metadata`
+    return parseCidString(value['/']) ? null : `"${path.join('.')}" is not a valid CID link`
+  }
+  if (isDagJsonBytes(value)) {
+    if (!rules.ipld) return `"${path.join('.')}" is IPLD bytes — bytes cannot be published in metadata`
+    try {
+      base64ToBytes(value['/'].bytes)
+      return null
+    } catch {
+      return `"${path.join('.')}" has invalid base64 bytes`
+    }
+  }
+  if (Array.isArray(value)) {
+    if (!rules.lists) return `"${path.join('.')}" is a list — lists cannot be published in metadata`
+    for (let i = 0; i < value.length; i++) {
+      const problem = findInvalidValue(value[i], rules, [...path, String(i)])
+      if (problem) return problem
+    }
+    return null
+  }
+  if (isPlainObject(value)) {
+    for (const [key, child] of Object.entries(value)) {
+      const problem = findInvalidValue(child, rules, [...path, key])
+      if (problem) return problem
+    }
+    return null
+  }
+  return `"${path.join('.')}" has an unsupported type`
+}
+
+// No text-transform: keys are case-sensitive data, so they display verbatim.
+export const FIELD_LABEL_CLASS = 'text-muted-foreground text-xs font-medium'
+const NESTED_GROUP_CLASS = 'border-border ml-1 flex flex-col gap-1 border-l-2 pl-3'
+
+// ---------------------------------------------------------------------------
+// Undo history
+// ---------------------------------------------------------------------------
+
+const HISTORY_LIMIT = 200
+
+/**
+ * Snapshot-based undo/redo history. Call `record()` immediately BEFORE
+ * applying an edit; `undo()`/`redo()` return the snapshot to restore, or null.
+ */
+export function useValueHistory<T>(current: T) {
+  const currentRef = useRef(current)
+  currentRef.current = current
+  const undoStack = useRef<T[]>([])
+  const redoStack = useRef<T[]>([])
+
+  const record = useCallback(() => {
+    undoStack.current.push(currentRef.current)
+    if (undoStack.current.length > HISTORY_LIMIT) undoStack.current.shift()
+    redoStack.current = []
+  }, [])
+
+  const undo = useCallback((): {value: T} | null => {
+    if (undoStack.current.length === 0) return null
+    const value = undoStack.current.pop()!
+    redoStack.current.push(currentRef.current)
+    return {value}
+  }, [])
+
+  const redo = useCallback((): {value: T} | null => {
+    if (redoStack.current.length === 0) return null
+    const value = redoStack.current.pop()!
+    undoStack.current.push(currentRef.current)
+    return {value}
+  }, [])
+
+  return {record, undo, redo}
+}
+
+// ---------------------------------------------------------------------------
+// Selection, clipboard, context menu
+// ---------------------------------------------------------------------------
+
+export type ValuePath = (string | number)[]
+
+function pathId(path: ValuePath): string {
+  return JSON.stringify(path)
+}
+
+type SelectionHandlers = {
+  getValue: () => unknown
+  setValue: (value: unknown) => void
+  remove?: () => void
+  rules: ValueEditorRules
+}
+
+export type ContextMenuAction = {
+  key: string
+  label: string
+  icon?: React.ReactNode
+  destructive?: boolean
+  onClick: () => void
+}
+
+type SelectionContextValue = {
+  selectedId: string | null
+  select: (id: string) => void
+  clear: () => void
+  register: (id: string, handlers: SelectionHandlers) => void
+  unregister: (id: string) => void
+  openContextMenu: (position: {x: number; y: number}, actions: ContextMenuAction[]) => void
+  /** Opens ipfs://... URLs from link values, when the host page provides navigation. */
+  openUrl?: (url: string) => void
+}
+
+const SelectionContext = createContext<SelectionContextValue | null>(null)
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  return target instanceof HTMLElement && !!target.closest('input,textarea,select,[contenteditable="true"]')
+}
+
+/** Parse and validate clipboard-ish text for pasting. Non-JSON pastes as a string. */
+function parsePastedText(text: string, rules: ValueEditorRules): {value: unknown} | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    parsed = text
+  }
+  const problem = findInvalidValue(parsed, rules)
+  if (problem) {
+    toast.error(`Cannot paste: ${problem}`)
+    return null
+  }
+  return {value: parsed}
+}
+
+function copyValueToClipboard(value: unknown) {
+  navigator.clipboard.writeText(JSON.stringify(toCanonicalOrder(value), null, 2))
+  toast.success('Copied value')
+}
+
+async function pasteFromClipboard(handlers: SelectionHandlers) {
+  let text: string
+  try {
+    text = await navigator.clipboard.readText()
+  } catch {
+    toast.error('Clipboard unavailable')
+    return
+  }
+  if (!text) return
+  const result = parsePastedText(text, handlers.rules)
+  if (result) handlers.setValue(result.value)
+}
+
+/**
+ * Enables row selection, clipboard, context menus, and undo shortcuts for all
+ * value editors below it. Click a row to select it: Cmd/Ctrl+C copies the
+ * value as JSON, Cmd/Ctrl+V pastes over it (validated), Delete removes it,
+ * Escape deselects. Cmd/Ctrl+Z / Shift+Cmd/Ctrl+Z call onUndo/onRedo.
+ */
+export function ValueEditorProvider({
+  children,
+  onUndo,
+  onRedo,
+  openUrl,
+}: {
+  children: React.ReactNode
+  onUndo?: () => void
+  onRedo?: () => void
+  openUrl?: (url: string) => void
+}) {
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [menu, setMenu] = useState<{x: number; y: number; actions: ContextMenuAction[]} | null>(null)
+  const registry = useRef(new Map<string, SelectionHandlers>())
+
+  const selectedIdRef = useRef(selectedId)
+  selectedIdRef.current = selectedId
+  const undoRef = useRef(onUndo)
+  undoRef.current = onUndo
+  const redoRef = useRef(onRedo)
+  redoRef.current = onRedo
+
+  const ctx = useRef<SelectionContextValue>({
+    selectedId: null,
+    select: (id) => setSelectedId(id),
+    clear: () => setSelectedId(null),
+    register: (id, handlers) => registry.current.set(id, handlers),
+    unregister: (id) => registry.current.delete(id),
+    openContextMenu: (position, actions) => setMenu({...position, actions}),
+  })
+  ctx.current = {...ctx.current, selectedId, openUrl}
+
+  useEffect(() => {
+    const getSelectedHandlers = () => {
+      const id = selectedIdRef.current
+      return id ? registry.current.get(id) : undefined
+    }
+
+    const onCopy = (e: ClipboardEvent) => {
+      if (isEditableTarget(e.target)) return
+      // Don't hijack copying of regular text selections.
+      if (document.getSelection()?.toString()) return
+      const handlers = getSelectedHandlers()
+      if (!handlers) return
+      e.preventDefault()
+      e.clipboardData?.setData('text/plain', JSON.stringify(toCanonicalOrder(handlers.getValue()), null, 2))
+    }
+
+    const onPaste = (e: ClipboardEvent) => {
+      if (isEditableTarget(e.target)) return
+      const handlers = getSelectedHandlers()
+      if (!handlers) return
+      const text = e.clipboardData?.getData('text/plain')
+      if (!text) return
+      e.preventDefault()
+      const result = parsePastedText(text, handlers.rules)
+      if (result) handlers.setValue(result.value)
+    }
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'z') {
+        // Inputs keep their native text undo.
+        if (isEditableTarget(e.target)) return
+        const action = e.shiftKey ? redoRef.current : undoRef.current
+        if (action) {
+          e.preventDefault()
+          action()
+        }
+        return
+      }
+      if (isEditableTarget(e.target)) return
+      if (e.key === 'Escape') {
+        setMenu(null)
+        setSelectedId(null)
+      } else if (e.key === 'Delete' || e.key === 'Backspace') {
+        const handlers = getSelectedHandlers()
+        if (handlers?.remove) {
+          e.preventDefault()
+          handlers.remove()
+          setSelectedId(null)
+        }
+      }
+    }
+
+    document.addEventListener('copy', onCopy)
+    document.addEventListener('paste', onPaste)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('copy', onCopy)
+      document.removeEventListener('paste', onPaste)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [])
+
+  return (
+    <SelectionContext.Provider value={ctx.current}>
+      {children}
+      {menu && (
+        <div
+          className="fixed inset-0 z-[100]"
+          onClick={() => setMenu(null)}
+          onContextMenu={(e) => {
+            e.preventDefault()
+            setMenu(null)
+          }}
+        >
+          <div
+            className="bg-popover text-popover-foreground absolute flex min-w-44 flex-col rounded-md border p-1 shadow-md"
+            style={{
+              left: Math.min(menu.x, typeof window !== 'undefined' ? window.innerWidth - 200 : menu.x),
+              top: Math.min(
+                menu.y,
+                typeof window !== 'undefined' ? window.innerHeight - menu.actions.length * 34 - 12 : menu.y,
+              ),
+            }}
+          >
+            {menu.actions.map((action) => (
+              <button
+                key={action.key}
+                type="button"
+                className={cn(
+                  'hover:bg-accent flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm transition-colors',
+                  action.destructive && 'text-destructive',
+                )}
+                onClick={() => {
+                  setMenu(null)
+                  action.onClick()
+                }}
+              >
+                {action.icon}
+                {action.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </SelectionContext.Provider>
+  )
+}
+
+/** Row-level wiring for selection and the context menu. */
+function useRowSelection(id: string, handlers: SelectionHandlers, getMenuActions: () => ContextMenuAction[]) {
+  const ctx = useContext(SelectionContext)
+  const isSelected = ctx?.selectedId === id
+
+  // Keep the registry fresh with the latest value/handlers on every render.
+  useEffect(() => {
+    if (!ctx) return
+    ctx.register(id, handlers)
+    return () => ctx.unregister(id)
+  })
+
+  const onRowClick = ctx
+    ? (e: React.MouseEvent) => {
+        const target = e.target as HTMLElement
+        if (target.closest('input,textarea,button,select,a,[contenteditable="true"],[role="combobox"]')) return
+        e.stopPropagation()
+        if (isSelected) ctx.clear()
+        else ctx.select(id)
+      }
+    : undefined
+
+  const onContextMenu = ctx
+    ? (e: React.MouseEvent) => {
+        // Right-click inside inputs keeps the native text menu.
+        if (isEditableTarget(e.target)) return
+        e.preventDefault()
+        e.stopPropagation()
+        ctx.select(id)
+        ctx.openContextMenu({x: e.clientX, y: e.clientY}, getMenuActions())
+      }
+    : undefined
+
+  return {isSelected: !!isSelected, onRowClick, onContextMenu}
+}
+
+const ROW_CLASS = '-mx-1 rounded-md px-1 py-0.5 transition-colors'
+const ROW_SELECTED_CLASS = 'bg-accent/70 ring-border ring-1'
+
+// ---------------------------------------------------------------------------
+// Row components
+// ---------------------------------------------------------------------------
+
+/**
+ * All row actions grouped behind one floating trigger, so deep nesting
+ * doesn't accumulate button columns or shrink the editors. Mirrors the
+ * right-click context menu exactly.
+ */
+function RowActionsMenu({
+  label,
+  getActions,
+  className,
+}: {
+  label: string
+  getActions: () => ContextMenuAction[]
+  className?: string
+}) {
+  const [open, setOpen] = useState(false)
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="iconSm"
+          aria-label={label}
+          className={cn(
+            'text-muted-foreground bg-background/85 shadow-xs backdrop-blur-[2px]',
+            'opacity-0 transition-opacity',
+            open && 'opacity-100',
+            className,
+          )}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <MoreHorizontal className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+        {getActions().map((action) => (
+          <DropdownMenuItem
+            key={action.key}
+            variant={action.destructive ? 'destructive' : 'default'}
+            onClick={() => action.onClick()}
+          >
+            {action.icon}
+            {action.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+function CollapseToggle({collapsed, onToggle}: {collapsed: boolean; onToggle: () => void}) {
+  return (
+    <button
+      type="button"
+      aria-label={collapsed ? 'Expand' : 'Collapse'}
+      aria-expanded={!collapsed}
+      className="text-muted-foreground hover:text-foreground flex size-4 shrink-0 items-center justify-center"
+      onClick={onToggle}
+    >
+      {collapsed ? <ChevronRight className="size-3.5" /> : <ChevronDown className="size-3.5" />}
+    </button>
+  )
+}
+
+/** Summary line shown in place of a collapsed container's editor. */
+function CollapsedSummary({value, onExpand}: {value: unknown; onExpand: () => void}) {
+  const summary = Array.isArray(value)
+    ? `List · ${value.length} ${value.length === 1 ? 'item' : 'items'}`
+    : (() => {
+        const count = canonicalEntries(value as Record<string, unknown>).length
+        return `Object · ${count} ${count === 1 ? 'field' : 'fields'}`
+      })()
+  return (
+    <button
+      type="button"
+      className="text-muted-foreground hover:text-foreground w-fit text-sm transition-colors"
+      onClick={onExpand}
+    >
+      {summary}
+    </button>
+  )
+}
+
+/** Shared context-menu actions for a value row. */
+function baseMenuActions({
+  value,
+  handlers,
+  isContainer,
+  collapsed,
+  setCollapsed,
+}: {
+  value: unknown
+  handlers: SelectionHandlers
+  isContainer: boolean
+  collapsed: boolean
+  setCollapsed: (collapsed: boolean) => void
+}): ContextMenuAction[] {
+  const actions: ContextMenuAction[] = [
+    {
+      key: 'copy',
+      label: 'Copy',
+      icon: <Copy className="size-4" />,
+      onClick: () => copyValueToClipboard(value),
+    },
+    {
+      key: 'paste',
+      label: 'Paste',
+      icon: <ClipboardPaste className="size-4" />,
+      onClick: () => void pasteFromClipboard(handlers),
+    },
+  ]
+  if (isContainer) {
+    actions.push({
+      key: 'collapse',
+      label: collapsed ? 'Expand' : 'Collapse',
+      icon: collapsed ? <ChevronsUpDown className="size-4" /> : <ChevronsDownUp className="size-4" />,
+      onClick: () => setCollapsed(!collapsed),
+    })
+  }
+  return actions
+}
+
+/**
+ * One keyed field row: collapsible for container values, selectable (click),
+ * with a right-click menu, copy, and remove. The field's NAME and TYPE are
+ * locked once created — they change only through the "Edit field" dialog
+ * (which fires `onEditField` with the new key and the coerced value). Shared
+ * by nested object editors and the top-level metadata field list.
+ */
+export function FieldRow({
+  fieldKey,
+  value,
+  siblingKeys,
+  onValue,
+  onEditField,
+  onRemove,
+  rules,
+  path,
+  className,
+}: {
+  fieldKey: string
+  value: unknown
+  /** Sibling keys (excluding this one) used for rename collision checks. */
+  siblingKeys: string[]
+  onValue: (value: unknown) => void
+  /**
+   * Rename and/or retype the field: receives the new key and the new value
+   * (already coerced to the chosen type). `newKey` may equal `fieldKey`.
+   */
+  onEditField: (newKey: string, newValue: unknown) => void
+  onRemove: () => void
+  rules: ValueEditorRules
+  path: ValuePath
+  className?: string
+}) {
+  const isContainer = isEditableContainer(value)
+  const [collapsed, setCollapsed] = useState(false)
+  const [editing, setEditing] = useState(false)
+  const handlers: SelectionHandlers = {getValue: () => value, setValue: onValue, remove: onRemove, rules}
+  const getMenuActions = () => [
+    ...baseMenuActions({value, handlers, isContainer, collapsed, setCollapsed}),
+    {
+      key: 'edit',
+      label: 'Edit field',
+      icon: <Pencil className="size-4" />,
+      onClick: () => setEditing(true),
+    },
+    {
+      key: 'remove',
+      label: `Remove ${fieldKey}`,
+      icon: <X className="size-4" />,
+      destructive: true,
+      onClick: onRemove,
+    },
+  ]
+  const {isSelected, onRowClick, onContextMenu} = useRowSelection(pathId(path), handlers, getMenuActions)
+
+  return (
+    <div
+      onClick={onRowClick}
+      onContextMenu={onContextMenu}
+      className={cn(
+        'group/row relative flex items-start gap-2',
+        ROW_CLASS,
+        isSelected && ROW_SELECTED_CLASS,
+        className,
+      )}
+    >
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <div className="flex items-center gap-1">
+          {isContainer ? (
+            <CollapseToggle collapsed={collapsed} onToggle={() => setCollapsed((c) => !c)} />
+          ) : (
+            <span className="size-4 shrink-0" />
+          )}
+          <span className={cn(FIELD_LABEL_CLASS, 'truncate')} title={fieldKey}>
+            {fieldKey}
+          </span>
+        </div>
+        <div className="pl-5">
+          {isContainer && collapsed ? (
+            <CollapsedSummary value={value} onExpand={() => setCollapsed(false)} />
+          ) : (
+            <ValueEditor value={value} onValue={onValue} rules={rules} path={path} />
+          )}
+        </div>
+      </div>
+      {/* Floating so nested rows keep their full width. */}
+      <div className="absolute top-1 right-0">
+        <RowActionsMenu
+          label={`Actions for ${fieldKey}`}
+          getActions={getMenuActions}
+          className={cn('group-focus-within/row:opacity-100 group-hover/row:opacity-100', isSelected && 'opacity-100')}
+        />
+      </div>
+      <FieldDialog
+        open={editing}
+        onOpenChange={setEditing}
+        mode="edit"
+        rules={rules}
+        existingKeys={siblingKeys}
+        initialName={fieldKey}
+        initialType={valueToFieldType(value)}
+        onSubmit={(newKey, newType) => {
+          const newValue = newType === valueToFieldType(value) ? value : coerceFieldValue(value, newType, rules)
+          onEditField(newKey, newValue)
+        }}
+      />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Display + editors
+// ---------------------------------------------------------------------------
+
+/** Read-only recursive rendering of a value. */
+export function ValueDisplay({value, rules = CBOR_VALUE_RULES}: {value: unknown; rules?: ValueEditorRules}) {
+  if (isDagJsonLink(value)) {
+    return (
+      <span className="flex items-center gap-1 font-mono text-sm break-all">
+        <Link2 className="text-muted-foreground size-3.5 shrink-0" />
+        {value['/']}
+      </span>
+    )
+  }
+  if (isDagJsonBytes(value)) {
+    let size: number | null = null
+    try {
+      size = base64ToBytes(value['/'].bytes).length
+    } catch {
+      // fall through to invalid display
+    }
+    return (
+      <span className="font-mono text-sm">
+        {size === null ? 'Invalid base64 data' : `${formatByteSize(size)} binary`}
+      </span>
+    )
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) return <p className="text-muted-foreground text-sm">Empty list</p>
+    return (
+      <div className={NESTED_GROUP_CLASS}>
+        {value.map((item, index) => (
+          <div key={index} className="flex items-baseline gap-2">
+            <span className="text-muted-foreground font-mono text-xs">{index + 1}.</span>
+            <ValueDisplay value={item} rules={rules} />
+          </div>
+        ))}
+      </div>
+    )
+  }
+  if (isPlainObject(value)) {
+    const entries = canonicalEntries(value, {hideNull: rules.hideNullEntries})
+    if (entries.length === 0) return <p className="text-muted-foreground text-sm">No fields</p>
+    return (
+      <div className={NESTED_GROUP_CLASS}>
+        {entries.map(([key, child]) => (
+          <div key={key} className="flex flex-col gap-1">
+            <span className={FIELD_LABEL_CLASS}>{key}</span>
+            <ValueDisplay value={child} rules={rules} />
+          </div>
+        ))}
+      </div>
+    )
+  }
+  if (value === '') return <span className="text-muted-foreground text-sm">(empty)</span>
+  return <span className="font-mono text-sm break-words whitespace-pre-wrap">{String(value)}</span>
+}
+
+/** Recursive type-aware editor for one value. */
+export function ValueEditor({
+  value,
+  onValue,
+  rules,
+  path = [],
+}: {
+  value: unknown
+  onValue: (value: unknown) => void
+  rules: ValueEditorRules
+  path?: ValuePath
+}) {
+  if (typeof value === 'boolean') {
+    return <Switch checked={value} onCheckedChange={(checked) => onValue(checked)} />
+  }
+  if (typeof value === 'number') {
+    return <NumberInput value={value} onValue={onValue} rules={rules} />
+  }
+  if (typeof value === 'string') {
+    return <StringLeafEditor value={value} onValue={onValue} />
+  }
+  if (isDagJsonLink(value)) {
+    return <LinkValueEditor value={value} onValue={onValue} />
+  }
+  if (isDagJsonBytes(value)) {
+    return <BytesValueEditor value={value} onValue={onValue} />
+  }
+  if (Array.isArray(value)) {
+    return <ListEditor value={value} onValue={onValue} rules={rules} path={path} />
+  }
+  if (isPlainObject(value)) {
+    return <ObjectEditor value={value} onValue={onValue} rules={rules} path={path} />
+  }
+  return <span className="text-muted-foreground font-mono text-sm">{String(value)}</span>
+}
+
+/** String leaf: free-text input, committing on blur/Enter. */
+function StringLeafEditor({value, onValue}: {value: string; onValue: (value: unknown) => void}) {
+  return <CommitOnBlurInput key={value} initialValue={value} onCommit={(text) => onValue(text)} />
+}
+
+/** IPLD link (`{"/": cid}`): editable CID with validation and an open action. */
+function LinkValueEditor({value, onValue}: {value: {'/': string}; onValue: (value: unknown) => void}) {
+  const ctx = useContext(SelectionContext)
+  const cid = value['/']
+  const isValid = !!parseCidString(cid)
+  return (
+    <div className="flex items-center gap-1">
+      <Tooltip content="IPLD link">
+        <Link2 className={cn('size-3.5 shrink-0', isValid ? 'text-muted-foreground' : 'text-destructive')} />
+      </Tooltip>
+      <CommitOnBlurInput
+        key={cid}
+        initialValue={cid}
+        className="font-mono text-xs"
+        onCommit={(text) => {
+          const next = text.trim()
+          if (!parseCidString(next)) {
+            toast.error('Not a valid CID')
+            return
+          }
+          onValue({'/': next})
+        }}
+      />
+      {ctx?.openUrl && isValid && (
+        <Tooltip content={`Open ipfs://${cid}`}>
+          <Button
+            variant="ghost"
+            size="iconSm"
+            aria-label={`Open ipfs://${cid}`}
+            className="text-muted-foreground"
+            onClick={() => ctx.openUrl!(`ipfs://${cid}`)}
+          >
+            <ExternalLink className="size-3.5" />
+          </Button>
+        </Tooltip>
+      )}
+    </div>
+  )
+}
+
+/** IPLD bytes (`{"/": {bytes}}`): size readout with download and replace-from-file. */
+function BytesValueEditor({value, onValue}: {value: {'/': {bytes: string}}; onValue: (value: unknown) => void}) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const b64 = value['/'].bytes
+  const size = useMemo(() => {
+    try {
+      return base64ToBytes(b64).length
+    } catch {
+      return null
+    }
+  }, [b64])
+
+  const download = () => {
+    const bytes = base64ToBytes(b64)
+    const url = URL.createObjectURL(new Blob([bytes as BlobPart], {type: 'application/octet-stream'}))
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = 'bytes.bin'
+    anchor.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      <span className={cn('font-mono text-sm', size === null && 'text-destructive')}>
+        {size === null ? 'Invalid base64 data' : `${formatByteSize(size)} binary`}
+      </span>
+      {size !== null && size > 0 && (
+        <Tooltip content="Download binary data">
+          <Button
+            variant="ghost"
+            size="iconSm"
+            aria-label="Download binary data"
+            className="text-muted-foreground"
+            onClick={download}
+          >
+            <Download className="size-3.5" />
+          </Button>
+        </Tooltip>
+      )}
+      <Tooltip content="Replace with file…">
+        <Button
+          variant="ghost"
+          size="iconSm"
+          aria-label="Replace with file"
+          className="text-muted-foreground"
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <FileUp className="size-3.5" />
+        </Button>
+      </Tooltip>
+      <input
+        ref={fileInputRef}
+        type="file"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0]
+          e.target.value = ''
+          if (!file) return
+          file
+            .arrayBuffer()
+            .then((buffer) => onValue({'/': {bytes: bytesToBase64(new Uint8Array(buffer))}}))
+            .catch(() => toast.error('Failed to read file'))
+        }}
+      />
+    </div>
+  )
+}
+
+/**
+ * Recursive object editor: one row per visible key. Removal follows
+ * `rules.removeKeys`; changes bubble up by rebuilding this object.
+ */
+export function ObjectEditor({
+  value,
+  onValue,
+  rules,
+  path = [],
+}: {
+  value: Record<string, unknown>
+  onValue: (value: unknown) => void
+  rules: ValueEditorRules
+  path?: ValuePath
+}) {
+  const entries = canonicalEntries(value, {hideNull: rules.hideNullEntries})
+  const removeKey = (key: string) => {
+    if (rules.removeKeys === 'tombstone') {
+      onValue({...value, [key]: null})
+    } else {
+      const next = {...value}
+      delete next[key]
+      onValue(next)
+    }
+  }
+  // Rename and/or retype a field in one update: same key just replaces the
+  // value; a new key drops the old (tombstone under metadata rules) and sets
+  // the new key to the (already coerced) value.
+  const editField = (key: string, newKey: string, newValue: unknown) => {
+    if (newKey === key) {
+      onValue({...value, [key]: newValue})
+      return
+    }
+    if (rules.removeKeys === 'tombstone') {
+      onValue({...value, [key]: null, [newKey]: newValue})
+    } else {
+      const next = {...value}
+      delete next[key]
+      next[newKey] = newValue
+      onValue(next)
+    }
+  }
+  return (
+    <div className={NESTED_GROUP_CLASS}>
+      {entries.length === 0 && <p className="text-muted-foreground text-sm">No fields</p>}
+      {entries.map(([key, child]) => (
+        <FieldRow
+          key={key}
+          fieldKey={key}
+          value={child}
+          siblingKeys={entries.map(([k]) => k).filter((k) => k !== key)}
+          onValue={(newChild) => onValue({...value, [key]: newChild})}
+          onEditField={(newKey, newValue) => editField(key, newKey, newValue)}
+          onRemove={() => removeKey(key)}
+          rules={rules}
+          path={[...path, key]}
+        />
+      ))}
+      <AddFieldForm
+        compact
+        rules={rules}
+        existingKeys={entries.map(([key]) => key)}
+        onAdd={(key, newChild) => onValue({...value, [key]: newChild})}
+      />
+    </div>
+  )
+}
+
+/** Recursive list editor: edit, collapse, select, drag to reorder, remove, and append items. */
+export function ListEditor({
+  value,
+  onValue,
+  rules,
+  path = [],
+}: {
+  value: unknown[]
+  onValue: (value: unknown) => void
+  rules: ValueEditorRules
+  path?: ValuePath
+}) {
+  const [dragIndex, setDragIndex] = useState<number | null>(null)
+  const [overIndex, setOverIndex] = useState<number | null>(null)
+
+  const move = (from: number, to: number) => {
+    if (from === to) return
+    const next = [...value]
+    const [item] = next.splice(from, 1)
+    next.splice(to, 0, item)
+    onValue(next)
+  }
+  const endDrag = () => {
+    setDragIndex(null)
+    setOverIndex(null)
+  }
+  return (
+    <div className={NESTED_GROUP_CLASS}>
+      {value.length === 0 && <p className="text-muted-foreground text-sm">Empty list</p>}
+      {value.map((item, index) => (
+        <ListItemRow
+          key={index}
+          item={item}
+          index={index}
+          count={value.length}
+          onItem={(newItem) => onValue(value.map((v, i) => (i === index ? newItem : v)))}
+          onMove={move}
+          onDuplicate={() => {
+            const next = [...value]
+            next.splice(index + 1, 0, structuredClone(item))
+            onValue(next)
+          }}
+          onRemove={() => onValue(value.filter((_, i) => i !== index))}
+          rules={rules}
+          path={[...path, index]}
+          drag={{
+            isDragging: dragIndex === index,
+            isDragOver: dragIndex !== null && dragIndex !== index && overIndex === index,
+            onDragStart: () => setDragIndex(index),
+            onDragOver: () => setOverIndex(index),
+            onDrop: () => {
+              if (dragIndex !== null) move(dragIndex, index)
+              endDrag()
+            },
+            onDragEnd: endDrag,
+            active: dragIndex !== null,
+          }}
+        />
+      ))}
+      <AddFieldForm compact itemMode rules={rules} onAdd={(_key, item) => onValue([...value, item])} />
+    </div>
+  )
+}
+
+type ListItemDrag = {
+  isDragging: boolean
+  isDragOver: boolean
+  active: boolean
+  onDragStart: () => void
+  onDragOver: () => void
+  onDrop: () => void
+  onDragEnd: () => void
+}
+
+function ListItemRow({
+  item,
+  index,
+  count,
+  onItem,
+  onMove,
+  onDuplicate,
+  onRemove,
+  rules,
+  path,
+  drag,
+}: {
+  item: unknown
+  index: number
+  count: number
+  onItem: (item: unknown) => void
+  onMove: (from: number, to: number) => void
+  onDuplicate: () => void
+  onRemove: () => void
+  rules: ValueEditorRules
+  path: ValuePath
+  drag: ListItemDrag
+}) {
+  const isContainer = isEditableContainer(item)
+  const [collapsed, setCollapsed] = useState(false)
+  const [editing, setEditing] = useState(false)
+  const handlers: SelectionHandlers = {getValue: () => item, setValue: onItem, remove: onRemove, rules}
+  const getMenuActions = () => [
+    ...baseMenuActions({value: item, handlers, isContainer, collapsed, setCollapsed}),
+    {
+      key: 'edit-type',
+      label: 'Edit type',
+      icon: <Pencil className="size-4" />,
+      onClick: () => setEditing(true),
+    },
+    {
+      key: 'duplicate',
+      label: 'Duplicate',
+      icon: <CopyPlus className="size-4" />,
+      onClick: onDuplicate,
+    },
+    ...(index > 0
+      ? [
+          {
+            key: 'move-up',
+            label: 'Move up',
+            icon: <ArrowUp className="size-4" />,
+            onClick: () => onMove(index, index - 1),
+          },
+        ]
+      : []),
+    ...(index < count - 1
+      ? [
+          {
+            key: 'move-down',
+            label: 'Move down',
+            icon: <ArrowDown className="size-4" />,
+            onClick: () => onMove(index, index + 1),
+          },
+        ]
+      : []),
+    {
+      key: 'remove',
+      label: 'Remove item',
+      icon: <X className="size-4" />,
+      destructive: true,
+      onClick: onRemove,
+    },
+  ]
+  const {isSelected, onRowClick, onContextMenu} = useRowSelection(pathId(path), handlers, getMenuActions)
+
+  return (
+    <div
+      onClick={onRowClick}
+      onContextMenu={onContextMenu}
+      onDragOver={(e) => {
+        if (!drag.active) return
+        e.preventDefault()
+        e.dataTransfer.dropEffect = 'move'
+        drag.onDragOver()
+      }}
+      onDrop={(e) => {
+        if (!drag.active) return
+        e.preventDefault()
+        drag.onDrop()
+      }}
+      className={cn(
+        'group/item relative flex items-start gap-2',
+        ROW_CLASS,
+        isSelected && ROW_SELECTED_CLASS,
+        drag.isDragging && 'opacity-40',
+        drag.isDragOver && 'ring-primary/50 bg-accent/40 ring-2',
+      )}
+    >
+      <div className="mt-1.5 flex shrink-0 items-center gap-1">
+        <span
+          draggable
+          aria-label="Drag to reorder"
+          className={cn(
+            'text-muted-foreground -ml-1 flex cursor-grab items-center opacity-0 transition-opacity active:cursor-grabbing',
+            'group-focus-within/item:opacity-100 group-hover/item:opacity-100',
+            (isSelected || drag.active) && 'opacity-100',
+          )}
+          onDragStart={(e) => {
+            e.dataTransfer.effectAllowed = 'move'
+            e.dataTransfer.setData('text/plain', JSON.stringify(toCanonicalOrder(item), null, 2))
+            drag.onDragStart()
+          }}
+          onDragEnd={drag.onDragEnd}
+        >
+          <GripVertical className="size-3.5" />
+        </span>
+        {isContainer ? (
+          <CollapseToggle collapsed={collapsed} onToggle={() => setCollapsed((c) => !c)} />
+        ) : (
+          <span className="size-4 shrink-0" />
+        )}
+        <span className="text-muted-foreground font-mono text-xs">{index + 1}.</span>
+      </div>
+      <div className="min-w-0 flex-1">
+        {isContainer && collapsed ? (
+          <div className="pt-1">
+            <CollapsedSummary value={item} onExpand={() => setCollapsed(false)} />
+          </div>
+        ) : (
+          <ValueEditor value={item} onValue={onItem} rules={rules} path={path} />
+        )}
+      </div>
+      {/* Floating so nested rows keep their full width. */}
+      <div className="absolute top-1 right-0">
+        <RowActionsMenu
+          label={`Actions for item ${index + 1}`}
+          getActions={getMenuActions}
+          className={cn(
+            'group-focus-within/item:opacity-100 group-hover/item:opacity-100',
+            isSelected && 'opacity-100',
+          )}
+        />
+      </div>
+      <FieldDialog
+        open={editing}
+        onOpenChange={setEditing}
+        mode="edit"
+        itemMode
+        rules={rules}
+        initialType={valueToFieldType(item)}
+        onSubmit={(_name, newType) => {
+          if (newType !== valueToFieldType(item)) onItem(coerceFieldValue(item, newType, rules))
+        }}
+      />
+    </div>
+  )
+}
+
+/** Number input that stages on blur/Enter, validates per rules, resets on Escape. */
+function NumberInput({
+  value,
+  onValue,
+  rules,
+  autoFocus,
+  onFocusChange,
+}: {
+  value: number
+  onValue: (value: unknown) => void
+  rules: ValueEditorRules
+  autoFocus?: boolean
+  onFocusChange?: (focused: boolean) => void
+}) {
+  const initial = String(value)
+  const [text, setText] = useState(initial)
+  const [error, setError] = useState<string | null>(null)
+  useEffect(() => {
+    setText(initial)
+    setError(null)
+  }, [initial])
+  return (
+    <div className="flex flex-col gap-1">
+      <Input
+        value={text}
+        inputMode="numeric"
+        autoFocus={autoFocus}
+        onFocus={() => onFocusChange?.(true)}
+        onChange={(e) => {
+          setText(e.target.value)
+          setError(null)
+        }}
+        onBlur={() => {
+          onFocusChange?.(false)
+          if (text === initial) return
+          const parsed = Number(text)
+          const valid = text.trim() !== '' && (rules.floats ? Number.isFinite(parsed) : Number.isInteger(parsed))
+          if (!valid) {
+            setError(rules.floats ? 'Enter a number' : 'Enter a whole number')
+            return
+          }
+          onValue(parsed)
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
+          if (e.key === 'Escape') setText(initial)
+        }}
+      />
+      {error && <p className="text-destructive text-xs">{error}</p>}
+    </div>
+  )
+}
+
+/** Text input that stages its value on blur or Enter, resets on Escape. */
+function CommitOnBlurInput({
+  initialValue,
+  placeholder,
+  className,
+  autoFocus,
+  onCommit,
+  onFocusChange,
+}: {
+  initialValue: string
+  placeholder?: string
+  className?: string
+  autoFocus?: boolean
+  onCommit: (text: string) => void
+  onFocusChange?: (focused: boolean) => void
+}) {
+  const [text, setText] = useState(initialValue)
+  return (
+    <Input
+      value={text}
+      placeholder={placeholder}
+      className={className}
+      autoFocus={autoFocus}
+      onFocus={() => onFocusChange?.(true)}
+      onChange={(e) => setText(e.target.value)}
+      onBlur={() => {
+        if (text !== initialValue) onCommit(text)
+        onFocusChange?.(false)
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
+        if (e.key === 'Escape') setText(initialValue)
+      }}
+    />
+  )
+}
+
+export type NewFieldType = 'text' | 'number' | 'toggle' | 'object' | 'list' | 'null' | 'link' | 'bytes'
+
+const FIELD_TYPE_LABEL: Record<NewFieldType, string> = {
+  text: 'Text',
+  number: 'Number',
+  toggle: 'Toggle',
+  object: 'Object',
+  list: 'List',
+  null: 'Null',
+  link: 'Link',
+  bytes: 'Bytes',
+}
+
+/** The types offerable under a given rule set (in menu order). */
+function fieldTypeOptions(rules: ValueEditorRules): NewFieldType[] {
+  const options: NewFieldType[] = ['text', 'number', 'toggle', 'object']
+  if (rules.lists) options.push('list')
+  if (!rules.hideNullEntries) options.push('null')
+  if (rules.ipld) options.push('link', 'bytes')
+  return options
+}
+
+/** The field type that best describes an existing value. */
+export function valueToFieldType(value: unknown): NewFieldType {
+  if (typeof value === 'string') return 'text'
+  if (typeof value === 'number') return 'number'
+  if (typeof value === 'boolean') return 'toggle'
+  if (value === null || value === undefined) return 'null'
+  if (isDagJsonLink(value)) return 'link'
+  if (isDagJsonBytes(value)) return 'bytes'
+  if (Array.isArray(value)) return 'list'
+  return 'object'
+}
+
+/** The empty/starter value for a freshly-chosen field type. */
+function defaultValueForType(type: NewFieldType): unknown {
+  switch (type) {
+    case 'text':
+      return ''
+    case 'number':
+      return 0
+    case 'toggle':
+      return true
+    case 'object':
+      return {}
+    case 'list':
+      return []
+    case 'null':
+      return null
+    case 'link':
+      return {'/': ''}
+    case 'bytes':
+      return {'/': {bytes: ''}}
+  }
+}
+
+/**
+ * Convert a value to a new field type, preserving it across compatible
+ * conversions (number ⇄ text, boolean ⇄ text/number, a valid CID string →
+ * link) and otherwise falling back to the target type's default. Used when a
+ * field's type is changed via the edit dialog.
+ */
+export function coerceFieldValue(value: unknown, toType: NewFieldType, rules: ValueEditorRules): unknown {
+  if (valueToFieldType(value) === toType) return value
+  switch (toType) {
+    case 'text':
+      if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+      return ''
+    case 'number': {
+      if (typeof value === 'boolean') return value ? 1 : 0
+      if (typeof value === 'string') {
+        const parsed = Number(value.trim())
+        const valid = value.trim() !== '' && (rules.floats ? Number.isFinite(parsed) : Number.isInteger(parsed))
+        if (valid) return parsed
+      }
+      return 0
+    }
+    case 'toggle':
+      if (typeof value === 'string') return value.trim().toLowerCase() === 'true'
+      if (typeof value === 'number') return value !== 0
+      return defaultValueForType('toggle')
+    case 'null':
+      return null
+    case 'link':
+      if (typeof value === 'string') {
+        const cid = value.trim().replace(/^ipfs:\/\//, '')
+        if (parseCidString(cid)) return {'/': cid}
+      }
+      return {'/': ''}
+    case 'object':
+    case 'list':
+    case 'bytes':
+    default:
+      return defaultValueForType(toType)
+  }
+}
+
+/**
+ * Modal that captures a field's NAME and TYPE only — used both to add a new
+ * field and to edit an existing field's name/type. The value itself is edited
+ * inline in the row afterward, so name/type stay locked until reopened here.
+ * `itemMode` drops the name input (list items are keyed by position, not name).
+ */
+function FieldDialog({
+  open,
+  onOpenChange,
+  mode,
+  itemMode = false,
+  rules,
+  existingKeys = [],
+  initialName = '',
+  initialType,
+  onSubmit,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  mode: 'add' | 'edit'
+  itemMode?: boolean
+  rules: ValueEditorRules
+  /** Sibling keys used for collision checks (excludes the field's own key in edit mode). */
+  existingKeys?: string[]
+  initialName?: string
+  initialType: NewFieldType
+  onSubmit: (name: string, type: NewFieldType) => void
+}) {
+  const [name, setName] = useState(initialName)
+  const [type, setType] = useState<NewFieldType>(initialType)
+  const [error, setError] = useState<string | null>(null)
+
+  // Seed the fields from the target field each time the dialog opens.
+  useEffect(() => {
+    if (!open) return
+    setName(initialName)
+    setType(initialType)
+    setError(null)
+  }, [open])
+
+  const options = fieldTypeOptions(rules)
+
+  const submit = () => {
+    if (itemMode) {
+      onSubmit('', type)
+      onOpenChange(false)
+      return
+    }
+    const trimmed = name.trim()
+    if (!trimmed) {
+      setError('Enter a field name')
+      return
+    }
+    if (existingKeys.includes(trimmed)) {
+      setError(`"${trimmed}" already exists`)
+      return
+    }
+    if (trimmed === '/') {
+      // DAG-JSON reserves the single "/" key for link and bytes forms.
+      setError('"/" is a reserved field name in DAG-CBOR blobs')
+      return
+    }
+    onSubmit(trimmed, type)
+    onOpenChange(false)
+  }
+
+  const title = itemMode
+    ? mode === 'add'
+      ? 'Add item'
+      : 'Edit item type'
+    : mode === 'add'
+      ? 'Add field'
+      : 'Edit field'
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md" onClick={(e) => e.stopPropagation()}>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-3">
+          {!itemMode && (
+            <div className="flex flex-col gap-1">
+              <label htmlFor="field-dialog-name" className="text-muted-foreground text-xs">
+                Field name
+              </label>
+              <Input
+                id="field-dialog-name"
+                value={name}
+                placeholder="Field name"
+                autoFocus
+                onChange={(e) => {
+                  setName(e.target.value)
+                  setError(null)
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') submit()
+                }}
+              />
+            </div>
+          )}
+          <div className="flex flex-col gap-1">
+            <label className="text-muted-foreground text-xs">Type</label>
+            <Select value={type} onValueChange={(v) => setType(v as NewFieldType)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {options.map((option) => (
+                  <SelectItem key={option} value={option}>
+                    {FIELD_TYPE_LABEL[option]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          {mode === 'edit' && (
+            <p className="text-muted-foreground text-xs">
+              Changing the type keeps the current value when compatible, otherwise resets it.
+            </p>
+          )}
+          {error && <p className="text-destructive text-xs">{error}</p>}
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button size="sm" onClick={submit}>
+            <Check className="size-4" />
+            {mode === 'add' ? 'Add' : 'Save'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+/**
+ * "+ Add field" affordance that opens the {@link FieldDialog} to pick a name +
+ * type; the field is created with that type's default value and its value is
+ * then edited inline. `itemMode` drops the name for appending list items.
+ */
+export function AddFieldForm({
+  existingKeys = [],
+  itemMode = false,
+  compact = false,
+  rules,
+  onAdd,
+}: {
+  existingKeys?: string[]
+  itemMode?: boolean
+  compact?: boolean
+  rules: ValueEditorRules
+  onAdd: (key: string, value: unknown) => void
+}) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div>
+      <Button
+        variant="ghost"
+        size="sm"
+        className={cn('text-muted-foreground', compact && 'h-6 px-1 text-xs')}
+        onClick={() => setOpen(true)}
+      >
+        <Plus className={compact ? 'size-3' : 'size-4'} />
+        {itemMode ? 'Add item' : 'Add field'}
+      </Button>
+      <FieldDialog
+        open={open}
+        onOpenChange={setOpen}
+        mode="add"
+        itemMode={itemMode}
+        rules={rules}
+        existingKeys={existingKeys}
+        initialName=""
+        initialType="text"
+        onSubmit={(name, type) => onAdd(name, defaultValueForType(type))}
+      />
+    </div>
+  )
+}

--- a/frontend/packages/ui/src/value-editor.tsx
+++ b/frontend/packages/ui/src/value-editor.tsx
@@ -19,23 +19,17 @@ import {
   Plus,
   X,
 } from 'lucide-react'
-import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
-import { Button } from './button'
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from './components/dialog'
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './components/dropdown-menu'
-import { Input } from './components/input'
-import { Switch } from './components/switch'
-import { base64ToBytes, bytesToBase64, formatByteSize, isDagJsonBytes, isDagJsonLink, parseCidString } from './dag-json'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './select-dropdown'
-import { toast } from './toast'
-import { Tooltip } from './tooltip'
-import { cn } from './utils'
+import {createContext, useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react'
+import {Button} from './button'
+import {Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle} from './components/dialog'
+import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from './components/dropdown-menu'
+import {Input} from './components/input'
+import {Switch} from './components/switch'
+import {base64ToBytes, bytesToBase64, formatByteSize, isDagJsonBytes, isDagJsonLink, parseCidString} from './dag-json'
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from './select-dropdown'
+import {toast} from './toast'
+import {Tooltip} from './tooltip'
+import {cn} from './utils'
 
 /**
  * Behavior rules for the recursive value editor, so it can serve both the
@@ -102,14 +96,14 @@ export function dagCborKeyCompare(a: string, b: string): number {
 }
 
 /** Entries of an object in canonical DAG-CBOR key order. */
-export function canonicalEntries(value: Record<string, unknown>, opts?: { hideNull?: boolean }): [string, unknown][] {
+export function canonicalEntries(value: Record<string, unknown>, opts?: {hideNull?: boolean}): [string, unknown][] {
   return Object.entries(value)
     .filter(([, v]) => v !== undefined && (!opts?.hideNull || v !== null))
     .sort(([a], [b]) => dagCborKeyCompare(a, b))
 }
 
 /** Rebuild a value with all nested object keys in canonical order (for JSON display). */
-export function toCanonicalOrder(value: unknown, opts?: { hideNull?: boolean }): unknown {
+export function toCanonicalOrder(value: unknown, opts?: {hideNull?: boolean}): unknown {
   if (Array.isArray(value)) return value.map((item) => toCanonicalOrder(item, opts))
   if (isPlainObject(value)) {
     return Object.fromEntries(canonicalEntries(value, opts).map(([k, v]) => [k, toCanonicalOrder(v, opts)]))
@@ -184,21 +178,21 @@ export function useValueHistory<T>(current: T) {
     redoStack.current = []
   }, [])
 
-  const undo = useCallback((): { value: T } | null => {
+  const undo = useCallback((): {value: T} | null => {
     if (undoStack.current.length === 0) return null
     const value = undoStack.current.pop()!
     redoStack.current.push(currentRef.current)
-    return { value }
+    return {value}
   }, [])
 
-  const redo = useCallback((): { value: T } | null => {
+  const redo = useCallback((): {value: T} | null => {
     if (redoStack.current.length === 0) return null
     const value = redoStack.current.pop()!
     undoStack.current.push(currentRef.current)
-    return { value }
+    return {value}
   }, [])
 
-  return { record, undo, redo }
+  return {record, undo, redo}
 }
 
 // ---------------------------------------------------------------------------
@@ -255,7 +249,7 @@ type SelectionActions = {
   navigate: (id: string, direction: NavDirection) => void
   /** Enter/Space on a row: toggle a container, else focus its first editor. */
   activate: (id: string) => void
-  openContextMenu: (position: { x: number; y: number }, actions: ContextMenuAction[]) => void
+  openContextMenu: (position: {x: number; y: number}, actions: ContextMenuAction[]) => void
 }
 
 /** Reactive tree state; changes here re-render rows (highlight, roving tab-stop). */
@@ -268,7 +262,7 @@ type SelectionState = {
 }
 
 const SelectionActionsContext = createContext<SelectionActions | null>(null)
-const SelectionStateContext = createContext<SelectionState>({ selectedId: null, tabbableId: null })
+const SelectionStateContext = createContext<SelectionState>({selectedId: null, tabbableId: null})
 
 function isEditableTarget(target: EventTarget | null): boolean {
   return target instanceof HTMLElement && !!target.closest('input,textarea,select,[contenteditable="true"]')
@@ -278,15 +272,13 @@ function isEditableTarget(target: EventTarget | null): boolean {
 function domOrderedRows(
   registry: Map<string, RowInfo>,
   elements: Map<string, HTMLElement>,
-): { id: string; info: RowInfo; element: HTMLElement }[] {
-  const rows: { id: string; info: RowInfo; element: HTMLElement }[] = []
+): {id: string; info: RowInfo; element: HTMLElement}[] {
+  const rows: {id: string; info: RowInfo; element: HTMLElement}[] = []
   registry.forEach((info, id) => {
     const element = elements.get(id)
-    if (element?.isConnected) rows.push({ id, info, element })
+    if (element?.isConnected) rows.push({id, info, element})
   })
-  rows.sort((a, b) =>
-    a.element.compareDocumentPosition(b.element) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1,
-  )
+  rows.sort((a, b) => (a.element.compareDocumentPosition(b.element) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1))
   return rows
 }
 
@@ -296,7 +288,7 @@ function isDescendantPath(child: ValuePath, parent: ValuePath): boolean {
 }
 
 /** Parse and validate clipboard-ish text for pasting. Non-JSON pastes as a string. */
-function parsePastedText(text: string, rules: ValueEditorRules): { value: unknown } | null {
+function parsePastedText(text: string, rules: ValueEditorRules): {value: unknown} | null {
   let parsed: unknown
   try {
     parsed = JSON.parse(text)
@@ -308,7 +300,7 @@ function parsePastedText(text: string, rules: ValueEditorRules): { value: unknow
     toast.error(`Cannot paste: ${problem}`)
     return null
   }
-  return { value: parsed }
+  return {value: parsed}
 }
 
 function copyValueToClipboard(value: unknown) {
@@ -357,7 +349,7 @@ export function ValueEditorProvider({
   const [selectedId, setSelectedId] = useState<string | null>(null)
   // The single tab-stop; defaults to the first row so Tab can enter the tree.
   const [tabbableId, setTabbableId] = useState<string | null>(null)
-  const [menu, setMenu] = useState<{ x: number; y: number; actions: ContextMenuAction[] } | null>(null)
+  const [menu, setMenu] = useState<{x: number; y: number; actions: ContextMenuAction[]} | null>(null)
   const registry = useRef(new Map<string, RowInfo>())
   const elements = useRef(new Map<string, HTMLElement>())
 
@@ -384,8 +376,8 @@ export function ValueEditorProvider({
       const rows = domOrderedRows(registry.current, elements.current)
       const idx = rows.findIndex((r) => r.id === id)
       if (idx < 0) return
-      const { info } = rows[idx]!
-      const go = (target?: { id: string }) => {
+      const {info} = rows[idx]!
+      const go = (target?: {id: string}) => {
         if (target) focusRow(target.id)
       }
       switch (direction) {
@@ -445,15 +437,15 @@ export function ValueEditorProvider({
       // fires on re-renders too — only touch the registry here. The `elements`
       // map is owned by the row's ref callback, which clears it on real unmount.
       registry.current.delete(id)
-      setTabbableId((cur) => (cur === id ? (registry.current.keys().next().value ?? null) : cur))
+      setTabbableId((cur) => (cur === id ? registry.current.keys().next().value ?? null : cur))
     },
     setElement: (id, element) => {
       if (element) elements.current.set(id, element)
       else elements.current.delete(id)
     },
-    openContextMenu: (position, menuActions) => setMenu({ ...position, actions: menuActions }),
+    openContextMenu: (position, menuActions) => setMenu({...position, actions: menuActions}),
   }).current
-  const state = useMemo<SelectionState>(() => ({ selectedId, tabbableId, openUrl }), [selectedId, tabbableId, openUrl])
+  const state = useMemo<SelectionState>(() => ({selectedId, tabbableId, openUrl}), [selectedId, tabbableId, openUrl])
 
   useEffect(() => {
     const getSelectedHandlers = () => {
@@ -531,7 +523,7 @@ export function ValueEditorProvider({
             }}
           >
             <div
-              className="flex absolute flex-col p-1 rounded-md border shadow-md bg-popover text-popover-foreground min-w-44"
+              className="bg-popover text-popover-foreground absolute flex min-w-44 flex-col rounded-md border p-1 shadow-md"
               style={{
                 left: Math.min(menu.x, typeof window !== 'undefined' ? window.innerWidth - 200 : menu.x),
                 top: Math.min(
@@ -590,7 +582,7 @@ function useRowSelection(
   },
 ) {
   const actions = useContext(SelectionActionsContext)
-  const { selectedId, tabbableId } = useContext(SelectionStateContext)
+  const {selectedId, tabbableId} = useContext(SelectionStateContext)
   const isSelected = selectedId === id
   const isTabbable = tabbableId === id
 
@@ -617,7 +609,7 @@ function useRowSelection(
   )
 
   if (!actions) {
-    return { isSelected: false, rowProps: {} as Record<string, never> }
+    return {isSelected: false, rowProps: {} as Record<string, never>}
   }
   const ctx = actions
 
@@ -626,7 +618,7 @@ function useRowSelection(
     role: 'treeitem' as const,
     tabIndex: isTabbable ? 0 : -1,
     'aria-selected': isSelected,
-    ...(row.isContainer ? { 'aria-expanded': !row.collapsed } : {}),
+    ...(row.isContainer ? {'aria-expanded': !row.collapsed} : {}),
     onFocus: (e: React.FocusEvent) => {
       // Selection follows focus — whether the row itself or any editor inside
       // it is focused (so tabbing between fields moves the highlight too). The
@@ -658,11 +650,11 @@ function useRowSelection(
       e.preventDefault()
       e.stopPropagation()
       ctx.focusRow(id)
-      ctx.openContextMenu({ x: e.clientX, y: e.clientY }, row.getMenuActions())
+      ctx.openContextMenu({x: e.clientX, y: e.clientY}, row.getMenuActions())
     },
   }
 
-  return { isSelected: !!isSelected, rowProps }
+  return {isSelected: !!isSelected, rowProps}
 }
 
 const ROW_CLASS = '-mx-1 rounded-md px-1 py-0.5 transition-colors'
@@ -721,13 +713,13 @@ function RowActionsMenu({
   )
 }
 
-function CollapseToggle({ collapsed, onToggle }: { collapsed: boolean; onToggle: () => void }) {
+function CollapseToggle({collapsed, onToggle}: {collapsed: boolean; onToggle: () => void}) {
   return (
     <button
       type="button"
       aria-label={collapsed ? 'Expand' : 'Collapse'}
       aria-expanded={!collapsed}
-      className="flex justify-center items-center text-muted-foreground hover:text-foreground size-4 shrink-0"
+      className="text-muted-foreground hover:text-foreground flex size-4 shrink-0 items-center justify-center"
       onClick={onToggle}
     >
       {collapsed ? <ChevronRight className="size-3.5" /> : <ChevronDown className="size-3.5" />}
@@ -752,28 +744,20 @@ function compactValuePreview(value: unknown, rules: ValueEditorRules): string {
     return `[${value.map((item) => compactValuePreview(item, rules)).join(' ')}]`
   }
   if (isPlainObject(value)) {
-    const entries = canonicalEntries(value, { hideNull: rules.hideNullEntries })
+    const entries = canonicalEntries(value, {hideNull: rules.hideNullEntries})
     return entries.map(([key, child]) => `${key}: ${compactValuePreview(child, rules)}`).join('   ')
   }
   return String(value)
 }
 
 /** Collapsed container: a one-line preview of the actual data; click to expand. */
-function CollapsedSummary({
-  value,
-  rules,
-  onExpand,
-}: {
-  value: unknown
-  rules: ValueEditorRules
-  onExpand: () => void
-}) {
+function CollapsedSummary({value, rules, onExpand}: {value: unknown; rules: ValueEditorRules; onExpand: () => void}) {
   const preview = compactValuePreview(value, rules)
   return (
     <button
       type="button"
       title={preview}
-      className="block overflow-hidden max-w-full font-mono text-xs text-left whitespace-pre transition-colors text-muted-foreground hover:text-foreground text-ellipsis"
+      className="text-muted-foreground hover:text-foreground block max-w-full overflow-hidden text-left font-mono text-xs text-ellipsis whitespace-pre transition-colors"
       onClick={onExpand}
     >
       {preview}
@@ -856,9 +840,9 @@ export function FieldRow({
   const isContainer = isEditableContainer(value)
   const [collapsed, setCollapsed] = useState(false)
   const [editing, setEditing] = useState(false)
-  const handlers: SelectionHandlers = { getValue: () => value, setValue: onValue, remove: onRemove, rules }
+  const handlers: SelectionHandlers = {getValue: () => value, setValue: onValue, remove: onRemove, rules}
   const getMenuActions = () => [
-    ...baseMenuActions({ value, handlers, isContainer, collapsed, setCollapsed }),
+    ...baseMenuActions({value, handlers, isContainer, collapsed, setCollapsed}),
     {
       key: 'edit',
       label: 'Edit field',
@@ -873,7 +857,7 @@ export function FieldRow({
       onClick: onRemove,
     },
   ]
-  const { isSelected, rowProps } = useRowSelection(pathId(path), {
+  const {isSelected, rowProps} = useRowSelection(pathId(path), {
     path,
     handlers,
     isContainer,
@@ -892,10 +876,10 @@ export function FieldRow({
         className,
       )}
     >
-      <div className="flex flex-col flex-1 gap-1 min-w-0">
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
         {/* Field name first so names align regardless of type; the collapse
             chevron sits after the name for containers. */}
-        <div className="flex gap-1 items-center">
+        <div className="flex items-center gap-1">
           <span className={cn(FIELD_LABEL_CLASS, 'truncate')} title={fieldKey}>
             {fieldKey}
           </span>
@@ -910,7 +894,7 @@ export function FieldRow({
         </div>
       </div>
       {/* Floating so nested rows keep their full width. */}
-      <div className="absolute right-0 top-1">
+      <div className="absolute top-1 right-0">
         <RowActionsMenu
           label={`Actions for ${fieldKey}`}
           getActions={getMenuActions}
@@ -941,10 +925,10 @@ export function FieldRow({
 // ---------------------------------------------------------------------------
 
 /** Read-only recursive rendering of a value. */
-export function ValueDisplay({ value, rules = CBOR_VALUE_RULES }: { value: unknown; rules?: ValueEditorRules }) {
+export function ValueDisplay({value, rules = CBOR_VALUE_RULES}: {value: unknown; rules?: ValueEditorRules}) {
   if (isDagJsonLink(value)) {
     return (
-      <span className="flex gap-1 items-center font-mono text-sm break-all">
+      <span className="flex items-center gap-1 font-mono text-sm break-all">
         <Link2 className="text-muted-foreground size-3.5 shrink-0" />
         {value['/']}
       </span>
@@ -964,12 +948,12 @@ export function ValueDisplay({ value, rules = CBOR_VALUE_RULES }: { value: unkno
     )
   }
   if (Array.isArray(value)) {
-    if (value.length === 0) return <p className="text-sm text-muted-foreground">Empty list</p>
+    if (value.length === 0) return <p className="text-muted-foreground text-sm">Empty list</p>
     return (
       <div className={NESTED_GROUP_CLASS}>
         {value.map((item, index) => (
-          <div key={index} className="flex gap-2 items-baseline">
-            <span className="font-mono text-xs text-muted-foreground">{index + 1}.</span>
+          <div key={index} className="flex items-baseline gap-2">
+            <span className="text-muted-foreground font-mono text-xs">{index + 1}.</span>
             <ValueDisplay value={item} rules={rules} />
           </div>
         ))}
@@ -977,8 +961,8 @@ export function ValueDisplay({ value, rules = CBOR_VALUE_RULES }: { value: unkno
     )
   }
   if (isPlainObject(value)) {
-    const entries = canonicalEntries(value, { hideNull: rules.hideNullEntries })
-    if (entries.length === 0) return <p className="text-sm text-muted-foreground">No fields</p>
+    const entries = canonicalEntries(value, {hideNull: rules.hideNullEntries})
+    if (entries.length === 0) return <p className="text-muted-foreground text-sm">No fields</p>
     return (
       <div className={NESTED_GROUP_CLASS}>
         {entries.map(([key, child]) => (
@@ -990,8 +974,8 @@ export function ValueDisplay({ value, rules = CBOR_VALUE_RULES }: { value: unkno
       </div>
     )
   }
-  if (value === '') return <span className="text-sm text-muted-foreground">(empty)</span>
-  return <span className="font-mono text-sm whitespace-pre-wrap break-words">{String(value)}</span>
+  if (value === '') return <span className="text-muted-foreground text-sm">(empty)</span>
+  return <span className="font-mono text-sm break-words whitespace-pre-wrap">{String(value)}</span>
 }
 
 /** Recursive type-aware editor for one value. */
@@ -1027,21 +1011,21 @@ export function ValueEditor({
   if (isPlainObject(value)) {
     return <ObjectEditor value={value} onValue={onValue} rules={rules} path={path} />
   }
-  return <span className="font-mono text-sm text-muted-foreground">{String(value)}</span>
+  return <span className="text-muted-foreground font-mono text-sm">{String(value)}</span>
 }
 
 /** String leaf: free-text input, committing on blur/Enter. */
-function StringLeafEditor({ value, onValue }: { value: string; onValue: (value: unknown) => void }) {
+function StringLeafEditor({value, onValue}: {value: string; onValue: (value: unknown) => void}) {
   return <CommitOnBlurInput key={value} initialValue={value} onCommit={(text) => onValue(text)} />
 }
 
 /** IPLD link (`{"/": cid}`): editable CID with validation and an open action. */
-function LinkValueEditor({ value, onValue }: { value: { '/': string }; onValue: (value: unknown) => void }) {
-  const { openUrl } = useContext(SelectionStateContext)
+function LinkValueEditor({value, onValue}: {value: {'/': string}; onValue: (value: unknown) => void}) {
+  const {openUrl} = useContext(SelectionStateContext)
   const cid = value['/']
   const isValid = !!parseCidString(cid)
   return (
-    <div className="flex gap-1 items-center">
+    <div className="flex items-center gap-1">
       <Tooltip content="IPLD link">
         <Link2 className={cn('size-3.5 shrink-0', isValid ? 'text-muted-foreground' : 'text-destructive')} />
       </Tooltip>
@@ -1055,7 +1039,7 @@ function LinkValueEditor({ value, onValue }: { value: { '/': string }; onValue: 
             toast.error('Not a valid CID')
             return
           }
-          onValue({ '/': next })
+          onValue({'/': next})
         }}
       />
       {openUrl && isValid && (
@@ -1076,7 +1060,7 @@ function LinkValueEditor({ value, onValue }: { value: { '/': string }; onValue: 
 }
 
 /** IPLD bytes (`{"/": {bytes}}`): size readout with download and replace-from-file. */
-function BytesValueEditor({ value, onValue }: { value: { '/': { bytes: string } }; onValue: (value: unknown) => void }) {
+function BytesValueEditor({value, onValue}: {value: {'/': {bytes: string}}; onValue: (value: unknown) => void}) {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const b64 = value['/'].bytes
   const size = useMemo(() => {
@@ -1089,7 +1073,7 @@ function BytesValueEditor({ value, onValue }: { value: { '/': { bytes: string } 
 
   const download = () => {
     const bytes = base64ToBytes(b64)
-    const url = URL.createObjectURL(new Blob([bytes as BlobPart], { type: 'application/octet-stream' }))
+    const url = URL.createObjectURL(new Blob([bytes as BlobPart], {type: 'application/octet-stream'}))
     const anchor = document.createElement('a')
     anchor.href = url
     anchor.download = 'bytes.bin'
@@ -1098,7 +1082,7 @@ function BytesValueEditor({ value, onValue }: { value: { '/': { bytes: string } 
   }
 
   return (
-    <div className="flex flex-wrap gap-1 items-center">
+    <div className="flex flex-wrap items-center gap-1">
       <span className={cn('font-mono text-sm', size === null && 'text-destructive')}>
         {size === null ? 'Invalid base64 data' : `${formatByteSize(size)} binary`}
       </span>
@@ -1136,7 +1120,7 @@ function BytesValueEditor({ value, onValue }: { value: { '/': { bytes: string } 
           if (!file) return
           file
             .arrayBuffer()
-            .then((buffer) => onValue({ '/': { bytes: bytesToBase64(new Uint8Array(buffer)) } }))
+            .then((buffer) => onValue({'/': {bytes: bytesToBase64(new Uint8Array(buffer))}}))
             .catch(() => toast.error('Failed to read file'))
         }}
       />
@@ -1159,12 +1143,12 @@ export function ObjectEditor({
   rules: ValueEditorRules
   path?: ValuePath
 }) {
-  const entries = canonicalEntries(value, { hideNull: rules.hideNullEntries })
+  const entries = canonicalEntries(value, {hideNull: rules.hideNullEntries})
   const removeKey = (key: string) => {
     if (rules.removeKeys === 'tombstone') {
-      onValue({ ...value, [key]: null })
+      onValue({...value, [key]: null})
     } else {
-      const next = { ...value }
+      const next = {...value}
       delete next[key]
       onValue(next)
     }
@@ -1174,13 +1158,13 @@ export function ObjectEditor({
   // the new key to the (already coerced) value.
   const editField = (key: string, newKey: string, newValue: unknown) => {
     if (newKey === key) {
-      onValue({ ...value, [key]: newValue })
+      onValue({...value, [key]: newValue})
       return
     }
     if (rules.removeKeys === 'tombstone') {
-      onValue({ ...value, [key]: null, [newKey]: newValue })
+      onValue({...value, [key]: null, [newKey]: newValue})
     } else {
-      const next = { ...value }
+      const next = {...value}
       delete next[key]
       next[newKey] = newValue
       onValue(next)
@@ -1188,14 +1172,14 @@ export function ObjectEditor({
   }
   return (
     <div className={NESTED_OBJECT_CLASS}>
-      {entries.length === 0 && <p className="text-sm text-muted-foreground">No fields</p>}
+      {entries.length === 0 && <p className="text-muted-foreground text-sm">No fields</p>}
       {entries.map(([key, child]) => (
         <FieldRow
           key={key}
           fieldKey={key}
           value={child}
           siblingKeys={entries.map(([k]) => k).filter((k) => k !== key)}
-          onValue={(newChild) => onValue({ ...value, [key]: newChild })}
+          onValue={(newChild) => onValue({...value, [key]: newChild})}
           onEditField={(newKey, newValue) => editField(key, newKey, newValue)}
           onRemove={() => removeKey(key)}
           rules={rules}
@@ -1206,7 +1190,7 @@ export function ObjectEditor({
         compact
         rules={rules}
         existingKeys={entries.map(([key]) => key)}
-        onAdd={(key, newChild) => onValue({ ...value, [key]: newChild })}
+        onAdd={(key, newChild) => onValue({...value, [key]: newChild})}
       />
     </div>
   )
@@ -1240,7 +1224,7 @@ export function ListEditor({
   }
   return (
     <div className={NESTED_GROUP_CLASS}>
-      {value.length === 0 && <p className="text-sm text-muted-foreground">Empty list</p>}
+      {value.length === 0 && <p className="text-muted-foreground text-sm">Empty list</p>}
       {value.map((item, index) => (
         <ListItemRow
           key={index}
@@ -1312,9 +1296,9 @@ function ListItemRow({
   const isContainer = isEditableContainer(item)
   const [collapsed, setCollapsed] = useState(false)
   const [editing, setEditing] = useState(false)
-  const handlers: SelectionHandlers = { getValue: () => item, setValue: onItem, remove: onRemove, rules }
+  const handlers: SelectionHandlers = {getValue: () => item, setValue: onItem, remove: onRemove, rules}
   const getMenuActions = () => [
-    ...baseMenuActions({ value: item, handlers, isContainer, collapsed, setCollapsed }),
+    ...baseMenuActions({value: item, handlers, isContainer, collapsed, setCollapsed}),
     {
       key: 'edit-type',
       label: 'Edit type',
@@ -1329,23 +1313,23 @@ function ListItemRow({
     },
     ...(index > 0
       ? [
-        {
-          key: 'move-up',
-          label: 'Move up',
-          icon: <ArrowUp className="size-4" />,
-          onClick: () => onMove(index, index - 1),
-        },
-      ]
+          {
+            key: 'move-up',
+            label: 'Move up',
+            icon: <ArrowUp className="size-4" />,
+            onClick: () => onMove(index, index - 1),
+          },
+        ]
       : []),
     ...(index < count - 1
       ? [
-        {
-          key: 'move-down',
-          label: 'Move down',
-          icon: <ArrowDown className="size-4" />,
-          onClick: () => onMove(index, index + 1),
-        },
-      ]
+          {
+            key: 'move-down',
+            label: 'Move down',
+            icon: <ArrowDown className="size-4" />,
+            onClick: () => onMove(index, index + 1),
+          },
+        ]
       : []),
     {
       key: 'remove',
@@ -1355,7 +1339,7 @@ function ListItemRow({
       onClick: onRemove,
     },
   ]
-  const { isSelected, rowProps } = useRowSelection(pathId(path), {
+  const {isSelected, rowProps} = useRowSelection(pathId(path), {
     path,
     handlers,
     isContainer,
@@ -1409,9 +1393,9 @@ function ListItemRow({
         ) : (
           <span className="size-4 shrink-0" />
         )}
-        <span className="font-mono text-xs text-muted-foreground">{index + 1}.</span>
+        <span className="text-muted-foreground font-mono text-xs">{index + 1}.</span>
       </div>
-      <div className="flex-1 min-w-0">
+      <div className="min-w-0 flex-1">
         {isContainer && collapsed ? (
           <div className="pt-1">
             <CollapsedSummary value={item} rules={rules} onExpand={() => setCollapsed(false)} />
@@ -1421,7 +1405,7 @@ function ListItemRow({
         )}
       </div>
       {/* Floating so nested rows keep their full width. */}
-      <div className="absolute right-0 top-1">
+      <div className="absolute top-1 right-0">
         <RowActionsMenu
           label={`Actions for item ${index + 1}`}
           getActions={getMenuActions}
@@ -1492,7 +1476,7 @@ function NumberInput({
           if (e.key === 'Escape') setText(initial)
         }}
       />
-      {error && <p className="text-xs text-destructive">{error}</p>}
+      {error && <p className="text-destructive text-xs">{error}</p>}
     </div>
   )
 }
@@ -1584,9 +1568,9 @@ function defaultValueForType(type: NewFieldType): unknown {
     case 'null':
       return null
     case 'link':
-      return { '/': '' }
+      return {'/': ''}
     case 'bytes':
-      return { '/': { bytes: '' } }
+      return {'/': {bytes: ''}}
   }
 }
 
@@ -1620,9 +1604,9 @@ export function coerceFieldValue(value: unknown, toType: NewFieldType, rules: Va
     case 'link':
       if (typeof value === 'string') {
         const cid = value.trim().replace(/^ipfs:\/\//, '')
-        if (parseCidString(cid)) return { '/': cid }
+        if (parseCidString(cid)) return {'/': cid}
       }
-      return { '/': '' }
+      return {'/': ''}
     case 'object':
     case 'list':
     case 'bytes':
@@ -1714,7 +1698,7 @@ function FieldDialog({
         <div className="flex flex-col gap-3">
           {!itemMode && (
             <div className="flex flex-col gap-1">
-              <label htmlFor="field-dialog-name" className="text-xs text-muted-foreground">
+              <label htmlFor="field-dialog-name" className="text-muted-foreground text-xs">
                 Field name
               </label>
               <Input
@@ -1733,7 +1717,7 @@ function FieldDialog({
             </div>
           )}
           <div className="flex flex-col gap-1">
-            <label className="text-xs text-muted-foreground">Type</label>
+            <label className="text-muted-foreground text-xs">Type</label>
             <Select value={type} onValueChange={(v) => setType(v as NewFieldType)}>
               <SelectTrigger>
                 <SelectValue />
@@ -1747,7 +1731,7 @@ function FieldDialog({
               </SelectContent>
             </Select>
           </div>
-          {error && <p className="text-xs text-destructive">{error}</p>}
+          {error && <p className="text-destructive text-xs">{error}</p>}
         </div>
         <DialogFooter>
           <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>

--- a/frontend/packages/ui/src/value-editor.tsx
+++ b/frontend/packages/ui/src/value-editor.tsx
@@ -159,6 +159,8 @@ export function findInvalidValue(value: unknown, rules: ValueEditorRules, path: 
 // No text-transform: keys are case-sensitive data, so they display verbatim.
 export const FIELD_LABEL_CLASS = 'text-muted-foreground text-xs font-medium'
 const NESTED_GROUP_CLASS = 'border-border ml-1 flex flex-col gap-1 border-l-2 pl-3'
+// Expanded objects get a boxed treatment (border + slight fill) so their extent is clear.
+const NESTED_OBJECT_CLASS = 'border-border bg-muted/40 flex flex-col gap-1 rounded-md border px-3 py-2'
 
 // ---------------------------------------------------------------------------
 // Undo history
@@ -541,11 +543,11 @@ function compactValuePreview(value: unknown, rules: ValueEditorRules): string {
     }
   }
   if (Array.isArray(value)) {
-    return `[${value.map((item) => compactValuePreview(item, rules)).join(', ')}]`
+    return `[${value.map((item) => compactValuePreview(item, rules)).join(' ')}]`
   }
   if (isPlainObject(value)) {
     const entries = canonicalEntries(value, {hideNull: rules.hideNullEntries})
-    return `{${entries.map(([key, child]) => `${key}: ${compactValuePreview(child, rules)}`).join(', ')}}`
+    return entries.map(([key, child]) => `${key}: ${compactValuePreview(child, rules)}`).join('   ')
   }
   return String(value)
 }
@@ -565,7 +567,7 @@ function CollapsedSummary({
     <button
       type="button"
       title={preview}
-      className="text-muted-foreground hover:text-foreground block max-w-full truncate text-left font-mono text-xs transition-colors"
+      className="text-muted-foreground hover:text-foreground block max-w-full overflow-hidden text-left font-mono text-xs text-ellipsis whitespace-pre transition-colors"
       onClick={onExpand}
     >
       {preview}
@@ -971,7 +973,7 @@ export function ObjectEditor({
     }
   }
   return (
-    <div className={NESTED_GROUP_CLASS}>
+    <div className={NESTED_OBJECT_CLASS}>
       {entries.length === 0 && <p className="text-muted-foreground text-sm">No fields</p>}
       {entries.map(([key, child]) => (
         <FieldRow

--- a/frontend/packages/ui/src/value-editor.tsx
+++ b/frontend/packages/ui/src/value-editor.tsx
@@ -653,16 +653,14 @@ export function FieldRow({
     >
       <div className="flex min-w-0 flex-1 flex-col gap-1">
         <div className="flex items-center gap-1">
-          {isContainer ? (
-            <CollapseToggle collapsed={collapsed} onToggle={() => setCollapsed((c) => !c)} />
-          ) : (
-            <span className="size-4 shrink-0" />
-          )}
+          {isContainer && <CollapseToggle collapsed={collapsed} onToggle={() => setCollapsed((c) => !c)} />}
           <span className={cn(FIELD_LABEL_CLASS, 'truncate')} title={fieldKey}>
             {fieldKey}
           </span>
         </div>
-        <div className="pl-5">
+        {/* Indent the value under the collapse toggle only for containers; flat
+            scalar fields stay flush-left so the attributes list aligns. */}
+        <div className={isContainer ? 'pl-5' : undefined}>
           {isContainer && collapsed ? (
             <CollapsedSummary value={value} onExpand={() => setCollapsed(false)} />
           ) : (

--- a/frontend/packages/ui/src/value-editor.tsx
+++ b/frontend/packages/ui/src/value-editor.tsx
@@ -19,8 +19,8 @@ import {
   Plus,
   X,
 } from 'lucide-react'
-import {createContext, useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react'
-import {Button} from './button'
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { Button } from './button'
 import {
   Dialog,
   DialogContent,
@@ -28,14 +28,14 @@ import {
   DialogHeader,
   DialogTitle,
 } from './components/dialog'
-import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from './components/dropdown-menu'
-import {Input} from './components/input'
-import {Switch} from './components/switch'
-import {base64ToBytes, bytesToBase64, formatByteSize, isDagJsonBytes, isDagJsonLink, parseCidString} from './dag-json'
-import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from './select-dropdown'
-import {toast} from './toast'
-import {Tooltip} from './tooltip'
-import {cn} from './utils'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './components/dropdown-menu'
+import { Input } from './components/input'
+import { Switch } from './components/switch'
+import { base64ToBytes, bytesToBase64, formatByteSize, isDagJsonBytes, isDagJsonLink, parseCidString } from './dag-json'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './select-dropdown'
+import { toast } from './toast'
+import { Tooltip } from './tooltip'
+import { cn } from './utils'
 
 /**
  * Behavior rules for the recursive value editor, so it can serve both the
@@ -102,14 +102,14 @@ export function dagCborKeyCompare(a: string, b: string): number {
 }
 
 /** Entries of an object in canonical DAG-CBOR key order. */
-export function canonicalEntries(value: Record<string, unknown>, opts?: {hideNull?: boolean}): [string, unknown][] {
+export function canonicalEntries(value: Record<string, unknown>, opts?: { hideNull?: boolean }): [string, unknown][] {
   return Object.entries(value)
     .filter(([, v]) => v !== undefined && (!opts?.hideNull || v !== null))
     .sort(([a], [b]) => dagCborKeyCompare(a, b))
 }
 
 /** Rebuild a value with all nested object keys in canonical order (for JSON display). */
-export function toCanonicalOrder(value: unknown, opts?: {hideNull?: boolean}): unknown {
+export function toCanonicalOrder(value: unknown, opts?: { hideNull?: boolean }): unknown {
   if (Array.isArray(value)) return value.map((item) => toCanonicalOrder(item, opts))
   if (isPlainObject(value)) {
     return Object.fromEntries(canonicalEntries(value, opts).map(([k, v]) => [k, toCanonicalOrder(v, opts)]))
@@ -184,21 +184,21 @@ export function useValueHistory<T>(current: T) {
     redoStack.current = []
   }, [])
 
-  const undo = useCallback((): {value: T} | null => {
+  const undo = useCallback((): { value: T } | null => {
     if (undoStack.current.length === 0) return null
     const value = undoStack.current.pop()!
     redoStack.current.push(currentRef.current)
-    return {value}
+    return { value }
   }, [])
 
-  const redo = useCallback((): {value: T} | null => {
+  const redo = useCallback((): { value: T } | null => {
     if (redoStack.current.length === 0) return null
     const value = redoStack.current.pop()!
     undoStack.current.push(currentRef.current)
-    return {value}
+    return { value }
   }, [])
 
-  return {record, undo, redo}
+  return { record, undo, redo }
 }
 
 // ---------------------------------------------------------------------------
@@ -255,7 +255,7 @@ type SelectionActions = {
   navigate: (id: string, direction: NavDirection) => void
   /** Enter/Space on a row: toggle a container, else focus its first editor. */
   activate: (id: string) => void
-  openContextMenu: (position: {x: number; y: number}, actions: ContextMenuAction[]) => void
+  openContextMenu: (position: { x: number; y: number }, actions: ContextMenuAction[]) => void
 }
 
 /** Reactive tree state; changes here re-render rows (highlight, roving tab-stop). */
@@ -268,7 +268,7 @@ type SelectionState = {
 }
 
 const SelectionActionsContext = createContext<SelectionActions | null>(null)
-const SelectionStateContext = createContext<SelectionState>({selectedId: null, tabbableId: null})
+const SelectionStateContext = createContext<SelectionState>({ selectedId: null, tabbableId: null })
 
 function isEditableTarget(target: EventTarget | null): boolean {
   return target instanceof HTMLElement && !!target.closest('input,textarea,select,[contenteditable="true"]')
@@ -278,11 +278,11 @@ function isEditableTarget(target: EventTarget | null): boolean {
 function domOrderedRows(
   registry: Map<string, RowInfo>,
   elements: Map<string, HTMLElement>,
-): {id: string; info: RowInfo; element: HTMLElement}[] {
-  const rows: {id: string; info: RowInfo; element: HTMLElement}[] = []
+): { id: string; info: RowInfo; element: HTMLElement }[] {
+  const rows: { id: string; info: RowInfo; element: HTMLElement }[] = []
   registry.forEach((info, id) => {
     const element = elements.get(id)
-    if (element?.isConnected) rows.push({id, info, element})
+    if (element?.isConnected) rows.push({ id, info, element })
   })
   rows.sort((a, b) =>
     a.element.compareDocumentPosition(b.element) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1,
@@ -296,7 +296,7 @@ function isDescendantPath(child: ValuePath, parent: ValuePath): boolean {
 }
 
 /** Parse and validate clipboard-ish text for pasting. Non-JSON pastes as a string. */
-function parsePastedText(text: string, rules: ValueEditorRules): {value: unknown} | null {
+function parsePastedText(text: string, rules: ValueEditorRules): { value: unknown } | null {
   let parsed: unknown
   try {
     parsed = JSON.parse(text)
@@ -308,7 +308,7 @@ function parsePastedText(text: string, rules: ValueEditorRules): {value: unknown
     toast.error(`Cannot paste: ${problem}`)
     return null
   }
-  return {value: parsed}
+  return { value: parsed }
 }
 
 function copyValueToClipboard(value: unknown) {
@@ -357,7 +357,7 @@ export function ValueEditorProvider({
   const [selectedId, setSelectedId] = useState<string | null>(null)
   // The single tab-stop; defaults to the first row so Tab can enter the tree.
   const [tabbableId, setTabbableId] = useState<string | null>(null)
-  const [menu, setMenu] = useState<{x: number; y: number; actions: ContextMenuAction[]} | null>(null)
+  const [menu, setMenu] = useState<{ x: number; y: number; actions: ContextMenuAction[] } | null>(null)
   const registry = useRef(new Map<string, RowInfo>())
   const elements = useRef(new Map<string, HTMLElement>())
 
@@ -384,8 +384,8 @@ export function ValueEditorProvider({
       const rows = domOrderedRows(registry.current, elements.current)
       const idx = rows.findIndex((r) => r.id === id)
       if (idx < 0) return
-      const {info} = rows[idx]!
-      const go = (target?: {id: string}) => {
+      const { info } = rows[idx]!
+      const go = (target?: { id: string }) => {
         if (target) focusRow(target.id)
       }
       switch (direction) {
@@ -451,9 +451,9 @@ export function ValueEditorProvider({
       if (element) elements.current.set(id, element)
       else elements.current.delete(id)
     },
-    openContextMenu: (position, menuActions) => setMenu({...position, actions: menuActions}),
+    openContextMenu: (position, menuActions) => setMenu({ ...position, actions: menuActions }),
   }).current
-  const state = useMemo<SelectionState>(() => ({selectedId, tabbableId, openUrl}), [selectedId, tabbableId, openUrl])
+  const state = useMemo<SelectionState>(() => ({ selectedId, tabbableId, openUrl }), [selectedId, tabbableId, openUrl])
 
   useEffect(() => {
     const getSelectedHandlers = () => {
@@ -522,43 +522,43 @@ export function ValueEditorProvider({
       <SelectionStateContext.Provider value={state}>
         {children}
         {menu && (
-        <div
-          className="fixed inset-0 z-[100]"
-          onClick={() => setMenu(null)}
-          onContextMenu={(e) => {
-            e.preventDefault()
-            setMenu(null)
-          }}
-        >
           <div
-            className="bg-popover text-popover-foreground absolute flex min-w-44 flex-col rounded-md border p-1 shadow-md"
-            style={{
-              left: Math.min(menu.x, typeof window !== 'undefined' ? window.innerWidth - 200 : menu.x),
-              top: Math.min(
-                menu.y,
-                typeof window !== 'undefined' ? window.innerHeight - menu.actions.length * 34 - 12 : menu.y,
-              ),
+            className="fixed inset-0 z-[100]"
+            onClick={() => setMenu(null)}
+            onContextMenu={(e) => {
+              e.preventDefault()
+              setMenu(null)
             }}
           >
-            {menu.actions.map((action) => (
-              <button
-                key={action.key}
-                type="button"
-                className={cn(
-                  'hover:bg-accent flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm transition-colors',
-                  action.destructive && 'text-destructive',
-                )}
-                onClick={() => {
-                  setMenu(null)
-                  action.onClick()
-                }}
-              >
-                {action.icon}
-                {action.label}
-              </button>
-            ))}
+            <div
+              className="flex absolute flex-col p-1 rounded-md border shadow-md bg-popover text-popover-foreground min-w-44"
+              style={{
+                left: Math.min(menu.x, typeof window !== 'undefined' ? window.innerWidth - 200 : menu.x),
+                top: Math.min(
+                  menu.y,
+                  typeof window !== 'undefined' ? window.innerHeight - menu.actions.length * 34 - 12 : menu.y,
+                ),
+              }}
+            >
+              {menu.actions.map((action) => (
+                <button
+                  key={action.key}
+                  type="button"
+                  className={cn(
+                    'hover:bg-accent flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm transition-colors',
+                    action.destructive && 'text-destructive',
+                  )}
+                  onClick={() => {
+                    setMenu(null)
+                    action.onClick()
+                  }}
+                >
+                  {action.icon}
+                  {action.label}
+                </button>
+              ))}
+            </div>
           </div>
-        </div>
         )}
       </SelectionStateContext.Provider>
     </SelectionActionsContext.Provider>
@@ -590,7 +590,7 @@ function useRowSelection(
   },
 ) {
   const actions = useContext(SelectionActionsContext)
-  const {selectedId, tabbableId} = useContext(SelectionStateContext)
+  const { selectedId, tabbableId } = useContext(SelectionStateContext)
   const isSelected = selectedId === id
   const isTabbable = tabbableId === id
 
@@ -617,7 +617,7 @@ function useRowSelection(
   )
 
   if (!actions) {
-    return {isSelected: false, rowProps: {} as Record<string, never>}
+    return { isSelected: false, rowProps: {} as Record<string, never> }
   }
   const ctx = actions
 
@@ -626,7 +626,7 @@ function useRowSelection(
     role: 'treeitem' as const,
     tabIndex: isTabbable ? 0 : -1,
     'aria-selected': isSelected,
-    ...(row.isContainer ? {'aria-expanded': !row.collapsed} : {}),
+    ...(row.isContainer ? { 'aria-expanded': !row.collapsed } : {}),
     onFocus: (e: React.FocusEvent) => {
       // Selection follows focus — whether the row itself or any editor inside
       // it is focused (so tabbing between fields moves the highlight too). The
@@ -658,11 +658,11 @@ function useRowSelection(
       e.preventDefault()
       e.stopPropagation()
       ctx.focusRow(id)
-      ctx.openContextMenu({x: e.clientX, y: e.clientY}, row.getMenuActions())
+      ctx.openContextMenu({ x: e.clientX, y: e.clientY }, row.getMenuActions())
     },
   }
 
-  return {isSelected: !!isSelected, rowProps}
+  return { isSelected: !!isSelected, rowProps }
 }
 
 const ROW_CLASS = '-mx-1 rounded-md px-1 py-0.5 transition-colors'
@@ -721,13 +721,13 @@ function RowActionsMenu({
   )
 }
 
-function CollapseToggle({collapsed, onToggle}: {collapsed: boolean; onToggle: () => void}) {
+function CollapseToggle({ collapsed, onToggle }: { collapsed: boolean; onToggle: () => void }) {
   return (
     <button
       type="button"
       aria-label={collapsed ? 'Expand' : 'Collapse'}
       aria-expanded={!collapsed}
-      className="text-muted-foreground hover:text-foreground flex size-4 shrink-0 items-center justify-center"
+      className="flex justify-center items-center text-muted-foreground hover:text-foreground size-4 shrink-0"
       onClick={onToggle}
     >
       {collapsed ? <ChevronRight className="size-3.5" /> : <ChevronDown className="size-3.5" />}
@@ -752,7 +752,7 @@ function compactValuePreview(value: unknown, rules: ValueEditorRules): string {
     return `[${value.map((item) => compactValuePreview(item, rules)).join(' ')}]`
   }
   if (isPlainObject(value)) {
-    const entries = canonicalEntries(value, {hideNull: rules.hideNullEntries})
+    const entries = canonicalEntries(value, { hideNull: rules.hideNullEntries })
     return entries.map(([key, child]) => `${key}: ${compactValuePreview(child, rules)}`).join('   ')
   }
   return String(value)
@@ -773,7 +773,7 @@ function CollapsedSummary({
     <button
       type="button"
       title={preview}
-      className="text-muted-foreground hover:text-foreground block max-w-full overflow-hidden text-left font-mono text-xs text-ellipsis whitespace-pre transition-colors"
+      className="block overflow-hidden max-w-full font-mono text-xs text-left whitespace-pre transition-colors text-muted-foreground hover:text-foreground text-ellipsis"
       onClick={onExpand}
     >
       {preview}
@@ -856,9 +856,9 @@ export function FieldRow({
   const isContainer = isEditableContainer(value)
   const [collapsed, setCollapsed] = useState(false)
   const [editing, setEditing] = useState(false)
-  const handlers: SelectionHandlers = {getValue: () => value, setValue: onValue, remove: onRemove, rules}
+  const handlers: SelectionHandlers = { getValue: () => value, setValue: onValue, remove: onRemove, rules }
   const getMenuActions = () => [
-    ...baseMenuActions({value, handlers, isContainer, collapsed, setCollapsed}),
+    ...baseMenuActions({ value, handlers, isContainer, collapsed, setCollapsed }),
     {
       key: 'edit',
       label: 'Edit field',
@@ -873,7 +873,7 @@ export function FieldRow({
       onClick: onRemove,
     },
   ]
-  const {isSelected, rowProps} = useRowSelection(pathId(path), {
+  const { isSelected, rowProps } = useRowSelection(pathId(path), {
     path,
     handlers,
     isContainer,
@@ -892,10 +892,10 @@ export function FieldRow({
         className,
       )}
     >
-      <div className="flex min-w-0 flex-1 flex-col gap-1">
+      <div className="flex flex-col flex-1 gap-1 min-w-0">
         {/* Field name first so names align regardless of type; the collapse
             chevron sits after the name for containers. */}
-        <div className="flex items-center gap-1">
+        <div className="flex gap-1 items-center">
           <span className={cn(FIELD_LABEL_CLASS, 'truncate')} title={fieldKey}>
             {fieldKey}
           </span>
@@ -910,7 +910,7 @@ export function FieldRow({
         </div>
       </div>
       {/* Floating so nested rows keep their full width. */}
-      <div className="absolute top-1 right-0">
+      <div className="absolute right-0 top-1">
         <RowActionsMenu
           label={`Actions for ${fieldKey}`}
           getActions={getMenuActions}
@@ -941,10 +941,10 @@ export function FieldRow({
 // ---------------------------------------------------------------------------
 
 /** Read-only recursive rendering of a value. */
-export function ValueDisplay({value, rules = CBOR_VALUE_RULES}: {value: unknown; rules?: ValueEditorRules}) {
+export function ValueDisplay({ value, rules = CBOR_VALUE_RULES }: { value: unknown; rules?: ValueEditorRules }) {
   if (isDagJsonLink(value)) {
     return (
-      <span className="flex items-center gap-1 font-mono text-sm break-all">
+      <span className="flex gap-1 items-center font-mono text-sm break-all">
         <Link2 className="text-muted-foreground size-3.5 shrink-0" />
         {value['/']}
       </span>
@@ -964,12 +964,12 @@ export function ValueDisplay({value, rules = CBOR_VALUE_RULES}: {value: unknown;
     )
   }
   if (Array.isArray(value)) {
-    if (value.length === 0) return <p className="text-muted-foreground text-sm">Empty list</p>
+    if (value.length === 0) return <p className="text-sm text-muted-foreground">Empty list</p>
     return (
       <div className={NESTED_GROUP_CLASS}>
         {value.map((item, index) => (
-          <div key={index} className="flex items-baseline gap-2">
-            <span className="text-muted-foreground font-mono text-xs">{index + 1}.</span>
+          <div key={index} className="flex gap-2 items-baseline">
+            <span className="font-mono text-xs text-muted-foreground">{index + 1}.</span>
             <ValueDisplay value={item} rules={rules} />
           </div>
         ))}
@@ -977,8 +977,8 @@ export function ValueDisplay({value, rules = CBOR_VALUE_RULES}: {value: unknown;
     )
   }
   if (isPlainObject(value)) {
-    const entries = canonicalEntries(value, {hideNull: rules.hideNullEntries})
-    if (entries.length === 0) return <p className="text-muted-foreground text-sm">No fields</p>
+    const entries = canonicalEntries(value, { hideNull: rules.hideNullEntries })
+    if (entries.length === 0) return <p className="text-sm text-muted-foreground">No fields</p>
     return (
       <div className={NESTED_GROUP_CLASS}>
         {entries.map(([key, child]) => (
@@ -990,8 +990,8 @@ export function ValueDisplay({value, rules = CBOR_VALUE_RULES}: {value: unknown;
       </div>
     )
   }
-  if (value === '') return <span className="text-muted-foreground text-sm">(empty)</span>
-  return <span className="font-mono text-sm break-words whitespace-pre-wrap">{String(value)}</span>
+  if (value === '') return <span className="text-sm text-muted-foreground">(empty)</span>
+  return <span className="font-mono text-sm whitespace-pre-wrap break-words">{String(value)}</span>
 }
 
 /** Recursive type-aware editor for one value. */
@@ -1027,21 +1027,21 @@ export function ValueEditor({
   if (isPlainObject(value)) {
     return <ObjectEditor value={value} onValue={onValue} rules={rules} path={path} />
   }
-  return <span className="text-muted-foreground font-mono text-sm">{String(value)}</span>
+  return <span className="font-mono text-sm text-muted-foreground">{String(value)}</span>
 }
 
 /** String leaf: free-text input, committing on blur/Enter. */
-function StringLeafEditor({value, onValue}: {value: string; onValue: (value: unknown) => void}) {
+function StringLeafEditor({ value, onValue }: { value: string; onValue: (value: unknown) => void }) {
   return <CommitOnBlurInput key={value} initialValue={value} onCommit={(text) => onValue(text)} />
 }
 
 /** IPLD link (`{"/": cid}`): editable CID with validation and an open action. */
-function LinkValueEditor({value, onValue}: {value: {'/': string}; onValue: (value: unknown) => void}) {
-  const {openUrl} = useContext(SelectionStateContext)
+function LinkValueEditor({ value, onValue }: { value: { '/': string }; onValue: (value: unknown) => void }) {
+  const { openUrl } = useContext(SelectionStateContext)
   const cid = value['/']
   const isValid = !!parseCidString(cid)
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex gap-1 items-center">
       <Tooltip content="IPLD link">
         <Link2 className={cn('size-3.5 shrink-0', isValid ? 'text-muted-foreground' : 'text-destructive')} />
       </Tooltip>
@@ -1055,7 +1055,7 @@ function LinkValueEditor({value, onValue}: {value: {'/': string}; onValue: (valu
             toast.error('Not a valid CID')
             return
           }
-          onValue({'/': next})
+          onValue({ '/': next })
         }}
       />
       {openUrl && isValid && (
@@ -1076,7 +1076,7 @@ function LinkValueEditor({value, onValue}: {value: {'/': string}; onValue: (valu
 }
 
 /** IPLD bytes (`{"/": {bytes}}`): size readout with download and replace-from-file. */
-function BytesValueEditor({value, onValue}: {value: {'/': {bytes: string}}; onValue: (value: unknown) => void}) {
+function BytesValueEditor({ value, onValue }: { value: { '/': { bytes: string } }; onValue: (value: unknown) => void }) {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const b64 = value['/'].bytes
   const size = useMemo(() => {
@@ -1089,7 +1089,7 @@ function BytesValueEditor({value, onValue}: {value: {'/': {bytes: string}}; onVa
 
   const download = () => {
     const bytes = base64ToBytes(b64)
-    const url = URL.createObjectURL(new Blob([bytes as BlobPart], {type: 'application/octet-stream'}))
+    const url = URL.createObjectURL(new Blob([bytes as BlobPart], { type: 'application/octet-stream' }))
     const anchor = document.createElement('a')
     anchor.href = url
     anchor.download = 'bytes.bin'
@@ -1098,7 +1098,7 @@ function BytesValueEditor({value, onValue}: {value: {'/': {bytes: string}}; onVa
   }
 
   return (
-    <div className="flex flex-wrap items-center gap-1">
+    <div className="flex flex-wrap gap-1 items-center">
       <span className={cn('font-mono text-sm', size === null && 'text-destructive')}>
         {size === null ? 'Invalid base64 data' : `${formatByteSize(size)} binary`}
       </span>
@@ -1136,7 +1136,7 @@ function BytesValueEditor({value, onValue}: {value: {'/': {bytes: string}}; onVa
           if (!file) return
           file
             .arrayBuffer()
-            .then((buffer) => onValue({'/': {bytes: bytesToBase64(new Uint8Array(buffer))}}))
+            .then((buffer) => onValue({ '/': { bytes: bytesToBase64(new Uint8Array(buffer)) } }))
             .catch(() => toast.error('Failed to read file'))
         }}
       />
@@ -1159,12 +1159,12 @@ export function ObjectEditor({
   rules: ValueEditorRules
   path?: ValuePath
 }) {
-  const entries = canonicalEntries(value, {hideNull: rules.hideNullEntries})
+  const entries = canonicalEntries(value, { hideNull: rules.hideNullEntries })
   const removeKey = (key: string) => {
     if (rules.removeKeys === 'tombstone') {
-      onValue({...value, [key]: null})
+      onValue({ ...value, [key]: null })
     } else {
-      const next = {...value}
+      const next = { ...value }
       delete next[key]
       onValue(next)
     }
@@ -1174,13 +1174,13 @@ export function ObjectEditor({
   // the new key to the (already coerced) value.
   const editField = (key: string, newKey: string, newValue: unknown) => {
     if (newKey === key) {
-      onValue({...value, [key]: newValue})
+      onValue({ ...value, [key]: newValue })
       return
     }
     if (rules.removeKeys === 'tombstone') {
-      onValue({...value, [key]: null, [newKey]: newValue})
+      onValue({ ...value, [key]: null, [newKey]: newValue })
     } else {
-      const next = {...value}
+      const next = { ...value }
       delete next[key]
       next[newKey] = newValue
       onValue(next)
@@ -1188,14 +1188,14 @@ export function ObjectEditor({
   }
   return (
     <div className={NESTED_OBJECT_CLASS}>
-      {entries.length === 0 && <p className="text-muted-foreground text-sm">No fields</p>}
+      {entries.length === 0 && <p className="text-sm text-muted-foreground">No fields</p>}
       {entries.map(([key, child]) => (
         <FieldRow
           key={key}
           fieldKey={key}
           value={child}
           siblingKeys={entries.map(([k]) => k).filter((k) => k !== key)}
-          onValue={(newChild) => onValue({...value, [key]: newChild})}
+          onValue={(newChild) => onValue({ ...value, [key]: newChild })}
           onEditField={(newKey, newValue) => editField(key, newKey, newValue)}
           onRemove={() => removeKey(key)}
           rules={rules}
@@ -1206,7 +1206,7 @@ export function ObjectEditor({
         compact
         rules={rules}
         existingKeys={entries.map(([key]) => key)}
-        onAdd={(key, newChild) => onValue({...value, [key]: newChild})}
+        onAdd={(key, newChild) => onValue({ ...value, [key]: newChild })}
       />
     </div>
   )
@@ -1240,7 +1240,7 @@ export function ListEditor({
   }
   return (
     <div className={NESTED_GROUP_CLASS}>
-      {value.length === 0 && <p className="text-muted-foreground text-sm">Empty list</p>}
+      {value.length === 0 && <p className="text-sm text-muted-foreground">Empty list</p>}
       {value.map((item, index) => (
         <ListItemRow
           key={index}
@@ -1312,9 +1312,9 @@ function ListItemRow({
   const isContainer = isEditableContainer(item)
   const [collapsed, setCollapsed] = useState(false)
   const [editing, setEditing] = useState(false)
-  const handlers: SelectionHandlers = {getValue: () => item, setValue: onItem, remove: onRemove, rules}
+  const handlers: SelectionHandlers = { getValue: () => item, setValue: onItem, remove: onRemove, rules }
   const getMenuActions = () => [
-    ...baseMenuActions({value: item, handlers, isContainer, collapsed, setCollapsed}),
+    ...baseMenuActions({ value: item, handlers, isContainer, collapsed, setCollapsed }),
     {
       key: 'edit-type',
       label: 'Edit type',
@@ -1329,23 +1329,23 @@ function ListItemRow({
     },
     ...(index > 0
       ? [
-          {
-            key: 'move-up',
-            label: 'Move up',
-            icon: <ArrowUp className="size-4" />,
-            onClick: () => onMove(index, index - 1),
-          },
-        ]
+        {
+          key: 'move-up',
+          label: 'Move up',
+          icon: <ArrowUp className="size-4" />,
+          onClick: () => onMove(index, index - 1),
+        },
+      ]
       : []),
     ...(index < count - 1
       ? [
-          {
-            key: 'move-down',
-            label: 'Move down',
-            icon: <ArrowDown className="size-4" />,
-            onClick: () => onMove(index, index + 1),
-          },
-        ]
+        {
+          key: 'move-down',
+          label: 'Move down',
+          icon: <ArrowDown className="size-4" />,
+          onClick: () => onMove(index, index + 1),
+        },
+      ]
       : []),
     {
       key: 'remove',
@@ -1355,7 +1355,7 @@ function ListItemRow({
       onClick: onRemove,
     },
   ]
-  const {isSelected, rowProps} = useRowSelection(pathId(path), {
+  const { isSelected, rowProps } = useRowSelection(pathId(path), {
     path,
     handlers,
     isContainer,
@@ -1409,9 +1409,9 @@ function ListItemRow({
         ) : (
           <span className="size-4 shrink-0" />
         )}
-        <span className="text-muted-foreground font-mono text-xs">{index + 1}.</span>
+        <span className="font-mono text-xs text-muted-foreground">{index + 1}.</span>
       </div>
-      <div className="min-w-0 flex-1">
+      <div className="flex-1 min-w-0">
         {isContainer && collapsed ? (
           <div className="pt-1">
             <CollapsedSummary value={item} rules={rules} onExpand={() => setCollapsed(false)} />
@@ -1421,7 +1421,7 @@ function ListItemRow({
         )}
       </div>
       {/* Floating so nested rows keep their full width. */}
-      <div className="absolute top-1 right-0">
+      <div className="absolute right-0 top-1">
         <RowActionsMenu
           label={`Actions for item ${index + 1}`}
           getActions={getMenuActions}
@@ -1492,7 +1492,7 @@ function NumberInput({
           if (e.key === 'Escape') setText(initial)
         }}
       />
-      {error && <p className="text-destructive text-xs">{error}</p>}
+      {error && <p className="text-xs text-destructive">{error}</p>}
     </div>
   )
 }
@@ -1584,9 +1584,9 @@ function defaultValueForType(type: NewFieldType): unknown {
     case 'null':
       return null
     case 'link':
-      return {'/': ''}
+      return { '/': '' }
     case 'bytes':
-      return {'/': {bytes: ''}}
+      return { '/': { bytes: '' } }
   }
 }
 
@@ -1620,9 +1620,9 @@ export function coerceFieldValue(value: unknown, toType: NewFieldType, rules: Va
     case 'link':
       if (typeof value === 'string') {
         const cid = value.trim().replace(/^ipfs:\/\//, '')
-        if (parseCidString(cid)) return {'/': cid}
+        if (parseCidString(cid)) return { '/': cid }
       }
-      return {'/': ''}
+      return { '/': '' }
     case 'object':
     case 'list':
     case 'bytes':
@@ -1714,7 +1714,7 @@ function FieldDialog({
         <div className="flex flex-col gap-3">
           {!itemMode && (
             <div className="flex flex-col gap-1">
-              <label htmlFor="field-dialog-name" className="text-muted-foreground text-xs">
+              <label htmlFor="field-dialog-name" className="text-xs text-muted-foreground">
                 Field name
               </label>
               <Input
@@ -1733,7 +1733,7 @@ function FieldDialog({
             </div>
           )}
           <div className="flex flex-col gap-1">
-            <label className="text-muted-foreground text-xs">Type</label>
+            <label className="text-xs text-muted-foreground">Type</label>
             <Select value={type} onValueChange={(v) => setType(v as NewFieldType)}>
               <SelectTrigger>
                 <SelectValue />
@@ -1747,12 +1747,7 @@ function FieldDialog({
               </SelectContent>
             </Select>
           </div>
-          {mode === 'edit' && (
-            <p className="text-muted-foreground text-xs">
-              Changing the type keeps the current value when compatible, otherwise resets it.
-            </p>
-          )}
-          {error && <p className="text-destructive text-xs">{error}</p>}
+          {error && <p className="text-xs text-destructive">{error}</p>}
         </div>
         <DialogFooter>
           <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>

--- a/frontend/packages/ui/src/value-editor.tsx
+++ b/frontend/packages/ui/src/value-editor.tsx
@@ -628,8 +628,11 @@ function useRowSelection(
     'aria-selected': isSelected,
     ...(row.isContainer ? {'aria-expanded': !row.collapsed} : {}),
     onFocus: (e: React.FocusEvent) => {
-      // Only when the row element itself is focused, not a child editor.
-      if (e.target === e.currentTarget) ctx.select(id)
+      // Selection follows focus — whether the row itself or any editor inside
+      // it is focused (so tabbing between fields moves the highlight too). The
+      // innermost row wins, so focusing a nested object's field selects it, not
+      // its ancestors.
+      if ((e.target as HTMLElement).closest('[role="treeitem"]') === e.currentTarget) ctx.select(id)
     },
     onKeyDown: (e: React.KeyboardEvent) => {
       // Let inner editors handle their own keys (text nav, etc.).
@@ -890,15 +893,15 @@ export function FieldRow({
       )}
     >
       <div className="flex min-w-0 flex-1 flex-col gap-1">
+        {/* Field name first so names align regardless of type; the collapse
+            chevron sits after the name for containers. */}
         <div className="flex items-center gap-1">
-          {isContainer && <CollapseToggle collapsed={collapsed} onToggle={() => setCollapsed((c) => !c)} />}
           <span className={cn(FIELD_LABEL_CLASS, 'truncate')} title={fieldKey}>
             {fieldKey}
           </span>
+          {isContainer && <CollapseToggle collapsed={collapsed} onToggle={() => setCollapsed((c) => !c)} />}
         </div>
-        {/* Indent the value under the collapse toggle only for containers; flat
-            scalar fields stay flush-left so the attributes list aligns. */}
-        <div className={isContainer ? 'pl-5' : undefined}>
+        <div>
           {isContainer && collapsed ? (
             <CollapsedSummary value={value} rules={rules} onExpand={() => setCollapsed(false)} />
           ) : (

--- a/frontend/packages/ui/src/value-editor.tsx
+++ b/frontend/packages/ui/src/value-editor.tsx
@@ -527,21 +527,48 @@ function CollapseToggle({collapsed, onToggle}: {collapsed: boolean; onToggle: ()
   )
 }
 
-/** Summary line shown in place of a collapsed container's editor. */
-function CollapsedSummary({value, onExpand}: {value: unknown; onExpand: () => void}) {
-  const summary = Array.isArray(value)
-    ? `List · ${value.length} ${value.length === 1 ? 'item' : 'items'}`
-    : (() => {
-        const count = canonicalEntries(value as Record<string, unknown>).length
-        return `Object · ${count} ${count === 1 ? 'field' : 'fields'}`
-      })()
+/** A compact, single-line rendering of a value's actual data (for collapsed rows). */
+function compactValuePreview(value: unknown, rules: ValueEditorRules): string {
+  if (value === null) return 'null'
+  if (typeof value === 'string') return JSON.stringify(value)
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (isDagJsonLink(value)) return `→ ${value['/']}`
+  if (isDagJsonBytes(value)) {
+    try {
+      return `${formatByteSize(base64ToBytes(value['/'].bytes).length)} binary`
+    } catch {
+      return 'binary'
+    }
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => compactValuePreview(item, rules)).join(', ')}]`
+  }
+  if (isPlainObject(value)) {
+    const entries = canonicalEntries(value, {hideNull: rules.hideNullEntries})
+    return `{${entries.map(([key, child]) => `${key}: ${compactValuePreview(child, rules)}`).join(', ')}}`
+  }
+  return String(value)
+}
+
+/** Collapsed container: a one-line preview of the actual data; click to expand. */
+function CollapsedSummary({
+  value,
+  rules,
+  onExpand,
+}: {
+  value: unknown
+  rules: ValueEditorRules
+  onExpand: () => void
+}) {
+  const preview = compactValuePreview(value, rules)
   return (
     <button
       type="button"
-      className="text-muted-foreground hover:text-foreground w-fit text-sm transition-colors"
+      title={preview}
+      className="text-muted-foreground hover:text-foreground block max-w-full truncate text-left font-mono text-xs transition-colors"
       onClick={onExpand}
     >
-      {summary}
+      {preview}
     </button>
   )
 }
@@ -662,7 +689,7 @@ export function FieldRow({
             scalar fields stay flush-left so the attributes list aligns. */}
         <div className={isContainer ? 'pl-5' : undefined}>
           {isContainer && collapsed ? (
-            <CollapsedSummary value={value} onExpand={() => setCollapsed(false)} />
+            <CollapsedSummary value={value} rules={rules} onExpand={() => setCollapsed(false)} />
           ) : (
             <ValueEditor value={value} onValue={onValue} rules={rules} path={path} />
           )}
@@ -1165,7 +1192,7 @@ function ListItemRow({
       <div className="min-w-0 flex-1">
         {isContainer && collapsed ? (
           <div className="pt-1">
-            <CollapsedSummary value={item} onExpand={() => setCollapsed(false)} />
+            <CollapsedSummary value={item} rules={rules} onExpand={() => setCollapsed(false)} />
           </div>
         ) : (
           <ValueEditor value={item} onValue={onItem} rules={rules} path={path} />

--- a/frontend/packages/ui/src/value-editor.tsx
+++ b/frontend/packages/ui/src/value-editor.tsx
@@ -226,21 +226,73 @@ export type ContextMenuAction = {
   onClick: () => void
 }
 
-type SelectionContextValue = {
-  selectedId: string | null
-  select: (id: string) => void
-  clear: () => void
-  register: (id: string, handlers: SelectionHandlers) => void
+/** Everything the tree needs to know about a rendered row, for navigation + focus. */
+type RowInfo = {
+  path: ValuePath
+  handlers: SelectionHandlers
+  isContainer: boolean
+  collapsed: boolean
+  setCollapsed: (collapsed: boolean) => void
+  getMenuActions: () => ContextMenuAction[]
+}
+
+type NavDirection = 'up' | 'down' | 'left' | 'right' | 'home' | 'end'
+
+/**
+ * Stable tree actions (referentially constant across renders, so row `ref`
+ * callbacks don't churn and element registration stays reliable).
+ */
+type SelectionActions = {
+  register: (id: string, info: RowInfo) => void
   unregister: (id: string) => void
+  setElement: (id: string, element: HTMLElement | null) => void
+  /** Select a row (highlight + make it the tab-stop) without moving DOM focus. */
+  select: (id: string) => void
+  /** Select a row and move DOM focus to it. */
+  focusRow: (id: string) => void
+  clear: () => void
+  /** Arrow-key navigation from a row. */
+  navigate: (id: string, direction: NavDirection) => void
+  /** Enter/Space on a row: toggle a container, else focus its first editor. */
+  activate: (id: string) => void
   openContextMenu: (position: {x: number; y: number}, actions: ContextMenuAction[]) => void
+}
+
+/** Reactive tree state; changes here re-render rows (highlight, roving tab-stop). */
+type SelectionState = {
+  selectedId: string | null
+  /** The single tab-stop for the whole tree (roving tabindex / one focus group). */
+  tabbableId: string | null
   /** Opens ipfs://... URLs from link values, when the host page provides navigation. */
   openUrl?: (url: string) => void
 }
 
-const SelectionContext = createContext<SelectionContextValue | null>(null)
+const SelectionActionsContext = createContext<SelectionActions | null>(null)
+const SelectionStateContext = createContext<SelectionState>({selectedId: null, tabbableId: null})
 
 function isEditableTarget(target: EventTarget | null): boolean {
   return target instanceof HTMLElement && !!target.closest('input,textarea,select,[contenteditable="true"]')
+}
+
+/** Registered rows in current DOM order (skips unmounted/collapsed-away rows). */
+function domOrderedRows(
+  registry: Map<string, RowInfo>,
+  elements: Map<string, HTMLElement>,
+): {id: string; info: RowInfo; element: HTMLElement}[] {
+  const rows: {id: string; info: RowInfo; element: HTMLElement}[] = []
+  registry.forEach((info, id) => {
+    const element = elements.get(id)
+    if (element?.isConnected) rows.push({id, info, element})
+  })
+  rows.sort((a, b) =>
+    a.element.compareDocumentPosition(b.element) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1,
+  )
+  return rows
+}
+
+/** True when `child` is a strictly-deeper path under `parent`. */
+function isDescendantPath(child: ValuePath, parent: ValuePath): boolean {
+  return child.length > parent.length && parent.every((seg, i) => child[i] === seg)
 }
 
 /** Parse and validate clipboard-ish text for pasting. Non-JSON pastes as a string. */
@@ -278,10 +330,18 @@ async function pasteFromClipboard(handlers: SelectionHandlers) {
 }
 
 /**
- * Enables row selection, clipboard, context menus, and undo shortcuts for all
- * value editors below it. Click a row to select it: Cmd/Ctrl+C copies the
- * value as JSON, Cmd/Ctrl+V pastes over it (validated), Delete removes it,
- * Escape deselects. Cmd/Ctrl+Z / Shift+Cmd/Ctrl+Z call onUndo/onRedo.
+ * Keyboard-navigable tree of value editors. Rows form one focus group with a
+ * roving tab-stop: Tab enters the tree, then:
+ *   ↑/↓        move between visible rows
+ *   ←          collapse an expanded container, else move to the parent row
+ *   →          expand a collapsed container, else move to the first child
+ *   Home/End   first / last visible row
+ *   Enter      toggle a container, else focus the row's value editor
+ *   Escape     deselect (or close the context menu)
+ *   Cmd/Ctrl+C / V   copy / paste the focused value (validated)
+ *   Delete/Backspace remove the focused row
+ *   Cmd/Ctrl+Z / Shift+…  undo / redo
+ * Selection follows DOM focus, so it stays consistent as the tree changes.
  */
 export function ValueEditorProvider({
   children,
@@ -295,8 +355,11 @@ export function ValueEditorProvider({
   openUrl?: (url: string) => void
 }) {
   const [selectedId, setSelectedId] = useState<string | null>(null)
+  // The single tab-stop; defaults to the first row so Tab can enter the tree.
+  const [tabbableId, setTabbableId] = useState<string | null>(null)
   const [menu, setMenu] = useState<{x: number; y: number; actions: ContextMenuAction[]} | null>(null)
-  const registry = useRef(new Map<string, SelectionHandlers>())
+  const registry = useRef(new Map<string, RowInfo>())
+  const elements = useRef(new Map<string, HTMLElement>())
 
   const selectedIdRef = useRef(selectedId)
   selectedIdRef.current = selectedId
@@ -305,20 +368,97 @@ export function ValueEditorProvider({
   const redoRef = useRef(onRedo)
   redoRef.current = onRedo
 
-  const ctx = useRef<SelectionContextValue>({
-    selectedId: null,
-    select: (id) => setSelectedId(id),
+  const select = useCallback((id: string) => {
+    setSelectedId(id)
+    setTabbableId(id)
+  }, [])
+  const focusRow = useCallback(
+    (id: string) => {
+      select(id)
+      elements.current.get(id)?.focus()
+    },
+    [select],
+  )
+  const navigate = useCallback(
+    (id: string, direction: NavDirection) => {
+      const rows = domOrderedRows(registry.current, elements.current)
+      const idx = rows.findIndex((r) => r.id === id)
+      if (idx < 0) return
+      const {info} = rows[idx]!
+      const go = (target?: {id: string}) => {
+        if (target) focusRow(target.id)
+      }
+      switch (direction) {
+        case 'down':
+          go(rows[idx + 1])
+          break
+        case 'up':
+          go(rows[idx - 1])
+          break
+        case 'home':
+          go(rows[0])
+          break
+        case 'end':
+          go(rows[rows.length - 1])
+          break
+        case 'right':
+          if (info.isContainer && info.collapsed) info.setCollapsed(false)
+          else if (info.isContainer) {
+            const next = rows[idx + 1]
+            if (next && isDescendantPath(next.info.path, info.path)) go(next)
+          }
+          break
+        case 'left':
+          if (info.isContainer && !info.collapsed) info.setCollapsed(true)
+          else go(rows.find((r) => r.id === pathId(info.path.slice(0, -1))))
+          break
+      }
+    },
+    [focusRow],
+  )
+  const activate = useCallback((id: string) => {
+    const info = registry.current.get(id)
+    if (!info) return
+    if (info.isContainer) {
+      info.setCollapsed(!info.collapsed)
+      return
+    }
+    // Leaf: focus its first editable control so typing edits the value.
+    elements.current.get(id)?.querySelector<HTMLElement>('input, textarea, [role="combobox"]')?.focus()
+  }, [])
+
+  // Stable actions object (identity never changes) — so row ref callbacks and
+  // effects don't churn as selection state changes.
+  const actions = useRef<SelectionActions>({
+    select,
+    focusRow,
     clear: () => setSelectedId(null),
-    register: (id, handlers) => registry.current.set(id, handlers),
-    unregister: (id) => registry.current.delete(id),
-    openContextMenu: (position, actions) => setMenu({...position, actions}),
-  })
-  ctx.current = {...ctx.current, selectedId, openUrl}
+    navigate,
+    activate,
+    register: (id, info) => {
+      registry.current.set(id, info)
+      // The first row to register becomes the tree's tab-stop.
+      setTabbableId((cur) => cur ?? id)
+    },
+    unregister: (id) => {
+      // NB: the effect that calls this re-runs every render, so its cleanup
+      // fires on re-renders too — only touch the registry here. The `elements`
+      // map is owned by the row's ref callback, which clears it on real unmount.
+      registry.current.delete(id)
+      setTabbableId((cur) => (cur === id ? (registry.current.keys().next().value ?? null) : cur))
+    },
+    setElement: (id, element) => {
+      if (element) elements.current.set(id, element)
+      else elements.current.delete(id)
+    },
+    openContextMenu: (position, menuActions) => setMenu({...position, actions: menuActions}),
+  }).current
+  const state = useMemo<SelectionState>(() => ({selectedId, tabbableId, openUrl}), [selectedId, tabbableId, openUrl])
 
   useEffect(() => {
     const getSelectedHandlers = () => {
       const id = selectedIdRef.current
-      return id ? registry.current.get(id) : undefined
+      return id ? registry.current.get(id)?.handlers : undefined
     }
 
     const onCopy = (e: ClipboardEvent) => {
@@ -378,9 +518,10 @@ export function ValueEditorProvider({
   }, [])
 
   return (
-    <SelectionContext.Provider value={ctx.current}>
-      {children}
-      {menu && (
+    <SelectionActionsContext.Provider value={actions}>
+      <SelectionStateContext.Provider value={state}>
+        {children}
+        {menu && (
         <div
           className="fixed inset-0 z-[100]"
           onClick={() => setMenu(null)}
@@ -418,45 +559,107 @@ export function ValueEditorProvider({
             ))}
           </div>
         </div>
-      )}
-    </SelectionContext.Provider>
+        )}
+      </SelectionStateContext.Provider>
+    </SelectionActionsContext.Provider>
   )
 }
 
-/** Row-level wiring for selection and the context menu. */
-function useRowSelection(id: string, handlers: SelectionHandlers, getMenuActions: () => ContextMenuAction[]) {
-  const ctx = useContext(SelectionContext)
-  const isSelected = ctx?.selectedId === id
+const ARROW_DIRECTIONS: Record<string, NavDirection> = {
+  ArrowDown: 'down',
+  ArrowUp: 'up',
+  ArrowLeft: 'left',
+  ArrowRight: 'right',
+  Home: 'home',
+  End: 'end',
+}
 
-  // Keep the registry fresh with the latest value/handlers on every render.
+/**
+ * Row-level wiring: registers the row for tree navigation and returns props to
+ * spread on the row element (roving tabindex, focus, arrow keys, context menu).
+ */
+function useRowSelection(
+  id: string,
+  row: {
+    path: ValuePath
+    handlers: SelectionHandlers
+    isContainer: boolean
+    collapsed: boolean
+    setCollapsed: (collapsed: boolean) => void
+    getMenuActions: () => ContextMenuAction[]
+  },
+) {
+  const actions = useContext(SelectionActionsContext)
+  const {selectedId, tabbableId} = useContext(SelectionStateContext)
+  const isSelected = selectedId === id
+  const isTabbable = tabbableId === id
+
+  // Keep the registry fresh with the latest value/handlers/collapse on every render.
   useEffect(() => {
-    if (!ctx) return
-    ctx.register(id, handlers)
-    return () => ctx.unregister(id)
+    if (!actions) return
+    actions.register(id, {
+      path: row.path,
+      handlers: row.handlers,
+      isContainer: row.isContainer,
+      collapsed: row.collapsed,
+      setCollapsed: row.setCollapsed,
+      getMenuActions: row.getMenuActions,
+    })
+    return () => actions.unregister(id)
   })
 
-  const onRowClick = ctx
-    ? (e: React.MouseEvent) => {
-        const target = e.target as HTMLElement
-        if (target.closest('input,textarea,button,select,a,[contenteditable="true"],[role="combobox"]')) return
-        e.stopPropagation()
-        if (isSelected) ctx.clear()
-        else ctx.select(id)
-      }
-    : undefined
+  // `actions` is referentially stable, so this ref callback never churns.
+  const setRef = useCallback(
+    (element: HTMLElement | null) => {
+      actions?.setElement(id, element)
+    },
+    [actions, id],
+  )
 
-  const onContextMenu = ctx
-    ? (e: React.MouseEvent) => {
-        // Right-click inside inputs keeps the native text menu.
-        if (isEditableTarget(e.target)) return
+  if (!actions) {
+    return {isSelected: false, rowProps: {} as Record<string, never>}
+  }
+  const ctx = actions
+
+  const rowProps = {
+    ref: setRef,
+    role: 'treeitem' as const,
+    tabIndex: isTabbable ? 0 : -1,
+    'aria-selected': isSelected,
+    ...(row.isContainer ? {'aria-expanded': !row.collapsed} : {}),
+    onFocus: (e: React.FocusEvent) => {
+      // Only when the row element itself is focused, not a child editor.
+      if (e.target === e.currentTarget) ctx.select(id)
+    },
+    onKeyDown: (e: React.KeyboardEvent) => {
+      // Let inner editors handle their own keys (text nav, etc.).
+      if (e.target !== e.currentTarget) return
+      const direction = ARROW_DIRECTIONS[e.key]
+      if (direction) {
         e.preventDefault()
-        e.stopPropagation()
-        ctx.select(id)
-        ctx.openContextMenu({x: e.clientX, y: e.clientY}, getMenuActions())
+        ctx.navigate(id, direction)
+      } else if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        ctx.activate(id)
       }
-    : undefined
+    },
+    onClick: (e: React.MouseEvent) => {
+      const target = e.target as HTMLElement
+      if (target.closest('input,textarea,button,select,a,[contenteditable="true"],[role="combobox"]')) return
+      e.stopPropagation()
+      ctx.focusRow(id)
+    },
+    onContextMenu: (e: React.MouseEvent) => {
+      // Right-click inside inputs keeps the native text menu.
+      if (isEditableTarget(e.target)) return
+      e.preventDefault()
+      e.stopPropagation()
+      ctx.focusRow(id)
+      ctx.openContextMenu({x: e.clientX, y: e.clientY}, row.getMenuActions())
+    },
+  }
 
-  return {isSelected: !!isSelected, onRowClick, onContextMenu}
+  return {isSelected: !!isSelected, rowProps}
 }
 
 const ROW_CLASS = '-mx-1 rounded-md px-1 py-0.5 transition-colors'
@@ -667,14 +870,20 @@ export function FieldRow({
       onClick: onRemove,
     },
   ]
-  const {isSelected, onRowClick, onContextMenu} = useRowSelection(pathId(path), handlers, getMenuActions)
+  const {isSelected, rowProps} = useRowSelection(pathId(path), {
+    path,
+    handlers,
+    isContainer,
+    collapsed,
+    setCollapsed,
+    getMenuActions,
+  })
 
   return (
     <div
-      onClick={onRowClick}
-      onContextMenu={onContextMenu}
+      {...rowProps}
       className={cn(
-        'group/row relative flex items-start gap-2',
+        'group/row relative flex items-start gap-2 outline-none',
         ROW_CLASS,
         isSelected && ROW_SELECTED_CLASS,
         className,
@@ -823,7 +1032,7 @@ function StringLeafEditor({value, onValue}: {value: string; onValue: (value: unk
 
 /** IPLD link (`{"/": cid}`): editable CID with validation and an open action. */
 function LinkValueEditor({value, onValue}: {value: {'/': string}; onValue: (value: unknown) => void}) {
-  const ctx = useContext(SelectionContext)
+  const {openUrl} = useContext(SelectionStateContext)
   const cid = value['/']
   const isValid = !!parseCidString(cid)
   return (
@@ -844,14 +1053,14 @@ function LinkValueEditor({value, onValue}: {value: {'/': string}; onValue: (valu
           onValue({'/': next})
         }}
       />
-      {ctx?.openUrl && isValid && (
+      {openUrl && isValid && (
         <Tooltip content={`Open ipfs://${cid}`}>
           <Button
             variant="ghost"
             size="iconSm"
             aria-label={`Open ipfs://${cid}`}
             className="text-muted-foreground"
-            onClick={() => ctx.openUrl!(`ipfs://${cid}`)}
+            onClick={() => openUrl(`ipfs://${cid}`)}
           >
             <ExternalLink className="size-3.5" />
           </Button>
@@ -1141,12 +1350,18 @@ function ListItemRow({
       onClick: onRemove,
     },
   ]
-  const {isSelected, onRowClick, onContextMenu} = useRowSelection(pathId(path), handlers, getMenuActions)
+  const {isSelected, rowProps} = useRowSelection(pathId(path), {
+    path,
+    handlers,
+    isContainer,
+    collapsed,
+    setCollapsed,
+    getMenuActions,
+  })
 
   return (
     <div
-      onClick={onRowClick}
-      onContextMenu={onContextMenu}
+      {...rowProps}
       onDragOver={(e) => {
         if (!drag.active) return
         e.preventDefault()
@@ -1159,7 +1374,7 @@ function ListItemRow({
         drag.onDrop()
       }}
       className={cn(
-        'group/item relative flex items-start gap-2',
+        'group/item relative flex items-start gap-2 outline-none',
         ROW_CLASS,
         isSelected && ROW_SELECTED_CLASS,
         drag.isDragging && 'opacity-40',


### PR DESCRIPTION
## Document Attributes editor

Adds a standalone **Attributes** view for editing a document's metadata as an open, extensible attribute map — isolated from the onyx type system and schema editor (branched fresh from `main`).

### What's included
- **`:metadata` route + hidden tab** — reachable from the document options menu; the tab stays hidden until the doc has custom attributes, then shows a **count of custom fields** (built-in `HMDocumentMetadataSchema` keys excluded).
- **Recursive attributes editor** — add a field via a dialog (name + type); name/type lock in and change only via "Edit field". Type changes preserve the value across compatible conversions (number↔text, boolean, valid CID→link) or reset. Includes undo/redo, row selection + clipboard + context menu, and a whole-object JSON mode. Self-contained, no schema/onyx deps.
- **Custom metadata survives round-trips** — `HMDocumentMetadataSchema` is now `.passthrough()`, so user-authored keys are no longer stripped on draft save/load or on the published-document read-back.
- **Publish + autosave from the Attributes view** — the publish button and "Saving…/Saved" indicator work the same on the Attributes tab as on content. The `writeDraft` actors preserve the document body when no editor is mounted, so an attributes-only publish can't wipe content (desktop + web).
- **Show in panel** — the Attributes view can be moved into the right-side panel; the panel version is the same editable view.
- **UI labeled "Attributes"** (route keys / identifiers stay `metadata`), redundant in-view title removed, attribute rows aligned flush-left.

### Verification
- `tsc --noEmit` clean: client, shared, ui, web, desktop
- Tests pass: client passthrough + custom-field count, shared routes + publish-path, ui editor (coerce/valueToFieldType, diffMetadata)

### Note
The publish content-preservation (preserving the body when no editor is mounted) is best exercised in the running desktop/web app — worth a manual round-trip check: edit an attribute → Publish → confirm the attribute persists and the body is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)