### PR TITLE
fix(backend): widen the op ID index so large imported documents load

### DIFF
--- a/backend/api/documents/v3alpha/docmodel/crdt.go
+++ b/backend/api/documents/v3alpha/docmodel/crdt.go
@@ -25,7 +25,7 @@ import (
 
 type opID struct {
 	Ts    int64
-	Idx   int32
+	Idx   int64
 	Actor core.ActorID
 }
 
@@ -55,23 +55,39 @@ func decodeOpID(s []uint64) (opID, error) {
 	}
 
 	if len(s) == 1 {
-		return opID{Ts: 0, Actor: math.MaxUint64, Idx: int32(s[0])}, nil //nolint:gosec // We know this should not overflow.
+		if s[0] > maxIdx {
+			return opID{}, fmt.Errorf("invalid opID: index %d overflows the maximum %d", s[0], maxIdx)
+		}
+		return opID{Ts: 0, Actor: math.MaxUint64, Idx: int64(s[0])}, nil //nolint:gosec // Bounds-checked above.
 	}
 
 	if len(s) != 3 {
 		return opID{}, fmt.Errorf("invalid opID: %v", s)
 	}
 
+	if s[1] > maxIdx {
+		return opID{}, fmt.Errorf("invalid opID: index %d overflows the maximum %d", s[1], maxIdx)
+	}
+
 	return opID{
 		Ts:    int64(s[0]), //nolint:gosec // We know this should not overflow.
-		Idx:   int32(s[1]), //nolint:gosec // We know this should not overflow.
+		Idx:   int64(s[1]), //nolint:gosec // Bounds-checked above.
 		Actor: core.ActorID(s[2]),
 	}, nil
 }
 
 const (
-	maxTs  = 1<<48 - 1
-	maxIdx = 1<<24 - 1
+	maxTs = 1<<48 - 1
+
+	// maxIdx is a policy bound, not a representation one: op IDs used to be
+	// packed into a fixed 15-byte encoding with a 24-bit index (removed in
+	// 2024's Breaking Change), but today the index is a plain int64 in memory
+	// and a full uint64 on the wire. The apply loop advances the index
+	// quadratically within multi-block ops, so the old 2^24 cap was reached by
+	// a single move op of only ~5.8k blocks — real imported documents exceed
+	// that. 2^31 allows ~65k blocks in one move op while still bounding the
+	// work a hostile change can ask for.
+	maxIdx = 1<<31 - 1
 )
 
 func newOpID(ts int64, actor core.ActorID, idx int) opID {
@@ -90,7 +106,7 @@ func newOpID(ts int64, actor core.ActorID, idx int) opID {
 
 	return opID{
 		Ts:    ts,
-		Idx:   int32(idx),
+		Idx:   int64(idx),
 		Actor: actor,
 	}
 }

--- a/backend/api/documents/v3alpha/docmodel/crdt.go
+++ b/backend/api/documents/v3alpha/docmodel/crdt.go
@@ -65,12 +65,16 @@ func decodeOpID(s []uint64) (opID, error) {
 		return opID{}, fmt.Errorf("invalid opID: %v", s)
 	}
 
+	if s[0] > maxTs {
+		return opID{}, fmt.Errorf("invalid opID: timestamp %d overflows the maximum %d", s[0], maxTs)
+	}
+
 	if s[1] > maxIdx {
 		return opID{}, fmt.Errorf("invalid opID: index %d overflows the maximum %d", s[1], maxIdx)
 	}
 
 	return opID{
-		Ts:    int64(s[0]), //nolint:gosec // We know this should not overflow.
+		Ts:    int64(s[0]), //nolint:gosec // Bounds-checked above.
 		Idx:   int64(s[1]), //nolint:gosec // Bounds-checked above.
 		Actor: core.ActorID(s[2]),
 	}, nil
@@ -400,12 +404,12 @@ func (e *docCRDT) ApplyChange(c cid.Cid, ch *blob.Change) error {
 		return fmt.Errorf("change %s: timestamp %d overflows the maximum op ID timestamp %d", c, ts, maxTs)
 	}
 
-	// A change carrying enough ops can push the op ID index past what the
-	// packed opID representation can hold (the index advances quadratically
-	// within multi-block ops). newOpID panics on such values because today's
-	// write path can never produce them, but changes arriving from the network
-	// can — huge imported documents from older writers exist in the wild — and
-	// applying those must fail with an error instead of crashing the process.
+	// A change carrying enough ops can push the op ID index past maxIdx (the
+	// index advances quadratically within multi-block ops — see below). newOpID
+	// panics on such values because today's write path can never produce them,
+	// but changes arriving from the network can — huge imported documents from
+	// older writers exist in the wild — and applying those must fail with an
+	// error instead of crashing the process.
 	checkedOpID := func(i int) (opID, error) {
 		if i > maxIdx {
 			return opID{}, fmt.Errorf("change %s: op ID index %d overflows the maximum %d", c, i, maxIdx)
@@ -413,6 +417,14 @@ func (e *docCRDT) ApplyChange(c cid.Cid, ch *blob.Change) error {
 		return newOpID(ts, actorID, i), nil
 	}
 
+	// The multi-block ops below advance idx by i, not by 1, so a single op
+	// carrying n blocks consumes about n²/2 index values. That is wire-visible
+	// behaviour, not an off-by-one: refs in existing changes encode the indexes
+	// this numbering produced, so switching to idx++ would renumber every op ID
+	// in existence and make historical refs fail to resolve ("causality
+	// violation: ref op ... is not found") on documents that load today.
+	// Changing it needs a versioned migration, not a one-line fix. The quadratic
+	// growth is also why maxIdx is where it is — see its comment.
 	idx := -1
 	for op, err := range ch.Ops() {
 		idx++

--- a/backend/api/documents/v3alpha/docmodel/crdt.go
+++ b/backend/api/documents/v3alpha/docmodel/crdt.go
@@ -65,12 +65,16 @@ func decodeOpID(s []uint64) (opID, error) {
 		return opID{}, fmt.Errorf("invalid opID: %v", s)
 	}
 
+	if s[0] > maxTs {
+		return opID{}, fmt.Errorf("invalid opID: timestamp %d overflows the maximum %d", s[0], maxTs)
+	}
+
 	if s[1] > maxIdx {
 		return opID{}, fmt.Errorf("invalid opID: index %d overflows the maximum %d", s[1], maxIdx)
 	}
 
 	return opID{
-		Ts:    int64(s[0]), //nolint:gosec // We know this should not overflow.
+		Ts:    int64(s[0]), //nolint:gosec // Bounds-checked above.
 		Idx:   int64(s[1]), //nolint:gosec // Bounds-checked above.
 		Actor: core.ActorID(s[2]),
 	}, nil
@@ -431,12 +435,12 @@ func (e *docCRDT) ApplyChange(c cid.Cid, ch *blob.Change) error {
 		return fmt.Errorf("change %s: timestamp %d overflows the maximum op ID timestamp %d", c, ts, maxTs)
 	}
 
-	// A change carrying enough ops can push the op ID index past what the
-	// packed opID representation can hold (the index advances quadratically
-	// within multi-block ops). newOpID panics on such values because today's
-	// write path can never produce them, but changes arriving from the network
-	// can — huge imported documents from older writers exist in the wild — and
-	// applying those must fail with an error instead of crashing the process.
+	// A change carrying enough ops can push the op ID index past maxIdx (the
+	// index advances quadratically within multi-block ops — see below). newOpID
+	// panics on such values because today's write path can never produce them,
+	// but changes arriving from the network can — huge imported documents from
+	// older writers exist in the wild — and applying those must fail with an
+	// error instead of crashing the process.
 	checkedOpID := func(i int) (opID, error) {
 		if i > maxIdx {
 			return opID{}, fmt.Errorf("change %s: op ID index %d overflows the maximum %d", c, i, maxIdx)
@@ -444,6 +448,14 @@ func (e *docCRDT) ApplyChange(c cid.Cid, ch *blob.Change) error {
 		return newOpID(ts, actorID, i), nil
 	}
 
+	// The multi-block ops below advance idx by i, not by 1, so a single op
+	// carrying n blocks consumes about n²/2 index values. That is wire-visible
+	// behaviour, not an off-by-one: refs in existing changes encode the indexes
+	// this numbering produced, so switching to idx++ would renumber every op ID
+	// in existence and make historical refs fail to resolve ("causality
+	// violation: ref op ... is not found") on documents that load today.
+	// Changing it needs a versioned migration, not a one-line fix. The quadratic
+	// growth is also why maxIdx is where it is — see its comment.
 	idx := -1
 	for op, err := range ch.Ops() {
 		idx++

--- a/backend/api/documents/v3alpha/docmodel/crdt_test.go
+++ b/backend/api/documents/v3alpha/docmodel/crdt_test.go
@@ -1,0 +1,101 @@
+package docmodel
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// decodeOpID is fed by the refs carried in changes that arrive from the network,
+// so out-of-range values must produce an error rather than silently truncating
+// into the opID struct (the index used to be cast through int32).
+func TestDecodeOpID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   []uint64
+		want opID
+		err  string
+	}{
+		{
+			name: "empty is the zero op ID",
+			in:   nil,
+			want: opID{},
+		},
+		{
+			name: "self reference",
+			in:   []uint64{42},
+			want: opID{Ts: 0, Idx: 42, Actor: math.MaxUint64},
+		},
+		{
+			name: "self reference at the index limit",
+			in:   []uint64{maxIdx},
+			want: opID{Ts: 0, Idx: maxIdx, Actor: math.MaxUint64},
+		},
+		{
+			name: "self reference above the index limit",
+			in:   []uint64{maxIdx + 1},
+			err:  "index 2147483648 overflows",
+		},
+		{
+			name: "full op ID",
+			in:   []uint64{1234, 56, 78},
+			want: opID{Ts: 1234, Idx: 56, Actor: 78},
+		},
+		{
+			name: "index above the limit",
+			in:   []uint64{1234, maxIdx + 1, 78},
+			err:  "index 2147483648 overflows",
+		},
+		{
+			name: "timestamp above the limit",
+			in:   []uint64{maxTs + 1, 56, 78},
+			err:  "timestamp 281474976710656 overflows",
+		},
+		{
+			// Without the bounds check this decodes to a negative timestamp,
+			// which sorts before every real op in opID.Compare.
+			name: "timestamp that would decode as negative",
+			in:   []uint64{math.MaxUint64, 56, 78},
+			err:  "timestamp 18446744073709551615 overflows",
+		},
+		{
+			name: "wrong length",
+			in:   []uint64{1, 2},
+			err:  "invalid opID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := decodeOpID(tt.in)
+			if tt.err != "" {
+				require.ErrorContains(t, err, tt.err)
+				require.Equal(t, opID{}, got, "failed decoding must not return a partial op ID")
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestEncodeDecodeOpIDRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, want := range []opID{
+		{},
+		{Ts: 0, Idx: 42, Actor: math.MaxUint64},
+		{Ts: 1234, Idx: 56, Actor: 78},
+		{Ts: maxTs - 1, Idx: maxIdx, Actor: 78},
+	} {
+		got, err := decodeOpID(encodeOpID(want))
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	}
+}

--- a/backend/api/documents/v3alpha/docmodel/docmodel_test.go
+++ b/backend/api/documents/v3alpha/docmodel/docmodel_test.go
@@ -375,31 +375,42 @@ func TestApplyChangeOpIndexOverflow(t *testing.T) {
 	alice := coretest.NewTester("alice").Account
 
 	// A multi-block op advances the op ID index quadratically per block, so a
-	// single move op with enough blocks overflows the packed 24-bit index.
-	// Today's writer can't author such a change (it re-applies its own ops),
-	// but they exist in the wild from older writers, and applying one — e.g.
-	// serving GetDocument for such a document — must fail with an error
-	// instead of panicking the whole process.
-	const numBlocks = 6000
+	// single move op with enough blocks overflows the op ID index cap. Today's
+	// writer can't author such a change (it re-applies its own ops), but they
+	// exist in the wild from older writers, and applying one — e.g. serving
+	// GetDocument for such a document — must fail with an error instead of
+	// panicking the whole process.
+	hugeMove := func(numBlocks int) *blob.Change {
+		moved := make([]string, numBlocks)
+		for i := range moved {
+			moved[i] = fmt.Sprintf("b%d", i)
+		}
 
-	moved := make([]string, numBlocks)
-	for i := range moved {
-		moved[i] = fmt.Sprintf("b%d", i)
+		return &blob.Change{
+			BaseBlob: blob.BaseBlob{
+				Type:   blob.TypeChange,
+				Signer: alice.Principal(),
+				Ts:     time.Now(),
+			},
+			Body: blob.ChangeBody{
+				Ops: []blob.OpMap{blob.NewOpMoveBlocks("", moved, []uint64{0, 0, 0})},
+			},
+		}
 	}
 
-	ch := &blob.Change{
-		BaseBlob: blob.BaseBlob{
-			Type:   blob.TypeChange,
-			Signer: alice.Principal(),
-			Ts:     time.Now(),
-		},
-		Body: blob.ChangeBody{
-			Ops: []blob.OpMap{blob.NewOpMoveBlocks("", moved, []uint64{0, 0, 0})},
-		},
-	}
+	t.Run("real-world-sized import applies", func(t *testing.T) {
+		// The largest single move op seen in the wild carries 6,411 blocks
+		// (op index peaks around 20.5M), which overflowed the old 2^24 cap.
+		doc := must.Do2(New("mydoc", cclock.New()))
+		require.NoError(t, doc.ApplyChange(cid.Undef, hugeMove(6411)))
+	})
 
-	doc := must.Do2(New("mydoc", cclock.New()))
-	err := doc.ApplyChange(cid.Undef, ch)
-	require.ErrorContains(t, err, "op ID index")
-	require.ErrorContains(t, err, "overflows")
+	t.Run("overflowing the cap fails cleanly", func(t *testing.T) {
+		// 70k blocks push the quadratic index past the 2^31-1 cap
+		// (at block ~65,537).
+		doc := must.Do2(New("mydoc", cclock.New()))
+		err := doc.ApplyChange(cid.Undef, hugeMove(70_000))
+		require.ErrorContains(t, err, "op ID index")
+		require.ErrorContains(t, err, "overflows")
+	})
 }

--- a/backend/api/documents/v3alpha/docmodel/docmodel_test.go
+++ b/backend/api/documents/v3alpha/docmodel/docmodel_test.go
@@ -344,31 +344,42 @@ func TestApplyChangeOpIndexOverflow(t *testing.T) {
 	alice := coretest.NewTester("alice").Account
 
 	// A multi-block op advances the op ID index quadratically per block, so a
-	// single move op with enough blocks overflows the packed 24-bit index.
-	// Today's writer can't author such a change (it re-applies its own ops),
-	// but they exist in the wild from older writers, and applying one — e.g.
-	// serving GetDocument for such a document — must fail with an error
-	// instead of panicking the whole process.
-	const numBlocks = 6000
+	// single move op with enough blocks overflows the op ID index cap. Today's
+	// writer can't author such a change (it re-applies its own ops), but they
+	// exist in the wild from older writers, and applying one — e.g. serving
+	// GetDocument for such a document — must fail with an error instead of
+	// panicking the whole process.
+	hugeMove := func(numBlocks int) *blob.Change {
+		moved := make([]string, numBlocks)
+		for i := range moved {
+			moved[i] = fmt.Sprintf("b%d", i)
+		}
 
-	moved := make([]string, numBlocks)
-	for i := range moved {
-		moved[i] = fmt.Sprintf("b%d", i)
+		return &blob.Change{
+			BaseBlob: blob.BaseBlob{
+				Type:   blob.TypeChange,
+				Signer: alice.Principal(),
+				Ts:     time.Now(),
+			},
+			Body: blob.ChangeBody{
+				Ops: []blob.OpMap{blob.NewOpMoveBlocks("", moved, []uint64{0, 0, 0})},
+			},
+		}
 	}
 
-	ch := &blob.Change{
-		BaseBlob: blob.BaseBlob{
-			Type:   blob.TypeChange,
-			Signer: alice.Principal(),
-			Ts:     time.Now(),
-		},
-		Body: blob.ChangeBody{
-			Ops: []blob.OpMap{blob.NewOpMoveBlocks("", moved, []uint64{0, 0, 0})},
-		},
-	}
+	t.Run("real-world-sized import applies", func(t *testing.T) {
+		// The largest single move op seen in the wild carries 6,411 blocks
+		// (op index peaks around 20.5M), which overflowed the old 2^24 cap.
+		doc := must.Do2(New("mydoc", cclock.New()))
+		require.NoError(t, doc.ApplyChange(cid.Undef, hugeMove(6411)))
+	})
 
-	doc := must.Do2(New("mydoc", cclock.New()))
-	err := doc.ApplyChange(cid.Undef, ch)
-	require.ErrorContains(t, err, "op ID index")
-	require.ErrorContains(t, err, "overflows")
+	t.Run("overflowing the cap fails cleanly", func(t *testing.T) {
+		// 70k blocks push the quadratic index past the 2^31-1 cap
+		// (at block ~65,537).
+		doc := must.Do2(New("mydoc", cclock.New()))
+		err := doc.ApplyChange(cid.Undef, hugeMove(70_000))
+		require.ErrorContains(t, err, "op ID index")
+		require.ErrorContains(t, err, "overflows")
+	})
 }

--- a/backend/api/documents/v3alpha/documents_test.go
+++ b/backend/api/documents/v3alpha/documents_test.go
@@ -1270,14 +1270,14 @@ func TestDeriveFirstContentImageHugeChange(t *testing.T) {
 
 	alice := coretest.NewTester("alice").Account
 
-	// A single move op with this many blocks overflows the docmodel's 24-bit op
-	// ID index when the change is applied (the apply loop advances the index
+	// A single move op with this many blocks overflows the docmodel's op ID
+	// index cap when the change is applied (the apply loop advances the index
 	// quadratically per block). Today's writer would fail authoring such a
 	// change (it re-applies its own ops), but blobs like this exist in the wild
 	// from older writers, and the indexer derives the fallback cover for every
 	// document Ref — including during the boot-time backfill reindex — so the
 	// deriver must surface an error instead of taking down the daemon.
-	const numBlocks = 6000
+	const numBlocks = 70_000
 
 	moved := make([]string, numBlocks)
 	for i := range moved {

--- a/backend/api/documents/v3alpha/documents_test.go
+++ b/backend/api/documents/v3alpha/documents_test.go
@@ -1408,14 +1408,14 @@ func TestDeriveFirstContentImageHugeChange(t *testing.T) {
 
 	alice := coretest.NewTester("alice").Account
 
-	// A single move op with this many blocks overflows the docmodel's 24-bit op
-	// ID index when the change is applied (the apply loop advances the index
+	// A single move op with this many blocks overflows the docmodel's op ID
+	// index cap when the change is applied (the apply loop advances the index
 	// quadratically per block). Today's writer would fail authoring such a
 	// change (it re-applies its own ops), but blobs like this exist in the wild
 	// from older writers, and the indexer derives the fallback cover for every
 	// document Ref — including during the boot-time backfill reindex — so the
 	// deriver must surface an error instead of taking down the daemon.
-	const numBlocks = 6000
+	const numBlocks = 70_000
 
 	moved := make([]string, numBlocks)
 	for i := range moved {


### PR DESCRIPTION
Stacked on #909 (error-instead-of-panic). That PR stops the crashes; this one makes the affected documents actually load.

## Why the cap exists and why it's safe to raise

The 2^24−1 index cap is a fossil: it enforced the packed 15-byte `EncodedOpID` layout (48-bit ts / 24-bit idx / 48-bit actor) that was removed in 2024's Breaking Change. Today `opID` is a plain struct in memory and refs serialize the index as a full uint64 — the cap is policy, not representation.

Since the apply loop advances the index quadratically inside multi-block ops, a single move op of ~5.8k blocks reached the old cap. That's real-world size: the "Código Civil" document under the demo-publish account carries a 6,411-block move op (index peaks ~20.5M) and is what the production gateway has been crashing on. Raising the cap to 2^31−1 allows ~65k blocks per move op — 10× the largest op seen — while keeping a bound on hostile changes. The struct field widens to int64 so the representation is no longer the constraint, and `decodeOpID` now bounds-checks incoming ref indexes instead of silently truncating through an int32 cast.

## Compatibility

- **No migration, no reindex, nothing persisted changes.** Op IDs are recomputed in memory on every load; the wire encoding is unchanged. Reverting simply makes over-cap documents error again.
- Documents that load today produce byte-identical op IDs — the numbering scheme is untouched, only the ceiling moves.
- Sequencing: nodes still on older builds keep failing on these documents (panic before #909, clean error after), so this should ride a release *after* #909 is widely deployed — especially before anyone edits the previously-frozen documents, since new changes building on high-index ops would be unappliable on old builds.

## Verification

Beyond unit tests (a 6,411-block op applies; a 70k-block op fails cleanly), I pulled the real document's change blobs from the production database and replayed them through this code: all changes apply, and the document hydrates with full content and metadata ("Real Decreto de 24 de julio de 1889 por el que se publica el Código Civil").

🤖 Generated with [Claude Code](https://claude.com/claude-code)