### PR TITLE
chore: auto-format agent-written files via Claude Code hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/scripts/format-hook.mjs\"",
+            "timeout": 30,
+            "statusMessage": "Formatting with Prettier"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,3 +88,10 @@
   - Do not use random pixel values for spacing or sizing.
   - Use parent `gap` for flex/grid spacing instead of child margins when possible.
 - Run relevant tests, type checks, and linters for touched areas before finishing.
+- Before every commit, make sure the files you touched are Prettier-formatted (`pnpm format:write` in the touched
+  packages, or `./node_modules/.bin/prettier --ignore-unknown --write <files>` from the repo root). CI's `Lint` job runs
+  `prettier --check` across every package plus `agents/` and `vault/`; one unformatted file fails it and blocks the web
+  image build. Formatting produces no local error signal — typecheck and tests pass on unformatted code — so it must be
+  checked explicitly, on the last commit of a session as much as the first. (Claude Code sessions get this automatically
+  via the `.claude/settings.json` PostToolUse hook running `scripts/format-hook.mjs`; other agents and editors without
+  format-on-save must run it themselves.)

--- a/dev
+++ b/dev
@@ -423,7 +423,10 @@ def main():
     @cmd(cmds, "frontend-validate", "Formats, Validates")
     def frontend_validate(args):
         run("node scripts/cleanup-desktop.js")
-        run("pnpm validate")
+        # There is no root `validate` script; format the whole workspace, then verify it the same
+        # way CI's Lint job does.
+        run("pnpm format:write")
+        run("pnpm format:check")
 
     @cmd(
         cmds,

--- a/scripts/format-hook.mjs
+++ b/scripts/format-hook.mjs
@@ -1,0 +1,23 @@
+// Claude Code PostToolUse hook: formats every file an agent writes with the repo's Prettier,
+// so unformatted code can never reach a commit. Editors give humans format-on-save
+// (.vscode/settings.json); this is the agent equivalent. Wired up in .claude/settings.json.
+//
+// Always exits 0: a formatter problem must not block the edit itself, and CI's
+// `format:check` remains the backstop.
+import {execFileSync} from 'node:child_process'
+import {readFileSync} from 'node:fs'
+import {resolve, sep} from 'node:path'
+
+const root = process.env.CLAUDE_PROJECT_DIR ?? process.cwd()
+try {
+  const payload = JSON.parse(readFileSync(0, 'utf8'))
+  const file = payload?.tool_input?.file_path ?? payload?.tool_input?.notebook_path ?? payload?.tool_response?.filePath
+  if (!file) process.exit(0)
+  const abs = resolve(root, file)
+  if (abs !== root && !abs.startsWith(root + sep)) process.exit(0)
+  execFileSync(resolve(root, 'node_modules/.bin/prettier'), ['--ignore-unknown', '--write', abs], {
+    cwd: root,
+    stdio: 'ignore',
+  })
+} catch {}
+process.exit(0)


### PR DESCRIPTION
## Summary

Unformatted agent commits are the repo's #1 CI failure class: **11 of the last 16 frontend CI failures** were `Lint / Validate Code Formatting`, and main has needed **21 standalone `fmt` fixup commits in six months** (~one every 8 days), including today's break of main by the #913 merge.

Root cause (from a dedicated investigation): formatting is the only quality gate with **zero local signal** — unformatted code compiles, typechecks, and passes tests, failing only minutes later in CI. Humans stay clean via `.vscode` format-on-save, which never fires for agents; prompt-level rules (agents/AGENTS.md, agent memory) have been tried and still fail on end-of-session commits.

This PR adds the agent equivalent of format-on-save, plus backstops:

- **`.claude/settings.json`** (committed, applies to every checkout/worktree): PostToolUse hook running `scripts/format-hook.mjs` after every Edit/Write — the touched file is Prettier-formatted immediately (~0.5s, `--ignore-unknown`, never blocks the edit, path-guarded to the repo). Verified live: the hook formatted files during the session that authored this PR.
- **`AGENTS.md`**: explicit pre-commit formatting rule for agents that don't run Claude Code hooks (Codex/Cursor/etc.).
- **`./dev frontend-validate`**: fixed — it called a nonexistent `pnpm validate`; now runs `pnpm format:write` + `pnpm format:check`, matching CI's Lint job.

## Follow-ups considered but not included

- Tracked `.githooks/pre-commit` + `core.hooksPath` bootstrap via postinstall (covers humans + all agents; more invasive, needs team buy-in).
- Same hook mechanism for the other silent-drift class: `ops/dist/deploy.js` rebuilds (4 fixup commits).

## Test plan

- [x] Pipe-tested the hook script: formats a misformatted `.ts`, no-ops on `go.mod`, refuses paths outside the repo
- [x] `jq -e` schema validation of `.claude/settings.json`
- [x] Live proof: hook fired and formatted files written during this session
- [x] `./dev frontend-validate` now runs real commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPjutzSVEs55HopERgZPF5