### PR TITLE
feat(ui): improve document metadata editing affordances

### DIFF
--- a/frontend/packages/shared/src/models/__tests__/document-sync-action.test.ts
+++ b/frontend/packages/shared/src/models/__tests__/document-sync-action.test.ts
@@ -1,5 +1,17 @@
-import {describe, expect, it} from 'vitest'
-import {resolveDocumentSyncAction} from '../use-document-machine'
+// @vitest-environment jsdom
+import type {HMDocument} from '@seed-hypermedia/client/hm-types'
+import React from 'react'
+import {createRoot, Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, beforeEach, describe, expect, it} from 'vitest'
+import {
+  DocumentMachineProvider,
+  resolveDocumentSyncAction,
+  selectDocument,
+  useDocumentSend,
+  useDocumentSelector,
+  useDocumentSync,
+} from '../use-document-machine'
 
 describe('resolveDocumentSyncAction', () => {
   it('loads the first resolved document', () => {
@@ -23,7 +35,100 @@ describe('resolveDocumentSyncAction', () => {
     expect(resolveDocumentSyncAction('v2', new Set(['v1', 'v2']), 'v1')).toBe('skip')
   })
 
+  it('applies a previously seen version when document version navigation selected it', () => {
+    expect(resolveDocumentSyncAction('v1', new Set(['v1', 'v2']), 'v2', true)).toBe('remoteUpdate')
+  })
+
   it('still applies a genuine remote edit that carries a new version', () => {
     expect(resolveDocumentSyncAction('v2', new Set(['v1', 'v2']), 'v3')).toBe('remoteUpdate')
+  })
+})
+
+describe('useDocumentSync', () => {
+  const documentId = {
+    id: 'hm://alice/doc',
+    uid: 'alice',
+    path: ['doc'],
+    version: null,
+    blockRef: null,
+    blockRange: null,
+    hostname: null,
+    scheme: 'hm',
+  } as any
+  const latestDocument = {
+    account: 'alice',
+    path: '/doc',
+    version: 'v2',
+    content: [],
+    metadata: {name: 'Latest'},
+    authors: ['alice'],
+    genesis: 'genesis',
+    visibility: 'PUBLIC',
+  } as unknown as HMDocument
+  const fixedDocument = {
+    ...latestDocument,
+    version: 'v1',
+    metadata: {name: 'Fixed'},
+  }
+  let container: HTMLDivElement
+  let root: Root
+  let syncedVersion: string | undefined
+  let send: ReturnType<typeof useDocumentSend>
+
+  function Probe({
+    document,
+    routeKey,
+    isPlaceholderData,
+  }: {
+    document: HMDocument
+    routeKey: string
+    isPlaceholderData: boolean
+  }) {
+    useDocumentSync(document, routeKey, isPlaceholderData)
+    send = useDocumentSend()
+    syncedVersion = useDocumentSelector(selectDocument)?.version
+    return null
+  }
+
+  function render(document: HMDocument, routeKey: string, isPlaceholderData: boolean) {
+    act(() => {
+      root.render(
+        React.createElement(DocumentMachineProvider, {
+          input: {documentId, canEdit: false},
+          children: React.createElement(Probe, {document, routeKey, isPlaceholderData}),
+        }),
+      )
+    })
+  }
+
+  beforeEach(() => {
+    ;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    syncedVersion = undefined
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('keeps rendered placeholder content out of sync until the selected version resolves', () => {
+    render(latestDocument, 'latest', false)
+    expect(syncedVersion).toBe('v2')
+    act(() => send({type: 'draft.resolved', draftId: null, content: null, cursorPosition: null}))
+
+    render(latestDocument, 'fixed-v1', true)
+    expect(syncedVersion).toBe('v2')
+
+    render(fixedDocument, 'fixed-v1', false)
+    expect(syncedVersion).toBe('v1')
+
+    render(fixedDocument, 'latest', true)
+    expect(syncedVersion).toBe('v1')
+
+    render(latestDocument, 'latest', false)
+    expect(syncedVersion).toBe('v2')
   })
 })

--- a/frontend/packages/shared/src/models/use-document-machine.ts
+++ b/frontend/packages/shared/src/models/use-document-machine.ts
@@ -281,8 +281,9 @@ export function resolveDocumentSyncAction(
   prevVersion: string | null,
   seenVersions: Set<string>,
   incomingVersion: string,
+  routeChanged = false,
 ): DocumentSyncAction {
-  if (incomingVersion && seenVersions.has(incomingVersion) && incomingVersion !== prevVersion) {
+  if (!routeChanged && incomingVersion && seenVersions.has(incomingVersion) && incomingVersion !== prevVersion) {
     return 'skip'
   }
   if (prevVersion === null) return 'loaded'
@@ -294,19 +295,23 @@ export function resolveDocumentSyncAction(
 /**
  * Sync a resolved document into the machine.
  * Sends `document.loaded` on first non-null document, then `document.remoteUpdate`
- * whenever the version changes — ignoring reverts to already-seen versions.
+ * whenever the version changes. Same-route reverts to already-seen versions
+ * are ignored, while an explicit route version change may revisit one.
  */
-export function useDocumentSync(document: HMDocument | null | undefined) {
+export function useDocumentSync(document: HMDocument | null | undefined, routeKey?: string, isPlaceholderData = false) {
   const actorRef = useDocumentMachineRef()
   const prevVersionRef = useRef<string | null>(null)
   const seenVersionsRef = useRef<Set<string>>(new Set())
+  const prevRouteKeyRef = useRef(routeKey)
 
   useEffect(() => {
-    if (!document) {
+    if (!document || isPlaceholderData) {
       return
     }
     const version = document.version
-    const action = resolveDocumentSyncAction(prevVersionRef.current, seenVersionsRef.current, version)
+    const routeChanged = prevRouteKeyRef.current !== routeKey
+    const action = resolveDocumentSyncAction(prevVersionRef.current, seenVersionsRef.current, version, routeChanged)
+    prevRouteKeyRef.current = routeKey
     if (version) seenVersionsRef.current.add(version)
     if (action === 'skip') {
       return
@@ -326,7 +331,7 @@ export function useDocumentSync(document: HMDocument | null | undefined) {
     )
     actorRef.send({type: action === 'loaded' ? 'document.loaded' : 'document.remoteUpdate', document})
     prevVersionRef.current = version
-  }, [actorRef, document])
+  }, [actorRef, document, isPlaceholderData, routeKey])
 }
 
 /**

--- a/frontend/packages/ui/src/__tests__/document-cover.test.tsx
+++ b/frontend/packages/ui/src/__tests__/document-cover.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import React from 'react'
+import {createRoot, type Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {UniversalAppProvider} from '@shm/shared/routing'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {DocumentCover} from '../document-cover'
+;(globalThis as typeof globalThis & {React?: typeof React; IS_REACT_ACT_ENVIRONMENT?: boolean}).React = React
+;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+function renderCover(node: React.ReactNode) {
+  act(() => {
+    root.render(
+      <UniversalAppProvider
+        openRoute={vi.fn()}
+        openUrl={vi.fn()}
+        universalClient={{request: vi.fn(), publish: vi.fn()} as any}
+        ipfsFileUrl="https://files.example/ipfs"
+      >
+        {node}
+      </UniversalAppProvider>,
+    )
+  })
+}
+
+describe('DocumentCover', () => {
+  it('renders editor cover actions on the actual cover image', () => {
+    const onRemove = vi.fn()
+    const onChangeCover = vi.fn()
+    renderCover(<DocumentCover cover="ipfs://cover-cid" onRemove={onRemove} onChangeCover={onChangeCover} />)
+
+    const removeButton = container.querySelector<HTMLButtonElement>('button[aria-label="Remove document cover image"]')
+    const changeButton = container.querySelector<HTMLButtonElement>('button[aria-label="Change document cover image"]')
+    const downloadLink = container.querySelector<HTMLAnchorElement>('a[aria-label="Download document cover image"]')
+
+    expect(removeButton).not.toBeNull()
+    expect(changeButton).not.toBeNull()
+    expect(downloadLink).not.toBeNull()
+    expect(downloadLink?.getAttribute('download')).toBe('')
+
+    act(() => {
+      removeButton?.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+    })
+
+    expect(onRemove).toHaveBeenCalledOnce()
+  })
+
+  it('lets editors choose a replacement cover image', () => {
+    const onChangeCover = vi.fn()
+    renderCover(<DocumentCover cover="ipfs://cover-cid" onChangeCover={onChangeCover} />)
+
+    const input = container.querySelector<HTMLInputElement>('input[aria-label="Choose replacement cover image"]')
+    const file = new File(['cover'], 'cover.png', {type: 'image/png'})
+    expect(input).not.toBeNull()
+
+    Object.defineProperty(input, 'files', {
+      value: [file],
+      configurable: true,
+    })
+
+    act(() => {
+      input?.dispatchEvent(new Event('change', {bubbles: true}))
+    })
+
+    expect(onChangeCover).toHaveBeenCalledWith(file)
+  })
+
+  it('opens the file picker from the change cover button without canceling the click', () => {
+    renderCover(<DocumentCover cover="ipfs://cover-cid" onChangeCover={vi.fn()} />)
+
+    const changeButton = container.querySelector<HTMLButtonElement>('button[aria-label="Change document cover image"]')
+    const input = container.querySelector<HTMLInputElement>('input[aria-label="Choose replacement cover image"]')
+    const inputClick = vi.spyOn(input!, 'click').mockImplementation(() => {})
+    const clickEvent = new MouseEvent('click', {bubbles: true, cancelable: true})
+
+    act(() => {
+      changeButton?.dispatchEvent(clickEvent)
+    })
+
+    expect(inputClick).toHaveBeenCalledOnce()
+    expect(clickEvent.defaultPrevented).toBe(false)
+  })
+
+  it('keeps cover actions visible on mobile and hover-gated on desktop', () => {
+    renderCover(<DocumentCover cover="ipfs://cover-cid" onRemove={vi.fn()} onChangeCover={vi.fn()} />)
+
+    const controls = container.querySelector<HTMLElement>('[data-document-cover-controls]')
+    expect(controls?.className).toContain('opacity-100')
+    expect(controls?.className).toContain('md:opacity-0')
+    expect(controls?.className).toContain('md:group-hover/cover:opacity-100')
+  })
+})

--- a/frontend/packages/ui/src/__tests__/document-header-breadcrumbs.test.tsx
+++ b/frontend/packages/ui/src/__tests__/document-header-breadcrumbs.test.tsx
@@ -176,4 +176,27 @@ describe('DocumentHeader Breadcrumbs', () => {
       errorSpy.mockRestore()
     }
   })
+
+  it('renders an editor remove button on the actual document icon', () => {
+    const onRemoveIcon = vi.fn()
+
+    renderWithProvider(
+      <DocumentHeader
+        docId={hmId('site', {path: ['doc']})}
+        docMetadata={{name: 'Doc', icon: 'ipfs://icon-cid'} as any}
+        authors={[]}
+        updateTime={null}
+        onRemoveIcon={onRemoveIcon}
+      />,
+    )
+
+    const removeButton = container.querySelector<HTMLButtonElement>('button[aria-label="Remove document icon"]')
+    expect(removeButton).not.toBeNull()
+
+    act(() => {
+      removeButton?.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+    })
+
+    expect(onRemoveIcon).toHaveBeenCalledOnce()
+  })
 })

--- a/frontend/packages/ui/src/__tests__/document-metadata-affordances.test.tsx
+++ b/frontend/packages/ui/src/__tests__/document-metadata-affordances.test.tsx
@@ -1,0 +1,345 @@
+// @vitest-environment jsdom
+import React from 'react'
+import {createRoot, type Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {DocumentMetadataAffordanceButtons} from '../document-metadata-affordances'
+;(globalThis as typeof globalThis & {React?: typeof React; IS_REACT_ACT_ENVIRONMENT?: boolean}).React = React
+;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+function renderButtons(props: Partial<React.ComponentProps<typeof DocumentMetadataAffordanceButtons>> = {}) {
+  const onMetadata = props.onMetadata ?? vi.fn()
+  act(() => {
+    root.render(
+      <DocumentMetadataAffordanceButtons
+        metadata={{}}
+        visible
+        onMetadata={onMetadata}
+        onRequestSummary={vi.fn()}
+        {...props}
+      />,
+    )
+  })
+  return {onMetadata}
+}
+
+function buttonWithText(text: string): HTMLButtonElement | null {
+  return Array.from(container.querySelectorAll('button')).find((button) => button.textContent?.includes(text)) ?? null
+}
+
+describe('DocumentMetadataAffordanceButtons', () => {
+  it('shows only buttons for missing metadata fields', () => {
+    renderButtons({metadata: {icon: 'ipfs://icon-cid', summary: 'A summary'}, fileUpload: vi.fn()})
+
+    expect(buttonWithText('Add icon')).toBeNull()
+    expect(buttonWithText('Add Summary')).toBeNull()
+    expect(buttonWithText('Add cover image')).not.toBeNull()
+  })
+
+  it('requests the summary editor when Add Summary is clicked', () => {
+    const onRequestSummary = vi.fn()
+    renderButtons({onRequestSummary})
+
+    act(() => {
+      buttonWithText('Add Summary')?.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+    })
+
+    expect(onRequestSummary).toHaveBeenCalledOnce()
+  })
+
+  it('uploads an icon image selected through the hidden file input', async () => {
+    const fileUpload = vi.fn(async () => 'bafyicon')
+    const onMetadata = vi.fn()
+    renderButtons({fileUpload, onMetadata})
+    const file = new File(['icon'], 'icon.png', {type: 'image/png'})
+    const input = container.querySelector<HTMLInputElement>('input[aria-label="Choose document icon"]')!
+
+    await act(async () => {
+      Object.defineProperty(input, 'files', {value: [file], configurable: true})
+      input.dispatchEvent(new Event('change', {bubbles: true}))
+    })
+
+    expect(fileUpload).toHaveBeenCalledWith(file)
+    expect(onMetadata).toHaveBeenCalledWith({icon: 'ipfs://bafyicon'})
+  })
+
+  it('uploads a cover image selected through the hidden file input', async () => {
+    const fileUpload = vi.fn(async () => 'ipfs://bafycover')
+    const onMetadata = vi.fn()
+    renderButtons({fileUpload, onMetadata})
+    const file = new File(['cover'], 'cover.png', {type: 'image/png'})
+    const input = container.querySelector<HTMLInputElement>('input[aria-label="Choose document cover image"]')!
+
+    await act(async () => {
+      Object.defineProperty(input, 'files', {value: [file], configurable: true})
+      input.dispatchEvent(new Event('change', {bubbles: true}))
+    })
+
+    expect(fileUpload).toHaveBeenCalledWith(file)
+    expect(onMetadata).toHaveBeenCalledWith({cover: 'ipfs://bafycover'})
+  })
+
+  it('keeps invisible affordances out of the tab order', () => {
+    renderButtons({visible: false, fileUpload: vi.fn()})
+
+    expect(buttonWithText('Add icon')?.tabIndex).toBe(-1)
+    expect(buttonWithText('Add Summary')?.tabIndex).toBe(-1)
+    expect(buttonWithText('Add cover image')?.tabIndex).toBe(-1)
+  })
+
+  it('hides image upload buttons when uploads are unavailable', () => {
+    renderButtons()
+
+    expect(buttonWithText('Add icon')).toBeNull()
+    expect(buttonWithText('Add cover image')).toBeNull()
+    expect(buttonWithText('Add Summary')).not.toBeNull()
+  })
+
+  it('can keep editor affordances visible on mobile while hiding them until hover on desktop', () => {
+    renderButtons({visible: false, fileUpload: vi.fn(), alwaysVisibleOnMobile: true})
+    const affordanceRow = container.querySelector('[data-document-metadata-affordances]')!
+
+    expect(affordanceRow.className).toContain('opacity-100')
+    expect(affordanceRow.className).toContain('md:opacity-0')
+  })
+})
+
+describe('EditableDocumentMetadataFields', () => {
+  async function renderFields(
+    props: Partial<
+      React.ComponentProps<typeof import('../document-metadata-affordances').EditableDocumentMetadataFields>
+    > = {},
+  ) {
+    const module = await import('../document-metadata-affordances')
+    const onMetadata = props.onMetadata ?? vi.fn()
+    act(() => {
+      root.render(
+        <module.EditableDocumentMetadataFields
+          name="New page"
+          summary=""
+          metadata={{}}
+          onMetadata={onMetadata}
+          onBeginEdit={vi.fn()}
+          {...props}
+        />,
+      )
+    })
+    return {onMetadata}
+  }
+
+  it('keeps editor affordances mobile-visible and desktop-hidden until hover', async () => {
+    await renderFields()
+    const affordanceRow = container.querySelector('[data-document-metadata-affordances]')!
+
+    act(() => {
+      container.querySelector<HTMLTextAreaElement>('textarea[aria-label="Document title"]')?.focus()
+    })
+
+    expect(affordanceRow.className).toContain('opacity-100')
+    expect(affordanceRow.className).toContain('md:opacity-0')
+  })
+
+  it('reserves affordance space and only fades visibility', async () => {
+    await renderFields({fileUpload: vi.fn()})
+    const affordanceRow = container.querySelector('[data-document-metadata-affordances]')!
+
+    expect(affordanceRow.className).toContain('opacity-0')
+    expect(affordanceRow.className).not.toContain('max-h-0')
+    expect(affordanceRow.className).not.toContain('translate-y')
+    expect(affordanceRow.className).not.toContain('blur')
+  })
+
+  it('offsets header affordances left to visually align with the title edge', async () => {
+    await renderFields({fileUpload: vi.fn()})
+    const affordanceRow = container.querySelector('[data-document-metadata-affordances]')!
+
+    expect(affordanceRow.className).toContain('-ml-2')
+  })
+
+  it('renders metadata buttons above the title', async () => {
+    await renderFields({fileUpload: vi.fn()})
+    const affordanceRow = container.querySelector('[data-document-metadata-affordances]')!
+    const title = container.querySelector<HTMLTextAreaElement>('textarea[aria-label="Document title"]')!
+
+    expect(affordanceRow.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('focuses an empty summary editor from Add Summary and hides it after empty blur', async () => {
+    await renderFields()
+
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('button[aria-label="Add document summary"]')
+        ?.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+    })
+
+    const summary = container.querySelector<HTMLTextAreaElement>('textarea[aria-label="Document summary"]')
+    expect(summary).not.toBeNull()
+    expect(document.activeElement).toBe(summary)
+
+    act(() => {
+      summary?.blur()
+    })
+
+    expect(container.querySelector<HTMLTextAreaElement>('textarea[aria-label="Document summary"]')).toBeNull()
+    expect(buttonWithText('Add Summary')).not.toBeNull()
+  })
+
+  it('saves summary text as metadata and keeps the editor visible after blur', async () => {
+    const onMetadata = vi.fn()
+    await renderFields({onMetadata})
+
+    act(() => {
+      buttonWithText('Add Summary')?.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+    })
+    const summary = container.querySelector<HTMLTextAreaElement>('textarea[aria-label="Document summary"]')!
+
+    act(() => {
+      summary.value = 'A concise summary'
+      summary.dispatchEvent(new Event('input', {bubbles: true}))
+    })
+
+    expect(onMetadata).toHaveBeenCalledWith({summary: 'A concise summary'})
+  })
+
+  it('keeps the Add Summary button until the summary textarea blurs', async () => {
+    const module = await import('../document-metadata-affordances')
+    const onMetadata = vi.fn()
+
+    act(() => {
+      root.render(
+        <module.EditableDocumentMetadataFields
+          name="New page"
+          summary=""
+          metadata={{}}
+          onMetadata={onMetadata}
+          onBeginEdit={vi.fn()}
+        />,
+      )
+    })
+
+    act(() => {
+      buttonWithText('Add Summary')?.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+    })
+
+    act(() => {
+      root.render(
+        <module.EditableDocumentMetadataFields
+          name="New page"
+          summary="A concise summary"
+          metadata={{summary: 'A concise summary'}}
+          onMetadata={onMetadata}
+          onBeginEdit={vi.fn()}
+        />,
+      )
+    })
+
+    expect(buttonWithText('Add Summary')).not.toBeNull()
+
+    act(() => {
+      container.querySelector<HTMLTextAreaElement>('textarea[aria-label="Document summary"]')?.blur()
+    })
+
+    expect(buttonWithText('Add Summary')).toBeNull()
+  })
+
+  it('keeps an emptied existing summary textarea visible until blur', async () => {
+    const module = await import('../document-metadata-affordances')
+    const onMetadata = vi.fn()
+
+    act(() => {
+      root.render(
+        <module.EditableDocumentMetadataFields
+          name="New page"
+          summary="A concise summary"
+          metadata={{summary: 'A concise summary'}}
+          onMetadata={onMetadata}
+          onBeginEdit={vi.fn()}
+        />,
+      )
+    })
+
+    const summary = container.querySelector<HTMLTextAreaElement>('textarea[aria-label="Document summary"]')!
+    act(() => {
+      summary.focus()
+      summary.value = ''
+      summary.dispatchEvent(new Event('input', {bubbles: true}))
+    })
+
+    act(() => {
+      root.render(
+        <module.EditableDocumentMetadataFields
+          name="New page"
+          summary=""
+          metadata={{}}
+          onMetadata={onMetadata}
+          onBeginEdit={vi.fn()}
+        />,
+      )
+    })
+
+    expect(container.querySelector<HTMLTextAreaElement>('textarea[aria-label="Document summary"]')).not.toBeNull()
+    expect(buttonWithText('Add Summary')).toBeNull()
+
+    act(() => {
+      container.querySelector<HTMLTextAreaElement>('textarea[aria-label="Document summary"]')?.blur()
+    })
+
+    expect(container.querySelector<HTMLTextAreaElement>('textarea[aria-label="Document summary"]')).toBeNull()
+    expect(buttonWithText('Add Summary')).not.toBeNull()
+  })
+})
+
+describe('HomeDocumentMetadataAffordanceBar', () => {
+  async function renderHomeBar(
+    props: Partial<
+      React.ComponentProps<typeof import('../document-metadata-affordances').HomeDocumentMetadataAffordanceBar>
+    > = {},
+  ) {
+    const module = await import('../document-metadata-affordances')
+    const onMetadata = props.onMetadata ?? vi.fn()
+    act(() => {
+      root.render(
+        <module.HomeDocumentMetadataAffordanceBar
+          metadata={{}}
+          onMetadata={onMetadata}
+          onBeginEdit={vi.fn()}
+          {...props}
+        />,
+      )
+    })
+    return {onMetadata}
+  }
+
+  it('renders a focusable top affordance area for home documents', async () => {
+    await renderHomeBar({fileUpload: vi.fn()})
+    const bar = container.querySelector<HTMLElement>('[data-home-document-metadata-affordances]')
+    expect(bar).not.toBeNull()
+    expect(bar?.tabIndex).toBe(-1)
+    expect(buttonWithText('Add icon')).not.toBeNull()
+    expect(container.querySelector('[data-document-metadata-affordances]')?.className).toContain('opacity-100')
+  })
+
+  it('does not render summary controls for home documents', async () => {
+    await renderHomeBar({metadata: {summary: 'Home summary'}, fileUpload: vi.fn()})
+
+    expect(buttonWithText('Add Summary')).toBeNull()
+    expect(container.querySelector<HTMLTextAreaElement>('textarea[aria-label="Document summary"]')).toBeNull()
+  })
+})

--- a/frontend/packages/ui/src/__tests__/editing-toolbar.test.tsx
+++ b/frontend/packages/ui/src/__tests__/editing-toolbar.test.tsx
@@ -206,6 +206,37 @@ describe('editing-toolbar publish disabled states', () => {
       cleanup(root, container)
     }
   })
+
+  it('uses a roomier publish popover layout', () => {
+    unpublishedChangeCountMock.mockReturnValue(2)
+    const docId = hmId('acct-1', {path: ['my-doc']})
+    const {container, root} = renderNode(
+      <PublishButtonWithPopover docId={docId} existingMenuItems={[]} unpublishedChildCount={0} />,
+    )
+
+    try {
+      const publishTrigger = findButtonByText(container, 'Publish')!
+
+      act(() => {
+        publishTrigger.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+      })
+
+      const popoverContent = document.body.querySelector('[data-slot="popover-content"]')
+      const publishButton = findButtonByText(document.body, 'Publish: Make it live now')
+      const body = popoverContent?.firstElementChild
+      const title = Array.from(document.body.querySelectorAll('p')).find(
+        (node) => node.textContent === 'Your document will be available at',
+      )
+
+      expect(popoverContent?.className).toContain('w-[26rem]')
+      expect(popoverContent?.className).toContain('p-6')
+      expect(body?.className).toContain('gap-5')
+      expect(title?.className).toContain('text-base')
+      expect(publishButton?.className).toContain('h-11')
+    } finally {
+      cleanup(root, container)
+    }
+  })
 })
 
 describe('PublishPopoverBody permalink editing', () => {

--- a/frontend/packages/ui/src/__tests__/feed.test.ts
+++ b/frontend/packages/ui/src/__tests__/feed.test.ts
@@ -4,6 +4,8 @@ import {
   getDraftVersionInsertIndex,
   getLatestDocUpdateVersion,
   isSelectedDocUpdateVersion,
+  RESTORE_VERSION_ACTION_BUTTON_CLASS,
+  RESTORE_VERSION_ACTION_ICON_CLASS,
   RESTORE_VERSION_DIALOG,
   shouldShowDraftVersionEntry,
 } from '../feed'
@@ -88,6 +90,14 @@ describe('restore version action helpers', () => {
         hasRestoreAction: true,
       }),
     ).toBe(true)
+  })
+
+  it('keeps version action buttons the same size while making their icons readable', () => {
+    expect(RESTORE_VERSION_ACTION_BUTTON_CLASS).toContain('text-foreground')
+    expect(RESTORE_VERSION_ACTION_BUTTON_CLASS).not.toContain('text-muted-foreground')
+    expect(RESTORE_VERSION_ACTION_BUTTON_CLASS).not.toContain('h-')
+    expect(RESTORE_VERSION_ACTION_BUTTON_CLASS).not.toContain('min-w-')
+    expect(RESTORE_VERSION_ACTION_ICON_CLASS).toBe('size-4')
   })
 
   it('does not allow restore without a provider-selected account', () => {

--- a/frontend/packages/ui/src/__tests__/options-panel.test.tsx
+++ b/frontend/packages/ui/src/__tests__/options-panel.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import React from 'react'
+import {createRoot, type Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {OptionsPanel} from '../options-panel'
+import {TooltipProvider} from '../tooltip'
+;(globalThis as typeof globalThis & {React?: typeof React; IS_REACT_ACT_ENVIRONMENT?: boolean}).React = React
+;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+function renderOptionsPanel(isHomeDoc: boolean) {
+  act(() => {
+    root.render(
+      <TooltipProvider>
+        <OptionsPanel
+          draftId="draft-1"
+          isHomeDoc={isHomeDoc}
+          metadata={
+            {
+              name: isHomeDoc ? 'Home' : 'Document',
+              summary: 'Summary',
+              icon: 'ipfs://icon-cid',
+              cover: 'ipfs://cover-cid',
+              showActivity: true,
+            } as any
+          }
+          onMetadata={vi.fn()}
+          fileUpload={vi.fn()}
+        />
+      </TooltipProvider>,
+    )
+  })
+}
+
+describe('OptionsPanel document metadata fields', () => {
+  it('keeps home document title and icon controls but removes summary and cover controls', () => {
+    renderOptionsPanel(true)
+
+    expect(container.textContent).toContain('Name')
+    expect(container.textContent).toContain('Icon')
+    expect(container.textContent).toContain('Header Logo')
+    expect(container.textContent).toContain('Header Layout')
+    expect(container.textContent).not.toContain('Summary')
+    expect(container.textContent).not.toContain('Cover Image')
+    expect(container.textContent).not.toContain('Document Options')
+  })
+
+  it('removes title, icon, cover, and summary controls for regular documents', () => {
+    renderOptionsPanel(false)
+
+    expect(container.textContent).not.toContain('Name')
+    expect(container.textContent).not.toContain('Icon')
+    expect(container.textContent).not.toContain('Summary')
+    expect(container.textContent).not.toContain('Cover Image')
+    expect(container.textContent).toContain('Show Outline')
+    expect(container.textContent).toContain('Enable Activity Tabs')
+    expect(container.textContent).toContain('Content Width')
+  })
+})

--- a/frontend/packages/ui/src/document-cover.tsx
+++ b/frontend/packages/ui/src/document-cover.tsx
@@ -1,17 +1,22 @@
-import {X} from 'lucide-react'
-import {useCallback, useEffect, useState} from 'react'
+import {Download, X} from 'lucide-react'
+import {ChangeEvent, useCallback, useEffect, useRef, useState} from 'react'
 import {createPortal} from 'react-dom'
+import {Button} from './button'
 import {useImageUrl} from './get-file-url'
 import {cn} from './utils'
 
 interface DocumentCoverProps {
   cover?: string
   className?: string
+  onRemove?: () => void
+  onChangeCover?: (file: File) => Promise<void> | void
 }
 
-export function DocumentCover({cover, className}: DocumentCoverProps) {
+export function DocumentCover({cover, className, onRemove, onChangeCover}: DocumentCoverProps) {
   const imageUrl = useImageUrl()
+  const replacementInputRef = useRef<HTMLInputElement | null>(null)
   const [modalState, setModalState] = useState<'closed' | 'opening' | 'open'>('closed')
+  const [isChangingCover, setIsChangingCover] = useState(false)
 
   const handleDoubleClick = useCallback(() => {
     setModalState('opening')
@@ -36,6 +41,25 @@ export function DocumentCover({cover, className}: DocumentCoverProps) {
     }
   }, [modalState])
 
+  const handleReplacementChange = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0]
+      if (!file || !onChangeCover) return
+
+      setIsChangingCover(true)
+      try {
+        await onChangeCover(file)
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error)
+        console.error(`Failed to change document cover image: ${message}`, error)
+      } finally {
+        setIsChangingCover(false)
+        event.target.value = ''
+      }
+    },
+    [onChangeCover],
+  )
+
   useEffect(() => {
     if (modalState !== 'closed') {
       document.addEventListener('keydown', handleKeyDown)
@@ -49,6 +73,8 @@ export function DocumentCover({cover, className}: DocumentCoverProps) {
   }, [modalState, handleKeyDown])
 
   if (!cover) return null
+  const coverUrl = imageUrl(cover, 'XL')
+  const hasCoverActions = !!onChangeCover || !!onRemove || !!coverUrl
 
   const maximizedContent = modalState !== 'closed' && (
     <div
@@ -92,7 +118,7 @@ export function DocumentCover({cover, className}: DocumentCoverProps) {
     <>
       <div
         className={cn(
-          'relative h-[25vh] w-full flex-shrink-0 cursor-pointer',
+          'group/cover relative h-[25vh] w-full flex-shrink-0 cursor-pointer',
           cover ? 'bg-transparent' : 'bg-accent',
           className,
         )}
@@ -101,7 +127,7 @@ export function DocumentCover({cover, className}: DocumentCoverProps) {
       >
         <img
           alt="Document cover"
-          src={imageUrl(cover, 'XL')}
+          src={coverUrl}
           style={{
             width: '100%',
             height: '100%',
@@ -113,6 +139,77 @@ export function DocumentCover({cover, className}: DocumentCoverProps) {
           }}
           className="transition-transform duration-200"
         />
+        {hasCoverActions ? (
+          <div
+            data-document-cover-controls
+            className="absolute right-4 bottom-4 z-20 flex items-center gap-1 rounded-lg bg-black/45 p-1 text-white opacity-100 shadow-sm backdrop-blur-sm transition-opacity duration-200 motion-reduce:transition-none md:pointer-events-none md:opacity-0 md:group-hover/cover:pointer-events-auto md:group-hover/cover:opacity-100 md:focus-within:pointer-events-auto md:focus-within:opacity-100"
+            onClick={(event) => {
+              event.stopPropagation()
+            }}
+          >
+            {onChangeCover ? (
+              <>
+                <input
+                  ref={replacementInputRef}
+                  type="file"
+                  accept="image/*"
+                  aria-label="Choose replacement cover image"
+                  className="sr-only"
+                  tabIndex={-1}
+                  onChange={(event) => void handleReplacementChange(event)}
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  aria-label="Change document cover image"
+                  loading={isChangingCover}
+                  className="h-7 rounded-md px-2 text-xs text-white hover:bg-white/15 hover:text-white active:bg-white/20"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    replacementInputRef.current?.click()
+                  }}
+                >
+                  Change
+                </Button>
+              </>
+            ) : null}
+            {coverUrl ? (
+              <Button
+                asChild
+                variant="ghost"
+                size="iconSm"
+                aria-label="Download document cover image"
+                className="h-7 min-w-7 rounded-md text-white hover:bg-white/15 hover:text-white active:bg-white/20"
+              >
+                <a
+                  href={coverUrl}
+                  download
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={(event) => event.stopPropagation()}
+                >
+                  <Download className="size-3.5" />
+                </a>
+              </Button>
+            ) : null}
+            {onRemove ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                aria-label="Remove document cover image"
+                className="h-7 rounded-md px-2 text-xs text-white hover:bg-white/15 hover:text-white active:bg-white/20"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  onRemove()
+                }}
+              >
+                Remove
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
       </div>
       {typeof window !== 'undefined' &&
         (() => {

--- a/frontend/packages/ui/src/document-header.tsx
+++ b/frontend/packages/ui/src/document-header.tsx
@@ -10,7 +10,9 @@ import {useAccount} from '@shm/shared/models/entity'
 import type {NavRoute} from '@shm/shared/routes'
 import {getVersionHeads} from '@shm/shared/utils/entity-id-url'
 import {useNavRoute} from '@shm/shared/utils/navigation'
+import {X} from 'lucide-react'
 import {useMemo} from 'react'
+import {Button} from './button'
 import {Container} from './container'
 import {DocumentDate} from './document-date'
 import {useHighlighter} from './highlight-context'
@@ -53,6 +55,7 @@ export function DocumentHeader({
   version,
   showTitle = true,
   children,
+  onRemoveIcon,
 }: {
   docId: UnpackedHypermediaId | null
   docMetadata: HMMetadata | null
@@ -65,6 +68,7 @@ export function DocumentHeader({
   version?: HMDocument['version'] | null
   showTitle?: boolean
   children?: React.ReactNode
+  onRemoveIcon?: () => void
 }) {
   const hasCover = useMemo(() => !!docMetadata?.cover, [docMetadata])
   const hasIcon = useMemo(() => !!docMetadata?.icon, [docMetadata])
@@ -93,12 +97,28 @@ export function DocumentHeader({
       <div className="flex flex-col gap-4">
         {!isHomeDoc && docId && hasIcon ? (
           <div
-            className="flex"
+            className="group/icon relative flex w-fit"
             style={{
               marginTop: hasCover ? -80 : 0,
             }}
           >
             <HMIcon size={100} id={docId} name={docMetadata?.name} icon={docMetadata?.icon} />
+            {onRemoveIcon ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="iconSm"
+                aria-label="Remove document icon"
+                className="absolute -top-2 -right-2 z-20 size-7 rounded-full bg-black/40 text-white opacity-100 shadow-sm backdrop-blur-sm transition-opacity hover:bg-black/60 md:pointer-events-none md:opacity-0 md:group-hover/icon:pointer-events-auto md:group-hover/icon:opacity-100 md:focus-visible:pointer-events-auto md:focus-visible:opacity-100"
+                onClick={(event) => {
+                  event.preventDefault()
+                  event.stopPropagation()
+                  onRemoveIcon()
+                }}
+              >
+                <X className="size-3.5" />
+              </Button>
+            ) : null}
           </div>
         ) : null}
         {breadcrumbs && breadcrumbs.length > 0 ? <Breadcrumbs breadcrumbs={breadcrumbs} /> : null}

--- a/frontend/packages/ui/src/document-metadata-affordances.tsx
+++ b/frontend/packages/ui/src/document-metadata-affordances.tsx
@@ -1,0 +1,345 @@
+import type {HMMetadata} from '@seed-hypermedia/client/hm-types'
+import {FileText, ImagePlus, Smile} from 'lucide-react'
+import {ChangeEvent, useEffect, useRef, useState} from 'react'
+import {Button} from './button'
+import {cn} from './utils'
+
+type MetadataAffordanceKey = 'icon' | 'cover'
+
+export type DocumentMetadataAffordanceButtonsProps = {
+  metadata?: Pick<HMMetadata, 'icon' | 'cover' | 'summary'> | null
+  visible: boolean
+  onMetadata: (values: Partial<HMMetadata>) => void
+  onRequestSummary: () => void
+  fileUpload?: (file: File) => Promise<string>
+  className?: string
+  onBeforeMetadataChange?: () => void
+  showSummary?: boolean
+  keepSummaryButtonVisible?: boolean
+  hideSummaryButton?: boolean
+  alwaysVisibleOnMobile?: boolean
+}
+
+export type EditableDocumentMetadataFieldsProps = {
+  name: string
+  summary: string
+  metadata?: Pick<HMMetadata, 'icon' | 'cover' | 'summary'> | null
+  onMetadata: (values: Partial<HMMetadata>) => void
+  onBeginEdit: () => void
+  fileUpload?: (file: File) => Promise<string>
+  className?: string
+  titleClassName?: string
+  summaryClassName?: string
+  onCancelEdit?: () => void
+  onSummaryEnter?: () => void
+}
+
+export type HomeDocumentMetadataAffordanceBarProps = {
+  metadata?: Pick<HMMetadata, 'icon' | 'cover' | 'summary'> | null
+  onMetadata: (values: Partial<HMMetadata>) => void
+  onBeginEdit: () => void
+  fileUpload?: (file: File) => Promise<string>
+  className?: string
+}
+
+function toIpfsUrl(cidOrUrl: string) {
+  return cidOrUrl.startsWith('ipfs://') ? cidOrUrl : `ipfs://${cidOrUrl}`
+}
+
+/** Subtle inline buttons that hint at optional document metadata fields. */
+export function DocumentMetadataAffordanceButtons({
+  metadata,
+  visible,
+  onMetadata,
+  onRequestSummary,
+  fileUpload,
+  className,
+  onBeforeMetadataChange,
+  showSummary = true,
+  keepSummaryButtonVisible = false,
+  hideSummaryButton = false,
+  alwaysVisibleOnMobile = false,
+}: DocumentMetadataAffordanceButtonsProps) {
+  const iconInputRef = useRef<HTMLInputElement>(null)
+  const coverInputRef = useRef<HTMLInputElement>(null)
+  const [uploading, setUploading] = useState<MetadataAffordanceKey | null>(null)
+  const hasIcon = !!metadata?.icon
+  const hasCover = !!metadata?.cover
+  const hasSummary = !!metadata?.summary
+  const showIconButton = !hasIcon && !!fileUpload
+  const showSummaryButton = showSummary && !hideSummaryButton && (!hasSummary || keepSummaryButtonVisible)
+  const showCoverButton = !hasCover && !!fileUpload
+  const hiddenClass = alwaysVisibleOnMobile
+    ? 'opacity-100 md:pointer-events-none md:opacity-0'
+    : 'pointer-events-none opacity-0'
+  const rowIsAccessible = visible || alwaysVisibleOnMobile
+  const tabIndex = rowIsAccessible ? undefined : -1
+
+  async function handleFileChange(field: MetadataAffordanceKey, event: ChangeEvent<HTMLInputElement>) {
+    event.stopPropagation()
+    const file = event.target.files?.[0]
+    if (!file || !fileUpload) return
+
+    setUploading(field)
+    try {
+      const cid = await fileUpload(file)
+      onBeforeMetadataChange?.()
+      onMetadata({[field]: toIpfsUrl(cid)} as Partial<HMMetadata>)
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error)
+      console.error(`Failed to upload document ${field}: ${message}`, error)
+    } finally {
+      setUploading(null)
+      event.target.value = ''
+    }
+  }
+
+  if (!showIconButton && !showSummaryButton && !showCoverButton) {
+    return null
+  }
+
+  return (
+    <div
+      data-document-metadata-affordances
+      className={cn(
+        'flex flex-wrap items-center gap-1.5 transition-opacity duration-200 motion-reduce:transition-none',
+        visible ? 'opacity-100' : hiddenClass,
+        className,
+      )}
+      aria-hidden={!rowIsAccessible}
+    >
+      {showIconButton ? (
+        <>
+          <input
+            ref={iconInputRef}
+            type="file"
+            accept="image/*"
+            aria-label="Choose document icon"
+            className="sr-only"
+            tabIndex={-1}
+            onChange={(event) => void handleFileChange('icon', event)}
+          />
+          <MetadataHintButton
+            aria-label="Add document icon"
+            icon={<Smile className="size-3.5" />}
+            loading={uploading === 'icon'}
+            tabIndex={tabIndex}
+            onClick={() => iconInputRef.current?.click()}
+          >
+            Add icon
+          </MetadataHintButton>
+        </>
+      ) : null}
+      {showSummaryButton ? (
+        <MetadataHintButton
+          aria-label="Add document summary"
+          icon={<FileText className="size-3.5" />}
+          tabIndex={tabIndex}
+          onClick={() => {
+            onBeforeMetadataChange?.()
+            onRequestSummary()
+          }}
+        >
+          Add Summary
+        </MetadataHintButton>
+      ) : null}
+      {showCoverButton ? (
+        <>
+          <input
+            ref={coverInputRef}
+            type="file"
+            accept="image/*"
+            aria-label="Choose document cover image"
+            className="sr-only"
+            tabIndex={-1}
+            onChange={(event) => void handleFileChange('cover', event)}
+          />
+          <MetadataHintButton
+            aria-label="Add document cover image"
+            icon={<ImagePlus className="size-3.5" />}
+            loading={uploading === 'cover'}
+            tabIndex={tabIndex}
+            onClick={() => coverInputRef.current?.click()}
+          >
+            Add cover image
+          </MetadataHintButton>
+        </>
+      ) : null}
+    </div>
+  )
+}
+
+/** Editable title/summary fields with subtle metadata add buttons. */
+export function EditableDocumentMetadataFields({
+  name,
+  summary,
+  metadata,
+  onMetadata,
+  onBeginEdit,
+  fileUpload,
+  className,
+  titleClassName,
+  summaryClassName,
+  onCancelEdit,
+  onSummaryEnter,
+}: EditableDocumentMetadataFieldsProps) {
+  const titleRef = useRef<HTMLTextAreaElement | null>(null)
+  const summaryRef = useRef<HTMLTextAreaElement | null>(null)
+  const [hovered, setHovered] = useState(false)
+  const [summaryRequested, setSummaryRequested] = useState(false)
+  const [summaryFocused, setSummaryFocused] = useState(false)
+  const summaryText = summary ?? ''
+  const showSummaryInput = !!summaryText || summaryRequested || summaryFocused
+  const showAffordances = hovered || summaryRequested
+
+  useEffect(() => {
+    if (titleRef.current) resizeTextarea(titleRef.current)
+  }, [name])
+
+  useEffect(() => {
+    if (summaryRef.current) resizeTextarea(summaryRef.current)
+  }, [summaryText, showSummaryInput])
+
+  useEffect(() => {
+    if (!summaryRequested) return
+    summaryRef.current?.focus()
+  }, [summaryRequested])
+
+  function requestSummary() {
+    setSummaryRequested(true)
+  }
+
+  return (
+    <div
+      className={cn('flex flex-col gap-2', className)}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <DocumentMetadataAffordanceButtons
+        metadata={metadata}
+        visible={showAffordances}
+        fileUpload={fileUpload}
+        className="-ml-2"
+        onBeforeMetadataChange={onBeginEdit}
+        onMetadata={onMetadata}
+        onRequestSummary={requestSummary}
+        keepSummaryButtonVisible={summaryRequested}
+        hideSummaryButton={summaryFocused && !summaryRequested && !summaryText}
+        alwaysVisibleOnMobile
+      />
+      <textarea
+        ref={titleRef}
+        rows={1}
+        aria-label="Document title"
+        className={cn(
+          'w-full resize-none border-none border-transparent bg-transparent text-4xl font-bold shadow-none ring-0 ring-transparent outline-none focus:ring-0',
+          titleClassName,
+        )}
+        value={name}
+        onFocus={onBeginEdit}
+        onInput={(event) => {
+          resizeTextarea(event.currentTarget)
+          onMetadata({name: event.currentTarget.value})
+        }}
+        onKeyDown={(event) => {
+          if (event.key === 'Escape') {
+            onCancelEdit?.()
+            event.currentTarget.blur()
+            return
+          }
+          if (event.key === 'Enter') {
+            event.preventDefault()
+            requestSummary()
+          }
+        }}
+        placeholder="Document Title"
+      />
+      {showSummaryInput ? (
+        <textarea
+          ref={summaryRef}
+          rows={1}
+          aria-label="Document summary"
+          className={cn(
+            'text-muted-foreground w-full resize-none border-none border-transparent bg-transparent font-serif text-xl font-normal shadow-none ring-0 ring-transparent outline-none focus:ring-0',
+            summaryClassName,
+          )}
+          value={summaryText}
+          onFocus={() => {
+            setSummaryFocused(true)
+            onBeginEdit()
+          }}
+          onInput={(event) => {
+            const nextSummary = event.currentTarget.value.replace(/\n/g, '')
+            resizeTextarea(event.currentTarget)
+            onMetadata({summary: nextSummary})
+          }}
+          onBlur={() => {
+            setSummaryRequested(false)
+            setSummaryFocused(false)
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'Escape') {
+              onCancelEdit?.()
+              event.currentTarget.blur()
+              return
+            }
+            if (event.key === 'Enter') {
+              event.preventDefault()
+              onSummaryEnter?.()
+            }
+          }}
+          placeholder="Document Summary"
+        />
+      ) : null}
+    </div>
+  )
+}
+
+/** Metadata affordance area used by home documents, which have no document header. */
+export function HomeDocumentMetadataAffordanceBar({
+  metadata,
+  onMetadata,
+  onBeginEdit,
+  fileUpload,
+  className,
+}: HomeDocumentMetadataAffordanceBarProps) {
+  const showAffordances = true
+
+  return (
+    <div data-home-document-metadata-affordances className={cn('flex flex-col gap-2 px-4 pt-5 sm:px-6', className)}>
+      <DocumentMetadataAffordanceButtons
+        metadata={metadata}
+        visible={showAffordances}
+        fileUpload={fileUpload}
+        onBeforeMetadataChange={onBeginEdit}
+        onMetadata={onMetadata}
+        onRequestSummary={() => {}}
+        showSummary={false}
+      />
+    </div>
+  )
+}
+
+function MetadataHintButton({
+  children,
+  icon,
+  ...props
+}: React.ComponentProps<'button'> & {icon: React.ReactNode; loading?: boolean}) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="xs"
+      className="text-muted-foreground hover:text-foreground h-7 rounded-full px-2 text-xs font-medium opacity-80 hover:bg-black/5 hover:opacity-100 active:scale-[0.98] dark:hover:bg-white/10"
+      {...props}
+    >
+      {icon}
+      <span>{children}</span>
+    </Button>
+  )
+}
+
+function resizeTextarea(el: HTMLTextAreaElement) {
+  el.style.height = 'auto'
+  el.style.height = `${el.scrollHeight}px`
+}

--- a/frontend/packages/ui/src/editing-toolbar.tsx
+++ b/frontend/packages/ui/src/editing-toolbar.tsx
@@ -156,14 +156,14 @@ export function PublishPopoverBody({
   const absoluteTime = publishedDoc?.updateTime ? formattedDateMedium(publishedDoc.updateTime) : undefined
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-5">
       {/* URL row */}
-      <div className="flex flex-col gap-2">
-        <p className="text-sm font-medium">Your document will be available at</p>
+      <div className="flex flex-col gap-3">
+        <p className="text-base font-medium">Your document will be available at</p>
         {documentUrl ? (
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-3">
             <span
-              className="text-muted-foreground min-w-0 flex-1 text-xs"
+              className="text-muted-foreground min-w-0 flex-1 text-sm"
               style={{
                 direction: 'rtl',
                 textAlign: 'left',
@@ -176,26 +176,26 @@ export function PublishPopoverBody({
             </span>
             <Tooltip content="Copy URL">
               <Button
-                size="iconSm"
+                size="icon"
                 variant="ghost"
                 className="shrink-0"
                 onClick={() => {
                   copyTextToClipboard(documentUrl).then(() => toast.success('Copied document URL'))
                 }}
               >
-                <Copy size={14} />
+                <Copy size={18} />
               </Button>
             </Tooltip>
           </div>
         ) : (
-          <div className="text-muted-foreground flex items-center gap-2 text-xs">
-            <Spinner className="size-3" />
+          <div className="text-muted-foreground flex items-center gap-2 text-sm">
+            <Spinner className="size-4" />
             <span>Loading…</span>
           </div>
         )}
         {isFirstPublish && slugify && (
-          <div className="flex flex-col gap-1">
-            <p className="text-muted-foreground text-xs">Edit your permalink</p>
+          <div className="flex flex-col gap-2">
+            <p className="text-muted-foreground text-sm">Edit your permalink</p>
             <Input
               value={`/${effectivePathSegment}`}
               disabled={isPrivate}
@@ -212,10 +212,10 @@ export function PublishPopoverBody({
                 }
               }}
               placeholder="/document-path"
-              className="h-8 border-black/10 text-xs dark:border-white/20"
+              className="h-10 border-black/10 text-sm dark:border-white/20"
             />
             {isPrivate ? (
-              <p className="text-muted-foreground text-xs">Private document paths are generated automatically.</p>
+              <p className="text-muted-foreground text-sm">Private document paths are generated automatically.</p>
             ) : null}
           </div>
         )}
@@ -233,18 +233,18 @@ export function PublishPopoverBody({
               onGoToVersions(docId)
             }}
             title={absoluteTime}
-            className="hover:bg-muted -mx-2 flex items-center gap-2 rounded px-2 py-1 text-left text-xs"
+            className="hover:bg-muted -mx-3 flex items-center gap-3 rounded px-3 py-2.5 text-left text-sm"
           >
-            <Clock className="text-muted-foreground size-3.5" />
+            <Clock className="text-muted-foreground size-5" />
             <span className="flex-1">
               <span className="text-foreground">{relativeTime ?? 'Published'}</span>
               {authorName ? <span className="text-muted-foreground"> by {authorName}</span> : null}
             </span>
-            <ChevronRight className="text-muted-foreground size-3.5" />
+            <ChevronRight className="text-muted-foreground size-5" />
           </button>
         ) : (
-          <div title={absoluteTime} className="-mx-2 flex items-center gap-2 rounded px-2 py-1 text-xs">
-            <Clock className="text-muted-foreground size-3.5" />
+          <div title={absoluteTime} className="-mx-3 flex items-center gap-3 rounded px-3 py-2.5 text-sm">
+            <Clock className="text-muted-foreground size-5" />
             <span className="flex-1">
               <span className="text-foreground">{relativeTime ?? 'Published'}</span>
               {authorName ? <span className="text-muted-foreground"> by {authorName}</span> : null}
@@ -252,22 +252,22 @@ export function PublishPopoverBody({
           </div>
         )
       ) : (
-        <div className="-mx-2 flex items-center gap-2 rounded px-2 py-1 text-xs">
-          <Clock className="text-muted-foreground size-3.5" />
+        <div className="-mx-3 flex items-center gap-3 rounded px-3 py-2.5 text-sm">
+          <Clock className="text-muted-foreground size-5" />
           <span className="text-muted-foreground flex-1">Not yet published</span>
         </div>
       )}
 
       {/* Changes count row */}
-      <div className="-mx-2 flex items-center gap-2 rounded px-2 py-1 text-xs">
-        <FileDiff className="text-muted-foreground size-3.5" />
+      <div className="-mx-3 flex items-center gap-3 rounded px-3 py-2.5 text-sm">
+        <FileDiff className="text-muted-foreground size-5" />
         <span className="flex-1">
           {changeCount === 0 ? 'No changes to publish' : `${changeCount} ${changeCount === 1 ? 'change' : 'changes'}`}
         </span>
       </div>
 
       {unpublishedChildCount > 0 ? (
-        <div className="border-warning bg-warning/10 text-warning-foreground -mx-1 rounded border px-3 py-2 text-xs">
+        <div className="border-warning bg-warning/10 text-warning-foreground -mx-2 rounded-md border px-4 py-3 text-sm">
           <p className="font-medium">
             {unpublishedChildCount === 1
               ? 'This document embeds an unpublished draft.'
@@ -281,11 +281,12 @@ export function PublishPopoverBody({
 
       <Separator className="bg-black/10 dark:bg-white/10" />
 
-      <div className="flex flex-col gap-1">
+      <div className="flex flex-col gap-2 pt-1">
         <Button
-          size="sm"
+          size="default"
           variant={publishDisabled ? 'ghost' : 'brand'}
           className={cn(
+            'h-11 text-base font-semibold',
             publishDisabled &&
               'bg-neutral-100 text-neutral-500 hover:bg-neutral-100 disabled:opacity-100 dark:bg-neutral-800 dark:text-neutral-400',
           )}
@@ -298,7 +299,7 @@ export function PublishPopoverBody({
         >
           Publish: Make it live now
         </Button>
-        <Button size="sm" variant="ghost" onClick={onClose}>
+        <Button size="default" variant="ghost" className="h-10 text-base" onClick={onClose}>
           Cancel
         </Button>
       </div>
@@ -415,7 +416,7 @@ export function PublishButtonWithPopover({
         <PopoverAnchor asChild>
           <PublishTrigger canPublish={canPublish} onClick={handlePublishTriggerClick} />
         </PopoverAnchor>
-        <PopoverContent align="end" className="w-80">
+        <PopoverContent align="end" className="w-[26rem] max-w-[calc(100vw-2rem)] p-6">
           <PublishPopoverBody
             docId={docId}
             changeCount={changeCount}

--- a/frontend/packages/ui/src/feed.tsx
+++ b/frontend/packages/ui/src/feed.tsx
@@ -104,6 +104,13 @@ export const RESTORE_VERSION_DIALOG = {
   restoreVariant: 'danger',
 } as const
 
+/** Shared classes for version-row action buttons; leaves the icon button dimensions untouched. */
+export const RESTORE_VERSION_ACTION_BUTTON_CLASS =
+  'text-foreground hover-hover:opacity-0 hover-hover:group-hover:opacity-100 transition-opacity duration-200 ease-in-out'
+
+/** Shared classes for version-row action icons so restore/copy actions stay readable. */
+export const RESTORE_VERSION_ACTION_ICON_CLASS = 'size-4'
+
 export function Feed({
   filterResource,
   filterAuthors,
@@ -510,14 +517,14 @@ function EventHeaderContent({
             aria-label="Restore"
             size="icon"
             variant="ghost"
-            className="text-muted-foreground hover-hover:opacity-0 hover-hover:group-hover:opacity-100 transition-opacity duration-200 ease-in-out"
+            className={RESTORE_VERSION_ACTION_BUTTON_CLASS}
             onClick={(e) => {
               e.preventDefault()
               e.stopPropagation()
               setRestoreDialogOpen(true)
             }}
           >
-            <RotateCcw className="size-3" />
+            <RotateCcw className={RESTORE_VERSION_ACTION_ICON_CLASS} />
           </Button>
         </Tooltip>
         <AlertDialogContent onClick={(e) => e.stopPropagation()}>
@@ -590,7 +597,7 @@ function EventHeaderContent({
             <Button
               size="icon"
               variant="ghost"
-              className="text-muted-foreground hover-hover:opacity-0 hover-hover:group-hover:opacity-100 transition-opacity duration-200 ease-in-out"
+              className={RESTORE_VERSION_ACTION_BUTTON_CLASS}
               onClick={(e) => {
                 e.preventDefault()
                 e.stopPropagation()
@@ -612,7 +619,7 @@ function EventHeaderContent({
                 onPushReference?.(versionedId)
               }}
             >
-              <Link className="size-3" />
+              <Link className={RESTORE_VERSION_ACTION_ICON_CLASS} />
             </Button>
           </Tooltip>
         </div>

--- a/frontend/packages/ui/src/options-panel.tsx
+++ b/frontend/packages/ui/src/options-panel.tsx
@@ -1,5 +1,5 @@
 import {HMMetadata} from '@seed-hypermedia/client/hm-types'
-import {useEffect, useRef, useState} from 'react'
+import {useState} from 'react'
 import {PanelContent} from './accessories'
 import {Button} from './button'
 import {DatePicker} from './components/date-picker'
@@ -10,7 +10,6 @@ import {getDaemonFileUrl} from './get-file-url'
 import {IconForm} from './icon-form'
 import {ImageForm} from './image-form'
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from './select-dropdown'
-import {SizableText} from './text'
 
 export function OptionsPanel({
   draftId,
@@ -34,21 +33,12 @@ export function OptionsPanel({
             <DocumentIconForm draftId={draftId} metadata={metadata} onMetadata={onMetadata} fileUpload={fileUpload} />
             <HeaderLogo draftId={draftId} metadata={metadata} onMetadata={onMetadata} fileUpload={fileUpload} />
             <HeaderLayout metadata={metadata} onMetadata={onMetadata} />
-
-            <SizableText className="mt-4 flex-1 px-1 select-none" size="md" weight="semibold">
-              Document Options
-            </SizableText>
-            <CoverImage draftId={draftId} metadata={metadata} onMetadata={onMetadata} fileUpload={fileUpload} />
             <OriginalPublishDate metadata={metadata} onMetadata={onMetadata} />
             <ContentWidth metadata={metadata} onMetadata={onMetadata} />
             <ActivityVisibility metadata={metadata} onMetadata={onMetadata} />
           </>
         ) : (
           <>
-            <NameInput metadata={metadata} onMetadata={onMetadata} />
-            <SummaryInput metadata={metadata} onMetadata={onMetadata} />
-            <DocumentIconForm draftId={draftId} metadata={metadata} onMetadata={onMetadata} fileUpload={fileUpload} />
-            <CoverImage draftId={draftId} metadata={metadata} onMetadata={onMetadata} fileUpload={fileUpload} />
             <OriginalPublishDate metadata={metadata} onMetadata={onMetadata} />
             <OutlineVisibility metadata={metadata} onMetadata={onMetadata} />
             <ActivityVisibility metadata={metadata} onMetadata={onMetadata} />
@@ -71,61 +61,6 @@ function NameInput({metadata, onMetadata}: {metadata: HMMetadata; onMetadata: (v
         onChange={(e) => {
           const name = e.target.value
           onMetadata({name})
-        }}
-      />
-    </div>
-  )
-}
-
-function SummaryInput({
-  metadata,
-  onMetadata,
-}: {
-  metadata: HMMetadata
-  onMetadata: (values: Partial<HMMetadata>) => void
-}) {
-  const textareaRef = useRef<HTMLTextAreaElement>(null)
-
-  const adjustHeight = (textarea: HTMLTextAreaElement) => {
-    textarea.style.height = 'auto'
-    textarea.style.height = `${textarea.scrollHeight > 150 ? 150 : textarea.scrollHeight}px`
-
-    if (textarea.scrollHeight > 150) {
-      textarea.style.overflow = 'auto'
-    } else {
-      textarea.style.overflow = 'hidden'
-    }
-  }
-
-  useEffect(() => {
-    if (textareaRef.current) {
-      adjustHeight(textareaRef.current)
-    }
-  }, [metadata.summary])
-
-  const handleTextareaChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const textarea = e.target
-    onMetadata({summary: textarea.value.replace(/\n/g, '')})
-  }
-
-  return (
-    <div className="flex flex-col gap-1">
-      <Label size="sm" className="text-muted-foreground">
-        Summary
-      </Label>
-      <textarea
-        ref={textareaRef}
-        className="bg-muted border-border w-full rounded-md border-1 p-2 px-4"
-        style={{
-          resize: 'none',
-          minHeight: '38px',
-          overflow: 'hidden',
-        }}
-        value={metadata.summary}
-        onChange={handleTextareaChange}
-        onInput={(e) => {
-          const textarea = e.target as HTMLTextAreaElement
-          adjustHeight(textarea)
         }}
       />
     </div>
@@ -164,45 +99,6 @@ function DocumentIconForm({
         onRemoveIcon={() => {
           onMetadata({
             icon: '',
-          })
-        }}
-      />
-    </div>
-  )
-}
-
-function CoverImage({
-  draftId,
-  metadata,
-  onMetadata,
-  fileUpload,
-}: {
-  draftId: string
-  metadata: HMMetadata
-  onMetadata: (values: Partial<HMMetadata>) => void
-  fileUpload?: (file: File) => Promise<string>
-}) {
-  return (
-    <div className="flex flex-col gap-1">
-      <Label size="sm" className="text-muted-foreground">
-        Cover Image
-      </Label>
-      <ImageForm
-        height={100}
-        id={`cover-${draftId}`}
-        label={metadata.cover}
-        url={metadata.cover ? getDaemonFileUrl(metadata.cover) : ''}
-        fileUpload={fileUpload}
-        onImageUpload={(imageCid) => {
-          if (imageCid) {
-            onMetadata({
-              cover: `ipfs://${imageCid}`,
-            })
-          }
-        }}
-        onRemove={() => {
-          onMetadata({
-            cover: '',
           })
         }}
       />

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -100,6 +100,7 @@ import {DirectoryPageContent} from './directory-page'
 import {DiscussionsPageContent} from './discussions-page'
 import {DocumentCover} from './document-cover'
 import {AuthorPayload, BreadcrumbEntry, Breadcrumbs, DocumentHeader} from './document-header'
+import {EditableDocumentMetadataFields, HomeDocumentMetadataAffordanceBar} from './document-metadata-affordances'
 import {DocumentMetadataView} from './document-metadata-view'
 import {DocumentTools} from './document-tools'
 import {DocumentVersionsPanel, isDocumentVersionsPanelRoute} from './document-versions-panel'
@@ -1457,6 +1458,8 @@ function DocumentBody({
   const isEditing = useDocumentSelector(selectIsEditing)
   const isUnpublishedDraft = useDocumentSelector(selectIsUnpublishedDraft)
   const ctx = useDocumentSelector(selectContext)
+  const send = useDocumentSend()
+  const {beginEditIfNeeded} = useEditorGate()
   // Draft metadata (partial) overrides published metadata, same as the options panel.
   const metadata = useMemo(
     () => ({...(ctx.document?.metadata || document.metadata || {}), ...ctx.metadata}),
@@ -1479,6 +1482,19 @@ function DocumentBody({
   const isBlockInPublishedVersion = useCallback(
     (blockId: string) => publishedBlockIds.has(blockId),
     [publishedBlockIds],
+  )
+  const removeCover = useCallback(() => {
+    beginEditIfNeeded()
+    send({type: 'change', metadata: {cover: ''}})
+  }, [beginEditIfNeeded, send])
+  const changeCover = useCallback(
+    async (file: File) => {
+      if (!fileUpload) return
+      const cid = await fileUpload(file)
+      beginEditIfNeeded()
+      send({type: 'change', metadata: {cover: cid.startsWith('ipfs://') ? cid : `ipfs://${cid}`}})
+    },
+    [beginEditIfNeeded, fileUpload, send],
   )
 
   // Capture the editor instance locally and forward to upstream onEditorReady.
@@ -2186,7 +2202,14 @@ function DocumentBody({
         !pageFooter && 'min-h-full',
       )}
     >
-      <DocumentCover cover={metadata?.cover} />
+      <DocumentCover
+        cover={metadata?.cover}
+        onRemove={canEdit && metadata?.cover ? removeCover : undefined}
+        onChangeCover={canEdit && metadata?.cover && fileUpload ? changeCover : undefined}
+      />
+      {isHomeDoc && canEdit && activeView === 'content' ? (
+        <HomeDocumentMetadataControls metadata={metadata as any} fileUpload={fileUpload} />
+      ) : null}
 
       {!isMobile ? (
         <div {...wrapperProps} className={cn(wrapperProps.className, 'flex-none', !showSidebars && 'justify-center')}>
@@ -2237,6 +2260,7 @@ function DocumentBody({
                   breadcrumbs={breadcrumbs}
                   visibility={headerVisibility}
                   version={document.version}
+                  fileUpload={fileUpload}
                 />
               ) : (
                 <DocumentHeader
@@ -2299,6 +2323,7 @@ function DocumentBody({
                 breadcrumbs={breadcrumbs}
                 visibility={headerVisibility}
                 version={document.version}
+                fileUpload={fileUpload}
               />
             ) : (
               <DocumentHeader
@@ -2560,6 +2585,7 @@ function EditableDocumentHeader({
   breadcrumbs,
   visibility,
   version,
+  fileUpload,
 }: {
   docId: UnpackedHypermediaId
   docMetadata: HMDocument['metadata']
@@ -2568,77 +2594,16 @@ function EditableDocumentHeader({
   breadcrumbs?: BreadcrumbEntry[]
   visibility?: string
   version?: HMDocument['version'] | null
+  fileUpload?: (file: File) => Promise<string>
 }) {
   const ctx = useDocumentSelector(selectContext)
   const isEditing = useDocumentSelector(selectIsEditing)
   const send = useDocumentSend()
-  const inputName = useRef<HTMLTextAreaElement | null>(null)
-  const inputSummary = useRef<HTMLTextAreaElement | null>(null)
 
   // Use machine context metadata if it has been changed, otherwise fall back to document metadata
   const name = ctx.metadata?.name ?? docMetadata?.name ?? ''
   const summary = ctx.metadata?.summary ?? docMetadata?.summary ?? ''
-
-  // Reflow both textareas. Runs the resize immediately, on the next animation
-  // frame (after React commits paint), and once fonts have loaded — reading
-  // `scrollHeight` before fonts settle or before the parent has its final
-  // width produces a stale height that sticks until the next window resize,
-  // which is why opening DevTools (a window resize) "fixes" the layout.
-  const reflowBoth = useCallback(() => {
-    const doResize = () => {
-      if (inputName.current) applyTitleResize(inputName.current)
-      if (inputSummary.current) applyTitleResize(inputSummary.current)
-    }
-    doResize()
-    requestAnimationFrame(doResize)
-    if (typeof document !== 'undefined' && (document as any).fonts?.ready) {
-      ;(document as any).fonts.ready.then(doResize).catch(() => {})
-    }
-  }, [])
-
-  useEffect(() => {
-    const target = inputName.current
-    if (!target) return
-    if (target.value !== name) {
-      target.value = name || ''
-    }
-    applyTitleResize(target)
-    requestAnimationFrame(() => {
-      if (inputName.current) applyTitleResize(inputName.current)
-    })
-  }, [name])
-
-  useEffect(() => {
-    const target = inputSummary.current
-    if (!target) return
-    if (target.value !== summary) {
-      target.value = summary || ''
-    }
-    applyTitleResize(target)
-    requestAnimationFrame(() => {
-      if (inputSummary.current) applyTitleResize(inputSummary.current)
-    })
-  }, [summary])
-
-  useEffect(() => {
-    reflowBoth()
-    window.addEventListener('resize', reflowBoth)
-
-    // Watch the parent container so any width change (panel open/close,
-    // content re-layout after publish, scrollbar appearing) re-reflows the
-    // textareas without waiting for a window resize.
-    const parent = inputName.current?.parentElement
-    let observer: ResizeObserver | null = null
-    if (parent && typeof ResizeObserver !== 'undefined') {
-      observer = new ResizeObserver(() => reflowBoth())
-      observer.observe(parent)
-    }
-
-    return () => {
-      window.removeEventListener('resize', reflowBoth)
-      observer?.disconnect()
-    }
-  }, [reflowBoth])
+  const metadata = {...(docMetadata || {}), ...ctx.metadata}
 
   return (
     <DocumentHeader
@@ -2650,63 +2615,37 @@ function EditableDocumentHeader({
       visibility={visibility as any}
       version={version}
       showTitle={false}
+      onRemoveIcon={
+        metadata.icon
+          ? () => {
+              if (!isEditing) send({type: 'edit.start'})
+              send({type: 'change', metadata: {icon: ''}})
+            }
+          : undefined
+      }
     >
-      <textarea
-        ref={inputName}
-        rows={1}
-        className="w-full resize-none border-none border-transparent bg-transparent text-4xl font-bold shadow-none ring-0 ring-transparent outline-none focus:ring-0"
-        defaultValue={name}
-        onFocus={() => {
+      <EditableDocumentMetadataFields
+        name={name}
+        summary={summary}
+        metadata={metadata as any}
+        fileUpload={fileUpload}
+        onBeginEdit={() => {
           if (!isEditing) send({type: 'edit.start'})
         }}
-        onChange={(e) => {
-          applyTitleResize(e.target)
-          send({type: 'change', metadata: {name: e.target.value}})
+        onMetadata={(metadata) => {
+          send({type: 'change', metadata})
         }}
-        onKeyDown={(e) => {
-          if (e.key === 'Escape' && isEditing) {
-            e.currentTarget.blur()
+        onCancelEdit={() => {
+          if (isEditing) {
             send({type: 'edit.cancel'})
           }
-          if (e.key === 'Enter') {
-            e.preventDefault()
-            inputSummary.current?.focus()
-          }
         }}
-        placeholder="Document Title"
-      />
-      <textarea
-        ref={inputSummary}
-        rows={1}
-        className="text-muted-foreground w-full resize-none border-none border-transparent bg-transparent font-serif text-xl font-normal shadow-none ring-0 ring-transparent outline-none focus:ring-0"
-        defaultValue={summary}
-        onFocus={() => {
-          if (!isEditing) send({type: 'edit.start'})
+        onSummaryEnter={() => {
+          send({type: 'edit.start', cursorPosition: 'end'})
         }}
-        onChange={(e) => {
-          applyTitleResize(e.target)
-          send({type: 'change', metadata: {summary: e.target.value}})
-        }}
-        onKeyDown={(e) => {
-          if (e.key === 'Escape' && isEditing) {
-            e.currentTarget.blur()
-            send({type: 'edit.cancel'})
-          }
-          if (e.key === 'Enter') {
-            e.preventDefault()
-            send({type: 'edit.start', cursorPosition: 'end'})
-          }
-        }}
-        placeholder="Document Summary"
       />
     </DocumentHeader>
   )
-}
-
-/** Auto-resize a textarea to fit its content. */
-function applyTitleResize(el: HTMLTextAreaElement) {
-  el.style.height = 'auto'
-  el.style.height = el.scrollHeight + 'px'
 }
 
 // Renders panel content based on panel type
@@ -2891,6 +2830,29 @@ function DocumentOptionsPanel({
         if (!newMetadata) return
         beginEditIfNeeded()
         send({type: 'change', metadata: newMetadata})
+      }}
+    />
+  )
+}
+
+function HomeDocumentMetadataControls({
+  metadata,
+  fileUpload,
+}: {
+  metadata: HMDocument['metadata']
+  fileUpload?: (file: File) => Promise<string>
+}) {
+  const send = useDocumentSend()
+  const {beginEditIfNeeded} = useEditorGate()
+
+  return (
+    <HomeDocumentMetadataAffordanceBar
+      metadata={metadata}
+      fileUpload={fileUpload}
+      onBeginEdit={beginEditIfNeeded}
+      onMetadata={(patch) => {
+        beginEditIfNeeded()
+        send({type: 'change', metadata: patch})
       }}
     />
   )

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -1112,6 +1112,8 @@ export function ResourcePage({
         <DocumentBody
           docId={renderedDocId}
           document={document}
+          documentSyncRouteKey={documentResourceRouteKey}
+          documentIsPlaceholderData={resource.isPreviousData}
           activeView={getActiveView(route.key)}
           isLatest={isLatest}
           siteUrl={siteHomeDocument?.metadata?.siteUrl}
@@ -1319,6 +1321,8 @@ function TransientResourceBanner({error}: {error: TransientResourceError}) {
 function DocumentBody({
   docId,
   document,
+  documentSyncRouteKey,
+  documentIsPlaceholderData,
   activeView,
   isLatest = true,
   siteUrl,
@@ -1354,6 +1358,10 @@ function DocumentBody({
 }: {
   docId: UnpackedHypermediaId
   document: HMDocument
+  /** Identifies intentional route-level version changes for document synchronization. */
+  documentSyncRouteKey?: string
+  /** Whether React Query is retaining the previous route's document while the selected version loads. */
+  documentIsPlaceholderData?: boolean
   /** Which tab/view to display */
   activeView: ActiveView
   isLatest?: boolean
@@ -1402,7 +1410,7 @@ function DocumentBody({
   transientResourceError?: TransientResourceError
 }) {
   // Sync document into state machine
-  useDocumentSync(document)
+  useDocumentSync(document, documentSyncRouteKey, documentIsPlaceholderData)
   // Sync canEdit changes into the machine (for account switching)
   useCapabilitySync(canEdit)
   // Sync isLatest changes into the machine (for old-version edit guard)


### PR DESCRIPTION
## Summary
- Add inline controls for editing document icon, summary, and cover metadata directly from document pages.
- Move regular document metadata editing out of the options panel while preserving home document controls.
- Improve cover image actions with change, remove, and download controls.
- Polish publish popover spacing and increase version action icon contrast.
- Fix selected document version syncing when navigating between route versions, with coverage for placeholder data handling.