### PR TITLE
fix(comments): resolve citing discussions from the comment's real target

### DIFF
--- a/frontend/packages/shared/src/__tests__/comments-resolvers.test.ts
+++ b/frontend/packages/shared/src/__tests__/comments-resolvers.test.ts
@@ -1,0 +1,160 @@
+import {describe, expect, it, vi} from 'vitest'
+import {createDiscussionsResolver} from '../models/comments-resolvers'
+import {hmId} from '../utils/entity-id-url'
+
+const targetDocId = hmId('z6MkTargetAccount', {path: ['notes', 'layout-problems']})
+const citingDocId = hmId('z6MkTargetAccount', {path: ['design', 'pending-us']})
+
+function makeComment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'z6MkCommentAuthor/z6TsidCiting',
+    version: 'bafyCommentVersion',
+    author: 'z6MkCommentAuthor',
+    targetAccount: citingDocId.uid,
+    targetPath: '/design/pending-us',
+    targetVersion: 'bafyTargetVersion',
+    replyParent: '',
+    replyParentVersion: '',
+    threadRoot: '',
+    threadRootVersion: '',
+    capability: '',
+    content: [
+      {
+        children: [],
+        block: {
+          type: 'Paragraph',
+          id: 'blk1',
+          revision: 'a',
+          attributes: {},
+          annotations: [],
+          text: 'a comment that links to the target doc',
+          link: '',
+        },
+      },
+    ],
+    createTime: {seconds: 1754000000, nanos: 0},
+    updateTime: {seconds: 1754000000, nanos: 0},
+    visibility: 'PUBLIC',
+    ...overrides,
+  }
+}
+
+function makeGrpcClient({
+  listComments = vi.fn().mockResolvedValue({comments: []}),
+  getComment = vi.fn().mockRejectedValue(new Error('not found')),
+  listCitations = vi.fn().mockResolvedValue({citations: []}),
+  getDocument = vi.fn().mockResolvedValue({metadata: undefined}),
+  getAccount = vi.fn().mockRejectedValue(new Error('account not found')),
+} = {}) {
+  return {
+    comments: {listComments, getComment},
+    resources: {listCitations},
+    documents: {getDocument, getAccount},
+  } as any
+}
+
+describe('createDiscussionsResolver', () => {
+  // Regression test for https://github.com/seed-hypermedia/seed/issues/921:
+  // the backend reports citation.sourceDocument as the requested IRI for every
+  // comment citation, so the resolver must not rely on it to find the citing
+  // comment's own document.
+  it('renders a comment on another document that links here as a citing discussion', async () => {
+    const citingComment = makeComment()
+    const client = makeGrpcClient({
+      listComments: vi
+        .fn()
+        .mockImplementation(async ({targetPath}) =>
+          targetPath === '/design/pending-us' ? {comments: [citingComment]} : {comments: []},
+        ),
+      getComment: vi.fn().mockImplementation(async ({id}) => {
+        if (id !== citingComment.id) throw new Error('not found')
+        return citingComment
+      }),
+      listCitations: vi.fn().mockResolvedValue({
+        citations: [
+          {
+            source: `hm://${citingComment.id}`,
+            sourceType: 'Comment',
+            // The backend (wrongly) reports the requested doc here; the resolver
+            // must ignore it and resolve the comment's real target itself.
+            sourceDocument: targetDocId.id,
+            target: targetDocId.id,
+          },
+        ],
+      }),
+    })
+
+    const result = await createDiscussionsResolver(client)(targetDocId)
+
+    expect(result.discussions).toEqual([])
+    expect(result.citingDiscussions).toHaveLength(1)
+    const group = result.citingDiscussions[0]!
+    expect(group.type).toBe('externalCommentGroup')
+    expect(group.id).toBe(`hm://${citingComment.id}`)
+    expect(group.comments[0]?.id).toBe(citingComment.id)
+    expect(group.target.id.id).toBe(citingDocId.id)
+  })
+
+  it('does not duplicate a citing comment that links to this document multiple times', async () => {
+    const citingComment = makeComment()
+    const getComment = vi.fn().mockResolvedValue(citingComment)
+    const client = makeGrpcClient({
+      listComments: vi
+        .fn()
+        .mockImplementation(async ({targetPath}) =>
+          targetPath === '/design/pending-us' ? {comments: [citingComment]} : {comments: []},
+        ),
+      getComment,
+      listCitations: vi.fn().mockResolvedValue({
+        citations: [
+          {source: `hm://${citingComment.id}`, sourceType: 'Comment', sourceDocument: targetDocId.id},
+          {source: `hm://${citingComment.id}`, sourceType: 'Comment', sourceDocument: targetDocId.id},
+        ],
+      }),
+    })
+
+    const result = await createDiscussionsResolver(client)(targetDocId)
+
+    expect(getComment).toHaveBeenCalledTimes(1)
+    expect(result.citingDiscussions).toHaveLength(1)
+  })
+
+  it('does not treat comments of this document as citing discussions', async () => {
+    const directComment = makeComment({
+      id: 'z6MkCommentAuthor/z6TsidDirect',
+      targetPath: '/notes/layout-problems',
+    })
+    const getComment = vi.fn().mockRejectedValue(new Error('should not be called'))
+    const client = makeGrpcClient({
+      listComments: vi
+        .fn()
+        .mockImplementation(async ({targetPath}) =>
+          targetPath === '/notes/layout-problems' ? {comments: [directComment]} : {comments: []},
+        ),
+      getComment,
+      listCitations: vi.fn().mockResolvedValue({
+        citations: [{source: `hm://${directComment.id}`, sourceType: 'Comment', sourceDocument: targetDocId.id}],
+      }),
+    })
+
+    const result = await createDiscussionsResolver(client)(targetDocId)
+
+    expect(getComment).not.toHaveBeenCalled()
+    expect(result.discussions).toHaveLength(1)
+    expect(result.citingDiscussions).toEqual([])
+  })
+
+  it('skips a citing comment that cannot be loaded instead of failing the request', async () => {
+    const client = makeGrpcClient({
+      getComment: vi.fn().mockRejectedValue(new Error('comment has been deleted')),
+      listCitations: vi.fn().mockResolvedValue({
+        citations: [{source: 'hm://z6MkOther/z6TsidGone', sourceType: 'Comment', sourceDocument: targetDocId.id}],
+      }),
+    })
+
+    const result = await createDiscussionsResolver(client)(targetDocId)
+
+    expect(result.discussions).toEqual([])
+    expect(result.citingDiscussions).toEqual([])
+  })
+})

