### PR TITLE
fix(ui): restore embedded comment navigation context

### DIFF
--- a/frontend/packages/ui/src/__tests__/embed-views.test.tsx
+++ b/frontend/packages/ui/src/__tests__/embed-views.test.tsx
@@ -2,13 +2,18 @@
 import React from 'react'
 import {createRoot, type Root} from 'react-dom/client'
 import {act} from 'react-dom/test-utils'
-import {hmId, packHmId} from '@shm/shared/utils/entity-id-url'
+import type {HMBlockEmbed, HMComment} from '@seed-hypermedia/client/hm-types'
+import type {NavRoute} from '@shm/shared'
+import {hmId, packHmId, unpackHmId} from '@shm/shared/utils/entity-id-url'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
-import {BlockEmbedCard} from '../embed-views'
+import {BlockEmbedCard, BlockEmbedContentComment, BlockEmbedLink} from '../embed-views'
 ;(globalThis as typeof globalThis & {React?: typeof React; IS_REACT_ACT_ENVIRONMENT?: boolean}).React = React
 ;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
 
-const {resourceId} = vi.hoisted(() => ({
+const {currentRoute, resourceId, routeLinkMock} = vi.hoisted(() => ({
+  currentRoute: {
+    value: null as unknown as NavRoute,
+  },
   resourceId: {
     id: 'hm://uid-1/doc',
     uid: 'uid-1',
@@ -20,7 +25,19 @@ const {resourceId} = vi.hoisted(() => ({
     hostname: null,
     scheme: null,
   },
+  routeLinkMock: vi.fn(),
 }))
+
+vi.mock('@shm/shared', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@shm/shared')>()
+  return {
+    ...actual,
+    useRouteLink: (route: unknown) => {
+      routeLinkMock(route)
+      return {href: '#embed-target', onClick: vi.fn()}
+    },
+  }
+})
 
 vi.mock('@shm/shared/models/entity', () => ({
   useResource: () => ({
@@ -46,29 +63,71 @@ vi.mock('@shm/shared/models/interaction-summary', () => ({
   useInteractionSummary: () => ({data: null}),
 }))
 
-vi.mock('../embed-wrapper', () => ({
-  EmbedWrapper: ({children, openOnClick, route, viewType}: any) => (
-    <div
-      data-testid="embed-wrapper"
-      data-open-on-click={String(openOnClick)}
-      data-route-key={route?.key ?? ''}
-      data-view={viewType}
-    >
-      {children}
-    </div>
-  ),
+vi.mock('../embed-wrapper', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../embed-wrapper')>()
+  return {
+    ...actual,
+    EmbedWrapper: ({children, openOnClick, route, viewType}: React.PropsWithChildren<EmbedWrapperTestProps>) => (
+      <div
+        data-testid="embed-wrapper"
+        data-open-on-click={String(openOnClick)}
+        data-route-key={route?.key ?? ''}
+        data-route={JSON.stringify(route ?? null)}
+        data-view={viewType}
+      >
+        {children}
+      </div>
+    ),
+  }
+})
+
+vi.mock('@shm/shared/utils/navigation', () => ({
+  useNavigate: () => vi.fn(),
+  useNavRoute: () => currentRoute.value,
+}))
+
+vi.mock('../comments', () => ({
+  CommentContent: () => <div data-testid="comment-content" />,
+  Discussions: () => <div data-testid="discussions" />,
+}))
+
+vi.mock('../hm-icon', () => ({
+  HMIcon: () => <div data-testid="hm-icon" />,
+}))
+
+vi.mock('../text', () => ({
+  SizableText: ({children}: {children: React.ReactNode}) => <span>{children}</span>,
 }))
 
 vi.mock('../newspaper', () => ({
-  DocumentCard: ({navigate, titleLinkOnly}: any) => (
-    <div data-testid="document-card" data-navigate={String(navigate)} data-title-link-only={String(titleLinkOnly)} />
+  DocumentCard: ({navigate, route, titleLinkOnly}: DocumentCardTestProps) => (
+    <div
+      data-testid="document-card"
+      data-navigate={String(navigate)}
+      data-route={JSON.stringify(route ?? null)}
+      data-title-link-only={String(titleLinkOnly)}
+    />
   ),
 }))
+
+type EmbedWrapperTestProps = {
+  openOnClick?: boolean
+  route?: NavRoute
+  viewType?: string
+}
+
+type DocumentCardTestProps = {
+  navigate?: boolean
+  route?: NavRoute
+  titleLinkOnly?: boolean
+}
 
 let container: HTMLDivElement
 let root: Root
 
 beforeEach(() => {
+  routeLinkMock.mockReset()
+  currentRoute.value = {key: 'document', id: hmId('uid-1', {path: ['doc']})}
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
@@ -136,5 +195,145 @@ describe('BlockEmbedCard navigation surface', () => {
     const card = container.querySelector('[data-testid="document-card"]') as HTMLElement | null
     expect(card?.dataset.navigate).toBe('false')
     expect(card?.dataset.titleLinkOnly).toBe('true')
+  })
+
+  it('passes the active panel route to whole-card navigation', () => {
+    const sourceDocId = hmId('uid-source', {path: ['source']})
+    currentRoute.value = {
+      key: 'comments',
+      id: sourceDocId,
+      panel: {key: 'comments', id: sourceDocId, openComment: 'source-comment'},
+    }
+    const {docId} = renderBlockEmbedCard()
+
+    const card = container.querySelector('[data-testid="document-card"]') as HTMLElement | null
+    expect(JSON.parse(card?.dataset.route ?? 'null')).toEqual({
+      key: 'document',
+      id: unpackHmId(packHmId(docId)),
+      panel: {key: 'comments', id: sourceDocId, openComment: 'source-comment'},
+    })
+  })
+
+  it('passes the active panel route to title-only card navigation', () => {
+    const sourceDocId = hmId('uid-source', {path: ['source']})
+    currentRoute.value = {
+      key: 'comments',
+      id: sourceDocId,
+      panel: {key: 'comments', id: sourceDocId, openComment: 'source-comment'},
+    }
+    const {docId} = renderBlockEmbedCard({titleLinkOnly: true})
+
+    const card = container.querySelector('[data-testid="document-card"]') as HTMLElement | null
+    expect(JSON.parse(card?.dataset.route ?? 'null')).toEqual({
+      key: 'document',
+      id: unpackHmId(packHmId(docId)),
+      panel: {key: 'comments', id: sourceDocId, openComment: 'source-comment'},
+    })
+  })
+})
+
+function renderHmLinkEmbed(openOnClick: boolean) {
+  const docId = hmId('uid-target', {path: ['target']})
+  const block: HMBlockEmbed = {
+    id: 'embed-link-1',
+    type: 'Embed',
+    text: '',
+    attributes: {view: 'Link', childrenType: 'Group'},
+    annotations: [],
+    link: packHmId(docId),
+  }
+
+  act(() => {
+    root.render(<BlockEmbedLink block={block} parentBlockId={null} openOnClick={openOnClick} />)
+  })
+
+  return {docId}
+}
+
+describe('HM link embed title navigation', () => {
+  it('preserves the active panel for title-only navigation', () => {
+    const sourceDocId = hmId('uid-source', {path: ['source']})
+    currentRoute.value = {
+      key: 'comments',
+      id: sourceDocId,
+      panel: {key: 'comments', id: sourceDocId, openComment: 'source-comment'},
+    }
+    const {docId} = renderHmLinkEmbed(false)
+
+    expect(routeLinkMock).toHaveBeenLastCalledWith({
+      key: 'document',
+      id: unpackHmId(packHmId(docId)),
+      panel: {key: 'comments', id: sourceDocId, openComment: 'source-comment'},
+    })
+  })
+})
+
+function renderBlockEmbedContentComment() {
+  const embeddedCommentId = hmId('uid-comment', {path: ['comment']})
+  const comment: HMComment = {
+    id: 'embedded-comment',
+    version: 'comment-version',
+    author: 'uid-author',
+    targetAccount: 'uid-target',
+    targetPath: 'target-document',
+    targetVersion: 'target-version',
+    content: [],
+    createTime: {seconds: 0, nanos: 0},
+    updateTime: {seconds: 0, nanos: 0},
+    visibility: 'PUBLIC',
+  }
+  const block: HMBlockEmbed = {
+    id: 'embed-1',
+    type: 'Embed',
+    text: '',
+    attributes: {view: 'Content', childrenType: 'Group'},
+    annotations: [],
+    link: '',
+  }
+
+  act(() => {
+    root.render(
+      <BlockEmbedContentComment
+        id={embeddedCommentId}
+        parentBlockId={null}
+        depth={0}
+        block={block}
+        comment={comment}
+        author={undefined}
+        targetResource={undefined}
+      />,
+    )
+  })
+
+  const wrapper = container.querySelector('[data-testid="embed-wrapper"]') as HTMLElement | null
+  return {embeddedCommentId, wrapper}
+}
+
+describe('BlockEmbedContentComment routing', () => {
+  it('navigates the main view to the comment target while preserving an active panel', () => {
+    const sourceDocId = hmId('uid-source', {path: ['source-document']})
+    currentRoute.value = {
+      key: 'comments',
+      id: sourceDocId,
+      panel: {key: 'comments', id: sourceDocId, openComment: 'source-comment'},
+    }
+
+    const {wrapper} = renderBlockEmbedContentComment()
+
+    expect(JSON.parse(wrapper?.dataset.route ?? 'null')).toEqual({
+      key: 'document',
+      id: hmId('uid-target', {path: ['target-document'], version: 'target-version'}),
+      panel: {key: 'comments', id: sourceDocId, openComment: 'source-comment'},
+    })
+  })
+
+  it('uses a standalone comments destination focused on the embedded comment without an active panel', () => {
+    const {wrapper} = renderBlockEmbedContentComment()
+
+    expect(JSON.parse(wrapper?.dataset.route ?? 'null')).toEqual({
+      key: 'comments',
+      id: hmId('uid-target', {path: ['target-document'], version: 'target-version'}),
+      openComment: 'embedded-comment',
+    })
   })
 })

--- a/frontend/packages/ui/src/__tests__/embed-wrapper.test.tsx
+++ b/frontend/packages/ui/src/__tests__/embed-wrapper.test.tsx
@@ -2,22 +2,30 @@
 import React from 'react'
 import {createRoot, type Root} from 'react-dom/client'
 import {act} from 'react-dom/test-utils'
+import type {NavRoute} from '@shm/shared'
 import {hmId} from '@shm/shared/utils/entity-id-url'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {EmbedWrapper} from '../embed-wrapper'
 ;(globalThis as typeof globalThis & {React?: typeof React; IS_REACT_ACT_ENVIRONMENT?: boolean}).React = React
 ;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
 
-const {routeOnClickMock} = vi.hoisted(() => ({
+const {currentRoute, routeOnClickMock, routeLinkMock} = vi.hoisted(() => ({
+  currentRoute: {
+    value: null as unknown as NavRoute,
+  },
   routeOnClickMock: vi.fn(),
+  routeLinkMock: vi.fn(),
 }))
 
 vi.mock('@shm/shared/routing', () => ({
-  useRouteLink: () => ({href: '#embed-target', onClick: routeOnClickMock}),
+  useRouteLink: (route: unknown) => {
+    routeLinkMock(route)
+    return {href: '#embed-target', onClick: routeOnClickMock}
+  },
 }))
 
 vi.mock('@shm/shared/utils/navigation', () => ({
-  useNavRoute: () => ({key: 'document', id: {id: 'hm://uid-1/doc', uid: 'uid-1', path: ['doc']}}),
+  useNavRoute: () => currentRoute.value,
 }))
 
 vi.mock('../highlight-context', () => ({
@@ -29,6 +37,8 @@ let root: Root
 
 beforeEach(() => {
   routeOnClickMock.mockReset()
+  routeLinkMock.mockReset()
+  currentRoute.value = {key: 'document', id: hmId('uid-1', {path: ['doc']})}
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
@@ -82,5 +92,33 @@ describe('EmbedWrapper', () => {
     innerLink?.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))
 
     expect(routeOnClickMock).not.toHaveBeenCalled()
+  })
+
+  it('preserves an active comments panel while passing a block-ref document embed id unchanged', () => {
+    const panelId = hmId('uid-source', {path: ['source']})
+    const targetId = hmId('uid-target', {
+      path: ['target'],
+      blockRef: 'embedded-block',
+      blockRange: {start: 2, end: 7},
+    })
+    currentRoute.value = {
+      key: 'comments',
+      id: panelId,
+      panel: {key: 'comments', id: panelId, openComment: 'source-comment'},
+    }
+
+    act(() => {
+      root.render(
+        <EmbedWrapper id={targetId} parentBlockId={null} route={{key: 'document', id: targetId}}>
+          embedded content
+        </EmbedWrapper>,
+      )
+    })
+
+    expect(routeLinkMock).toHaveBeenLastCalledWith({
+      key: 'document',
+      id: targetId,
+      panel: {key: 'comments', id: panelId, openComment: 'source-comment'},
+    })
   })
 })

--- a/frontend/packages/ui/src/__tests__/resource-page-common.test.ts
+++ b/frontend/packages/ui/src/__tests__/resource-page-common.test.ts
@@ -3,6 +3,7 @@ import {describe, expect, it, vi} from 'vitest'
 import {
   getDocumentResourceRouteKey,
   getCommentReplyPanelRoute,
+  getCommentsPanelTarget,
   hasUnpublishedDraftForResourceState,
   shouldSuppressMainCommentEditor,
   getRenderedDocumentId,
@@ -311,6 +312,34 @@ describe('getCommentReplyPanelRoute', () => {
       openComment: 'alice/other-comment-tsid',
     })
     expect(panelRoute.id.path).toEqual(['other-doc'])
+  })
+})
+
+describe('getCommentsPanelTarget', () => {
+  const mainDocId = hmId('alice', {path: ['embedded-doc']})
+  const sourceDocId = hmId('alice', {path: ['source-doc']})
+
+  it('uses the comments panel source document and focused comment', () => {
+    const panelRoute: Extract<NavRoute, {key: 'document'}>['panel'] = {
+      key: 'comments',
+      id: sourceDocId,
+      openComment: 'alice/source-comment',
+    }
+
+    expect(getCommentsPanelTarget(mainDocId, panelRoute)).toEqual({
+      docId: sourceDocId,
+      openComment: 'alice/source-comment',
+    })
+  })
+
+  it('uses the main document when no comments panel is open or another panel type is open', () => {
+    expect(getCommentsPanelTarget(mainDocId, null)).toEqual({docId: mainDocId, openComment: undefined})
+    expect(
+      getCommentsPanelTarget(mainDocId, {
+        key: 'activity',
+        id: sourceDocId,
+      }),
+    ).toEqual({docId: mainDocId, openComment: undefined})
   })
 })
 

--- a/frontend/packages/ui/src/embed-views.tsx
+++ b/frontend/packages/ui/src/embed-views.tsx
@@ -27,7 +27,7 @@ import {useAccount, useResource, useResources} from '@shm/shared/models/entity'
 import {useReadOnlyViewer} from '@shm/shared/readonly-viewer-context'
 import {isHmDescendantOf} from '@shm/shared/utils/breadcrumbs'
 import {hmId} from '@shm/shared/utils/entity-id-url'
-import {useNavigate} from '@shm/shared/utils/navigation'
+import {useNavigate, useNavRoute} from '@shm/shared/utils/navigation'
 import {AlertCircle, FileSymlink as FileSymlinkIcon, FileText as FileTextIcon, Globe, Undo2} from 'lucide-react'
 import React, {ReactNode, useCallback, useMemo, useState} from 'react'
 import {toast} from 'sonner'
@@ -632,6 +632,40 @@ export function BlockEmbedContentComment({
   openOnClick?: boolean
   isStaleVersion?: boolean
 }) {
+  const currentRoute = useNavRoute()
+  const targetDocId = getCommentTargetId(comment)
+
+  const route = useMemo(() => {
+    if (!targetDocId) return undefined
+
+    const currentDocId =
+      currentRoute.key === 'document' || currentRoute.key === 'comments' || currentRoute.key === 'feed'
+        ? currentRoute.id
+        : null
+
+    const isSameDocument =
+      !!currentDocId &&
+      targetDocId.uid === currentDocId.uid &&
+      (targetDocId.path?.join('/') ?? '') === (currentDocId.path?.join('/') ?? '')
+
+    if (isSameDocument) {
+      return {
+        key: 'document' as const,
+        id: targetDocId,
+        panel: {
+          key: 'comments' as const,
+          id,
+          openComment: comment.id,
+        },
+      }
+    }
+    return {
+      key: 'comments' as const,
+      id: targetDocId,
+      openComment: comment.id,
+    }
+  }, [targetDocId, currentRoute, id, comment.id])
+
   return (
     <EmbedWrapper
       viewType={block.attributes?.view}
@@ -639,15 +673,7 @@ export function BlockEmbedContentComment({
       id={id}
       parentBlockId={parentBlockId || ''}
       openOnClick={openOnClick}
-      route={{
-        key: 'document',
-        id: getCommentTargetId(comment)!,
-        panel: {
-          key: 'comments',
-          id,
-          openComment: comment.id,
-        },
-      }}
+      route={route}
     >
       <CommentEmbedHeader
         comment={comment}

--- a/frontend/packages/ui/src/embed-views.tsx
+++ b/frontend/packages/ui/src/embed-views.tsx
@@ -14,6 +14,7 @@ import {
 import {
   abbreviateUid,
   formattedDateMedium,
+  getRoutePanel,
   getCommentTargetId,
   getDocumentTitle,
   RenderResourceProvider,
@@ -27,6 +28,7 @@ import {useAccount, useResource, useResources} from '@shm/shared/models/entity'
 import {useReadOnlyViewer} from '@shm/shared/readonly-viewer-context'
 import {isHmDescendantOf} from '@shm/shared/utils/breadcrumbs'
 import {hmId} from '@shm/shared/utils/entity-id-url'
+import type {DocumentPanelRoute} from '@shm/shared/routes'
 import {useNavigate, useNavRoute} from '@shm/shared/utils/navigation'
 import {AlertCircle, FileSymlink as FileSymlinkIcon, FileText as FileTextIcon, Globe, Undo2} from 'lucide-react'
 import React, {ReactNode, useCallback, useMemo, useState} from 'react'
@@ -35,7 +37,7 @@ import {getBlockNodeById} from './blocks-content-utils'
 import {Button} from './button'
 import {CommentContent, Discussions} from './comments'
 import {copyUrlToClipboardWithFeedback} from './copy-to-clipboard'
-import {EmbedWrapper} from './embed-wrapper'
+import {EmbedWrapper, getEmbedDocumentRoute} from './embed-wrapper'
 import {HMIcon} from './hm-icon'
 import {DocumentNameLink} from './inline-descriptor'
 import {DocumentCard} from './newspaper'
@@ -131,6 +133,8 @@ export function BlockEmbedCard({
   hideInlineActions?: boolean
 }) {
   const id = unpackHmId(block.link) ?? undefined
+  const currentRoute = useNavRoute()
+  const documentRoute = useMemo(() => (id ? getEmbedDocumentRoute(id, currentRoute) : undefined), [id, currentRoute])
   const renderResourceStack = useRenderResourceStack()
   const parentDocumentId = [...renderResourceStack].reverse().find((resource) => resource.kind === 'document')?.id
   const doc = useResource(id, {subscribed: true})
@@ -192,7 +196,7 @@ export function BlockEmbedCard({
       id={id}
       parentBlockId={parentBlockId}
       hideBorder
-      route={{key: 'document', id}}
+      route={documentRoute}
       openOnClick={false}
       viewType="Card"
     >
@@ -202,6 +206,7 @@ export function BlockEmbedCard({
           document: document,
         }}
         docId={id}
+        route={documentRoute}
         accountsMetadata={accountsMetadata}
         navigate={openOnClick && !titleLinkOnly}
         titleLinkOnly={titleLinkOnly}
@@ -251,6 +256,7 @@ function HmLinkEmbed({
   parentBlockId: string | null
   openOnClick: boolean
 }) {
+  const currentRoute = useNavRoute()
   const doc = useResource(id, {subscribed: true})
   const document = doc.data?.type === 'document' ? doc.data.document : undefined
   const title = getDocumentTitle(document) || abbreviateUid(id.uid)
@@ -259,7 +265,8 @@ function HmLinkEmbed({
     [...renderStack].reverse().find((entry) => entry.kind === 'document' && entry.id.id !== id.id)?.id ?? null
   const isSubdoc = isHmDescendantOf(id, parentDocId)
   const Icon = isSubdoc ? FileTextIcon : FileSymlinkIcon
-  const titleLink = useRouteLink(openOnClick ? null : {key: 'document', id})
+  const documentRoute = useMemo(() => getEmbedDocumentRoute(id, currentRoute), [id, currentRoute])
+  const titleLink = useRouteLink(openOnClick ? null : documentRoute)
   const titleIsLink = !openOnClick && !!titleLink.href
 
   return (
@@ -267,7 +274,7 @@ function HmLinkEmbed({
       id={id}
       parentBlockId={parentBlockId}
       hideBorder
-      route={{key: 'document', id}}
+      route={documentRoute}
       openOnClick={openOnClick}
       viewType="Link"
     >
@@ -634,29 +641,16 @@ export function BlockEmbedContentComment({
 }) {
   const currentRoute = useNavRoute()
   const targetDocId = getCommentTargetId(comment)
+  const activePanel = getRoutePanel(currentRoute) as DocumentPanelRoute | null
 
   const route = useMemo(() => {
     if (!targetDocId) return undefined
 
-    const currentDocId =
-      currentRoute.key === 'document' || currentRoute.key === 'comments' || currentRoute.key === 'feed'
-        ? currentRoute.id
-        : null
-
-    const isSameDocument =
-      !!currentDocId &&
-      targetDocId.uid === currentDocId.uid &&
-      (targetDocId.path?.join('/') ?? '') === (currentDocId.path?.join('/') ?? '')
-
-    if (isSameDocument) {
+    if (activePanel) {
       return {
         key: 'document' as const,
         id: targetDocId,
-        panel: {
-          key: 'comments' as const,
-          id,
-          openComment: comment.id,
-        },
+        panel: activePanel,
       }
     }
     return {
@@ -664,7 +658,7 @@ export function BlockEmbedContentComment({
       id: targetDocId,
       openComment: comment.id,
     }
-  }, [targetDocId, currentRoute, id, comment.id])
+  }, [targetDocId, activePanel, comment.id])
 
   return (
     <EmbedWrapper

--- a/frontend/packages/ui/src/embed-wrapper.tsx
+++ b/frontend/packages/ui/src/embed-wrapper.tsx
@@ -1,6 +1,6 @@
 import './blocks-content.css'
 import {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
-import {NavRoute} from '@shm/shared'
+import {getRoutePanel, type DocumentPanelRoute, type DocumentRoute, type NavRoute} from '@shm/shared'
 import {useRouteLink} from '@shm/shared/routing'
 import {useNavRoute} from '@shm/shared/utils/navigation'
 import {packHmId} from '@shm/shared/utils/entity-id-url'
@@ -19,6 +19,12 @@ function isInteractiveEmbedClickTarget(event: MouseEvent<HTMLElement>) {
   )
 
   return !!interactiveEl && interactiveEl !== embedEl
+}
+
+/** Builds a document route for an embed while retaining the currently active panel. */
+export function getEmbedDocumentRoute(id: UnpackedHypermediaId, currentRoute: NavRoute): DocumentRoute {
+  const panel = getRoutePanel(currentRoute) as DocumentPanelRoute | null
+  return panel ? {key: 'document', id, panel} : {key: 'document', id}
 }
 
 export function EmbedWrapper({
@@ -47,18 +53,11 @@ export function EmbedWrapper({
   const highlight = useHighlighter()
   const currentRoute = useNavRoute()
 
-  // If current route has a panel, preserve it when navigating to documents
+  // Preserve any active panel when navigating an embed to a document.
   const effectiveRoute = useMemo(() => {
     if (!route) return route
-    // Only modify document routes that don't already have a panel
     if (route.key === 'document' && !route.panel) {
-      // Preserve panel from current document/feed route
-      if (currentRoute.key === 'document' && currentRoute.panel) {
-        return {...route, panel: currentRoute.panel}
-      }
-      if (currentRoute.key === 'feed' && currentRoute.panel) {
-        return {...route, panel: currentRoute.panel}
-      }
+      return getEmbedDocumentRoute(route.id, currentRoute)
     }
     return route
   }, [route, currentRoute])

--- a/frontend/packages/ui/src/newspaper.tsx
+++ b/frontend/packages/ui/src/newspaper.tsx
@@ -6,7 +6,14 @@ import {
   HMResourceFetchResult,
   UnpackedHypermediaId,
 } from '@seed-hypermedia/client/hm-types'
-import {findFirstBlock, hmId, plainTextOfContent, useRouteLink, useUniversalAppContext} from '@shm/shared'
+import {
+  findFirstBlock,
+  hmId,
+  plainTextOfContent,
+  type DocumentRoute,
+  useRouteLink,
+  useUniversalAppContext,
+} from '@shm/shared'
 import {useDocumentActions} from '@shm/shared/document-actions-context'
 import {useResource} from '@shm/shared/models/entity'
 import {useInteractionSummary} from '@shm/shared/models/interaction-summary'
@@ -315,6 +322,7 @@ export function DocumentCardShell({
 
 export function DocumentCard({
   docId,
+  route,
   entity,
   metadata,
   visibility,
@@ -333,6 +341,8 @@ export function DocumentCard({
   ...props
 }: HTMLAttributes<HTMLDivElement> & {
   docId: UnpackedHypermediaId
+  /** Optional document route for callers that need to preserve an active panel. */
+  route?: DocumentRoute
   entity: HMResourceFetchResult | null | undefined
   metadata?: HMDocumentInfo['metadata']
   visibility?: HMDocumentInfo['visibility']
@@ -351,7 +361,7 @@ export function DocumentCard({
   relocationOrigin?: DocumentCardActionOrigin
 }) {
   const highlighter = useHighlighter()
-  const linkProps = useRouteLink(docId ? {key: 'document', id: docId} : null)
+  const linkProps = useRouteLink(route ?? (docId ? {key: 'document', id: docId} : null))
   const {onClick: routeOnClick, tag: _routeTag, ...linkAttributes} = linkProps
   const navigate = useNavigate()
   const actions = useDocumentActions()

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -367,6 +367,16 @@ export type ActiveView =
   | 'all-documents'
   | 'metadata'
 
+/** Returns the document and focused comment rendered by a comments panel. */
+export function getCommentsPanelTarget(
+  docId: UnpackedHypermediaId,
+  panelRoute: DocumentPanelRoute | null,
+): {docId: UnpackedHypermediaId; openComment?: string} {
+  return panelRoute?.key === 'comments'
+    ? {docId: panelRoute.id ?? docId, openComment: panelRoute.openComment}
+    : {docId, openComment: undefined}
+}
+
 /** Selects the action controls shown for document content. */
 export function getDocumentContentAction({
   activeView,
@@ -1518,6 +1528,7 @@ function DocumentBody({
   // Extract panel from route (only document/feed routes have panels)
   const panelRoute = getRoutePanel(route) as DocumentPanelRoute | null
   const panelKey = panelRoute?.key ?? null
+  const commentsPanelTarget = getCommentsPanelTarget(docId, panelRoute)
 
   // Extract discussions-specific params from route or from explicit props
   const discussionsParams =
@@ -2437,12 +2448,12 @@ function DocumentBody({
         {mobilePanelOpen && (
           <MobilePanelSheet isOpen={mobilePanelOpen} title={getPanelTitle(panelKey)} onClose={handlePanelClose}>
             <DiscussionsPageContent
-              docId={docId}
+              docId={commentsPanelTarget.docId}
               showTitle={false}
               showOpenInPanel={false}
               contentMaxWidth={contentMaxWidth}
               targetDomain={siteUrl}
-              openComment={panelRoute?.key === 'comments' ? panelRoute.openComment : undefined}
+              openComment={commentsPanelTarget.openComment}
               targetBlockId={panelRoute?.key === 'comments' ? panelRoute.targetBlockId : undefined}
               blockId={panelRoute?.key === 'comments' ? panelRoute.blockId : undefined}
               blockRange={panelRoute?.key === 'comments' ? panelRoute.blockRange : undefined}
@@ -2458,12 +2469,12 @@ function DocumentBody({
                           })
                         : undefined
                     }
-                    docId={docId}
+                    docId={commentsPanelTarget.docId}
                     quotingBlockId={panelRoute?.key === 'comments' ? panelRoute.targetBlockId : undefined}
                     quotingRange={
                       panelRoute?.key === 'comments' ? extractQuotingRange(panelRoute.blockRange) : undefined
                     }
-                    commentId={panelRoute?.key === 'comments' ? panelRoute.openComment : undefined}
+                    commentId={commentsPanelTarget.openComment}
                     isReplying={
                       panelRoute?.key === 'comments' ? panelRoute.isReplying ?? !!panelRoute.openComment : false
                     }
@@ -2733,9 +2744,11 @@ function PanelContentRenderer({
         />
       )
     case 'comments':
+      const commentsPanelTarget = getCommentsPanelTarget(docId, panelRoute)
       return (
         <CommentsPanelContent
-          docId={docId}
+          docId={commentsPanelTarget.docId}
+          openComment={commentsPanelTarget.openComment}
           panelRoute={panelRoute}
           contentMaxWidth={contentMaxWidth}
           targetDomain={siteUrl}
@@ -2758,12 +2771,14 @@ function PanelContentRenderer({
 
 function CommentsPanelContent({
   docId,
+  openComment,
   panelRoute,
   contentMaxWidth,
   targetDomain,
   CommentEditor,
 }: {
   docId: UnpackedHypermediaId
+  openComment?: string
   panelRoute: Extract<DocumentPanelRoute, {key: 'comments'}>
   contentMaxWidth: number
   targetDomain?: string
@@ -2810,7 +2825,7 @@ function CommentsPanelContent({
         showOpenInPanel={false}
         contentMaxWidth={contentMaxWidth}
         targetDomain={targetDomain}
-        openComment={panelRoute.openComment}
+        openComment={openComment}
         targetBlockId={panelRoute.targetBlockId}
         blockId={panelRoute.blockId}
         blockRange={panelRoute.blockRange}
@@ -2818,15 +2833,15 @@ function CommentsPanelContent({
           CommentEditor ? (
             <CommentEditor
               key={getCommentEditorRouteKey({
-                openComment: panelRoute.openComment,
+                openComment,
                 targetBlockId: panelRoute.targetBlockId,
                 blockRange: panelRoute.blockRange,
               })}
               docId={docId}
               quotingBlockId={panelRoute.targetBlockId}
               quotingRange={extractQuotingRange(panelRoute.blockRange)}
-              commentId={panelRoute.openComment}
-              isReplying={panelRoute.isReplying ?? !!panelRoute.openComment}
+              commentId={openComment}
+              isReplying={panelRoute.isReplying ?? !!openComment}
               replyCommentVersion={panelRoute.replyCommentVersion}
               rootReplyCommentVersion={panelRoute.rootReplyCommentVersion}
               focusOnMount


### PR DESCRIPTION
## Summary

- Open embedded comments in the current document’s comments panel when they belong to that document.
- Navigate comments from other documents to the correct document context.
- Avoid linking embedded comments when their target document is unavailable.

Fixes #879 