### PR TITLE
feat(agents): per-agent memory filesystem with tools and desktop Memory tab

### DIFF
--- a/agents/docs/desktop-ui.md
+++ b/agents/docs/desktop-ui.md
@@ -122,16 +122,19 @@ Features:
   detail view;
 - trigger detail shows operational metadata plus the sessions created by that trigger;
 - Memory tab (`pages/agents/memory.tsx`) browses and edits the agent's private memory filesystem: an entry list with
-  per-row delete (two-step inline confirm), a monospace text editor with dirty-state Save/Revert, and a new-file form
-  accepting nested relative paths. It uses the signed `ListAgentMemory` / `ReadAgentMemoryFile` / `WriteAgentMemoryFile`
-  / `DeleteAgentMemoryFile` actions via `useAgentMemory` / `useAgentMemoryFile` / `useWriteAgentMemoryFile` /
-  `useDeleteAgentMemoryFile` in `models/agents.ts`, and refreshes live from `agent-memory-changed` change events when
-  session tools write memory;
+  per-row delete (two-step inline confirm) and file sizes, a monospace text editor with dirty-state Save/Revert for text
+  files, inline image/audio/video previews for binary files, an on-demand per-file download button, an **Add file**
+  local-upload button, a **From URL** form that server-side downloads a web file into memory, a **New file** form
+  accepting nested relative paths, and a **Publish to IPFS** button that uploads the file via the HM server and surfaces
+  its copyable `ipfs://<cid>` URL. Files can also be dragged and dropped onto the list (multiple at once): dropping on
+  the list uploads to the memory root, dropping on a folder row uploads into that folder, with drop-target highlighting.
+  It uses the signed agent-memory actions via the memory hooks in `models/agents.ts`, and refreshes live from
+  `agent-memory-changed` change events when session tools write memory;
 - Tools tab autosaves Seed-approved tool toggles and the uploaded HM account keys the agent may use for signing and
   publishing tools; the tool groups are the Seed read group (read/search/activity), the **web group**
   (`web_search`/`web_read`, which require server-side web backends), the **memory group**
-  (`memory_list`/`memory_read`/`memory_write`/`memory_delete`), and the write group. Tool groups come from
-  `frontend/apps/desktop/src/pages/agents/agent-tools.ts`;
+  (`memory_list`/`memory_read`/`memory_write`/`memory_delete`/`memory_download`/`memory_upload_ipfs`), and the write
+  group. Tool groups come from `frontend/apps/desktop/src/pages/agents/agent-tools.ts`;
 - the Tools tab reflects the connected server's abilities: each group lists its individual member tools, and tools the
   server cannot run are greyed out with an explanation. Availability is read from the server health response (`webTools`
   capability flags) via `getToolAvailability`; for example `web_search` is greyed when no SearXNG backend is configured,

--- a/agents/docs/desktop-ui.md
+++ b/agents/docs/desktop-ui.md
@@ -115,15 +115,22 @@ the agent's account immediately starts a session in which it responds. See `sign
 Features:
 
 - metadata/status display;
-- document-style tabs: Sessions (default), Triggers, Tools, Prompt, and Settings;
+- document-style tabs: Sessions (default), Triggers, Memory, Tools, Prompt, and Settings;
 - Sessions tab lists sessions and creates new sessions;
 - Triggers tab lists agent-scoped triggers and creates new triggers;
 - clicking a trigger keeps the user inside the agent page, shows Triggers breadcrumbs, and opens an editable trigger
   detail view;
 - trigger detail shows operational metadata plus the sessions created by that trigger;
+- Memory tab (`pages/agents/memory.tsx`) browses and edits the agent's private memory filesystem: an entry list with
+  per-row delete (two-step inline confirm), a monospace text editor with dirty-state Save/Revert, and a new-file form
+  accepting nested relative paths. It uses the signed `ListAgentMemory` / `ReadAgentMemoryFile` / `WriteAgentMemoryFile`
+  / `DeleteAgentMemoryFile` actions via `useAgentMemory` / `useAgentMemoryFile` / `useWriteAgentMemoryFile` /
+  `useDeleteAgentMemoryFile` in `models/agents.ts`, and refreshes live from `agent-memory-changed` change events when
+  session tools write memory;
 - Tools tab autosaves Seed-approved tool toggles and the uploaded HM account keys the agent may use for signing and
   publishing tools; the tool groups are the Seed read group (read/search/activity), the **web group**
