### PR TITLE
feat(agents): reasoning levels for agent models

### DIFF
--- a/agents/e2e-reasoning.ts
+++ b/agents/e2e-reasoning.ts
@@ -1,0 +1,62 @@
+// Manual e2e: drives the real Service against the real OpenAI API to prove the
+// gpt-5.6-terra + tools fix and reasoning levels. Run: bun e2e-reasoning.ts <api-key>
+// Kept as a manual script (not a bun test) because it spends real tokens.
+import {Database} from 'bun:sqlite'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import * as apisvc from './src/api-service'
+import * as sqlite from './src/sqlite'
+import * as blobs from '@shm/shared/blobs'
+
+const apiKey = process.argv[2]
+if (!apiKey) throw new Error('usage: bun e2e-reasoning.ts <openai-api-key>')
+
+const db = new Database(':memory:', {create: true, strict: true})
+const result = sqlite.openWithDatabase(db)
+if (!result.ok) throw new Error('schema mismatch')
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'seed-agents-e2e-'))
+const account = blobs.generateNobleKeyPair()
+const svc = new apisvc.Service(db, dataDir)
+
+async function send(action: unknown): Promise<any> {
+  return svc.message(await apisvc.createSignedEnvelope(account, {action} as never))
+}
+
+await send({_: 'SetModelProvider', name: 'openai', provider: {type: 'openai', secretRefs: {apiKey: 'openai-key'}}})
+await send({_: 'SetSecret', name: 'openai-key', value: new TextEncoder().encode(apiKey)})
+
+async function runScenario(model: string, reasoningLevel?: string): Promise<void> {
+  const created = await send({
+    _: 'CreateAgent',
+    definition: {
+      name: `E2E ${model} ${reasoningLevel ?? 'off'}`,
+      systemPrompt: 'You are terse. Answer in one short sentence.',
+      modelProvider: 'openai',
+      model,
+      ...(reasoningLevel ? {reasoningLevel} : {}),
+    },
+  })
+  if (created._ !== 'CreateAgentResponse') throw new Error('create failed')
+  const session = await send({_: 'CreateSession', agentId: created.agentId})
+  if (session._ !== 'CreateSessionResponse') throw new Error('session failed')
+  const reply = await send({
+    _: 'MessageSession',
+    sessionId: session.sessionId,
+    content: [{type: 'text', text: 'What is 2+2? Reply with just the number.'}],
+  })
+  if (reply._ !== 'MessageSessionResponse') throw new Error(`message failed: ${JSON.stringify(reply)}`)
+  const events = await send({_: 'GetSession', sessionId: session.sessionId})
+  const last = events.events[events.events.length - 1]?.event
+  console.log(`✔ ${model} / ${reasoningLevel ?? 'off'} →`, JSON.stringify(last).slice(0, 140))
+}
+
+try {
+  await runScenario('gpt-5.6-terra') // the exact case that 400'd in prod (tools + default reasoning)
+  await runScenario('gpt-5.6-terra', 'low') // reasoning + tools via Responses API
+  await runScenario('gpt-5-mini') // unchanged completions path
+  await runScenario('gpt-5-mini', 'minimal') // 5.0-family level via Responses API
+  console.log('ALL SCENARIOS PASSED')
+} finally {
+  fs.rmSync(dataDir, {recursive: true, force: true})
+}

--- a/agents/protocol/src/index.ts
+++ b/agents/protocol/src/index.ts
@@ -1,4 +1,7 @@
 export * from './tool-registry'
