### PR TITLE
feat(editor): carry text formatting across new blocks

### DIFF
--- a/frontend/packages/editor/e2e/tests/block-manipulation.e2e.ts
+++ b/frontend/packages/editor/e2e/tests/block-manipulation.e2e.ts
@@ -27,6 +27,19 @@ test.describe('Block Manipulation', () => {
       expect(blocks[1].content[0].text).toContain('Second paragraph')
     })
 
+    test('Should carry text formatting to the block created by Enter', async ({editorHelpers, page}) => {
+      await page.evaluate(() => {
+        window.TEST_EDITOR?.editor?.addStyles({textSize: 'large', textFamily: 'serif'})
+      })
+      await editorHelpers.typeText('First paragraph')
+      await editorHelpers.pressKey('Enter')
+      await editorHelpers.typeText('Second paragraph')
+
+      const blocks = await editorHelpers.getBlocks()
+      expect(blocks[0].content[0].styles).toMatchObject({textSize: 'large', textFamily: 'serif'})
+      expect(blocks[1].content[0].styles).toMatchObject({textSize: 'large', textFamily: 'serif'})
+    })
+
     test('Should insert heading with slash menu', async ({editorHelpers, page}) => {
       await editorHelpers.openSlashMenu()
       await editorHelpers.clickSlashMenuItem('Heading')

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/splitBlock.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/splitBlock.test.ts
@@ -93,6 +93,33 @@ describe('splitBlockCommand', () => {
       expect(topGroup.child(1).firstChild!.textContent).toBe('')
       expect(topGroup.child(2).firstChild!.textContent).toBe('Second')
     })
+
+    it('keeps active text formatting as stored marks for typing in the new block', () => {
+      const bold = schema.marks['bold']!.create()
+      const italic = schema.marks['italic']!.create()
+      const textSize = schema.marks['textSize']!.create({value: 'large'})
+      const textFamily = schema.marks['textFamily']!.create({value: 'serif'})
+      const link = schema.marks['link']!.create({href: 'https://example.com'})
+      const paragraph = schema.nodes['paragraph']!.create(
+        null,
+        schema.text('First', [bold, italic, textSize, textFamily, link]),
+      )
+      const doc = schema.nodes['doc']!.create(
+        null,
+        schema.nodes['blockChildren']!.create(null, schema.nodes['blockNode']!.create({id: 'block-1'}, paragraph)),
+      )
+      const splitPos = findPosInBlock(doc, 'block-1') + 5
+      const newState = runSplit(doc, splitPos)
+
+      const marks = newState.storedMarks?.map((mark) => ({type: mark.type.name, attrs: mark.attrs}))
+      expect(marks).toEqual(
+        expect.arrayContaining([
+          {type: 'textSize', attrs: {value: 'large'}},
+          {type: 'textFamily', attrs: {value: 'serif'}},
+        ]),
+      )
+      expect(marks?.length).toBe(2)
+    })
   })
 
   // Test 3: Split in Unordered list preserves list attrs

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/test-helpers-prosemirror.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/test-helpers-prosemirror.ts
@@ -35,6 +35,25 @@ export function createMinimalSchema(): Schema {
         group: 'inline',
       },
     },
+    marks: {
+      bold: {},
+      italic: {},
+      link: {
+        attrs: {
+          href: {default: null},
+        },
+      },
+      textFamily: {
+        attrs: {
+          value: {default: null},
+        },
+      },
+      textSize: {
+        attrs: {
+          value: {default: null},
+        },
+      },
+    },
   })
 }
 

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/commands/nestBlock.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/commands/nestBlock.ts
@@ -7,16 +7,27 @@ import {BlockNoteEditor} from '../../../BlockNoteEditor'
 import {getBlockInfoFromPos, getBlockInfoFromSelection} from '../../../extensions/Blocks/helpers/getBlockInfoFromPos'
 import {getGroupInfoFromPos, getParentGroupInfoFromPos} from '../../../extensions/Blocks/helpers/getGroupInfoFromPos'
 import {isInGridContainer} from '../../../extensions/Blocks/nodes/BlockChildren'