-  (`web_search`/`web_read`, which require server-side web backends), and the write group. Tool groups come from
+  (`web_search`/`web_read`, which require server-side web backends), the **memory group**
+  (`memory_list`/`memory_read`/`memory_write`/`memory_delete`), and the write group. Tool groups come from
   `frontend/apps/desktop/src/pages/agents/agent-tools.ts`;
 - the Tools tab reflects the connected server's abilities: each group lists its individual member tools, and tools the
   server cannot run are greyed out with an explanation. Availability is read from the server health response (`webTools`

--- a/agents/docs/implementation-history.md
+++ b/agents/docs/implementation-history.md
@@ -23,6 +23,14 @@ Completed:
   group.
 - Unit tests for sandboxing/limits (`src/agent-memory.test.ts`) and a signed-action round-trip test including
   cross-account denial (`src/api-service.test.ts`).
+- Second iteration added binary/media support: files are UTF-8 text or raw bytes (model never receives binary content),
+  `memory_download` streams web files into memory with a 100 MiB cap and content-type-derived naming,
+  `memory_upload_ipfs` publishes memory files through the HM server's `/ipfs/file-upload` endpoint for use in Hypermedia
+  content, matching signed actions (`DownloadAgentMemoryFile`, `UploadAgentMemoryFileToIpfs`) give the user the same
+  powers, and the Memory tab gained media previews, per-file downloads, local-file upload (button and drag-and-drop onto
+  the list or a specific folder row), URL download, and IPFS publishing with copyable `ipfs://` URLs. Memory-enabled
+  system prompts embed an automatic `<memory_files>` top-level listing (root files/folders with file counts, subfolders
+  unexpanded) so agents start sessions already knowing what they remember.
 
 ### Web research tools (`web_search`, `web_read`)
 

--- a/agents/docs/implementation-history.md
+++ b/agents/docs/implementation-history.md
@@ -5,6 +5,25 @@ future agents can reconstruct why the system looks the way it does.
 
 ## Recent commit notes
 
+### Per-agent memory filesystem (`memory_*` tools + Memory tab)
+
+Completed:
+
+- Added `agents/src/agent-memory.ts`: a sandboxed per-agent filesystem at `<stateDir>/memory` with list/read/write/
+  delete operations, strict relative-path validation (no `..`, no absolute paths, symlinks refused), and size limits (1
+  MiB/file, 100 MiB/agent, 2000 entries).
+- Registered a four-tool memory cluster (`memory_list`, `memory_read`, `memory_write`, `memory_delete`) in the shared
+  tool registry and wired it into Pi execution; when enabled, the system prompt tells the model to check memory at task
+  start and store durable learnings.
+- Added signed actions `ListAgentMemory` / `ReadAgentMemoryFile` / `WriteAgentMemoryFile` / `DeleteAgentMemoryFile` so
+  users have the same full access as the agent; writes emit `agent-memory-changed` account-change events, also fanned
+  out to `agents/<agentId>` WebSocket subscribers.
+- Added the desktop Memory tab (`pages/agents/memory.tsx`): file list with inline delete confirmation, monospace editor
+  with Save/Revert, and new-file creation; memory tools are part of `DEFAULT_AGENT_TOOLS` and toggleable as a Tools-tab
+  group.
+- Unit tests for sandboxing/limits (`src/agent-memory.test.ts`) and a signed-action round-trip test including
+  cross-account denial (`src/api-service.test.ts`).
+
 ### Web research tools (`web_search`, `web_read`)
 
 Completed:

--- a/agents/docs/persistence.md
+++ b/agents/docs/persistence.md
@@ -106,6 +106,11 @@ Important columns:
 
 `definition_cbor` encodes `AgentDefinition`.
 
+`state_dir` points at the per-agent directory under the service data dir. Its `memory/` subdirectory is the agent's
+private memory filesystem (see `agents/src/agent-memory.ts`), read and written by both the `memory_*` session tools and
+the signed agent-memory actions. It lives on disk, not in SQLite, and is removed with the rest of `state_dir` when the
+agent is deleted.
+
 Current agent statuses:
 
 - `idle`

--- a/agents/docs/prompt-injection-map.md
+++ b/agents/docs/prompt-injection-map.md
@@ -25,6 +25,9 @@ File: `agents/src/api-service.ts`
      resolved Markdown;
   2. `seedAssistantSystemPrompt({includeTitleToolInstruction: true})`;
   3. optional `<available_signing_identities>` JSON plus signing instructions when the agent has selected signing keys.
+- When memory tools are enabled, `#agentSystemPrompt()` also appends memory guidance plus an automatic `<memory_files>`
+  top-level listing built from the agent's memory directory (`memoryListingPrompt()` / `summarizeMemoryTopLevel()`),
+  regenerated for every run.
 - `GetSession` returns this generated prompt as `systemPromptMarkdown` for UI inspection.
 
 ### Pi SDK prompt injection boundary

--- a/agents/docs/readme.md
+++ b/agents/docs/readme.md
@@ -40,8 +40,9 @@ Completed and usable locally:
 - `read` using shared Seed Hypermedia URL resolution;
 - `web_search` and `web_read` web research tools: self-hosted SearXNG search plus a tiered MediaWiki → in-process static
   (Readability + Turndown) → Crawl4AI reader, with no third-party API keys;
-- per-agent persistent memory filesystem: sandboxed `memory_list`/`memory_read`/`memory_write`/`memory_delete` session
-  tools, signed agent-memory actions, and a desktop Memory tab for full user read/write access to the same files;
+- per-agent persistent memory filesystem: sandboxed `memory_*` session tools (list/read/write/delete plus web download
+  and IPFS publish), binary/media file support, signed agent-memory actions, and a desktop Memory tab with editing,
+  media previews, on-demand downloads, local-file upload, URL download, and IPFS publishing;
 - per-agent tool toggles plus server-side HM account-key creation/selection for signing/publishing tools;
 - desktop Agents routes, provider dialogs, create-agent dialog, agent detail, Tools tab, session page;
 - server-side `/agents` live session inspector;

--- a/agents/docs/readme.md
+++ b/agents/docs/readme.md
@@ -40,6 +40,8 @@ Completed and usable locally:
 - `read` using shared Seed Hypermedia URL resolution;
 - `web_search` and `web_read` web research tools: self-hosted SearXNG search plus a tiered MediaWiki → in-process static
   (Readability + Turndown) → Crawl4AI reader, with no third-party API keys;
+- per-agent persistent memory filesystem: sandboxed `memory_list`/`memory_read`/`memory_write`/`memory_delete` session
+  tools, signed agent-memory actions, and a desktop Memory tab for full user read/write access to the same files;
 - per-agent tool toggles plus server-side HM account-key creation/selection for signing/publishing tools;
 - desktop Agents routes, provider dialogs, create-agent dialog, agent detail, Tools tab, session page;
 - server-side `/agents` live session inspector;
@@ -94,6 +96,8 @@ Agents service:
   subscription verification.
 - `agents/src/web-tools.ts` — self-hosted `web_search` (SearXNG) and tiered `web_read` (MediaWiki/static/Crawl4AI)
   implementations.
+- `agents/src/agent-memory.ts` — sandboxed per-agent memory filesystem shared by the `memory_*` tools and the signed
+  agent-memory actions.
 - `agents/src/auth.ts` — signed envelope verification and local account authorization.
 - `agents/src/sqlite.ts` — open/schema validation/migration gate.
 - `agents/src/sqlite-schema.sql` — canonical schema.
@@ -108,7 +112,8 @@ Desktop:
 - `frontend/apps/desktop/src/models/agents.ts` — React Query hooks, server settings, CRUD actions, signed WS
   subscription hook, partial streaming state.
 - `frontend/apps/desktop/src/pages/agents.tsx` — compatibility entry that renders the Agents list route.
-- `frontend/apps/desktop/src/pages/agents/` — separate Agents list, server, detail, session, and shared dialog modules.
+- `frontend/apps/desktop/src/pages/agents/` — separate Agents list, server, detail, session, memory-tab, and shared
+  dialog modules.
 - `frontend/apps/desktop/src/components/assistant-panel.tsx` — desktop assistant panel, also using shared chat
   rendering.
 - `frontend/apps/desktop/src/components/assistant-message-rendering.tsx` — shared user/assistant message, markdown,

--- a/agents/docs/security.md
+++ b/agents/docs/security.md
@@ -168,9 +168,16 @@ handling is strict:
   length bounded, and the resolved absolute path is re-verified to sit inside `<stateDir>/memory`;
 - symlinks are refused as read/write targets and skipped in listings, so memory operations cannot follow a planted link
   out of the sandbox;
-- size limits (1 MiB per file, 100 MiB per agent, 2000 entries) bound disk usage from runaway model writes;
+- size limits (1 MiB per text write, 100 MiB per file, 1 GiB per agent, 2000 entries) bound disk usage from runaway
+  model writes and downloads; downloads are streamed and aborted at the cap;
 - ownership is checked through the agent row before any filesystem operation, so accounts cannot touch other accounts'
   memory;
+- `memory_download` fetches model-chosen URLs server-side with the same open-fetch policy as `web_read`; it shares that
+  tool's SSRF exposure (no private-address blocking yet), which is tracked as web-tool hardening;
+- binary memory files are never sent to the model — `memory_read` returns metadata only for binary content — but their
+  raw bytes are returned to the owning user over the signed API for preview/download;
+- `memory_upload_ipfs` / `UploadAgentMemoryFileToIpfs` publish the file to IPFS through the HM server, making it
+  publicly retrievable by CID; treat publishing as irreversible disclosure;
 - memory content is model-visible and user-visible by design; do not store secrets in agent memory.
 
 ## Replay protection status

--- a/agents/docs/security.md
+++ b/agents/docs/security.md
@@ -159,6 +159,20 @@ Mitigations present:
 - failures degrade to `tool_result.error` (or a `degraded` flag for partial search), never silent fabrication;
 - no third-party API keys or outbound calls beyond SearXNG, the target site, and the optional Crawl4AI container.
 
+## Agent memory safety
+
+Agent memory (`agents/src/agent-memory.ts`) exposes a real filesystem directory to model-controlled tool input, so path
+handling is strict:
+
+- every path is validated before use: string-only, no null bytes, no `..` segments, backslashes normalized, depth and
+  length bounded, and the resolved absolute path is re-verified to sit inside `<stateDir>/memory`;
+- symlinks are refused as read/write targets and skipped in listings, so memory operations cannot follow a planted link
+  out of the sandbox;
+- size limits (1 MiB per file, 100 MiB per agent, 2000 entries) bound disk usage from runaway model writes;
+- ownership is checked through the agent row before any filesystem operation, so accounts cannot touch other accounts'
+  memory;
+- memory content is model-visible and user-visible by design; do not store secrets in agent memory.
+
 ## Replay protection status
 
 Implemented:

--- a/agents/docs/signed-api.md
+++ b/agents/docs/signed-api.md
@@ -87,6 +87,8 @@ Current `AgentAction` union:
 - `ReadAgentMemoryFile`
 - `WriteAgentMemoryFile`
 - `DeleteAgentMemoryFile`
+- `DownloadAgentMemoryFile`
+- `UploadAgentMemoryFileToIpfs`
 - `CreateSession`
 - `ListSessions`
 - `UpdateSession`
@@ -400,28 +402,45 @@ same `clientRequestId` idempotency pattern as other create actions.
 
 Each agent owns a private memory filesystem at `<stateDir>/memory`, shared with the `memory_*` session tools and shown
 on the desktop Memory tab. All actions validate agent ownership for the signed account, and every path is a sandboxed
-relative path (no absolute paths, no `..`, symlinks refused).
+relative path (no absolute paths, no `..`, symlinks refused). Files can be UTF-8 text or binary.
 
 ```ts
-type AgentMemoryEntry = {path: string; type: 'file' | 'dir'; size: number; updatedAt: number}
-type AgentMemoryFile = {path: string; content: string; size: number; updatedAt: number}
+type AgentMemoryEntry = {path: string; type: 'file' | 'dir'; size: number; updatedAt: number; mimeType?: string}
+type AgentMemoryFile = {
+  path: string
+  size: number
+  updatedAt: number
+  mimeType?: string
+  encoding: 'utf8' | 'binary'
+  content?: string // present when encoding is 'utf8'
+  data?: Uint8Array // present when encoding is 'binary'
+}
 ```
 
 Actions:
 
 - `ListAgentMemory {agentId}` returns `{_: 'ListAgentMemoryResponse'; agentId; entries: AgentMemoryEntry[]; totalBytes}`
   with every file and directory sorted by path.
-- `ReadAgentMemoryFile {agentId, path}` returns `{_: 'ReadAgentMemoryFileResponse'; agentId; file: AgentMemoryFile}`
-  with the UTF-8 text content.
+- `ReadAgentMemoryFile {agentId, path}` returns `{_: 'ReadAgentMemoryFileResponse'; agentId; file: AgentMemoryFile}`.
+  Small clean-UTF-8 files come back as text; everything else comes back as raw bytes for preview/download in the Memory
+  tab.
 - `WriteAgentMemoryFile {agentId, path, content}` returns `{_: 'WriteAgentMemoryFileResponse'; agentId; entry}` after
-  writing the full file content, creating parent directories as needed. Writes and deletes emit an `account-change`
-  event with reason `agent-memory-changed`, which is also fanned out to `agents/<agentId>` WebSocket subscribers so open
-  Memory tabs refresh.
+  writing the full file content, creating parent directories as needed. `content` may be a string (UTF-8 text) or
+  `Uint8Array` bytes (e.g. a local file uploaded from the Memory tab). Writes, downloads, and deletes emit an
+  `account-change` event with reason `agent-memory-changed`, which is also fanned out to `agents/<agentId>` WebSocket
+  subscribers so open Memory tabs refresh.
 - `DeleteAgentMemoryFile {agentId, path}` returns `{_: 'DeleteAgentMemoryFileResponse'; agentId; path; deleted}` and
   removes a file, or a directory recursively; `deleted` is false when nothing existed.
+- `DownloadAgentMemoryFile {agentId, url, path?}` server-side fetches a public http(s) URL into memory (streamed,
+  size-capped) and returns `{_: 'DownloadAgentMemoryFileResponse'; agentId; entry; finalUrl; contentType?}`. Omitting
+  `path` stores the file under `downloads/` named from the URL; extension-less paths gain an extension from the response
+  content type.
+- `UploadAgentMemoryFileToIpfs {agentId, path}` uploads the file to the HM server's `/ipfs/file-upload` endpoint and
+  returns `{_: 'UploadAgentMemoryFileToIpfsResponse'; agentId; path; cid; url; size; mimeType?}`, where `url` is the
+  `ipfs://<cid>` URL usable from Hypermedia content. Publishing makes the file publicly retrievable.
 
-Limits (see `agents/src/agent-memory.ts`): 1 MiB per file, 100 MiB per agent, 2000 entries, 512-byte paths, 16 levels of
-nesting.
+Limits (see `agents/src/agent-memory.ts`): 1 MiB per text write, 100 MiB per file, 1 GiB per agent, 2000 entries,
+512-byte paths, 16 levels of nesting.
 
 ### `CreateSession`
 

--- a/agents/docs/signed-api.md
+++ b/agents/docs/signed-api.md
@@ -83,6 +83,10 @@ Current `AgentAction` union:
 - `CreateAgentTrigger`
 - `UpdateAgentTrigger`
 - `DeleteAgentTrigger`
+- `ListAgentMemory`
+- `ReadAgentMemoryFile`
+- `WriteAgentMemoryFile`
+- `DeleteAgentMemoryFile`
 - `CreateSession`
 - `ListSessions`
 - `UpdateSession`
@@ -391,6 +395,33 @@ Actions:
 
 All trigger actions verify account ownership through the owning agent/trigger rows. `CreateAgentTrigger` supports the
 same `clientRequestId` idempotency pattern as other create actions.
+
+### Agent memory actions
+
+Each agent owns a private memory filesystem at `<stateDir>/memory`, shared with the `memory_*` session tools and shown
+on the desktop Memory tab. All actions validate agent ownership for the signed account, and every path is a sandboxed
+relative path (no absolute paths, no `..`, symlinks refused).
+
+```ts
+type AgentMemoryEntry = {path: string; type: 'file' | 'dir'; size: number; updatedAt: number}
+type AgentMemoryFile = {path: string; content: string; size: number; updatedAt: number}
+```
+
+Actions:
+
+- `ListAgentMemory {agentId}` returns `{_: 'ListAgentMemoryResponse'; agentId; entries: AgentMemoryEntry[]; totalBytes}`
+  with every file and directory sorted by path.
+- `ReadAgentMemoryFile {agentId, path}` returns `{_: 'ReadAgentMemoryFileResponse'; agentId; file: AgentMemoryFile}`
+  with the UTF-8 text content.
+- `WriteAgentMemoryFile {agentId, path, content}` returns `{_: 'WriteAgentMemoryFileResponse'; agentId; entry}` after
+  writing the full file content, creating parent directories as needed. Writes and deletes emit an `account-change`
+  event with reason `agent-memory-changed`, which is also fanned out to `agents/<agentId>` WebSocket subscribers so open
+  Memory tabs refresh.
+- `DeleteAgentMemoryFile {agentId, path}` returns `{_: 'DeleteAgentMemoryFileResponse'; agentId; path; deleted}` and
+  removes a file, or a directory recursively; `deleted` is false when nothing existed.
+
+Limits (see `agents/src/agent-memory.ts`): 1 MiB per file, 100 MiB per agent, 2000 entries, 512-byte paths, 16 levels of
+nesting.
 
 ### `CreateSession`
 

--- a/agents/docs/tools.md
+++ b/agents/docs/tools.md
@@ -26,6 +26,8 @@ memory_list
 memory_read
 memory_write
 memory_delete
+memory_download
+memory_upload_ipfs
 ```
 
 `read` is available by default for existing agents whose saved definition omits `tools`. Agents with an explicit `tools`
@@ -221,25 +223,40 @@ backends are configured through its health response (`webTools: {search, readBro
 desktop Tools tab uses this to grey out tools the server cannot run, and exposes each tool's exact model-facing
 description and input/output schemas through a per-tool info dialog (see `desktop-ui.md`).
 
-## Memory tools (`memory_list`, `memory_read`, `memory_write`, `memory_delete`)
+## Memory tools (`memory_list`, `memory_read`, `memory_write`, `memory_delete`, `memory_download`, `memory_upload_ipfs`)
 
 Each agent owns a private persistent filesystem at `<stateDir>/memory`, implemented in `agents/src/agent-memory.ts` and
-shared across all of the agent's sessions. The four memory tools give the model list/read/write/delete access to that
-directory; the signed `ListAgentMemory` / `ReadAgentMemoryFile` / `WriteAgentMemoryFile` / `DeleteAgentMemoryFile`
-actions give the user the same access from the desktop Memory tab, so both sides always see the same files.
+shared across all of the agent's sessions. The memory tools give the model access to that directory; the signed
+agent-memory actions give the user the same access from the desktop Memory tab, so both sides always see the same real
+files on disk.
 
 Key behavior:
 
 - All paths are relative to the memory root and strictly sandboxed: absolute paths, `..` segments, and null bytes are
   rejected, resolved paths are verified to stay inside the root, and symlinks are refused for reads/writes and skipped
   in listings.
-- Files are UTF-8 text. `memory_write` replaces the whole file and creates parent directories automatically; edits are
-  read-modify-write.
-- Limits: 1 MiB per file, 100 MiB per agent, 2000 entries, 512-byte paths, 16 levels of nesting.
-- Tool-driven writes/deletes emit `account-change` (`agent-memory-changed`) events, fanned out to both `account/<id>`
-  and `agents/<agentId>` WebSocket subscribers, so the desktop Memory tab updates live while a session runs.
+- Files can be UTF-8 text or binary. `memory_write` writes text and replaces the whole file, creating parent directories
+  automatically; edits are read-modify-write. `memory_read` returns text content for text files; for binary files it
+  returns size/MIME metadata only — raw bytes never go to the model.
+- `memory_download` fetches any public http(s) URL (including binary media) into memory, streamed with a hard size cap.
+  When no target path is given the file lands in `downloads/` named from the URL; extension-less paths gain one from the
+  response content type. Same open-fetch policy as `web_read`.
+- `memory_upload_ipfs` uploads one memory file to the HM server's `/ipfs/file-upload` endpoint and returns its
+  `ipfs://<cid>` URL, so the agent can reference stored media from Hypermedia content (documents, avatars) created with
+  the `write` tool. Publishing to IPFS makes the file publicly retrievable.
+- MIME types are inferred from file extensions (`inferMimeType`) for previews, downloads, and IPFS uploads.
+- Limits: 1 MiB per text write, 100 MiB per file (binary/downloads), 1 GiB per agent, 2000 entries, 512-byte paths, 16
+  levels of nesting.
+- Tool-driven writes/downloads/deletes emit `account-change` (`agent-memory-changed`) events, fanned out to both
+  `account/<id>` and `agents/<agentId>` WebSocket subscribers, so the desktop Memory tab updates live while a session
+  runs.
 - When any memory tool is enabled, the agent system prompt describes the memory filesystem and instructs the model to
-  check memory at task start and store durable learnings as small organized files.
+  check memory at task start, store durable learnings as small organized files, and use download/IPFS publishing for web
+  media.
+- Memory-enabled system prompts also automatically embed a `<memory_files>` listing of the top level of memory — root
+  files with sizes and root folders with contained file counts, without expanding subfolder contents — built fresh per
+  run by `summarizeMemoryTopLevel`. The agent starts every session knowing what it has without an explicit `memory_list`
+  call; `memory_list` remains the way to see full nested paths.
 
 ## `write`
 

--- a/agents/docs/tools.md
+++ b/agents/docs/tools.md
@@ -22,6 +22,10 @@ list_activity_feed
 web_search
 web_read
 write
+memory_list
+memory_read
+memory_write
+memory_delete
 ```
 
 `read` is available by default for existing agents whose saved definition omits `tools`. Agents with an explicit `tools`
@@ -216,6 +220,26 @@ Both web tools declare an `outputSchema` in the registry in addition to `inputSc
 backends are configured through its health response (`webTools: {search, readBrowser}`; see `operations.md`). The
 desktop Tools tab uses this to grey out tools the server cannot run, and exposes each tool's exact model-facing
 description and input/output schemas through a per-tool info dialog (see `desktop-ui.md`).
+
+## Memory tools (`memory_list`, `memory_read`, `memory_write`, `memory_delete`)
+
+Each agent owns a private persistent filesystem at `<stateDir>/memory`, implemented in `agents/src/agent-memory.ts` and
+shared across all of the agent's sessions. The four memory tools give the model list/read/write/delete access to that
+directory; the signed `ListAgentMemory` / `ReadAgentMemoryFile` / `WriteAgentMemoryFile` / `DeleteAgentMemoryFile`
+actions give the user the same access from the desktop Memory tab, so both sides always see the same files.
+
+Key behavior:
+
+- All paths are relative to the memory root and strictly sandboxed: absolute paths, `..` segments, and null bytes are
+  rejected, resolved paths are verified to stay inside the root, and symlinks are refused for reads/writes and skipped
+  in listings.
+- Files are UTF-8 text. `memory_write` replaces the whole file and creates parent directories automatically; edits are
+  read-modify-write.
+- Limits: 1 MiB per file, 100 MiB per agent, 2000 entries, 512-byte paths, 16 levels of nesting.
+- Tool-driven writes/deletes emit `account-change` (`agent-memory-changed`) events, fanned out to both `account/<id>`
+  and `agents/<agentId>` WebSocket subscribers, so the desktop Memory tab updates live while a session runs.
+- When any memory tool is enabled, the agent system prompt describes the memory filesystem and instructs the model to
+  check memory at task start and store durable learnings as small organized files.
 
 ## `write`
 

--- a/agents/protocol/src/index.ts
+++ b/agents/protocol/src/index.ts
@@ -119,6 +119,10 @@ export type UnsignedAgentAction =
   | CreateAgentTrigger
   | UpdateAgentTrigger
   | DeleteAgentTrigger
+  | ListAgentMemory
+  | ReadAgentMemoryFile
+  | WriteAgentMemoryFile
+  | DeleteAgentMemoryFile
   | CreateSession
   | ListSessions
   | UpdateSession
@@ -292,6 +296,53 @@ export type AgentScheduleTrigger =
   | {kind: 'interval'; every: number; unit: 'minutes' | 'hours'}
   | {kind: 'weekly'; daysOfWeek: number[]; timeOfDay: string; timezone: string}
   | {kind: 'once'; runAt: number; timezone?: string}
+
+/** One file or directory inside an agent's private memory filesystem. */
+export type AgentMemoryEntry = {
+  /** Relative path from the agent memory root, always `/`-separated. */
+  path: string
+  type: 'file' | 'dir'
+  /** File size in bytes; 0 for directories. */
+  size: number
+  /** Last modification time in Unix epoch milliseconds. */
+  updatedAt: number
+}
+
+/** Contents of one agent memory file. */
+export type AgentMemoryFile = {
+  path: string
+  content: string
+  size: number
+  updatedAt: number
+}
+
+/** Lists every file and directory in an agent's memory. */
+export type ListAgentMemory = {
+  _: 'ListAgentMemory'
+  agentId: string
+}
+
+/** Reads one UTF-8 text file from an agent's memory. */
+export type ReadAgentMemoryFile = {
+  _: 'ReadAgentMemoryFile'
+  agentId: string
+  path: string
+}
+
+/** Writes one UTF-8 text file into an agent's memory, creating parent directories as needed. */
+export type WriteAgentMemoryFile = {
+  _: 'WriteAgentMemoryFile'
+  agentId: string
+  path: string
+  content: string
+}
+
+/** Deletes one file, or one directory recursively, from an agent's memory. */
+export type DeleteAgentMemoryFile = {
+  _: 'DeleteAgentMemoryFile'
+  agentId: string
+  path: string
+}
 
 /** Creates a chat-like session for an agent. */
 export type CreateSession = {
@@ -664,6 +715,38 @@ export type DeleteAgentTriggerResponse = {
   triggerId: string
 }
 
+/** Successful response for `ListAgentMemory`. */
+export type ListAgentMemoryResponse = {
+  _: 'ListAgentMemoryResponse'
+  agentId: string
+  entries: AgentMemoryEntry[]
+  /** Total bytes across all memory files. */
+  totalBytes: number
+}
+
+/** Successful response for `ReadAgentMemoryFile`. */
+export type ReadAgentMemoryFileResponse = {
+  _: 'ReadAgentMemoryFileResponse'
+  agentId: string
+  file: AgentMemoryFile
+}
+
+/** Successful response for `WriteAgentMemoryFile`. */
+export type WriteAgentMemoryFileResponse = {
+  _: 'WriteAgentMemoryFileResponse'
+  agentId: string
+  entry: AgentMemoryEntry
+}
+
+/** Successful response for `DeleteAgentMemoryFile`. */
+export type DeleteAgentMemoryFileResponse = {
+  _: 'DeleteAgentMemoryFileResponse'
+  agentId: string
+  path: string
+  /** False when nothing existed at the path. */
+  deleted: boolean
+}
+
 /** Successful response for `CreateSession`. */
 export type CreateSessionResponse = {
   _: 'CreateSessionResponse'
@@ -743,6 +826,10 @@ export type AgentResponse =
   | CreateAgentTriggerResponse
   | UpdateAgentTriggerResponse
   | DeleteAgentTriggerResponse
+  | ListAgentMemoryResponse
+  | ReadAgentMemoryFileResponse
+  | WriteAgentMemoryFileResponse
+  | DeleteAgentMemoryFileResponse
   | CreateSessionResponse
   | ListSessionsResponse
   | UpdateSessionResponse

--- a/agents/protocol/src/index.ts
+++ b/agents/protocol/src/index.ts
@@ -123,6 +123,8 @@ export type UnsignedAgentAction =
   | ReadAgentMemoryFile
   | WriteAgentMemoryFile
   | DeleteAgentMemoryFile
+  | DownloadAgentMemoryFile
+  | UploadAgentMemoryFileToIpfs
   | CreateSession
   | ListSessions
   | UpdateSession
@@ -306,14 +308,23 @@ export type AgentMemoryEntry = {
   size: number
   /** Last modification time in Unix epoch milliseconds. */
   updatedAt: number
+  /** MIME type inferred from the file extension, when recognized. */
+  mimeType?: string
 }
 
-/** Contents of one agent memory file. */
+/** Contents of one agent memory file: UTF-8 text or raw binary bytes. */
 export type AgentMemoryFile = {
   path: string
-  content: string
   size: number
   updatedAt: number
+  /** MIME type inferred from the file extension, when recognized. */
+  mimeType?: string
+  /** How the file content is delivered: `utf8` uses `content`, `binary` uses `data`. */
+  encoding: 'utf8' | 'binary'
+  /** UTF-8 text content, present when `encoding` is `utf8`. */
+  content?: string
+  /** Raw file bytes, present when `encoding` is `binary`. */
+  data?: Uint8Array
 }
 
 /** Lists every file and directory in an agent's memory. */
@@ -322,24 +333,48 @@ export type ListAgentMemory = {
   agentId: string
 }
 
-/** Reads one UTF-8 text file from an agent's memory. */
+/** Reads one file (text or binary) from an agent's memory. */
 export type ReadAgentMemoryFile = {
   _: 'ReadAgentMemoryFile'
   agentId: string
   path: string
 }
 
-/** Writes one UTF-8 text file into an agent's memory, creating parent directories as needed. */
+/**
+ * Writes one file into an agent's memory, creating parent directories as needed. String content is
+ * stored as UTF-8 text; `Uint8Array` content is stored verbatim (e.g. media uploaded from the
+ * Memory tab).
+ */
 export type WriteAgentMemoryFile = {
   _: 'WriteAgentMemoryFile'
   agentId: string
   path: string
-  content: string
+  content: string | Uint8Array
 }
 
 /** Deletes one file, or one directory recursively, from an agent's memory. */
 export type DeleteAgentMemoryFile = {
   _: 'DeleteAgentMemoryFile'
+  agentId: string
+  path: string
+}
+
+/** Downloads a web URL into an agent's memory filesystem. */
+export type DownloadAgentMemoryFile = {
+  _: 'DownloadAgentMemoryFile'
+  agentId: string
+  /** The http(s) URL to download. */
+  url: string
+  /** Target memory path. Omit to store under `downloads/` named from the URL. */
+  path?: string
+}
+
+/**
+ * Uploads one agent memory file to the HM server's IPFS endpoint so it can be referenced from
+ * Hypermedia content by its `ipfs://<cid>` URL.
+ */
+export type UploadAgentMemoryFileToIpfs = {
+  _: 'UploadAgentMemoryFileToIpfs'
   agentId: string
   path: string
 }
@@ -747,6 +782,30 @@ export type DeleteAgentMemoryFileResponse = {
   deleted: boolean
 }
 
+/** Successful response for `DownloadAgentMemoryFile`. */
+export type DownloadAgentMemoryFileResponse = {
+  _: 'DownloadAgentMemoryFileResponse'
+  agentId: string
+  entry: AgentMemoryEntry
+  /** URL actually fetched, after redirects. */
+  finalUrl: string
+  /** Content type reported by the server, when present. */
+  contentType?: string
+}
+
+/** Successful response for `UploadAgentMemoryFileToIpfs`. */
+export type UploadAgentMemoryFileToIpfsResponse = {
+  _: 'UploadAgentMemoryFileToIpfsResponse'
+  agentId: string
+  path: string
+  /** The IPFS content identifier of the uploaded file. */
+  cid: string
+  /** `ipfs://<cid>` URL usable from Hypermedia content. */
+  url: string
+  size: number
+  mimeType?: string
+}
+
 /** Successful response for `CreateSession`. */
 export type CreateSessionResponse = {
   _: 'CreateSessionResponse'
@@ -830,6 +889,8 @@ export type AgentResponse =
   | ReadAgentMemoryFileResponse
   | WriteAgentMemoryFileResponse
   | DeleteAgentMemoryFileResponse
+  | DownloadAgentMemoryFileResponse
+  | UploadAgentMemoryFileToIpfsResponse
   | CreateSessionResponse
   | ListSessionsResponse
   | UpdateSessionResponse

--- a/agents/protocol/src/tool-registry.ts
+++ b/agents/protocol/src/tool-registry.ts
@@ -174,6 +174,10 @@ export type SeedToolRegistry = {
   web_search: SeedToolMetadata
   web_read: SeedToolMetadata
   write: SeedToolMetadata
+  memory_list: SeedToolMetadata
+  memory_read: SeedToolMetadata
+  memory_write: SeedToolMetadata
+  memory_delete: SeedToolMetadata
   set_session_title: SeedToolMetadata
 }
 
@@ -537,6 +541,158 @@ export const seedToolRegistry: SeedToolRegistry = {
     runtimes: ['agent-service'],
     userConfigurable: true,
   },
+  memory_list: {
+    name: 'memory_list',
+    label: 'List Memory',
+    description:
+      'List every file and directory in your private persistent memory. Memory is a filesystem owned by this agent, shared across all of your sessions and visible to your user. Use it to recall notes, learnings, and state you stored earlier. Call this before reading or writing when you are unsure what already exists.',
+    inputSchema: {type: 'object', additionalProperties: false, properties: {}},
+    outputSchema: {
+      type: 'object',
+      properties: {
+        summary: {type: 'string', description: 'One-line summary of the memory contents.'},
+        entries: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              path: {type: 'string', description: 'Relative path from the memory root.'},
+              type: {type: 'string', enum: ['file', 'dir']},
+              size: {type: 'integer', description: 'File size in bytes; 0 for directories.'},
+              updatedAt: {type: 'integer', description: 'Last modification time in Unix epoch milliseconds.'},
+            },
+          },
+        },
+        totalBytes: {type: 'integer'},
+      },
+    },
+    render: {
+      kind: 'generic',
+      label: 'List Memory',
+      color: 'muted',
+      summaryOutputPath: 'summary',
+      details: [
+        {label: 'Output', source: 'output'},
+        {label: 'Input', source: 'input'},
+      ],
+    },
+    runtimes: ['agent-service'],
+    userConfigurable: true,
+  },
+  memory_read: {
+    name: 'memory_read',
+    label: 'Read Memory',
+    description:
+      'Read one UTF-8 text file from your private persistent memory by its relative path (for example `notes/project.md`). Use memory_list first when you do not know the exact path.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        path: {type: 'string', minLength: 1, description: 'Relative path of the memory file to read.'},
+      },
+      required: ['path'],
+    },
+    outputSchema: {
+      type: 'object',
+      properties: {
+        summary: {type: 'string'},
+        path: {type: 'string'},
+        content: {type: 'string', description: 'The full UTF-8 text content of the file.'},
+        size: {type: 'integer'},
+        updatedAt: {type: 'integer'},
+      },
+    },
+    render: {
+      kind: 'read',
+      label: 'Read Memory',
+      color: 'emerald',
+      primaryArg: 'path',
+      summaryArg: 'path',
+      summaryOutputPath: 'summary',
+      details: [
+        {label: 'Content', source: 'output', path: 'content', format: 'markdown'},
+        {label: 'Input', source: 'input'},
+        {label: 'Output', source: 'output'},
+      ],
+    },
+    runtimes: ['agent-service'],
+    userConfigurable: true,
+  },
+  memory_write: {
+    name: 'memory_write',
+    label: 'Write Memory',
+    description:
+      'Write one UTF-8 text file into your private persistent memory, creating parent directories automatically and replacing any existing file at that path. Use this to remember durable notes, learnings, preferences, and state across sessions. Keep files small and organized under descriptive relative paths such as `notes/topic.md`. To append or edit, read the file first and write back the full updated content.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        path: {type: 'string', minLength: 1, description: 'Relative path of the memory file to write.'},
+        content: {type: 'string', description: 'The full UTF-8 text content to store at the path.'},
+      },
+      required: ['path', 'content'],
+    },
+    outputSchema: {
+      type: 'object',
+      properties: {
+        summary: {type: 'string'},
+        path: {type: 'string'},
+        size: {type: 'integer'},
+        updatedAt: {type: 'integer'},
+      },
+    },
+    render: {
+      kind: 'write',
+      label: 'Write Memory',
+      color: 'violet',
+      primaryArg: 'path',
+      summaryArg: 'path',
+      summaryOutputPath: 'summary',
+      details: [
+        {label: 'Content', source: 'input', path: 'content', format: 'markdown'},
+        {label: 'Input', source: 'input'},
+        {label: 'Output', source: 'output'},
+      ],
+    },
+    runtimes: ['agent-service'],
+    userConfigurable: true,
+  },
+  memory_delete: {
+    name: 'memory_delete',
+    label: 'Delete Memory',
+    description:
+      'Delete one file, or one directory recursively, from your private persistent memory. Only delete content that is clearly obsolete or that the user asked you to remove.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        path: {type: 'string', minLength: 1, description: 'Relative path of the memory file or directory to delete.'},
+      },
+      required: ['path'],
+    },
+    outputSchema: {
+      type: 'object',
+      properties: {
+        summary: {type: 'string'},
+        path: {type: 'string'},
+        deleted: {type: 'boolean'},
+      },
+    },
+    render: {
+      kind: 'write',
+      label: 'Delete Memory',
+      color: 'amber',
+      primaryArg: 'path',
+      summaryArg: 'path',
+      summaryOutputPath: 'summary',
+      details: [
+        {label: 'Input', source: 'input'},
+        {label: 'Output', source: 'output'},
+      ],
+    },
+    runtimes: ['agent-service'],
+    userConfigurable: true,
+  },
   set_session_title: {
     name: 'set_session_title',
     label: 'Set Session Title',
@@ -557,9 +713,6 @@ export const seedToolRegistry: SeedToolRegistry = {
     runtimes: ['agent-service'],
     hidden: true,
   },
-  // write_file: {},
-  // read_file: {},
-  // exexcute_bash: {},
 }
 
 export type SeedToolName = keyof typeof seedToolRegistry

--- a/agents/protocol/src/tool-registry.ts
+++ b/agents/protocol/src/tool-registry.ts
@@ -178,6 +178,8 @@ export type SeedToolRegistry = {
   memory_read: SeedToolMetadata
   memory_write: SeedToolMetadata
   memory_delete: SeedToolMetadata
+  memory_download: SeedToolMetadata
+  memory_upload_ipfs: SeedToolMetadata
   set_session_title: SeedToolMetadata
 }
 