+export * from './reasoning'
+
+import type {ReasoningLevel} from './reasoning'
 
 /** Shared options for Seed assistant/agent system prompt construction. */
 export type SeedAssistantPromptOptions = {
@@ -39,6 +42,12 @@ export type AgentDefinition = {
   systemPrompt: string | AgentPromptBlock[]
   modelProvider: string
   model: string
+  /**
+   * Reasoning level for reasoning-capable models. Must be one of the levels
+   * `modelReasoningSupport` reports for the model. Absent means off (or the
+   * provider default when reasoning cannot be disabled).
+   */
+  reasoningLevel?: ReasoningLevel
   tools?: string[]
   signingKey?: string
   signingKeys?: string[]

--- a/agents/protocol/src/reasoning.test.ts
+++ b/agents/protocol/src/reasoning.test.ts
@@ -1,0 +1,70 @@
+import {describe, expect, test} from 'bun:test'
+import {isReasoningLevel, modelReasoningSupport} from './reasoning'
+
+describe('modelReasoningSupport', () => {
+  test('openai gpt-5.0 family: minimal..high, reasoning cannot be disabled', () => {
+    for (const model of ['gpt-5', 'gpt-5-mini', 'gpt-5-nano']) {
+      expect(modelReasoningSupport('openai', model)).toEqual({
+        levels: ['minimal', 'low', 'medium', 'high'],
+        offBehavior: 'default',
+        supportsEffortNone: false,
+      })
+    }
+  })
+
+  test('openai gpt-5.1: none + low..high', () => {
+    expect(modelReasoningSupport('openai', 'gpt-5.1')).toEqual({
+      levels: ['low', 'medium', 'high'],
+      offBehavior: 'off',
+      supportsEffortNone: true,
+    })
+  })
+
+  test('openai gpt-5.2 and newer: none + low..xhigh', () => {
+    for (const model of ['gpt-5.2', 'gpt-5.4', 'gpt-5.6-terra', 'gpt-6']) {
+      expect(modelReasoningSupport('openai', model)).toEqual({
+        levels: ['low', 'medium', 'high', 'xhigh'],
+        offBehavior: 'off',
+        supportsEffortNone: true,
+      })
+    }
+  })
+
+  test('openai o-series and non-reasoning models', () => {
+    expect(modelReasoningSupport('openai', 'o3')?.levels).toEqual(['low', 'medium', 'high'])
+    expect(modelReasoningSupport('openai', 'gpt-4.1')).toBeNull()
+    expect(modelReasoningSupport('openai', 'gpt-4o-mini')).toBeNull()
+    expect(modelReasoningSupport('openai', 'gpt-5-chat-latest')).toBeNull()
+  })
+
+  test('anthropic: extended thinking from claude-3-7 onward', () => {
+    expect(modelReasoningSupport('anthropic', 'claude-3-7-sonnet-latest')?.levels).toEqual([
+      'minimal',
+      'low',
+      'medium',
+      'high',
+    ])
+    expect(modelReasoningSupport('anthropic', 'claude-sonnet-4-5')?.offBehavior).toBe('off')
+    expect(modelReasoningSupport('anthropic', 'claude-3-5-haiku-latest')).toBeNull()
+  })
+
+  test('google: thinking from gemini-2.5, always-on for pro tiers', () => {
+    expect(modelReasoningSupport('google', 'gemini-2.5-pro')?.offBehavior).toBe('default')
+    expect(modelReasoningSupport('google', 'gemini-2.5-flash')?.offBehavior).toBe('off')
+    expect(modelReasoningSupport('google', 'gemini-2.0-flash')).toBeNull()
+  })
+
+  test('unknown provider types expose no reasoning control', () => {
+    expect(modelReasoningSupport('ollama', 'gpt-5.6-terra')).toBeNull()
+    expect(modelReasoningSupport('custom', 'claude-sonnet-4-5')).toBeNull()
+  })
+})
+
+describe('isReasoningLevel', () => {
+  test('accepts levels and rejects everything else', () => {
+    expect(isReasoningLevel('xhigh')).toBe(true)
+    expect(isReasoningLevel('none')).toBe(false)
+    expect(isReasoningLevel('off')).toBe(false)
+    expect(isReasoningLevel(3)).toBe(false)
+  })
+})

--- a/agents/protocol/src/reasoning.ts
+++ b/agents/protocol/src/reasoning.ts
@@ -1,0 +1,132 @@
+/**
+ * Model reasoning knowledge shared by the agents server and every model-picker UI.
+ *
+ * The level lists are empirically verified against the live provider APIs (see the
+ * per-provider notes below) rather than scraped from a catalog, because providers
+ * gate levels per model generation — e.g. OpenAI's gpt-5 family accepts `minimal`
+ * but not `none`, while gpt-5.1+ accepts `none` but not `minimal`.
+ */
+
+/** A user-selectable reasoning level, ordered from least to most reasoning. */
+export type ReasoningLevel = 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
+
+/** All levels in display order. */
+export const REASONING_LEVELS: ReasoningLevel[] = ['minimal', 'low', 'medium', 'high', 'xhigh']
+
+/** Display label per level, used by dropdowns and tags. */
+export const REASONING_LEVEL_LABELS: Record<ReasoningLevel, string> = {
+  minimal: 'Minimal',
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+  xhigh: 'X-High',
+}
+
+/** Short human explanation per level, used by dropdowns and tag tooltips. */
+export const REASONING_LEVEL_DESCRIPTIONS: Record<ReasoningLevel, string> = {
+  minimal: 'Barely any reasoning — fastest and cheapest, best for simple tasks.',
+  low: 'A little reasoning before answering — quick with a light quality boost.',
+  medium: 'Moderate reasoning — balanced speed, cost, and answer quality.',
+  high: 'Extensive reasoning — slower and costlier, best for hard problems.',
+  xhigh: 'Maximum reasoning — the model thinks as long as it needs. Slowest and most expensive.',
+}
+
+/**
+ * What "no level selected" means for a model:
+ * - `off`: the model does no reasoning (the server disables or omits it).
+ * - `default`: reasoning cannot be turned off; the provider's default level applies.
+ */
+export type ReasoningOffBehavior = 'off' | 'default'
+
+export type ModelReasoningSupport = {
+  /** Levels the model accepts, in display order. */
+  levels: ReasoningLevel[]
+  /** Meaning of leaving the reasoning level unset. */
+  offBehavior: ReasoningOffBehavior
+  /**
+   * The model accepts an explicit "no reasoning" value (OpenAI `reasoning_effort:
+   * 'none'`). Newer OpenAI chat models (gpt-5.1+) default reasoning ON server-side
+   * and reject function tools unless reasoning is explicitly disabled, so the
+   * server must send `none` rather than omitting the field.
+   */
+  supportsEffortNone: boolean
+}
+
+const OPENAI_LEVELS_BY_GENERATION: Record<'gpt5' | 'gpt51' | 'gpt52plus' | 'oseries', ModelReasoningSupport> = {
+  // Verified 2026-07-29: gpt-5 / gpt-5-mini accept minimal|low|medium|high; reasoning cannot be disabled.
+  gpt5: {levels: ['minimal', 'low', 'medium', 'high'], offBehavior: 'default', supportsEffortNone: false},
+  // Verified 2026-07-29: gpt-5.1 accepts none|low|medium|high.
+  gpt51: {levels: ['low', 'medium', 'high'], offBehavior: 'off', supportsEffortNone: true},
+  // Verified 2026-07-29: gpt-5.2, gpt-5.4, gpt-5.6-terra accept none|low|medium|high|xhigh.
+  gpt52plus: {levels: ['low', 'medium', 'high', 'xhigh'], offBehavior: 'off', supportsEffortNone: true},
+  // o-series reasons at low|medium|high and cannot be disabled.
+  oseries: {levels: ['low', 'medium', 'high'], offBehavior: 'default', supportsEffortNone: false},
+}
+
+function openaiReasoningSupport(modelId: string): ModelReasoningSupport | null {
+  if (/^o[134](-|$)/.test(modelId)) return OPENAI_LEVELS_BY_GENERATION.oseries
+  const gpt = modelId.match(/^gpt-(\d+)(?:\.(\d+))?/)
+  if (!gpt) return null
+  const major = Number(gpt[1])
+  const minor = Number(gpt[2] ?? '0')
+  if (major < 5) return null
+  if (major > 5 || minor >= 2) return OPENAI_LEVELS_BY_GENERATION.gpt52plus
+  if (minor === 1) return OPENAI_LEVELS_BY_GENERATION.gpt51
+  // Chat-tuned variants of the 5.0 family do not expose reasoning control.
+  if (modelId.startsWith('gpt-5-chat')) return null
+  return OPENAI_LEVELS_BY_GENERATION.gpt5
+}
+
+function anthropicReasoningSupport(modelId: string): ModelReasoningSupport | null {
+  // Extended thinking shipped with claude-3-7; every later generation supports it.
+  // Ids look like claude-3-7-sonnet-*, claude-sonnet-4-5, claude-opus-4-1, claude-fable-5.
+  const legacy = modelId.match(/^claude-(\d+)-(\d+)/)
+  if (legacy) {
+    const [major, minor] = [Number(legacy[1]), Number(legacy[2])]
+    if (major < 3 || (major === 3 && minor < 7)) return null
+    return {levels: ['minimal', 'low', 'medium', 'high'], offBehavior: 'off', supportsEffortNone: false}
+  }
+  if (/^claude-[a-z]+-(\d+)/.test(modelId)) {
+    // Family-first ids (claude-sonnet-4-5 and newer) all support thinking.
+    return {levels: ['minimal', 'low', 'medium', 'high'], offBehavior: 'off', supportsEffortNone: false}
+  }
+  return null
+}
+
+function googleReasoningSupport(modelId: string): ModelReasoningSupport | null {
+  const gemini = modelId.match(/^gemini-(\d+)(?:\.(\d+))?/)
+  if (!gemini) return null
+  const major = Number(gemini[1])
+  const minor = Number(gemini[2] ?? '0')
+  // Thinking arrived with gemini-2.5. Pro-tier models cannot fully disable it.
+  if (major < 2 || (major === 2 && minor < 5)) return null
+  const alwaysOn = modelId.includes('-pro')
+  return {
+    levels: ['minimal', 'low', 'medium', 'high'],
+    offBehavior: alwaysOn ? 'default' : 'off',
+    supportsEffortNone: false,
+  }
+}
+
+/**
+ * Returns the reasoning support for a model, or null when the model (or the
+ * provider type) has no controllable reasoning. `providerType` is the agents
+ * server provider type ('openai' | 'anthropic' | 'google' | ...).
+ */
+export function modelReasoningSupport(providerType: string, modelId: string): ModelReasoningSupport | null {
+  switch (providerType) {
+    case 'openai':
+      return openaiReasoningSupport(modelId)
+    case 'anthropic':
+      return anthropicReasoningSupport(modelId)
+    case 'google':
+      return googleReasoningSupport(modelId)
+    default:
+      return null
+  }
+}
+
+/** Type guard for values arriving from stored definitions or API input. */
+export function isReasoningLevel(value: unknown): value is ReasoningLevel {
+  return typeof value === 'string' && (REASONING_LEVELS as string[]).includes(value)
+}

--- a/agents/src/api-service.test.ts
+++ b/agents/src/api-service.test.ts
@@ -2384,6 +2384,90 @@ describe('api service', () => {
     expect(decoded.account).toEqual(account.principal)
     expect(decoded.nested.bytes).toEqual(new Uint8Array([1, 2, 3]))
   })
+
+  test('accepts a reasoning level the model supports and persists it', async () => {
+    const {db, dataDir, cleanup} = createTestState()
+    try {
+      const account = blobs.generateNobleKeyPair()
+      const svc = new apisvc.Service(db, dataDir)
+      await setDefaultProvider(svc, account)
+      const create = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {
+            _: 'CreateAgent',
+            definition: {
+              name: 'Reasoner',
+              systemPrompt: 'ok',
+              modelProvider: 'openai',
+              model: 'gpt-5.6-terra',
+              reasoningLevel: 'xhigh',
+            },
+          },
+        }),
+      )
+      expect(create._).toBe('CreateAgentResponse')
+      const list = await svc.message(await apisvc.createSignedEnvelope(account, {action: {_: 'ListAgents'}}))
+      if (list._ !== 'ListAgentsResponse') throw new Error('unexpected response')
+      expect(list.agents[0]?.definition.reasoningLevel).toBe('xhigh')
+    } finally {
+      db.close()
+      cleanup()
+    }
+  })
+
+  test('rejects reasoning levels the model does not accept', async () => {
+    const {db, dataDir, cleanup} = createTestState()
+    try {
+      const account = blobs.generateNobleKeyPair()
+      const svc = new apisvc.Service(db, dataDir)
+      await setDefaultProvider(svc, account)
+      const createAgent = async (model: string, reasoningLevel: string) =>
+        svc.message(
+          await apisvc.createSignedEnvelope(account, {
+            action: {
+              _: 'CreateAgent',
+              definition: {
+                name: 'Reasoner',
+                systemPrompt: 'ok',
+                modelProvider: 'openai',
+                model,
+                reasoningLevel,
+              } as never,
+            },
+          }),
+        )
+      // gpt-5-mini accepts minimal..high but not xhigh.
+      await expect(createAgent('gpt-5-mini', 'xhigh')).rejects.toThrow('does not support reasoning level')
+      // gpt-5.6 dropped minimal.
+      await expect(createAgent('gpt-5.6-terra', 'minimal')).rejects.toThrow('does not support reasoning level')
+      // Non-reasoning models take no level at all.
+      await expect(createAgent('gpt-4.1', 'high')).rejects.toThrow('does not support a reasoning level')
+      // Unknown enum values are rejected before the model check.
+      await expect(createAgent('gpt-5.6-terra', 'maximum')).rejects.toThrow('Reasoning level is invalid')
+    } finally {
+      db.close()
+      cleanup()
+    }
+  })
+
+  test('restoreReasoningEffort reasserts the validated level on clamped payloads', () => {
+    const definition = {
+      name: 'a',
+      systemPrompt: 'ok',
+      modelProvider: 'openai',
+      model: 'gpt-5.6-terra',
+      reasoningLevel: 'xhigh',
+    } as never
+    expect(
+      apisvc.restoreReasoningEffort({model: 'gpt-5.6-terra', reasoning: {effort: 'high', summary: 'auto'}}, definition),
+    ).toEqual({model: 'gpt-5.6-terra', reasoning: {effort: 'xhigh', summary: 'auto'}})
+    // Payloads without a reasoning object (level off, non-OpenAI providers) pass through untouched.
+    const plain = {model: 'gpt-5.6-terra'}
+    expect(apisvc.restoreReasoningEffort(plain, {...(definition as object), reasoningLevel: undefined} as never)).toBe(
+      plain,
+    )
+    expect(apisvc.restoreReasoningEffort(plain, definition)).toBe(plain)
+  })
 })
 
 async function setDefaultProvider(svc: apisvc.Service, account: blobs.Signer): Promise<void> {

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -1,6 +1,12 @@
 import type {Database} from 'bun:sqlite'
 import type * as api from '@/api'
-import {seedAssistantSystemPrompt, seedToolRegistry, type SeedToolMetadata} from '@seed-hypermedia/agents-protocol'
+import {
+  isReasoningLevel,
+  modelReasoningSupport,
+  seedAssistantSystemPrompt,
+  seedToolRegistry,
+  type SeedToolMetadata,
+} from '@seed-hypermedia/agents-protocol'
 import * as activityTriggers from '@/activity-triggers'
 import * as scheduleTriggers from '@/schedule-triggers'
 import * as auth from '@/auth'
@@ -263,9 +269,12 @@ export class Service {
   #createAgentOnce(accountId: string, rawDefinition: api.AgentDefinition): api.CreateAgentResponse {
     const definition = normalizeDefinition(rawDefinition)
     const provider = this.#db
-      .query<{name: string}, [string, string]>(`SELECT name FROM model_providers WHERE account_id = ? AND name = ?`)
+      .query<{name: string; type: string}, [string, string]>(
+        `SELECT name, type FROM model_providers WHERE account_id = ? AND name = ?`,
+      )
       .get(accountId, definition.modelProvider)
     if (!provider) throw new APIError(400, 'Model provider not found')
+    validateReasoningLevel(provider.type, definition)
     this.#validateSigningKeys(accountId, definition)
 
     const now = Date.now()
@@ -669,9 +678,12 @@ export class Service {
       .get(accountId, agentId)
     if (!existing) throw new APIError(404, 'Agent not found')
     const provider = this.#db
-      .query<{name: string}, [string, string]>(`SELECT name FROM model_providers WHERE account_id = ? AND name = ?`)
+      .query<{name: string; type: string}, [string, string]>(
+        `SELECT name, type FROM model_providers WHERE account_id = ? AND name = ?`,
+      )
       .get(accountId, definition.modelProvider)
     if (!provider) throw new APIError(400, 'Model provider not found')
+    validateReasoningLevel(provider.type, definition)
     this.#validateSigningKeys(accountId, definition)
 
     const now = Date.now()
@@ -1159,7 +1171,7 @@ export class Service {
       cwd,
       agentDir: path.join(this.#dataDir, 'pi'),
       model,
-      thinkingLevel: 'off',
+      thinkingLevel: definition.reasoningLevel ?? 'off',
       authStorage,
       modelRegistry,
       resourceLoader,
@@ -1197,10 +1209,13 @@ export class Service {
         agentId: session.agentId,
         provider: providerName,
         model: definition.model,
+        reasoningLevel: definition.reasoningLevel,
         activeTools: piSession.getActiveToolNames(),
         payloadTools,
       })
-      return mergeModelDefaults ? mergePiPayloadDefaults(payload, mergeModelDefaults) : payload
+      let next = restoreReasoningEffort(payload, definition)
+      if (mergeModelDefaults) next = mergePiPayloadDefaults(next, mergeModelDefaults)
+      return next
     }
     piSession.state.messages = this.#piMessages(sessionId) as never
     let partialId = crypto.randomUUID()
@@ -2384,6 +2399,11 @@ function normalizeDefinition(raw: api.AgentDefinition): api.AgentDefinition {
 
   const definition: api.AgentDefinition = {name, systemPrompt, modelProvider, model}
 
+  if (raw.reasoningLevel !== undefined) {
+    if (!isReasoningLevel(raw.reasoningLevel)) throw new APIError(400, 'Reasoning level is invalid')
+    definition.reasoningLevel = raw.reasoningLevel
+  }
+
   if (raw.signingKey !== undefined) {
     definition.signingKey = normalizeBoundedString(raw.signingKey, 'Signing key', MAX_NAME_BYTES)
   }
@@ -2431,6 +2451,28 @@ function normalizeDefinition(raw: api.AgentDefinition): api.AgentDefinition {
   }
 
   return definition
+}
+
+/**
+ * Rejects a reasoning level the target model does not accept. Providers gate
+ * levels per model generation (e.g. gpt-5 takes `minimal` but not `xhigh`,
+ * gpt-5.2+ the reverse), so this needs the provider type, which callers resolve
+ * from the stored provider record.
+ */
+function validateReasoningLevel(providerType: string, definition: api.AgentDefinition): void {
+  if (!definition.reasoningLevel) return
+  const support = modelReasoningSupport(providerType, definition.model)
+  if (!support) {
+    throw new APIError(400, `Model ${definition.model} does not support a reasoning level`)
+  }
+  if (!support.levels.includes(definition.reasoningLevel)) {
+    throw new APIError(
+      400,
+      `Model ${definition.model} does not support reasoning level '${
+        definition.reasoningLevel
+      }' (valid: ${support.levels.join(', ')})`,
+    )
+  }
 }
 
 function normalizeAgentTriggerInput(
@@ -2621,7 +2663,7 @@ function normalizeOptionalMetadata(raw: Record<string, unknown> | undefined): Re
 }
 
 /** Pi streaming API a provider is routed through. */
-type PiProviderApi = 'openai-completions' | 'anthropic-messages' | 'google-generative-ai'
+type PiProviderApi = 'openai-completions' | 'openai-responses' | 'anthropic-messages' | 'google-generative-ai'
 
 /** Shape of the upstream model-list endpoint a provider exposes. */
 type ProviderModelListStrategy = 'openai' | 'anthropic' | 'google'
@@ -2647,6 +2689,9 @@ type ProviderSpec = {
 
 const PROVIDER_SPECS: Record<string, ProviderSpec> = {
   openai: {
+    // Default path for models without reasoning control. Models that need
+    // reasoning (or whose reasoning must be explicitly disabled, gpt-5.1+) are
+    // rerouted to 'openai-responses' in piModelForDefinition.
     api: 'openai-completions',
     defaultBaseUrl: 'https://api.openai.com/v1',
     modelList: 'openai',
@@ -2810,12 +2855,25 @@ function piModelForDefinition(
   baseUrl: string,
   definition: api.AgentDefinition,
 ): NonNullable<Parameters<pi.ModelRegistry['registerProvider']>[1]['models']>[number] {
+  const support = modelReasoningSupport(type, definition.model)
+  // Pi only sends reasoning parameters for models flagged `reasoning`. The flag
+  // goes on when a level is selected, and also when the model needs an explicit
+  // "no reasoning" value (Pi's openai-responses path sends `effort: 'none'` for
+  // reasoning-flagged models with no level, which such models require before
+  // they accept function tools).
+  const reasoning = Boolean(support && (definition.reasoningLevel || support.supportsEffortNone))
+  // OpenAI's newest chat models (gpt-5.1+) reject function tools on
+  // /v1/chat/completions unless reasoning is explicitly disabled, and reject
+  // tools entirely once a reasoning effort is set there. The Responses API is
+  // OpenAI's supported path for tools + reasoning, so reasoning-flagged OpenAI
+  // models ride it while everything else keeps the plain completions path.
+  const api = type === 'openai' && reasoning ? 'openai-responses' : providerSpec(type).api
   return {
     id: definition.model,
     name: definition.model,
-    api: providerSpec(type).api,
+    api,
     baseUrl,
-    reasoning: false,
+    reasoning,
     input: ['text'],
     cost: {input: 0, output: 0, cacheRead: 0, cacheWrite: 0},
     contextWindow: 128000,
@@ -4122,6 +4180,22 @@ function piToolResultOutput(result: {content?: unknown; details?: unknown}): unk
 function mergePiPayloadDefaults(payload: unknown, defaults: Record<string, unknown>): unknown {
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return payload
   return {...(payload as Record<string, unknown>), ...defaults}
+}
+
+/**
+ * Reasserts the agent's validated reasoning level on an OpenAI Responses
+ * payload. Pi clamps levels for models its bundled catalog does not know
+ * (e.g. it downgrades xhigh to high for gpt-5.6+), but the definition's level
+ * was validated against the live per-model matrix and is authoritative.
+ * Exported for tests.
+ */
+export function restoreReasoningEffort(payload: unknown, definition: api.AgentDefinition): unknown {
+  if (!definition.reasoningLevel) return payload
+  if (!isRecord(payload) || !isRecord(payload.reasoning) || typeof payload.reasoning.effort !== 'string') {
+    return payload
+  }
+  if (payload.reasoning.effort === definition.reasoningLevel) return payload
+  return {...payload, reasoning: {...payload.reasoning, effort: definition.reasoningLevel}}
 }
 
 function emptyPiUsage(): {

--- a/frontend/apps/desktop/src/pages/agents/detail.tsx
+++ b/frontend/apps/desktop/src/pages/agents/detail.tsx
@@ -61,7 +61,9 @@ import {
 import {TriggerSourceFields, summarizeTriggerSource} from './trigger-types'
 import {AddModelProviderDialog, EditAgentNameDialog, type AgentAccountRenameStatus} from './dialogs'
 import {AgentHeader, AgentSubpageHeader, type AgentPageTab} from './header'
+import {modelReasoningSupport, type ReasoningLevel} from '@seed-hypermedia/agents-protocol'
 import {ModelSelect} from './model-select'
+import {coerceReasoningLevel, ReasoningSelect} from './reasoning-select'
 import {curateProviderModels, pickDefaultProviderModel} from './model-utils'
 import {AgentPromptEditor, promptBlocksToMarkdown} from './prompt-editor'
 import {ProviderSelect} from './provider-select'
@@ -100,6 +102,7 @@ function AgentDetailPage({
   const [name, setName] = useState('')
   const [modelProvider, setModelProvider] = useState('')
   const [model, setModel] = useState('')
+  const [reasoningLevel, setReasoningLevel] = useState<ReasoningLevel | undefined>(undefined)
   const providerModels = useProviderModels(serverUrl, selectedAccountId, modelProvider)
   const selectedProviderType = modelProviders.data?.find((provider) => provider.name === modelProvider)?.type
   const [systemPrompt, setSystemPrompt] = useState<HMBlockNode[]>([])
@@ -118,6 +121,7 @@ function AgentDetailPage({
       setName(agent.data.agent.definition.name)
       setModel(agent.data.agent.definition.model)
       setModelProvider(agent.data.agent.definition.modelProvider)
+      setReasoningLevel(agent.data.agent.definition.reasoningLevel)
     }
     if (!promptDirty) {
       const nextPromptKey = agentPromptStableKey(agent.data.agent.definition.systemPrompt)
@@ -141,6 +145,7 @@ function AgentDetailPage({
     if (nextProvider === modelProvider) return
     setModelProvider(nextProvider)
     setModel('') // belongs to the previous provider; the effect above picks a new default
+    setReasoningLevel(undefined)
     setNameModelDirty(true)
   }
 
@@ -194,7 +199,13 @@ function AgentDetailPage({
     const persistedName = currentDefinition.name
     const persistedModel = currentDefinition.model
     const persistedProvider = currentDefinition.modelProvider
-    if (draftName === persistedName && model === persistedModel && modelProvider === persistedProvider) {
+    const draftReasoningLevel = coerceReasoningLevel(selectedProviderType, model, reasoningLevel)
+    if (
+      draftName === persistedName &&
+      model === persistedModel &&
+      modelProvider === persistedProvider &&
+      draftReasoningLevel === currentDefinition.reasoningLevel
+    ) {
       setSettingsSaveState('idle')
       return
     }
@@ -204,10 +215,14 @@ function AgentDetailPage({
     const timer = setTimeout(
       () => {
         setSettingsSaveState('saving')
+        const nextDefinition = {...currentDefinition, name: draftName, model, modelProvider}
+        // Avoid an explicit-undefined key: CBOR-encoding it would not equal an absent field.
+        if (draftReasoningLevel) nextDefinition.reasoningLevel = draftReasoningLevel
+        else delete nextDefinition.reasoningLevel
         void updateAgent
           .mutateAsync({
             agentId,
-            definition: {...currentDefinition, name: draftName, model, modelProvider},
+            definition: nextDefinition,
           })
           .then((result) => {
             if (settingsSaveIdRef.current !== saveId) return
@@ -215,6 +230,7 @@ function AgentDetailPage({
             setName(result.agent.definition.name)
             setModel(result.agent.definition.model)
             setModelProvider(result.agent.definition.modelProvider)
+            setReasoningLevel(result.agent.definition.reasoningLevel)
             if (!promptDirty) {
               loadedPromptKeyRef.current = agentPromptStableKey(result.agent.definition.systemPrompt)
               setSystemPrompt(agentPromptToBlocks(result.agent.definition.systemPrompt))
@@ -235,7 +251,17 @@ function AgentDetailPage({
       model === persistedModel ? 600 : 0,
     )
     return () => clearTimeout(timer)
-  }, [agent.data, agentId, model, modelProvider, name, promptDirty, updateAgent.mutateAsync])
+  }, [
+    agent.data,
+    agentId,
+    model,
+    modelProvider,
+    name,
+    reasoningLevel,
+    selectedProviderType,
+    promptDirty,
+    updateAgent.mutateAsync,
+  ])
 
   const promptEditorDisabled = !selectedAccountId || serverHealth.isError || agent.isError
 
@@ -453,6 +479,7 @@ function AgentDetailPage({
                         value={model}
                         onChange={(nextModel) => {
                           setModel(nextModel)
+                          setReasoningLevel((level) => coerceReasoningLevel(selectedProviderType, nextModel, level))
                           setNameModelDirty(true)
                         }}
                         isLoading={providerModels.isLoading}
@@ -460,6 +487,22 @@ function AgentDetailPage({
                         error={providerModels.error}
                       />
                     </label>
+                    {selectedProviderType && model && modelReasoningSupport(selectedProviderType, model) ? (
+                      <label className="flex flex-col gap-1">
+                        <SizableText size="sm" weight="bold">
+                          Reasoning
+                        </SizableText>
+                        <ReasoningSelect
+                          providerType={selectedProviderType}
+                          model={model}
+                          value={reasoningLevel}
+                          onChange={(level) => {
+                            setReasoningLevel(level)
+                            setNameModelDirty(true)
+                          }}
+                        />
+                      </label>
+                    ) : null}
                   </div>
                   <div className="flex flex-col gap-2">
                     <SizableText

--- a/frontend/apps/desktop/src/pages/agents/dialogs.tsx
+++ b/frontend/apps/desktop/src/pages/agents/dialogs.tsx
@@ -36,7 +36,9 @@ import {Camera, ExternalLink, Plus, Trash2} from 'lucide-react'
 import {useEffect, useState} from 'react'
 import {generateAgentName} from './agent-name'
 import {DEFAULT_AGENT_TOOLS} from './agent-tools'
+import {modelReasoningSupport, type ReasoningLevel} from '@seed-hypermedia/agents-protocol'
 import {ModelSelect} from './model-select'
+import {coerceReasoningLevel, ReasoningSelect} from './reasoning-select'
 import {pickDefaultProviderModel} from './model-utils'
 import {AgentPromptEditor, promptBlocksToMarkdown} from './prompt-editor'
 import {ProviderIcon} from './provider-icons'
@@ -601,6 +603,7 @@ export function CreateAgentDialog({
   const addProviderDialog = useAppDialog(AddModelProviderDialog)
   const [name, setName] = useState(generateAgentName)
   const [model, setModel] = useState('')
+  const [reasoningLevel, setReasoningLevel] = useState<ReasoningLevel | undefined>(undefined)
   const [systemPrompt, setSystemPrompt] = useState<HMBlockNode[]>(() =>
     markdownBlockNodesToHMBlockNodes(parseMarkdown('You are a helpful agent.').tree),
   )
@@ -646,6 +649,7 @@ export function CreateAgentDialog({
         systemPrompt: promptBlocksToMarkdown(systemPrompt),
         modelProvider: providerName,
         model,
+        reasoningLevel: coerceReasoningLevel(selectedProviderType, model, reasoningLevel),
         tools: DEFAULT_AGENT_TOOLS,
         signingKey: signingKeyName,
         signingKeys: [signingKeyName],
@@ -743,13 +747,29 @@ export function CreateAgentDialog({
             models={providerModels.data}
             providerType={selectedProviderType}
             value={model}
-            onChange={setModel}
+            onChange={(nextModel) => {
+              setModel(nextModel)
+              setReasoningLevel((level) => coerceReasoningLevel(selectedProviderType, nextModel, level))
+            }}
             isLoading={providerModels.isLoading}
             isError={providerModels.isError}
             error={providerModels.error}
             disabled={!providerName}
           />
         </label>
+        {selectedProviderType && model && modelReasoningSupport(selectedProviderType, model) ? (
+          <label className="flex flex-col gap-1">
+            <SizableText size="sm" weight="bold">
+              Reasoning
+            </SizableText>
+            <ReasoningSelect
+              providerType={selectedProviderType}
+              model={model}
+              value={reasoningLevel}
+              onChange={setReasoningLevel}
+            />
+          </label>
+        ) : null}
       </div>
       {addProviderDialog.content}
       <div className="flex flex-col gap-1">

--- a/frontend/apps/desktop/src/pages/agents/header.tsx
+++ b/frontend/apps/desktop/src/pages/agents/header.tsx
@@ -6,6 +6,7 @@ import {useIsomorphicLayoutEffect} from '@shm/shared/utils/use-isomorphic-layout
 import {Button} from '@shm/ui/button'
 import {Badge} from '@shm/ui/components/badge'
 import {PageTab} from '@shm/ui/page-tabs'
+import {ReasoningBadge} from './reasoning-select'
 import {SizableText} from '@shm/ui/text'
 import {
   ArrowLeft,
@@ -293,6 +294,7 @@ export function AgentHeader({
                 {agent.definition.model}
               </Badge>
             ) : null}
+            {agent ? <ReasoningBadge level={agent.definition.reasoningLevel} /> : null}
             {activeTab === 'sessions' && onCreateSession ? (
               <Button onClick={onCreateSession} disabled={creatingSession}>
                 <MessageSquarePlus className="mr-2 size-4" /> New session

--- a/frontend/apps/desktop/src/pages/agents/reasoning-select.tsx
+++ b/frontend/apps/desktop/src/pages/agents/reasoning-select.tsx
@@ -1,0 +1,97 @@
+import {
+  isReasoningLevel,
+  modelReasoningSupport,
+  REASONING_LEVEL_DESCRIPTIONS,
+  REASONING_LEVEL_LABELS,
+  type ReasoningLevel,
+} from '@seed-hypermedia/agents-protocol'
+import {Badge} from '@shm/ui/components/badge'
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@shm/ui/select-dropdown'
+import {Tooltip} from '@shm/ui/tooltip'
+import {Brain} from 'lucide-react'
+
+const OFF_VALUE = '__off__'
+
+/**
+ * Reasoning-level dropdown paired with every model selector. Rendered only for
+ * reasoning-capable models (`modelReasoningSupport` decides), listing just the
+ * levels that model accepts. "Off" means no reasoning — or the provider default
+ * when the model cannot disable it.
+ */
+export function ReasoningSelect({
+  providerType,
+  model,
+  value,
+  onChange,
+  disabled,
+}: {
+  providerType: string | undefined
+  model: string
+  value: ReasoningLevel | undefined
+  onChange: (level: ReasoningLevel | undefined) => void
+  disabled?: boolean
+}) {
+  const support = providerType ? modelReasoningSupport(providerType, model) : null
+  if (!support) return null
+  const offLabel = support.offBehavior === 'default' ? 'Default' : 'Off'
+  return (
+    <Select
+      value={value ?? OFF_VALUE}
+      onValueChange={(next) => onChange(isReasoningLevel(next) ? next : undefined)}
+      disabled={disabled}
+    >
+      <SelectTrigger>
+        <SelectValue placeholder={offLabel} />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={OFF_VALUE}>
+          <span className="flex flex-col items-start">
+            <span>{offLabel}</span>
+            <span className="text-muted-foreground text-xs">
+              {support.offBehavior === 'default'
+                ? 'The provider decides how much this model reasons.'
+                : 'The model answers directly without extra reasoning.'}
+            </span>
+          </span>
+        </SelectItem>
+        {support.levels.map((level) => (
+          <SelectItem key={level} value={level}>
+            <span className="flex flex-col items-start">
+              <span>{REASONING_LEVEL_LABELS[level]}</span>
+              <span className="text-muted-foreground text-xs">{REASONING_LEVEL_DESCRIPTIONS[level]}</span>
+            </span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+/**
+ * Compact reasoning-level tag shown beside model tags, with a tooltip that
+ * explains what the level means. Renders nothing when the agent has no
+ * reasoning level configured.
+ */
+export function ReasoningBadge({level}: {level: ReasoningLevel | undefined}) {
+  if (!level || !isReasoningLevel(level)) return null
+  return (
+    <Tooltip content={`Reasoning ${REASONING_LEVEL_LABELS[level]}: ${REASONING_LEVEL_DESCRIPTIONS[level]}`} asChild>
+      <Badge variant="outline" className="flex-none gap-1">
+        <Brain className="size-3" />
+        {REASONING_LEVEL_LABELS[level]}
+      </Badge>
+    </Tooltip>
+  )
+}
+
+/** Drops a stored reasoning level the newly selected model cannot honor. */
+export function coerceReasoningLevel(
+  providerType: string | undefined,
+  model: string,
+  level: ReasoningLevel | undefined,
+): ReasoningLevel | undefined {
+  if (!level) return undefined
+  const support = providerType ? modelReasoningSupport(providerType, model) : null
+  if (!support || !support.levels.includes(level)) return undefined
+  return level
+}


### PR DESCRIPTION
## Summary

OpenAI's newest chat models (gpt-5.1+) turn reasoning **on server-side by default** and reject function tools on `/v1/chat/completions` unless reasoning is explicitly disabled — every agent session on `gpt-5.6-terra` failed with a 400 before producing any output. This PR fixes that and adds user-facing reasoning levels on top.

### The fix
Reasoning-flagged OpenAI models are routed per-model to Pi's `openai-responses` API, which sends `reasoning: {effort: 'none'}` when reasoning is off (what gpt-5.1+ requires before accepting tools) and the chosen effort when it is on. All other models keep the battle-tested completions path, so existing agents and tests are untouched.

### Reasoning levels
- **Protocol**: `AgentDefinition.reasoningLevel` plus a `modelReasoningSupport` matrix, empirically verified against the live API per model generation — gpt-5/5-mini take `minimal–high`, gpt-5.1 `low–high` (+off), gpt-5.2+ (incl. terra) add `xhigh`; Anthropic from claude-3-7; Gemini from 2.5.
- **Server**: validates the level against the matrix on create/update, passes it to Pi as `thinkingLevel`, and reasserts the validated effort on payloads Pi clamps for models newer than its bundled catalog.
- **Desktop**: a Reasoning dropdown appears beside every model selector for reasoning-capable models, listing only that model's valid levels with per-level explanations; the agent header shows a reasoning tag with an explanatory tooltip next to the model tag.

## Test plan
- [x] 99/99 agents tests (3 new: level validation, persistence, payload restoration)
- [x] 8 new protocol matrix tests
- [x] Desktop typecheck + agents page vitest
- [x] Live e2e against the real OpenAI API (`agents/e2e-reasoning.ts`): gpt-5.6-terra with tools answers with reasoning off **and** at level low; gpt-5-mini works on both paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)