### PR TITLE
fix(editor): keep controls visible on autoplay videos

### DIFF
--- a/frontend/packages/editor/src/ssr-render.test.tsx
+++ b/frontend/packages/editor/src/ssr-render.test.tsx
@@ -82,6 +82,33 @@ describe('renderDocumentToHTML', () => {
     expect(html).toContain('the caption')
   })
 
+  it('keeps native controls on autoplay videos', () => {
+    const html = render([
+      {
+        block: {
+          id: 'video1',
+          type: 'Video',
+          text: '',
+          annotations: [],
+          link: 'ipfs://bafyvideocid',
+          attributes: {
+            name: 'demo.mp4',
+            autoplay: true,
+            loop: true,
+            muted: true,
+          },
+        },
+        children: [],
+      },
+    ] as any)
+    const videoTag = html.match(/<video[^>]*>/)?.[0]
+
+    expect(videoTag).toContain('controls=""')
+    expect(videoTag).toContain('autoplay=""')
+    expect(videoTag).toContain('loop=""')
+    expect(videoTag).toContain('muted=""')
+  })
+
   it('renders code blocks with the shared chrome and highlight spans', () => {
     const html = render([
       {

--- a/frontend/packages/editor/src/video.tsx
+++ b/frontend/packages/editor/src/video.tsx
@@ -508,7 +508,7 @@ const VideoDisplay = ({editor, block, assign}: DisplayComponentProps) => {
             key={videoSrc}
             contentEditable={false}
             playsInline
-            controls={!autoplay}
+            controls
             preload="metadata"
             autoPlay={!editor.isEditable && autoplay}
             loop={!editor.isEditable && loop}


### PR DESCRIPTION
## Summary
- Keep native video controls visible when videos are configured to autoplay so users can enter fullscreen.
- Preserve autoplay, loop, and muted behavior for published, non-editable documents.
- Add SSR coverage to verify autoplay videos render with controls.

## Related
- fixes #600

---

Fixes #600