### PR TITLE
Repair missing RBSR migration tables

### DIFF
--- a/backend/storage/storage_migrations.go
+++ b/backend/storage/storage_migrations.go
@@ -63,6 +63,27 @@ type migration struct {
 //
 // In case of even the most minor doubts, consult with the team before adding a new migration, and submit the code to review if needed.
 var migrations = []migration{
+	// Repair installs that already advanced past the original RBSR-table
+	// migration without receiving it. The tables are derived and safe to create
+	// empty; fresh data dirs already have them from schema.sql.
+	{Version: "2026-08-05.103117", Run: func(_ *Store, conn *sqlite.Conn) error {
+		return sqlitex.ExecScript(conn, sqlfmt(`
+			CREATE TABLE IF NOT EXISTS rbsr_scope (
+			    id INTEGER PRIMARY KEY,
+			    iri TEXT NOT NULL,
+			    kind INTEGER NOT NULL,
+			    materialized INTEGER NOT NULL DEFAULT 0,
+			    last_access INTEGER NOT NULL DEFAULT 0,
+			    UNIQUE (iri, kind)
+			);
+			CREATE TABLE IF NOT EXISTS rbsr_item (
+			    scope INTEGER NOT NULL REFERENCES rbsr_scope (id) ON UPDATE CASCADE ON DELETE CASCADE,
+			    blob INTEGER NOT NULL REFERENCES blobs (id) ON UPDATE CASCADE ON DELETE CASCADE,
+			    PRIMARY KEY (scope, blob)
+			) WITHOUT ROWID;
+			CREATE INDEX IF NOT EXISTS rbsr_item_by_blob ON rbsr_item (blob);
+		`))
+	}},
 	// Add an expression index on the redirect target of document generations, so
 	// that the comment-activity aggregation in document listings can walk redirect
 	// chains with indexed lookups instead of scanning the whole table. DDL must

--- a/backend/storage/storage_migrations.go
+++ b/backend/storage/storage_migrations.go
@@ -63,11 +63,19 @@ type migration struct {
 //
 // In case of even the most minor doubts, consult with the team before adding a new migration, and submit the code to review if needed.
 var migrations = []migration{
-	// Repair installs that already advanced past the original RBSR-table
-	// migration without receiving it. The tables are derived and safe to create
-	// empty; fresh data dirs already have them from schema.sql.
+	// This is a bug-fix migration which re-creates the RBSR-related tables if they are missing.
+	// Some users have reported daemon startup issues that's caused by these tables missing.
+	// During the development of this feature we did some weird things and seems like we might have updated a past migration
+	// without bumping its version number, and it could be that some users have ran those pre-release versions.
+	// This migration simply ensures those tables exist, and forces reindex of all the data just to be sure.
 	{Version: "2026-08-05.103117", Run: func(_ *Store, conn *sqlite.Conn) error {
+		if err := scheduleReindex(conn); err != nil {
+			return err
+		}
+
 		return sqlitex.ExecScript(conn, sqlfmt(`
+			DROP TABLE IF EXISTS rbsr_scope;
+			DROP TABLE IF EXISTS rbsr_item;
 			CREATE TABLE IF NOT EXISTS rbsr_scope (
 			    id INTEGER PRIMARY KEY,
 			    iri TEXT NOT NULL,
@@ -86,10 +94,7 @@ var migrations = []migration{
 	}},
 	// Add an expression index on the redirect target of document generations, so
 	// that the comment-activity aggregation in document listings can walk redirect
-	// chains with indexed lookups instead of scanning the whole table. DDL must
-	// stay in lock-step with schema.sql (the migration snapshot test compares).
-	// Drop-first because data dirs fresh-initialized from a pre-merge branch
-	// build already have this index from schema.sql.
+	// chains with indexed lookups instead of scanning the whole table.
 	{Version: "2026-07-28.193121", Run: func(_ *Store, conn *sqlite.Conn) error {
 		return sqlitex.ExecScript(conn, sqlfmt(`
 			DROP INDEX IF EXISTS document_generations_by_redirect;
@@ -105,10 +110,7 @@ var migrations = []migration{
 	// Add the embeddings_index bookkeeping table: one row per fts entry that has
 	// been embedded. The vec0 embeddings table can't be indexed on fts_id, so the
 	// embedder's pending scan had to full-scan the vector table on every pass;
-	// this table gives that anti-join an integer primary key to probe. DDL must
-	// stay in lock-step with schema.sql (the migration snapshot test compares).
-	// Drop-first because data dirs fresh-initialized from a pre-merge branch
-	// build already have this table from schema.sql. Backfilled from the
+	// this table gives that anti-join an integer primary key to probe. Backfilled from the
 	// existing embeddings so already-embedded content isn't re-embedded.
 	{Version: "2026-07-24.124310", Run: func(_ *Store, conn *sqlite.Conn) error {
 		return sqlitex.ExecScript(conn, sqlfmt(`
@@ -122,12 +124,7 @@ var migrations = []migration{
 	}},
 	// Add the maintained RBSR fingerprint index tables (rbsr_scope / rbsr_item).
 	// They're derived, incremental acceleration for syncing and re-materialize
-	// lazily, so the migration only needs to create the empty tables. DDL must
-	// stay in lock-step with schema.sql (the migration snapshot test compares).
-	// Drop-first because data dirs fresh-initialized from a pre-merge branch
-	// build already have these tables (from schema.sql) while their VERSION file
-	// predates this migration; the tables hold no durable data, so replacing
-	// them also fixes any stale shape.
+	// lazily, so the migration only needs to create the empty tables.
 	{Version: "2026-06-09.094401", Run: func(_ *Store, conn *sqlite.Conn) error {
 		return sqlitex.ExecScript(conn, sqlfmt(`
 			DROP TABLE IF EXISTS rbsr_item;
@@ -151,9 +148,7 @@ var migrations = []migration{
 	// Drop the UNIQUE constraint from peers.addresses. Two peers can legitimately
 	// share an address set (relay-shared, NAT-shared, address reuse after a peer
 	// leaves) and the old constraint aborted entire bulk peer-exchange INSERTs
-	// on the first colliding row. We park the data in a tmp table, drop the
-	// original, recreate with the canonical DDL (matching schema.sql so the
-	// migration snapshot test passes), copy back, and drop the tmp.
+	// on the first colliding row.
 	{Version: "2026-05-19.151347", Run: func(_ *Store, conn *sqlite.Conn) error {
 		return sqlitex.ExecScript(conn, sqlfmt(`
 			CREATE TABLE peers_tmp AS SELECT id, pid, addresses, explicitly_connected, created_at, updated_at FROM peers;

--- a/backend/storage/storage_migrations_test.go
+++ b/backend/storage/storage_migrations_test.go
@@ -14,6 +14,7 @@ import (
 	"seed/backend/core/keystore"
 	"seed/backend/testutil"
 	"seed/backend/util/must"
+	"seed/backend/util/sqlite"
 	"seed/backend/util/sqlite/sqlitex"
 	"seed/backend/util/sqlitegen"
 	"slices"
@@ -155,6 +156,35 @@ func TestMigrationListSorted(t *testing.T) {
 	if len(out) != len(migrations) {
 		t.Fatalf("the list of migrations must not contain duplicates: %v", migrations)
 	}
+}
+
+func TestMigrationRestoresMissingRBSRTables(t *testing.T) {
+	alice := coretest.NewTester("alice")
+	dir := t.TempDir()
+
+	store, err := Open(dir, alice.Device.Libp2pKey(), keystore.NewMemory(), "debug")
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+
+	db, err := newSQLite(sqlitePath(dir))
+	require.NoError(t, err)
+	require.NoError(t, db.ForWrite(func(conn *sqlite.Conn) error {
+		if err := sqlitex.ExecTransient(conn, "DROP TABLE rbsr_item", nil); err != nil {
+			return err
+		}
+		return sqlitex.ExecTransient(conn, "DROP TABLE rbsr_scope", nil)
+	}))
+	require.NoError(t, db.Close())
+	require.NoError(t, writeVersionFile(dir, "2026-07-28.193121"))
+
+	store, err = Open(dir, alice.Device.Libp2pKey(), keystore.NewMemory(), "debug")
+	require.NoError(t, err)
+	defer store.Close()
+
+	rawSchema := getRawSQLSchema(t, store.db)
+	require.Contains(t, rawSchema, "rbsr_scope")
+	require.Contains(t, rawSchema, "rbsr_item")
+	require.Contains(t, rawSchema, "rbsr_item_by_blob")
 }
 
 func copyDir(src, dst string) error {

--- a/backend/storage/storage_migrations_test.go
+++ b/backend/storage/storage_migrations_test.go
@@ -14,7 +14,6 @@ import (
 	"seed/backend/core/keystore"
 	"seed/backend/testutil"
 	"seed/backend/util/must"
-	"seed/backend/util/sqlite"
 	"seed/backend/util/sqlite/sqlitex"
 	"seed/backend/util/sqlitegen"
 	"slices"
@@ -156,35 +155,6 @@ func TestMigrationListSorted(t *testing.T) {
 	if len(out) != len(migrations) {
 		t.Fatalf("the list of migrations must not contain duplicates: %v", migrations)
 	}
-}
-
-func TestMigrationRestoresMissingRBSRTables(t *testing.T) {
-	alice := coretest.NewTester("alice")
-	dir := t.TempDir()
-
-	store, err := Open(dir, alice.Device.Libp2pKey(), keystore.NewMemory(), "debug")
-	require.NoError(t, err)
-	require.NoError(t, store.Close())
-
-	db, err := newSQLite(sqlitePath(dir))
-	require.NoError(t, err)
-	require.NoError(t, db.ForWrite(func(conn *sqlite.Conn) error {
-		if err := sqlitex.ExecTransient(conn, "DROP TABLE rbsr_item", nil); err != nil {
-			return err
-		}
-		return sqlitex.ExecTransient(conn, "DROP TABLE rbsr_scope", nil)
-	}))
-	require.NoError(t, db.Close())
-	require.NoError(t, writeVersionFile(dir, "2026-07-28.193121"))
-
-	store, err = Open(dir, alice.Device.Libp2pKey(), keystore.NewMemory(), "debug")
-	require.NoError(t, err)
-	defer store.Close()
-
-	rawSchema := getRawSQLSchema(t, store.db)
-	require.Contains(t, rawSchema, "rbsr_scope")
-	require.Contains(t, rawSchema, "rbsr_item")
-	require.Contains(t, rawSchema, "rbsr_item_by_blob")
 }
 
 func copyDir(src, dst string) error {


### PR DESCRIPTION
## What changed

Adds a forward storage migration (`2026-08-05.103117`) that idempotently recreates the derived RBSR tables/index when an existing data directory is missing them:

- `rbsr_scope`
- `rbsr_item`
- `rbsr_item_by_blob`

## Why

A Windows user reported that the desktop app appeared to do nothing on launch/install. The pasted logs show the daemon does start, but then exits almost immediately:

```text
DaemonStarted
P2PNodeReady
GracefulShutdownStarted
sqlite.Exec: Conn.Prepare: SQLITE_ERROR: no such table: rbsr_item
Go daemon closed code=1
```

After the daemon exits, the desktop keeps polling gRPC and only sees `ECONNREFUSED`, eventually timing out with `Timed out: waiting for daemon gRPC to be ready`.

The root cause is an existing user data directory that had advanced beyond the original RBSR migration version while missing the `rbsr_*` derived tables. Reindex/sync code now expects those tables, so startup can fail before the desktop gets a stable daemon connection.

## Impact

Affected existing installs should repair themselves on next startup instead of failing daemon boot. Fresh data directories are unchanged because these tables already come from `schema.sql`. The tables are derived, so creating them empty is safe; they can re-materialize lazily as existing RBSR code runs.

## Validation

Ran:

```sh
go test ./backend/storage -run TestMigrationRestoresMissingRBSRTables -count=1
go test ./backend/storage -count=1
go test ./backend/blob ./backend/daemon ./backend/storage -count=1
go test ./backend/...
golangci-lint run --new-from-merge-base origin/main ./backend/...
```

All passed; lint reported `0 issues`.