### PR TITLE
Add create site (space) flow for web and desktop apps

### DIFF
--- a/frontend/apps/desktop/src/components/create-space-dialog.tsx
+++ b/frontend/apps/desktop/src/components/create-space-dialog.tsx
@@ -1,0 +1,88 @@
+import {useSelectedAccountId} from '@/selected-account'
+import {client} from '@/trpc'
+import {fileUpload} from '@/utils/file-upload'
+import {useNavigate} from '@/utils/useNavigate'
+import {hmId} from '@shm/shared'
+import {Dialog, DialogSideContent, DialogTitle} from '@shm/ui/components/dialog'
+import {createSpaceMetadata} from '@shm/ui/create-space-platform'
+import {CreateSpaceForm, type CreateSpaceFormState} from '@shm/ui/create-space-form'
+import {Spinner} from '@shm/ui/spinner'
+import {SizableText} from '@shm/ui/text'
+import {toast} from '@shm/ui/toast'
+import {nanoid} from 'nanoid'
+import {useCallback, useState} from 'react'
+
+// Imperative opener for the "Create a space" panel.
+export function useCreateSpaceDialog() {
+  const [isOpen, setIsOpen] = useState(false)
+  const open = useCallback(() => setIsOpen(true), [])
+  const close = useCallback(() => setIsOpen(false), [])
+  const content = (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogSideContent>
+        <DialogTitle className="sr-only">Create a space</DialogTitle>
+        {isOpen ? <CreateSpaceFlow onClose={close} /> : null}
+      </DialogSideContent>
+    </Dialog>
+  )
+  return {open, close, content}
+}
+
+/**
+ * The form with its desktop commit: populate a home document draft under
+ * the selected identity with the collected metadata, then open the home editor.
+ */
+export function CreateSpaceFlow({onClose}: {onClose: () => void}) {
+  const navigate = useNavigate()
+  const selectedAccountId = useSelectedAccountId()
+  const [busy, setBusy] = useState(false)
+
+  async function handleComplete(state: CreateSpaceFormState) {
+    if (!selectedAccountId) {
+      toast.error('Create or select an identity before creating a space.')
+      return
+    }
+    setBusy(true)
+    try {
+      // Upload images to IPFS, then write a populated home draft for
+      // the selected identity.
+      const [coverCid, logoCid] = await Promise.all([
+        state.cover ? fileUpload(state.cover) : Promise.resolve(undefined),
+        state.logo ? fileUpload(state.logo) : Promise.resolve(undefined),
+      ])
+      const metadata = createSpaceMetadata(state, {coverCid, logoCid})
+      await client.drafts.write.mutate({
+        id: nanoid(10),
+        editUid: selectedAccountId,
+        editPath: [],
+        metadata,
+        content: [],
+        deps: [],
+        visibility: 'PUBLIC',
+      })
+      // Open the home editor so the user can add content and publish.
+      navigate({key: 'document', id: hmId(selectedAccountId, {path: []})})
+      onClose()
+    } catch (e) {
+      toast.error('Failed to set up space: ' + (e instanceof Error ? e.message : String(e)))
+      setBusy(false)
+    }
+  }
+
+  if (busy) {
+    return <CenteredStatus title="Setting up your space…" />
+  }
+
+  return <CreateSpaceForm onComplete={handleComplete} onClose={onClose} />
+}
+
+function CenteredStatus({title}: {title: string}) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
+      <Spinner />
+      <SizableText size="sm" className="text-muted-foreground">
+        {title}
+      </SizableText>
+    </div>
+  )
+}

--- a/frontend/apps/desktop/src/components/sidebar.tsx
+++ b/frontend/apps/desktop/src/components/sidebar.tsx
@@ -4,7 +4,7 @@ import {useContactList} from '@/models/contacts'
 import {useSubscribedDocuments} from '@/models/library'
 import {grpcClient} from '@/grpc-client'
 import {useSelectedAccountId} from '@/selected-account'
