### PR TITLE
fix(editor): stop rebuilding BlockNote editors on every render

### DIFF
--- a/frontend/packages/editor/src/blocknote/react/BlockNoteView.tsx
+++ b/frontend/packages/editor/src/blocknote/react/BlockNoteView.tsx
@@ -2,6 +2,7 @@ import {BlockNoteEditor, BlockSchema, mergeCSSClasses} from '../core'
 import {MantineProvider, createStyles} from '@mantine/core'
 import {EditorContent} from '@tiptap/react'
 import {HTMLAttributes, ReactNode, useEffect, useMemo, useState} from 'react'
+import {getEditorViewKey} from '../../editor-view-key'
 import {Theme, blockNoteToMantineTheme} from './BlockNoteTheme'
 import {darkDefaultTheme, lightDefaultTheme} from './defaultThemes'
 import {FormattingToolbarPositioner} from './FormattingToolbar/components/FormattingToolbarPositioner'
@@ -25,6 +26,7 @@ function BaseBlockNoteView<BSchema extends BlockSchema>(
 
   return (
     <EditorContent
+      key={props.editor ? getEditorViewKey(props.editor) : undefined}
       editor={props.editor?._tiptapEditor || null}
       className={mergeCSSClasses(classes.root, props.className || '')}
       {...rest}

--- a/frontend/packages/editor/src/document-editor.tsx
+++ b/frontend/packages/editor/src/document-editor.tsx
@@ -227,6 +227,14 @@ export function DocumentEditor({
     return editorBlocks.length > 0 ? editorBlocks : [{type: 'paragraph' as const}]
   }, [effectiveBlocks])
 
+  // Rebuilding the editor tears down and recreates every ProseMirror node view,
+  // so key it on the serialized content rather than on `initialContent`'s
+  // identity — query refetches and machine emissions hand us a fresh array with
+  // identical content. `resourceId.id` stays in the deps so navigating between
+  // two documents that happen to have identical content still gets a new editor
+  // (option closures below capture `resourceId`).
+  const initialContentKey = useMemo(() => JSON.stringify(initialContent), [initialContent])
+
   const editor = useBlockNote<HMBlockSchema>(
     {
       editable: false,
@@ -449,7 +457,7 @@ export function DocumentEditor({
         ],
       },
     },
-    [initialContent],
+    [initialContentKey, resourceId.id],
   )
 
   // Keep the editor ref current so the paste-handler block-fragment landing

--- a/frontend/packages/editor/src/editor-view-key.ts
+++ b/frontend/packages/editor/src/editor-view-key.ts
@@ -1,0 +1,21 @@
+let nextEditorViewKey = 0
+const editorViewKeys = new WeakMap<object, number>()
+
+/**
+ * Stable per-instance key for an editor. Assigning it as the `key` of tiptap's
+ * `EditorContent` forces a remount whenever `useBlockNote` swaps in a new editor.
+ *
+ * Without it, @tiptap/react reuses the same `PureEditorContent` instance and its
+ * `initialized` flag stays `true` from the previous editor, so the new editor's
+ * `createNodeViews()` — called from `componentDidUpdate` — registers node views
+ * through `flushSync`, which React rejects during a lifecycle method. Remounting
+ * resets `initialized` to `false`, so registration happens synchronously instead.
+ */
+export function getEditorViewKey(editor: object): number {
+  let key = editorViewKeys.get(editor)
+  if (key === undefined) {
+    key = nextEditorViewKey++
+    editorViewKeys.set(editor, key)
+  }
+  return key
+}

--- a/frontend/packages/editor/src/readonly-blocknote-view.tsx
+++ b/frontend/packages/editor/src/readonly-blocknote-view.tsx
@@ -1,28 +1,7 @@
 import {BlockNoteEditor, BlockSchema} from './blocknote/core'
 import {EditorContent} from '@tiptap/react'
 import {HTMLAttributes, ReactNode} from 'react'
-
-let nextEditorViewKey = 0
-const editorViewKeys = new WeakMap<object, number>()
-
-/**
- * Stable per-instance key for an editor. Assigning a key to `EditorContent`
- * forces a remount when `useBlockNote` swaps in a new editor instance.
- *
- * Without it, @tiptap/react reuses the same `PureEditorContent` instance and its
- * `initialized` flag stays `true` from the previous editor, so the new editor's
- * `createNodeViews()` — called from `componentDidUpdate` — registers node views
- * through `flushSync`, which React rejects during a lifecycle method. Remounting
- * resets `initialized` to `false`, so registration happens synchronously instead.
- */
-function getEditorViewKey(editor: object): number {
-  let key = editorViewKeys.get(editor)
-  if (key === undefined) {
-    key = nextEditorViewKey++
-    editorViewKeys.set(editor, key)
-  }
-  return key
-}
+import {getEditorViewKey} from './editor-view-key'
 
 /**
  * Minimal BlockNote view that renders EditorContent without MantineProvider.

--- a/frontend/packages/editor/src/readonly-blocknote-view.tsx
+++ b/frontend/packages/editor/src/readonly-blocknote-view.tsx
@@ -2,6 +2,28 @@ import {BlockNoteEditor, BlockSchema} from './blocknote/core'
 import {EditorContent} from '@tiptap/react'
 import {HTMLAttributes, ReactNode} from 'react'
 
+let nextEditorViewKey = 0
+const editorViewKeys = new WeakMap<object, number>()
+
+/**
+ * Stable per-instance key for an editor. Assigning a key to `EditorContent`
+ * forces a remount when `useBlockNote` swaps in a new editor instance.
+ *
+ * Without it, @tiptap/react reuses the same `PureEditorContent` instance and its
+ * `initialized` flag stays `true` from the previous editor, so the new editor's
+ * `createNodeViews()` — called from `componentDidUpdate` — registers node views
+ * through `flushSync`, which React rejects during a lifecycle method. Remounting
+ * resets `initialized` to `false`, so registration happens synchronously instead.
+ */
+function getEditorViewKey(editor: object): number {
+  let key = editorViewKeys.get(editor)
+  if (key === undefined) {
+    key = nextEditorViewKey++
+    editorViewKeys.set(editor, key)
+  }
+  return key
+}
+
 /**
  * Minimal BlockNote view that renders EditorContent without MantineProvider.
  * Use for read-only viewer contexts (feed, comments, embeds) where no editing
@@ -17,7 +39,7 @@ export function ReadOnlyBlockNoteView<BSchema extends BlockSchema>({
   children?: ReactNode
 } & HTMLAttributes<HTMLDivElement>) {
   return (
-    <EditorContent editor={editor._tiptapEditor || null} className={className} {...rest}>
+    <EditorContent key={getEditorViewKey(editor)} editor={editor._tiptapEditor || null} className={className} {...rest}>
       {children ?? <></>}
     </EditorContent>
   )

--- a/frontend/packages/shared/src/models/use-document-machine.ts
+++ b/frontend/packages/shared/src/models/use-document-machine.ts
@@ -644,11 +644,18 @@ export function selectShouldFocusDraftTitle(snapshot: DocumentMachineSnapshot): 
   )
 }
 
+/**
+ * Shared empty result so the selector stays referentially stable when there is
+ * no content. `useSelector` compares with `Object.is`, so a fresh `[]` here made
+ * every machine emission look like new blocks — which rebuilt the whole editor.
+ */
+const NO_BLOCKS: HMBlockNode[] = []
+
 /** The blocks the editor should render from the document machine's current source of truth. */
 export function selectRenderableBlocks(snapshot: DocumentMachineSnapshot): HMBlockNode[] {
   const ctx = snapshot.context
-  if (selectShouldUseDraftOverlay(snapshot)) return ctx.draftContent ?? []
-  return ctx.document?.content ?? []
+  if (selectShouldUseDraftOverlay(snapshot)) return ctx.draftContent ?? NO_BLOCKS
+  return ctx.document?.content ?? NO_BLOCKS
 }
 
 /** The blocks the editor should render: draft content (if available) or published document content. */

--- a/frontend/packages/ui/src/comments.tsx
+++ b/frontend/packages/ui/src/comments.tsx
@@ -876,8 +876,13 @@ export function CommentContent({
     blockRef: selection?.blockId || null,
     blockRange: selection?.blockRange || null,
   }
-  const zoomedBlock = zoomBlockRef ? getBlockNodeById(comment.content, zoomBlockRef) : null
-  const zoomedContent = zoomedBlock ? [zoomedBlock] : comment.content
+  // Must stay referentially stable: the viewer rebuilds its whole editor whenever
+  // `blocks` changes identity, so a fresh array literal would tear down and
+  // recreate a ProseMirror instance on every render.
+  const zoomedContent = useMemo(() => {
+    const zoomedBlock = zoomBlockRef ? getBlockNodeById(comment.content, zoomBlockRef) : null
+    return zoomedBlock ? [zoomedBlock] : comment.content
+  }, [zoomBlockRef, comment.content])
 
   if (!Viewer) return null
 
@@ -922,9 +927,11 @@ export function QuotedDocBlock({
   blockRange?: BlockRange
 }) {
   const Viewer = useReadOnlyViewer()
-  const blockContent = useMemo(() => {
+  // Memoized as an array so the viewer keeps the same editor across renders.
+  const blocks = useMemo(() => {
     if (!doc.content) return null
-    return getBlockNodeById(doc.content, blockId)
+    const blockNode = getBlockNodeById(doc.content, blockId)
+    return blockNode ? [blockNode] : null
   }, [doc.content, blockId])
 
   // Only forward a codepoint range — `{expanded: true}` blockRange variants
@@ -938,9 +945,9 @@ export function QuotedDocBlock({
           <BlockQuote size={23} />
         </div>
         <div className="min-w-0 flex-1">
-          {blockContent && Viewer && (
+          {blocks && Viewer && (
             <Viewer
-              blocks={[blockContent]}
+              blocks={blocks}
               resourceId={{...docId, blockRef: blockId}}
               focusBlockId={fragmentRange ? blockId : undefined}
               blockRange={fragmentRange}

--- a/frontend/packages/ui/src/feed.tsx
+++ b/frontend/packages/ui/src/feed.tsx
@@ -921,32 +921,27 @@ function CitationSourceBlock({sourceId}: {sourceId: UnpackedHypermediaId}) {
   const resource = useResource(sourceId)
   const Viewer = useReadOnlyViewer()
 
+  // Must stay referentially stable: the viewer rebuilds its whole editor whenever
+  // the `blocks` array changes identity, so an inline `[blockNode]` literal would
+  // tear down and recreate a ProseMirror instance on every render.
+  const blocks = useMemo(() => {
+    const data = resource.data
+    const content =
+      data?.type === 'document' ? data.document?.content : data?.type === 'comment' ? data.comment?.content : undefined
+    if (!content || !sourceId.blockRef) return null
+    const blockNode = findContentBlock(content, sourceId.blockRef)
+    return blockNode ? [blockNode] : null
+  }, [resource.data, sourceId.blockRef])
+
   if (resource.isLoading) {
     return <div className="text-muted-foreground text-xs">Loading block…</div>
   }
 
-  if (resource.error || !resource.data || !Viewer) {
+  if (resource.error || !resource.data || !Viewer || !blocks) {
     return null
   }
 
-  const content =
-    resource.data.type === 'document'
-      ? resource.data.document?.content
-      : resource.data.type === 'comment'
-        ? resource.data.comment?.content
-        : undefined
-
-  if (!content || !sourceId.blockRef) {
-    return null
-  }
-
-  const blockNode = findContentBlock(content, sourceId.blockRef)
-
-  if (!blockNode) {
-    return null
-  }
-
-  return <Viewer blocks={[blockNode]} resourceId={sourceId} textUnit={14} layoutUnit={16} />
+  return <Viewer blocks={blocks} resourceId={sourceId} textUnit={14} layoutUnit={16} />
 }
 
 export function getEventRoute(event: LoadedEvent): NavRoute | null {


### PR DESCRIPTION
## Problem

The console was filling with:

> Warning: flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering.

The warning is a symptom. The real bug is that both BlockNote editors — the read-only viewer and the editable document editor — were being destroyed and rebuilt far more often than they needed to be, tearing down and recreating every ProseMirror node view each time.

## Why the warning fires

`@tiptap/react@2.0.3`, `PureEditorContent.init()`:

```js
init() {
  const { editor } = this.props
  if (editor && editor.options.element) {
    if (editor.contentComponent) return   // guard only checks the NEW editor
    editor.contentComponent = this
    editor.createNodeViews()              // fires setRenderer() per React node view
    this.initialized = true
  }
}
maybeFlushSync(fn) {
  if (this.initialized) flushSync(fn)     // still true from the PREVIOUS editor
  else fn()
}
```

`init()` runs from `componentDidMount`/`componentDidUpdate`. The `initialized` flag exists to keep `flushSync` out of that first mount, but it is never reset when the `editor` **prop is swapped for a new instance**. Mount editor A → `initialized = true`; swap in editor B → `componentDidUpdate` → `init()` → `createNodeViews()` → `setRenderer` → `flushSync` inside a lifecycle method.

So the warning is a reliable signal that an editor instance was replaced.

## Why the editors were being replaced

`useBlockNote` destroys and rebuilds the editor whenever its dep list changes, and both call paths keyed that on object identity:

- **Read-only viewer** — `ReadOnlyViewer` memoizes `initialContent` on `[blocks]`, and three call sites passed a fresh array literal every render (`blocks={[blockNode]}`). The node itself was stable; only the wrapper array was new.
- **Document editor** — `DocumentEditor` keyed on `[initialContent]`, derived from the `blocks` prop. That prop comes from `selectRenderableBlocks`, which returned `ctx.document?.content ?? []` — a **fresh array literal** whenever content was nullish. `useDocumentSelector` wraps xstate's `useSelector`, which compares with `Object.is`, so every machine emission looked like new blocks.

## Changes

- Memoize the `blocks` arrays at the three read-only call sites (`feed.tsx`, `comments.tsx` ×2). `embed-views.tsx` already did this correctly.
- Add `editor-view-key.ts` and key `EditorContent` on the editor instance in both `ReadOnlyBlockNoteView` and `BaseBlockNoteView`, so a genuinely new editor remounts `PureEditorContent` with `initialized` reset instead of flushing synchronously inside a lifecycle method.
- `selectRenderableBlocks` returns a shared `NO_BLOCKS` constant instead of a fresh `[]`.
- `DocumentEditor` keys its editor on the serialized content rather than `initialContent`'s identity, so refetches returning identical content no longer rebuild it. `resourceId.id` stays in the deps because the editor's option closures capture it — without it, navigating between two documents with identical content would reuse an editor holding a stale `resourceId` in `getSlashMenuItems` and the extensions.

## Testing

`tsc --noEmit` clean on `editor`, `ui`, and `shared`; prettier clean. Test suites re-run on all three packages — `shared` fully green (1001 passed).

Three suites fail, all **pre-existing** — verified by re-running them with these changes stashed, where they fail identically:

- `readonly-viewer-gallery.test.tsx` — asserts `ReadOnlyViewer` renders `ImageGalleryOverlay`, which it no longer does; the test has drifted from the component
- `BlockManipulationExtension.test.ts` (7)
- `lazy-viewport-mount.test.tsx`

Not verified in the running app — worth a look at the feed and a document page to confirm the console is quiet.

## Known issue, not addressed here

While tracing this, a separate `validateDOMNesting: <a> cannot appear as a descendant of <a>` surfaced. `EmbedWrapper` renders an `<a>` when the embed is clickable (`embed-wrapper.tsx:67`), and its children legitimately contain links — `DocumentNameLink`, and any hyperlink in embedded body content, since the link mark also renders as `<a>` (`tiptap-extension-link/link.ts:196`). Fixing it means dropping one of the two anchors, which is a product call — the outer `href` is load-bearing on web for open-in-new-tab and crawlability, and a stretched-link overlay would break selecting text inside embeds. Left for a separate change.