@@ -583,7 +585,7 @@ export const seedToolRegistry: SeedToolRegistry = {
     name: 'memory_read',
     label: 'Read Memory',
     description:
-      'Read one UTF-8 text file from your private persistent memory by its relative path (for example `notes/project.md`). Use memory_list first when you do not know the exact path.',
+      'Read one file from your private persistent memory by its relative path (for example `notes/project.md`). Text files return their full content; binary files (media, downloads) return size and MIME metadata only — use memory_upload_ipfs to publish binary files for use in Hypermedia content. Use memory_list first when you do not know the exact path.',
     inputSchema: {
       type: 'object',
       additionalProperties: false,
@@ -597,8 +599,10 @@ export const seedToolRegistry: SeedToolRegistry = {
       properties: {
         summary: {type: 'string'},
         path: {type: 'string'},
-        content: {type: 'string', description: 'The full UTF-8 text content of the file.'},
+        encoding: {type: 'string', enum: ['utf8', 'binary']},
+        content: {type: 'string', description: 'The full UTF-8 text content; absent for binary files.'},
         size: {type: 'integer'},
+        mimeType: {type: 'string'},
         updatedAt: {type: 'integer'},
       },
     },
@@ -685,6 +689,90 @@ export const seedToolRegistry: SeedToolRegistry = {
       primaryArg: 'path',
       summaryArg: 'path',
       summaryOutputPath: 'summary',
+      details: [
+        {label: 'Input', source: 'input'},
+        {label: 'Output', source: 'output'},
+      ],
+    },
+    runtimes: ['agent-service'],
+    userConfigurable: true,
+  },
+  memory_download: {
+    name: 'memory_download',
+    label: 'Download to Memory',
+    description:
+      'Download a file from a public http(s) URL into your private persistent memory. Works for any file type including binary media (images, audio, video, PDFs); the file is stored verbatim and can then be previewed by your user on the Memory tab or published with memory_upload_ipfs. Omit path to store the file under downloads/ named from the URL; when the path has no extension, one is added from the response content type. Use this instead of web_read when you need the actual file rather than extracted text.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        url: {type: 'string', minLength: 1, description: 'The public http(s) URL of the file to download.'},
+        path: {
+          type: 'string',
+          description: 'Optional target memory path such as media/photo.jpg. Defaults to downloads/<url filename>.',
+        },
+      },
+      required: ['url'],
+    },
+    outputSchema: {
+      type: 'object',
+      properties: {
+        summary: {type: 'string'},
+        path: {type: 'string', description: 'The memory path where the file was stored.'},
+        size: {type: 'integer'},
+        mimeType: {type: 'string'},
+        finalUrl: {type: 'string', description: 'The URL actually fetched, after redirects.'},
+        contentType: {type: 'string'},
+      },
+    },
+    render: {
+      kind: 'write',
+      label: 'Download to Memory',
+      color: 'violet',
+      primaryArg: 'url',
+      summaryArg: 'url',
+      summaryOutputPath: 'summary',
+      links: [{source: 'input', path: 'url', label: 'Source URL'}],
+      details: [
+        {label: 'Input', source: 'input'},
+        {label: 'Output', source: 'output'},
+      ],
+    },
+    runtimes: ['agent-service'],
+    userConfigurable: true,
+  },
+  memory_upload_ipfs: {
+    name: 'memory_upload_ipfs',
+    label: 'Upload Memory to IPFS',
+    description:
+      'Upload one file from your private persistent memory to IPFS via the Hypermedia server, returning an ipfs://<cid> URL. Use that URL to reference the file from Hypermedia content — for example as an image in a document created with the write tool, or as a profile avatar. Works for binary media downloaded with memory_download as well as text files.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        path: {type: 'string', minLength: 1, description: 'Relative memory path of the file to upload.'},
+      },
+      required: ['path'],
+    },
+    outputSchema: {
+      type: 'object',
+      properties: {
+        summary: {type: 'string'},
+        path: {type: 'string'},
+        cid: {type: 'string', description: 'The IPFS content identifier.'},
+        url: {type: 'string', description: 'ipfs://<cid> URL usable from Hypermedia content.'},
+        size: {type: 'integer'},
+        mimeType: {type: 'string'},
+      },
+    },
+    render: {
+      kind: 'write',
+      label: 'Upload Memory to IPFS',
+      color: 'indigo',
+      primaryArg: 'path',
+      summaryArg: 'path',
+      summaryOutputPath: 'summary',
+      links: [{source: 'output', path: 'url', label: 'IPFS file'}],
       details: [
         {label: 'Input', source: 'input'},
         {label: 'Output', source: 'output'},

--- a/agents/src/agent-memory.test.ts
+++ b/agents/src/agent-memory.test.ts
@@ -1,0 +1,98 @@
+import {describe, expect, test} from 'bun:test'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import {
+  AgentMemoryError,
+  MAX_MEMORY_FILE_BYTES,
+  deleteMemoryPath,
+  listMemory,
+  memoryRootPath,
+  readMemoryFile,
+  resolveMemoryPath,
+  writeMemoryFile,
+} from '@/agent-memory'
+
+function withStateDir(run: (stateDir: string) => void): void {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-memory-test-'))
+  try {
+    run(stateDir)
+  } finally {
+    fs.rmSync(stateDir, {recursive: true, force: true})
+  }
+}
+
+describe('agent memory', () => {
+  test('writes, lists, reads, and deletes files', () => {
+    withStateDir((stateDir) => {
+      const written = writeMemoryFile(stateDir, 'notes/todo.md', '# Todo\n\n- remember this\n')
+      expect(written).toMatchObject({path: 'notes/todo.md', type: 'file'})
+      writeMemoryFile(stateDir, 'MEMORY.md', 'index')
+
+      const listed = listMemory(stateDir)
+      expect(listed.entries.map((entry) => `${entry.type}:${entry.path}`)).toEqual([
+        'file:MEMORY.md',
+        'dir:notes',
+        'file:notes/todo.md',
+      ])
+      expect(listed.totalBytes).toBeGreaterThan(0)
+
+      const file = readMemoryFile(stateDir, 'notes/todo.md')
+      expect(file.content).toBe('# Todo\n\n- remember this\n')
+
+      expect(deleteMemoryPath(stateDir, 'notes')).toEqual({path: 'notes', deleted: true})
+      expect(deleteMemoryPath(stateDir, 'notes')).toEqual({path: 'notes', deleted: false})
+      expect(listMemory(stateDir).entries.map((entry) => entry.path)).toEqual(['MEMORY.md'])
+    })
+  })
+
+  test('normalizes friendly path variants to the same file', () => {
+    withStateDir((stateDir) => {
+      writeMemoryFile(stateDir, '/notes//./deep\\file.txt', 'hello')
+      expect(readMemoryFile(stateDir, 'notes/deep/file.txt').content).toBe('hello')
+      expect(resolveMemoryPath(stateDir, './a/b').relPath).toBe('a/b')
+    })
+  })
+
+  test('rejects traversal, absolute escapes, and invalid paths', () => {
+    withStateDir((stateDir) => {
+      for (const bad of ['../escape.txt', 'a/../../escape.txt', 'a/..', '', '/', 'a\0b', 42 as unknown as string]) {
+        expect(() => resolveMemoryPath(stateDir, bad)).toThrow(AgentMemoryError)
+      }
+      // Resolved paths always stay inside the memory root.
+      const {absPath} = resolveMemoryPath(stateDir, 'ok.txt')
+      expect(absPath.startsWith(memoryRootPath(stateDir) + path.sep)).toBe(true)
+    })
+  })
+
+  test('rejects oversized file writes and reads', () => {
+    withStateDir((stateDir) => {
+      expect(() => writeMemoryFile(stateDir, 'big.txt', 'x'.repeat(MAX_MEMORY_FILE_BYTES + 1))).toThrow('byte limit')
+      fs.mkdirSync(memoryRootPath(stateDir), {recursive: true})
+      fs.writeFileSync(path.join(memoryRootPath(stateDir), 'huge.txt'), 'x'.repeat(MAX_MEMORY_FILE_BYTES + 1))
+      expect(() => readMemoryFile(stateDir, 'huge.txt')).toThrow('too large')
+    })
+  })
+
+  test('refuses to read through symlinks and skips them in listings', () => {
+    withStateDir((stateDir) => {
+      writeMemoryFile(stateDir, 'real.txt', 'data')
+      const outside = path.join(stateDir, 'outside-secret.txt')
+      fs.writeFileSync(outside, 'secret')
+      fs.symlinkSync(outside, path.join(memoryRootPath(stateDir), 'link.txt'))
+
+      expect(() => readMemoryFile(stateDir, 'link.txt')).toThrow(AgentMemoryError)
+      expect(() => writeMemoryFile(stateDir, 'link.txt', 'nope')).toThrow(AgentMemoryError)
+      expect(listMemory(stateDir).entries.map((entry) => entry.path)).toEqual(['real.txt'])
+    })
+  })
+
+  test('errors when reading a directory or a missing file', () => {
+    withStateDir((stateDir) => {
+      writeMemoryFile(stateDir, 'dir/file.txt', 'x')
+      expect(() => readMemoryFile(stateDir, 'dir')).toThrow('directory')
+      expect(() => readMemoryFile(stateDir, 'missing.txt')).toThrow('not found')
+      expect(() => writeMemoryFile(stateDir, 'dir', 'x')).toThrow('directory')
+    })
+  })
+})

--- a/agents/src/agent-memory.test.ts
+++ b/agents/src/agent-memory.test.ts
@@ -4,8 +4,6 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import {
   AgentMemoryError,
-  MAX_MEMORY_FILE_BYTES,
-  MAX_MEMORY_TEXT_BYTES,
   deleteMemoryPath,
   downloadToMemory,
   listMemory,
@@ -93,18 +91,17 @@ describe('agent memory', () => {
     })
   })
 
-  test('bounds text writes, binary writes, and reads separately', () => {
+  test('accepts large text and binary writes and reads them back', () => {
     withStateDir((stateDir) => {
-      expect(() => writeMemoryFile(stateDir, 'big.txt', 'x'.repeat(MAX_MEMORY_TEXT_BYTES + 1))).toThrow('byte limit')
-      // Binary content is allowed beyond the text limit.
-      writeMemoryFile(stateDir, 'big.bin', new Uint8Array(MAX_MEMORY_TEXT_BYTES + 1))
-      expect(readMemoryFile(stateDir, 'big.bin').encoding).toBe('binary')
+      // Sizes chosen above the caps that used to exist: memory has no size limits.
+      const bigText = 'x'.repeat(2 * 1024 * 1024)
+      writeMemoryFile(stateDir, 'big.txt', bigText)
+      const readBack = readMemoryFile(stateDir, 'big.txt')
+      expect(readBack.encoding).toBe('utf8')
+      expect(readBack.content?.length).toBe(bigText.length)
 
-      // A sparse file over the hard per-file limit is refused on read.
-      const hugePath = path.join(memoryRootPath(stateDir), 'huge.bin')
-      fs.writeFileSync(hugePath, '')
-      fs.truncateSync(hugePath, MAX_MEMORY_FILE_BYTES + 1)
-      expect(() => readMemoryFile(stateDir, 'huge.bin')).toThrow('too large')
+      writeMemoryFile(stateDir, 'big.bin', new Uint8Array(3 * 1024 * 1024))
+      expect(readMemoryFile(stateDir, 'big.bin').encoding).toBe('binary')
     })
   })
 
@@ -165,15 +162,8 @@ describe('agent memory', () => {
     })
   })
 
-  test('rejects downloads that exceed the file size limit or use bad URLs', async () => {
+  test('rejects bad download URLs', async () => {
     await withStateDir(async (stateDir) => {
-      globalThis.fetch = (async () =>
-        new Response('x', {
-          headers: {'content-type': 'text/plain', 'content-length': String(MAX_MEMORY_FILE_BYTES + 1)},
-        })) as unknown as typeof fetch
-      await expect(downloadToMemory(stateDir, 'https://example.com/huge.bin', undefined)).rejects.toThrow(
-        'byte file limit',
-      )
       await expect(downloadToMemory(stateDir, 'ftp://example.com/x', undefined)).rejects.toThrow('http or https')
       await expect(downloadToMemory(stateDir, 'not a url', undefined)).rejects.toThrow('Invalid download URL')
     })

--- a/agents/src/agent-memory.test.ts
+++ b/agents/src/agent-memory.test.ts
@@ -1,32 +1,45 @@
-import {describe, expect, test} from 'bun:test'
+import {afterEach, describe, expect, test} from 'bun:test'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import {
   AgentMemoryError,
   MAX_MEMORY_FILE_BYTES,
+  MAX_MEMORY_TEXT_BYTES,
   deleteMemoryPath,
+  downloadToMemory,
   listMemory,
   memoryRootPath,
   readMemoryFile,
   resolveMemoryPath,
+  summarizeMemoryTopLevel,
   writeMemoryFile,
 } from '@/agent-memory'
 
-function withStateDir(run: (stateDir: string) => void): void {
+function withStateDir(run: (stateDir: string) => void | Promise<void>): void | Promise<void> {
   const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-memory-test-'))
+  const cleanup = () => fs.rmSync(stateDir, {recursive: true, force: true})
   try {
-    run(stateDir)
-  } finally {
-    fs.rmSync(stateDir, {recursive: true, force: true})
+    const result = run(stateDir)
+    if (result instanceof Promise) return result.finally(cleanup)
+    cleanup()
+  } catch (error) {
+    cleanup()
+    throw error
   }
 }
+
+const realFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = realFetch
+})
 
 describe('agent memory', () => {
   test('writes, lists, reads, and deletes files', () => {
     withStateDir((stateDir) => {
       const written = writeMemoryFile(stateDir, 'notes/todo.md', '# Todo\n\n- remember this\n')
-      expect(written).toMatchObject({path: 'notes/todo.md', type: 'file'})
+      expect(written).toMatchObject({path: 'notes/todo.md', type: 'file', mimeType: 'text/markdown'})
       writeMemoryFile(stateDir, 'MEMORY.md', 'index')
 
       const listed = listMemory(stateDir)
@@ -38,11 +51,26 @@ describe('agent memory', () => {
       expect(listed.totalBytes).toBeGreaterThan(0)
 
       const file = readMemoryFile(stateDir, 'notes/todo.md')
+      expect(file.encoding).toBe('utf8')
       expect(file.content).toBe('# Todo\n\n- remember this\n')
 
       expect(deleteMemoryPath(stateDir, 'notes')).toEqual({path: 'notes', deleted: true})
       expect(deleteMemoryPath(stateDir, 'notes')).toEqual({path: 'notes', deleted: false})
       expect(listMemory(stateDir).entries.map((entry) => entry.path)).toEqual(['MEMORY.md'])
+    })
+  })
+
+  test('round-trips binary files with inferred mime types', () => {
+    withStateDir((stateDir) => {
+      const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 1, 2, 3])
+      const written = writeMemoryFile(stateDir, 'media/cover.png', pngBytes)
+      expect(written).toMatchObject({path: 'media/cover.png', type: 'file', size: 12, mimeType: 'image/png'})
+
+      const file = readMemoryFile(stateDir, 'media/cover.png')
+      expect(file.encoding).toBe('binary')
+      expect(file.mimeType).toBe('image/png')
+      expect(file.content).toBeUndefined()
+      expect(Array.from(file.data ?? [])).toEqual(Array.from(pngBytes))
     })
   })
 
@@ -65,12 +93,18 @@ describe('agent memory', () => {
     })
   })
 
-  test('rejects oversized file writes and reads', () => {
+  test('bounds text writes, binary writes, and reads separately', () => {
     withStateDir((stateDir) => {
-      expect(() => writeMemoryFile(stateDir, 'big.txt', 'x'.repeat(MAX_MEMORY_FILE_BYTES + 1))).toThrow('byte limit')
-      fs.mkdirSync(memoryRootPath(stateDir), {recursive: true})
-      fs.writeFileSync(path.join(memoryRootPath(stateDir), 'huge.txt'), 'x'.repeat(MAX_MEMORY_FILE_BYTES + 1))
-      expect(() => readMemoryFile(stateDir, 'huge.txt')).toThrow('too large')
+      expect(() => writeMemoryFile(stateDir, 'big.txt', 'x'.repeat(MAX_MEMORY_TEXT_BYTES + 1))).toThrow('byte limit')
+      // Binary content is allowed beyond the text limit.
+      writeMemoryFile(stateDir, 'big.bin', new Uint8Array(MAX_MEMORY_TEXT_BYTES + 1))
+      expect(readMemoryFile(stateDir, 'big.bin').encoding).toBe('binary')
+
+      // A sparse file over the hard per-file limit is refused on read.
+      const hugePath = path.join(memoryRootPath(stateDir), 'huge.bin')
+      fs.writeFileSync(hugePath, '')
+      fs.truncateSync(hugePath, MAX_MEMORY_FILE_BYTES + 1)
+      expect(() => readMemoryFile(stateDir, 'huge.bin')).toThrow('too large')
     })
   })
 
@@ -93,6 +127,62 @@ describe('agent memory', () => {
       expect(() => readMemoryFile(stateDir, 'dir')).toThrow('directory')
       expect(() => readMemoryFile(stateDir, 'missing.txt')).toThrow('not found')
       expect(() => writeMemoryFile(stateDir, 'dir', 'x')).toThrow('directory')
+    })
+  })
+
+  test('summarizes the top level without expanding subfolders', async () => {
+    withStateDir((stateDir) => {
+      writeMemoryFile(stateDir, 'MEMORY.md', 'index')
+      writeMemoryFile(stateDir, 'notes/a.md', 'aa')
+      writeMemoryFile(stateDir, 'notes/deep/b.md', 'bbb')
+      writeMemoryFile(stateDir, 'media/pic.png', new Uint8Array(4))
+
+      const summary = summarizeMemoryTopLevel(stateDir)
+      expect(summary.totalFiles).toBe(4)
+      expect(summary.entries).toEqual([
+        {name: 'MEMORY.md', type: 'file', size: 5},
+        {name: 'media', type: 'dir', size: 4, fileCount: 1},
+        {name: 'notes', type: 'dir', size: 5, fileCount: 2},
+      ])
+    })
+  })
+
+  test('downloads a web file into memory with a derived name and extension', async () => {
+    await withStateDir(async (stateDir) => {
+      const jpgBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 1, 2, 3])
+      globalThis.fetch = (async () =>
+        new Response(jpgBytes, {headers: {'content-type': 'image/jpeg'}})) as unknown as typeof fetch
+
+      // Explicit path without an extension gains one from the content type.
+      const explicit = await downloadToMemory(stateDir, 'https://example.com/photos/cat', 'media/cat')
+      expect(explicit.entry).toMatchObject({path: 'media/cat.jpg', size: 7, mimeType: 'image/jpeg'})
+      expect(explicit.contentType).toBe('image/jpeg')
+
+      // Default path lands in downloads/ named from the URL.
+      const derived = await downloadToMemory(stateDir, 'https://example.com/photos/cat.jpg', undefined)
+      expect(derived.entry.path).toBe('downloads/cat.jpg')
+      expect(readMemoryFile(stateDir, 'downloads/cat.jpg').encoding).toBe('binary')
+    })
+  })
+
+  test('rejects downloads that exceed the file size limit or use bad URLs', async () => {
+    await withStateDir(async (stateDir) => {
+      globalThis.fetch = (async () =>
+        new Response('x', {
+          headers: {'content-type': 'text/plain', 'content-length': String(MAX_MEMORY_FILE_BYTES + 1)},
+        })) as unknown as typeof fetch
+      await expect(downloadToMemory(stateDir, 'https://example.com/huge.bin', undefined)).rejects.toThrow(
+        'byte file limit',
+      )
+      await expect(downloadToMemory(stateDir, 'ftp://example.com/x', undefined)).rejects.toThrow('http or https')
+      await expect(downloadToMemory(stateDir, 'not a url', undefined)).rejects.toThrow('Invalid download URL')
+    })
+  })
+
+  test('reports failed downloads with an upstream error', async () => {
+    await withStateDir(async (stateDir) => {
+      globalThis.fetch = (async () => new Response('missing', {status: 404})) as unknown as typeof fetch
+      await expect(downloadToMemory(stateDir, 'https://example.com/gone.png', undefined)).rejects.toThrow('HTTP 404')
     })
   })
 })

--- a/agents/src/agent-memory.ts
+++ b/agents/src/agent-memory.ts
@@ -17,20 +17,12 @@ import * as path from 'node:path'
 /** Name of the memory directory inside an agent's state directory. */
 export const MEMORY_DIR_NAME = 'memory'
 
-/** Maximum size of a text write (model tool or Memory-tab editor) in bytes. */
-export const MAX_MEMORY_TEXT_BYTES = 1024 * 1024
-/** Maximum size of any single memory file (binary uploads, downloads) in bytes. */
-export const MAX_MEMORY_FILE_BYTES = 100 * 1024 * 1024
-/** Maximum total bytes across all files in one agent's memory. */
-export const MAX_MEMORY_TOTAL_BYTES = 1024 * 1024 * 1024
-/** Maximum number of entries (files + directories) in one agent's memory. */
-export const MAX_MEMORY_ENTRIES = 2_000
 /** Maximum length of a normalized relative memory path in bytes. */
 export const MAX_MEMORY_PATH_BYTES = 512
 /** Maximum directory nesting depth of a memory path. */
 export const MAX_MEMORY_PATH_DEPTH = 16
