### PR TITLE
Fix: pooled-writer leaked transaction silently discards acknowledged writes (2026-07-24 prod data loss)

### DIFF
--- a/backend/api/daemon/v1alpha/daemon_writer_tx_leak_test.go
+++ b/backend/api/daemon/v1alpha/daemon_writer_tx_leak_test.go
@@ -27,12 +27,13 @@ import (
 // destroyed ~2.5 hours later when the leaked transaction rolled back — no
 // daemon restart involved.
 //
-// The leak sequence uses only public API: a WithTx whose request ctx is
-// canceled mid-transaction. WithTx's internal ROLLBACK fails on the tripped
-// interrupt, and Pool.Put recycles the connection without noticing the open
-// transaction. Every later StoreBlobs then nests as a silent savepoint inside
-// it. See the companion tests in util/sqlite/sqlitex/tx_leak_test.go for the
-// pool-level mechanics.
+// The trigger uses only public API: a WithTx whose request ctx is canceled
+// mid-transaction. Before the fix, WithTx's internal ROLLBACK failed on the
+// tripped interrupt and Pool.Put recycled the connection without noticing the
+// open transaction; every later StoreBlobs then nested as a silent savepoint
+// inside it. The fix (WithTx force-rollback + Pool.Put repair) must keep
+// StoreBlobs' acknowledgment truthful. See the companion tests in
+// util/sqlite/sqlitex/tx_leak_test.go for the pool-level mechanics.
 func TestStoreBlobsAckMustBeDurable(t *testing.T) {
 	u := coretest.NewTester("alice")
 	keyMaterial := []byte("0123456789abcdef0123456789abcdef")
@@ -53,9 +54,9 @@ func TestStoreBlobsAckMustBeDurable(t *testing.T) {
 
 	srv := NewServer(store, &mockedP2PNode{}, idx, tMgr, zap.NewNop())
 
-	// Leak an open transaction into the pool's write connection: an earlier
-	// request is canceled mid-transaction, so WithTx's ROLLBACK is interrupted
-	// and the connection returns to the pool still inside the transaction.
+	// The prod trigger: an earlier request is canceled mid-transaction, so
+	// WithTx's plain ROLLBACK is interrupted. Before the fix this leaked the
+	// open transaction into the pool's write connection.
 	poisonCtx, cancel := context.WithCancel(context.Background())
 	conn, release, err := store.DB().WriteConn(poisonCtx)
 	require.NoError(t, err)

--- a/backend/api/daemon/v1alpha/daemon_writer_tx_leak_test.go
+++ b/backend/api/daemon/v1alpha/daemon_writer_tx_leak_test.go
@@ -1,0 +1,93 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"seed/backend/blob"
+	"seed/backend/core/coretest"
+	taskmanager "seed/backend/daemon/taskmanager"
+	daemon "seed/backend/genproto/daemon/v1alpha"
+	"seed/backend/storage"
+	"seed/backend/storage/vault"
+	"seed/backend/util/sqlite/sqlitex"
+
+	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multicodec"
+	"github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestStoreBlobsAckMustBeDurable reproduces the 2026-07-24 prod incident shape
+// at the gRPC surface: StoreBlobs acknowledged 3 blobs (returned their CIDs)
+// while the pool's single write connection was carrying a transaction leaked by
+// an earlier interrupted request; the blobs were invisible to readers and were
+// destroyed ~2.5 hours later when the leaked transaction rolled back — no
+// daemon restart involved.
+//
+// The leak sequence uses only public API: a WithTx whose request ctx is
+// canceled mid-transaction. WithTx's internal ROLLBACK fails on the tripped
+// interrupt, and Pool.Put recycles the connection without noticing the open
+// transaction. Every later StoreBlobs then nests as a silent savepoint inside
+// it. See the companion tests in util/sqlite/sqlitex/tx_leak_test.go for the
+// pool-level mechanics.
+func TestStoreBlobsAckMustBeDurable(t *testing.T) {
+	u := coretest.NewTester("alice")
+	keyMaterial := []byte("0123456789abcdef0123456789abcdef")
+	dataDir := t.TempDir()
+	secretStore, err := vault.NewMemorySecretStore()
+	require.NoError(t, err)
+	require.NoError(t, secretStore.Store("local", "", keyMaterial))
+
+	ks, err := vault.New(dataDir, secretStore)
+	require.NoError(t, err)
+
+	store, err := storage.Open(dataDir, u.Device.Libp2pKey(), ks, "debug")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	tMgr := taskmanager.NewTaskManager()
+	idx, err := blob.OpenIndex(t.Context(), store.DB(), zap.NewNop())
+	require.NoError(t, err)
+
+	srv := NewServer(store, &mockedP2PNode{}, idx, tMgr, zap.NewNop())
+
+	// Leak an open transaction into the pool's write connection: an earlier
+	// request is canceled mid-transaction, so WithTx's ROLLBACK is interrupted
+	// and the connection returns to the pool still inside the transaction.
+	poisonCtx, cancel := context.WithCancel(context.Background())
+	conn, release, err := store.DB().WriteConn(poisonCtx)
+	require.NoError(t, err)
+	err = sqlitex.WithTx(conn, func() error {
+		if err := sqlitex.Exec(conn, "CREATE TABLE IF NOT EXISTS leak_marker (x int);", nil); err != nil {
+			return err
+		}
+		cancel()
+		return errors.New("simulated canceled request")
+	})
+	require.Error(t, err)
+	release()
+
+	// A client publishes a blob. Raw codec keeps the blob out of the indexers
+	// so the test isolates storage durability from indexing semantics.
+	data := []byte("daemon writer tx leak probe")
+	mh, err := multihash.Sum(data, multihash.SHA2_256, -1)
+	require.NoError(t, err)
+	c := cid.NewCidV1(uint64(multicodec.Raw), mh)
+
+	resp, err := srv.StoreBlobs(t.Context(), &daemon.StoreBlobsRequest{
+		Blobs: []*daemon.Blob{{Cid: c.String(), Data: data}},
+	})
+	require.NoError(t, err, "StoreBlobs acknowledged the blob")
+	require.Equal(t, []string{c.String()}, resp.Cids)
+
+	// The acknowledgment must mean the blob is actually there: readable through
+	// the index (which uses a read connection). Today it is trapped inside the
+	// leaked transaction — exactly how prod acknowledged document blobs that a
+	// Resource read immediately reported as not-found.
+	ok, err := idx.Has(t.Context(), c)
+	require.NoError(t, err)
+	require.True(t, ok,
+		"blob acknowledged by StoreBlobs is not readable: it is trapped in a transaction leaked into the connection pool and will be destroyed when that transaction rolls back")
+}

--- a/backend/util/sqlite/sqlitex/debug_handler.go
+++ b/backend/util/sqlite/sqlitex/debug_handler.go
@@ -43,6 +43,12 @@ type sqlitePage struct {
 	RecentBusyCap   int
 	RecentReadCap   int
 	BusyEventsCount int
+	// LeakedTxRepairs is the number of open transactions Pool.Put found on
+	// returned connections and rolled back. Anything non-zero means a code
+	// path is leaking transactions into the pool; before this repair existed,
+	// such a leak silently converted later commits into savepoints and
+	// discarded them wholesale (2026-07-24 prod data loss).
+	LeakedTxRepairs uint64
 }
 
 // aggregateRow renders one entry on the "Aggregate writer-slot utilization"
@@ -248,7 +254,8 @@ func buildSQLitePage() sqlitePage {
 	now := time.Now()
 
 	page := sqlitePage{
-		GeneratedAt: now.Format(time.RFC3339),
+		GeneratedAt:     now.Format(time.RFC3339),
+		LeakedTxRepairs: LeakedTxRepairs(),
 	}
 
 	for _, a := range snap.Active {
@@ -683,7 +690,7 @@ th.grp{background:#ececec;text-align:center}
 </style>
 </head><body>
 <h1>SQLite writer health</h1>
-<div class="meta">snapshot: {{.GeneratedAt}} &middot; <a href="/debug/metrics">/debug/metrics</a> &middot; <a href="/debug/network">/debug/network</a></div>
+<div class="meta">snapshot: {{.GeneratedAt}} &middot; <a href="/debug/metrics">/debug/metrics</a> &middot; <a href="/debug/network">/debug/network</a>{{if .LeakedTxRepairs}} &middot; <span style="color:#c00">leaked-tx repairs: {{.LeakedTxRepairs}}</span>{{end}}</div>
 
 <details class="help"><summary>What this page measures</summary>
 <p>Every call to <code>sqlitex.WithTx</code> opens a real SQLite write transaction via <code>BEGIN IMMEDIATE</code>. Only one such transaction can be in flight at a time across the whole daemon. This page records per-caller wall durations and <code>SQLITE_BUSY</code> counts so we can tell who is holding the writer slot and who is being starved.</p>

--- a/backend/util/sqlite/sqlitex/debug_handler.go
+++ b/backend/util/sqlite/sqlitex/debug_handler.go
@@ -49,6 +49,12 @@ type sqlitePage struct {
 	// such a leak silently converted later commits into savepoints and
 	// discarded them wholesale (2026-07-24 prod data loss).
 	LeakedTxRepairs uint64
+	// LeakedTxRepairFailures is the number of leaked transactions Put could
+	// not roll back. Unlike LeakedTxRepairs this is not contained: the
+	// connection re-entered the pool with its transaction still open. Check
+	// the SQLiteLeakedTxRepairFailed logs for the offending caller, and treat
+	// acknowledged writes on this daemon as suspect until it is understood.
+	LeakedTxRepairFailures uint64
 }
 
 // aggregateRow renders one entry on the "Aggregate writer-slot utilization"
@@ -254,8 +260,9 @@ func buildSQLitePage() sqlitePage {
 	now := time.Now()
 
 	page := sqlitePage{
-		GeneratedAt:     now.Format(time.RFC3339),
-		LeakedTxRepairs: LeakedTxRepairs(),
+		GeneratedAt:            now.Format(time.RFC3339),
+		LeakedTxRepairs:        LeakedTxRepairs(),
+		LeakedTxRepairFailures: LeakedTxRepairFailures(),
 	}
 
 	for _, a := range snap.Active {
@@ -690,7 +697,7 @@ th.grp{background:#ececec;text-align:center}
 </style>
 </head><body>
 <h1>SQLite writer health</h1>
-<div class="meta">snapshot: {{.GeneratedAt}} &middot; <a href="/debug/metrics">/debug/metrics</a> &middot; <a href="/debug/network">/debug/network</a>{{if .LeakedTxRepairs}} &middot; <span style="color:#c00">leaked-tx repairs: {{.LeakedTxRepairs}}</span>{{end}}</div>
+<div class="meta">snapshot: {{.GeneratedAt}} &middot; <a href="/debug/metrics">/debug/metrics</a> &middot; <a href="/debug/network">/debug/network</a>{{if .LeakedTxRepairs}} &middot; <span style="color:#c00">leaked-tx repairs: {{.LeakedTxRepairs}}</span>{{end}}{{if .LeakedTxRepairFailures}} &middot; <span style="color:#c00"><b>leaked-tx repairs FAILED: {{.LeakedTxRepairFailures}}</b> — a connection is in the pool with an open transaction; see SQLiteLeakedTxRepairFailed logs</span>{{end}}</div>
 
 <details class="help"><summary>What this page measures</summary>
 <p>Every call to <code>sqlitex.WithTx</code> opens a real SQLite write transaction via <code>BEGIN IMMEDIATE</code>. Only one such transaction can be in flight at a time across the whole daemon. This page records per-caller wall durations and <code>SQLITE_BUSY</code> counts so we can tell who is holding the writer slot and who is being starved.</p>

--- a/backend/util/sqlite/sqlitex/instrumentation.go
+++ b/backend/util/sqlite/sqlitex/instrumentation.go
@@ -41,12 +41,26 @@ func SetLogger(logger *slog.Logger) {
 
 const (
 	// maxCallerLabels bounds Prometheus series and per-caller reservoir
-	// memory. Note the package's own test suite spends from this same
-	// budget (each test function that opens an instrumented tx is a
-	// distinct label): at 64 the suite sat within a handful of labels of
-	// the cap, and any few added tests silently pushed the page tests'
-	// callers into "other". 128 keeps ample headroom at ~8 MiB worst-case
-	// reservoir memory (see reservoirCap).
+	// memory. Raised 64 -> 128 because 64 had become thin headroom from two
+	// directions:
+	//
+	//   - The backend has roughly 60 distinct functions that enter this
+	//     package (static count of enclosing funcs around WithTx / Save /
+	//     Read / WithSave callsites, so an upper bound on what a given
+	//     process actually registers — not a live measurement). Close
+	//     enough to 64 to be uncomfortable, and the failure is silent:
+	//     slots are claimed in runtime arrival order, so once full it is
+	//     whichever callers happen to run first that keep their names,
+	//     and a hot writer that starts later disappears into "other".
+	//     To check a real daemon, look for an "other" row in the
+	//     per-caller tables on /debug/sqlite.
+	//   - The package's own test suite spends from this same budget (each
+	//     test function that opens an instrumented tx is a distinct label,
+	//     and the tracker is a process-global with no reset), so adding a
+	//     handful of tests could silently bucket the page tests' callers
+	//     into "other" and fail them in full-suite runs only.
+	//
+	// 128 costs ~8 MiB worst-case reservoir memory (see reservoirCap).
 	maxCallerLabels = 128
 	slowThreshold   = 100 * time.Millisecond
 	// recentWriteCap caps the top-K ring of slowest write-side transactions

--- a/backend/util/sqlite/sqlitex/instrumentation.go
+++ b/backend/util/sqlite/sqlitex/instrumentation.go
@@ -31,7 +31,14 @@ import (
 // blow up the Prometheus series count.
 
 const (
-	maxCallerLabels = 64
+	// maxCallerLabels bounds Prometheus series and per-caller reservoir
+	// memory. Note the package's own test suite spends from this same
+	// budget (each test function that opens an instrumented tx is a
+	// distinct label): at 64 the suite sat within a handful of labels of
+	// the cap, and any few added tests silently pushed the page tests'
+	// callers into "other". 128 keeps ample headroom at ~8 MiB worst-case
+	// reservoir memory (see reservoirCap).
+	maxCallerLabels = 128
 	slowThreshold   = 100 * time.Millisecond
 	// recentWriteCap caps the top-K ring of slowest write-side transactions
 	// (commits/rollbacks/savepoint_top/savepoint and begin_busy/interrupted
@@ -225,8 +232,8 @@ type readStats struct {
 // much longer time window than the reservoir for callers with rare slow
 // events (the cap on the recent-slow ring is per total events, not per
 // caller, so for a 2%-slow caller it spans ~50x more history than a fixed
-// reservoir of all events). At 8192 floats per caller × 64-caller cap ≈
-// 4 MiB; still cheap, and brings the windows closer so the visible recent
+// reservoir of all events). At 8192 floats per caller × 128-caller cap ≈
+// 8 MiB; still cheap, and brings the windows closer so the visible recent
 // max is reflected in p99 for high-frequency callers like syncing.loadStore.
 const reservoirCap = 8192
 
@@ -1182,14 +1189,14 @@ type trackerSnapshot struct {
 // writeCallerSnapshot mirrors the original per-caller stats shape, minus
 // the now-removed Max column.
 type writeCallerSnapshot struct {
-	Count         uint64
-	Commits       uint64
-	Rollbacks     uint64
-	BusyCount     uint64
-	HoldP10Ms     float64
-	HoldP50Ms     float64
-	HoldP90Ms     float64
-	HoldP99Ms     float64
+	Count     uint64
+	Commits   uint64
+	Rollbacks uint64
+	BusyCount uint64
+	HoldP10Ms float64
+	HoldP50Ms float64
+	HoldP90Ms float64
+	HoldP99Ms float64
 	// HoldMaxMs is the all-time max writer-slot hold for this caller —
 	// survives ring eviction so a rare slow commit stays visible after the
 	// reservoir wraps past it.

--- a/backend/util/sqlite/sqlitex/instrumentation.go
+++ b/backend/util/sqlite/sqlitex/instrumentation.go
@@ -2,6 +2,7 @@ package sqlitex
 
 import (
 	"fmt"
+	"log/slog"
 	"math"
 	"runtime"
 	"sort"
@@ -14,6 +15,14 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+// log is the package logger. Mirrors the sqlite package's SetLogger contract.
+var log = slog.Default()
+
+// SetLogger sets the logger for this package.
+func SetLogger(logger *slog.Logger) {
+	log = logger
+}
 
 // Instrumentation for write transactions opened through WithTx.
 //
@@ -158,10 +167,15 @@ var (
 		Name: "seed_sqlite_writetx_inflight",
 		Help: "Currently in-flight write transactions (between BEGIN IMMEDIATE success and COMMIT/ROLLBACK).",
 	}, []string{"caller"})
+
+	mLeakedTx = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "seed_sqlite_leaked_tx_total",
+		Help: "Connections returned to the pool inside an open transaction, by the caller that released them. outcome=repaired means Put rolled the transaction back; outcome=failed means the rollback itself failed and the connection may still be poisoned.",
+	}, []string{"caller", "outcome"})
 )
 
 func init() {
-	prometheus.MustRegister(mTxDuration, mBeginWait, mBeginBusy, mInFlight)
+	prometheus.MustRegister(mTxDuration, mBeginWait, mBeginBusy, mInFlight, mLeakedTx)
 }
 
 // callerStats accumulates per-caller stats for the debug page, split into

--- a/backend/util/sqlite/sqlitex/pool.go
+++ b/backend/util/sqlite/sqlitex/pool.go
@@ -21,6 +21,7 @@ import (
 	"runtime/trace"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"seed/backend/util/sqlite"
@@ -270,6 +271,19 @@ outer:
 	return nil
 }
 
+// leakedTxRepairs counts connections that were returned to the pool while
+// still inside an open transaction and were repaired (rolled back) by Put.
+// Non-zero values mean some code path is leaking transactions — most likely
+// an interrupted cleanup that WithTx/Save could not run — and deserve
+// investigation even though Put contains the damage.
+var leakedTxRepairs atomic.Uint64
+
+// LeakedTxRepairs reports how many leaked open transactions Pool.Put has
+// rolled back since the process started. Surfaced on /debug/sqlite.
+func LeakedTxRepairs() uint64 {
+	return leakedTxRepairs.Load()
+}
+
 // Put puts an SQLite connection back into the Pool.
 //
 // Put will panic if conn is nil or if the conn was not originally created by
@@ -294,6 +308,30 @@ func (p *Pool) Put(conn *sqlite.Conn) {
 
 	if !found {
 		panic("sqlite.Pool.Put: connection not created by this pool")
+	}
+
+	// A connection must never re-enter the pool inside an open transaction:
+	// the next lessee's WithTx would silently degrade to a savepoint inside
+	// it, report success, stay invisible to readers, and be destroyed when
+	// the leaked transaction eventually rolls back (this silently discarded
+	// ~2.5 hours of acknowledged writes on prod, 2026-07-24). WithTx repairs
+	// its own failure paths; this is the last line of defense for any other
+	// path that BEGINs without cleaning up — e.g. a top-level Save whose
+	// release was interrupted. Repair rather than panic: the common trigger
+	// is a canceled request ctx, which is normal operation. The interrupt is
+	// masked for the ROLLBACK because a tripped interrupt is usually what
+	// prevented cleanup in the first place; the next lessee gets a fresh
+	// interrupt from get() regardless.
+	if !conn.GetAutocommit() {
+		conn.SetInterrupt(nil)
+		if err := Exec(conn, "ROLLBACK;", nil); err != nil {
+			// With the interrupt masked and no active statements (checked
+			// above), ROLLBACK on an open transaction cannot fail short of
+			// connection corruption — same class of invariant violation as
+			// the active-statement check.
+			panic(fmt.Sprintf("sqlite.Pool.Put: failed to roll back a transaction leaked into the pool: %v", err))
+		}
+		leakedTxRepairs.Add(1)
 	}
 
 	conn.ResetTxTracking()

--- a/backend/util/sqlite/sqlitex/pool.go
+++ b/backend/util/sqlite/sqlitex/pool.go
@@ -278,10 +278,80 @@ outer:
 // investigation even though Put contains the damage.
 var leakedTxRepairs atomic.Uint64
 
+// leakedTxRepairFailures counts the leaked transactions Put could not roll
+// back. Unlike leakedTxRepairs this is not a contained problem: the
+// connection went back into the pool with its transaction still open, so the
+// write blackhole this repair exists to prevent may be live right now.
+var leakedTxRepairFailures atomic.Uint64
+
 // LeakedTxRepairs reports how many leaked open transactions Pool.Put has
 // rolled back since the process started. Surfaced on /debug/sqlite.
 func LeakedTxRepairs() uint64 {
 	return leakedTxRepairs.Load()
+}
+
+// LeakedTxRepairFailures reports how many leaked open transactions Pool.Put
+// found but could not roll back. Any non-zero value is an emergency: see
+// leakedTxRepairFailures. Surfaced on /debug/sqlite.
+func LeakedTxRepairFailures() uint64 {
+	return leakedTxRepairFailures.Load()
+}
+
+// repairLeakedTx rolls back a transaction found open on a connection that is
+// being returned to the pool.
+//
+// It deliberately never panics. Put runs from deferred release() closures all
+// over the daemon, including inside net/http handler goroutines (the daemon
+// HTTP server carries POST /ipfs/{cid} and the whole grpc-web surface) and
+// inside singleflight — both of which recover panics. A panic here would
+// therefore not stop the process; it would strand this connection outside the
+// pool forever, so every later writer blocks in get() with no error and
+// Pool.Close panics at shutdown. That is strictly worse, and much harder to
+// diagnose, than the leak this repair exists to contain. Report loudly and
+// keep the pool whole instead.
+func (p *Pool) repairLeakedTx(conn *sqlite.Conn) {
+	// Discard any capture buffer the leaking scope left behind before we run
+	// a statement on its connection: captureExecStart would otherwise append
+	// the repair to a stranger's buffer and can fire its promote callback,
+	// registering a tracker.startActive with no matching endActive — a
+	// permanently in-flight phantom writer on /debug/sqlite.
+	endCapture(conn)
+
+	// resolveCaller skips sqlitex frames, so from here it names whoever
+	// called release(). That is the code path that leaked the transaction,
+	// which is the whole question an operator has when the counter moves.
+	caller := tracker.normalizeCaller(resolveCaller())
+	role := "unknown"
+	switch p.roles[conn] {
+	case connRead:
+		role = "read"
+	case connWrite:
+		role = "write"
+	}
+
+	// Mask the interrupt: a tripped interrupt is usually what prevented the
+	// leaker's own cleanup from running, and it would fail this ROLLBACK the
+	// same way. Safe — ROLLBACK only unwinds state this connection already
+	// owns and cannot block on the writer lock. The next lessee gets a fresh
+	// interrupt from get() regardless.
+	conn.SetInterrupt(nil)
+	if err := Exec(conn, "ROLLBACK;", nil); err != nil {
+		leakedTxRepairFailures.Add(1)
+		mLeakedTx.WithLabelValues(caller, "failed").Inc()
+		log.Error("SQLiteLeakedTxRepairFailed",
+			"caller", caller,
+			"role", role,
+			"error", err,
+		)
+		return
+	}
+
+	leakedTxRepairs.Add(1)
+	mLeakedTx.WithLabelValues(caller, "repaired").Inc()
+	log.Warn("SQLiteLeakedTxRepaired",
+		"caller", caller,
+		"role", role,
+	)
 }
 
 // Put puts an SQLite connection back into the Pool.
@@ -317,21 +387,13 @@ func (p *Pool) Put(conn *sqlite.Conn) {
 	// ~2.5 hours of acknowledged writes on prod, 2026-07-24). WithTx repairs
 	// its own failure paths; this is the last line of defense for any other
 	// path that BEGINs without cleaning up — e.g. a top-level Save whose
-	// release was interrupted. Repair rather than panic: the common trigger
-	// is a canceled request ctx, which is normal operation. The interrupt is
-	// masked for the ROLLBACK because a tripped interrupt is usually what
-	// prevented cleanup in the first place; the next lessee gets a fresh
-	// interrupt from get() regardless.
+	// release was interrupted, or the migration runner's own BEGIN IMMEDIATE.
+	// GetAutocommit is a read-only predicate (sqlite3_get_autocommit): it
+	// asks "is this connection mid-transaction right now", and at this point
+	// — after release(), with the next lessee being a different caller — the
+	// answer can only be yes because something leaked.
 	if !conn.GetAutocommit() {
-		conn.SetInterrupt(nil)
-		if err := Exec(conn, "ROLLBACK;", nil); err != nil {
-			// With the interrupt masked and no active statements (checked
-			// above), ROLLBACK on an open transaction cannot fail short of
-			// connection corruption — same class of invariant violation as
-			// the active-statement check.
-			panic(fmt.Sprintf("sqlite.Pool.Put: failed to roll back a transaction leaked into the pool: %v", err))
-		}
-		leakedTxRepairs.Add(1)
+		p.repairLeakedTx(conn)
 	}
 
 	conn.ResetTxTracking()

--- a/backend/util/sqlite/sqlitex/pool.go
+++ b/backend/util/sqlite/sqlitex/pool.go
@@ -329,13 +329,11 @@ func (p *Pool) repairLeakedTx(conn *sqlite.Conn) {
 		role = "write"
 	}
 
-	// Mask the interrupt: a tripped interrupt is usually what prevented the
-	// leaker's own cleanup from running, and it would fail this ROLLBACK the
-	// same way. Safe — ROLLBACK only unwinds state this connection already
-	// owns and cannot block on the writer lock. The next lessee gets a fresh
-	// interrupt from get() regardless.
-	conn.SetInterrupt(nil)
-	if err := Exec(conn, "ROLLBACK;", nil); err != nil {
+	// forceRollback masks the interrupt for the ROLLBACK: a tripped interrupt
+	// is usually what prevented the leaker's own cleanup from running, and it
+	// would fail this one the same way. The next lessee gets a fresh interrupt
+	// from get() regardless.
+	if err := forceRollback(conn); err != nil {
 		leakedTxRepairFailures.Add(1)
 		mLeakedTx.WithLabelValues(caller, "failed").Inc()
 		log.Error("SQLiteLeakedTxRepairFailed",

--- a/backend/util/sqlite/sqlitex/tx.go
+++ b/backend/util/sqlite/sqlitex/tx.go
@@ -109,7 +109,7 @@ func WithTx(conn *sqlite.Conn, fn func() error) error {
 			// finally rolls back.
 			if frerr := forceRollback(conn); frerr != nil {
 				tracker.recordTx(caller, beginWait, time.Since(t1), poolWait, outcomeRollback, stmts, nil, nil, "")
-				return fmt.Errorf("ROLLBACK error: %v; original error: %w", errors.Join(rberr, frerr), err)
+				return fmt.Errorf("ROLLBACK error: %w; original error: %w", errors.Join(rberr, frerr), err)
 			}
 		}
 		tracker.recordTx(caller, beginWait, time.Since(t1), poolWait, outcomeRollback, stmts, nil, nil, "")

--- a/backend/util/sqlite/sqlitex/tx.go
+++ b/backend/util/sqlite/sqlitex/tx.go
@@ -99,14 +99,32 @@ func WithTx(conn *sqlite.Conn, fn func() error) error {
 	if err := fn(); err != nil {
 		stmts := endCapture(conn)
 		if rberr := Exec(conn, "ROLLBACK", nil); rberr != nil {
-			tracker.recordTx(caller, beginWait, time.Since(t1), poolWait, outcomeRollback, stmts, nil, nil, "")
-			return fmt.Errorf("ROLLBACK error: %v; original error: %w", rberr, err)
+			// The usual reason ROLLBACK fails is a tripped interrupt: the
+			// caller's ctx was canceled mid-transaction, so the binding fails
+			// every call before it reaches SQLite — including this cleanup.
+			// The transaction must not outlive WithTx either way: left open,
+			// it follows the connection back into the pool, later WithTx
+			// calls on it silently degrade to savepoints, and their
+			// acknowledged writes are destroyed when the leaked transaction
+			// finally rolls back.
+			if frerr := forceRollback(conn); frerr != nil {
+				tracker.recordTx(caller, beginWait, time.Since(t1), poolWait, outcomeRollback, stmts, nil, nil, "")
+				return fmt.Errorf("ROLLBACK error: %v; original error: %w", errors.Join(rberr, frerr), err)
+			}
 		}
 		tracker.recordTx(caller, beginWait, time.Since(t1), poolWait, outcomeRollback, stmts, nil, nil, "")
 		return err
 	}
 
 	commitErr := Exec(conn, "COMMIT", nil)
+	if commitErr != nil {
+		// A failed COMMIT does not always unwind the transaction: an
+		// interrupted one never reaches SQLite at all. Roll back explicitly
+		// so the connection leaves WithTx in autocommit mode no matter what.
+		if frerr := forceRollback(conn); frerr != nil {
+			commitErr = errors.Join(commitErr, frerr)
+		}
+	}
 	stmts := endCapture(conn)
 	outcome := outcomeCommit
 	if commitErr != nil {
@@ -114,6 +132,21 @@ func WithTx(conn *sqlite.Conn, fn func() error) error {
 	}
 	tracker.recordTx(caller, beginWait, time.Since(t1), poolWait, outcome, stmts, nil, nil, "")
 	return commitErr
+}
+
+// forceRollback unwinds the connection's open transaction even when the
+// connection's interrupt has tripped, by masking the interrupt for the
+// duration of the ROLLBACK. Masking is safe here: ROLLBACK only unwinds
+// state this connection already owns and cannot block on the writer lock.
+// No-op if the connection is already in autocommit mode (e.g. the failed
+// COMMIT actually did unwind the transaction).
+func forceRollback(conn *sqlite.Conn) error {
+	if conn.GetAutocommit() {
+		return nil
+	}
+	old := conn.SetInterrupt(nil)
+	defer conn.SetInterrupt(old)
+	return Exec(conn, "ROLLBACK;", nil)
 }
 
 // classifyBeginBusy maps an extended SQLite error code from a failed

--- a/backend/util/sqlite/sqlitex/tx.go
+++ b/backend/util/sqlite/sqlitex/tx.go
@@ -98,21 +98,22 @@ func WithTx(conn *sqlite.Conn, fn func() error) error {
 
 	if err := fn(); err != nil {
 		stmts := endCapture(conn)
-		if rberr := Exec(conn, "ROLLBACK", nil); rberr != nil {
-			// The usual reason ROLLBACK fails is a tripped interrupt: the
-			// caller's ctx was canceled mid-transaction, so the binding fails
-			// every call before it reaches SQLite — including this cleanup.
-			// The transaction must not outlive WithTx either way: left open,
-			// it follows the connection back into the pool, later WithTx
-			// calls on it silently degrade to savepoints, and their
-			// acknowledged writes are destroyed when the leaked transaction
-			// finally rolls back.
-			if frerr := forceRollback(conn); frerr != nil {
-				tracker.recordTx(caller, beginWait, time.Since(t1), poolWait, outcomeRollback, stmts, nil, nil, "")
-				return fmt.Errorf("ROLLBACK error: %w; original error: %w", errors.Join(rberr, frerr), err)
-			}
-		}
+		// Roll back with the interrupt masked, unconditionally. The usual
+		// reason cleanup fails is a tripped interrupt: the caller's ctx was
+		// canceled mid-transaction, so the binding fails every call before it
+		// reaches SQLite — including this ROLLBACK. Attempting the unmasked
+		// one first only buys a guaranteed failure whose statement lands in
+		// the capture. Same contract as savepoint.go's release path.
+		//
+		// The transaction must not outlive WithTx: left open, it follows the
+		// connection back into the pool, later WithTx calls on it silently
+		// degrade to savepoints, and their acknowledged writes are destroyed
+		// when the leaked transaction finally rolls back.
+		rberr := forceRollback(conn)
 		tracker.recordTx(caller, beginWait, time.Since(t1), poolWait, outcomeRollback, stmts, nil, nil, "")
+		if rberr != nil {
+			return fmt.Errorf("ROLLBACK error: %w; original error: %w", rberr, err)
+		}
 		return err
 	}
 
@@ -140,6 +141,12 @@ func WithTx(conn *sqlite.Conn, fn func() error) error {
 // state this connection already owns and cannot block on the writer lock.
 // No-op if the connection is already in autocommit mode (e.g. the failed
 // COMMIT actually did unwind the transaction).
+//
+// Shared by WithTx's failure paths and Pool.Put's leaked-transaction repair.
+// savepoint.go's release path does the same interrupt masking inline rather
+// than calling through here: it must roll back to a named savepoint (and then
+// RELEASE it), and its masked region contains a re-panic that a closure
+// boundary would break — see the recover() note on Save.
 func forceRollback(conn *sqlite.Conn) error {
 	if conn.GetAutocommit() {
 		return nil

--- a/backend/util/sqlite/sqlitex/tx_leak_test.go
+++ b/backend/util/sqlite/sqlitex/tx_leak_test.go
@@ -1,0 +1,175 @@
+package sqlitex_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"seed/backend/util/sqlite"
+	"seed/backend/util/sqlite/sqlitex"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests reproduce the acknowledged-write blackhole observed on prod
+// hyper.media on 2026-07-24 (10:40-13:04 UTC), where ~2.5 hours of writes that
+// StoreBlobs had acknowledged were silently rolled back without any daemon
+// restart. The failure is a composition of three behaviors:
+//
+//  1. WithTx's error path runs ROLLBACK; if that ROLLBACK itself fails — which
+//     is guaranteed when the caller's ctx was canceled, because the binding
+//     fails every call on a tripped interrupt before reaching SQLite — the
+//     connection is left inside the open transaction (tx.go).
+//  2. Pool.Put checks for unreset statements (checkReset) but never checks
+//     sqlite3_get_autocommit(), so the poisoned connection re-enters the pool
+//     with its transaction still open (pool.go).
+//  3. WithTx's nested-transaction fallback silently converts subsequent
+//     "transactions" on that connection into savepoints (tx.go). Every later
+//     writer that leases the single pooled write connection reports success,
+//     but its data is invisible to read connections and is destroyed wholesale
+//     when the leaked outer transaction eventually rolls back.
+//
+// The fix should ensure a connection returned to the pool is never inside a
+// transaction: repair it (rollback + log loudly) or refuse to recycle it.
+// Panicking in Put would be wrong — interrupts are a normal part of request
+// cancellation, which is exactly how the leak starts.
+
+// newFilePool returns a file-backed pool, matching production (the shared-cache
+// in-memory pool has different locking semantics).
+func newFilePool(t *testing.T) *sqlitex.Pool {
+	t.Helper()
+	dir := t.TempDir()
+	flags := sqlite.SQLITE_OPEN_READWRITE | sqlite.SQLITE_OPEN_CREATE | sqlite.SQLITE_OPEN_URI | sqlite.SQLITE_OPEN_NOMUTEX
+	pool, err := sqlitex.Open("file:"+dir+"/test.db", flags, 4)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Close() })
+	return pool
+}
+
+// leakOpenTxOnWriter drives the pool's write connection through the
+// interrupted-rollback sequence using only public API: a WithTx whose body
+// fails after its request ctx is canceled. WithTx's internal ROLLBACK is
+// interrupted, so the connection goes back to the pool with the transaction
+// still open. This is the exact prod trigger (a canceled/interrupted request on
+// the daemon's single writer connection).
+func leakOpenTxOnWriter(t *testing.T, pool *sqlitex.Pool) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	conn, release, err := pool.WriteConn(ctx)
+	require.NoError(t, err)
+
+	errBoom := errors.New("simulated request failure")
+	err = sqlitex.WithTx(conn, func() error {
+		if err := sqlitex.Exec(conn, "INSERT INTO leaktest (x) VALUES (0);", nil); err != nil {
+			return err
+		}
+		// The request's ctx is canceled mid-transaction (client gone, timeout,
+		// shutdown). Every subsequent call on this conn — including WithTx's
+		// own ROLLBACK — now fails with SQLITE_INTERRUPT.
+		cancel()
+		return errBoom
+	})
+	require.Error(t, err, "WithTx must report the failure")
+
+	// Returning the connection to the pool is where the leak happens: Put does
+	// not notice the open transaction.
+	release()
+}
+
+func setupLeakTable(t *testing.T, pool *sqlitex.Pool) {
+	t.Helper()
+	require.NoError(t, pool.WithTx(context.Background(), func(c *sqlite.Conn) error {
+		return sqlitex.Exec(c, "CREATE TABLE IF NOT EXISTS leaktest (x int);", nil)
+	}))
+}
+
+// TestPoolPutMustNotRecycleOpenTransaction asserts the pool invariant directly:
+// a connection handed out by WriteConn must be in autocommit mode. Today the
+// leaked transaction survives Put and the next lessee silently inherits it.
+func TestPoolPutMustNotRecycleOpenTransaction(t *testing.T) {
+	pool := newFilePool(t)
+	setupLeakTable(t, pool)
+
+	leakOpenTxOnWriter(t, pool)
+
+	conn, release, err := pool.WriteConn(context.Background())
+	require.NoError(t, err)
+	defer release()
+
+	require.True(t, conn.GetAutocommit(),
+		"pool handed out a write connection that is inside a leaked open transaction; every WithTx on it will silently become a savepoint")
+}
+
+// TestWithTxAcknowledgedWriteVisibleToReaders asserts the durability contract
+// from the caller's point of view: if WithTx returns nil, the write must be
+// visible to read connections. Today the write lands inside the leaked
+// transaction via the silent savepoint fallback: WithTx reports success, but
+// readers cannot see the row. This is exactly what the agents service hit:
+// StoreBlobs returned the CIDs, and an immediate Resource read said not-found.
+func TestWithTxAcknowledgedWriteVisibleToReaders(t *testing.T) {
+	pool := newFilePool(t)
+	setupLeakTable(t, pool)
+
+	leakOpenTxOnWriter(t, pool)
+
+	// An innocent writer: leases the (poisoned) write connection, does a
+	// transaction, and is told it committed.
+	conn, release, err := pool.WriteConn(context.Background())
+	require.NoError(t, err)
+	err = sqlitex.WithTx(conn, func() error {
+		return sqlitex.Exec(conn, "INSERT INTO leaktest (x) VALUES (42);", nil)
+	})
+	release()
+	require.NoError(t, err, "the write was acknowledged")
+
+	var count int64
+	require.NoError(t, pool.Query(context.Background(), func(c *sqlite.Conn) error {
+		got, err := sqlitex.QueryOne[int64](c, "SELECT count(*) FROM leaktest WHERE x = 42")
+		count = got
+		return err
+	}))
+	require.EqualValues(t, 1, count,
+		"a write acknowledged by WithTx must be visible to read connections; it is trapped inside a leaked transaction another caller left open")
+}
+
+// TestWithTxAcknowledgedWriteSurvivesLeakedTxRollback reproduces the data-loss
+// endgame: the acknowledged write must survive whatever later happens to the
+// leaked outer transaction. Today a single ROLLBACK on the poisoned connection
+// erases the acknowledged write hours after the caller was told it committed —
+// on prod this destroyed every blob stored between 10:40 and 13:04.
+func TestWithTxAcknowledgedWriteSurvivesLeakedTxRollback(t *testing.T) {
+	pool := newFilePool(t)
+	setupLeakTable(t, pool)
+
+	leakOpenTxOnWriter(t, pool)
+
+	conn, release, err := pool.WriteConn(context.Background())
+	require.NoError(t, err)
+	err = sqlitex.WithTx(conn, func() error {
+		return sqlitex.Exec(conn, "INSERT INTO leaktest (x) VALUES (43);", nil)
+	})
+	release()
+	require.NoError(t, err, "the write was acknowledged")
+
+	// Some later failure path issues a ROLLBACK on the same pooled connection
+	// (in prod, whatever finally rolled back the leaked transaction ~2.5 hours
+	// in). With a healthy pool there is no open transaction, so this errors and
+	// is harmless; with the leaked transaction it unwinds everything nested
+	// inside, including writes that were reported as committed.
+	conn, release, err = pool.WriteConn(context.Background())
+	require.NoError(t, err)
+	_ = sqlitex.Exec(conn, "ROLLBACK;", nil)
+	release()
+
+	var count int64
+	require.NoError(t, pool.Query(context.Background(), func(c *sqlite.Conn) error {
+		got, err := sqlitex.QueryOne[int64](c, "SELECT count(*) FROM leaktest WHERE x = 43")
+		count = got
+		return err
+	}))
+	require.EqualValues(t, 1, count,
+		"an acknowledged write was silently destroyed by the rollback of a transaction leaked into the pool")
+}

--- a/backend/util/sqlite/sqlitex/tx_leak_test.go
+++ b/backend/util/sqlite/sqlitex/tx_leak_test.go
@@ -283,14 +283,12 @@ func TestPoolPutRepairsLeakedReadTransaction(t *testing.T) {
 	// Every read connection the pool can hand out must be clean. Lease the
 	// whole read side at once so the repaired conn cannot hide behind a
 	// healthy sibling.
-	var conns []*sqlite.Conn
 	var releases []func()
 	for range 3 {
 		c, rel, err := pool.ReadConn(context.Background())
 		require.NoError(t, err)
 		require.True(t, c.GetAutocommit(),
 			"pool handed out a read connection still inside a leaked transaction")
-		conns = append(conns, c)
 		releases = append(releases, rel)
 	}
 	for _, rel := range releases {

--- a/backend/util/sqlite/sqlitex/tx_leak_test.go
+++ b/backend/util/sqlite/sqlitex/tx_leak_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"seed/backend/util/sqlite"
 	"seed/backend/util/sqlite/sqlitex"
@@ -251,4 +252,82 @@ func TestWithTxAcknowledgedWriteSurvivesLeakedTxRollback(t *testing.T) {
 
 	require.EqualValues(t, 1, countLeakRows(t, pool, 43),
 		"an acknowledged write must survive later rollbacks on the pooled connection")
+}
+
+// TestPoolPutRepairsLeakedReadTransaction pins the repair on the read side of
+// the pool, which the write-path tests do not cover. A read connection handed
+// back mid-transaction is less dramatic than the writer — no acknowledged
+// write is at stake — but it is not harmless: an open read transaction pins
+// the WAL at its snapshot, so checkpointing cannot advance past it for as long
+// as the connection sits in the pool, and the next lessee silently reads stale
+// data from that snapshot instead of current state.
+func TestPoolPutRepairsLeakedReadTransaction(t *testing.T) {
+	pool := newFilePool(t)
+	setupLeakTable(t, pool)
+	repairsBefore := sqlitex.LeakedTxRepairs()
+
+	conn, release, err := pool.ReadConn(context.Background())
+	require.NoError(t, err)
+	// A deferred BEGIN takes the connection out of autocommit; the SELECT
+	// materialises the read snapshot it is pinned to.
+	require.NoError(t, sqlitex.Exec(conn, "BEGIN;", nil))
+	require.NoError(t, sqlitex.Exec(conn, "SELECT count(*) FROM leaktest;", nil))
+	require.False(t, conn.GetAutocommit(), "precondition: the read tx is open")
+	release() // leaks it into the read side of the pool
+
+	require.Equal(t, repairsBefore+1, sqlitex.LeakedTxRepairs(),
+		"Put must repair and count a leaked read transaction too")
+	require.Zero(t, sqlitex.LeakedTxRepairFailures(),
+		"the repair itself must not have failed")
+
+	// Every read connection the pool can hand out must be clean. Lease the
+	// whole read side at once so the repaired conn cannot hide behind a
+	// healthy sibling.
+	var conns []*sqlite.Conn
+	var releases []func()
+	for range 3 {
+		c, rel, err := pool.ReadConn(context.Background())
+		require.NoError(t, err)
+		require.True(t, c.GetAutocommit(),
+			"pool handed out a read connection still inside a leaked transaction")
+		conns = append(conns, c)
+		releases = append(releases, rel)
+	}
+	for _, rel := range releases {
+		rel()
+	}
+}
+
+// TestPoolSurvivesRepeatedLeaks guards the property the previous panic-based
+// repair would have broken: Put must always return the connection to the pool.
+// Put runs inside net/http handler goroutines and singleflight, both of which
+// recover panics, so a panic there would not crash the daemon — it would
+// silently retire the pool's only write connection and every later writer
+// would block in get() forever. Leaking repeatedly must leave the pool fully
+// usable.
+func TestPoolSurvivesRepeatedLeaks(t *testing.T) {
+	pool := newFilePool(t)
+	setupLeakTable(t, pool)
+
+	for i := range 5 {
+		interruptRequestOnWriter(t, pool)
+
+		// The write connection must still be leasable and usable after each
+		// leak. A stranded conn would hang here instead of failing.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		conn, release, err := pool.WriteConn(ctx)
+		require.NoError(t, err, "write connection was not returned to the pool after leak %d", i)
+		require.True(t, conn.GetAutocommit())
+		require.NoError(t, sqlitex.WithTx(conn, func() error {
+			return sqlitex.Exec(conn, "INSERT INTO leaktest (x) VALUES (?);", nil, int64(100+i))
+		}))
+		release()
+		cancel()
+
+		require.EqualValues(t, 1, countLeakRows(t, pool, int64(100+i)),
+			"write after leak %d must be durable", i)
+	}
+
+	require.Zero(t, sqlitex.LeakedTxRepairFailures(),
+		"no repair should have failed on a healthy connection")
 }

--- a/backend/util/sqlite/sqlitex/tx_leak_test.go
+++ b/backend/util/sqlite/sqlitex/tx_leak_test.go
@@ -11,28 +11,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// These tests reproduce the acknowledged-write blackhole observed on prod
-// hyper.media on 2026-07-24 (10:40-13:04 UTC), where ~2.5 hours of writes that
+// These tests pin the durability contract that was violated on prod
+// hyper.media on 2026-07-24 (10:40-13:04 UTC), when ~2.5 hours of writes that
 // StoreBlobs had acknowledged were silently rolled back without any daemon
-// restart. The failure is a composition of three behaviors:
+// restart. The failure was a composition of three behaviors:
 //
-//  1. WithTx's error path runs ROLLBACK; if that ROLLBACK itself fails — which
-//     is guaranteed when the caller's ctx was canceled, because the binding
-//     fails every call on a tripped interrupt before reaching SQLite — the
-//     connection is left inside the open transaction (tx.go).
-//  2. Pool.Put checks for unreset statements (checkReset) but never checks
-//     sqlite3_get_autocommit(), so the poisoned connection re-enters the pool
+//  1. WithTx's error path ran ROLLBACK; when that ROLLBACK itself failed —
+//     guaranteed when the caller's ctx was canceled, because the binding fails
+//     every call on a tripped interrupt before reaching SQLite — the
+//     connection was left inside the open transaction (tx.go).
+//  2. Pool.Put checked for unreset statements (checkReset) but not for
+//     sqlite3_get_autocommit(), so the poisoned connection re-entered the pool
 //     with its transaction still open (pool.go).
-//  3. WithTx's nested-transaction fallback silently converts subsequent
+//  3. WithTx's nested-transaction fallback silently converted subsequent
 //     "transactions" on that connection into savepoints (tx.go). Every later
-//     writer that leases the single pooled write connection reports success,
-//     but its data is invisible to read connections and is destroyed wholesale
-//     when the leaked outer transaction eventually rolls back.
+//     writer that leased the single pooled write connection reported success,
+//     but its data was invisible to read connections and was destroyed
+//     wholesale when the leaked outer transaction eventually rolled back.
 //
-// The fix should ensure a connection returned to the pool is never inside a
-// transaction: repair it (rollback + log loudly) or refuse to recycle it.
-// Panicking in Put would be wrong — interrupts are a normal part of request
-// cancellation, which is exactly how the leak starts.
+// The fix closes both ends: WithTx force-rolls-back with the interrupt masked
+// whenever its normal cleanup fails, and Pool.Put repairs (rolls back) any
+// open transaction it finds on a returned connection, counting repairs in
+// LeakedTxRepairs.
 
 // newFilePool returns a file-backed pool, matching production (the shared-cache
 // in-memory pool has different locking semantics).
@@ -46,13 +46,14 @@ func newFilePool(t *testing.T) *sqlitex.Pool {
 	return pool
 }
 
-// leakOpenTxOnWriter drives the pool's write connection through the
-// interrupted-rollback sequence using only public API: a WithTx whose body
-// fails after its request ctx is canceled. WithTx's internal ROLLBACK is
-// interrupted, so the connection goes back to the pool with the transaction
-// still open. This is the exact prod trigger (a canceled/interrupted request on
-// the daemon's single writer connection).
-func leakOpenTxOnWriter(t *testing.T, pool *sqlitex.Pool) {
+var errBoom = errors.New("simulated request failure")
+
+// interruptRequestOnWriter drives the pool's write connection through the
+// prod-incident trigger using only public API: a WithTx whose body fails after
+// its request ctx is canceled (client gone, timeout, shutdown). WithTx's plain
+// ROLLBACK is interrupted; before the fix the connection then went back to the
+// pool with the transaction still open.
+func interruptRequestOnWriter(t *testing.T, pool *sqlitex.Pool) {
 	t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -61,21 +62,15 @@ func leakOpenTxOnWriter(t *testing.T, pool *sqlitex.Pool) {
 	conn, release, err := pool.WriteConn(ctx)
 	require.NoError(t, err)
 
-	errBoom := errors.New("simulated request failure")
 	err = sqlitex.WithTx(conn, func() error {
 		if err := sqlitex.Exec(conn, "INSERT INTO leaktest (x) VALUES (0);", nil); err != nil {
 			return err
 		}
-		// The request's ctx is canceled mid-transaction (client gone, timeout,
-		// shutdown). Every subsequent call on this conn — including WithTx's
-		// own ROLLBACK — now fails with SQLITE_INTERRUPT.
 		cancel()
 		return errBoom
 	})
 	require.Error(t, err, "WithTx must report the failure")
 
-	// Returning the connection to the pool is where the leak happens: Put does
-	// not notice the open transaction.
 	release()
 }
 
@@ -86,14 +81,123 @@ func setupLeakTable(t *testing.T, pool *sqlitex.Pool) {
 	}))
 }
 
-// TestPoolPutMustNotRecycleOpenTransaction asserts the pool invariant directly:
-// a connection handed out by WriteConn must be in autocommit mode. Today the
-// leaked transaction survives Put and the next lessee silently inherits it.
+// commitLeakRow is the "innocent writer": it leases the write connection,
+// inserts a row in a transaction, and is told it committed.
+func commitLeakRow(t *testing.T, pool *sqlitex.Pool, x int64) {
+	t.Helper()
+	conn, release, err := pool.WriteConn(context.Background())
+	require.NoError(t, err)
+	err = sqlitex.WithTx(conn, func() error {
+		return sqlitex.Exec(conn, "INSERT INTO leaktest (x) VALUES (?);", nil, x)
+	})
+	release()
+	require.NoError(t, err, "the write was acknowledged")
+}
+
+func countLeakRows(t *testing.T, pool *sqlitex.Pool, x int64) int64 {
+	t.Helper()
+	var count int64
+	require.NoError(t, pool.Query(context.Background(), func(c *sqlite.Conn) error {
+		got, err := sqlitex.QueryOne[int64](c, "SELECT count(*) FROM leaktest WHERE x = ?", x)
+		count = got
+		return err
+	}))
+	return count
+}
+
+// TestWithTxInterruptedRollbackLeavesAutocommit pins the source fix: even when
+// the caller's ctx is canceled mid-transaction (so WithTx's plain ROLLBACK is
+// interrupted), WithTx must not return with the transaction still open, and it
+// must surface the body's error rather than a rollback failure.
+func TestWithTxInterruptedRollbackLeavesAutocommit(t *testing.T) {
+	pool := newFilePool(t)
+	setupLeakTable(t, pool)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conn, release, err := pool.WriteConn(ctx)
+	require.NoError(t, err)
+	defer release()
+
+	err = sqlitex.WithTx(conn, func() error {
+		if err := sqlitex.Exec(conn, "INSERT INTO leaktest (x) VALUES (0);", nil); err != nil {
+			return err
+		}
+		cancel()
+		return errBoom
+	})
+	require.ErrorIs(t, err, errBoom,
+		"with the transaction rolled back as promised, the body's error is the one to surface")
+	require.True(t, conn.GetAutocommit(),
+		"WithTx must never return with the transaction still open")
+}
+
+// TestWithTxInterruptedCommitRollsBack pins the commit-side of the source fix:
+// a COMMIT that fails on a tripped interrupt never reached SQLite, so the
+// transaction is still open when WithTx would return. WithTx must roll it back
+// and report the failure — the write must be neither silently kept open nor
+// half-committed.
+func TestWithTxInterruptedCommitRollsBack(t *testing.T) {
+	pool := newFilePool(t)
+	setupLeakTable(t, pool)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conn, release, err := pool.WriteConn(ctx)
+	require.NoError(t, err)
+
+	err = sqlitex.WithTx(conn, func() error {
+		if err := sqlitex.Exec(conn, "INSERT INTO leaktest (x) VALUES (77);", nil); err != nil {
+			return err
+		}
+		cancel() // trips the interrupt after the body succeeds, so COMMIT fails
+		return nil
+	})
+	require.Error(t, err, "an uncommittable transaction must be reported as failed")
+	require.True(t, conn.GetAutocommit(),
+		"WithTx must never return with the transaction still open")
+	release()
+
+	require.EqualValues(t, 0, countLeakRows(t, pool, 77),
+		"a transaction whose COMMIT failed must be rolled back, not linger uncommitted")
+}
+
+// TestPoolPutRepairsLeakedOpenTransaction pins the safety net independently of
+// WithTx: a transaction left open on a connection by any code path (here a raw
+// BEGIN IMMEDIATE) must be rolled back by Put, counted in LeakedTxRepairs, and
+// invisible to the next lessee.
+func TestPoolPutRepairsLeakedOpenTransaction(t *testing.T) {
+	pool := newFilePool(t)
+	setupLeakTable(t, pool)
+	repairsBefore := sqlitex.LeakedTxRepairs()
+
+	conn, release, err := pool.WriteConn(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, sqlitex.Exec(conn, "BEGIN IMMEDIATE TRANSACTION;", nil))
+	require.NoError(t, sqlitex.Exec(conn, "INSERT INTO leaktest (x) VALUES (13);", nil))
+	release() // leaks the open transaction into the pool
+
+	require.Equal(t, repairsBefore+1, sqlitex.LeakedTxRepairs(),
+		"Put must repair and count the leaked transaction")
+
+	conn, release, err = pool.WriteConn(context.Background())
+	require.NoError(t, err)
+	defer release()
+	require.True(t, conn.GetAutocommit(),
+		"the repaired connection must be in autocommit mode")
+
+	require.EqualValues(t, 0, countLeakRows(t, pool, 13),
+		"the leaked transaction's uncommitted write must be rolled back, not committed on the leaker's behalf")
+}
+
+// TestPoolPutMustNotRecycleOpenTransaction asserts the pool invariant through
+// the prod trigger: after an interrupted request, a connection handed out by
+// WriteConn must be in autocommit mode.
 func TestPoolPutMustNotRecycleOpenTransaction(t *testing.T) {
 	pool := newFilePool(t)
 	setupLeakTable(t, pool)
 
-	leakOpenTxOnWriter(t, pool)
+	interruptRequestOnWriter(t, pool)
 
 	conn, release, err := pool.WriteConn(context.Background())
 	require.NoError(t, err)
@@ -105,71 +209,46 @@ func TestPoolPutMustNotRecycleOpenTransaction(t *testing.T) {
 
 // TestWithTxAcknowledgedWriteVisibleToReaders asserts the durability contract
 // from the caller's point of view: if WithTx returns nil, the write must be
-// visible to read connections. Today the write lands inside the leaked
-// transaction via the silent savepoint fallback: WithTx reports success, but
-// readers cannot see the row. This is exactly what the agents service hit:
-// StoreBlobs returned the CIDs, and an immediate Resource read said not-found.
+// visible to read connections. Before the fix the write landed inside the
+// leaked transaction via the silent savepoint fallback: WithTx reported
+// success, but readers could not see the row. This is exactly what the agents
+// service hit: StoreBlobs returned the CIDs, and an immediate Resource read
+// said not-found.
 func TestWithTxAcknowledgedWriteVisibleToReaders(t *testing.T) {
 	pool := newFilePool(t)
 	setupLeakTable(t, pool)
 
-	leakOpenTxOnWriter(t, pool)
+	interruptRequestOnWriter(t, pool)
 
-	// An innocent writer: leases the (poisoned) write connection, does a
-	// transaction, and is told it committed.
-	conn, release, err := pool.WriteConn(context.Background())
-	require.NoError(t, err)
-	err = sqlitex.WithTx(conn, func() error {
-		return sqlitex.Exec(conn, "INSERT INTO leaktest (x) VALUES (42);", nil)
-	})
-	release()
-	require.NoError(t, err, "the write was acknowledged")
+	commitLeakRow(t, pool, 42)
 
-	var count int64
-	require.NoError(t, pool.Query(context.Background(), func(c *sqlite.Conn) error {
-		got, err := sqlitex.QueryOne[int64](c, "SELECT count(*) FROM leaktest WHERE x = 42")
-		count = got
-		return err
-	}))
-	require.EqualValues(t, 1, count,
-		"a write acknowledged by WithTx must be visible to read connections; it is trapped inside a leaked transaction another caller left open")
+	require.EqualValues(t, 1, countLeakRows(t, pool, 42),
+		"a write acknowledged by WithTx must be visible to read connections")
 }
 
 // TestWithTxAcknowledgedWriteSurvivesLeakedTxRollback reproduces the data-loss
-// endgame: the acknowledged write must survive whatever later happens to the
-// leaked outer transaction. Today a single ROLLBACK on the poisoned connection
-// erases the acknowledged write hours after the caller was told it committed —
-// on prod this destroyed every blob stored between 10:40 and 13:04.
+// endgame: the acknowledged write must survive whatever later happens on the
+// pooled connection. Before the fix a single ROLLBACK erased the acknowledged
+// write hours after the caller was told it committed — on prod this destroyed
+// every blob stored between 10:40 and 13:04.
 func TestWithTxAcknowledgedWriteSurvivesLeakedTxRollback(t *testing.T) {
 	pool := newFilePool(t)
 	setupLeakTable(t, pool)
 
-	leakOpenTxOnWriter(t, pool)
+	interruptRequestOnWriter(t, pool)
 
-	conn, release, err := pool.WriteConn(context.Background())
-	require.NoError(t, err)
-	err = sqlitex.WithTx(conn, func() error {
-		return sqlitex.Exec(conn, "INSERT INTO leaktest (x) VALUES (43);", nil)
-	})
-	release()
-	require.NoError(t, err, "the write was acknowledged")
+	commitLeakRow(t, pool, 43)
 
 	// Some later failure path issues a ROLLBACK on the same pooled connection
 	// (in prod, whatever finally rolled back the leaked transaction ~2.5 hours
-	// in). With a healthy pool there is no open transaction, so this errors and
-	// is harmless; with the leaked transaction it unwinds everything nested
+	// in). With a healthy pool there is no open transaction, so this errors
+	// harmlessly; with a leaked transaction it would unwind everything nested
 	// inside, including writes that were reported as committed.
-	conn, release, err = pool.WriteConn(context.Background())
+	conn, release, err := pool.WriteConn(context.Background())
 	require.NoError(t, err)
 	_ = sqlitex.Exec(conn, "ROLLBACK;", nil)
 	release()
 
-	var count int64
-	require.NoError(t, pool.Query(context.Background(), func(c *sqlite.Conn) error {
-		got, err := sqlitex.QueryOne[int64](c, "SELECT count(*) FROM leaktest WHERE x = 43")
-		count = got
-		return err
-	}))
-	require.EqualValues(t, 1, count,
-		"an acknowledged write was silently destroyed by the rollback of a transaction leaked into the pool")
+	require.EqualValues(t, 1, countLeakRows(t, pool, 43),
+		"an acknowledged write must survive later rollbacks on the pooled connection")
 }


### PR DESCRIPTION
## Summary

Reproduces **and fixes** the mechanism behind the 2026-07-24 prod incident on hyper.media where **~2.5 hours of acknowledged writes (10:40–13:04 UTC) were silently rolled back** without any daemon restart.

The first commit adds failing tests that isolate the bug; the second commit fixes it and turns them green.

## The incident (evidence from prod)

- At `10:56:12Z` the agents service published a document (genesis + change + ref). The daemon logged `StoreBlobsWrite … blobCount:3 … Finished` (0.25s, success) and returned the CIDs. An immediate `Resource` read said `not-found` — and still does.
- Prod `db.sqlite` today contains **zero blobs with `insert_time` between 10:37:15 and 13:04:05**, despite successful `StoreBlobsWrite` log entries at 10:56, 12:00, and 12:08. The daemon did **not** restart between 09:11 and 23:41.
- Blob IDs were **reused**: the daemon logged `PutBlockExistsSample blobsID:120410/120411` at 10:58, but those IDs now hold *different* blobs inserted at 17:03 — the ID counter rewound when everything after ID 120393 rolled back. The two bitswap blobs from 10:58 were re-delivered by peers at 13:04:05 and became rows 120394/120395; the agent's document was published once and was never re-sent.
- `RBSRIndexServeFallback: "scopes lost materialization mid-load"` fired 20–100×/min from ~10:40 until exactly 13:04 — `materializeScope`'s work on the writer connection never became visible to read connections, so every reconcile re-materialized and warned. The warnings and the write blackhole end at the same minute.

## Mechanism

Three behaviors composed into an acknowledged-write blackhole on the pool's single write connection:

1. **`sqlitex.WithTx` error path** (`tx.go`): if the caller's ctx is canceled mid-transaction, the binding fails every subsequent call on the tripped interrupt — including WithTx's own `ROLLBACK`. WithTx returned an error, but the connection was left **inside the open transaction**.
2. **`Pool.Put`** (`pool.go`): checked for unreset statements (`checkReset`) but never `sqlite3_get_autocommit()`, so the poisoned connection re-entered the pool with its transaction open.
3. **`WithTx` nested fallback** (`tx.go`): every later writer leasing that connection hit `"transaction within a transaction"` and silently became a **savepoint** inside the leaked transaction. It reported success; its data was invisible to read connections; and it was destroyed wholesale when the leaked transaction eventually rolled back.

## The fix

Both ends are closed, so neither depends on the other:

- **`WithTx` repairs its own failures** (`tx.go`): a new `forceRollback` masks the interrupt (`SetInterrupt(nil)`, restore after) and rolls back whenever the plain `ROLLBACK` fails or a `COMMIT` fails without unwinding the transaction. Masking is safe: `ROLLBACK` only unwinds state the connection already owns and cannot block on the writer lock. When the recovery succeeds, WithTx returns the body's original error instead of a `ROLLBACK error`.
- **`Pool.Put` is the safety net** (`pool.go`): any connection returned inside an open transaction — from *any* code path, e.g. a top-level `Save` whose release was interrupted — is rolled back before re-entering the pool. Repair rather than panic, because the common trigger (a canceled request ctx) is normal operation. Repairs are counted in a new `sqlitex.LeakedTxRepairs()` counter and surfaced in red on `/debug/sqlite`, so a leaking code path stays visible instead of silently absorbed.

An uncommitted leaked transaction is rolled back, never committed on the leaker's behalf — the leaker was already told its transaction failed.

## Tests

`backend/util/sqlite/sqlitex/tx_leak_test.go` — public API only:

- `TestWithTxInterruptedRollbackLeavesAutocommit` — pins the source fix (fn-error path): WithTx must never return with the transaction open, and surfaces the body's error.
- `TestWithTxInterruptedCommitRollsBack` — pins the commit path: an interrupted COMMIT is reported as failure and the transaction is rolled back, not left open.
- `TestPoolPutRepairsLeakedOpenTransaction` — pins the safety net independently (raw `BEGIN IMMEDIATE` leak): repaired, counted, and the uncommitted write discarded.
- `TestPoolPutMustNotRecycleOpenTransaction`, `TestWithTxAcknowledgedWriteVisibleToReaders`, `TestWithTxAcknowledgedWriteSurvivesLeakedTxRollback` — the incident contract: after an interrupted request, leased connections are clean, acknowledged writes are reader-visible, and they survive later rollbacks on the pooled connection.

`backend/api/daemon/v1alpha/daemon_writer_tx_leak_test.go` — the incident shape at the gRPC surface:

- `TestStoreBlobsAckMustBeDurable` — after an interrupted request, `StoreBlobs`'s acknowledgment must be truthful: the blob is readable via `Index.Has` on a read connection. (Before the fix this test also took 10s instead of 0.01s — the read stalled behind the leaked writer lock.)

All of the above were red before the fix commit and are green after it. Full `./backend/util/sqlite/...`, `./backend/blob`, and `./backend/storage/...` suites pass.

## Side discovery: debug-tracker label budget

Adding these tests initially broke five unrelated `/debug/sqlite` page tests in the full-suite run only. Root cause: `maxCallerLabels = 64` — the Prometheus-cardinality guard — is a budget the test suite itself spends from (each test function that opens an instrumented tx is a distinct label), and the suite already sat within a handful of labels of the cap. Any few added tests silently bucketed later tests' callers into `"other"`. Bumped to 128 (~8 MiB worst-case reservoir memory) with a comment documenting the coupling.

## Notes

- A separate issue surfaced during the same investigation: the daemon crash-looped at 23:41Z on `'annotations[0].starts': source data must be an array or slice, got int` while decoding a change blob — a malformed-blob DoS vector. Not addressed here.
- This mechanism is also a plausible root cause for historically "flaky" pushes to shared servers (pushes ACK'd, then silently discarded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G9GyuSrhLz4z7DPQ8scZuz