-import {getOrCreateSiteHome} from '@/utils/create-site'
+import {useCreateSpaceDialog} from './create-space-dialog'
 import {useNavigate} from '@/utils/useNavigate'
 import {
   HMAccountsMetadata,
@@ -745,7 +745,7 @@ function MySiteSection({selectedAccountId}: {selectedAccountId?: string}) {
   const navigate = useNavigate()
   const route = useNavRoute()
   const active = siteId ? isSiteDocumentsActiveRoute(route, siteId) : false
-  const [isCreatingSite, setIsCreatingSite] = React.useState(false)
+  const createSpaceDialog = useCreateSpaceDialog()
 
   if (!selectedAccountId) return null
 
@@ -810,29 +810,11 @@ function MySiteSection({selectedAccountId}: {selectedAccountId?: string}) {
   return (
     <SidebarSection title="My Site">
       <Tooltip content="Create your site to publish documents and share your profile.">
-        <Button
-          className="w-full"
-          variant="default"
-          disabled={isCreatingSite}
-          onClick={async () => {
-            setIsCreatingSite(true)
-            try {
-              const homeId = await getOrCreateSiteHome(selectedAccountId)
-              navigate({
-                key: 'document',
-                id: homeId,
-              })
-            } catch (error) {
-              console.error('Failed to verify site before creating draft:', error)
-              toast.error('Could not verify whether your site already exists. Please try again.')
-            } finally {
-              setIsCreatingSite(false)
-            }
-          }}
-        >
+        <Button className="w-full" variant="default" onClick={() => createSpaceDialog.open()}>
           Create my Site
         </Button>
       </Tooltip>
+      {createSpaceDialog.content}
     </SidebarSection>
   )
 }

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -19,8 +19,6 @@ import {usePublishSite, useRemoveSiteDialog} from '@/components/publish-site'
 import {SearchInput} from '@/components/search-input'
 import {domainResolver, grpcClient} from '@/grpc-client'
 import {roleCanWrite, useSelectedAccountCapability} from '@/models/access-control'
-import {useIsSiteOwner} from '@shm/shared/models/capabilities'
-import {createEmailSubscribersMenuItem} from '@shm/ui/site-email-subscribers'
 import {useDraft} from '@/models/accounts'
 import {useMyAccountIds} from '@/models/daemon'
 import {
@@ -52,6 +50,8 @@ import {CommentsProvider} from '@shm/shared/comments-service-provider'
 import {DEFAULT_GATEWAY_URL} from '@shm/shared/constants'
 import type {LinkExtensionOptions} from '@shm/shared/document-content-props'
 import {canCreateChildDocuments} from '@shm/shared/document-utils'
+import {useIsSiteOwner} from '@shm/shared/models/capabilities'
+import {createEmailSubscribersMenuItem} from '@shm/ui/site-email-subscribers'
 // import {hasQueryBlockTargetingSelf, hasSelfQueryBlockInEditorContent} from '@shm/shared/content'
 import {
   DiscardDraftInput,
@@ -443,7 +443,12 @@ export default function DesktopResourcePage() {
         })
         const result = await client.drafts.write.mutate({
           id: draftId,
-          metadata: input.metadata,
+          // Merge over the stored metadata rather than replacing it. The
+          // session overlay (input.metadata) can be empty before draft.resolved
+          // populates it (e.g. a home draft pre-written with metadata values by
+          // the create space form), and a full replace would wipe those
+          // fields on the first autosave.
+          metadata: {...existingDraft?.metadata, ...input.metadata},
           signingAccount: input.signingAccountId || undefined,
           content,
           cursorPosition,

--- a/frontend/apps/web/app/auth.tsx
+++ b/frontend/apps/web/app/auth.tsx
@@ -462,6 +462,10 @@ export function useVaultSuccessDialog() {
       dialog.open({variant})
       return
     }
+    if (variant === 'publish-draft') {
+      toast.success('Your space is live! You can change its settings anytime.')
+      return
+    }
     if (variant === 'join') {
       toast.success(`You've joined ${siteName} — you can now comment and participate`)
       return

--- a/frontend/apps/web/app/document-edit/use-web-can-edit.ts
+++ b/frontend/apps/web/app/document-edit/use-web-can-edit.ts
@@ -4,6 +4,7 @@ import {useUniversalAppContext} from '@shm/shared'
 import {WEB_IS_GATEWAY} from '@shm/shared/constants'
 import {roleCanWrite} from '@shm/shared/models/capabilities'
 import {useCapabilities} from '@shm/shared/models/entity'
+import {isPendingSpaceUid} from '@shm/shared/utils/pending-space'
 import {useMemo} from 'react'
 
 /**
@@ -83,7 +84,8 @@ export function resolveWebCanEdit(args: {
 export function useWebCanEdit(docId: UnpackedHypermediaId | null | undefined): WebCanEditResult {
   const userKeyPair = useLocalKeyPair()
   const {origin, originHomeId} = useUniversalAppContext()
-  const capabilities = useCapabilities(docId ?? undefined)
+  // Skip the capability lookup for anonymous pending drafts.
+  const capabilities = useCapabilities(isPendingSpaceUid(docId?.uid) ? undefined : docId ?? undefined)
   const capabilitiesLoading = capabilities.isLoading
 
   return useMemo<WebCanEditResult>(

--- a/frontend/apps/web/app/document-edit/web-create-space-draft.ts
+++ b/frontend/apps/web/app/document-edit/web-create-space-draft.ts
@@ -98,3 +98,25 @@ export async function adoptPendingSpaceDraft(
   })
   return homeId
 }
+
+/**
+ * After a failed publish, re-point the home draft to a
+ * placeholder edit route under the new account and
+ * return the web path to navigate to.
+ */
+export async function repointSpaceHomeDraftToAccount(draftId: string, accountUid: string): Promise<string | null> {
+  const draft = await getWebDocDraft(draftId)
+  if (!draft) return null
+  const editId = hmId(accountUid, {path: [`-${draftId}`]})
+  await putWebDocDraft({
+    ...draft,
+    docId: editId.id,
+    signingAccountId: accountUid,
+    locationUid: accountUid,
+    locationPath: [],
+    editUid: accountUid,
+    editPath: [], // still publishes to the home path
+  })
+  markSpaceHomeDraftId(draftId)
+  return `/hm/${accountUid}/-${draftId}`
+}

--- a/frontend/apps/web/app/document-edit/web-create-space-draft.ts
+++ b/frontend/apps/web/app/document-edit/web-create-space-draft.ts
@@ -1,0 +1,100 @@
+import type {HMMetadata, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {hmId} from '@shm/shared/utils/entity-id-url'
+import {PENDING_SPACE_UID_PREFIX} from '@shm/shared/utils/pending-space'
+import {nanoid} from 'nanoid'
+import {getWebDocDraft, putWebDocDraft} from './web-draft-db'
+
+export {isPendingSpaceUid} from '@shm/shared/utils/pending-space'
+
+// Tracks which local draft ids are pending home drafts. Kept in
+// localStorage so the editor's autosave, which
+// rewrites the draft's editPath, can't erase the marker.
+const SPACE_HOME_DRAFT_IDS_KEY = 'space-home-draft-ids'
+
+function readSpaceHomeDraftIds(): Set<string> {
+  if (typeof localStorage === 'undefined') return new Set()
+  try {
+    return new Set(JSON.parse(localStorage.getItem(SPACE_HOME_DRAFT_IDS_KEY) || '[]') as string[])
+  } catch {
+    return new Set()
+  }
+}
+
+function markSpaceHomeDraftId(draftId: string): void {
+  if (typeof localStorage === 'undefined') return
+  const ids = readSpaceHomeDraftIds()
+  ids.add(draftId)
+  try {
+    localStorage.setItem(SPACE_HOME_DRAFT_IDS_KEY, JSON.stringify([...ids]))
+  } catch {
+    // Ignore — localStorage may be unavailable.
+  }
+}
+
+// True when a local draft id is a "create a space" home draft.
+export function isSpaceHomeDraftId(draftId: string | null | undefined): boolean {
+  return !!draftId && readSpaceHomeDraftIds().has(draftId)
+}
+
+export type PendingSpaceHomeDraft = {
+  // Persistent local draft id, used to adopt the draft after sign-in.
+  draftId: string
+  // Route id for the editor.
+  id: UnpackedHypermediaId
+  // Web URL to navigate to so the editor opens on this draft.
+  webPath: string
+}
+
+/**
+ * Create a local home draft, edited via a `-<draftId>` placeholder route.
+ * `editPath: []` marks it as a home doc for publish.
+ */
+export async function createSpaceHomeDraft(
+  metadata: Partial<HMMetadata>,
+  accountUid?: string | null,
+): Promise<PendingSpaceHomeDraft> {
+  const uid = accountUid || `${PENDING_SPACE_UID_PREFIX}${nanoid(10)}`
+  const draftId = nanoid(10)
+  const id = hmId(uid, {path: [`-${draftId}`]})
+  await putWebDocDraft({
+    draftId,
+    docId: id.id,
+    signingAccountId: accountUid || '', // empty when signed out
+    content: [],
+    metadata,
+    deps: [],
+    navigation: null,
+    locationUid: uid,
+    locationPath: [],
+    editUid: uid,
+    editPath: [], // home doc target for publish
+    cursorPosition: null,
+    visibility: 'PUBLIC',
+  })
+  markSpaceHomeDraftId(draftId)
+  return {draftId, id, webPath: `/hm/${uid}/-${draftId}`}
+}
+
+/**
+ * Re-key a pending home draft to a real account after sign-in and return the
+ * real home doc id. The draft keeps its content/metadata and only the identity
+ * fields change, so the existing editor/publish pipeline can own and publish it.
+ */
+export async function adoptPendingSpaceDraft(
+  pendingDraftId: string,
+  accountUid: string,
+): Promise<UnpackedHypermediaId | null> {
+  const draft = await getWebDocDraft(pendingDraftId)
+  if (!draft) return null
+  const homeId = hmId(accountUid, {path: []})
+  await putWebDocDraft({
+    ...draft,
+    docId: homeId.id,
+    signingAccountId: accountUid,
+    locationUid: accountUid,
+    locationPath: [],
+    editUid: accountUid,
+    editPath: [],
+  })
+  return homeId
+}

--- a/frontend/apps/web/app/document-edit/web-document-actors.test.ts
+++ b/frontend/apps/web/app/document-edit/web-document-actors.test.ts
@@ -1,10 +1,10 @@
-import 'fake-indexeddb/auto'
-import {indexedDB} from 'fake-indexeddb'
 import {decode as cborDecode, encode as cborEncode} from '@ipld/dag-cbor'
 import type {HMBlockNode, HMDocument, HMSigner, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {ResourceVisibility} from '@shm/shared/client/.generated/documents/v3alpha/documents_pb'
 import type {PublishInput} from '@shm/shared/models/document-machine'
 import type {UniversalClient} from '@shm/shared/universal-client'
+import {indexedDB} from 'fake-indexeddb'
+import 'fake-indexeddb/auto'
 import * as Block from 'multiformats/block'
 import {sha256} from 'multiformats/hashes/sha2'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
@@ -16,7 +16,7 @@ import {
   type CreateWebDocumentMachineDeps,
   type WebEditorAccessor,
 } from './web-document-actors'
-import {_resetWebDocDraftDBForTesting, putWebDocDraft, getWebDocDraft, listWebDocDraftsForDoc} from './web-draft-db'
+import {_resetWebDocDraftDBForTesting, getWebDocDraft, listWebDocDraftsForDoc, putWebDocDraft} from './web-draft-db'
 
 const enqueueWebDocumentCardCleanupMock = vi.hoisted(() => vi.fn(async () => ({enqueued: true})))
 
@@ -636,6 +636,79 @@ describe('publishWebDocument', () => {
 
     const finalResourceCall = deps.requestMock.mock.calls.filter((c: any) => c[0] === 'Resource').at(-1)!
     expect(finalResourceCall[1].path).toEqual(['secret-generated-path'])
+  })
+
+  it('first-publish home document bootstraps a genesis Change and Ref, and bases the change on it', async () => {
+    // Web's pending space draft's first publish
+    // A brand-new home document has no genesis on the server,
+    // and PrepareDocumentChange can't bootstrap one.
+    // publishWebDocument must publish a client-signed genesis Change and version Ref
+    // first, then base PrepareDocumentChange on that genesis.
+    const docId = makeDocId(OWNER) // root path [] — home document
+    const after = makeBaselineDoc([], {path: ''})
+
+    await putWebDocDraft({
+      draftId,
+      docId: docId.id,
+      signingAccountId: OWNER,
+      content: [paragraph('b1', 'welcome')],
+      metadata: {name: 'My Space'},
+      deps: [],
+      navigation: null,
+      locationUid: OWNER,
+      locationPath: [],
+      editUid: OWNER,
+      editPath: [],
+      visibility: 'PUBLIC',
+      cursorPosition: null,
+    })
+
+    let resourceCalls = 0
+    const requestMock = vi.fn(async (key: string) => {
+      if (key === 'PrepareDocumentChange') {
+        return {unsignedChange: createTestUnsignedChangeBytes()}
+      }
+      if (key === 'Resource') {
+        resourceCalls += 1
+        // 1: load editDocument. 2+: post-publish fetch.
+        return resourceCalls === 1 ? ({type: 'not-found'} as any) : ({type: 'document', document: after} as any)
+      }
+      throw new Error(`unexpected request: ${key}`)
+    }) as AnyMock
+
+    const deps = makeDeps({
+      docId,
+      request: requestMock,
+      after,
+      editorBlocks: [
+        {
+          id: 'b1',
+          type: 'paragraph',
+          props: {childrenType: 'Group'},
+          content: [{type: 'text', text: 'welcome'}],
+          children: [],
+        },
+      ],
+    })
+
+    await publishWebDocument({...baseInput, documentId: docId}, deps)
+
+    // The genesis bootstrap is the first publish: a Change blob then a Ref blob.
+    const publishCalls = (deps.client.publish as AnyMock).mock.calls
+    expect(publishCalls.length).toBeGreaterThanOrEqual(2)
+    const genesisBlobs = publishCalls[0]![0].blobs
+    const genesisChange = cborDecode(genesisBlobs[0]!.data) as Record<string, unknown>
+    const genesisRef = cborDecode(genesisBlobs[1]!.data) as Record<string, unknown>
+    expect(genesisChange.type).toBe('Change')
+    expect(genesisRef.type).toBe('Ref')
+    // A first-publish Ref points its genesis at the genesis Change itself.
+    const genesisCid = genesisBlobs[0]!.cid
+    expect(String(genesisRef.genesisBlob)).toBe(genesisCid)
+
+    // PrepareDocumentChange must base off the freshly bootstrapped genesis, not
+    // the empty base version it would otherwise use for a doc with no deps.
+    const prepareCall = deps.requestMock.mock.calls.find((c: any) => c[0] === 'PrepareDocumentChange')!
+    expect(prepareCall[1].baseVersion).toBe(genesisCid)
   })
 
   it('non-owner publish includes capability CID', async () => {

--- a/frontend/apps/web/app/document-edit/web-document-actors.ts
+++ b/frontend/apps/web/app/document-edit/web-document-actors.ts
@@ -143,7 +143,10 @@ function makeWriteDraftActor(deps: CreateWebDocumentMachineDeps) {
       signingAccountId: input.signingAccountId ?? '',
       capabilityCid: existingDraft?.capabilityCid ?? deps.getCapabilityCid(),
       content,
-      metadata: input.metadata ?? {},
+      // Merge over the stored metadata rather than replacing it. The session
+      // overlay (input.metadata) can be empty/partial before the draft resolves,
+      // and a full replace would wipe those fields on the first autosave.
+      metadata: {...(existingDraft?.metadata ?? {}), ...(input.metadata ?? {})},
       deps: input.deps,
       navigation: input.navigation ?? null,
       locationUid: isReservedRouteDraft ? deps.docId.uid : input.locationUid || null,

--- a/frontend/apps/web/app/document-edit/web-document-actors.ts
+++ b/frontend/apps/web/app/document-edit/web-document-actors.ts
@@ -10,12 +10,9 @@
  * closing over the host's editor accessor + universal client + signer factory.
  */
 
-import {signDocumentChange} from '@seed-hypermedia/client'
-import {ResourceVisibility} from '@shm/shared/client/.generated/documents/v3alpha/documents_pb'
-import {hmId} from '@shm/shared/utils/entity-id-url'
+import {createGenesisChange, createVersionRef, signDocumentChange} from '@seed-hypermedia/client'
 import type {EditorBlock} from '@seed-hypermedia/client/editor-types'
 import {editorBlocksToHMBlockNodes} from '@seed-hypermedia/client/editorblock-to-hmblock'
-import {hmBlocksToEditorContent} from '@seed-hypermedia/client/hmblock-to-editorblock'
 import type {
   HMBlockNode,
   HMDocument,
@@ -23,6 +20,8 @@ import type {
   HMSigner,
   UnpackedHypermediaId,
 } from '@seed-hypermedia/client/hm-types'
+import {hmBlocksToEditorContent} from '@seed-hypermedia/client/hmblock-to-editorblock'
+import {ResourceVisibility} from '@shm/shared/client/.generated/documents/v3alpha/documents_pb'
 import {
   documentMachine,
   retargetQueryBlockIncludesForPublish,
@@ -40,16 +39,18 @@ import type {UniversalClient} from '@shm/shared/universal-client'
 import {
   compareBlocksWithMap,
   createBlocksMap,
-  extractDeletes,
   expandObjectRemovals,
+  extractDeletes,
   getDocAttributeChanges,
 } from '@shm/shared/utils/document-changes'
+import {hmId} from '@shm/shared/utils/entity-id-url'
 import {getNavigationChanges} from '@shm/shared/utils/navigation-changes'
 import {hmIdPathToEntityQueryPath} from '@shm/shared/utils/path-api'
 import {computeInlineDraftPublishPath} from '@shm/shared/utils/publish-paths'
 import {nanoid} from 'nanoid'
 import {fromPromise} from 'xstate'
 
+import {enqueueWebDocumentCardCleanup} from './web-document-card-cleanup'
 import {
   deleteWebDocDraft,
   getWebDocDraft,
@@ -57,7 +58,6 @@ import {
   putWebDocDraft,
   type WebDocDraft,
 } from './web-draft-db'
-import {enqueueWebDocumentCardCleanup} from './web-document-card-cleanup'
 import {getWebDraftPlaceholderId, isWebDraftPlaceholderPath, isWebPrivateDraftPlaceholderPath} from './web-draft-path'
 
 /** @deprecated Use `EditorAccessor` from `@shm/shared/models/document-machine` instead. */
@@ -287,27 +287,56 @@ export async function publishWebDocument(input: PublishInput, deps: CreateWebDoc
   // Web signs client-side via `signDocumentChange`. Generation must be strictly
   // greater than existing HEAD's — a tie keeps the old HEAD.
   const signer = deps.getSigner(signerAccountUid)
+
+  const existingGenerationRaw = editDocument?.generationInfo?.generation
+  const existingGenerationNum = existingGenerationRaw != null ? Number(existingGenerationRaw) : 0
+  const nextGeneration = Math.max(Date.now(), existingGenerationNum + 1)
+
+  // New home document has no genesis on the server yet, and the
+  // server's PrepareChange can't bootstrap one. This is pending draft's first
+  // publish on web. Publish a client-signed genesis Change and a version Ref
+  // so the document becomes resolvable, then continue with the normal
+  // PrepareDocumentChange using that genesis as the base version.
+  let effectiveBaseVersion = baseVersion
+  let effectiveGenesis: string | undefined = editDocument?.genesis
+  if (!editDocument && publishPath.length === 0) {
+    const genesisChange = await createGenesisChange(signer)
+    const genesisRef = await createVersionRef(
+      {
+        space: deps.docId.uid,
+        path: '',
+        genesis: genesisChange.cid.toString(),
+        version: genesisChange.cid.toString(),
+        generation: nextGeneration,
+        capability: capabilityCid,
+      },
+      signer,
+    )
+    await (deps.client as any).publish({
+      blobs: [{data: genesisChange.bytes, cid: genesisChange.cid.toString()}, ...genesisRef.blobs],
+    })
+    effectiveBaseVersion = genesisChange.cid.toString()
+    effectiveGenesis = genesisChange.cid.toString()
+  }
+
   const prepareResult = (await deps.client.request(
     'PrepareDocumentChange' as any,
     {
       account: deps.docId.uid,
       path,
-      baseVersion,
+      baseVersion: effectiveBaseVersion,
       changes: allChanges as any,
       capability: capabilityCid,
       visibility,
     } as any,
   )) as any
 
-  const existingGenerationRaw = editDocument?.generationInfo?.generation
-  const existingGenerationNum = existingGenerationRaw != null ? Number(existingGenerationRaw) : 0
-  const nextGeneration = Math.max(Date.now(), existingGenerationNum + 1)
   const {changeCid, publishInput} = await signDocumentChange(
     {
       account: deps.docId.uid,
       path,
       unsignedChange: prepareResult.unsignedChange,
-      genesis: editDocument?.genesis,
+      genesis: effectiveGenesis,
       generation: nextGeneration,
       capability: capabilityCid,
       visibility,

--- a/frontend/apps/web/app/local-db.ts
+++ b/frontend/apps/web/app/local-db.ts
@@ -1,5 +1,5 @@
-import {HMBlockNodeSchema, unpackedHmIdSchema} from '@seed-hypermedia/client/hm-types'
 import type {HMBlockNode, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {HMBlockNodeSchema, unpackedHmIdSchema} from '@seed-hypermedia/client/hm-types'
 import {z} from 'zod'
 
 function upgradeStore(db: IDBDatabase, storeName: string, options?: IDBObjectStoreParameters): IDBObjectStore | null {
@@ -342,7 +342,12 @@ export interface PendingFollowIntent {
   profileUid: string
 }
 
-export type PendingIntent = PendingCommentIntent | PendingJoinIntent | PendingFollowIntent
+export interface PendingPublishDraftIntent {
+  type: 'publish-draft'
+  draftId: string
+}
+
+export type PendingIntent = PendingCommentIntent | PendingJoinIntent | PendingFollowIntent | PendingPublishDraftIntent
 
 // Zod schemas for validating stored intent data
 const PendingCommentIntentSchema = z.object({
@@ -372,10 +377,16 @@ const PendingFollowIntentSchema = z.object({
   profileUid: z.string(),
 })
 
+const PendingPublishDraftIntentSchema = z.object({
+  type: z.literal('publish-draft'),
+  draftId: z.string(),
+})
+
 const PendingIntentSchema = z.discriminatedUnion('type', [
   PendingCommentIntentSchema,
   PendingJoinIntentSchema,
   PendingFollowIntentSchema,
+  PendingPublishDraftIntentSchema,
 ])
 
 const PENDING_INTENT_KEY = 'pending'

--- a/frontend/apps/web/app/pending-intent.ts
+++ b/frontend/apps/web/app/pending-intent.ts
@@ -15,6 +15,7 @@ export type PendingIntentResult =
   | {type: 'join'; joinStatus: JoinSiteResult}
   | {type: 'follow'}
   | {type: 'comment'; commentUrl: string}
+  | {type: 'publish-draft'; spaceUrl: string}
 
 let pendingIntentProcessingPromise: Promise<PendingIntentResult> | null = null
 
@@ -163,6 +164,53 @@ async function runProcessPendingIntent(originHomeId?: UnpackedHypermediaId): Pro
     await followProfile(signer, intent.profileUid)
     await clearPendingIntent()
     return {type: 'follow'}
+  }
+
+  if (intent.type === 'publish-draft') {
+    console.log('[processPendingIntent] Publish-draft intent', intent)
+    try {
+      const accountUid = await getCurrentAccountUidWithDelegation()
+      if (!accountUid) {
+        await clearPendingIntent()
+        return {type: 'none'}
+      }
+      const {adoptPendingSpaceDraft} = await import('./document-edit/web-create-space-draft')
+      const {publishWebDocument} = await import('./document-edit/web-document-actors')
+      // Re-key the anonymous home draft to the new account, then publish it.
+      const homeId = await adoptPendingSpaceDraft(intent.draftId, accountUid)
+      if (!homeId) {
+        await clearPendingIntent()
+        return {type: 'none'}
+      }
+      await publishWebDocument(
+        {
+          documentId: homeId,
+          draftId: intent.draftId,
+          deps: [],
+          metadata: {},
+          navigation: undefined,
+          publishAccountUid: accountUid,
+          deletedChildDraftIds: [],
+        },
+        {
+          docId: homeId,
+          getEditor: () => null,
+          client: webUniversalClient,
+          getSigner: (uid) => {
+            if (!webUniversalClient.getSigner) throw new Error('No signer available for publish')
+            return webUniversalClient.getSigner(uid)
+          },
+          getCapabilityCid: () => undefined,
+          onPublishSuccess: () => {},
+        },
+      )
+      await clearPendingIntent()
+      return {type: 'publish-draft', spaceUrl: `/hm/${accountUid}`}
+    } catch (e) {
+      console.error('Failed to process publish-draft intent:', e)
+      await clearPendingIntent()
+      return {type: 'none'}
+    }
   }
 
   if (intent.type === 'comment') {

--- a/frontend/apps/web/app/pending-intent.ts
+++ b/frontend/apps/web/app/pending-intent.ts
@@ -4,6 +4,7 @@ import {queryKeys} from '@shm/shared'
 import {invalidateQueries} from '@shm/shared/models/query-client'
 import type {NavRoute} from '@shm/shared/routes'
 import {routeToUrl} from '@shm/shared/utils/entity-id-url'
+import {toast} from '@shm/ui/toast'
 import {getCurrentAccountUidWithDelegation, getCurrentSigner} from './auth'
 import {clearPendingIntent, getPendingIntent, getStoredLocalKeys} from './local-db'
 import {webUniversalClient} from './universal-client'
@@ -16,6 +17,7 @@ export type PendingIntentResult =
   | {type: 'follow'}
   | {type: 'comment'; commentUrl: string}
   | {type: 'publish-draft'; spaceUrl: string}
+  | {type: 'publish-draft-failed'; retryUrl: string}
 
 let pendingIntentProcessingPromise: Promise<PendingIntentResult> | null = null
 
@@ -168,13 +170,15 @@ async function runProcessPendingIntent(originHomeId?: UnpackedHypermediaId): Pro
 
   if (intent.type === 'publish-draft') {
     console.log('[processPendingIntent] Publish-draft intent', intent)
+    const accountUid = await getCurrentAccountUidWithDelegation()
+    if (!accountUid) {
+      await clearPendingIntent()
+      return {type: 'none'}
+    }
+    const {adoptPendingSpaceDraft, repointSpaceHomeDraftToAccount} = await import(
+      './document-edit/web-create-space-draft'
+    )
     try {
-      const accountUid = await getCurrentAccountUidWithDelegation()
-      if (!accountUid) {
-        await clearPendingIntent()
-        return {type: 'none'}
-      }
-      const {adoptPendingSpaceDraft} = await import('./document-edit/web-create-space-draft')
       const {publishWebDocument} = await import('./document-edit/web-document-actors')
       // Re-key the anonymous home draft to the new account, then publish it.
       const homeId = await adoptPendingSpaceDraft(intent.draftId, accountUid)
@@ -208,7 +212,12 @@ async function runProcessPendingIntent(originHomeId?: UnpackedHypermediaId): Pro
       return {type: 'publish-draft', spaceUrl: `/hm/${accountUid}`}
     } catch (e) {
       console.error('Failed to process publish-draft intent:', e)
+      toast.error('Your account was created, but publishing your space failed. You can try publishing again.')
       await clearPendingIntent()
+      // Re-point the home draft to a placeholder edit route
+      // under the new account and redirect there for retry.
+      const retryUrl = await repointSpaceHomeDraftToAccount(intent.draftId, accountUid)
+      if (retryUrl) return {type: 'publish-draft-failed', retryUrl}
       return {type: 'none'}
     }
   }

--- a/frontend/apps/web/app/routes/hm.auth.callback.tsx
+++ b/frontend/apps/web/app/routes/hm.auth.callback.tsx
@@ -137,11 +137,14 @@ export default function AuthCallbackRoute() {
         const intentResult = await processPendingIntent(originHomeId)
 
         let targetUrl = returnUrl
-        let successVariant: 'comment' | 'join' | 'login' | 'welcome-back' = 'login'
+        let successVariant: 'comment' | 'join' | 'login' | 'welcome-back' | 'publish-draft' = 'login'
 
         if (intentResult.type === 'comment') {
           targetUrl = intentResult.commentUrl
           successVariant = 'comment'
+        } else if (intentResult.type === 'publish-draft') {
+          targetUrl = intentResult.spaceUrl
+          successVariant = 'publish-draft'
         } else if (intentResult.type === 'join') {
           successVariant = intentResult.joinStatus === 'joined' ? 'join' : 'welcome-back'
         } else if (originHomeId?.uid) {

--- a/frontend/apps/web/app/routes/hm.auth.callback.tsx
+++ b/frontend/apps/web/app/routes/hm.auth.callback.tsx
@@ -7,9 +7,9 @@ import {
   getAuthState,
   writeLocalKeys,
 } from '@/local-db'
+import {queryAPI} from '@/models'
 import {getSiteMembershipStatus, processPendingIntent} from '@/pending-intent'
 import {webUniversalClient} from '@/universal-client'
-import {queryAPI} from '@/models'
 import {useNavigate} from '@remix-run/react'
 import {createSeedClient} from '@seed-hypermedia/client'
 import {useUniversalAppContext} from '@shm/shared'
@@ -137,7 +137,7 @@ export default function AuthCallbackRoute() {
         const intentResult = await processPendingIntent(originHomeId)
 
         let targetUrl = returnUrl
-        let successVariant: 'comment' | 'join' | 'login' | 'welcome-back' | 'publish-draft' = 'login'
+        let successVariant: 'comment' | 'join' | 'login' | 'welcome-back' | 'publish-draft' | null = 'login'
 
         if (intentResult.type === 'comment') {
           targetUrl = intentResult.commentUrl
@@ -145,6 +145,9 @@ export default function AuthCallbackRoute() {
         } else if (intentResult.type === 'publish-draft') {
           targetUrl = intentResult.spaceUrl
           successVariant = 'publish-draft'
+        } else if (intentResult.type === 'publish-draft-failed') {
+          targetUrl = intentResult.retryUrl
+          successVariant = null
         } else if (intentResult.type === 'join') {
           successVariant = intentResult.joinStatus === 'joined' ? 'join' : 'welcome-back'
         } else if (originHomeId?.uid) {
@@ -155,7 +158,7 @@ export default function AuthCallbackRoute() {
         }
 
         const nextUrl = new URL(targetUrl, window.location.origin)
-        nextUrl.searchParams.set('vault_success', successVariant)
+        if (successVariant) nextUrl.searchParams.set('vault_success', successVariant)
         navigate(`${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`, {replace: true})
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)

--- a/frontend/apps/web/app/routes/hm.create-site.tsx
+++ b/frontend/apps/web/app/routes/hm.create-site.tsx
@@ -1,0 +1,105 @@
+import {useLocalKeyPair} from '@/auth'
+import {createSpaceHomeDraft} from '@/document-edit/web-create-space-draft'
+import {makeWebFileUpload} from '@/document-edit/web-image-upload'
+import {webUniversalClient} from '@/universal-client'
+import {useNavigate} from '@remix-run/react'
+import {hmId} from '@shm/shared/utils/entity-id-url'
+import {Button} from '@shm/ui/button'
+import {createSpaceMetadata} from '@shm/ui/create-space-platform'
+import {CreateSpaceForm, type CreateSpaceFormState} from '@shm/ui/create-space-form'
+import {Spinner} from '@shm/ui/spinner'
+import {SizableText} from '@shm/ui/text'
+import {toast} from '@shm/ui/toast'
+import {useQuery} from '@tanstack/react-query'
+import {useMemo, useState} from 'react'
+
+function Panel({children}: {children: React.ReactNode}) {
+  return (
+    <div className="flex min-h-screen w-full justify-end bg-black/5 dark:bg-black/30">
+      <div className="bg-background flex w-full max-w-[440px] flex-col shadow-xl">{children}</div>
+    </div>
+  )
+}
+
+/**
+ * "Create a space" entry point. The form writes a local home draft (anonymous
+ * pending draft when signed out, or a real draft under the account when signed
+ * in) and opens the editor; publishing that draft creates the space. Cover/logo
+ * images are uploaded to IPFS here and referenced in the draft metadata.
+ */
+export default function CreateSiteRoute() {
+  const navigate = useNavigate()
+  const userKeyPair = useLocalKeyPair()
+  const accountUid = userKeyPair?.delegatedAccountUid ?? userKeyPair?.id ?? null
+  const [busy, setBusy] = useState(false)
+  const fileUpload = useMemo(() => makeWebFileUpload(webUniversalClient), [])
+
+  // When signed in, check whether this account already has a space.
+  const existingSpace = useQuery({
+    queryKey: ['create-space-existing-home', accountUid],
+    enabled: !!accountUid,
+    queryFn: async () => {
+      if (!accountUid) return false
+      try {
+        const res = (await webUniversalClient.request('Resource', hmId(accountUid, {path: []}))) as {type?: string}
+        return res?.type === 'document'
+      } catch {
+        return false
+      }
+    },
+  })
+
+  async function handleComplete(state: CreateSpaceFormState) {
+    setBusy(true)
+    try {
+      // Upload cover/logo to IPFS and reference the resulting CIDs
+      // in the metadata, mirroring the web draft image flow.
+      const [coverCid, logoCid] = await Promise.all([
+        state.cover ? fileUpload(state.cover) : Promise.resolve(undefined),
+        state.logo ? fileUpload(state.logo) : Promise.resolve(undefined),
+      ])
+      const metadata = createSpaceMetadata(state, {coverCid, logoCid})
+      const {webPath} = await createSpaceHomeDraft(metadata, accountUid)
+      navigate(webPath)
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to create space')
+      setBusy(false)
+    }
+  }
+
+  if (accountUid && existingSpace.isLoading) {
+    return (
+      <Panel>
+        <div className="flex flex-1 items-center justify-center p-6">
+          <Spinner />
+        </div>
+      </Panel>
+    )
+  }
+
+  if (accountUid && existingSpace.data) {
+    return (
+      <Panel>
+        <div className="flex flex-col gap-4 p-6">
+          <SizableText size="2xl" weight="bold" asChild>
+            <h2>You already have a space</h2>
+          </SizableText>
+          <SizableText className="text-muted-foreground">
+            This account already has a space, and each account can have one. To create another, sign in with a different
+            identity.
+          </SizableText>
+          <Button variant="default" onClick={() => navigate(`/hm/${accountUid}`)}>
+            Go to your space
+          </Button>
+        </div>
+      </Panel>
+    )
+  }
+
+  return (
+    <Panel>
+      <CreateSpaceForm onComplete={handleComplete} onClose={() => navigate('/')} />
+      {busy ? <div className="fixed inset-0 z-50 cursor-progress" aria-hidden /> : null}
+    </Panel>
+  )
+}

--- a/frontend/apps/web/app/web-resource-page.tsx
+++ b/frontend/apps/web/app/web-resource-page.tsx
@@ -9,6 +9,7 @@ import type {DocumentContentProps} from '@shm/shared/document-content-props'
 import {canCreateChildDocuments} from '@shm/shared/document-utils'
 import {type EditorAccessor} from '@shm/shared/models/document-machine'
 import {useResource} from '@shm/shared/models/entity'
+import {HomeDraftProvider} from '@shm/shared/home-draft-context'
 import {selectContext, useDocumentMachineRef} from '@shm/shared/models/use-document-machine'
 import {QueryBlockDraftsProvider} from '@shm/shared/query-block-drafts-context'
 import {replaceRouteDocumentId} from '@shm/shared/routes'
@@ -482,8 +483,10 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
       !!signingAccountId && (id.uid === signingAccountId || (effectiveCanEdit && id.uid === docId.uid)),
     [docId.uid, effectiveCanEdit, signingAccountId],
   )
+  const homeDraftOverride: boolean | undefined = isSpaceHomeDraft || isPendingSpace ? true : undefined
+  const isHomeTarget = homeDraftOverride ?? !docId.path?.length
   const moveMenuItem = useMemo<MenuItemType | null>(() => {
-    if (!effectiveCanEdit || !signingAccountId || !docId.path?.length) return null
+    if (!effectiveCanEdit || !signingAccountId || isHomeTarget) return null
     return {
       key: 'move',
       label: 'Move',
@@ -511,9 +514,9 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
         destinationDialog.open({id: docId, mode: 'move'})
       },
     }
-  }, [destinationDialog, docId, draftData, effectiveCanEdit, placeholderDraftId, signingAccountId])
+  }, [destinationDialog, docId, draftData, effectiveCanEdit, isHomeTarget, placeholderDraftId, signingAccountId])
   const deleteMenuItem = useMemo<MenuItemType | null>(() => {
-    if (!effectiveCanEdit || !signingAccountId || !docId.path?.length) return null
+    if (!effectiveCanEdit || !signingAccountId || isHomeTarget) return null
     return {
       key: 'delete',
       label: 'Delete Document',
@@ -528,7 +531,7 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
         })
       },
     }
-  }, [docId, effectiveCanEdit, onDeleteDocument, replaceRoute, signingAccountId])
+  }, [docId, effectiveCanEdit, isHomeTarget, onDeleteDocument, replaceRoute, signingAccountId])
   const optionsMenuItems = useMemo(
     () => [newMenuItem, ...webMenuItems, moveMenuItem, deleteMenuItem].filter(Boolean) as MenuItemType[],
     [deleteMenuItem, moveMenuItem, newMenuItem, webMenuItems],
@@ -623,37 +626,39 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
             >
               <QuerySearchInputProvider value={WebQuerySearchInput}>
                 <WebDraftBreadcrumbProvider>
-                  <ResourcePage
-                    docId={docId}
-                    resourceId={useLocalDraftShell ? null : docId}
-                    CommentEditor={CommentEditor}
-                    pageFooter={<PageFooter id={docId} />}
-                    onEditProfile={onEditProfile}
-                    profileHeaderButtons={profileHeaderButtons}
-                    onFollowClick={onFollowClick}
-                    rightActions={<WebHeaderActions siteUid={docId.uid} />}
-                    optionsMenuItems={optionsMenuItems}
-                    inlineInsert={inlineInsert}
-                    DocumentContentComponent={DocumentContentComponent}
-                    ssrContentHTML={ssrContentHTML}
-                    perspectiveAccountUid={ownAccountUid}
-                    linkExtensionOptions={linkExtensionOptions}
-                    canEdit={effectiveCanEdit}
-                    machine={machine}
-                    machineExtras={<WebDraftExternalModificationListener />}
-                    signingAccountId={signingAccountId ?? undefined}
-                    publishAccountUid={signingAccountId ?? undefined}
-                    onEditorReady={onEditorReady}
-                    existingDraft={existingDraft}
-                    reservedDraftId={reservedDraftId}
-                    existingDraftVisibility={draftData?.visibility}
-                    existingDraftContent={existingDraftContent}
-                    existingDraftCursorPosition={existingDraftCursorPosition}
-                    existingDraftDeps={draftData?.deps}
-                    draftVersionOnDiscardConfirm={webToolbarCallbacks.onDiscardConfirm}
-                    editingFloatingActions={editingFloatingActions}
-                    fileUpload={fileUpload}
-                  />
+                  <HomeDraftProvider value={homeDraftOverride}>
+                    <ResourcePage
+                      docId={docId}
+                      resourceId={useLocalDraftShell ? null : docId}
+                      CommentEditor={CommentEditor}
+                      pageFooter={<PageFooter id={docId} />}
+                      onEditProfile={onEditProfile}
+                      profileHeaderButtons={profileHeaderButtons}
+                      onFollowClick={onFollowClick}
+                      rightActions={<WebHeaderActions siteUid={docId.uid} />}
+                      optionsMenuItems={optionsMenuItems}
+                      inlineInsert={inlineInsert}
+                      DocumentContentComponent={DocumentContentComponent}
+                      ssrContentHTML={ssrContentHTML}
+                      perspectiveAccountUid={ownAccountUid}
+                      linkExtensionOptions={linkExtensionOptions}
+                      canEdit={effectiveCanEdit}
+                      machine={machine}
+                      machineExtras={<WebDraftExternalModificationListener />}
+                      signingAccountId={signingAccountId ?? undefined}
+                      publishAccountUid={signingAccountId ?? undefined}
+                      onEditorReady={onEditorReady}
+                      existingDraft={existingDraft}
+                      reservedDraftId={reservedDraftId}
+                      existingDraftVisibility={draftData?.visibility}
+                      existingDraftContent={existingDraftContent}
+                      existingDraftCursorPosition={existingDraftCursorPosition}
+                      existingDraftDeps={draftData?.deps}
+                      draftVersionOnDiscardConfirm={webToolbarCallbacks.onDiscardConfirm}
+                      editingFloatingActions={editingFloatingActions}
+                      fileUpload={fileUpload}
+                    />
+                  </HomeDraftProvider>
                 </WebDraftBreadcrumbProvider>
               </QuerySearchInputProvider>
             </QueryBlockDraftsProvider>

--- a/frontend/apps/web/app/web-resource-page.tsx
+++ b/frontend/apps/web/app/web-resource-page.tsx
@@ -3,12 +3,13 @@ import {QuerySearchInputProvider} from '@shm/editor/query-search-context'
 import {hmId, useJoinSite, useUniversalAppContext, useUniversalClient} from '@shm/shared'
 import {CommentsProvider, InlineEditCommentProps} from '@shm/shared/comments-service-provider'
 import {NOTIFY_SERVICE_HOST} from '@shm/shared/constants'
+import {getDocumentTitle} from '@shm/shared/content'
 import {DocumentActionsProvider} from '@shm/shared/document-actions-context'
 import type {DocumentContentProps} from '@shm/shared/document-content-props'
 import {canCreateChildDocuments} from '@shm/shared/document-utils'
 import {type EditorAccessor} from '@shm/shared/models/document-machine'
-import {selectContext, useDocumentMachineRef} from '@shm/shared/models/use-document-machine'
 import {useResource} from '@shm/shared/models/entity'
+import {selectContext, useDocumentMachineRef} from '@shm/shared/models/use-document-machine'
 import {QueryBlockDraftsProvider} from '@shm/shared/query-block-drafts-context'
 import {replaceRouteDocumentId} from '@shm/shared/routes'
 import {getDraftPlaceholderParentId} from '@shm/shared/utils/breadcrumbs'
@@ -17,7 +18,6 @@ import type {DocumentCardActionOrigin} from '@shm/shared/utils/document-actions'
 import {createWebHMUrl, latestId} from '@shm/shared/utils/entity-id-url'
 import {useNavRoute, useNavigate} from '@shm/shared/utils/navigation'
 import {pathNameify} from '@shm/shared/utils/path'
-import {getDocumentTitle} from '@shm/shared/content'
 import {entityQueryPathToHmIdPath} from '@shm/shared/utils/path-api'
 import {computeInlineDraftPublishPath} from '@shm/shared/utils/publish-paths'
 import {getDraftReturnParentId, isReservedLazyDraftId} from '@shm/shared/utils/reserved-draft-ids'
@@ -44,6 +44,7 @@ import {
 } from './auth'
 import {preloadCommenting} from './client-lazy'
 import {useWebCanEdit} from './document-edit/use-web-can-edit'
+import {isPendingSpaceUid, isSpaceHomeDraftId} from './document-edit/web-create-space-draft'
 import {createWebDocumentMachine} from './document-edit/web-document-actors'
 import {
   loadWebCleanupDraft,
@@ -137,6 +138,7 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
   const universalClient = useUniversalClient()
   const linkExtensionOptions = useMemo(() => ({universalClient}), [universalClient])
   const {canEdit, signingAccountId, capability, capabilitiesLoading} = useWebCanEdit(docId)
+  const {createAccount, content: createAccountContent} = useCreateAccount()
   const keyPairLoaded = useLocalKeyPairLoaded()
   const fileUpload = useMemo(() => makeWebFileUpload(universalClient), [universalClient])
 
@@ -202,17 +204,21 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
   const draftQuery = useQuery({
     queryKey: ['web-doc-draft', docId.id, signingAccountId ?? null, placeholderDraftId ?? null] as const,
     queryFn: async () => {
-      if (!signingAccountId) return null
+      const isPending = isPendingSpaceUid(docId.uid)
+      if (!signingAccountId && !isPending) return null
       if (placeholderDraftId) {
         const draft = await getWebDocDraft(placeholderDraftId)
         if (draft?.docId !== docId.id) return null
-        if (draft.signingAccountId !== signingAccountId) return null
+        if (draft.signingAccountId !== signingAccountId && !isPending) return null
         return draft
       }
       if (!canEdit) return null
       return getLatestWebDocDraftForDoc(docId.id)
     },
-    enabled: typeof window !== 'undefined' && !!signingAccountId && (canEdit || !!placeholderDraftId),
+    enabled:
+      typeof window !== 'undefined' &&
+      (!!signingAccountId || isPendingSpaceUid(docId.uid)) &&
+      (canEdit || !!placeholderDraftId),
     staleTime: 60_000,
     keepPreviousData: false,
   })
@@ -230,9 +236,15 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
       : null
   const isDraftStale = false
 
+  const isPendingSpace = isPendingSpaceUid(docId.uid)
+  // A create space home draft.
+  const isSpaceHomeDraft = isSpaceHomeDraftId(placeholderDraftId)
   const canEditLocalPlaceholderDraft =
-    !!placeholderDraftId && !!draftData && !!signingAccountId && draftData.signingAccountId === signingAccountId
-  const effectiveCanEdit = canEdit || canEditLocalPlaceholderDraft || (!!placeholderDraftId && !!signingAccountId)
+    !!placeholderDraftId &&
+    !!draftData &&
+    (isPendingSpace || (!!signingAccountId && draftData.signingAccountId === signingAccountId))
+  const effectiveCanEdit =
+    canEdit || canEditLocalPlaceholderDraft || (!!placeholderDraftId && (!!signingAccountId || isPendingSpace))
   const effectiveCapabilityCid = capability && capability.id !== '_owner' ? capability.id : draftData?.capabilityCid
 
   // Build a documentMachine wired to web actors. Stable per (docId, signing identity, capability).
@@ -388,8 +400,37 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
           panel: createDocumentVersionsPanelRoute(id),
         } as any)
       },
+      // Pending space home drafts publish by first creating an account.
+      // Stashes a publish-draft intent, then open the account dialog
+      // and resume after the vault sign in.
+      onPublishIntercept: () => {
+        const isSpaceDraft = isSpaceHomeDraft || isPendingSpace
+        if (!isSpaceDraft || !placeholderDraftId) return false
+        void setPendingIntent({type: 'publish-draft', draftId: placeholderDraftId}).then(() => {
+          if (userKeyPair) {
+            void processPendingIntent(originHomeId ?? undefined).then((result) => {
+              if (result.type === 'publish-draft') window.location.assign(result.spaceUrl)
+            })
+          } else {
+            createAccount({source: 'join'})
+          }
+        })
+        return true
+      },
     }),
-    [origin, originHomeId, navigate, replaceRoute, docId, route],
+    [
+      origin,
+      originHomeId,
+      navigate,
+      replaceRoute,
+      docId,
+      route,
+      isSpaceHomeDraft,
+      isPendingSpace,
+      placeholderDraftId,
+      userKeyPair,
+      createAccount,
+    ],
   )
 
   const showPublishToolbar = route.key === 'document' || route.key === 'metadata'
@@ -621,6 +662,7 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
       </CommentsProvider>
       {editProfileDialog.content}
       {followAccountContent}
+      {createAccountContent}
       {newMenuContent}
       {deleteDialog.content}
       {destinationDialog.content}

--- a/frontend/packages/shared/src/home-draft-context.tsx
+++ b/frontend/packages/shared/src/home-draft-context.tsx
@@ -1,0 +1,9 @@
+import {createContext, useContext} from 'react'
+
+const HomeDraftContext = createContext<boolean | undefined>(undefined)
+
+export const HomeDraftProvider = HomeDraftContext.Provider
+
+export function useIsHomeDraftOverride(): boolean | undefined {
+  return useContext(HomeDraftContext)
+}

--- a/frontend/packages/shared/src/models/entity.ts
+++ b/frontend/packages/shared/src/models/entity.ts
@@ -27,6 +27,7 @@ import {DISCOVERY_TIMEOUT_MS} from '../constants'
 import {useUniversalAppContext, useUniversalClient} from '../routing'
 import {useStream} from '../use-stream'
 import {createWebHMUrl, entityQueryPathToHmIdPath, extractViewTermFromUrl, hmId, latestId, unpackHmId} from '../utils'
+import {isPendingSpaceUid} from '../utils/pending-space'
 import {
   queryAccount,
   queryCapabilities,
@@ -685,7 +686,9 @@ export function useChanges(id: UnpackedHypermediaId | null | undefined) {
 
 export function useCapabilities(id: UnpackedHypermediaId | null | undefined) {
   const client = useUniversalClient()
-  return useQuery(queryCapabilities(client, id))
+  // Skip the capability lookup for anonymous pending drafts.
+  const targetId = isPendingSpaceUid(id?.uid) ? undefined : id
+  return useQuery(queryCapabilities(client, targetId))
 }
 
 export function useCollaborators(docId: UnpackedHypermediaId) {
@@ -704,7 +707,7 @@ export function useCollaborators(docId: UnpackedHypermediaId) {
   }
 }
 
-export function useSiteMembers(id: UnpackedHypermediaId) {
+export function useSiteMembers(id: UnpackedHypermediaId | null | undefined) {
   const collaborators = useDocumentCollaborators(id)
   const accounts = collaborators.data?.accounts || {}
 

--- a/frontend/packages/shared/src/utils/pending-space.ts
+++ b/frontend/packages/shared/src/utils/pending-space.ts
@@ -1,0 +1,13 @@
+/**
+ * A "pending space" is a local-only home draft that a
+ * signed-out user is editing before they have an account.
+ * It is addressed by a uid with this prefix, which is not
+ * a real account so backend entity queries (capabilities,
+ * collaborators, directory, …) must be skipped for it.
+ */
+
+export const PENDING_SPACE_UID_PREFIX = 'pending-'
+
+export function isPendingSpaceUid(uid: string | null | undefined): boolean {
+  return !!uid && uid.startsWith(PENDING_SPACE_UID_PREFIX)
+}

--- a/frontend/packages/ui/src/__tests__/create-space-form.test.tsx
+++ b/frontend/packages/ui/src/__tests__/create-space-form.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import React from 'react'
+import {createRoot, type Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {CreateSpaceForm, type CreateSpaceFormState} from '../create-space-form'
+import {TooltipProvider} from '../tooltip'
+;(globalThis as typeof globalThis & {React?: typeof React}).React = React
+
+function renderForm(props: React.ComponentProps<typeof CreateSpaceForm>) {
+  act(() => {
+    root.render(
+      <TooltipProvider>
+        <CreateSpaceForm {...props} />
+      </TooltipProvider>,
+    )
+  })
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+function findButton(label: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === label)
+  if (!button) throw new Error(`Button "${label}" not found`)
+  return button
+}
+
+function clickButton(label: string) {
+  act(() => {
+    findButton(label).dispatchEvent(new MouseEvent('click', {bubbles: true}))
+  })
+}
+
+describe('CreateSpaceForm', () => {
+  it('disables continue button until the space has a name', () => {
+    renderForm({onComplete: () => {}})
+    expect(findButton('Continue').disabled).toBe(true)
+
+    act(() => {
+      root.unmount()
+    })
+    root = createRoot(container)
+    renderForm({onComplete: () => {}, initialState: {name: 'Alberti studio'}})
+    expect(findButton('Continue').disabled).toBe(false)
+  })
+
+  it('walks through all three steps and completes with the collected state', () => {
+    const onComplete = vi.fn()
+    renderForm({onComplete, initialState: {name: 'Alberti studio'}})
+    expect(container.textContent).toContain("Let's start! Name your space")
+    expect(container.textContent).toContain('Step 1/3')
+
+    clickButton('Continue')
+    expect(container.textContent).toContain('Add the main identity elements of your space')
+    expect(container.textContent).toContain('Step 2/3')
+
+    clickButton('Skip for now')
+    expect(container.textContent).toContain('Navigation & Appearance')
+    expect(container.textContent).toContain('Step 3/3')
+
+    clickButton('Create space')
+    expect(onComplete).toHaveBeenCalledOnce()
+    const state = onComplete.mock.calls[0]?.[0] as CreateSpaceFormState
+    expect(state.name).toBe('Alberti studio')
+    expect(state.cover).toBeNull()
+    expect(state.logo).toBeNull()
+  })
+
+  it('calls onClose when the close button is pressed', () => {
+    const onClose = vi.fn()
+    renderForm({onComplete: () => {}, onClose})
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[aria-label="Close"]')!
+        .dispatchEvent(new MouseEvent('click', {bubbles: true}))
+    })
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('only renders the close button when onClose is provided', () => {
+    renderForm({onComplete: () => {}})
+    expect(container.querySelector('[aria-label="Close"]')).toBeNull()
+  })
+})

--- a/frontend/packages/ui/src/__tests__/create-space-platform.test.ts
+++ b/frontend/packages/ui/src/__tests__/create-space-platform.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import {describe, expect, it} from 'vitest'
+import {defaultCreateSpaceFormState, type CreateSpaceFormState} from '../create-space-form'
+import {createSpaceMetadata} from '../create-space-platform'
+
+function stateWith(overrides: Partial<CreateSpaceFormState>): CreateSpaceFormState {
+  return {...defaultCreateSpaceFormState, ...overrides}
+}
+
+describe('createSpaceMetadata', () => {
+  it('maps the collected form fields onto home-doc metadata', () => {
+    const metadata = createSpaceMetadata(stateWith({name: 'My Space', contentWidth: 'M', showActivity: false}), {})
+    expect(metadata).toEqual({
+      name: 'My Space',
+      contentWidth: 'M',
+      showActivity: false,
+      theme: {headerLayout: ''},
+    })
+  })
+
+  it('stores the header-layout value from the layout table, not the form value', () => {
+    expect(createSpaceMetadata(stateWith({headerLayout: 'horizontal'}), {}).theme).toEqual({headerLayout: ''})
+    expect(createSpaceMetadata(stateWith({headerLayout: 'center'}), {}).theme).toEqual({headerLayout: 'Center'})
+  })
+
+  it('adds ipfs:// cover and logo (as the icon/avatar) only when their CIDs are provided', () => {
+    const withImages = createSpaceMetadata(stateWith({}), {coverCid: 'bafcover', logoCid: 'bafylogo'})
+    expect(withImages.cover).toBe('ipfs://bafcover')
+    expect(withImages.icon).toBe('ipfs://bafylogo')
+
+    const withoutImages = createSpaceMetadata(stateWith({}), {})
+    expect(withoutImages).not.toHaveProperty('cover')
+    expect(withoutImages).not.toHaveProperty('icon')
+  })
+
+  it('adds only the image that has a CID', () => {
+    const coverOnly = createSpaceMetadata(stateWith({}), {coverCid: 'bafcover'})
+    expect(coverOnly.cover).toBe('ipfs://bafcover')
+    expect(coverOnly).not.toHaveProperty('icon')
+  })
+})

--- a/frontend/packages/ui/src/__tests__/create-space-platform.test.ts
+++ b/frontend/packages/ui/src/__tests__/create-space-platform.test.ts
@@ -23,19 +23,19 @@ describe('createSpaceMetadata', () => {
     expect(createSpaceMetadata(stateWith({headerLayout: 'center'}), {}).theme).toEqual({headerLayout: 'Center'})
   })
 
-  it('adds ipfs:// cover and logo (as the icon/avatar) only when their CIDs are provided', () => {
+  it('adds ipfs:// cover and logo (as the header logo) only when their CIDs are provided', () => {
     const withImages = createSpaceMetadata(stateWith({}), {coverCid: 'bafcover', logoCid: 'bafylogo'})
     expect(withImages.cover).toBe('ipfs://bafcover')
-    expect(withImages.icon).toBe('ipfs://bafylogo')
+    expect(withImages.seedExperimentalLogo).toBe('ipfs://bafylogo')
 
     const withoutImages = createSpaceMetadata(stateWith({}), {})
     expect(withoutImages).not.toHaveProperty('cover')
-    expect(withoutImages).not.toHaveProperty('icon')
+    expect(withoutImages).not.toHaveProperty('seedExperimentalLogo')
   })
 
   it('adds only the image that has a CID', () => {
     const coverOnly = createSpaceMetadata(stateWith({}), {coverCid: 'bafcover'})
     expect(coverOnly.cover).toBe('ipfs://bafcover')
-    expect(coverOnly).not.toHaveProperty('icon')
+    expect(coverOnly).not.toHaveProperty('seedExperimentalLogo')
   })
 })

--- a/frontend/packages/ui/src/components/dialog.tsx
+++ b/frontend/packages/ui/src/components/dialog.tsx
@@ -80,6 +80,38 @@ function DialogContent({
   )
 }
 
+/**
+ * Right-side panel variant of {@link DialogContent}: a full-height panel
+ * pinned to the right edge over a dimmed, blurred backdrop.
+ */
+function DialogSideContent({
+  className,
+  children,
+  contentClassName,
+  style,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  contentClassName?: string
+  style?: React.CSSProperties
+}) {
+  return (
+    <DialogPortal data-slot="dialog-side-portal">
+      <DialogOverlay className="backdrop-blur-sm" />
+      <DialogPrimitive.Content
+        data-slot="dialog-side-content"
+        className={cn(
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-right-8 fixed inset-y-0 right-0 z-50 flex w-full max-w-[440px] flex-col overflow-hidden shadow-xl duration-200',
+          className,
+        )}
+        style={style}
+        {...props}
+      >
+        <div className={cn('flex min-h-0 flex-1 flex-col overflow-hidden', contentClassName)}>{children}</div>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
 function DialogHeader({className, ...props}: React.ComponentProps<'div'>) {
   return (
     <div
@@ -129,6 +161,7 @@ export {
   DialogHeader,
   DialogOverlay,
   DialogPortal,
+  DialogSideContent,
   DialogTitle,
   DialogTrigger,
 }

--- a/frontend/packages/ui/src/create-space-form.tsx
+++ b/frontend/packages/ui/src/create-space-form.tsx
@@ -6,13 +6,12 @@ import {Input} from './components/input'
 import {Label} from './components/label'
 import {ScrollArea} from './components/scroll-area'
 import {Switch} from './components/switch'
-import {SwitchField} from './form-fields'
 import {ImageForm} from './image-form'
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from './select-dropdown'
 import {SizableText} from './text'
 import {Tooltip} from './tooltip'
 
-export const SPACE_NAME_MAX_LENGTH = 20
+export const SPACE_NAME_MAX_LENGTH = 60
 const TOTAL_STEPS = 3
 
 // Values for the header layout select. `stored` is the value persisted in
@@ -31,7 +30,6 @@ export type CreateSpaceFormState = {
   logo: File | null
   headerLayout: CreateSpaceHeaderLayout
   contentWidth: 'S' | 'M' | 'L'
-  showPublicationDate: boolean
   showActivity: boolean
 }
 
@@ -41,7 +39,6 @@ export const defaultCreateSpaceFormState: CreateSpaceFormState = {
   logo: null,
   headerLayout: 'horizontal',
   contentWidth: 'L',
-  showPublicationDate: true,
   showActivity: true,
 }
 
@@ -247,14 +244,6 @@ function AppearanceStep({state, update}: StepProps) {
             </SelectContent>
           </Select>
         </div>
-      </div>
-      <div className="bg-muted rounded-lg p-3">
-        <SwitchField
-          label="Set publication display date"
-          id="space-publication-date"
-          checked={state.showPublicationDate}
-          onCheckedChange={(showPublicationDate) => update({showPublicationDate})}
-        />
       </div>
       <div className="bg-muted flex items-center justify-between gap-4 rounded-lg p-3">
         <div className="flex items-center gap-1.5">

--- a/frontend/packages/ui/src/create-space-form.tsx
+++ b/frontend/packages/ui/src/create-space-form.tsx
@@ -1,0 +1,274 @@
+import {HelpCircle, X} from 'lucide-react'
+import {useEffect, useMemo, useState} from 'react'
+import {Button} from './button'
+import {Badge} from './components/badge'
+import {Input} from './components/input'
+import {Label} from './components/label'
+import {ScrollArea} from './components/scroll-area'
+import {Switch} from './components/switch'
+import {SwitchField} from './form-fields'
+import {ImageForm} from './image-form'
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from './select-dropdown'
+import {SizableText} from './text'
+import {Tooltip} from './tooltip'
+
+export const SPACE_NAME_MAX_LENGTH = 20
+const TOTAL_STEPS = 3
+
+// Values for the header layout select. `stored` is the value persisted in
+// home doc metadata.
+export const CREATE_SPACE_HEADER_LAYOUTS = [
+  {value: 'horizontal', label: 'Horizontal', stored: '' as const},
+  {value: 'center', label: 'Center', stored: 'Center' as const},
+] as const
+
+export type CreateSpaceHeaderLayout = (typeof CREATE_SPACE_HEADER_LAYOUTS)[number]['value']
+
+// Values the form collects before an account or space exists.
+export type CreateSpaceFormState = {
+  name: string
+  cover: File | null
+  logo: File | null
+  headerLayout: CreateSpaceHeaderLayout
+  contentWidth: 'S' | 'M' | 'L'
+  showPublicationDate: boolean
+  showActivity: boolean
+}
+
+export const defaultCreateSpaceFormState: CreateSpaceFormState = {
+  name: '',
+  cover: null,
+  logo: null,
+  headerLayout: 'horizontal',
+  contentWidth: 'L',
+  showPublicationDate: true,
+  showActivity: true,
+}
+
+type StepProps = {
+  state: CreateSpaceFormState
+  update: (values: Partial<CreateSpaceFormState>) => void
+}
+
+/**
+ * Create a space panel. Collects a CreateSpaceFormState and passes it to
+ * onComplete callback.
+ */
+export function CreateSpaceForm({
+  onComplete,
+  onClose,
+  initialState,
+}: {
+  onComplete: (state: CreateSpaceFormState) => void
+  onClose?: () => void
+  initialState?: Partial<CreateSpaceFormState>
+}) {
+  const [step, setStep] = useState(0)
+  const [state, setState] = useState<CreateSpaceFormState>({
+    ...defaultCreateSpaceFormState,
+    ...initialState,
+  })
+
+  function update(values: Partial<CreateSpaceFormState>) {
+    setState((prev) => ({...prev, ...values}))
+  }
+
+  const isLastStep = step === TOTAL_STEPS - 1
+  const canContinue = step > 0 || state.name.trim().length > 0
+
+  function goNext() {
+    if (isLastStep) onComplete(state)
+    else setStep(step + 1)
+  }
+
+  return (
+    <div className="flex h-full flex-1 flex-col overflow-hidden">
+      <div className="flex items-start justify-between p-4 pb-0">
+        <Badge className="bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200">
+          Step {step + 1}/{TOTAL_STEPS}
+        </Badge>
+        {onClose ? (
+          <Button variant="ghost" size="icon" aria-label="Close" onClick={onClose}>
+            <X className="size-4" />
+          </Button>
+        ) : null}
+      </div>
+      <ScrollArea className="flex-1">
+        <div className="flex flex-col gap-5 p-4">
+          {step === 0 ? <NameStep state={state} update={update} /> : null}
+          {step === 1 ? <IdentityStep state={state} update={update} /> : null}
+          {step === 2 ? <AppearanceStep state={state} update={update} /> : null}
+        </div>
+      </ScrollArea>
+      <div className="flex gap-2 p-4">
+        {step === 1 ? (
+          <Button variant="outline" size="lg" className="flex-1" onClick={goNext}>
+            Skip for now
+          </Button>
+        ) : null}
+        <Button variant="default" size="lg" className="flex-1" disabled={!canContinue} onClick={goNext}>
+          {isLastStep ? 'Create space' : 'Continue'}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function StepHeader({title, description}: {title: string; description: string}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <SizableText size="2xl" weight="bold" asChild>
+        <h2>{title}</h2>
+      </SizableText>
+      <SizableText size="sm" className="text-muted-foreground">
+        {description}
+      </SizableText>
+    </div>
+  )
+}
+
+function NameStep({state, update}: StepProps) {
+  return (
+    <>
+      <StepHeader
+        title="Let's start! Name your space"
+        description="This is how your space appears in links and search. You can always change it later from space settings."
+      />
+      <div className="flex flex-col gap-1">
+        <div className="flex items-baseline justify-between">
+          <Label htmlFor="space-name">Space name</Label>
+          <SizableText size="xs" className="text-muted-foreground">
+            {state.name.length}/{SPACE_NAME_MAX_LENGTH}
+          </SizableText>
+        </div>
+        <Input
+          id="space-name"
+          value={state.name}
+          maxLength={SPACE_NAME_MAX_LENGTH}
+          onChange={(e) => update({name: e.target.value})}
+        />
+      </div>
+    </>
+  )
+}
+
+// Object URL for previewing an in memory image file, revoked on change/unmount.
+function useFilePreviewUrl(file: File | null) {
+  const url = useMemo(() => (file ? URL.createObjectURL(file) : ''), [file])
+  useEffect(() => {
+    return () => {
+      if (url) URL.revokeObjectURL(url)
+    }
+  }, [url])
+  return url
+}
+
+function IdentityStep({state, update}: StepProps) {
+  const coverUrl = useFilePreviewUrl(state.cover)
+  const logoUrl = useFilePreviewUrl(state.logo)
+  return (
+    <>
+      <StepHeader
+        title="Add the main identity elements of your space"
+        description="You can skip this and do it later from space settings if you prefer."
+      />
+      <div className="flex flex-col gap-1">
+        <Label>Home cover image</Label>
+        <ImageForm
+          id="space-cover"
+          height={120}
+          url={coverUrl}
+          uploadOnChange={false}
+          suggestedSize="1600 × 400px"
+          onImageUpload={(file) => {
+            if (file instanceof File) update({cover: file})
+          }}
+          onRemove={() => update({cover: null})}
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <Label>Space logo</Label>
+        <ImageForm
+          id="space-logo"
+          height={100}
+          url={logoUrl}
+          uploadOnChange={false}
+          emptyLabel="Add Logo"
+          suggestedSize="100px height JPG or PNG"
+          onImageUpload={(file) => {
+            if (file instanceof File) update({logo: file})
+          }}
+          onRemove={() => update({logo: null})}
+        />
+      </div>
+    </>
+  )
+}
+
+function AppearanceStep({state, update}: StepProps) {
+  return (
+    <>
+      <StepHeader
+        title="Navigation & Appearance"
+        description="Set up how your space and documents look. You can skip this and do it later from space settings if you prefer."
+      />
+      <div className="flex gap-3">
+        <div className="flex flex-1 flex-col gap-1">
+          <Label>Header layout</Label>
+          <Select
+            value={state.headerLayout}
+            onValueChange={(headerLayout: CreateSpaceFormState['headerLayout']) => update({headerLayout})}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {CREATE_SPACE_HEADER_LAYOUTS.map((layout) => (
+                <SelectItem key={layout.value} value={layout.value}>
+                  {layout.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-1 flex-col gap-1">
+          <Label>Content width</Label>
+          <Select
+            value={state.contentWidth}
+            onValueChange={(contentWidth: CreateSpaceFormState['contentWidth']) => update({contentWidth})}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="S">Small</SelectItem>
+              <SelectItem value="M">Medium</SelectItem>
+              <SelectItem value="L">Large</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div className="bg-muted rounded-lg p-3">
+        <SwitchField
+          label="Set publication display date"
+          id="space-publication-date"
+          checked={state.showPublicationDate}
+          onCheckedChange={(showPublicationDate) => update({showPublicationDate})}
+        />
+      </div>
+      <div className="bg-muted flex items-center justify-between gap-4 rounded-lg p-3">
+        <div className="flex items-center gap-1.5">
+          <Label htmlFor="space-activity-tabs">Show activity tabs</Label>
+          <Tooltip content="Show the People, Comments, and Citations tabs on your site's pages.">
+            <HelpCircle className="text-muted-foreground size-3.5" />
+          </Tooltip>
+        </div>
+        <Switch
+          id="space-activity-tabs"
+          checked={state.showActivity}
+          onCheckedChange={(showActivity) => update({showActivity})}
+        />
+      </div>
+    </>
+  )
+}

--- a/frontend/packages/ui/src/create-space-platform.ts
+++ b/frontend/packages/ui/src/create-space-platform.ts
@@ -18,6 +18,6 @@ export function createSpaceMetadata(
     theme: {headerLayout: storedHeaderLayout},
   }
   if (images.coverCid) metadata.cover = `ipfs://${images.coverCid}`
-  if (images.logoCid) metadata.icon = `ipfs://${images.logoCid}`
+  if (images.logoCid) metadata.seedExperimentalLogo = `ipfs://${images.logoCid}`
   return metadata
 }

--- a/frontend/packages/ui/src/create-space-platform.ts
+++ b/frontend/packages/ui/src/create-space-platform.ts
@@ -1,0 +1,23 @@
+import type {HMMetadata} from '@seed-hypermedia/client/hm-types'
+import {CREATE_SPACE_HEADER_LAYOUTS, type CreateSpaceFormState} from './create-space-form'
+
+/**
+ * Map the form's collected state to home doc metadata, given the CIDs of
+ * any uploaded images. Shared so desktop and web write identical metadata.
+ */
+export function createSpaceMetadata(
+  state: CreateSpaceFormState,
+  images: {coverCid?: string; logoCid?: string},
+): Partial<HMMetadata> {
+  const storedHeaderLayout =
+    CREATE_SPACE_HEADER_LAYOUTS.find((layout) => layout.value === state.headerLayout)?.stored ?? ''
+  const metadata: Partial<HMMetadata> = {
+    name: state.name,
+    contentWidth: state.contentWidth,
+    showActivity: state.showActivity,
+    theme: {headerLayout: storedHeaderLayout},
+  }
+  if (images.coverCid) metadata.cover = `ipfs://${images.coverCid}`
+  if (images.logoCid) metadata.icon = `ipfs://${images.logoCid}`
+  return metadata
+}

--- a/frontend/packages/ui/src/editing-toolbar.tsx
+++ b/frontend/packages/ui/src/editing-toolbar.tsx
@@ -42,6 +42,12 @@ export type EditingToolbarCallbacks = {
    * unpublished child drafts.
    */
   getUnpublishedChildCount?: () => number
+  /**
+   * Intercept the publish action before it reaches the document machine. Return
+   * true when handled to skip the normal publish. Return false/undefined
+   * to publish normally.
+   */
+  onPublishIntercept?: (pathOverride?: string[]) => boolean
 }
 
 /** Dark pill shown top-right while autosave is saving or just saved. */
@@ -344,6 +350,7 @@ export function PublishButtonWithPopover({
   computeFirstPublishPath,
   onGoToVersions,
   getUnpublishedChildCount,
+  onPublishIntercept,
 }: {
   docId: UnpackedHypermediaId
   existingMenuItems: MenuItemType[]
@@ -384,6 +391,8 @@ export function PublishButtonWithPopover({
   const publishNow = (pathOverride?: string[]) => {
     if (!canPublish) return
     popoverState.onOpenChange(false)
+    // Signed-out drafts hand off to account creation instead of publishing directly.
+    if (onPublishIntercept?.(pathOverride)) return
     send({type: 'edit.start'})
     send({type: 'publish.start', pathOverride})
   }

--- a/frontend/packages/ui/src/editing-toolbar.tsx
+++ b/frontend/packages/ui/src/editing-toolbar.tsx
@@ -1,6 +1,7 @@
 import {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {type DocumentMachineEvent} from '@shm/shared/models/document-machine'
 import {useAccount} from '@shm/shared/models/entity'
+import {useIsHomeDraftOverride} from '@shm/shared/home-draft-context'
 import {
   selectDocument,
   selectDraftId,
@@ -113,7 +114,8 @@ export function PublishPopoverBody({
   const draftId = useDocumentSelector(selectDraftId)
   const metadata = useDocumentSelector(selectMetadata)
 
-  const isHomeDoc = (docId.path?.length ?? 0) === 0
+  const homeDraftOverride = useIsHomeDraftOverride()
+  const isHomeDoc = homeDraftOverride ?? (docId.path?.length ?? 0) === 0
   const isFirstPublish = !publishedDoc?.version && !isHomeDoc
   const isPrivate = publishedDoc?.visibility === 'PRIVATE'
   const lastSeg = docId.path?.at(-1) || ''

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -9,7 +9,6 @@ import {
   HMResource,
   UnpackedHypermediaId,
 } from '@seed-hypermedia/client/hm-types'
-import {useQuery} from '@tanstack/react-query'
 import {
   createInspectNavRoute,
   DocumentPanelRoute,
@@ -75,6 +74,7 @@ import {
 } from '@shm/shared/models/use-document-machine'
 import {useEditorGate} from '@shm/shared/models/use-editor-gate'
 import {getRoutePanel} from '@shm/shared/routes'
+import {useOpenUrl} from '@shm/shared/routing'
 import {getBreadcrumbDocumentIds, isDraftPathSegment} from '@shm/shared/utils/breadcrumbs'
 import {
   activityFilterToSlug,
@@ -83,10 +83,11 @@ import {
   parseFragment,
   routeToUrl,
 } from '@shm/shared/utils/entity-id-url'
-import {useOpenUrl} from '@shm/shared/routing'
 import {useNavigate, useNavRoute} from '@shm/shared/utils/navigation'
+import {isPendingSpaceUid} from '@shm/shared/utils/pending-space'
 import {getReservedLazyDraftBreadcrumbName} from '@shm/shared/utils/reserved-draft-ids'
 import {useIsomorphicLayoutEffect} from '@shm/shared/utils/use-isomorphic-layout-effect'
+import {useQuery} from '@tanstack/react-query'
 import {FilePen, Info, Quote, Search} from 'lucide-react'
 import {lazy, ReactNode, Suspense, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {AccountPage} from './account-page'
@@ -97,8 +98,8 @@ import {ScrollArea} from './components/scroll-area'
 import {DirectoryPageContent} from './directory-page'
 import {DiscussionsPageContent} from './discussions-page'
 import {DocumentCover} from './document-cover'
-import {DocumentMetadataView} from './document-metadata-view'
 import {AuthorPayload, BreadcrumbEntry, Breadcrumbs, DocumentHeader} from './document-header'
+import {DocumentMetadataView} from './document-metadata-view'
 import {DocumentTools} from './document-tools'
 import {DocumentVersionsPanel, isDocumentVersionsPanelRoute} from './document-versions-panel'
 import {Feed, type DraftVersionEntry} from './feed'
@@ -1590,16 +1591,18 @@ function DocumentBody({
   const headerVisibility =
     document.visibility === 'PRIVATE' || draftVisibility === 'PRIVATE' ? 'PRIVATE' : document.visibility
   const siteId = useMemo(() => hmId(docId.uid), [docId.uid])
-  const siteMembers = useSiteMembers(siteId)
-  const directory = useDirectory(docId)
-  const interactionSummary = useInteractionSummary(docId)
-  const collaborators = useDocumentCollaborators(docId)
+  // Skip the queries for anonymous pending drafts.
+  const isLocalOnlyDoc = isPendingSpaceUid(docId.uid)
+  const siteMembers = useSiteMembers(isLocalOnlyDoc ? null : siteId)
+  const directory = useDirectory(isLocalOnlyDoc ? null : docId)
+  const interactionSummary = useInteractionSummary(isLocalOnlyDoc ? null : docId)
+  const collaborators = useDocumentCollaborators(isLocalOnlyDoc ? null : docId)
   const peopleCount = useMemo(
     () => getRenderedCollaboratorsCount(collaborators.data, isHomeDoc),
     [collaborators.data, isHomeDoc],
   )
   const citationsDocId = useMemo(() => ({...docId, blockRef: null, blockRange: null}), [docId])
-  const citations = useCitations(citationsDocId)
+  const citations = useCitations(isLocalOnlyDoc ? null : citationsDocId)
 
   // Breadcrumbs: fetch parent documents for non-home docs
   const breadcrumbIds = useMemo(() => {

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -72,6 +72,7 @@ import {
   useScrollSync,
   useVersionLatestSync,
 } from '@shm/shared/models/use-document-machine'
+import {useIsHomeDraftOverride} from '@shm/shared/home-draft-context'
 import {useEditorGate} from '@shm/shared/models/use-editor-gate'
 import {getRoutePanel} from '@shm/shared/routes'
 import {useOpenUrl} from '@shm/shared/routing'
@@ -1224,7 +1225,8 @@ export function PageWrapper({
   // outside DocumentMachineProvider (loading/error/discovery branches), in
   // which case we fall back to the published headerData.items.
   const machineNav = useDocumentNavigationOptional()
-  const isHomeDoc = !docId.path?.length
+  const homeDraftOverride = useIsHomeDraftOverride()
+  const isHomeDoc = homeDraftOverride ?? !docId.path?.length
   const liveItems: DocNavigationItem[] | undefined =
     isHomeDoc && machineNav
       ? machineNav
@@ -1586,7 +1588,8 @@ function DocumentBody({
     })
   }, []) // only on mount
 
-  const isHomeDoc = !docId.path?.length
+  const homeDraftOverride = useIsHomeDraftOverride()
+  const isHomeDoc = homeDraftOverride ?? !docId.path?.length
   const draftVisibility = existingDraft ? existingDraftVisibility : undefined
   const headerVisibility =
     document.visibility === 'PRIVATE' || draftVisibility === 'PRIVATE' ? 'PRIVATE' : document.visibility
@@ -2851,7 +2854,8 @@ function DocumentOptionsPanel({
   const ctx = useDocumentSelector(selectContext)
   const send = useDocumentSend()
   const {beginEditIfNeeded} = useEditorGate()
-  const isHomeDoc = !docId.path?.length
+  const homeDraftOverride = useIsHomeDraftOverride()
+  const isHomeDoc = homeDraftOverride ?? !docId.path?.length
 
   const metadata = {...(ctx.document?.metadata || {}), ...ctx.metadata}
   // draftId may not exist yet when the panel is opened in read mode. Fall back

--- a/frontend/packages/ui/src/site-header.tsx
+++ b/frontend/packages/ui/src/site-header.tsx
@@ -6,6 +6,7 @@ import {
   UnpackedHypermediaId,
 } from '@seed-hypermedia/client/hm-types'
 import {getMetadataName, NavRoute, SearchResult, useRouteLink, useValidatedWebRouteLink} from '@shm/shared'
+import {useIsHomeDraftOverride} from '@shm/shared/home-draft-context'
 import React, {useEffect, useMemo, useRef, useState} from 'react'
 import {Button} from './button'
 import {ScrollArea} from './components/scroll-area'
@@ -83,11 +84,12 @@ export function SiteHeader({
     }
   }
   // Determine the home document for logo/branding
-  // Priority: current doc if on home page, otherwise siteHomeDocument
-  const homeDoc =
-    docId && !docId.path?.length
-      ? {document, id: docId} // On home page — document IS the home doc
-      : {document: siteHomeDocument ?? undefined, id: siteHomeId} // Non-home: use site home (may be undefined while loading)
+  // Priority: current doc if on home page, otherwise siteHomeDocument.
+  const homeDraftOverride = useIsHomeDraftOverride()
+  const isHomeView = homeDraftOverride ?? !!(docId && !docId.path?.length)
+  const homeDoc = isHomeView
+    ? {document, id: docId} // On home page — document IS the home doc
+    : {document: siteHomeDocument ?? undefined, id: siteHomeId} // Non-home: use site home (may be undefined while loading)
   const headerSearch = (
     <>
       <Button


### PR DESCRIPTION
Adds a "Create a Space" flow - a multi-step panel for creating a space, shared between desktop and web.

- UI: `CreateSpaceForm`, which collects name, cover, logo, and appearance settings,
   mapped to home-doc metadata by the shared `createSpaceMetadata`.
- Desktop: the sidebar "Create my Site" CTA opens the form in a drawer,
  writes a populated home-document draft under the selected identity, and
  opens the editor. Publishing the draft creates the space. The CTA is
  hidden once that identity already has a home document.
- Web (signed out): creates an anonymous `pending-` draft, lets the user
  edit it, and on publish creates an identity (vault round-trip), re-keys the
  draft to the new account, and publishes it.
- Web (signed in): creates a real draft directly and publishes.

### First-publish genesis bootstrap

A brand-new home document has no genesis on the server, and
`PrepareDocumentChange` can't bootstrap one. `publishWebDocument` now
publishes a client-signed genesis `Change` and version `Ref` first, then bases
the change on that genesis, mirroring the SDK's `publishDocument`
first-publish path.

## Testing

- `createSpaceMetadata` mapping (header-layout table, ipfs cover/icon) unit tests.
- Genesis first-publish (`publishWebDocument`) unit test (asserts genesis Change + Ref, then `PrepareDocumentChange` based on genesis).
- `CreateSpaceForm` step rendering unit tests.

## Known follow-ups

- **No web entry point yet**: `/hm/create-site` is reachable only by manually inputting the URL. The
  marketing/avatar/profile entry points are deferred until designs are ready.
- `site` to `space` rename and removing "document settings" from the
  3-dots menu are deferred to post-merge.