-/** Timeout for one web download into memory. */
-export const MEMORY_DOWNLOAD_TIMEOUT_MS = 60_000
+/** Abort a web download when no bytes arrive for this long (idle timeout, not a total cap). */
+export const MEMORY_DOWNLOAD_IDLE_TIMEOUT_MS = 60_000
 
 /** One file or directory inside an agent's memory. */
 export type AgentMemoryEntry = {
@@ -66,7 +58,7 @@ export type AgentMemoryDownloadResult = {
   contentType?: string
 }
 
-/** Error raised for invalid memory paths or violated memory limits. */
+/** Error raised for invalid memory paths or unusable memory content. */
 export class AgentMemoryError extends Error {
   readonly status: number
 
@@ -175,7 +167,6 @@ export function listMemory(stateDir: string): {entries: AgentMemoryEntry[]; tota
       return
     }
     for (const dirent of names) {
-      if (entries.length >= MAX_MEMORY_ENTRIES) return
       const rel = dirRel ? `${dirRel}/${dirent.name}` : dirent.name
       const abs = path.join(dirAbs, dirent.name)
       if (dirent.isSymbolicLink()) continue
@@ -197,7 +188,7 @@ export function listMemory(stateDir: string): {entries: AgentMemoryEntry[]; tota
 }
 
 /**
- * Reads one memory file. Small files that decode as clean UTF-8 come back as text
+ * Reads one memory file. Files that decode as clean UTF-8 come back as text
  * (`encoding: 'utf8'`, `content`); everything else comes back as raw bytes
  * (`encoding: 'binary'`, `data`).
  */
@@ -206,7 +197,6 @@ export function readMemoryFile(stateDir: string, rawPath: unknown): AgentMemoryF
   const stat = lstatOrNull(absPath)
   if (!stat || stat.isSymbolicLink()) throw new AgentMemoryError(404, `Memory file not found: ${relPath}`)
   if (stat.isDirectory()) throw new AgentMemoryError(400, `Memory path is a directory, not a file: ${relPath}`)
-  if (stat.size > MAX_MEMORY_FILE_BYTES) throw new AgentMemoryError(400, `Memory file is too large to read: ${relPath}`)
   const bytes = fs.readFileSync(absPath)
   const base = {
     path: relPath,
@@ -214,54 +204,33 @@ export function readMemoryFile(stateDir: string, rawPath: unknown): AgentMemoryF
     updatedAt: Math.round(stat.mtimeMs),
     mimeType: inferMimeType(relPath),
   }
-  const text = bytes.byteLength <= MAX_MEMORY_TEXT_BYTES ? decodeUtf8OrNull(bytes) : null
+  const text = decodeUtf8OrNull(bytes)
   if (text !== null) return {...base, encoding: 'utf8', content: text}
   return {...base, encoding: 'binary', data: new Uint8Array(bytes)}
 }
 
 /**
  * Writes one memory file, creating parent directories as needed. String content is written as
- * UTF-8 text (bounded by {@link MAX_MEMORY_TEXT_BYTES}); `Uint8Array` content is written verbatim
- * (bounded by {@link MAX_MEMORY_FILE_BYTES}).
+ * UTF-8 text; `Uint8Array` content is written verbatim.
  */
 export function writeMemoryFile(stateDir: string, rawPath: unknown, content: unknown): AgentMemoryEntry {
   let contentBytes: Uint8Array
   if (typeof content === 'string') {
     contentBytes = new TextEncoder().encode(content)
-    if (contentBytes.byteLength > MAX_MEMORY_TEXT_BYTES) {
-      throw new AgentMemoryError(400, `Memory text content exceeds the ${MAX_MEMORY_TEXT_BYTES} byte limit`)
-    }
   } else if (content instanceof Uint8Array) {
     contentBytes = content
-    if (contentBytes.byteLength > MAX_MEMORY_FILE_BYTES) {
-      throw new AgentMemoryError(400, `Memory file content exceeds the ${MAX_MEMORY_FILE_BYTES} byte limit`)
-    }
   } else {
     throw new AgentMemoryError(400, 'Memory file content must be a string or bytes')
   }
   const {relPath, absPath} = resolveMemoryPath(stateDir, rawPath)
-  return writeMemoryBytes(stateDir, relPath, absPath, contentBytes)
+  return writeMemoryBytes(relPath, absPath, contentBytes)
 }
 
 /** Shared write path used by text/binary writes and web downloads after content is in hand. */
-function writeMemoryBytes(
-  stateDir: string,
-  relPath: string,
-  absPath: string,
-  contentBytes: Uint8Array,
-): AgentMemoryEntry {
+function writeMemoryBytes(relPath: string, absPath: string, contentBytes: Uint8Array): AgentMemoryEntry {
   const existing = lstatOrNull(absPath)
   if (existing?.isSymbolicLink()) throw new AgentMemoryError(400, `Memory path is not writable: ${relPath}`)
   if (existing?.isDirectory()) throw new AgentMemoryError(400, `Memory path is a directory, not a file: ${relPath}`)
-
-  const {entries, totalBytes} = listMemory(stateDir)
-  const previousSize = existing?.isFile() ? existing.size : 0
-  if (totalBytes - previousSize + contentBytes.byteLength > MAX_MEMORY_TOTAL_BYTES) {
-    throw new AgentMemoryError(400, 'Agent memory is full')
-  }
-  if (!existing && entries.length >= MAX_MEMORY_ENTRIES) {
-    throw new AgentMemoryError(400, 'Agent memory has too many files')
-  }
 
   fs.mkdirSync(path.dirname(absPath), {recursive: true})
   fs.writeFileSync(absPath, contentBytes)
@@ -272,8 +241,8 @@ function writeMemoryBytes(
 /**
  * Downloads a web URL into the agent's memory. When `rawPath` is omitted, the file is stored under
  * `downloads/` named from the URL; when the chosen path has no extension, one is added from the
- * response content type when recognized. The download is streamed and aborted beyond
- * {@link MAX_MEMORY_FILE_BYTES}.
+ * response content type when recognized. Downloads of any size are allowed; the stream is only
+ * aborted when it stalls for {@link MEMORY_DOWNLOAD_IDLE_TIMEOUT_MS}.
  */
 export async function downloadToMemory(
   stateDir: string,
@@ -292,7 +261,11 @@ export async function downloadToMemory(
   }
 
   const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), MEMORY_DOWNLOAD_TIMEOUT_MS)
+  let timeout = setTimeout(() => controller.abort(), MEMORY_DOWNLOAD_IDLE_TIMEOUT_MS)
+  const resetIdleTimeout = () => {
+    clearTimeout(timeout)
+    timeout = setTimeout(() => controller.abort(), MEMORY_DOWNLOAD_IDLE_TIMEOUT_MS)
+  }
   let response: Response
   try {
     response = await fetch(url, {
@@ -313,40 +286,26 @@ export async function downloadToMemory(
   }
 
   const contentType = response.headers.get('content-type') ?? undefined
-  const declaredLength = Number(response.headers.get('content-length'))
-  if (Number.isFinite(declaredLength) && declaredLength > MAX_MEMORY_FILE_BYTES) {
-    clearTimeout(timeout)
-    controller.abort()
-    throw new AgentMemoryError(400, `Download exceeds the ${MAX_MEMORY_FILE_BYTES} byte file limit`)
-  }
-
   const chunks: Uint8Array[] = []
   let received = 0
   try {
     if (response.body) {
       const reader = response.body.getReader()
       for (;;) {
+        resetIdleTimeout()
         const {done, value} = await reader.read()
         if (done) break
         if (value) {
           received += value.byteLength
-          if (received > MAX_MEMORY_FILE_BYTES) {
-            controller.abort()
-            throw new AgentMemoryError(400, `Download exceeds the ${MAX_MEMORY_FILE_BYTES} byte file limit`)
-          }
           chunks.push(value)
         }
       }
     } else {
       const bytes = new Uint8Array(await response.arrayBuffer())
       received = bytes.byteLength
-      if (received > MAX_MEMORY_FILE_BYTES) {
-        throw new AgentMemoryError(400, `Download exceeds the ${MAX_MEMORY_FILE_BYTES} byte file limit`)
-      }
       chunks.push(bytes)
     }
   } catch (error) {
-    if (error instanceof AgentMemoryError) throw error
     throw new AgentMemoryError(
       502,
       `Download of ${url} failed: ${error instanceof Error ? error.message : 'stream error'}`,
@@ -362,7 +321,7 @@ export async function downloadToMemory(
     const ext = extensionForMimeType(contentType)
     if (ext) ({relPath, absPath} = resolveMemoryPath(stateDir, `${relPath}.${ext}`))
   }
-  const entry = writeMemoryBytes(stateDir, relPath, absPath, content)
+  const entry = writeMemoryBytes(relPath, absPath, content)
   return {entry, finalUrl: response.url || url.toString(), contentType}
 }
 

--- a/agents/src/agent-memory.ts
+++ b/agents/src/agent-memory.ts
@@ -1,0 +1,185 @@
+/**
+ * Per-agent persistent memory filesystem.
+ *
+ * Every agent owns a private directory at `<stateDir>/memory`. Agent sessions read and write it
+ * through the `memory_*` tools, and users get full read/write access through the signed
+ * `*AgentMemory*` actions rendered in the desktop Memory tab. All paths are relative to the memory
+ * root and are strictly sandboxed: no absolute paths, no `..` traversal, no symlink targets.
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+/** Name of the memory directory inside an agent's state directory. */
+export const MEMORY_DIR_NAME = 'memory'
+
+/** Maximum size of a single memory file in bytes. */
+export const MAX_MEMORY_FILE_BYTES = 1024 * 1024
+/** Maximum total bytes across all files in one agent's memory. */
+export const MAX_MEMORY_TOTAL_BYTES = 100 * 1024 * 1024
+/** Maximum number of entries (files + directories) in one agent's memory. */
+export const MAX_MEMORY_ENTRIES = 2_000
+/** Maximum length of a normalized relative memory path in bytes. */
+export const MAX_MEMORY_PATH_BYTES = 512
+/** Maximum directory nesting depth of a memory path. */
+export const MAX_MEMORY_PATH_DEPTH = 16
+
+/** One file or directory inside an agent's memory. */
+export type AgentMemoryEntry = {
+  /** Relative path from the memory root, always `/`-separated. */
+  path: string
+  type: 'file' | 'dir'
+  /** File size in bytes; 0 for directories. */
+  size: number
+  /** Last modification time in Unix epoch milliseconds. */
+  updatedAt: number
+}
+
+/** Contents of one memory file. */
+export type AgentMemoryFile = {
+  path: string
+  content: string
+  size: number
+  updatedAt: number
+}
+
+/** Error raised for invalid memory paths or violated memory limits. */
+export class AgentMemoryError extends Error {
+  readonly status: number
+
+  constructor(status: number, message: string) {
+    super(message)
+    this.status = status
+  }
+}
+
+/** Returns the memory root directory for an agent state directory. */
+export function memoryRootPath(stateDir: string): string {
+  return path.join(stateDir, MEMORY_DIR_NAME)
+}
+
+/**
+ * Validates a user- or model-supplied relative path and resolves it inside the memory root.
+ * Returns the normalized relative path (always `/`-separated) and the absolute filesystem path.
+ */
+export function resolveMemoryPath(stateDir: string, rawPath: unknown): {relPath: string; absPath: string} {
+  if (typeof rawPath !== 'string') throw new AgentMemoryError(400, 'Memory path must be a string')
+  if (rawPath.includes('\0')) throw new AgentMemoryError(400, 'Memory path contains an invalid character')
+  const segments = rawPath
+    .replaceAll('\\', '/')
+    .split('/')
+    .filter((segment) => segment !== '' && segment !== '.')
+  if (!segments.length) throw new AgentMemoryError(400, 'Memory path is required')
+  if (segments.length > MAX_MEMORY_PATH_DEPTH) throw new AgentMemoryError(400, 'Memory path is nested too deeply')
+  for (const segment of segments) {
+    if (segment === '..') throw new AgentMemoryError(400, 'Memory path cannot contain ".."')
+  }
+  const relPath = segments.join('/')
+  if (new TextEncoder().encode(relPath).byteLength > MAX_MEMORY_PATH_BYTES) {
+    throw new AgentMemoryError(400, 'Memory path is too long')
+  }
+  const root = memoryRootPath(stateDir)
+  const absPath = path.join(root, ...segments)
+  const relative = path.relative(root, absPath)
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new AgentMemoryError(400, 'Memory path escapes the memory directory')
+  }
+  return {relPath, absPath}
+}
+
+/** Lists every file and directory in the agent's memory, sorted by path. */
+export function listMemory(stateDir: string): {entries: AgentMemoryEntry[]; totalBytes: number} {
+  const root = memoryRootPath(stateDir)
+  const entries: AgentMemoryEntry[] = []
+  let totalBytes = 0
+  const walk = (dirAbs: string, dirRel: string): void => {
+    let names: fs.Dirent[]
+    try {
+      names = fs.readdirSync(dirAbs, {withFileTypes: true})
+    } catch {
+      return
+    }
+    for (const dirent of names) {
+      if (entries.length >= MAX_MEMORY_ENTRIES) return
+      const rel = dirRel ? `${dirRel}/${dirent.name}` : dirent.name
+      const abs = path.join(dirAbs, dirent.name)
+      if (dirent.isSymbolicLink()) continue
+      if (dirent.isDirectory()) {
+        const stat = statOrNull(abs)
+        entries.push({path: rel, type: 'dir', size: 0, updatedAt: stat?.mtimeMs ? Math.round(stat.mtimeMs) : 0})
+        walk(abs, rel)
+      } else if (dirent.isFile()) {
+        const stat = statOrNull(abs)
+        if (!stat) continue
+        totalBytes += stat.size
+        entries.push({path: rel, type: 'file', size: stat.size, updatedAt: Math.round(stat.mtimeMs)})
+      }
+    }
+  }
+  walk(root, '')
+  entries.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))
+  return {entries, totalBytes}
+}
+
+/** Reads one memory file as UTF-8 text. */
+export function readMemoryFile(stateDir: string, rawPath: unknown): AgentMemoryFile {
+  const {relPath, absPath} = resolveMemoryPath(stateDir, rawPath)
+  const stat = lstatOrNull(absPath)
+  if (!stat || stat.isSymbolicLink()) throw new AgentMemoryError(404, `Memory file not found: ${relPath}`)
+  if (stat.isDirectory()) throw new AgentMemoryError(400, `Memory path is a directory, not a file: ${relPath}`)
+  if (stat.size > MAX_MEMORY_FILE_BYTES) throw new AgentMemoryError(400, `Memory file is too large to read: ${relPath}`)
+  const content = fs.readFileSync(absPath, 'utf8')
+  return {path: relPath, content, size: stat.size, updatedAt: Math.round(stat.mtimeMs)}
+}
+
+/** Writes one memory file as UTF-8 text, creating parent directories as needed. */
+export function writeMemoryFile(stateDir: string, rawPath: unknown, content: unknown): AgentMemoryEntry {
+  if (typeof content !== 'string') throw new AgentMemoryError(400, 'Memory file content must be a string')
+  const {relPath, absPath} = resolveMemoryPath(stateDir, rawPath)
+  const contentBytes = new TextEncoder().encode(content)
+  if (contentBytes.byteLength > MAX_MEMORY_FILE_BYTES) {
+    throw new AgentMemoryError(400, `Memory file content exceeds the ${MAX_MEMORY_FILE_BYTES} byte limit`)
+  }
+  const existing = lstatOrNull(absPath)
+  if (existing?.isSymbolicLink()) throw new AgentMemoryError(400, `Memory path is not writable: ${relPath}`)
+  if (existing?.isDirectory()) throw new AgentMemoryError(400, `Memory path is a directory, not a file: ${relPath}`)
+
+  const {entries, totalBytes} = listMemory(stateDir)
+  const previousSize = existing?.isFile() ? existing.size : 0
+  if (totalBytes - previousSize + contentBytes.byteLength > MAX_MEMORY_TOTAL_BYTES) {
+    throw new AgentMemoryError(400, 'Agent memory is full')
+  }
+  if (!existing && entries.length >= MAX_MEMORY_ENTRIES) {
+    throw new AgentMemoryError(400, 'Agent memory has too many files')
+  }
+
+  fs.mkdirSync(path.dirname(absPath), {recursive: true})
+  fs.writeFileSync(absPath, contentBytes)
+  const stat = fs.statSync(absPath)
+  return {path: relPath, type: 'file', size: stat.size, updatedAt: Math.round(stat.mtimeMs)}
+}
+
+/** Deletes one memory file, or one directory recursively. Returns false when nothing existed. */
+export function deleteMemoryPath(stateDir: string, rawPath: unknown): {path: string; deleted: boolean} {
+  const {relPath, absPath} = resolveMemoryPath(stateDir, rawPath)
+  const stat = lstatOrNull(absPath)
+  if (!stat) return {path: relPath, deleted: false}
+  fs.rmSync(absPath, {recursive: true, force: true})
+  return {path: relPath, deleted: true}
+}
+
+function statOrNull(target: string): fs.Stats | null {
+  try {
+    return fs.statSync(target)
+  } catch {
+    return null
+  }
+}
+
+function lstatOrNull(target: string): fs.Stats | null {
+  try {
+    return fs.lstatSync(target)
+  } catch {
+    return null
+  }
+}

--- a/agents/src/agent-memory.ts
+++ b/agents/src/agent-memory.ts
@@ -5,6 +5,10 @@
  * through the `memory_*` tools, and users get full read/write access through the signed
  * `*AgentMemory*` actions rendered in the desktop Memory tab. All paths are relative to the memory
  * root and are strictly sandboxed: no absolute paths, no `..` traversal, no symlink targets.
+ *
+ * Files can be UTF-8 text (editable in the Memory tab, readable by the model) or binary (media and
+ * other downloads, previewable/downloadable in the Memory tab and publishable to IPFS for use in
+ * Hypermedia content).
  */
 
 import * as fs from 'node:fs'
@@ -13,16 +17,20 @@ import * as path from 'node:path'
 /** Name of the memory directory inside an agent's state directory. */
 export const MEMORY_DIR_NAME = 'memory'
 
-/** Maximum size of a single memory file in bytes. */
-export const MAX_MEMORY_FILE_BYTES = 1024 * 1024
+/** Maximum size of a text write (model tool or Memory-tab editor) in bytes. */
+export const MAX_MEMORY_TEXT_BYTES = 1024 * 1024
+/** Maximum size of any single memory file (binary uploads, downloads) in bytes. */
+export const MAX_MEMORY_FILE_BYTES = 100 * 1024 * 1024
 /** Maximum total bytes across all files in one agent's memory. */
-export const MAX_MEMORY_TOTAL_BYTES = 100 * 1024 * 1024
+export const MAX_MEMORY_TOTAL_BYTES = 1024 * 1024 * 1024
 /** Maximum number of entries (files + directories) in one agent's memory. */
 export const MAX_MEMORY_ENTRIES = 2_000
 /** Maximum length of a normalized relative memory path in bytes. */
 export const MAX_MEMORY_PATH_BYTES = 512
 /** Maximum directory nesting depth of a memory path. */
 export const MAX_MEMORY_PATH_DEPTH = 16
+/** Timeout for one web download into memory. */
+export const MEMORY_DOWNLOAD_TIMEOUT_MS = 60_000
 
 /** One file or directory inside an agent's memory. */
 export type AgentMemoryEntry = {
@@ -33,14 +41,29 @@ export type AgentMemoryEntry = {
   size: number
   /** Last modification time in Unix epoch milliseconds. */
   updatedAt: number
+  /** MIME type inferred from the file extension, when recognized. */
+  mimeType?: string
 }
 
-/** Contents of one memory file. */
-export type AgentMemoryFile = {
+/** Contents of one memory file: UTF-8 text or raw binary bytes. */
+export type AgentMemoryFileData = {
   path: string
-  content: string
   size: number
   updatedAt: number
+  mimeType?: string
+  /** How the file content is delivered: `utf8` uses `content`, `binary` uses `data`. */
+  encoding: 'utf8' | 'binary'
+  content?: string
+  data?: Uint8Array
+}
+
+/** Result of downloading a web URL into memory. */
+export type AgentMemoryDownloadResult = {
+  entry: AgentMemoryEntry
+  /** URL actually fetched, after redirects. */
+  finalUrl: string
+  /** Content type reported by the server, when present. */
+  contentType?: string
 }
 
 /** Error raised for invalid memory paths or violated memory limits. */
@@ -51,6 +74,58 @@ export class AgentMemoryError extends Error {
     super(message)
     this.status = status
   }
+}
+
+/** MIME types inferred from file extensions, for previews and IPFS uploads. */
+const MIME_TYPES: Record<string, string> = {
+  md: 'text/markdown',
+  txt: 'text/plain',
+  csv: 'text/csv',
+  json: 'application/json',
+  html: 'text/html',
+  css: 'text/css',
+  js: 'text/javascript',
+  ts: 'text/plain',
+  xml: 'application/xml',
+  yaml: 'text/plain',
+  yml: 'text/plain',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  avif: 'image/avif',
+  svg: 'image/svg+xml',
+  ico: 'image/x-icon',
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  ogg: 'audio/ogg',
+  m4a: 'audio/mp4',
+  flac: 'audio/flac',
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+  mov: 'video/quicktime',
+  mkv: 'video/x-matroska',
+  pdf: 'application/pdf',
+  zip: 'application/zip',
+  gz: 'application/gzip',
+  tar: 'application/x-tar',
+  wasm: 'application/wasm',
+}
+
+/** Returns the MIME type inferred from a path's file extension, when recognized. */
+export function inferMimeType(filePath: string): string | undefined {
+  const ext = filePath.split('.').at(-1)?.toLowerCase()
+  return ext ? MIME_TYPES[ext] : undefined
+}
+
+/** Returns a known file extension for a MIME type, used to name extension-less downloads. */
+function extensionForMimeType(mimeType: string): string | undefined {
+  const bare = mimeType.split(';')[0]?.trim().toLowerCase()
+  for (const [ext, mime] of Object.entries(MIME_TYPES)) {
+    if (mime === bare) return ext
+  }
+  return undefined
 }
 
 /** Returns the memory root directory for an agent state directory. */
@@ -112,7 +187,7 @@ export function listMemory(stateDir: string): {entries: AgentMemoryEntry[]; tota
         const stat = statOrNull(abs)
         if (!stat) continue
         totalBytes += stat.size
-        entries.push({path: rel, type: 'file', size: stat.size, updatedAt: Math.round(stat.mtimeMs)})
+        entries.push(fileEntry(rel, stat))
       }
     }
   }
@@ -121,25 +196,60 @@ export function listMemory(stateDir: string): {entries: AgentMemoryEntry[]; tota
   return {entries, totalBytes}
 }
 
-/** Reads one memory file as UTF-8 text. */
-export function readMemoryFile(stateDir: string, rawPath: unknown): AgentMemoryFile {
+/**
+ * Reads one memory file. Small files that decode as clean UTF-8 come back as text
+ * (`encoding: 'utf8'`, `content`); everything else comes back as raw bytes
+ * (`encoding: 'binary'`, `data`).
+ */
+export function readMemoryFile(stateDir: string, rawPath: unknown): AgentMemoryFileData {
   const {relPath, absPath} = resolveMemoryPath(stateDir, rawPath)
   const stat = lstatOrNull(absPath)
   if (!stat || stat.isSymbolicLink()) throw new AgentMemoryError(404, `Memory file not found: ${relPath}`)
   if (stat.isDirectory()) throw new AgentMemoryError(400, `Memory path is a directory, not a file: ${relPath}`)
   if (stat.size > MAX_MEMORY_FILE_BYTES) throw new AgentMemoryError(400, `Memory file is too large to read: ${relPath}`)
-  const content = fs.readFileSync(absPath, 'utf8')
-  return {path: relPath, content, size: stat.size, updatedAt: Math.round(stat.mtimeMs)}
+  const bytes = fs.readFileSync(absPath)
+  const base = {
+    path: relPath,
+    size: stat.size,
+    updatedAt: Math.round(stat.mtimeMs),
+    mimeType: inferMimeType(relPath),
+  }
+  const text = bytes.byteLength <= MAX_MEMORY_TEXT_BYTES ? decodeUtf8OrNull(bytes) : null
+  if (text !== null) return {...base, encoding: 'utf8', content: text}
+  return {...base, encoding: 'binary', data: new Uint8Array(bytes)}
 }
 
-/** Writes one memory file as UTF-8 text, creating parent directories as needed. */
+/**
+ * Writes one memory file, creating parent directories as needed. String content is written as
+ * UTF-8 text (bounded by {@link MAX_MEMORY_TEXT_BYTES}); `Uint8Array` content is written verbatim
+ * (bounded by {@link MAX_MEMORY_FILE_BYTES}).
+ */
 export function writeMemoryFile(stateDir: string, rawPath: unknown, content: unknown): AgentMemoryEntry {
-  if (typeof content !== 'string') throw new AgentMemoryError(400, 'Memory file content must be a string')
-  const {relPath, absPath} = resolveMemoryPath(stateDir, rawPath)
-  const contentBytes = new TextEncoder().encode(content)
-  if (contentBytes.byteLength > MAX_MEMORY_FILE_BYTES) {
-    throw new AgentMemoryError(400, `Memory file content exceeds the ${MAX_MEMORY_FILE_BYTES} byte limit`)
+  let contentBytes: Uint8Array
+  if (typeof content === 'string') {
+    contentBytes = new TextEncoder().encode(content)
+    if (contentBytes.byteLength > MAX_MEMORY_TEXT_BYTES) {
+      throw new AgentMemoryError(400, `Memory text content exceeds the ${MAX_MEMORY_TEXT_BYTES} byte limit`)
+    }
+  } else if (content instanceof Uint8Array) {
+    contentBytes = content
+    if (contentBytes.byteLength > MAX_MEMORY_FILE_BYTES) {
+      throw new AgentMemoryError(400, `Memory file content exceeds the ${MAX_MEMORY_FILE_BYTES} byte limit`)
+    }
+  } else {
+    throw new AgentMemoryError(400, 'Memory file content must be a string or bytes')
   }
+  const {relPath, absPath} = resolveMemoryPath(stateDir, rawPath)
+  return writeMemoryBytes(stateDir, relPath, absPath, contentBytes)
+}
+
+/** Shared write path used by text/binary writes and web downloads after content is in hand. */
+function writeMemoryBytes(
+  stateDir: string,
+  relPath: string,
+  absPath: string,
+  contentBytes: Uint8Array,
+): AgentMemoryEntry {
   const existing = lstatOrNull(absPath)
   if (existing?.isSymbolicLink()) throw new AgentMemoryError(400, `Memory path is not writable: ${relPath}`)
   if (existing?.isDirectory()) throw new AgentMemoryError(400, `Memory path is a directory, not a file: ${relPath}`)
@@ -156,7 +266,142 @@ export function writeMemoryFile(stateDir: string, rawPath: unknown, content: unk
   fs.mkdirSync(path.dirname(absPath), {recursive: true})
   fs.writeFileSync(absPath, contentBytes)
   const stat = fs.statSync(absPath)
-  return {path: relPath, type: 'file', size: stat.size, updatedAt: Math.round(stat.mtimeMs)}
+  return fileEntry(relPath, stat)
+}
+
+/**
+ * Downloads a web URL into the agent's memory. When `rawPath` is omitted, the file is stored under
+ * `downloads/` named from the URL; when the chosen path has no extension, one is added from the
+ * response content type when recognized. The download is streamed and aborted beyond
+ * {@link MAX_MEMORY_FILE_BYTES}.
+ */
+export async function downloadToMemory(
+  stateDir: string,
+  rawUrl: unknown,
+  rawPath: unknown,
+): Promise<AgentMemoryDownloadResult> {
+  if (typeof rawUrl !== 'string' || !rawUrl.trim()) throw new AgentMemoryError(400, 'Download URL is required')
+  let url: URL
+  try {
+    url = new URL(rawUrl.trim())
+  } catch {
+    throw new AgentMemoryError(400, `Invalid download URL: ${rawUrl}`)
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new AgentMemoryError(400, 'Download URL must use http or https')
+  }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), MEMORY_DOWNLOAD_TIMEOUT_MS)
+  let response: Response
+  try {
+    response = await fetch(url, {
+      redirect: 'follow',
+      signal: controller.signal,
+      headers: {'User-Agent': 'SeedAgents/1.0 (+https://seed.hyper.media)'},
+    })
+  } catch (error) {
+    clearTimeout(timeout)
+    throw new AgentMemoryError(
+      502,
+      `Could not download ${url}: ${error instanceof Error ? error.message : 'request failed'}`,
+    )
+  }
+  if (!response.ok) {
+    clearTimeout(timeout)
+    throw new AgentMemoryError(502, `Could not download ${url}: HTTP ${response.status}`)
+  }
+
+  const contentType = response.headers.get('content-type') ?? undefined
+  const declaredLength = Number(response.headers.get('content-length'))
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_MEMORY_FILE_BYTES) {
+    clearTimeout(timeout)
+    controller.abort()
+    throw new AgentMemoryError(400, `Download exceeds the ${MAX_MEMORY_FILE_BYTES} byte file limit`)
+  }
+
+  const chunks: Uint8Array[] = []
+  let received = 0
+  try {
+    if (response.body) {
+      const reader = response.body.getReader()
+      for (;;) {
+        const {done, value} = await reader.read()
+        if (done) break
+        if (value) {
+          received += value.byteLength
+          if (received > MAX_MEMORY_FILE_BYTES) {
+            controller.abort()
+            throw new AgentMemoryError(400, `Download exceeds the ${MAX_MEMORY_FILE_BYTES} byte file limit`)
+          }
+          chunks.push(value)
+        }
+      }
+    } else {
+      const bytes = new Uint8Array(await response.arrayBuffer())
+      received = bytes.byteLength
+      if (received > MAX_MEMORY_FILE_BYTES) {
+        throw new AgentMemoryError(400, `Download exceeds the ${MAX_MEMORY_FILE_BYTES} byte file limit`)
+      }
+      chunks.push(bytes)
+    }
+  } catch (error) {
+    if (error instanceof AgentMemoryError) throw error
+    throw new AgentMemoryError(
+      502,
+      `Download of ${url} failed: ${error instanceof Error ? error.message : 'stream error'}`,
+    )
+  } finally {
+    clearTimeout(timeout)
+  }
+
+  const content = concatBytes(chunks, received)
+  const relPathInput = rawPath === undefined || rawPath === null || rawPath === '' ? defaultDownloadPath(url) : rawPath
+  let {relPath, absPath} = resolveMemoryPath(stateDir, relPathInput)
+  if (!/\.[A-Za-z0-9]{1,8}$/.test(relPath) && contentType) {
+    const ext = extensionForMimeType(contentType)
+    if (ext) ({relPath, absPath} = resolveMemoryPath(stateDir, `${relPath}.${ext}`))
+  }
+  const entry = writeMemoryBytes(stateDir, relPath, absPath, content)
+  return {entry, finalUrl: response.url || url.toString(), contentType}
+}
+
+/** One root-level memory entry in the system-prompt summary. */
+export type AgentMemoryTopLevelEntry = {
+  name: string
+  type: 'file' | 'dir'
+  /** File size in bytes; total bytes of contained files for directories. */
+  size: number
+  /** Number of files inside, for directories. */
+  fileCount?: number
+}
+
+/**
+ * Summarizes the top level of the agent's memory for automatic system-prompt injection: root
+ * files and directories (with contained file counts), without recursing into subfolder contents.
+ */
+export function summarizeMemoryTopLevel(stateDir: string): {
+  entries: AgentMemoryTopLevelEntry[]
+  totalFiles: number
+  totalBytes: number
+} {
+  const {entries, totalBytes} = listMemory(stateDir)
+  const top: AgentMemoryTopLevelEntry[] = []
+  for (const entry of entries) {
+    if (entry.path.includes('/')) continue
+    if (entry.type === 'file') {
+      top.push({name: entry.path, type: 'file', size: entry.size})
+    } else {
+      const inside = entries.filter((child) => child.type === 'file' && child.path.startsWith(`${entry.path}/`))
+      top.push({
+        name: entry.path,
+        type: 'dir',
+        size: inside.reduce((sum, child) => sum + child.size, 0),
+        fileCount: inside.length,
+      })
+    }
+  }
+  return {entries: top, totalFiles: entries.filter((entry) => entry.type === 'file').length, totalBytes}
 }
 
 /** Deletes one memory file, or one directory recursively. Returns false when nothing existed. */
@@ -166,6 +411,44 @@ export function deleteMemoryPath(stateDir: string, rawPath: unknown): {path: str
   if (!stat) return {path: relPath, deleted: false}
   fs.rmSync(absPath, {recursive: true, force: true})
   return {path: relPath, deleted: true}
+}
+
+/** Default memory path for a download without an explicit target: `downloads/<url filename>`. */
+function defaultDownloadPath(url: URL): string {
+  const lastSegment = decodeURIComponent(url.pathname.split('/').filter(Boolean).at(-1) ?? '')
+  const safe = lastSegment.replaceAll('\\', '-').replaceAll('..', '-').slice(0, 128)
+  return `downloads/${safe || `download-${Date.now()}`}`
+}
+
+function fileEntry(relPath: string, stat: fs.Stats): AgentMemoryEntry {
+  return {
+    path: relPath,
+    type: 'file',
+    size: stat.size,
+    updatedAt: Math.round(stat.mtimeMs),
+    mimeType: inferMimeType(relPath),
+  }
+}
+
+/** Decodes bytes as strict UTF-8 text, or returns null for binary content. */
+function decodeUtf8OrNull(bytes: Uint8Array): string | null {
+  if (bytes.includes(0)) return null
+  try {
+    return new TextDecoder('utf-8', {fatal: true}).decode(bytes)
+  } catch {
+    return null
+  }
+}
+
+function concatBytes(chunks: Uint8Array[], total: number): Uint8Array {
+  if (chunks.length === 1) return chunks[0]!
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return out
 }
 
 function statOrNull(target: string): fs.Stats | null {

--- a/agents/src/api-service.test.ts
+++ b/agents/src/api-service.test.ts
@@ -108,6 +108,84 @@ describe('api service', () => {
     }
   })
 
+  test('reads and writes agent memory through signed actions', async () => {
+    const {db, dataDir, cleanup} = createTestState()
+    try {
+      const account = blobs.generateNobleKeyPair()
+      const events: apisvc.ServiceEvent[] = []
+      const svc = new apisvc.Service(db, dataDir, {onEvent: (event) => events.push(event)})
+      await setDefaultProvider(svc, account)
+      const create = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {
+            _: 'CreateAgent',
+            definition: {name: 'Memory Agent', systemPrompt: 'ok', modelProvider: 'openai', model: 'gpt'},
+          },
+        }),
+      )
+      if (create._ !== 'CreateAgentResponse') throw new Error('unexpected response')
+      const agentId = create.agentId
+
+      const emptyList = await svc.message(
+        await apisvc.createSignedEnvelope(account, {action: {_: 'ListAgentMemory', agentId}}),
+      )
+      expect(emptyList).toMatchObject({_: 'ListAgentMemoryResponse', agentId, entries: [], totalBytes: 0})
+
+      const write = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {_: 'WriteAgentMemoryFile', agentId, path: 'notes/first.md', content: 'remember me'},
+        }),
+      )
+      expect(write).toMatchObject({
+        _: 'WriteAgentMemoryFileResponse',
+        agentId,
+        entry: {path: 'notes/first.md', type: 'file'},
+      })
+      expect(events.some((event) => event.type === 'account-change' && event.reason === 'agent-memory-changed')).toBe(
+        true,
+      )
+
+      const read = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {_: 'ReadAgentMemoryFile', agentId, path: 'notes/first.md'},
+        }),
+      )
+      expect(read).toMatchObject({
+        _: 'ReadAgentMemoryFileResponse',
+        file: {path: 'notes/first.md', content: 'remember me'},
+      })
+
+      const listed = await svc.message(
+        await apisvc.createSignedEnvelope(account, {action: {_: 'ListAgentMemory', agentId}}),
+      )
+      if (listed._ !== 'ListAgentMemoryResponse') throw new Error('unexpected response')
+      expect(listed.entries.map((entry) => `${entry.type}:${entry.path}`)).toEqual(['dir:notes', 'file:notes/first.md'])
+
+      await expect(
+        svc.message(
+          await apisvc.createSignedEnvelope(account, {
+            action: {_: 'WriteAgentMemoryFile', agentId, path: '../escape.txt', content: 'nope'},
+          }),
+        ),
+      ).rejects.toThrow('Memory path cannot contain ".."')
+      expect(fs.existsSync(path.join(dataDir, 'agents', 'escape.txt'))).toBe(false)
+
+      // Another account cannot touch this agent's memory.
+      const stranger = blobs.generateNobleKeyPair()
+      await expect(
+        svc.message(await apisvc.createSignedEnvelope(stranger, {action: {_: 'ListAgentMemory', agentId}})),
+      ).rejects.toThrow('Agent not found')
+
+      const remove = await svc.message(
+        await apisvc.createSignedEnvelope(account, {action: {_: 'DeleteAgentMemoryFile', agentId, path: 'notes'}}),
+      )
+      expect(remove).toMatchObject({_: 'DeleteAgentMemoryFileResponse', path: 'notes', deleted: true})
+    } finally {
+      db.close()
+      cleanup()
+    }
+  })
+
   test('creates a default user-mention trigger for the agent signing identity', async () => {
     const {db, dataDir, cleanup} = createTestState()
     try {

--- a/agents/src/api-service.test.ts
+++ b/agents/src/api-service.test.ts
@@ -186,6 +186,106 @@ describe('api service', () => {
     }
   })
 
+  test('handles binary memory files, web downloads, and IPFS uploads via signed actions', async () => {
+    const {db, dataDir, cleanup} = createTestState()
+    const realFetch = globalThis.fetch
+    try {
+      const account = blobs.generateNobleKeyPair()
+      const svc = new apisvc.Service(db, dataDir, {hmServerUrl: 'https://hm.example'})
+      await setDefaultProvider(svc, account)
+      const create = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {
+            _: 'CreateAgent',
+            definition: {
+              name: 'Media Agent',
+              systemPrompt: 'ok',
+              modelProvider: 'openai',
+              model: 'gpt',
+              tools: ['memory_list', 'memory_read', 'memory_write', 'memory_download', 'memory_upload_ipfs'],
+            },
+          },
+        }),
+      )
+      if (create._ !== 'CreateAgentResponse') throw new Error('unexpected response')
+      const agentId = create.agentId
+
+      // Binary write + read round trip through the signed actions.
+      const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 9, 9])
+      const write = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {_: 'WriteAgentMemoryFile', agentId, path: 'media/pic.png', content: pngBytes},
+        }),
+      )
+      expect(write).toMatchObject({
+        _: 'WriteAgentMemoryFileResponse',
+        entry: {path: 'media/pic.png', size: 10, mimeType: 'image/png'},
+      })
+      const read = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {_: 'ReadAgentMemoryFile', agentId, path: 'media/pic.png'},
+        }),
+      )
+      if (read._ !== 'ReadAgentMemoryFileResponse') throw new Error('unexpected response')
+      expect(read.file.encoding).toBe('binary')
+      expect(Array.from(read.file.data ?? [])).toEqual(Array.from(pngBytes))
+
+      // Web download into memory.
+      globalThis.fetch = (async (url: string | URL | Request) => {
+        if (String(url).includes('cdn.example')) {
+          return new Response(new Uint8Array([1, 2, 3]), {headers: {'content-type': 'image/jpeg'}})
+        }
+        throw new Error(`unexpected fetch: ${String(url)}`)
+      }) as unknown as typeof fetch
+      const download = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {_: 'DownloadAgentMemoryFile', agentId, url: 'https://cdn.example/photo.jpg'},
+        }),
+      )
+      expect(download).toMatchObject({
+        _: 'DownloadAgentMemoryFileResponse',
+        entry: {path: 'downloads/photo.jpg', size: 3, mimeType: 'image/jpeg'},
+      })
+
+      // IPFS upload via the HM server endpoint.
+      globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+        expect(String(url)).toBe('https://hm.example/ipfs/file-upload')
+        expect(init?.method).toBe('POST')
+        return new Response('bafkTestCid123\n')
+      }) as unknown as typeof fetch
+      const upload = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {_: 'UploadAgentMemoryFileToIpfs', agentId, path: 'media/pic.png'},
+        }),
+      )
+      expect(upload).toMatchObject({
+        _: 'UploadAgentMemoryFileToIpfsResponse',
+        path: 'media/pic.png',
+        cid: 'bafkTestCid123',
+        url: 'ipfs://bafkTestCid123',
+        mimeType: 'image/png',
+      })
+
+      // The session system prompt automatically lists top-level memory without expanding folders.
+      const session = await svc.message(
+        await apisvc.createSignedEnvelope(account, {action: {_: 'CreateSession', agentId}}),
+      )
+      if (session._ !== 'CreateSessionResponse') throw new Error('unexpected response')
+      const loaded = await svc.message(
+        await apisvc.createSignedEnvelope(account, {action: {_: 'GetSession', sessionId: session.sessionId}}),
+      )
+      if (loaded._ !== 'GetSessionResponse') throw new Error('unexpected response')
+      expect(loaded.systemPromptMarkdown).toContain('<memory_files>')
+      expect(loaded.systemPromptMarkdown).toContain('media/ — 1 file')
+      expect(loaded.systemPromptMarkdown).toContain('downloads/ — 1 file')
+      expect(loaded.systemPromptMarkdown).not.toContain('media/pic.png')
+    } finally {
+      globalThis.fetch = realFetch
+      db.close()
+      cleanup()
+    }
+  })
+
   test('creates a default user-mention trigger for the agent signing identity', async () => {
     const {db, dataDir, cleanup} = createTestState()
     try {

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -235,6 +235,15 @@ export class Service {
         )
       case 'DeleteAgentMemoryFile':
         return this.#deleteAgentMemoryFile(verified.accountId, envelope.action.agentId, envelope.action.path)
+      case 'DownloadAgentMemoryFile':
+        return this.#downloadAgentMemoryFile(
+          verified.accountId,
+          envelope.action.agentId,
+          envelope.action.url,
+          envelope.action.path,
+        )
+      case 'UploadAgentMemoryFileToIpfs':
+        return this.#uploadAgentMemoryFileToIpfs(verified.accountId, envelope.action.agentId, envelope.action.path)
       case 'CreateSession':
         return this.#createSession(
           verified.accountId,
@@ -842,12 +851,52 @@ export class Service {
     accountId: string,
     agentId: string,
     filePath: string,
-    content: string,
+    content: string | Uint8Array,
   ): api.WriteAgentMemoryFileResponse {
     const stateDir = this.#agentMemoryStateDir(accountId, agentId)
     const entry = withMemoryErrors(() => agentMemory.writeMemoryFile(stateDir, filePath, content))
     this.#emit({type: 'account-change', accountId, reason: 'agent-memory-changed', agentId})
     return {_: 'WriteAgentMemoryFileResponse', agentId, entry}
+  }
+
+  async #downloadAgentMemoryFile(
+    accountId: string,
+    agentId: string,
+    url: string,
+    filePath?: string,
+  ): Promise<api.DownloadAgentMemoryFileResponse> {
+    const stateDir = this.#agentMemoryStateDir(accountId, agentId)
+    const result = await withMemoryErrorsAsync(() => agentMemory.downloadToMemory(stateDir, url, filePath))
+    this.#emit({type: 'account-change', accountId, reason: 'agent-memory-changed', agentId})
+    return {
+      _: 'DownloadAgentMemoryFileResponse',
+      agentId,
+      entry: result.entry,
+      finalUrl: result.finalUrl,
+      contentType: result.contentType,
+    }
+  }
+
+  async #uploadAgentMemoryFileToIpfs(
+    accountId: string,
+    agentId: string,
+    filePath: string,
+  ): Promise<api.UploadAgentMemoryFileToIpfsResponse> {
+    const stateDir = this.#agentMemoryStateDir(accountId, agentId)
+    const file = withMemoryErrors(() => agentMemory.readMemoryFile(stateDir, filePath))
+    const bytes =
+      file.encoding === 'binary' ? file.data ?? new Uint8Array() : new TextEncoder().encode(file.content ?? '')
+    const fileName = file.path.split('/').at(-1) || 'file'
+    const {cid, url} = await uploadBytesToHmIpfs(this.#hmServerUrl, bytes, file.mimeType, fileName)
+    return {
+      _: 'UploadAgentMemoryFileToIpfsResponse',
+      agentId,
+      path: file.path,
+      cid,
+      url,
+      size: file.size,
+      mimeType: file.mimeType,
+    }
   }
 
   #deleteAgentMemoryFile(accountId: string, agentId: string, filePath: string): api.DeleteAgentMemoryFileResponse {
@@ -1216,7 +1265,8 @@ export class Service {
     return `${accountId}/${sessionId}`
   }
 
-  async #agentSystemPrompt(accountId: string, definition: api.AgentDefinition): Promise<string> {
+  /** Builds the model-facing system prompt; `stateDir` enables the automatic memory listing. */
+  async #agentSystemPrompt(accountId: string, definition: api.AgentDefinition, stateDir?: string): Promise<string> {
     const signingKeys = definition.signingKeys || (definition.signingKey ? [definition.signingKey] : [])
     const systemPrompt = await promptBlocksToResolvedMarkdown(
       normalizeSystemPromptBlocks(definition.systemPrompt),
@@ -1231,10 +1281,13 @@ export class Service {
       seedToolRegistry.memory_read.name,
       seedToolRegistry.memory_write.name,
       seedToolRegistry.memory_delete.name,
+      seedToolRegistry.memory_download.name,
+      seedToolRegistry.memory_upload_ipfs.name,
     ]
     const memoryEnabled = (definition.tools ?? []).some((tool) => memoryToolNames.includes(tool))
     const memoryPrompt = memoryEnabled
-      ? '\n\nYou have a private persistent memory filesystem shared across all of your sessions, accessed with the memory_list, memory_read, memory_write, and memory_delete tools. Your user can also browse and edit these files. At the start of a task, check memory for relevant notes. Store durable learnings, preferences, and ongoing state as small, well-organized text files (for example notes/topic.md); update files by reading them and writing back the full revised content.'
+      ? '\n\nYou have a private persistent memory filesystem shared across all of your sessions, accessed with the memory_list, memory_read, memory_write, and memory_delete tools. Your user can also browse and edit these files. At the start of a task, check memory for relevant notes. Store durable learnings, preferences, and ongoing state as small, well-organized text files (for example notes/topic.md); update files by reading them and writing back the full revised content. Use memory_download to save web files (including binary media) into memory, and memory_upload_ipfs to publish a memory file to IPFS, returning an ipfs:// URL you can reference from Hypermedia content.' +
+        (stateDir ? memoryListingPrompt(stateDir) : '')
       : ''
     const basePrompt = `${systemPrompt}\n\n${sharedPrompt}${memoryPrompt}`
     if (!signingKeys.length) return basePrompt
@@ -1301,7 +1354,10 @@ export class Service {
 
     const cwd = this.#dataDir
     const settingsManager = pi.SettingsManager.inMemory({compaction: {enabled: false}})
-    const resourceLoader = createSeedPiResourceLoader(await this.#agentSystemPrompt(accountId, definition))
+    const agentStateDir = this.#agentMemoryStateDir(accountId, session.agentId)
+    const resourceLoader = createSeedPiResourceLoader(
+      await this.#agentSystemPrompt(accountId, definition, agentStateDir),
+    )
     const {session: piSession} = await pi.createAgentSession({
       cwd,
       agentDir: path.join(this.#dataDir, 'pi'),
@@ -1317,7 +1373,7 @@ export class Service {
         definition,
         hmServerUrl: this.#hmServerUrl,
         web: this.#web,
-        stateDir: this.#agentMemoryStateDir(accountId, session.agentId),
+        stateDir: agentStateDir,
         onMemoryChange: () =>
           this.#emit({type: 'account-change', accountId, reason: 'agent-memory-changed', agentId: session.agentId}),
         setSessionTitle: (title) => this.#setSessionTitleFromAgent(accountId, sessionId, title),
@@ -1334,7 +1390,9 @@ export class Service {
             tool === seedToolRegistry.memory_list.name ||
             tool === seedToolRegistry.memory_read.name ||
             tool === seedToolRegistry.memory_write.name ||
-            tool === seedToolRegistry.memory_delete.name,
+            tool === seedToolRegistry.memory_delete.name ||
+            tool === seedToolRegistry.memory_download.name ||
+            tool === seedToolRegistry.memory_upload_ipfs.name,
         ),
         seedToolRegistry.set_session_title.name,
       ],
@@ -1764,7 +1822,7 @@ export class Service {
       _: 'GetSessionResponse',
       session: sessionRowToInfo(session, triggerContext ?? undefined),
       events: events.map(sessionEventRowToInfo),
-      systemPromptMarkdown: await this.#agentSystemPrompt(accountId, definition),
+      systemPromptMarkdown: await this.#agentSystemPrompt(accountId, definition, agent.state_dir),
       ...(triggerContext ? {triggerContext} : {}),
     }
   }
@@ -2264,23 +2322,42 @@ async function publishSigningIdentityProfile(
 }
 
 /**
- * Uploads raw avatar bytes to the HM node's public IPFS file-upload endpoint and
- * returns the resulting `ipfs://<cid>` URI for use as a profile avatar.
+ * Uploads raw bytes to the HM node's public IPFS file-upload endpoint and returns the resulting
+ * CID plus its `ipfs://<cid>` URI for use in Hypermedia content.
  */
-async function uploadIconToHmNode(hmServerUrl: string, icon: api.SigningIdentityIcon): Promise<string> {
+async function uploadBytesToHmIpfs(
+  hmServerUrl: string,
+  data: Uint8Array,
+  mimeType?: string,
+  fileName?: string,
+): Promise<{cid: string; url: string}> {
   const formData = new FormData()
-  const blob = new Blob([new Uint8Array(icon.data)], icon.mimeType ? {type: icon.mimeType} : undefined)
-  formData.append('file', blob, icon.fileName || 'icon')
+  const blob = new Blob([new Uint8Array(data)], mimeType ? {type: mimeType} : undefined)
+  formData.append('file', blob, fileName || 'file')
   const response = await fetch(`${hmServerUrl.replace(/\/$/, '')}/ipfs/file-upload`, {
     method: 'POST',
     body: formData,
   })
   if (!response.ok) {
-    throw new Error(`Upload failed with status ${response.status}`)
+    throw new APIError(502, `IPFS upload failed with status ${response.status}`)
   }
   const cid = (await response.text()).trim()
-  if (!cid) throw new Error('Upload returned an empty CID')
-  return `ipfs://${cid}`
+  if (!cid) throw new APIError(502, 'IPFS upload returned an empty CID')
+  return {cid, url: `ipfs://${cid}`}
+}
+
+/**
+ * Uploads raw avatar bytes to the HM node's public IPFS file-upload endpoint and
+ * returns the resulting `ipfs://<cid>` URI for use as a profile avatar.
+ */
+async function uploadIconToHmNode(hmServerUrl: string, icon: api.SigningIdentityIcon): Promise<string> {
+  const {url} = await uploadBytesToHmIpfs(
+    hmServerUrl,
+    new Uint8Array(icon.data),
+    icon.mimeType,
+    icon.fileName || 'icon',
+  )
+  return url
 }
 
 async function publishSigningIdentityProfileAndHome(
@@ -2320,10 +2397,47 @@ async function publishSigningIdentityProfileAndHome(
   })
 }
 
+/**
+ * Renders the automatic top-level memory listing appended to memory-enabled system prompts.
+ * Root files and folders only (with contained file counts), so the agent knows what it has
+ * without an explicit memory_list call, while deep folders don't bloat the prompt.
+ */
+function memoryListingPrompt(stateDir: string): string {
+  let summary: ReturnType<typeof agentMemory.summarizeMemoryTopLevel>
+  try {
+    summary = agentMemory.summarizeMemoryTopLevel(stateDir)
+  } catch {
+    return ''
+  }
+  if (!summary.entries.length) {
+    return '\n\n<memory_files>\n(empty)\n</memory_files>\nYour memory is currently empty.'
+  }
+  const lines = summary.entries.map((entry) =>
+    entry.type === 'dir'
+      ? `${entry.name}/ — ${entry.fileCount ?? 0} file${(entry.fileCount ?? 0) === 1 ? '' : 's'}`
+      : `${entry.name} — ${entry.size} bytes`,
+  )
+  return `\n\n<memory_files>\n${lines.join('\n')}\n</memory_files>\nThis is the current top level of your memory (${
+    summary.totalFiles
+  } file${
+    summary.totalFiles === 1 ? '' : 's'
+  } total). Folder contents are not expanded here: use memory_list to see every path and memory_read to read a file.`
+}
+
 /** Reraises agent-memory errors as API errors so they carry an HTTP status. */
 function withMemoryErrors<T>(run: () => T): T {
   try {
     return run()
+  } catch (error) {
+    if (error instanceof agentMemory.AgentMemoryError) throw new APIError(error.status, error.message)
+    throw error
+  }
+}
+
+/** Async variant of {@link withMemoryErrors} for downloads. */
+async function withMemoryErrorsAsync<T>(run: () => Promise<T>): Promise<T> {
+  try {
+    return await run()
   } catch (error) {
     if (error instanceof agentMemory.AgentMemoryError) throw new APIError(error.status, error.message)
     throw error
@@ -3232,7 +3346,17 @@ function createAgentServicePiTools(context: AgentServicePiToolContext): pi.ToolD
     defineSeedPiTool(seedToolRegistry.memory_read, (params) => {
       const input = isRecord(params) ? params : {}
       const file = withMemoryErrors(() => agentMemory.readMemoryFile(context.stateDir, input.path))
-      return {summary: `Read ${file.path} (${file.size} bytes).`, ...file}
+      // Raw bytes never go to the model: binary files return metadata only.
+      const {data: _data, ...meta} = file
+      if (file.encoding === 'binary') {
+        return {
+          summary: `${file.path} is a binary file (${file.size} bytes${
+            file.mimeType ? `, ${file.mimeType}` : ''
+          }); content not shown. Use memory_upload_ipfs to publish it for Hypermedia content.`,
+          ...meta,
+        }
+      }
+      return {summary: `Read ${file.path} (${file.size} bytes).`, ...meta}
     }),
     defineSeedPiTool(seedToolRegistry.memory_write, (params) => {
       const input = isRecord(params) ? params : {}
@@ -3247,6 +3371,39 @@ function createAgentServicePiTools(context: AgentServicePiToolContext): pi.ToolD
       return {
         summary: result.deleted ? `Deleted ${result.path}.` : `Nothing existed at ${result.path}.`,
         ...result,
+      }
+    }),
+    defineSeedPiTool(seedToolRegistry.memory_download, async (params) => {
+      const input = isRecord(params) ? params : {}
+      const result = await withMemoryErrorsAsync(() =>
+        agentMemory.downloadToMemory(context.stateDir, input.url, input.path),
+      )
+      context.onMemoryChange()
+      return {
+        summary: `Downloaded ${result.finalUrl} to ${result.entry.path} (${result.entry.size} bytes${
+          result.entry.mimeType ? `, ${result.entry.mimeType}` : ''
+        }).`,
+        path: result.entry.path,
+        size: result.entry.size,
+        mimeType: result.entry.mimeType,
+        finalUrl: result.finalUrl,
+        contentType: result.contentType,
+      }
+    }),
+    defineSeedPiTool(seedToolRegistry.memory_upload_ipfs, async (params) => {
+      const input = isRecord(params) ? params : {}
+      const file = withMemoryErrors(() => agentMemory.readMemoryFile(context.stateDir, input.path))
+      const bytes =
+        file.encoding === 'binary' ? file.data ?? new Uint8Array() : new TextEncoder().encode(file.content ?? '')
+      const fileName = file.path.split('/').at(-1) || 'file'
+      const {cid, url} = await uploadBytesToHmIpfs(context.hmServerUrl, bytes, file.mimeType, fileName)
+      return {
+        summary: `Uploaded ${file.path} to IPFS as ${url}.`,
+        path: file.path,
+        cid,
+        url,
+        size: file.size,
+        mimeType: file.mimeType,
       }
     }),
     defineSeedPiTool(seedToolRegistry.set_session_title, (params) => {

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -8,6 +8,7 @@ import {
   type SeedToolMetadata,
 } from '@seed-hypermedia/agents-protocol'
 import * as activityTriggers from '@/activity-triggers'
+import * as agentMemory from '@/agent-memory'
 import * as scheduleTriggers from '@/schedule-triggers'
 import * as auth from '@/auth'
 import * as cbor from '@/cbor'
@@ -221,6 +222,19 @@ export class Service {
         return this.#updateAgentTrigger(verified.accountId, envelope.action.triggerId, envelope.action.patch)
       case 'DeleteAgentTrigger':
         return this.#deleteAgentTrigger(verified.accountId, envelope.action.triggerId)
+      case 'ListAgentMemory':
+        return this.#listAgentMemory(verified.accountId, envelope.action.agentId)
+      case 'ReadAgentMemoryFile':
+        return this.#readAgentMemoryFile(verified.accountId, envelope.action.agentId, envelope.action.path)
+      case 'WriteAgentMemoryFile':
+        return this.#writeAgentMemoryFile(
+          verified.accountId,
+          envelope.action.agentId,
+          envelope.action.path,
+          envelope.action.content,
+        )
+      case 'DeleteAgentMemoryFile':
+        return this.#deleteAgentMemoryFile(verified.accountId, envelope.action.agentId, envelope.action.path)
       case 'CreateSession':
         return this.#createSession(
           verified.accountId,
@@ -805,6 +819,44 @@ export class Service {
     return {_: 'DeleteAgentResponse', agentId}
   }
 
+  /** Returns the memory state directory for an agent owned by the account, or throws 404. */
+  #agentMemoryStateDir(accountId: string, agentId: string): string {
+    const agent = this.#getAgentInfo(accountId, agentId)
+    if (!agent) throw new APIError(404, 'Agent not found')
+    return agent.stateDir
+  }
+
+  #listAgentMemory(accountId: string, agentId: string): api.ListAgentMemoryResponse {
+    const stateDir = this.#agentMemoryStateDir(accountId, agentId)
+    const {entries, totalBytes} = withMemoryErrors(() => agentMemory.listMemory(stateDir))
+    return {_: 'ListAgentMemoryResponse', agentId, entries, totalBytes}
+  }
+
+  #readAgentMemoryFile(accountId: string, agentId: string, filePath: string): api.ReadAgentMemoryFileResponse {
+    const stateDir = this.#agentMemoryStateDir(accountId, agentId)
+    const file = withMemoryErrors(() => agentMemory.readMemoryFile(stateDir, filePath))
+    return {_: 'ReadAgentMemoryFileResponse', agentId, file}
+  }
+
+  #writeAgentMemoryFile(
+    accountId: string,
+    agentId: string,
+    filePath: string,
+    content: string,
+  ): api.WriteAgentMemoryFileResponse {
+    const stateDir = this.#agentMemoryStateDir(accountId, agentId)
+    const entry = withMemoryErrors(() => agentMemory.writeMemoryFile(stateDir, filePath, content))
+    this.#emit({type: 'account-change', accountId, reason: 'agent-memory-changed', agentId})
+    return {_: 'WriteAgentMemoryFileResponse', agentId, entry}
+  }
+
+  #deleteAgentMemoryFile(accountId: string, agentId: string, filePath: string): api.DeleteAgentMemoryFileResponse {
+    const stateDir = this.#agentMemoryStateDir(accountId, agentId)
+    const result = withMemoryErrors(() => agentMemory.deleteMemoryPath(stateDir, filePath))
+    if (result.deleted) this.#emit({type: 'account-change', accountId, reason: 'agent-memory-changed', agentId})
+    return {_: 'DeleteAgentMemoryFileResponse', agentId, path: result.path, deleted: result.deleted}
+  }
+
   #listAgentTriggers(accountId: string, agentId: string): api.ListAgentTriggersResponse {
     this.#requireAgent(accountId, agentId)
     const rows = this.#db
@@ -1174,7 +1226,17 @@ export class Service {
       currentTime: new Date().toISOString(),
       includeTitleToolInstruction: true,
     })
-    const basePrompt = `${systemPrompt}\n\n${sharedPrompt}`
+    const memoryToolNames = [
+      seedToolRegistry.memory_list.name,
+      seedToolRegistry.memory_read.name,
+      seedToolRegistry.memory_write.name,
+      seedToolRegistry.memory_delete.name,
+    ]
+    const memoryEnabled = (definition.tools ?? []).some((tool) => memoryToolNames.includes(tool))
+    const memoryPrompt = memoryEnabled
+      ? '\n\nYou have a private persistent memory filesystem shared across all of your sessions, accessed with the memory_list, memory_read, memory_write, and memory_delete tools. Your user can also browse and edit these files. At the start of a task, check memory for relevant notes. Store durable learnings, preferences, and ongoing state as small, well-organized text files (for example notes/topic.md); update files by reading them and writing back the full revised content.'
+      : ''
+    const basePrompt = `${systemPrompt}\n\n${sharedPrompt}${memoryPrompt}`
     if (!signingKeys.length) return basePrompt
     const identities = signingKeys.flatMap((name) => {
       const row = this.#db
@@ -1255,6 +1317,9 @@ export class Service {
         definition,
         hmServerUrl: this.#hmServerUrl,
         web: this.#web,
+        stateDir: this.#agentMemoryStateDir(accountId, session.agentId),
+        onMemoryChange: () =>
+          this.#emit({type: 'account-change', accountId, reason: 'agent-memory-changed', agentId: session.agentId}),
         setSessionTitle: (title) => this.#setSessionTitleFromAgent(accountId, sessionId, title),
       }),
       tools: [
@@ -1265,7 +1330,11 @@ export class Service {
             tool === seedToolRegistry.list_activity_feed.name ||
             tool === seedToolRegistry.web_search.name ||
             tool === seedToolRegistry.web_read.name ||
-            tool === seedToolRegistry.write.name,
+            tool === seedToolRegistry.write.name ||
+            tool === seedToolRegistry.memory_list.name ||
+            tool === seedToolRegistry.memory_read.name ||
+            tool === seedToolRegistry.memory_write.name ||
+            tool === seedToolRegistry.memory_delete.name,
         ),
         seedToolRegistry.set_session_title.name,
       ],
@@ -2251,6 +2320,16 @@ async function publishSigningIdentityProfileAndHome(
   })
 }
 
+/** Reraises agent-memory errors as API errors so they carry an HTTP status. */
+function withMemoryErrors<T>(run: () => T): T {
+  try {
+    return run()
+  } catch (error) {
+    if (error instanceof agentMemory.AgentMemoryError) throw new APIError(error.status, error.message)
+    throw error
+  }
+}
+
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
@@ -2990,6 +3069,10 @@ type WriteToolContext = {
 type AgentServicePiToolContext = WriteToolContext & {
   setSessionTitle: (title: string) => api.SessionInfo
   web: WebToolsConfig
+  /** Agent state directory holding the private memory filesystem. */
+  stateDir: string
+  /** Called after a memory tool mutates files, so clients watching the Memory tab refresh. */
+  onMemoryChange: () => void
 }
 
 type ResolvedAgentSigner = {
@@ -3135,6 +3218,37 @@ function createAgentServicePiTools(context: AgentServicePiToolContext): pi.ToolD
       }
     }),
     defineSeedPiTool(seedToolRegistry.write, (params) => writeHypermedia(context, params)),
+    defineSeedPiTool(seedToolRegistry.memory_list, () => {
+      const {entries, totalBytes} = withMemoryErrors(() => agentMemory.listMemory(context.stateDir))
+      const files = entries.filter((entry) => entry.type === 'file')
+      return {
+        summary: files.length
+          ? `Memory holds ${files.length} file${files.length === 1 ? '' : 's'} (${totalBytes} bytes).`
+          : 'Memory is empty.',
+        entries,
+        totalBytes,
+      }
+    }),
+    defineSeedPiTool(seedToolRegistry.memory_read, (params) => {
+      const input = isRecord(params) ? params : {}
+      const file = withMemoryErrors(() => agentMemory.readMemoryFile(context.stateDir, input.path))
+      return {summary: `Read ${file.path} (${file.size} bytes).`, ...file}
+    }),
+    defineSeedPiTool(seedToolRegistry.memory_write, (params) => {
+      const input = isRecord(params) ? params : {}
+      const entry = withMemoryErrors(() => agentMemory.writeMemoryFile(context.stateDir, input.path, input.content))
+      context.onMemoryChange()
+      return {summary: `Wrote ${entry.path} (${entry.size} bytes).`, ...entry}
+    }),
+    defineSeedPiTool(seedToolRegistry.memory_delete, (params) => {
+      const input = isRecord(params) ? params : {}
+      const result = withMemoryErrors(() => agentMemory.deleteMemoryPath(context.stateDir, input.path))
+      if (result.deleted) context.onMemoryChange()
+      return {
+        summary: result.deleted ? `Deleted ${result.path}.` : `Nothing existed at ${result.path}.`,
+        ...result,
+      }
+    }),
     defineSeedPiTool(seedToolRegistry.set_session_title, (params) => {
       const title = isRecord(params) && typeof params.title === 'string' ? params.title : ''
       console.info('[agents/runtime] set_session_title tool called')

--- a/agents/src/main.ts
+++ b/agents/src/main.ts
@@ -483,6 +483,8 @@ async function main(): Promise<void> {
   const server = serve({
     port: cfg.http.port,
     hostname: cfg.http.hostname,
+    // Agent memory accepts files of any size, so uploads must not hit Bun's 128MB default cap.
+    maxRequestBodySize: Number.MAX_SAFE_INTEGER,
     development: !isProd && {
       hmr: true,
       console: true,

--- a/agents/src/main.ts
+++ b/agents/src/main.ts
@@ -457,6 +457,15 @@ async function main(): Promise<void> {
           key: `account/${event.accountId}`,
           value: {reason: event.reason, agentId: event.agentId, sessionId: event.sessionId},
         })
+        // Memory writes happen mid-session with no agent-change event, so also notify
+        // agent-page subscribers watching the Memory tab.
+        if (event.reason === 'agent-memory-changed' && event.agentId) {
+          sendIfSubscribed(ws, `agents/${event.agentId}`, {
+            _: 'change',
+            key: `account/${event.accountId}`,
+            value: {reason: event.reason, agentId: event.agentId, sessionId: event.sessionId},
+          })
+        }
       }
     }
   }

--- a/frontend/apps/desktop/src/agents-client.ts
+++ b/frontend/apps/desktop/src/agents-client.ts
@@ -42,6 +42,10 @@ export type ModelProviderInfo = AgentsProtocol.RedactedModelProvider
 export type ModelProviderConfig = AgentsProtocol.ModelProviderConfig
 /** Public model metadata returned by the agents service. */
 export type ProviderModelInfo = AgentsProtocol.ProviderModelInfo
+/** One file or directory inside an agent's private memory filesystem. */
+export type AgentMemoryEntry = AgentsProtocol.AgentMemoryEntry
+/** Contents of one agent memory file. */
+export type AgentMemoryFile = AgentsProtocol.AgentMemoryFile
 /** Public metadata for a server-side Seed account key secret. */
 export type SigningIdentity = AgentsProtocol.SigningIdentity
 /** Avatar image payload for updating an agent account profile. */

--- a/frontend/apps/desktop/src/models/agents.ts
+++ b/frontend/apps/desktop/src/models/agents.ts
@@ -800,6 +800,79 @@ export function useAgentTrigger(
   })
 }
 
+/** Lists the files and directories in one agent's private memory. */
+export function useAgentMemory(
+  serverUrl: string | undefined,
+  accountUid: string | null | undefined,
+  agentId: string | undefined,
+) {
+  return useQuery({
+    queryKey: ['agents', 'memory', serverUrl, accountUid, agentId],
+    queryFn: async () => {
+      if (!serverUrl || !accountUid || !agentId) return null
+      const res = await sendAgentAction({serverUrl, accountUid, action: {_: 'ListAgentMemory', agentId}})
+      if (res._ !== 'ListAgentMemoryResponse') throw new Error('Unexpected ListAgentMemory response')
+      return res
+    },
+    enabled: !!serverUrl && !!accountUid && !!agentId,
+    refetchInterval: AGENT_BACKGROUND_REFETCH_INTERVAL_MS,
+    refetchIntervalInBackground: true,
+    retry: false,
+    useErrorBoundary: false,
+  })
+}
+
+/** Reads one file from an agent's private memory. */
+export function useAgentMemoryFile(
+  serverUrl: string | undefined,
+  accountUid: string | null | undefined,
+  agentId: string | undefined,
+  filePath: string | undefined,
+) {
+  return useQuery({
+    queryKey: ['agents', 'memory', serverUrl, accountUid, agentId, 'file', filePath],
+    queryFn: async () => {
+      if (!serverUrl || !accountUid || !agentId || !filePath) return null
+      const res = await sendAgentAction({
+        serverUrl,
+        accountUid,
+        action: {_: 'ReadAgentMemoryFile', agentId, path: filePath},
+      })
+      if (res._ !== 'ReadAgentMemoryFileResponse') throw new Error('Unexpected ReadAgentMemoryFile response')
+      return res.file
+    },
+    enabled: !!serverUrl && !!accountUid && !!agentId && !!filePath,
+    retry: false,
+    useErrorBoundary: false,
+  })
+}
+
+/** Writes one file into an agent's private memory. */
+export function useWriteAgentMemoryFile(serverUrl: string | undefined, accountUid: string | null | undefined) {
+  return useMutation({
+    mutationFn: async ({agentId, path, content}: {agentId: string; path: string; content: string}) => {
+      if (!serverUrl || !accountUid) throw new Error('Select an account and agent server first')
+      return sendAgentAction({serverUrl, accountUid, action: {_: 'WriteAgentMemoryFile', agentId, path, content}})
+    },
+    onSuccess() {
+      invalidateQueries(['agents', 'memory'])
+    },
+  })
+}
+
+/** Deletes one file or directory from an agent's private memory. */
+export function useDeleteAgentMemoryFile(serverUrl: string | undefined, accountUid: string | null | undefined) {
+  return useMutation({
+    mutationFn: async ({agentId, path}: {agentId: string; path: string}) => {
+      if (!serverUrl || !accountUid) throw new Error('Select an account and agent server first')
+      return sendAgentAction({serverUrl, accountUid, action: {_: 'DeleteAgentMemoryFile', agentId, path}})
+    },
+    onSuccess() {
+      invalidateQueries(['agents', 'memory'])
+    },
+  })
+}
+
 /** Creates an activity trigger for one agent. */
 export function useCreateAgentTrigger(serverUrl: string | undefined, accountUid: string | null | undefined) {
   return useMutation({

--- a/frontend/apps/desktop/src/models/agents.ts
+++ b/frontend/apps/desktop/src/models/agents.ts
@@ -847,15 +847,53 @@ export function useAgentMemoryFile(
   })
 }
 
-/** Writes one file into an agent's private memory. */
+/** Writes one file (UTF-8 text or binary bytes) into an agent's private memory. */
 export function useWriteAgentMemoryFile(serverUrl: string | undefined, accountUid: string | null | undefined) {
   return useMutation({
-    mutationFn: async ({agentId, path, content}: {agentId: string; path: string; content: string}) => {
+    mutationFn: async ({agentId, path, content}: {agentId: string; path: string; content: string | Uint8Array}) => {
       if (!serverUrl || !accountUid) throw new Error('Select an account and agent server first')
       return sendAgentAction({serverUrl, accountUid, action: {_: 'WriteAgentMemoryFile', agentId, path, content}})
     },
     onSuccess() {
       invalidateQueries(['agents', 'memory'])
+    },
+  })
+}
+
+/** Downloads a web URL into an agent's private memory on the server. */
+export function useDownloadAgentMemoryFile(serverUrl: string | undefined, accountUid: string | null | undefined) {
+  return useMutation({
+    mutationFn: async ({agentId, url, path}: {agentId: string; url: string; path?: string}) => {
+      if (!serverUrl || !accountUid) throw new Error('Select an account and agent server first')
+      const res = await sendAgentAction({
+        serverUrl,
+        accountUid,
+        action: path
+          ? {_: 'DownloadAgentMemoryFile', agentId, url, path}
+          : {_: 'DownloadAgentMemoryFile', agentId, url},
+      })
+      if (res._ !== 'DownloadAgentMemoryFileResponse') throw new Error('Unexpected DownloadAgentMemoryFile response')
+      return res
+    },
+    onSuccess() {
+      invalidateQueries(['agents', 'memory'])
+    },
+  })
+}
+
+/** Uploads one agent memory file to IPFS via the HM server, returning its ipfs:// URL. */
+export function useUploadAgentMemoryFileToIpfs(serverUrl: string | undefined, accountUid: string | null | undefined) {
+  return useMutation({
+    mutationFn: async ({agentId, path}: {agentId: string; path: string}) => {
+      if (!serverUrl || !accountUid) throw new Error('Select an account and agent server first')
+      const res = await sendAgentAction({
+        serverUrl,
+        accountUid,
+        action: {_: 'UploadAgentMemoryFileToIpfs', agentId, path},
+      })
+      if (res._ !== 'UploadAgentMemoryFileToIpfsResponse')
+        throw new Error('Unexpected UploadAgentMemoryFileToIpfs response')
+      return res
     },
   })
 }

--- a/frontend/apps/desktop/src/pages/agents/agent-tools.ts
+++ b/frontend/apps/desktop/src/pages/agents/agent-tools.ts
@@ -13,12 +13,25 @@ export const AGENT_WEB_TOOL_GROUP = [seedToolRegistry.web_search.name, seedToolR
 /** Tool that lets an agent create, sign, and publish Seed content. */
 export const AGENT_WRITE_TOOL = seedToolRegistry.write.name
 
+/** Tools that let an agent read and write its private persistent memory filesystem. */
+export const AGENT_MEMORY_TOOL_GROUP = [
+  seedToolRegistry.memory_list.name,
+  seedToolRegistry.memory_read.name,
+  seedToolRegistry.memory_write.name,
+  seedToolRegistry.memory_delete.name,
+]
+
 /**
- * Tools granted to a newly created agent: full read access, web search/read, and
- * write, so the agent can research and publish as its own auto-created account
- * without extra setup.
+ * Tools granted to a newly created agent: full read access, web search/read, persistent
+ * memory, and write, so the agent can research, remember, and publish as its own
+ * auto-created account without extra setup.
  */
-export const DEFAULT_AGENT_TOOLS = [...AGENT_READ_TOOL_GROUP, ...AGENT_WEB_TOOL_GROUP, AGENT_WRITE_TOOL]
+export const DEFAULT_AGENT_TOOLS = [
+  ...AGENT_READ_TOOL_GROUP,
+  ...AGENT_WEB_TOOL_GROUP,
+  ...AGENT_MEMORY_TOOL_GROUP,
+  AGENT_WRITE_TOOL,
+]
 
 /** Web-backend capabilities a server advertises in its health response. */
 export type AgentServerWebCapabilities = {search: boolean; readBrowser: boolean}

--- a/frontend/apps/desktop/src/pages/agents/agent-tools.ts
+++ b/frontend/apps/desktop/src/pages/agents/agent-tools.ts
@@ -19,6 +19,8 @@ export const AGENT_MEMORY_TOOL_GROUP = [
   seedToolRegistry.memory_read.name,
   seedToolRegistry.memory_write.name,
   seedToolRegistry.memory_delete.name,
+  seedToolRegistry.memory_download.name,
+  seedToolRegistry.memory_upload_ipfs.name,
 ]
 
 /**

--- a/frontend/apps/desktop/src/pages/agents/detail.tsx
+++ b/frontend/apps/desktop/src/pages/agents/detail.tsx
@@ -53,11 +53,13 @@ import {Info, KeyRound, Plus, Trash2} from 'lucide-react'
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {getSeedToolMetadata, seedToolRegistry} from '../../../../../../agents/protocol/src/tool-registry'
 import {
+  AGENT_MEMORY_TOOL_GROUP,
   AGENT_READ_TOOL_GROUP,
   AGENT_WEB_TOOL_GROUP,
   getToolAvailability,
   type AgentServerWebCapabilities,
 } from './agent-tools'
+import {AgentMemoryTab} from './memory'
 import {TriggerSourceFields, summarizeTriggerSource} from './trigger-types'
 import {AddModelProviderDialog, EditAgentNameDialog, type AgentAccountRenameStatus} from './dialogs'
 import {AgentHeader, AgentSubpageHeader, type AgentPageTab} from './header'
@@ -408,6 +410,10 @@ function AgentDetailPage({
                 />
               ) : null}
 
+              {tab === 'memory' ? (
+                <AgentMemoryTab serverUrl={serverUrl} accountUid={selectedAccountId ?? null} agentId={agentId} />
+              ) : null}
+
               {tab === 'tools' ? (
                 <AgentToolsTab
                   definition={agent.data.agent.definition}
@@ -695,6 +701,11 @@ const AGENT_TOOL_OPTIONS = [
     names: AGENT_WEB_TOOL_GROUP,
     title: 'Search and read the web',
     description: 'Search the public web and read web pages as markdown. Requires server web backends.',
+  },
+  {
+    names: AGENT_MEMORY_TOOL_GROUP,
+    title: 'Memory',
+    description: 'Read and write private files in this agent’s persistent memory, shown on the Memory tab.',
   },
   {
     names: [seedToolRegistry.write.name],

--- a/frontend/apps/desktop/src/pages/agents/header.tsx
+++ b/frontend/apps/desktop/src/pages/agents/header.tsx
@@ -10,6 +10,7 @@ import {ReasoningBadge} from './reasoning-select'
 import {SizableText} from '@shm/ui/text'
 import {
   ArrowLeft,
+  Brain,
   GitBranch,
   MessageSquarePlus,
   MessagesSquare,
@@ -20,7 +21,7 @@ import {
 } from 'lucide-react'
 import React, {Fragment, type ReactNode, useRef, useState} from 'react'
 
-export type AgentPageTab = 'sessions' | 'triggers' | 'tools' | 'prompt' | 'settings'
+export type AgentPageTab = 'sessions' | 'triggers' | 'memory' | 'tools' | 'prompt' | 'settings'
 
 export type AgentHeaderInfo = {
   definition: AgentDefinition
@@ -209,6 +210,7 @@ export function AgentHeader({
       icon: GitBranch,
       count: triggersCount || undefined,
     },
+    {key: 'memory' as const, label: 'Memory', tooltip: "Browse and edit the agent's memory files", icon: Brain},
     {key: 'tools' as const, label: 'Tools', tooltip: 'Control tools and signing identities', icon: Wrench},
     {key: 'prompt' as const, label: 'Prompt', tooltip: 'Edit the system prompt', icon: ScrollText},
     {key: 'settings' as const, label: 'Settings', tooltip: 'Edit agent settings', icon: Settings},

--- a/frontend/apps/desktop/src/pages/agents/memory.tsx
+++ b/frontend/apps/desktop/src/pages/agents/memory.tsx
@@ -1,18 +1,40 @@
-import type {AgentMemoryEntry} from '@/agents-client'
-import {useAgentMemory, useAgentMemoryFile, useDeleteAgentMemoryFile, useWriteAgentMemoryFile} from '@/models/agents'
+import type {AgentMemoryEntry, AgentMemoryFile} from '@/agents-client'
+import {
+  useAgentMemory,
+  useAgentMemoryFile,
+  useDeleteAgentMemoryFile,
+  useDownloadAgentMemoryFile,
+  useUploadAgentMemoryFileToIpfs,
+  useWriteAgentMemoryFile,
+} from '@/models/agents'
 import {formattedDateMedium} from '@shm/shared/utils/date'
 import {Button} from '@shm/ui/button'
 import {Input} from '@shm/ui/components/input'
 import {Spinner} from '@shm/ui/spinner'
 import {SizableText} from '@shm/ui/text'
 import {toast} from '@shm/ui/toast'
-import {FilePlus, FileText, Folder, RotateCcw, Save, Trash2} from 'lucide-react'
-import {useEffect, useState} from 'react'
+import {
+  Copy,
+  Download,
+  FilePlus,
+  FileText,
+  Folder,
+  Globe,
+  RotateCcw,
+  Save,
+  Trash2,
+  Upload,
+  UploadCloud,
+} from 'lucide-react'
+import {useEffect, useMemo, useRef, useState} from 'react'
 
 /**
  * The agent Memory tab: a browser/editor for the agent's private persistent filesystem.
  * The same files are read and written by the agent's `memory_*` session tools, so this
- * gives the user full visibility and control over what the agent remembers.
+ * gives the user full visibility and control over what the agent remembers. Text files
+ * are editable in place; binary files (media the agent downloaded, or files the user
+ * uploads) get previews, on-demand download, and one-click IPFS publishing for use in
+ * Hypermedia content.
  */
 export function AgentMemoryTab({
   serverUrl,
@@ -26,11 +48,20 @@ export function AgentMemoryTab({
   const memory = useAgentMemory(serverUrl, accountUid, agentId)
   const writeFile = useWriteAgentMemoryFile(serverUrl, accountUid)
   const deleteFile = useDeleteAgentMemoryFile(serverUrl, accountUid)
+  const downloadFromWeb = useDownloadAgentMemoryFile(serverUrl, accountUid)
+  const uploadToIpfs = useUploadAgentMemoryFileToIpfs(serverUrl, accountUid)
   const [selectedPath, setSelectedPath] = useState<string | null>(null)
   const [draftText, setDraftText] = useState<string | null>(null)
   const [newFilePath, setNewFilePath] = useState('')
-  const [showNewFile, setShowNewFile] = useState(false)
+  const [addPanel, setAddPanel] = useState<'none' | 'new-file' | 'from-url'>('none')
+  const [webUrl, setWebUrl] = useState('')
+  const [webPath, setWebPath] = useState('')
   const [confirmDeletePath, setConfirmDeletePath] = useState<string | null>(null)
+  /** Where dragged files would land: '' = memory root, a path = that folder, null = no drag. */
+  const [dropTarget, setDropTarget] = useState<string | null>(null)
+  /** Last IPFS publish result per memory path, kept so the URL stays visible/copyable. */
+  const [ipfsUrls, setIpfsUrls] = useState<Record<string, string>>({})
+  const uploadInputRef = useRef<HTMLInputElement>(null)
   const file = useAgentMemoryFile(serverUrl, accountUid, agentId, selectedPath ?? undefined)
 
   const entries = memory.data?.entries ?? []
@@ -58,10 +89,48 @@ export function AgentMemoryTab({
     try {
       await writeFile.mutateAsync({agentId, path, content: ''})
       setNewFilePath('')
-      setShowNewFile(false)
+      setAddPanel('none')
       selectFile(path.replace(/^\/+/, ''))
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Could not create memory file')
+    }
+  }
+
+  async function handleDownloadFromWeb() {
+    const url = webUrl.trim()
+    if (!url) return
+    try {
+      const result = await downloadFromWeb.mutateAsync({agentId, url, path: webPath.trim() || undefined})
+      setWebUrl('')
+      setWebPath('')
+      setAddPanel('none')
+      selectFile(result.entry.path)
+      toast.success(`Downloaded to ${result.entry.path}`)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Could not download the file')
+    }
+  }
+
+  /** Uploads local files into memory, optionally inside a target directory. */
+  async function handleUploadLocalFiles(localFiles: File[], dirPath?: string) {
+    let lastPath: string | null = null
+    for (const localFile of localFiles) {
+      try {
+        const bytes = new Uint8Array(await localFile.arrayBuffer())
+        const path = dirPath ? `${dirPath}/${localFile.name}` : localFile.name
+        await writeFile.mutateAsync({agentId, path, content: bytes})
+        lastPath = path
+      } catch (error) {
+        toast.error(error instanceof Error ? `${localFile.name}: ${error.message}` : 'Could not add the file to memory')
+      }
+    }
+    if (lastPath) {
+      selectFile(lastPath)
+      toast.success(
+        localFiles.length === 1
+          ? `Added ${lastPath} to memory`
+          : `Added ${localFiles.length} files to memory${dirPath ? ` in ${dirPath}/` : ''}`,
+      )
     }
   }
 
@@ -88,7 +157,20 @@ export function AgentMemoryTab({
     }
   }
 
+  async function handlePublishToIpfs() {
+    if (!selectedPath) return
+    try {
+      const result = await uploadToIpfs.mutateAsync({agentId, path: selectedPath})
+      setIpfsUrls((current) => ({...current, [result.path]: result.url}))
+      await copyText(result.url)
+      toast.success(`Published to IPFS — URL copied: ${result.url}`)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Could not upload to IPFS')
+    }
+  }
+
   const dirty = draftText !== null && draftText !== (file.data?.content ?? '')
+  const selectedIpfsUrl = selectedPath ? ipfsUrls[selectedPath] : undefined
 
   return (
     <section className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden">
@@ -102,12 +184,44 @@ export function AgentMemoryTab({
               : ''}
           </SizableText>
         </div>
-        <Button variant="outline" size="sm" onClick={() => setShowNewFile((current) => !current)}>
-          <FilePlus className="mr-2 size-4" /> New file
-        </Button>
+        <div className="flex flex-none items-center gap-2">
+          <input
+            ref={uploadInputRef}
+            type="file"
+            multiple
+            className="hidden"
+            onChange={(event) => {
+              const localFiles = Array.from(event.currentTarget.files ?? [])
+              event.currentTarget.value = ''
+              if (localFiles.length) void handleUploadLocalFiles(localFiles)
+            }}
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => uploadInputRef.current?.click()}
+            disabled={writeFile.isLoading}
+          >
+            <Upload className="mr-2 size-4" /> Add file
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setAddPanel((current) => (current === 'from-url' ? 'none' : 'from-url'))}
+          >
+            <Globe className="mr-2 size-4" /> From URL
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setAddPanel((current) => (current === 'new-file' ? 'none' : 'new-file'))}
+          >
+            <FilePlus className="mr-2 size-4" /> New file
+          </Button>
+        </div>
       </div>
 
-      {showNewFile ? (
+      {addPanel === 'new-file' ? (
         <form
           className="border-border bg-card flex items-center gap-2 rounded-lg border p-2"
           onSubmit={(event) => {
@@ -125,14 +239,66 @@ export function AgentMemoryTab({
           <Button type="submit" size="sm" disabled={!newFilePath.trim() || writeFile.isLoading}>
             Create
           </Button>
-          <Button type="button" variant="ghost" size="sm" onClick={() => setShowNewFile(false)}>
+          <Button type="button" variant="ghost" size="sm" onClick={() => setAddPanel('none')}>
+            Cancel
+          </Button>
+        </form>
+      ) : null}
+
+      {addPanel === 'from-url' ? (
+        <form
+          className="border-border bg-card flex items-center gap-2 rounded-lg border p-2"
+          onSubmit={(event) => {
+            event.preventDefault()
+            void handleDownloadFromWeb()
+          }}
+        >
+          <Input
+            autoFocus
+            value={webUrl}
+            onChange={(event) => setWebUrl(event.target.value)}
+            placeholder="https://example.com/file.png"
+            aria-label="URL to download into memory"
+          />
+          <Input
+            value={webPath}
+            onChange={(event) => setWebPath(event.target.value)}
+            placeholder="Optional path (media/file.png)"
+            aria-label="Optional memory path for the download"
+            className="max-w-56"
+          />
+          <Button type="submit" size="sm" disabled={!webUrl.trim() || downloadFromWeb.isLoading}>
+            {downloadFromWeb.isLoading ? 'Downloading…' : 'Download'}
+          </Button>
+          <Button type="button" variant="ghost" size="sm" onClick={() => setAddPanel('none')}>
             Cancel
           </Button>
         </form>
       ) : null}
 
       <div className="flex min-h-0 flex-1 gap-4">
-        <div className="border-border bg-card flex w-64 flex-none flex-col overflow-y-auto rounded-xl border p-2">
+        <div
+          className={`border-border bg-card flex w-64 flex-none flex-col overflow-y-auto rounded-xl border p-2 ${
+            dropTarget === '' ? 'ring-primary/50 ring-2' : ''
+          }`}
+          onDragOver={(event) => {
+            if (!hasDraggedFiles(event)) return
+            event.preventDefault()
+            // Dir rows stop propagation while hovered, so reaching here means the root is targeted.
+            setDropTarget('')
+          }}
+          onDragLeave={(event) => {
+            if (event.currentTarget.contains(event.relatedTarget as Node | null)) return
+            setDropTarget(null)
+          }}
+          onDrop={(event) => {
+            if (!hasDraggedFiles(event)) return
+            event.preventDefault()
+            setDropTarget(null)
+            const localFiles = Array.from(event.dataTransfer.files)
+            if (localFiles.length) void handleUploadLocalFiles(localFiles)
+          }}
+        >
           {memory.isLoading ? (
             <div className="flex items-center justify-center p-4">
               <Spinner />
@@ -143,7 +309,8 @@ export function AgentMemoryTab({
             </SizableText>
           ) : entries.length === 0 ? (
             <SizableText size="sm" color="muted" className="p-2">
-              No memory yet. The agent stores files here as it works, and you can add files for it to find.
+              No memory yet. The agent stores files here as it works, and you can add files for it to find — or drop
+              files here.
             </SizableText>
           ) : (
             entries.map((entry) => (
@@ -157,6 +324,29 @@ export function AgentMemoryTab({
                 onCancelDelete={() => setConfirmDeletePath(null)}
                 onConfirmDelete={() => void handleDelete(entry.path)}
                 deleting={deleteFile.isLoading && confirmDeletePath === entry.path}
+                dropTargeted={entry.type === 'dir' && dropTarget === entry.path}
+                onDirDragOver={
+                  entry.type === 'dir'
+                    ? (event) => {
+                        if (!hasDraggedFiles(event)) return
+                        event.preventDefault()
+                        event.stopPropagation()
+                        setDropTarget(entry.path)
+                      }
+                    : undefined
+                }
+                onDirDrop={
+                  entry.type === 'dir'
+                    ? (event) => {
+                        if (!hasDraggedFiles(event)) return
+                        event.preventDefault()
+                        event.stopPropagation()
+                        setDropTarget(null)
+                        const localFiles = Array.from(event.dataTransfer.files)
+                        if (localFiles.length) void handleUploadLocalFiles(localFiles, entry.path)
+                      }
+                    : undefined
+                }
               />
             ))
           )}
@@ -179,20 +369,37 @@ export function AgentMemoryTab({
                 {file.error instanceof Error ? file.error.message : 'Could not read this memory file.'}
               </SizableText>
             </div>
-          ) : (
+          ) : file.data ? (
             <>
               <div className="border-border flex items-center gap-2 border-b px-3 py-2">
                 <FileText className="text-muted-foreground size-4 flex-none" />
                 <SizableText size="sm" weight="bold" className="min-w-0 flex-1 truncate font-mono">
                   {selectedPath}
                 </SizableText>
-                {file.data ? (
-                  <SizableText size="xs" color="muted" className="flex-none">
-                    {formatBytes(dirty ? new TextEncoder().encode(draftText ?? '').byteLength : file.data.size)}
-                    {file.data.updatedAt ? ` · ${formattedDateMedium(new Date(file.data.updatedAt))}` : ''}
-                  </SizableText>
-                ) : null}
-                {dirty ? (
+                <SizableText size="xs" color="muted" className="flex-none">
+                  {formatBytes(dirty ? new TextEncoder().encode(draftText ?? '').byteLength : file.data.size)}
+                  {file.data.mimeType ? ` · ${file.data.mimeType}` : ''}
+                  {file.data.updatedAt ? ` · ${formattedDateMedium(new Date(file.data.updatedAt))}` : ''}
+                </SizableText>
+                <Button
+                  variant="ghost"
+                  size="iconSm"
+                  className="flex-none"
+                  aria-label={`Download ${selectedPath}`}
+                  onClick={() => file.data && saveFileToDisk(file.data)}
+                >
+                  <Download className="size-3.5" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="flex-none"
+                  onClick={() => void handlePublishToIpfs()}
+                  disabled={uploadToIpfs.isLoading}
+                >
+                  <UploadCloud className="mr-1 size-3.5" /> {uploadToIpfs.isLoading ? 'Publishing…' : 'Publish to IPFS'}
+                </Button>
+                {file.data.encoding === 'utf8' && dirty ? (
                   <Button
                     variant="ghost"
                     size="sm"
@@ -203,27 +410,88 @@ export function AgentMemoryTab({
                     <RotateCcw className="mr-1 size-3.5" /> Revert
                   </Button>
                 ) : null}
-                <Button
-                  size="sm"
-                  className="flex-none"
-                  onClick={() => void handleSave()}
-                  disabled={!dirty || writeFile.isLoading}
-                >
-                  <Save className="mr-1 size-3.5" /> {writeFile.isLoading ? 'Saving…' : 'Save'}
-                </Button>
+                {file.data.encoding === 'utf8' ? (
+                  <Button
+                    size="sm"
+                    className="flex-none"
+                    onClick={() => void handleSave()}
+                    disabled={!dirty || writeFile.isLoading}
+                  >
+                    <Save className="mr-1 size-3.5" /> {writeFile.isLoading ? 'Saving…' : 'Save'}
+                  </Button>
+                ) : null}
               </div>
-              <textarea
-                aria-label={`Memory file ${selectedPath}`}
-                className="focus:ring-primary/25 min-h-0 flex-1 resize-none bg-transparent p-3 font-mono text-sm outline-none focus:ring-2"
-                value={draftText ?? file.data?.content ?? ''}
-                onChange={(event) => setDraftText(event.currentTarget.value)}
-                spellCheck={false}
-              />
+              {selectedIpfsUrl ? (
+                <div className="border-border bg-muted/40 flex items-center gap-2 border-b px-3 py-1.5">
+                  <SizableText size="xs" color="muted" className="flex-none">
+                    IPFS:
+                  </SizableText>
+                  <SizableText size="xs" className="min-w-0 flex-1 truncate font-mono">
+                    {selectedIpfsUrl}
+                  </SizableText>
+                  <Button
+                    variant="ghost"
+                    size="iconSm"
+                    className="flex-none"
+                    aria-label="Copy IPFS URL"
+                    onClick={() => void copyText(selectedIpfsUrl).then(() => toast.success('IPFS URL copied'))}
+                  >
+                    <Copy className="size-3.5" />
+                  </Button>
+                </div>
+              ) : null}
+              {file.data.encoding === 'utf8' ? (
+                <textarea
+                  aria-label={`Memory file ${selectedPath}`}
+                  className="focus:ring-primary/25 min-h-0 flex-1 resize-none bg-transparent p-3 font-mono text-sm outline-none focus:ring-2"
+                  value={draftText ?? file.data.content ?? ''}
+                  onChange={(event) => setDraftText(event.currentTarget.value)}
+                  spellCheck={false}
+                />
+              ) : (
+                <BinaryFilePreview file={file.data} />
+              )}
             </>
-          )}
+          ) : null}
         </div>
       </div>
     </section>
+  )
+}
+
+/** Renders an inline media preview for binary memory files, or a download hint otherwise. */
+function BinaryFilePreview({file}: {file: AgentMemoryFile}) {
+  const objectUrl = useMemo(() => {
+    if (!file.data) return null
+    const blob = new Blob([new Uint8Array(file.data)], file.mimeType ? {type: file.mimeType} : undefined)
+    return URL.createObjectURL(blob)
+  }, [file])
+
+  useEffect(() => {
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl)
+    }
+  }, [objectUrl])
+
+  const kind = file.mimeType?.split('/')[0]
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-4">
+      {objectUrl && kind === 'image' ? (
+        <img src={objectUrl} alt={file.path} className="max-h-full max-w-full rounded-md object-contain" />
+      ) : objectUrl && kind === 'video' ? (
+        <video src={objectUrl} controls className="max-h-full max-w-full rounded-md" />
+      ) : objectUrl && kind === 'audio' ? (
+        <audio src={objectUrl} controls className="w-full max-w-md" />
+      ) : (
+        <div className="flex flex-col items-center gap-2">
+          <FileText className="text-muted-foreground size-8" />
+          <SizableText size="sm" color="muted">
+            No preview for this file type{file.mimeType ? ` (${file.mimeType})` : ''}. Use the download button to save
+            it.
+          </SizableText>
+        </div>
+      )}
+    </div>
   )
 }
 
@@ -236,6 +504,9 @@ function MemoryEntryRow({
   onRequestDelete,
   onCancelDelete,
   onConfirmDelete,
+  dropTargeted,
+  onDirDragOver,
+  onDirDrop,
 }: {
   entry: AgentMemoryEntry
   selected: boolean
@@ -245,15 +516,21 @@ function MemoryEntryRow({
   onRequestDelete: () => void
   onCancelDelete: () => void
   onConfirmDelete: () => void
+  /** True while dragged files hover this directory row. */
+  dropTargeted?: boolean
+  onDirDragOver?: (event: React.DragEvent<HTMLDivElement>) => void
+  onDirDrop?: (event: React.DragEvent<HTMLDivElement>) => void
 }) {
   const depth = entry.path.split('/').length - 1
   const name = entry.path.split('/').at(-1) || entry.path
   return (
     <div
       className={`group flex items-center gap-1 rounded-md px-1 py-0.5 ${
-        selected ? 'bg-primary/10' : 'hover:bg-muted/60'
+        selected ? 'bg-primary/10' : dropTargeted ? 'bg-primary/15 ring-primary/50 ring-1' : 'hover:bg-muted/60'
       }`}
       style={{paddingLeft: `${4 + depth * 14}px`}}
+      onDragOver={onDirDragOver}
+      onDrop={onDirDrop}
     >
       {entry.type === 'dir' ? (
         <span className="text-muted-foreground flex min-w-0 flex-1 items-center gap-1.5 py-0.5">
@@ -264,6 +541,7 @@ function MemoryEntryRow({
         <button type="button" className="flex min-w-0 flex-1 items-center gap-1.5 py-0.5 text-left" onClick={onSelect}>
           <FileText className="text-muted-foreground size-3.5 flex-none" />
           <span className="truncate font-mono text-xs">{name}</span>
+          <span className="text-muted-foreground/70 ml-auto flex-none pr-1 text-[10px]">{formatBytes(entry.size)}</span>
         </button>
       )}
       {confirmingDelete ? (
@@ -288,6 +566,34 @@ function MemoryEntryRow({
       )}
     </div>
   )
+}
+
+/** True when a drag event carries OS files (rather than in-app text/element drags). */
+function hasDraggedFiles(event: React.DragEvent): boolean {
+  return Array.from(event.dataTransfer.types).includes('Files')
+}
+
+/** Saves a memory file to the user's computer via a browser download. */
+function saveFileToDisk(file: AgentMemoryFile) {
+  const bytes =
+    file.encoding === 'binary' ? file.data ?? new Uint8Array() : new TextEncoder().encode(file.content ?? '')
+  const blob = new Blob([new Uint8Array(bytes)], file.mimeType ? {type: file.mimeType} : undefined)
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = file.path.split('/').at(-1) || 'file'
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(url)
+}
+
+async function copyText(text: string) {
+  try {
+    await navigator.clipboard.writeText(text)
+  } catch {
+    // Clipboard access can fail outside a focused window; the URL stays visible for manual copy.
+  }
 }
 
 function formatBytes(bytes: number): string {

--- a/frontend/apps/desktop/src/pages/agents/memory.tsx
+++ b/frontend/apps/desktop/src/pages/agents/memory.tsx
@@ -10,6 +10,7 @@ import {
 import {formattedDateMedium} from '@shm/shared/utils/date'
 import {Button} from '@shm/ui/button'
 import {Input} from '@shm/ui/components/input'
+import {OptionsDropdown} from '@shm/ui/options-dropdown'
 import {Spinner} from '@shm/ui/spinner'
 import {SizableText} from '@shm/ui/text'
 import {toast} from '@shm/ui/toast'
@@ -276,10 +277,10 @@ export function AgentMemoryTab({
         </form>
       ) : null}
 
-      <div className="flex min-h-0 flex-1 gap-4">
+      <div className="border-border bg-card flex min-h-0 flex-1 overflow-hidden rounded-xl border">
         <div
-          className={`border-border bg-card flex w-64 flex-none flex-col overflow-y-auto rounded-xl border p-2 ${
-            dropTarget === '' ? 'ring-primary/50 ring-2' : ''
+          className={`border-border flex w-64 flex-none flex-col overflow-y-auto border-r p-2 ${
+            dropTarget === '' ? 'ring-primary/50 ring-2 ring-inset' : ''
           }`}
           onDragOver={(event) => {
             if (!hasDraggedFiles(event)) return
@@ -352,7 +353,7 @@ export function AgentMemoryTab({
           )}
         </div>
 
-        <div className="border-border bg-card flex min-w-0 flex-1 flex-col overflow-hidden rounded-xl border">
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
           {selectedPath === null ? (
             <div className="flex flex-1 items-center justify-center p-6">
               <SizableText size="sm" color="muted">
@@ -381,45 +382,45 @@ export function AgentMemoryTab({
                   {file.data.mimeType ? ` · ${file.data.mimeType}` : ''}
                   {file.data.updatedAt ? ` · ${formattedDateMedium(new Date(file.data.updatedAt))}` : ''}
                 </SizableText>
-                <Button
-                  variant="ghost"
-                  size="iconSm"
-                  className="flex-none"
-                  aria-label={`Download ${selectedPath}`}
-                  onClick={() => file.data && saveFileToDisk(file.data)}
-                >
-                  <Download className="size-3.5" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="flex-none"
-                  onClick={() => void handlePublishToIpfs()}
-                  disabled={uploadToIpfs.isLoading}
-                >
-                  <UploadCloud className="mr-1 size-3.5" /> {uploadToIpfs.isLoading ? 'Publishing…' : 'Publish to IPFS'}
-                </Button>
                 {file.data.encoding === 'utf8' && dirty ? (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="flex-none"
-                    onClick={() => setDraftText(null)}
-                    disabled={writeFile.isLoading}
-                  >
-                    <RotateCcw className="mr-1 size-3.5" /> Revert
-                  </Button>
+                  <>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="flex-none"
+                      onClick={() => setDraftText(null)}
+                      disabled={writeFile.isLoading}
+                    >
+                      <RotateCcw className="mr-1 size-3.5" /> Revert
+                    </Button>
+                    <Button
+                      size="sm"
+                      className="flex-none"
+                      onClick={() => void handleSave()}
+                      disabled={writeFile.isLoading}
+                    >
+                      <Save className="mr-1 size-3.5" /> {writeFile.isLoading ? 'Saving…' : 'Save'}
+                    </Button>
+                  </>
                 ) : null}
-                {file.data.encoding === 'utf8' ? (
-                  <Button
-                    size="sm"
-                    className="flex-none"
-                    onClick={() => void handleSave()}
-                    disabled={!dirty || writeFile.isLoading}
-                  >
-                    <Save className="mr-1 size-3.5" /> {writeFile.isLoading ? 'Saving…' : 'Save'}
-                  </Button>
-                ) : null}
+                <OptionsDropdown
+                  align="end"
+                  menuItems={[
+                    {
+                      key: 'download',
+                      icon: <Download className="size-4" />,
+                      label: 'Download',
+                      onClick: () => file.data && saveFileToDisk(file.data),
+                    },
+                    {
+                      key: 'publish-ipfs',
+                      icon: <UploadCloud className="size-4" />,
+                      label: uploadToIpfs.isLoading ? 'Publishing…' : 'Publish to IPFS',
+                      disabled: uploadToIpfs.isLoading,
+                      onClick: () => void handlePublishToIpfs(),
+                    },
+                  ]}
+                />
               </div>
               {selectedIpfsUrl ? (
                 <div className="border-border bg-muted/40 flex items-center gap-2 border-b px-3 py-1.5">

--- a/frontend/apps/desktop/src/pages/agents/memory.tsx
+++ b/frontend/apps/desktop/src/pages/agents/memory.tsx
@@ -450,7 +450,7 @@ export function AgentMemoryTab({
                   spellCheck={false}
                 />
               ) : (
-                <BinaryFilePreview file={file.data} />
+                <BinaryFilePreview file={file.data} onDownload={() => file.data && saveFileToDisk(file.data)} />
               )}
             </>
           ) : null}
@@ -460,10 +460,13 @@ export function AgentMemoryTab({
   )
 }
 
-/** Renders an inline media preview for binary memory files, or a download hint otherwise. */
-function BinaryFilePreview({file}: {file: AgentMemoryFile}) {
+/**
+ * Renders binary memory files: inline previews for images (including animated GIFs), video, and
+ * audio, and a download-first card for every other binary type.
+ */
+function BinaryFilePreview({file, onDownload}: {file: AgentMemoryFile; onDownload: () => void}) {
   const objectUrl = useMemo(() => {
-    if (!file.data) return null
+    if (!file.data || !file.data.byteLength) return null
     const blob = new Blob([new Uint8Array(file.data)], file.mimeType ? {type: file.mimeType} : undefined)
     return URL.createObjectURL(blob)
   }, [file])
@@ -475,23 +478,59 @@ function BinaryFilePreview({file}: {file: AgentMemoryFile}) {
   }, [objectUrl])
 
   const kind = file.mimeType?.split('/')[0]
-  return (
-    <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-4">
-      {objectUrl && kind === 'image' ? (
+  if (objectUrl && kind === 'image') {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-4">
         <img src={objectUrl} alt={file.path} className="max-h-full max-w-full rounded-md object-contain" />
-      ) : objectUrl && kind === 'video' ? (
+      </div>
+    )
+  }
+  if (objectUrl && kind === 'video') {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-4">
         <video src={objectUrl} controls className="max-h-full max-w-full rounded-md" />
-      ) : objectUrl && kind === 'audio' ? (
+      </div>
+    )
+  }
+  if (objectUrl && kind === 'audio') {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-4">
         <audio src={objectUrl} controls className="w-full max-w-md" />
-      ) : (
-        <div className="flex flex-col items-center gap-2">
-          <FileText className="text-muted-foreground size-8" />
-          <SizableText size="sm" color="muted">
-            No preview for this file type{file.mimeType ? ` (${file.mimeType})` : ''}. Use the download button to save
-            it.
+      </div>
+    )
+  }
+  const name = file.path.split('/').at(-1) || file.path
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-6">
+      <div className="border-border bg-muted/30 flex w-full max-w-sm flex-col items-center gap-3 rounded-xl border border-dashed p-8">
+        <div className="bg-muted text-muted-foreground flex size-14 items-center justify-center rounded-xl">
+          <FileText className="size-7" />
+        </div>
+        <div className="flex flex-col items-center gap-0.5">
+          <SizableText size="sm" weight="bold" className="max-w-full truncate font-mono">
+            {name}
+          </SizableText>
+          <SizableText size="xs" color="muted">
+            {formatBytes(file.size)}
+            {file.mimeType ? ` · ${file.mimeType}` : ' · binary file'}
           </SizableText>
         </div>
-      )}
+        {objectUrl ? (
+          <>
+            <SizableText size="xs" color="muted" className="text-center">
+              This file type has no inline preview.
+            </SizableText>
+            <Button onClick={onDownload}>
+              <Download className="mr-2 size-4" /> Download
+            </Button>
+          </>
+        ) : (
+          <SizableText size="xs" color="muted" className="text-center">
+            The file content could not be loaded for preview. If this agent server was recently updated, restart it and
+            reopen the file.
+          </SizableText>
+        )}
+      </div>
     </div>
   )
 }

--- a/frontend/apps/desktop/src/pages/agents/memory.tsx
+++ b/frontend/apps/desktop/src/pages/agents/memory.tsx
@@ -1,0 +1,297 @@
+import type {AgentMemoryEntry} from '@/agents-client'
+import {useAgentMemory, useAgentMemoryFile, useDeleteAgentMemoryFile, useWriteAgentMemoryFile} from '@/models/agents'
+import {formattedDateMedium} from '@shm/shared/utils/date'
+import {Button} from '@shm/ui/button'
+import {Input} from '@shm/ui/components/input'
+import {Spinner} from '@shm/ui/spinner'
+import {SizableText} from '@shm/ui/text'
+import {toast} from '@shm/ui/toast'
+import {FilePlus, FileText, Folder, RotateCcw, Save, Trash2} from 'lucide-react'
+import {useEffect, useState} from 'react'
+
+/**
+ * The agent Memory tab: a browser/editor for the agent's private persistent filesystem.
+ * The same files are read and written by the agent's `memory_*` session tools, so this
+ * gives the user full visibility and control over what the agent remembers.
+ */
+export function AgentMemoryTab({
+  serverUrl,
+  accountUid,
+  agentId,
+}: {
+  serverUrl: string
+  accountUid: string | null
+  agentId: string
+}) {
+  const memory = useAgentMemory(serverUrl, accountUid, agentId)
+  const writeFile = useWriteAgentMemoryFile(serverUrl, accountUid)
+  const deleteFile = useDeleteAgentMemoryFile(serverUrl, accountUid)
+  const [selectedPath, setSelectedPath] = useState<string | null>(null)
+  const [draftText, setDraftText] = useState<string | null>(null)
+  const [newFilePath, setNewFilePath] = useState('')
+  const [showNewFile, setShowNewFile] = useState(false)
+  const [confirmDeletePath, setConfirmDeletePath] = useState<string | null>(null)
+  const file = useAgentMemoryFile(serverUrl, accountUid, agentId, selectedPath ?? undefined)
+
+  const entries = memory.data?.entries ?? []
+  const fileCount = entries.filter((entry) => entry.type === 'file').length
+
+  // Drop the selection when the selected file disappears from the listing (e.g. the
+  // agent or another window deleted it).
+  useEffect(() => {
+    if (!selectedPath || !memory.data) return
+    if (!memory.data.entries.some((entry) => entry.type === 'file' && entry.path === selectedPath)) {
+      setSelectedPath(null)
+      setDraftText(null)
+    }
+  }, [memory.data, selectedPath])
+
+  function selectFile(path: string) {
+    setSelectedPath(path)
+    setDraftText(null)
+    setConfirmDeletePath(null)
+  }
+
+  async function handleCreateFile() {
+    const path = newFilePath.trim()
+    if (!path) return
+    try {
+      await writeFile.mutateAsync({agentId, path, content: ''})
+      setNewFilePath('')
+      setShowNewFile(false)
+      selectFile(path.replace(/^\/+/, ''))
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Could not create memory file')
+    }
+  }
+
+  async function handleSave() {
+    if (selectedPath === null || draftText === null) return
+    try {
+      await writeFile.mutateAsync({agentId, path: selectedPath, content: draftText})
+      setDraftText(null)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Could not save memory file')
+    }
+  }
+
+  async function handleDelete(path: string) {
+    try {
+      await deleteFile.mutateAsync({agentId, path})
+      setConfirmDeletePath(null)
+      if (selectedPath === path || selectedPath?.startsWith(`${path}/`)) {
+        setSelectedPath(null)
+        setDraftText(null)
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Could not delete from memory')
+    }
+  }
+
+  const dirty = draftText !== null && draftText !== (file.data?.content ?? '')
+
+  return (
+    <section className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex flex-col">
+          <SizableText weight="bold">Memory</SizableText>
+          <SizableText size="xs" color="muted">
+            Private files this agent reads and writes across sessions. You can edit everything here.
+            {memory.data
+              ? ` ${fileCount} file${fileCount === 1 ? '' : 's'}, ${formatBytes(memory.data.totalBytes)}.`
+              : ''}
+          </SizableText>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => setShowNewFile((current) => !current)}>
+          <FilePlus className="mr-2 size-4" /> New file
+        </Button>
+      </div>
+
+      {showNewFile ? (
+        <form
+          className="border-border bg-card flex items-center gap-2 rounded-lg border p-2"
+          onSubmit={(event) => {
+            event.preventDefault()
+            void handleCreateFile()
+          }}
+        >
+          <Input
+            autoFocus
+            value={newFilePath}
+            onChange={(event) => setNewFilePath(event.target.value)}
+            placeholder="notes/topic.md"
+            aria-label="New memory file path"
+          />
+          <Button type="submit" size="sm" disabled={!newFilePath.trim() || writeFile.isLoading}>
+            Create
+          </Button>
+          <Button type="button" variant="ghost" size="sm" onClick={() => setShowNewFile(false)}>
+            Cancel
+          </Button>
+        </form>
+      ) : null}
+
+      <div className="flex min-h-0 flex-1 gap-4">
+        <div className="border-border bg-card flex w-64 flex-none flex-col overflow-y-auto rounded-xl border p-2">
+          {memory.isLoading ? (
+            <div className="flex items-center justify-center p-4">
+              <Spinner />
+            </div>
+          ) : memory.isError ? (
+            <SizableText size="sm" color="muted" className="p-2">
+              Could not load memory from the agent server.
+            </SizableText>
+          ) : entries.length === 0 ? (
+            <SizableText size="sm" color="muted" className="p-2">
+              No memory yet. The agent stores files here as it works, and you can add files for it to find.
+            </SizableText>
+          ) : (
+            entries.map((entry) => (
+              <MemoryEntryRow
+                key={entry.path}
+                entry={entry}
+                selected={entry.type === 'file' && entry.path === selectedPath}
+                confirmingDelete={confirmDeletePath === entry.path}
+                onSelect={() => (entry.type === 'file' ? selectFile(entry.path) : undefined)}
+                onRequestDelete={() => setConfirmDeletePath(entry.path)}
+                onCancelDelete={() => setConfirmDeletePath(null)}
+                onConfirmDelete={() => void handleDelete(entry.path)}
+                deleting={deleteFile.isLoading && confirmDeletePath === entry.path}
+              />
+            ))
+          )}
+        </div>
+
+        <div className="border-border bg-card flex min-w-0 flex-1 flex-col overflow-hidden rounded-xl border">
+          {selectedPath === null ? (
+            <div className="flex flex-1 items-center justify-center p-6">
+              <SizableText size="sm" color="muted">
+                Select a file to view and edit it.
+              </SizableText>
+            </div>
+          ) : file.isLoading ? (
+            <div className="flex flex-1 items-center justify-center p-6">
+              <Spinner />
+            </div>
+          ) : file.isError ? (
+            <div className="flex flex-1 items-center justify-center p-6">
+              <SizableText size="sm" color="muted">
+                {file.error instanceof Error ? file.error.message : 'Could not read this memory file.'}
+              </SizableText>
+            </div>
+          ) : (
+            <>
+              <div className="border-border flex items-center gap-2 border-b px-3 py-2">
+                <FileText className="text-muted-foreground size-4 flex-none" />
+                <SizableText size="sm" weight="bold" className="min-w-0 flex-1 truncate font-mono">
+                  {selectedPath}
+                </SizableText>
+                {file.data ? (
+                  <SizableText size="xs" color="muted" className="flex-none">
+                    {formatBytes(dirty ? new TextEncoder().encode(draftText ?? '').byteLength : file.data.size)}
+                    {file.data.updatedAt ? ` · ${formattedDateMedium(new Date(file.data.updatedAt))}` : ''}
+                  </SizableText>
+                ) : null}
+                {dirty ? (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="flex-none"
+                    onClick={() => setDraftText(null)}
+                    disabled={writeFile.isLoading}
+                  >
+                    <RotateCcw className="mr-1 size-3.5" /> Revert
+                  </Button>
+                ) : null}
+                <Button
+                  size="sm"
+                  className="flex-none"
+                  onClick={() => void handleSave()}
+                  disabled={!dirty || writeFile.isLoading}
+                >
+                  <Save className="mr-1 size-3.5" /> {writeFile.isLoading ? 'Saving…' : 'Save'}
+                </Button>
+              </div>
+              <textarea
+                aria-label={`Memory file ${selectedPath}`}
+                className="focus:ring-primary/25 min-h-0 flex-1 resize-none bg-transparent p-3 font-mono text-sm outline-none focus:ring-2"
+                value={draftText ?? file.data?.content ?? ''}
+                onChange={(event) => setDraftText(event.currentTarget.value)}
+                spellCheck={false}
+              />
+            </>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function MemoryEntryRow({
+  entry,
+  selected,
+  confirmingDelete,
+  deleting,
+  onSelect,
+  onRequestDelete,
+  onCancelDelete,
+  onConfirmDelete,
+}: {
+  entry: AgentMemoryEntry
+  selected: boolean
+  confirmingDelete: boolean
+  deleting: boolean
+  onSelect: () => void
+  onRequestDelete: () => void
+  onCancelDelete: () => void
+  onConfirmDelete: () => void
+}) {
+  const depth = entry.path.split('/').length - 1
+  const name = entry.path.split('/').at(-1) || entry.path
+  return (
+    <div
+      className={`group flex items-center gap-1 rounded-md px-1 py-0.5 ${
+        selected ? 'bg-primary/10' : 'hover:bg-muted/60'
+      }`}
+      style={{paddingLeft: `${4 + depth * 14}px`}}
+    >
+      {entry.type === 'dir' ? (
+        <span className="text-muted-foreground flex min-w-0 flex-1 items-center gap-1.5 py-0.5">
+          <Folder className="size-3.5 flex-none" />
+          <span className="truncate font-mono text-xs">{name}</span>
+        </span>
+      ) : (
+        <button type="button" className="flex min-w-0 flex-1 items-center gap-1.5 py-0.5 text-left" onClick={onSelect}>
+          <FileText className="text-muted-foreground size-3.5 flex-none" />
+          <span className="truncate font-mono text-xs">{name}</span>
+        </button>
+      )}
+      {confirmingDelete ? (
+        <span className="flex flex-none items-center gap-1">
+          <Button variant="destructive" size="xs" onClick={onConfirmDelete} disabled={deleting}>
+            {deleting ? 'Deleting…' : 'Delete'}
+          </Button>
+          <Button variant="ghost" size="xs" onClick={onCancelDelete} disabled={deleting}>
+            Cancel
+          </Button>
+        </span>
+      ) : (
+        <Button
+          variant="ghost"
+          size="iconSm"
+          aria-label={`Delete ${entry.path}`}
+          className="flex-none opacity-0 group-hover:opacity-100"
+          onClick={onRequestDelete}
+        >
+          <Trash2 className="size-3.5" />
+        </Button>
+      )}
+    </div>
+  )
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}

--- a/frontend/packages/shared/src/routes.ts
+++ b/frontend/packages/shared/src/routes.ts
@@ -340,7 +340,7 @@ export const agentRouteSchema = z.object({
   key: z.literal('agent'),
   agentId: z.string(),
   serverUrl: z.string().optional(),
-  tab: z.enum(['sessions', 'triggers', 'tools', 'prompt', 'settings']).optional(),
+  tab: z.enum(['sessions', 'triggers', 'memory', 'tools', 'prompt', 'settings']).optional(),
   triggerId: z.string().optional(),
 })
 /** Navigation route for one server-hosted agent. */


### PR DESCRIPTION
## Summary

Stacked on #911 (`feat/local-agents`). Adds persistent per-agent memory:

- **Memory filesystem**: each agent gets a memory file tree with read/write/list tools exposed to the model (`agents/src/agent-memory.ts` + tool registry entries)
- **Binary memory**: binary files supported with web downloads, IPFS publishing, and auto-listed memory contents
- **Desktop Memory tab**: new Memory tab on the agent detail page for browsing and managing an agent's memory, with media previews and a download-first fallback for binary files
- **API**: signed API endpoints for memory access (`agents/src/api-service.ts`), covered by tests (`agent-memory.test.ts`, `api-service.test.ts`)

## Test plan

- [ ] Agents package tests pass (`agent-memory.test.ts`, `api-service.test.ts`)
- [ ] Desktop Memory tab lists, previews, and downloads memory files
- [ ] Agent can read/write memory via tools across sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)