### PR TITLE
fix(backend): oversized changes fail to apply instead of crashing the daemon

### DIFF
--- a/backend/api/documents/v3alpha/docmodel/crdt.go
+++ b/backend/api/documents/v3alpha/docmodel/crdt.go
@@ -411,6 +411,23 @@ func (e *docCRDT) ApplyChange(c cid.Cid, ch *blob.Change) error {
 		panic("BUG: actor wasn't derived when applying change")
 	}
 
+	if ts != math.MaxInt64 && ts >= maxTs {
+		return fmt.Errorf("change %s: timestamp %d overflows the maximum op ID timestamp %d", c, ts, maxTs)
+	}
+
+	// A change carrying enough ops can push the op ID index past what the
+	// packed opID representation can hold (the index advances quadratically
+	// within multi-block ops). newOpID panics on such values because today's
+	// write path can never produce them, but changes arriving from the network
+	// can — huge imported documents from older writers exist in the wild — and
+	// applying those must fail with an error instead of crashing the process.
+	checkedOpID := func(i int) (opID, error) {
+		if i > maxIdx {
+			return opID{}, fmt.Errorf("change %s: op ID index %d overflows the maximum %d", c, i, maxIdx)
+		}
+		return newOpID(ts, actorID, i), nil
+	}
+
 	idx := -1
 	for op, err := range ch.Ops() {
 		idx++
@@ -421,7 +438,10 @@ func (e *docCRDT) ApplyChange(c cid.Cid, ch *blob.Change) error {
 		switch op := op.(type) {
 		case blob.OpSetKey:
 			key := []string{op.Key}
-			opid := newOpID(ts, actorID, idx)
+			opid, err := checkedOpID(idx)
+			if err != nil {
+				return err
+			}
 			e.setMetadata(opid, key, op.Value)
 		case blob.OpReplaceBlock:
 			blk := op.Block
@@ -430,7 +450,10 @@ func (e *docCRDT) ApplyChange(c cid.Cid, ch *blob.Change) error {
 				reg = newMVReg[blob.Block]()
 				e.stateBlocks[blk.ID()] = reg
 			}
-			opid := newOpID(ts, actorID, idx)
+			opid, err := checkedOpID(idx)
+			if err != nil {
+				return err
+			}
 			reg.Set(opid, blk)
 
 			// We now support having detached blocks, so we need to make sure they exist in the tree.
@@ -465,7 +488,10 @@ func (e *docCRDT) ApplyChange(c cid.Cid, ch *blob.Change) error {
 			var lastOp opID
 			for i, blk := range op.Blocks {
 				idx += i
-				opid := newOpID(ts, actorID, idx)
+				opid, err := checkedOpID(idx)
+				if err != nil {
+					return err
+				}
 				if i > 0 {
 					refID = lastOp
 				}
@@ -477,7 +503,10 @@ func (e *docCRDT) ApplyChange(c cid.Cid, ch *blob.Change) error {
 		case blob.OpDeleteBlocks:
 			for i, blk := range op.Blocks {
 				idx += i
-				opid := newOpID(ts, actorID, idx)
+				opid, err := checkedOpID(idx)
+				if err != nil {
+					return err
+				}
 				if err := e.tree.Integrate(opid, TrashNodeID, blk, opID{}); err != nil {
 					return err
 				}
@@ -489,7 +518,10 @@ func (e *docCRDT) ApplyChange(c cid.Cid, ch *blob.Change) error {
 
 			for i, kv := range op.Attrs {
 				idx += i
-				opid := newOpID(ts, actorID, idx)
+				opid, err := checkedOpID(idx)
+				if err != nil {
+					return err
+				}
 				e.setMetadata(opid, kv.Key, kv.Value)
 			}
 		default:

--- a/backend/api/documents/v3alpha/docmodel/crdt.go
+++ b/backend/api/documents/v3alpha/docmodel/crdt.go
@@ -380,6 +380,23 @@ func (e *docCRDT) ApplyChange(c cid.Cid, ch *blob.Change) error {
 		panic("BUG: actor wasn't derived when applying change")
 	}
 
+	if ts != math.MaxInt64 && ts >= maxTs {
+		return fmt.Errorf("change %s: timestamp %d overflows the maximum op ID timestamp %d", c, ts, maxTs)
+	}
+
+	// A change carrying enough ops can push the op ID index past what the
+	// packed opID representation can hold (the index advances quadratically
+	// within multi-block ops). newOpID panics on such values because today's
+	// write path can never produce them, but changes arriving from the network
+	// can — huge imported documents from older writers exist in the wild — and
+	// applying those must fail with an error instead of crashing the process.
+	checkedOpID := func(i int) (opID, error) {
+		if i > maxIdx {
+			return opID{}, fmt.Errorf("change %s: op ID index %d overflows the maximum %d", c, i, maxIdx)
+		}
+		return newOpID(ts, actorID, i), nil
+	}
+
 	idx := -1
 	for op, err := range ch.Ops() {
 		idx++
@@ -394,7 +411,10 @@ func (e *docCRDT) ApplyChange(c cid.Cid, ch *blob.Change) error {
 				reg = newMVReg[any]()
 				e.stateMetadata.Set([]string{op.Key}, reg)
 			}
-			opid := newOpID(ts, actorID, idx)
+			opid, err := checkedOpID(idx)
+			if err != nil {
+				return err
+			}
 			reg.Set(opid, op.Value)
 		case blob.OpReplaceBlock:
 			blk := op.Block
@@ -403,7 +423,10 @@ func (e *docCRDT) ApplyChange(c cid.Cid, ch *blob.Change) error {
 				reg = newMVReg[blob.Block]()
 				e.stateBlocks[blk.ID()] = reg
 			}
-			opid := newOpID(ts, actorID, idx)
+			opid, err := checkedOpID(idx)
+			if err != nil {
+				return err
+			}
 			reg.Set(opid, blk)
 
 			// We now support having detached blocks, so we need to make sure they exist in the tree.
@@ -438,7 +461,10 @@ func (e *docCRDT) ApplyChange(c cid.Cid, ch *blob.Change) error {
 			var lastOp opID
 			for i, blk := range op.Blocks {
 				idx += i
-				opid := newOpID(ts, actorID, idx)
+				opid, err := checkedOpID(idx)
+				if err != nil {
+					return err
+				}
 				if i > 0 {
 					refID = lastOp
 				}
@@ -450,7 +476,10 @@ func (e *docCRDT) ApplyChange(c cid.Cid, ch *blob.Change) error {
 		case blob.OpDeleteBlocks:
 			for i, blk := range op.Blocks {
 				idx += i
-				opid := newOpID(ts, actorID, idx)
+				opid, err := checkedOpID(idx)
+				if err != nil {
+					return err
+				}
 				if err := e.tree.Integrate(opid, TrashNodeID, blk, opID{}); err != nil {
 					return err
 				}
@@ -462,7 +491,10 @@ func (e *docCRDT) ApplyChange(c cid.Cid, ch *blob.Change) error {
 
 			for i, kv := range op.Attrs {
 				idx += i
-				opid := newOpID(ts, actorID, idx)
+				opid, err := checkedOpID(idx)
+				if err != nil {
+					return err
+				}
 				reg := e.stateMetadata.GetMaybe(kv.Key)
 				if reg == nil {
 					reg = newMVReg[any]()

--- a/backend/api/documents/v3alpha/docmodel/docmodel_test.go
+++ b/backend/api/documents/v3alpha/docmodel/docmodel_test.go
@@ -1,13 +1,16 @@
 package docmodel
 
 import (
+	"fmt"
 	"seed/backend/blob"
 	"seed/backend/core/coretest"
 	documents "seed/backend/genproto/documents/v3alpha"
 	"seed/backend/util/cclock"
 	"seed/backend/util/must"
 	"testing"
+	"time"
 
+	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -366,4 +369,37 @@ func TestBug_HydratePreservesStructuralParentWithoutBlockState(t *testing.T) {
 	require.Equal(t, "row", hdoc.Content[0].Children[0].Block.Id)
 
 	require.Equal(t, "after", hdoc.Content[1].Block.Id)
+}
+
+func TestApplyChangeOpIndexOverflow(t *testing.T) {
+	alice := coretest.NewTester("alice").Account
+
+	// A multi-block op advances the op ID index quadratically per block, so a
+	// single move op with enough blocks overflows the packed 24-bit index.
+	// Today's writer can't author such a change (it re-applies its own ops),
+	// but they exist in the wild from older writers, and applying one — e.g.
+	// serving GetDocument for such a document — must fail with an error
+	// instead of panicking the whole process.
+	const numBlocks = 6000
+
+	moved := make([]string, numBlocks)
+	for i := range moved {
+		moved[i] = fmt.Sprintf("b%d", i)
+	}
+
+	ch := &blob.Change{
+		BaseBlob: blob.BaseBlob{
+			Type:   blob.TypeChange,
+			Signer: alice.Principal(),
+			Ts:     time.Now(),
+		},
+		Body: blob.ChangeBody{
+			Ops: []blob.OpMap{blob.NewOpMoveBlocks("", moved, []uint64{0, 0, 0})},
+		},
+	}
+
+	doc := must.Do2(New("mydoc", cclock.New()))
+	err := doc.ApplyChange(cid.Undef, ch)
+	require.ErrorContains(t, err, "op ID index")
+	require.ErrorContains(t, err, "overflows")
 }

--- a/backend/api/documents/v3alpha/docmodel/docmodel_test.go
+++ b/backend/api/documents/v3alpha/docmodel/docmodel_test.go
@@ -1,13 +1,16 @@
 package docmodel
 
 import (
+	"fmt"
 	"seed/backend/blob"
 	"seed/backend/core/coretest"
 	documents "seed/backend/genproto/documents/v3alpha"
 	"seed/backend/util/cclock"
 	"seed/backend/util/must"
 	"testing"
+	"time"
 
+	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -335,4 +338,37 @@ func TestBug_HydratePreservesStructuralParentWithoutBlockState(t *testing.T) {
 	require.Equal(t, "row", hdoc.Content[0].Children[0].Block.Id)
 
 	require.Equal(t, "after", hdoc.Content[1].Block.Id)
+}
+
+func TestApplyChangeOpIndexOverflow(t *testing.T) {
+	alice := coretest.NewTester("alice").Account
+
+	// A multi-block op advances the op ID index quadratically per block, so a
+	// single move op with enough blocks overflows the packed 24-bit index.
+	// Today's writer can't author such a change (it re-applies its own ops),
+	// but they exist in the wild from older writers, and applying one — e.g.
+	// serving GetDocument for such a document — must fail with an error
+	// instead of panicking the whole process.
+	const numBlocks = 6000
+
+	moved := make([]string, numBlocks)
+	for i := range moved {
+		moved[i] = fmt.Sprintf("b%d", i)
+	}
+
+	ch := &blob.Change{
+		BaseBlob: blob.BaseBlob{
+			Type:   blob.TypeChange,
+			Signer: alice.Principal(),
+			Ts:     time.Now(),
+		},
+		Body: blob.ChangeBody{
+			Ops: []blob.OpMap{blob.NewOpMoveBlocks("", moved, []uint64{0, 0, 0})},
+		},
+	}
+
+	doc := must.Do2(New("mydoc", cclock.New()))
+	err := doc.ApplyChange(cid.Undef, ch)
+	require.ErrorContains(t, err, "op ID index")
+	require.ErrorContains(t, err, "overflows")
 }

--- a/backend/api/documents/v3alpha/documents_test.go
+++ b/backend/api/documents/v3alpha/documents_test.go
@@ -1265,19 +1265,18 @@ func TestListDirectoryDerivesFallbackCoverImage(t *testing.T) {
 	require.Empty(t, img, "removing the image must clear the derived value")
 }
 
-func TestDeriveFirstContentImageRecoversFromPanic(t *testing.T) {
+func TestDeriveFirstContentImageHugeChange(t *testing.T) {
 	t.Parallel()
 
 	alice := coretest.NewTester("alice").Account
 
 	// A single move op with this many blocks overflows the docmodel's 24-bit op
 	// ID index when the change is applied (the apply loop advances the index
-	// quadratically per block), which panics deep inside ApplyChange. Today's
-	// writer would panic authoring such a change (it re-applies its own ops),
-	// but blobs like this exist in the wild from older writers, and the indexer
-	// derives the fallback cover for every document Ref — including during the
-	// boot-time backfill reindex — so the deriver must surface an error instead
-	// of letting the panic crash the daemon.
+	// quadratically per block). Today's writer would fail authoring such a
+	// change (it re-applies its own ops), but blobs like this exist in the wild
+	// from older writers, and the indexer derives the fallback cover for every
+	// document Ref — including during the boot-time backfill reindex — so the
+	// deriver must surface an error instead of taking down the daemon.
 	const numBlocks = 6000
 
 	moved := make([]string, numBlocks)
@@ -1300,7 +1299,7 @@ func TestDeriveFirstContentImageRecoversFromPanic(t *testing.T) {
 		CID:  cid.Undef,
 		Data: ch,
 	}})
-	require.ErrorContains(t, err, "idx too big")
+	require.ErrorContains(t, err, "op ID index")
 }
 
 func TestUpdateReadStatus(t *testing.T) {

--- a/backend/api/documents/v3alpha/documents_test.go
+++ b/backend/api/documents/v3alpha/documents_test.go
@@ -1403,19 +1403,18 @@ func TestReindexDerivesFallbackCoverImage(t *testing.T) {
 	require.False(t, ok, "a doc that gained a cover must not carry a derived fallback after reindex")
 }
 
-func TestDeriveFirstContentImageRecoversFromPanic(t *testing.T) {
+func TestDeriveFirstContentImageHugeChange(t *testing.T) {
 	t.Parallel()
 
 	alice := coretest.NewTester("alice").Account
 
 	// A single move op with this many blocks overflows the docmodel's 24-bit op
 	// ID index when the change is applied (the apply loop advances the index
-	// quadratically per block), which panics deep inside ApplyChange. Today's
-	// writer would panic authoring such a change (it re-applies its own ops),
-	// but blobs like this exist in the wild from older writers, and the indexer
-	// derives the fallback cover for every document Ref — including during the
-	// boot-time backfill reindex — so the deriver must surface an error instead
-	// of letting the panic crash the daemon.
+	// quadratically per block). Today's writer would fail authoring such a
+	// change (it re-applies its own ops), but blobs like this exist in the wild
+	// from older writers, and the indexer derives the fallback cover for every
+	// document Ref — including during the boot-time backfill reindex — so the
+	// deriver must surface an error instead of taking down the daemon.
 	const numBlocks = 6000
 
 	moved := make([]string, numBlocks)
@@ -1438,7 +1437,7 @@ func TestDeriveFirstContentImageRecoversFromPanic(t *testing.T) {
 		CID:  cid.Undef,
 		Data: ch,
 	}})
-	require.ErrorContains(t, err, "idx too big")
+	require.ErrorContains(t, err, "op ID index")
 }
 
 func TestUpdateReadStatus(t *testing.T) {


### PR DESCRIPTION
## Production is crashing on this today

`daemon_gateway` on prod panicked **7 times in the last 72 hours** with `panic: BUG: idx too big`, each one triggered by a plain **`GetDocument`** call (verified in container logs; the restart count matches). There is no gRPC recovery interceptor, so each panic kills the whole daemon.

The trigger is `hm://z6MkpsGurNh1FnR1ZhUpdxGkHv4LKcAeYYuCjXrhcjziUbWY/es` ("Legislacion Espanola", account "demo publish"; formerly at `/spain`): its 1.3MB change contains a single `MoveBlocks` op with **6,411 blocks**. The ApplyChange loop advances the op ID index quadratically per block (`idx += i`), so it crosses the packed 24-bit limit at block 5,791 and panics `newOpID`. Anyone opening that page takes down the gateway — a public URL that works as a DoS button. This is the same landmine #900's deriver stepped on during the backfill reindex (fixed at the deriver boundary in #908); this PR fixes the underlying apply path that prod is crashing through.

## The fix

Validate the op ID index (and timestamp, which panics identically in the same packed representation) on the **apply** path and return an error instead of panicking. Serving such a document now fails that one request; the daemon keeps running.

This covers the write path too, rather than leaving it panicking: authoring a change runs through this same apply loop (`CreateChange` → `applyChangeUnsafe` → `crdt.ApplyChange`, `docmodel.go:377,201`), so a local writer that somehow produced an oversized change now gets an *error* as well — a failed save rather than a crash. What does keep its panic is the block-tree mutation in `crdt_block_tree.go:384,409`, whose counter advances linearly and genuinely cannot reach the limit, so a panic there still means a real bug. (Thanks @juligasa — an earlier version of this description claimed the write path still panicked; it doesn't, and nothing should be built on that assumption.)

Covered by tests at both levels: `docmodel.ApplyChange` returns the error directly, and `DeriveFirstContentImage` (index path) surfaces it without panicking.

## Sequencing

This wants to be **widely deployed before #910**, and the point is stronger than "old nodes keep failing on old documents." Once #910 ships, an import can *create* content that pre-#910 gateways cannot read at all — so the previously-frozen documents should not be edited until #910 is out across the gateways. Until then, this PR is what keeps a node encountering one of them alive.

## Not in scope

The document itself stays unopenable here (error instead of crash). Making it actually load means renumbering op IDs — the write side counts linearly, the apply side quadratically, so ≥3-block move ops get different identities depending on the scheme, and historical refs resolve against the applied numbering. That's #910.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