+import {getCarryableStoredMarks} from './splitBlock'
 import {updateGroupChildrenCommand} from './updateGroup'
 
 function liftListItem(editor: Editor, posInBlock: number) {
   return function ({state, dispatch}: {state: EditorState; dispatch: any}) {
+    const storedMarks = getCarryableStoredMarks(state)
+    console.log(
+      '[CTF] liftListItem | depth:',
+      state.selection.$from.depth - 1,
+      '| hasDispatch:',
+      !!dispatch,
+      '| hasChildren:',
+      false,
+    )
     const blockInfo = getBlockInfoFromPos(state, posInBlock)
 
     if (state.selection.$from.depth - 1 > 2 && dispatch) {
       // If there are children, need to manually append siblings
       // into block's children to avoid the range error.
       if (blockInfo.block.node.childCount > 1) {
+        console.log('[CTF] liftListItem | complex path with children')
         const blockChildren = state.tr.doc
           .resolve(blockInfo.block.beforePos + blockInfo.blockContent.node.nodeSize + 2)
           .node().content
@@ -110,11 +121,14 @@ function liftListItem(editor: Editor, posInBlock: number) {
 
         state.tr.insert(insertPos, block)
         state.tr.setSelection(new TextSelection(state.tr.doc.resolve(insertPos + 2)))
+        state.tr.setStoredMarks(storedMarks)
+        console.log('[CTF] liftListItem | complex dispatch with storedMarks')
 
         dispatch(state.tr)
 
         return true
       } else {
+        console.log('[CTF] liftListItem | simple path: setTimeout -> editor.commands.liftListItem')
         setTimeout(() => {
           editor.commands.liftListItem('blockNode')
         })
@@ -122,6 +136,7 @@ function liftListItem(editor: Editor, posInBlock: number) {
       }
     }
 
+    console.log('[CTF] liftListItem | fallthrough: depth <= 2 or no dispatch')
     return true
   }
 }
@@ -133,12 +148,15 @@ export function sinkListItem(
   listLevel: string,
 ) {
   return function ({state, dispatch}: {state: EditorState; dispatch: any}) {
+    const storedMarks = getCarryableStoredMarks(state)
+    console.log('[CTF] sinkListItem | storedMarks count:', storedMarks.length, '| hasDispatch:', !!dispatch)
     const {$from, $to} = state.selection
     const range = $from.blockRange(
       $to,
       (node) => node.childCount > 0 && node.type.name === 'blockChildren', // change necessary to not look at first item child type
     )
     if (!range) {
+      console.log('[CTF] sinkListItem | SKIPPED: no range')
       return false
     }
     const startIndex = range.startIndex
@@ -166,8 +184,10 @@ export function sinkListItem(
       dispatch(
         state.tr
           .step(new ReplaceAroundStep(before - (nestedBefore ? 3 : 1), after, before, after, slice, 1, true))
+          .setStoredMarks(storedMarks)
           .scrollIntoView(),
       )
+      console.log('[CTF] sinkListItem | dispatched with setStoredMarks')
     }
     return true
   }
@@ -185,6 +205,7 @@ export function nestBlock(editor: BlockNoteEditor<any>, listType: HMBlockChildre
 }
 
 export function unnestBlock(editor: Editor, posInBlock: number) {
+  console.log('[CTF] unnestBlock called at pos:', posInBlock)
   return editor.commands.command(liftListItem(editor, posInBlock))
 }
 

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/commands/splitBlock.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/commands/splitBlock.ts
@@ -1,11 +1,25 @@
 import {selectableNodeTypes} from '../../../extensions/BlockManipulation/BlockManipulationExtension'
-import {Node} from 'prosemirror-model'
+import {Mark, Node} from 'prosemirror-model'
 import {EditorState, TextSelection} from 'prosemirror-state'
 import {getBlockInfoFromPos} from '../../../extensions/Blocks/helpers/getBlockInfoFromPos'
+
+const carryableMarkNames = new Set(['textSize', 'textFamily'])
+
+/** Returns active text formatting marks that should continue after creating a new block. */
+export function getCarryableStoredMarks(state: EditorState): Mark[] {
+  const source = state.storedMarks ? 'storedMarks' : 'selection.$from.marks()'
+  const marks = state.storedMarks ?? state.selection.$from.marks()
+  const allNames = marks.map((m) => m.type.name)
+  const filtered = marks.filter((mark) => carryableMarkNames.has(mark.type.name))
+  const filteredNames = filtered.map((m) => `${m.type.name}=${JSON.stringify(m.attrs)}`)
+  console.log('[CTF] getCarryableStoredMarks | source:', source, '| allMarks:', allNames, '| carryable:', filteredNames)
+  return filtered
+}
 
 export const splitBlockCommand = (posInBlock: number, keepType?: boolean, keepProps?: boolean, insertNode?: Node) => {
   return ({state, dispatch}: {state: EditorState; dispatch: ((args?: any) => any) | undefined}) => {
     let tr = state.tr
+    const storedMarks = getCarryableStoredMarks(state)
 
     const blockInfo = getBlockInfoFromPos(state, posInBlock)
 
@@ -38,6 +52,12 @@ export const splitBlockCommand = (posInBlock: number, keepType?: boolean, keepPr
       }
       tr = tr.setSelection(selection)
     }
+
+    tr = tr.setStoredMarks(storedMarks)
+    console.log(
+      '[CTF] splitBlockCommand | setting storedMarks:',
+      storedMarks.map((m) => `${m.type.name}=${JSON.stringify(m.attrs)}`),
+    )
 
     if (dispatch) {
       dispatch(tr)

--- a/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/BlockNode.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/BlockNode.ts
@@ -3,7 +3,7 @@ import {Fragment, Slice} from 'prosemirror-model'
 import {EditorState, Plugin, PluginKey, TextSelection} from 'prosemirror-state'
 import {Decoration, DecorationSet} from 'prosemirror-view'
 
-import {splitBlockCommand} from '../../../api/blockManipulation/commands/splitBlock'
+import {getCarryableStoredMarks, splitBlockCommand} from '../../../api/blockManipulation/commands/splitBlock'
 import {updateGroupCommand} from '../../../api/blockManipulation/commands/updateGroup'
 import {mergeCSSClasses} from '../../../shared/utils'
 import {BlockNoteDOMAttributes} from '../api/blockTypes'
@@ -294,6 +294,7 @@ export const BlockNode = Node.create<{
                 .run()
             })
           } else {
+            const storedMarks = getCarryableStoredMarks(state)
             const originalBlockContent = state.doc.cut(block.beforePos + 2, state.selection.from)
             let newBlockContent = state.doc.cut(state.selection.from, block.beforePos + blockContent.node.nodeSize)
             const newBlock =
@@ -321,6 +322,7 @@ export const BlockNode = Node.create<{
 
               // Set the selection to the start of the new block's content node.
               state.tr.setSelection(new TextSelection(state.doc.resolve(newBlockContentPos)))
+              state.tr.setStoredMarks(storedMarks)
 
               state.tr.replace(
                 block.beforePos + 2,

--- a/frontend/packages/editor/src/blocknote/core/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
@@ -1,10 +1,10 @@
 import {Extension} from '@tiptap/core'
 import {Decoration, DecorationSet} from '@tiptap/pm/view'
 import {Node as PMNode} from 'prosemirror-model'
-import {NodeSelection, TextSelection} from 'prosemirror-state'
+import {NodeSelection, Plugin, PluginKey, TextSelection} from 'prosemirror-state'
 import {mergeBlocksCommand} from '../../api/blockManipulation/commands/mergeBlocks'
 import {nestBlock, unnestBlock} from '../../api/blockManipulation/commands/nestBlock'
-import {splitBlockCommand} from '../../api/blockManipulation/commands/splitBlock'
+import {getCarryableStoredMarks, splitBlockCommand} from '../../api/blockManipulation/commands/splitBlock'
 import {updateBlockCommand} from '../../api/blockManipulation/commands/updateBlock'
 import {updateGroupChildrenCommand, updateGroupCommand} from '../../api/blockManipulation/commands/updateGroup'
 import {BlockNoteEditor} from '../../BlockNoteEditor'
@@ -507,6 +507,7 @@ export const KeyboardShortcutsExtension = Extension.create<{
           commands.command(({state, dispatch}) => {
             const blockInfo = getBlockInfoFromSelection(state)
             const {block: blockContainer, blockContent} = blockInfo
+            const storedMarks = getCarryableStoredMarks(state)
 
             const selectionAtBlockStart = state.selection.$anchor.parentOffset === 0
             const selectionEmpty = state.selection.anchor === state.selection.head
@@ -523,6 +524,7 @@ export const KeyboardShortcutsExtension = Extension.create<{
 
                 state.tr.insert(newBlockInsertionPos, newBlock).scrollIntoView()
                 state.tr.setSelection(new TextSelection(state.doc.resolve(newBlockContentPos)))
+                state.tr.setStoredMarks(storedMarks)
               }
 
               return true
@@ -554,8 +556,9 @@ export const KeyboardShortcutsExtension = Extension.create<{
           }),
       ])
 
-    const handleTab = () =>
-      this.editor.commands.first(({commands}) => [
+    const handleTab = () => {
+      console.log('[CTF] handleTab started')
+      return this.editor.commands.first(({commands}) => [
         // If the current block's previous sibling is a table, create an empty paragraph
         // blockNode, and indent a group under it.
         () =>
@@ -635,6 +638,7 @@ export const KeyboardShortcutsExtension = Extension.create<{
 
             if (container) {
               // Try sinking the list item.
+              console.log('[CTF] Tab fallback (Command 3) | in container | calling chain().sinkListItem')
               const result = chain().sinkListItem('blockNode').run()
               // Update group children if sinking was successful.
               if (result) {
@@ -667,6 +671,7 @@ export const KeyboardShortcutsExtension = Extension.create<{
             }
           }),
       ])
+    }
 
     return {
       Backspace: handleBackspace,
@@ -674,9 +679,14 @@ export const KeyboardShortcutsExtension = Extension.create<{
       Enter: handleEnter,
       Tab: handleTab,
       'Shift-Tab': () => {
+        console.log('[CTF] Shift-Tab handler entered')
         // Prevent outdent of grid children
-        if (isInGridContainer(this.editor.state, this.editor.state.selection.from)) return true
+        if (isInGridContainer(this.editor.state, this.editor.state.selection.from)) {
+          console.log('[CTF] Shift-Tab | SKIPPED: in grid container')
+          return true
+        }
         const {block} = getBlockInfoFromSelection(this.editor.state)
+        console.log('[CTF] Shift-Tab | calling unnestBlock at pos:', block.beforePos + 1)
         return unnestBlock(this.editor, block.beforePos + 1)
       },
       // "Shift-Mod-ArrowUp": () => {
@@ -716,5 +726,60 @@ export const KeyboardShortcutsExtension = Extension.create<{
         return false
       },
     }
+  },
+
+  addProseMirrorPlugins() {
+    let capturedMarks: ReturnType<typeof getCarryableStoredMarks> | null = null
+
+    return [
+      new Plugin({
+        key: new PluginKey('CarryStoredMarks'),
+        props: {
+          handleDOMEvents: {
+            keydown(view, event) {
+              if ((event.key === 'Enter' && !event.shiftKey) || event.key === 'Tab') {
+                capturedMarks = getCarryableStoredMarks(view.state)
+                console.log(
+                  '[CTF] Plugin keydown | key:',
+                  event.key,
+                  '| capturedMarks count:',
+                  capturedMarks?.length ?? 0,
+                  '| names:',
+                  capturedMarks?.map((m) => `${m.type.name}=${JSON.stringify(m.attrs)}`),
+                )
+              } else {
+                capturedMarks = null
+              }
+              return false
+            },
+          },
+        },
+        appendTransaction(transactions, _oldState, newState) {
+          if (!capturedMarks?.length) return null
+          if (!transactions.some((transaction) => transaction.docChanged)) {
+            console.log('[CTF] Plugin appendTransaction | WAITING: no docChanged yet, keeping marks')
+            return null
+          }
+          if (!(newState.selection instanceof TextSelection) || !newState.selection.empty) {
+            console.log(
+              '[CTF] Plugin appendTransaction | SKIPPED: selection not empty TextSelection | type:',
+              newState.selection.constructor.name,
+              '| empty:',
+              newState.selection.empty,
+            )
+            capturedMarks = null
+            return null
+          }
+
+          const marks = capturedMarks
+          capturedMarks = null
+          console.log(
+            '[CTF] Plugin appendTransaction | APPLYING storedMarks:',
+            marks.map((m) => `${m.type.name}=${JSON.stringify(m.attrs)}`),
+          )
+          return newState.tr.setStoredMarks(marks)
+        },
+      }),
+    ]
   },
 })


### PR DESCRIPTION
## Summary
- Preserve `textSize` and `textFamily` formatting when pressing Enter to create a new block.
- Keep carryable text formatting active across block lift and sink operations.
- Add unit and E2E coverage for formatting continuity on new blocks.