### PR TITLE
test(editor): locate cursor selection plugin by key

### DIFF
--- a/frontend/packages/editor/src/blocknote/core/extensions/BlockManipulation/BlockManipulationExtension.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/BlockManipulation/BlockManipulationExtension.test.ts
@@ -44,10 +44,11 @@ const schema = new Schema({
 })
 
 function getCursorSelectPlugin(openUrl = vi.fn()) {
-  return (BlockManipulationExtension as any).config.addProseMirrorPlugins.call({
+  const plugins = (BlockManipulationExtension as any).config.addProseMirrorPlugins.call({
     editor: {},
     options: {openUrl},
-  })[0]
+  })
+  return plugins.find((plugin: {key: string}) => plugin.key.startsWith('CursorSelectPlugin'))
 }
 
 function clickEventWithTarget(target: HTMLElement) {


### PR DESCRIPTION
## Summary

- Update block manipulation tests to find the cursor selection plugin by its key instead of relying on plugin order.
- Keep embed click behavior tests stable when other ProseMirror plugins are added or reordered.

---

Fixes #879