### PR TITLE
fix(editor): comment typing no longer slows down as the comment grows (#884)

### DIFF
--- a/frontend/apps/desktop/src/components/commenting.tsx
+++ b/frontend/apps/desktop/src/components/commenting.tsx
@@ -15,7 +15,7 @@ import {
   HMPublishBlobsInput,
   UnpackedHypermediaId,
 } from '@seed-hypermedia/client/hm-types'
-import {CommentEditor} from '@shm/editor/comment-editor'
+import {CommentEditor, type CommentEditorSubmitHandle} from '@shm/editor/comment-editor'
 import {queryClient, queryKeys} from '@shm/shared'
 import {BlockNode} from '@shm/shared/client/.generated/documents/v3alpha/documents_pb'
 import type {InlineEditCommentProps} from '@shm/shared/comments-service-provider'
@@ -115,6 +115,7 @@ function CommentBoxImpl(props: {
   const saveTimeoutRef = useRef<NodeJS.Timeout>()
   const pendingBlocksRef = useRef<HMBlockNode[] | null>(null)
   const latestBlocksRef = useRef<HMBlockNode[] | null>(null)
+  const submitHandleRef = useRef<CommentEditorSubmitHandle | null>(null)
   const flushPendingDraftSaveRef = useRef<() => void>(() => {})
 
   const commentDraftQueryKey = [
@@ -383,6 +384,10 @@ function CommentBoxImpl(props: {
     ) => {
       if (isSubmitting) return
 
+      // Content changes are debounced in the editor; flush so latestBlocksRef
+      // holds the final content before reading it below.
+      submitHandleRef.current?.flush()
+
       if (!account) {
         const contentBlocks = latestBlocksRef.current || draft.data?.blocks || []
         if (!contentBlocks.some(hasBlockContent)) return
@@ -476,6 +481,7 @@ function CommentBoxImpl(props: {
       <CommentEditor
         focusOnMount={focusOnMount}
         isReplying={isReplying || !!commentId}
+        submitHandleRef={submitHandleRef}
         handleSubmit={handleSubmit}
         initialBlocks={draft.data?.blocks}
         onContentChange={handleContentChange}

--- a/frontend/apps/web/app/commenting.tsx
+++ b/frontend/apps/web/app/commenting.tsx
@@ -8,7 +8,7 @@ import {
   HMPublishBlobsOutput,
   UnpackedHypermediaId,
 } from '@seed-hypermedia/client/hm-types'
-import {CommentEditor} from '@shm/editor/comment-editor'
+import {CommentEditor, type CommentEditorSubmitHandle} from '@shm/editor/comment-editor'
 import {
   getValidatedWebSeedLinkState,
   hmId,
@@ -119,6 +119,7 @@ export default function WebCommenting({
 
   // Track latest editor content for non-destructive reads (e.g. persisting intent to IDB)
   const latestBlocksRef = useRef<HMBlockNode[] | null>(null)
+  const submitHandleRef = useRef<CommentEditorSubmitHandle | null>(null)
 
   // Generation counter: bumped on clearDraft to force editor remount via key
   const [editorGeneration, setEditorGeneration] = useState(0)
@@ -274,6 +275,10 @@ export default function WebCommenting({
     ) => {
       if (isSubmitting || !docVersion) return // Prevent double submission
 
+      // Content changes are debounced in the editor; flush so latestBlocksRef
+      // holds the final content before reading it below.
+      submitHandleRef.current?.flush()
+
       if (!userKeyPair) {
         // Persist intent to IDB so it can be processed after account creation
         // (works for both local and vault flows).
@@ -415,6 +420,7 @@ export default function WebCommenting({
         key={`${draftId}-${editorGeneration}`}
         focusOnMount={focusOnMount ?? autoFocus}
         isReplying={isReplyEditor}
+        submitHandleRef={submitHandleRef}
         handleSubmit={handleSubmit}
         initialBlocks={initialBlocks}
         onContentChange={(blocks, mediaRefs) => {

--- a/frontend/packages/editor/src/block-group-map.test.ts
+++ b/frontend/packages/editor/src/block-group-map.test.ts
@@ -1,0 +1,150 @@
+import {Node as TipTapNode, Schema} from '@tiptap/pm/model'
+import {describe, expect, it} from 'vitest'
+import type {BlockNoteEditor} from './blocknote/core/BlockNoteEditor'
+import {buildBlockGroupsById, getBlockGroup} from './utils'
+
+/**
+ * Regression tests for #884: serverBlockNodesFromEditorBlocks used to call
+ * getBlockGroup (a full-document traversal) once per block, making every
+ * serialization O(n²) in document size. buildBlockGroupsById replaces that
+ * with a single traversal; these tests pin its equivalence to getBlockGroup
+ * and its scaling advantage.
+ */
+
+// Minimal schema mirroring the parts of the editor schema that getBlockGroup
+// inspects: containers carry an `id` attr, `blockChildren` carries list attrs.
+const schema = new Schema({
+  nodes: {
+    doc: {content: 'blockGroup'},
+    blockGroup: {content: 'blockContainer+'},
+    blockContainer: {
+      content: 'paragraph blockChildren?',
+      attrs: {id: {default: null}},
+    },
+    blockChildren: {
+      content: 'blockContainer+',
+      attrs: {
+        listType: {default: null},
+        listLevel: {default: '1'},
+        start: {default: null},
+        columnCount: {default: null},
+      },
+    },
+    paragraph: {content: 'text*'},
+    text: {},
+  },
+})
+
+type BlockSpec = {
+  id: string
+  listType?: string
+  start?: number
+  columnCount?: string
+  children?: BlockSpec[]
+}
+
+function createBlock(spec: BlockSpec): TipTapNode {
+  const content: TipTapNode[] = [schema.nodes.paragraph!.create(null, schema.text(`text of ${spec.id}`))]
+  if (spec.children?.length) {
+    content.push(
+      schema.nodes.blockChildren!.create(
+        {
+          listType: spec.listType ?? null,
+          start: spec.start ?? null,
+          columnCount: spec.columnCount ?? null,
+          listLevel: '1',
+        },
+        spec.children.map(createBlock),
+      ),
+    )
+  }
+  return schema.nodes.blockContainer!.create({id: spec.id}, content)
+}
+
+function createDoc(specs: BlockSpec[]): TipTapNode {
+  return schema.nodes.doc!.create(null, schema.nodes.blockGroup!.create(null, specs.map(createBlock)))
+}
+
+function collectIds(specs: BlockSpec[]): string[] {
+  return specs.flatMap((spec) => [spec.id, ...collectIds(spec.children ?? [])])
+}
+
+function fakeEditor(doc: TipTapNode): BlockNoteEditor {
+  return {_tiptapEditor: {state: {doc}}} as unknown as BlockNoteEditor
+}
+
+function expectEquivalence(specs: BlockSpec[]) {
+  const doc = createDoc(specs)
+  const editor = fakeEditor(doc)
+  const groupsById = buildBlockGroupsById(doc)
+  for (const id of collectIds(specs)) {
+    expect(groupsById.get(id), `group for block ${id}`).toEqual(getBlockGroup(editor, id))
+  }
+}
+
+describe('buildBlockGroupsById', () => {
+  it('matches getBlockGroup for flat blocks without child groups', () => {
+    expectEquivalence([{id: 'a'}, {id: 'b'}, {id: 'c'}])
+  })
+
+  it('matches getBlockGroup for blocks with list groups and attributes', () => {
+    expectEquivalence([
+      {id: 'a', listType: 'Unordered', children: [{id: 'a1'}, {id: 'a2'}]},
+      {id: 'b', listType: 'Ordered', start: 3, children: [{id: 'b1'}]},
+      {id: 'c', listType: 'Grid', columnCount: '2', children: [{id: 'c1'}, {id: 'c2'}]},
+      {id: 'd'},
+    ])
+  })
+
+  it('matches getBlockGroup for deeply nested mixed groups', () => {
+    expectEquivalence([
+      {
+        id: 'a',
+        listType: 'Unordered',
+        children: [
+          {id: 'a1', listType: 'Ordered', start: 2, children: [{id: 'a1x'}, {id: 'a1y'}]},
+          {id: 'a2', listType: 'Group', children: [{id: 'a2x'}]},
+        ],
+      },
+      {id: 'b', listType: 'Group', children: [{id: 'b1', listType: 'Unordered', children: [{id: 'b1x'}]}]},
+    ])
+  })
+
+  it('matches getBlockGroup when a parent group has no listType but a nested one does', () => {
+    // getBlockGroup returns the first blockChildren descendant with a
+    // listType, even if it belongs to a nested block; preserve that quirk.
+    expectEquivalence([
+      {
+        id: 'a',
+        children: [{id: 'a1', listType: 'Ordered', children: [{id: 'a1x'}]}],
+      },
+    ])
+  })
+
+  it('scales linearly: single traversal beats per-block getBlockGroup on a large document', () => {
+    const specs: BlockSpec[] = Array.from({length: 1200}, (_, i) => ({
+      id: `block-${i}`,
+      listType: 'Unordered',
+      children: [{id: `block-${i}-child`}],
+    }))
+    const doc = createDoc(specs)
+    const editor = fakeEditor(doc)
+    const ids = collectIds(specs)
+
+    const oldStart = performance.now()
+    const oldGroups = new Map(ids.map((id) => [id, getBlockGroup(editor, id)]))
+    const oldElapsed = performance.now() - oldStart
+
+    const newStart = performance.now()
+    const groupsById = buildBlockGroupsById(doc)
+    const newElapsed = performance.now() - newStart
+
+    for (const id of ids) {
+      expect(groupsById.get(id)).toEqual(oldGroups.get(id))
+    }
+
+    // The old path is O(blocks × document size) — ~90x slower at this size
+    // (measured ~228ms vs ~2.5ms), so this comparison has a wide safety margin.
+    expect(newElapsed).toBeLessThan(oldElapsed)
+  })
+})

--- a/frontend/packages/editor/src/comment-editor-content-change.test.tsx
+++ b/frontend/packages/editor/src/comment-editor-content-change.test.tsx
@@ -1,0 +1,211 @@
+// @vitest-environment jsdom
+import {UniversalAppProvider} from '@shm/shared'
+import {hmId} from '@shm/shared/utils/entity-id-url'
+import React from 'react'
+import {createRoot, type Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+
+/**
+ * Regression tests for #884: typing in long comments was slow because every
+ * ProseMirror update synchronously serialized the whole document (an O(n²)
+ * operation) to feed onContentChange. Serialization must now be debounced off
+ * the keystroke path and flushed on blur/submit/unmount.
+ */
+
+// Counts full-document serializations: one call = one expensive conversion.
+const serializeSpy = vi.hoisted(() => vi.fn(() => [{toJson: () => ({block: {id: 'b1', type: 'paragraph'}})}]))
+
+vi.mock('./utils', () => ({
+  serverBlockNodesFromEditorBlocks: serializeSpy,
+  createMediaBlock: vi.fn(),
+  handleDragMedia: vi.fn(),
+  selectAllEditorContent: vi.fn(),
+}))
+
+const fakeEditorRef = vi.hoisted(() => ({current: null as any}))
+
+vi.mock('./blocknote', () => ({
+  BlockNoteEditor: class {},
+  getBlockInfoFromPos: vi.fn(),
+  useBlockNote: () => fakeEditorRef.current,
+}))
+vi.mock('./blocknote/core/extensions/SlashMenu/defaultSlashMenuItems', () => ({
+  insertOrUpdateBlock: vi.fn(),
+}))
+vi.mock('./blocknote/core/extensions/DragMedia/DragExtension', () => ({
+  FILE_DROP_INSERTED_EVENT: 'hm-file-drop-inserted',
+}))
+vi.mock('./blocknote/core/extensions/SlashMenu/SlashMenuPlugin', () => ({
+  slashMenuPluginKey: {getState: () => undefined},
+}))
+vi.mock('./mention-suggestion-plugin', () => ({
+  mentionSuggestionPluginKey: {getState: () => undefined},
+}))
+vi.mock('./editor-view', () => ({
+  HyperMediaEditorView: () => <div data-testid="editor-view" />,
+}))
+vi.mock('./hypermedia-link-plugin', () => ({
+  createHypermediaDocLinkPlugin: () => ({plugin: {}}),
+}))
+vi.mock('./mobile-mentions-dialog', () => ({MobileMentionsDialog: () => null}))
+vi.mock('./mobile-slash-dialog', () => ({MobileSlashDialog: () => null}))
+vi.mock('./schema', () => ({hmBlockSchema: {}}))
+vi.mock('./slash-menu-items', () => ({getSlashMenuItems: () => []}))
+vi.mock('./use-mobile', () => ({
+  isMobileDevice: () => false,
+  useMobile: () => false,
+}))
+
+import {CommentEditor, type CommentEditorSubmitHandle} from './comment-editor'
+
+function createFakeEditor() {
+  const handlers = new Map<string, Set<() => void>>()
+  const dom = document.createElement('div')
+  const editor: any = {
+    topLevelBlocks: [{id: 'b1', type: 'paragraph', props: {}, content: [], children: []}],
+    removeBlocks: vi.fn(),
+    replaceBlocks: vi.fn(),
+    insertBlocks: vi.fn(),
+    _tiptapEditor: {
+      on: (event: string, fn: () => void) => {
+        if (!handlers.has(event)) handlers.set(event, new Set())
+        handlers.get(event)!.add(fn)
+      },
+      off: (event: string, fn: () => void) => {
+        handlers.get(event)?.delete(fn)
+      },
+      commands: {focus: vi.fn(), blur: vi.fn()},
+      chain: () => ({focus: () => ({run: vi.fn()})}),
+      view: {dom, state: {doc: {content: {size: 10}}}},
+      state: {},
+    },
+  }
+  return {
+    editor,
+    emit: (event: string) => {
+      handlers.get(event)?.forEach((fn) => fn())
+    },
+  }
+}
+
+let container: HTMLDivElement
+let root: Root
+let fake: ReturnType<typeof createFakeEditor>
+let onContentChange: ReturnType<typeof vi.fn>
+let submitHandleRef: {current: CommentEditorSubmitHandle | null}
+
+function renderCommentEditor() {
+  act(() => {
+    root.render(
+      <UniversalAppProvider
+        originHomeId={hmId('uid1')}
+        openUrl={vi.fn()}
+        openRoute={vi.fn()}
+        openRouteNewWindow={vi.fn()}
+        universalClient={{request: vi.fn(), publish: vi.fn()} as any}
+      >
+        <CommentEditor
+          handleSubmit={vi.fn()}
+          submitButton={() => <></>}
+          onContentChange={onContentChange}
+          submitHandleRef={submitHandleRef as any}
+        />
+      </UniversalAppProvider>,
+    )
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  fake = createFakeEditor()
+  fakeEditorRef.current = fake.editor
+  onContentChange = vi.fn()
+  submitHandleRef = {current: null}
+  serializeSpy.mockClear()
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+  vi.useRealTimers()
+})
+
+describe('CommentEditor content change emission (#884)', () => {
+  it('does not serialize the document on each keystroke; emits once after the debounce', () => {
+    renderCommentEditor()
+
+    act(() => {
+      for (let i = 0; i < 25; i++) fake.emit('update')
+    })
+
+    // Nothing expensive may run on the keystroke path.
+    expect(serializeSpy).not.toHaveBeenCalled()
+    expect(onContentChange).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+
+    // 25 keystrokes collapse into a single serialization + emission.
+    expect(serializeSpy).toHaveBeenCalledTimes(1)
+    expect(onContentChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('flushes the pending change immediately when the editor blurs', () => {
+    renderCommentEditor()
+
+    act(() => {
+      fake.emit('update')
+      fake.emit('blur')
+    })
+
+    expect(onContentChange).toHaveBeenCalledTimes(1)
+
+    // The debounce timer must not fire a duplicate emission afterwards.
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(onContentChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('exposes flush() on the submit handle for submit-time freshness', () => {
+    renderCommentEditor()
+
+    act(() => {
+      fake.emit('update')
+    })
+    expect(onContentChange).not.toHaveBeenCalled()
+
+    act(() => {
+      submitHandleRef.current?.flush()
+    })
+    expect(onContentChange).toHaveBeenCalledTimes(1)
+
+    // flush with nothing pending is a no-op
+    act(() => {
+      submitHandleRef.current?.flush()
+    })
+    expect(onContentChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('flushes the pending change on unmount so drafts are not lost', () => {
+    renderCommentEditor()
+
+    act(() => {
+      fake.emit('update')
+    })
+    expect(onContentChange).not.toHaveBeenCalled()
+
+    act(() => {
+      root.unmount()
+    })
+    expect(onContentChange).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/packages/editor/src/comment-editor.tsx
+++ b/frontend/packages/editor/src/comment-editor.tsx
@@ -259,6 +259,8 @@ export type CommentEditorSubmitHandle = {
   submit: () => void
   reset: () => void
   focus: (options?: {moveCursorToEnd?: boolean}) => void
+  /** Emits any pending (debounced) onContentChange synchronously. */
+  flush: () => void
   getContent: (
     prepareAttachments: (binaries: Uint8Array[]) => Promise<{
       blobs: {cid: string; data: Uint8Array}[]
@@ -396,7 +398,7 @@ export function CommentEditor({
   const [isDraggingOver, setIsDraggingOver] = useState(false)
   const tx = useTx()
   const isInitializedRef = useRef(false)
-  const hasPendingContentChangeRef = useRef(false)
+  const contentChangeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const hasLocalEditsRef = useRef(false)
   const isApplyingInitialBlocksRef = useRef(false)
   const shouldFocusOnActivateRef = useRef(false)
@@ -435,7 +437,13 @@ export function CommentEditor({
     return Math.max(0, editor._tiptapEditor.view.state.doc.content.size - 4)
   }
 
-  const emitContentChangeNow = () => {
+  // Serializes the whole document for onContentChange. Too expensive to run
+  // per keystroke (typing lags on long comments, #884), so changes only
+  // schedule this and it runs debounced, or synchronously on blur/submit/unmount.
+  const flushContentChange = () => {
+    if (!contentChangeTimeoutRef.current) return
+    clearTimeout(contentChangeTimeoutRef.current)
+    contentChangeTimeoutRef.current = null
     if (!onContentChange) return
 
     try {
@@ -448,7 +456,7 @@ export function CommentEditor({
         Object.keys(mediaRefs).length > 0 ? mediaRefs : undefined,
       )
     } catch (error) {
-      console.error('Failed to emit immediate content change:', error)
+      console.error('Failed to emit content change:', error)
     }
   }
 
@@ -500,7 +508,7 @@ export function CommentEditor({
       lastId = blockNode.id
     }
 
-    emitContentChangeNow()
+    flushContentChange()
   }
 
   const isFileDrag = (dataTransfer: DataTransfer | null | undefined) => {
@@ -648,28 +656,28 @@ export function CommentEditor({
     }
   }, [editor])
 
-  // Notify parent of content changes
+  // Notify parent of content changes, debounced (see flushContentChange)
   useEffect(() => {
     if (!onContentChange) return
 
     const handleChange = () => {
-      hasPendingContentChangeRef.current = true
       if (!isApplyingInitialBlocksRef.current) {
         hasLocalEditsRef.current = true
       }
-      emitContentChangeNow()
-      hasPendingContentChangeRef.current = false
+      if (contentChangeTimeoutRef.current) {
+        clearTimeout(contentChangeTimeoutRef.current)
+      }
+      contentChangeTimeoutRef.current = setTimeout(flushContentChange, 300)
     }
 
-    // Listen to editor changes
     editor._tiptapEditor.on('update', handleChange)
+    // Flush when focus leaves the editor (e.g. tapping a save/submit button)
+    editor._tiptapEditor.on('blur', flushContentChange)
 
     return () => {
       editor._tiptapEditor.off('update', handleChange)
-      if (hasPendingContentChangeRef.current) {
-        emitContentChangeNow()
-        hasPendingContentChangeRef.current = false
-      }
+      editor._tiptapEditor.off('blur', flushContentChange)
+      flushContentChange()
     }
   }, [editor, onContentChange])
 
@@ -712,7 +720,7 @@ export function CommentEditor({
 
     const editorDom = editor._tiptapEditor.view.dom
     const handleInsertedFileDrop = () => {
-      emitContentChangeNow()
+      flushContentChange()
     }
 
     editorDom.addEventListener(FILE_DROP_INSERTED_EVENT, handleInsertedFileDrop)
@@ -766,6 +774,10 @@ export function CommentEditor({
       resultCIDs: string[]
     }>,
   ) => {
+    // Emit any debounced content change before the destructive mutations below,
+    // so parents (draft persistence) hold the final pre-publish content.
+    flushContentChange()
+
     // @ts-expect-error
     const editorBlocks: EditorBlock[] = editor.topLevelBlocks
 
@@ -895,6 +907,7 @@ export function CommentEditor({
       submit: () => submitCallbackRef.current?.(),
       reset,
       focus: focusEditor,
+      flush: flushContentChange,
       getContent,
     }
   }

--- a/frontend/packages/editor/src/utils.ts
+++ b/frontend/packages/editor/src/utils.ts
@@ -137,11 +137,49 @@ export function getBlockGroup(
   return undefined
 }
 
+type BlockGroupInfo = {type: string; listLevel: string; start?: number; columnCount?: string}
+
+// Single-pass equivalent of calling getBlockGroup for every block: each block id
+// maps to the first blockChildren descendant (in document order) with a listType.
+export function buildBlockGroupsById(doc: TipTapNode): Map<string, BlockGroupInfo> {
+  const groups = new Map<string, BlockGroupInfo>()
+  const openBlockIds: string[] = []
+
+  function visit(node: TipTapNode) {
+    if (node.attrs.listType && node.type.name === 'blockChildren') {
+      for (const id of openBlockIds) {
+        if (!groups.has(id)) {
+          groups.set(id, {
+            type: node.attrs.listType,
+            start: node.attrs.start,
+            listLevel: node.attrs.listLevel,
+            columnCount: node.attrs.columnCount,
+          })
+        }
+      }
+    }
+    const id: string | undefined = node.attrs.id
+    if (id) openBlockIds.push(id)
+    node.forEach((child) => visit(child))
+    if (id) openBlockIds.pop()
+  }
+
+  doc.firstChild?.forEach((child) => visit(child))
+  return groups
+}
+
 export function serverBlockNodesFromEditorBlocks(editor: BlockNoteEditor, editorBlocks: EditorBlock[]): BlockNode[] {
+  if (!editorBlocks) return []
+  const tiptap = editor?._tiptapEditor
+  const groupsById = tiptap ? buildBlockGroupsById(tiptap.state.doc) : new Map<string, BlockGroupInfo>()
+  return blockNodesFromEditorBlocks(editorBlocks, groupsById)
+}
+
+function blockNodesFromEditorBlocks(editorBlocks: EditorBlock[], groupsById: Map<string, BlockGroupInfo>): BlockNode[] {
   if (!editorBlocks) return []
 
   return editorBlocks.map((block: EditorBlock) => {
-    const childGroup = getBlockGroup(editor, block.id)
+    const childGroup = groupsById.get(block.id)
     const serverBlock = editorBlockToHMBlock(block)
     if (childGroup) {
       // @ts-expect-error
@@ -166,7 +204,7 @@ export function serverBlockNodesFromEditorBlocks(editor: BlockNoteEditor, editor
     }
     const blockNode = new BlockNode({
       block: Block.fromJson(serverBlock),
-      children: serverBlockNodesFromEditorBlocks(editor, block.children),
+      children: blockNodesFromEditorBlocks(block.children, groupsById),
     })
     return blockNode
   })


### PR DESCRIPTION
Fixes #884

## The problem, in plain terms

On the web (and worst on phones), typing a comment got slower and slower as the comment grew. After a paragraph or two, each character could take a noticeable moment to appear.

The cause: to keep your draft saved, the editor converted **the entire comment** into its storage format **on every single keystroke**. And that conversion had a hidden multiplier — for each block (paragraph, list item, image…) it re-scanned the whole document from the top. So a comment with twice the text cost roughly **four times** the work, all running in the split second between pressing a key and seeing the letter.

## The fix — two parts

**1. Don't do the heavy work while you type.**
Keystrokes now just start a short (300ms) countdown. The convert-and-save only runs after you pause typing — so while you're typing, nothing expensive runs at all. To make sure no content is ever lost, the conversion is also forced to run immediately at every moment that matters:

- when you tap **Publish** (or press Enter/Cmd+Enter)
- when you tap away from the editor
- when the editor closes (e.g. you navigate away)

**2. Make the heavy work light.**
The conversion itself now scans the document **once** to gather what it needs, instead of once per block. Measured on a 2,400-block document: **~228ms → ~2.5ms** (~90x faster). This helps everywhere the conversion still runs — draft saves and publishing — on web, desktop, and the agents composer, which all share this editor.

## How it's tested

Two new test suites lock the fix in place (`frontend/packages/editor`):

- **`comment-editor-content-change.test.tsx`** — simulates 25 keystrokes and asserts **zero** conversions happen during typing and exactly **one** after the pause (previously: 25). Also proves pending changes are emitted on blur, on submit, and on unmount, so drafts can't be lost.
- **`block-group-map.test.ts`** — proves the new single-pass scan returns **exactly** the same results as the old per-block scan (flat, nested, and edge cases), plus a timing assertion showing the single pass is faster on a large document.

Also verified:

- Full editor test suite: 322 passing; the only 8 failures also fail on `main` untouched (pre-existing, unrelated).
- `tsc` typechecks clean for the editor package, web app, and desktop app.
- Not yet tested by hand on a physical phone — worth a quick type-a-long-comment check on the preview deploy.

## Trade-off to know about

Drafts are now written up to ~300ms after you stop typing rather than instantly. The forced saves above cover publish/blur/close, so the only theoretical loss window is force-killing the tab mid-word — a window the existing 500ms draft-save debounce already had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)