--- a/frontend/packages/shared/src/models/comments-resolvers.ts
+++ b/frontend/packages/shared/src/models/comments-resolvers.ts
@@ -11,10 +11,32 @@ import {
 } from '@seed-hypermedia/client/hm-types'
 import {BIG_INT} from '../constants'
 import {LIST_PAGE_SIZE, listAllPages} from '../list-all-pages'
-import {hmIdPathToEntityQueryPath} from '../utils/path-api'
+import {entityQueryPathToHmIdPath, hmIdPathToEntityQueryPath} from '../utils/path-api'
 import {getCommentGroups} from '../comments'
-import {parseFragment, unpackHmId} from '../utils'
+import {hmId, parseFragment, unpackHmId} from '../utils'
 import {documentMetadataParseAdjustments} from './entity'
+
+/**
+ * Maps items to async results with at most `limit` requests in flight. The daemon has no
+ * in-flight cap of its own, so callers fanning out per-item RPCs bound the burst here
+ * (docs/daemon-saturation-incident.md). Real relief is server-side citation/comment
+ * pagination; until then this keeps a heavily-cited document from firing a whole
+ * citations page of lookups at once.
+ */
+async function mapWithConcurrency<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const results = new Array<R>(items.length)
+  let next = 0
+  const workers = Array.from({length: Math.min(limit, items.length)}, async () => {
+    while (next < items.length) {
+      const index = next++
+      results[index] = await fn(items[index]!)
+    }
+  })
+  await Promise.all(workers)
+  return results
+}
+
+const CITING_LOOKUP_CONCURRENCY = 16
 
 /**
  * Parses raw comment data with validation, filtering out invalid comments
@@ -169,22 +191,43 @@ export function createDiscussionsResolver(client: GRPCClient) {
     const discussions = getCommentGroups(allComments, commentId)
     discussions.forEach((g) => g.comments.forEach(addAuthor))
 
-    // Process citing discussions - group by doc to dedupe listComments calls
-    const mentionsByDoc = new Map<string, {mention: any; id: UnpackedHypermediaId}[]>()
-    citationsResult
-      ?.filter((m) => m.sourceType === 'Comment' && m.sourceDocument !== targetId.id)
-      .forEach((mention) => {
-        const id = unpackHmId(mention.sourceDocument)
-        if (!id) return
-        if (!mentionsByDoc.has(mention.sourceDocument)) {
-          mentionsByDoc.set(mention.sourceDocument, [])
-        }
-        mentionsByDoc.get(mention.sourceDocument)!.push({mention, id})
-      })
+    // Process citing discussions: comments on other documents that link to this one.
+    // citation.sourceDocument can't be used to find the citing comment's own document,
+    // because the backend sets it to the requested IRI for every comment citation (see
+    // seed-hypermedia/seed#921), so fetch each candidate comment and read its real target.
+    const directCommentIds = new Set(allComments.map((c) => c.id))
+    const citingCommentIds = new Set(
+      citationsResult
+        ?.filter((m) => m.sourceType === 'Comment')
+        .map((m) => m.source.slice('hm://'.length))
+        .filter((id) => !directCommentIds.has(id)) ?? [],
+    )
 
-    const citingResults = await Promise.all(
-      Array.from(mentionsByDoc.values()).map(async (mentions) => {
-        const docId = mentions[0]!.id
+    const citingComments = (
+      await mapWithConcurrency(Array.from(citingCommentIds), CITING_LOOKUP_CONCURRENCY, (id) =>
+        client.comments
+          .getComment({id})
+          .then(parseComment)
+          .catch(() => null),
+      )
+    ).filter((c): c is HMComment => c !== null)
+
+    // Group by the citing comment's own document to dedupe listComments calls
+    const citingByDoc = new Map<string, {docId: UnpackedHypermediaId; comments: HMComment[]}>()
+    citingComments.forEach((comment) => {
+      const docId = hmId(comment.targetAccount, {path: entityQueryPathToHmIdPath(comment.targetPath)})
+      // A comment targeting this document that listComments didn't return
+      // (e.g. deleted or private) is not a citing discussion.
+      if (!docId.uid || docId.id === targetId.id) return
+      const group = citingByDoc.get(docId.id) ?? {docId, comments: []}
+      group.comments.push(comment)
+      citingByDoc.set(docId.id, group)
+    })
+
+    const citingResults = await mapWithConcurrency(
+      Array.from(citingByDoc.values()),
+      CITING_LOOKUP_CONCURRENCY,
+      async ({docId, comments: docCitingComments}) => {
         const [commentsRes, metadata] = await Promise.all([
           client.comments
             .listComments({
@@ -195,28 +238,23 @@ export function createDiscussionsResolver(client: GRPCClient) {
             .catch(() => null),
           loadDocumentMetadata(client, docId),
         ])
-        if (!commentsRes) return []
 
-        const comments = commentsRes.comments.map(parseComment).filter((c): c is HMComment => c !== null)
+        const comments = commentsRes?.comments.map(parseComment).filter((c): c is HMComment => c !== null) ?? []
 
-        return mentions.map(({mention}): HMExternalCommentGroup | null => {
-          const citingCommentId = mention.source.slice(5)
-          const citingComment = comments.find((c) => c.id === citingCommentId)
-          if (!citingComment) return null
-
+        return docCitingComments.map((citingComment): HMExternalCommentGroup => {
           addAuthor(citingComment)
-          const replies = getCommentGroups(comments, citingCommentId)[0]?.comments ?? []
+          const replies = getCommentGroups(comments, citingComment.id)[0]?.comments ?? []
           replies.forEach(addAuthor)
 
           return {
             comments: [citingComment, ...replies],
             moreCommentsCount: 0,
-            id: mention.source,
+            id: `hm://${citingComment.id}`,
             target: metadata,
             type: 'externalCommentGroup',
           }
         })
-      }),
+      },
     )
 
     const citingDiscussions = citingResults.flat().filter((d): d is HMExternalCommentGroup => d !== null)


### PR DESCRIPTION
## Summary

Fixes #921 — a document showed a comment count of 1 while the comments panel rendered the "no comments" empty state.

The count badge is derived from `ListCitations` and counts every comment-sourced citation — including comments on *other* documents that merely link to this one. The comments panel is designed to render those as **citing discussions**, but `createDiscussionsResolver` identified them by `citation.sourceDocument !== targetId.id`, and the backend has set `sourceDocument` to the *requested* IRI for every comment citation since 5213a8e1f (May 2026). The filter never matched, so citing discussions silently stopped rendering everywhere — leaving the badge counting a comment the panel never showed.

For the document in #921, the "1" is a comment on `design/pending-us` whose body links to `notes/layout-problems-and-improvements`.

## The fix

`createDiscussionsResolver` no longer trusts `citation.sourceDocument`:

1. Comment citations already present in the doc's own `listComments` result are direct discussion comments — skipped.
2. Each remaining comment is fetched via `getComment`; its real target comes from the comment's own `targetAccount`/`targetPath`. Comments that fail to load (deleted/private) are skipped gracefully.
3. Groups are built per real target document as before. Deduping by comment id also fixes duplicate groups when one comment links the doc multiple times.

This fixes both web and desktop (shared resolver).

## Verification

- New regression tests in `comments-resolvers.test.ts` covering the #921 scenario (backend reporting the wrong `sourceDocument`), dedupe, direct-comment classification, and unloadable comments.
- Full `@shm/shared` suite passes (74 files, 1005 tests); `tsc --noEmit` clean.
- Drove the real resolver end-to-end against the live seedteamtalks.hyper.media API: it now returns the citing librarian comment (`hm://z6MktvJHD…/z6HwrJYJoryPjK` targeting `design/pending-us`) for the document reported in the issue.

## Follow-up (not in this PR)

The underlying backend regression remains: `ListCitations`/`ListEntityMentions` report `sourceDocument` = requested IRI for all comment citations (`resources.go` `qListCitationsTpl` Comment branch, and the twin in `entities.go`). The citations panel's comment previews, the activity feed, and the email notifier still rely on it and degrade quietly for external comments. Restoring `source_resource.iri` there would fix all consumers at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)