### PR TITLE
feat(ui): add responsive site file browser sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ AGENTS.local.md
 __pycache__/
 *.pyc
 .playwright-mcp/
+.superpowers/

--- a/docs/projects/file-browser-sidebar.md
+++ b/docs/projects/file-browser-sidebar.md
@@ -1,0 +1,226 @@
+# Site File Browser Sidebar
+
+## Problem
+
+Sites can contain many documents arranged in a path hierarchy, but readers cannot currently browse that complete
+structure while reading a document. The Site Header exposes selected navigation items, and the All Documents page
+exposes the full directory, but neither provides persistent, contextual navigation alongside the main site content.
+
+Readers need to see where the current document sits in the site, move between related documents, and narrow a large list
+by title without leaving the page. The experience must work consistently across desktop, desktop-sized web, and mobile
+web while preserving the existing document authorization behavior.
+
+## Solution
+
+Add a shared File Browser below the Site Header. The browser renders the site's readable documents as an expandable
+hierarchy and provides title filtering, active-document context, and responsive containers for wide and mobile layouts.
+
+### User stories
+
+- As a reader, I can browse all site documents that I am authorized to read without leaving the current document.
+- As a reader, I can expand and collapse document branches to understand the site's hierarchy.
+- As a reader, I can see the active document and its ancestors when I navigate.
+- As a reader, I can filter documents by title and quickly navigate to a matching result.
+- As an authorized reader, I can identify private documents by a lock shown before their titles.
+- As a desktop user, I can resize or collapse the browser and give the main document more space.
+- As a mobile user, I can open the same browser in a full-height drawer from the Site Header.
+
+### Shared document browser
+
+- Implement one shared File Browser behavior component in `@shm/ui` for desktop, web, and mobile.
+- Query the selected site's root with the existing `useDirectory(siteRootId, {mode: 'AllDescendants'})` flow.
+- Render exactly the documents returned by the existing authorization-aware query.
+- Do not add a frontend public/private filter. Public-only gateways and authenticated capabilities remain responsible
+  for deciding which documents are returned.
+- Exclude drafts in this iteration by using `useDirectory`, not `useDirectoryWithDrafts`.
+- Reuse the existing `buildDocumentTree` hierarchy utility.
+- Use platform-specific containers around the shared behavior:
+  - an inline resizable panel for desktop and wide web;
+  - an overlay drawer for mobile.
+
+### Hierarchy and navigation
+
+- Render document titles in their path hierarchy.
+- Show top-level documents when no branch is expanded.
+- Give documents with children an explicit expand/collapse control.
+- Automatically expand the ancestor chain of the active document on initialization and route changes.
+- Highlight the active document row.
+- Preserve unrelated manual expansion choices when the active route changes.
+- Selecting a document uses the existing platform navigation abstraction.
+- A private document renders a lock icon immediately before its title.
+- The lock has an accessible label or tooltip such as `Private document`; the icon is not the only accessible indication
+  of privacy.
+- Public rows do not reserve an empty icon slot in this iteration.
+- Keep the row composition capable of receiving other document icons later, without building a general document-icon
+  system now.
+
+### Search
+
+- Place a search input at the top of the File Browser, below its title and controls.
+- Match a case-insensitive substring against the displayed document title only.
+- Do not search document paths, bodies, authors, or other metadata.
+- While a query is present, replace the tree with a flat list of matching documents.
+- Hide hierarchy expand/collapse controls in filtered results.
+- Display a clear `No documents found` state when there are no matches.
+- Clearing the query restores the hierarchical tree and its previous manual expansion state.
+
+### Desktop and wide-web layout
+
+- Position the File Browser below the Site Header and to the left of the main content.
+- Show the browser by default.
+- Opening and resizing it pushes and resizes the main content; it does not overlay the main content.
+- Use the existing `react-resizable-panels` dependency and established panel styling.
+- Use these initial sizing constraints:
+  - default width: 288 px;
+  - minimum width: 240 px;
+  - maximum width: 40% of the available content area.
+- Put the collapse button in the File Browser header.
+- When collapsed, return the available width to the main content and retain a compact affordance for reopening the
+  browser.
+- Do not persist the open width in local storage, account settings, or desktop window state. A fresh load starts at 288
+  px.
+- Keep the panel below the Site Header so the site identity and primary site navigation continue to span the complete
+  viewport width.
+
+### Mobile layout
+
+- Put the File Browser open button in the Site Header.
+- Open a drawer from the left.
+- Make the drawer 100% of the viewport height and 80% of the viewport width.
+- Render a dismissible backdrop over the remaining 20% of the viewport.
+- Mobile content is overlaid, not resized or pushed.
+- Use a solid, square-edged surface so the drawer reads as structural navigation rather than a floating modal.
+- Use a compact two-line drawer header with the File Browser label, the current site name as secondary text, and an
+  explicit close button at the far right.
+- Put the search input in a padded section below the header, separated from the header and document list by subtle
+  borders.
+- Keep the header and search fixed while the document list scrolls independently.
+- Apply mobile safe-area padding at the top and bottom.
+- Close the drawer after selecting a document.
+- Close the drawer on backdrop activation and Escape where a keyboard is available.
+- Move focus into the drawer when it opens, trap focus while open, and restore focus to the Site Header trigger when it
+  closes.
+
+### Component states
+
+- **Loading:** show a stable skeleton that resembles the search field and document rows without shifting the main
+  layout.
+- **Loaded:** show the hierarchy or filtered result list.
+- **Empty site:** explain that the site has no browsable documents.
+- **No search results:** show `No documents found` without replacing the search input.
+- **Error:** show a concise directory-loading error with a retry action.
+- **Active:** distinguish the current document using existing selection tokens and keep it visible after route changes.
+- **Hover, pressed, and focus:** use existing interaction and focus tokens for rows and controls.
+- **Reduced motion:** avoid nonessential drawer and expansion motion when reduced motion is requested.
+
+### Accessibility and performance
+
+- Use buttons for expand/collapse actions and links/navigation controls for document activation.
+- Provide accessible names for browser open, close, collapse, expand, resize, search, and privacy controls.
+- Expose expanded state through `aria-expanded` where appropriate.
+- Make the resize handle keyboard operable through the existing panel library behavior.
+- Preserve visible focus and logical tab order in both containers.
+- Animate expand/collapse to measured content size if animation is used; do not use an arbitrary maximum-height
+  technique.
+- Build and filter the tree with memoized derivations so ordinary state changes do not repeatedly reconstruct a large
+  directory.
+- Avoid animating every row in a large hierarchy.
+
+### Acceptance criteria
+
+- Desktop app and desktop-sized web show the File Browser by default below the Site Header.
+- The desktop/wide-web browser starts at 288 px, cannot shrink below 240 px, and cannot grow beyond 40% of the content
+  area.
+- Dragging the divider resizes the browser and main content together.
+- Collapsing the browser returns its width to the main content, and it can be reopened.
+- Reloading resets the browser to its default width.
+- Mobile exposes an open button in the Site Header and opens a full-height, 80%-wide drawer from the left.
+- The mobile drawer uses a compact two-line header, separated search section, independently scrolling document list,
+  square outer edge, and safe-area padding.
+- The hierarchy is built from all descendants returned by `useDirectory` for the current site.
+- Drafts are absent, and no additional client-side visibility filter is applied.
+- The active document is highlighted and its ancestor chain is expanded.
+- Branches can be expanded and collapsed with pointer and keyboard input.
+- Private documents have an accessible lock immediately before the title.
+- Search matches titles case-insensitively and renders flat results.
+- Clearing search restores the tree's earlier expansion state.
+- Selecting a document navigates correctly on web and desktop and closes the mobile drawer.
+- Loading, empty, no-results, and error states are present and do not obscure the search control unnecessarily.
+
+## Scope
+
+### Phase 1: Shared behavior and tests — 2 to 3 engineering days
+
+- Extract reusable title filtering from the current All Documents implementation or colocate it with the shared tree
+  utility.
+- Add tests for active-path expansion, manual expansion preservation, flat title filtering, private-lock presentation,
+  and empty states.
+- Build the shared File Browser component using existing directory, tree, navigation, icon, input, tooltip, and token
+  primitives.
+
+Dependencies:
+
+- Existing `useDirectory` and universal-client authorization behavior.
+- Existing `buildDocumentTree` hierarchy utility.
+- Existing shared route-link/navigation helpers.
+
+### Phase 2: Desktop and wide-web integration — 2 to 3 engineering days
+
+- Add the shared File Browser beneath the Site Header in the common resource-page layout.
+- Integrate a horizontal `react-resizable-panels` layout with the approved width constraints.
+- Add collapse/reopen behavior without width persistence.
+- Verify document, profile, utility, loading, draft, and error routes do not unintentionally inherit or break the panel.
+
+Dependencies:
+
+- Phase 1 shared component.
+- Existing shared resource-page wrapper and panel styling.
+
+### Phase 3: Mobile integration and responsive testing — 1 to 2 engineering days
+
+- Add the File Browser trigger to the Site Header on mobile layouts.
+- Render the browser in a full-height, 80%-wide left drawer.
+- Implement dismissal, navigation-close, scroll containment, focus management, and reduced-motion behavior.
+- Test representative mobile viewport widths and deep hierarchies.
+
+Dependencies:
+
+- Phase 1 shared component.
+- Existing mobile sheet/portal primitives.
+
+### Phase 4: Verification and polish — 1 to 2 engineering days
+
+- Run shared unit/component tests and platform-specific route tests.
+- Add or update desktop/web integration tests for open, resize, collapse, search, navigation, and mobile drawer flows.
+- Run frontend type checking, tests, audit, workspace formatting, and the frontend agent-ci workflow.
+- Manually verify desktop app, desktop web, and mobile web against the approved mockup and accessibility behavior.
+
+### Estimate
+
+The first iteration is expected to require approximately **6 to 10 engineering days**, depending on how much the common
+resource-page layout must change to keep the Site Header full-width across every supported route.
+
+## Rabbit Holes
+
+- Persisting panel width or open/collapsed state across reloads, devices, accounts, or desktop windows.
+- Adding distinct icons for public documents or different document types.
+- Refactoring the existing desktop application sidebar, which is separate from this site-level browser.
+- Replacing the All Documents table with the new File Browser.
+- Virtualizing the hierarchy before measurements show that ordinary memoized rendering is insufficient.
+- Supporting body-content search, fuzzy search, ranking, highlighting, or server-side search.
+- Adding drag-and-drop document organization or editing document paths from the browser.
+- Combining Site Header navigation, document outlines, and the File Browser into one navigation system.
+- Broad changes to authorization or private-document capability logic.
+
+## No Gos
+
+- Do not duplicate authorization logic in the frontend or filter the returned directory to public documents only.
+- Do not show drafts in this iteration.
+- Do not persist the selected panel width or collapsed state.
+- Do not make the mobile drawer resizable or push mobile content sideways.
+- Do not search document bodies, paths, authors, or other metadata.
+- Do not preserve hierarchy in search results; filtered results are deliberately flat.
+- Do not add a new resize, drawer, state-machine, or icon dependency when established project primitives already cover
+  the behavior.
+- Do not make unrelated Site Header, All Documents, desktop sidebar, or document-layout refactors.
+- Do not implement document creation, deletion, moving, renaming, reordering, or bulk actions in the File Browser.

--- a/docs/superpowers/plans/2026-08-05-file-browser-sidebar.md
+++ b/docs/superpowers/plans/2026-08-05-file-browser-sidebar.md
@@ -1,0 +1,75 @@
+# Site File Browser Sidebar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an authorization-aware hierarchical File Browser below the Site Header on desktop/web and in an 80%-wide
+left drawer on mobile.
+
+**Architecture:** A shared `SiteFileBrowser` owns querying, tree/search state, and navigation rows.
+`SiteFileBrowserLayout` selects an inline `react-resizable-panels` container or mobile drawer, while `PageWrapper`
+supplies the active site and document IDs and `SiteHeader` supplies the mobile trigger.
+
+**Tech Stack:** React, TypeScript, TanStack Query, Tailwind, react-resizable-panels, Vitest/jsdom.
+
+## Global Constraints
+
+- Reuse `useDirectory(..., {mode: 'AllDescendants'})`; do not duplicate visibility filtering.
+- Exclude drafts and search displayed titles only.
+- Desktop width is 288 px default, 240 px minimum, and 40% maximum, with no persistence.
+- Mobile drawer is full height and 80% width.
+- Private locks appear immediately before document titles.
+
+---
+
+### Task 1: Tree search and active-path utilities
+
+**Files:**
+
+- Modify: `frontend/packages/shared/src/utils/all-documents-tree.ts`
+- Test: `frontend/packages/shared/src/__tests__/all-documents-tree.test.ts`
+
+- [ ] Add failing tests for flat title-only filtering and active ancestor path calculation.
+- [ ] Run the focused test and confirm the new exports are missing.
+- [ ] Add minimal exported, documented utility functions.
+- [ ] Re-run the focused test and confirm it passes.
+
+### Task 2: Shared File Browser component
+
+**Files:**
+
+- Create: `frontend/packages/ui/src/site-file-browser.tsx`
+- Test: `frontend/packages/ui/src/__tests__/site-file-browser.test.tsx`
+
+- [ ] Add failing component tests for the directory query, hierarchy, active path, title search, private lock, and
+      navigation callback.
+- [ ] Run the focused test and confirm the component is missing.
+- [ ] Implement the shared component with loading, empty, no-results, and error states.
+- [ ] Re-run the focused tests and refactor only while green.
+
+### Task 3: Responsive containers and Site Header trigger
+
+**Files:**
+
+- Create: `frontend/packages/ui/src/site-file-browser-layout.tsx`
+- Modify: `frontend/packages/ui/src/site-header.tsx`
+- Modify: `frontend/packages/ui/src/resource-page-common.tsx`
+- Test: `frontend/packages/ui/src/__tests__/site-file-browser-layout.test.tsx`
+
+- [ ] Add failing tests for desktop default/open/collapse behavior and the mobile trigger/drawer contract.
+- [ ] Run the focused tests and confirm the missing layout behavior.
+- [ ] Implement the inline panel and 80%-wide mobile drawer using existing primitives and tokens.
+- [ ] Integrate it below `SiteHeader` in `PageWrapper` and connect the mobile trigger.
+- [ ] Re-run focused and affected Site Header tests.
+
+### Task 4: Verification
+
+**Files:**
+
+- Modify only files required to resolve verification failures caused by this feature.
+
+- [ ] Run the shared and UI focused tests.
+- [ ] Run frontend typecheck and the affected package tests.
+- [ ] Run `pnpm -r format:write` and `pnpm -r format:check`.
+- [ ] Run `pnpm audit` and report any pre-existing or introduced findings.
+- [ ] Manually smoke-test desktop open/resize/collapse and mobile open/search/navigate/close behavior.

--- a/frontend/apps/desktop/src/__tests__/agents-models.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/agents-models.test.tsx
@@ -119,11 +119,11 @@ describe('agent server models', () => {
 
     vi.resetModules()
     const mod = await import('../models/agents')
-    const rendered = renderHook(() => mod.useAgentServerUrls())
+    const rendered = renderHook(() => mod.useConfiguredAgentServerUrls())
 
     await waitForCondition(() => rendered.result().data !== undefined)
 
-    expect(rendered.result().data).toEqual(['http://localhost:3050'])
+    expect(rendered.result().data).toEqual([mod.DEFAULT_AGENT_SERVER_URL])
 
     cleanupRendered(rendered.root, rendered.container, rendered.queryClient)
   })
@@ -133,11 +133,11 @@ describe('agent server models', () => {
 
     vi.resetModules()
     const mod = await import('../models/agents')
-    const rendered = renderHook(() => mod.useAgentServerUrls())
+    const rendered = renderHook(() => mod.useConfiguredAgentServerUrls())
 
     await waitForCondition(() => rendered.result().data !== undefined)
 
-    expect(rendered.result().data).toEqual(['https://agentic.seed.hyper.media'])
+    expect(rendered.result().data).toEqual([mod.DEFAULT_AGENT_SERVER_URL])
 
     cleanupRendered(rendered.root, rendered.container, rendered.queryClient)
   })
@@ -148,7 +148,7 @@ describe('agent server models', () => {
 
     vi.resetModules()
     const mod = await import('../models/agents')
-    const rendered = renderHook(() => mod.useAgentServerUrls())
+    const rendered = renderHook(() => mod.useConfiguredAgentServerUrls())
 
     await waitForCondition(() => rendered.result().data !== undefined)
 

--- a/frontend/packages/shared/src/__tests__/all-documents-tree.test.ts
+++ b/frontend/packages/shared/src/__tests__/all-documents-tree.test.ts
@@ -1,6 +1,6 @@
 import type {HMDocumentInfo} from '@seed-hypermedia/client/hm-types'
 import {describe, expect, test} from 'vitest'
-import {buildDocumentTree, flattenTree} from '../utils/all-documents-tree'
+import {buildDocumentTree, filterDocumentsByTitle, flattenTree, getAncestorPathKeys} from '../utils/all-documents-tree'
 
 function makeDoc(path: string[], name?: string): HMDocumentInfo {
   return {
@@ -90,5 +90,17 @@ describe('all documents tree', () => {
       new Set(),
     )
     expect(rows.every((row) => row.depth === 0)).toBe(true)
+  })
+
+  test('filters documents by title into a flat list', () => {
+    const docs = [makeDoc(['guides'], 'Guides'), makeDoc(['guides', 'install'], 'Install Seed')]
+
+    expect(filterDocumentsByTitle(docs, 'INSTALL')).toEqual([docs[1]])
+    expect(filterDocumentsByTitle(docs, 'guides/install')).toEqual([])
+  })
+
+  test('returns ancestor path keys for the active document', () => {
+    expect(getAncestorPathKeys(['guides', 'install', 'linux'])).toEqual(['guides', 'guides/install'])
+    expect(getAncestorPathKeys(['guides'])).toEqual([])
   })
 })

--- a/frontend/packages/shared/src/utils/all-documents-tree.ts
+++ b/frontend/packages/shared/src/utils/all-documents-tree.ts
@@ -22,6 +22,19 @@ function documentName(doc: HMDocumentInfo): string {
   return getMetadataName(doc.metadata) ?? doc.path?.join('/') ?? ''
 }
 
+/** Filters documents by a case-insensitive substring of their displayed title. */
+export function filterDocumentsByTitle(docs: HMDocumentInfo[], query: string): HMDocumentInfo[] {
+  const normalized = query.trim().toLocaleLowerCase()
+  if (!normalized) return docs
+  return docs.filter((doc) => documentName(doc).toLocaleLowerCase().includes(normalized))
+}
+
+/** Returns the hierarchical path keys that must be expanded to reveal a document. */
+export function getAncestorPathKeys(path: string[] | null | undefined): string[] {
+  if (!path) return []
+  return path.slice(0, -1).map((_, index) => path.slice(0, index + 1).join('/'))
+}
+
 export function buildDocumentTree(docs: HMDocumentInfo[]): DocumentTreeNode[] {
   const pathMap = new Map<string, HMDocumentInfo>()
   for (const doc of docs) {

--- a/frontend/packages/ui/src/__tests__/resource-page-shell.test.tsx
+++ b/frontend/packages/ui/src/__tests__/resource-page-shell.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import {hmId} from '@shm/shared'
+import {act} from 'react-dom/test-utils'
+import {createContext, useContext, useState} from 'react'
+import {createPortal} from 'react-dom'
+import {createRoot, type Root} from 'react-dom/client'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {PageWrapper} from '../resource-page-common'
+;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('../use-media', () => ({useMedia: () => ({xs: false})}))
+
+vi.mock('../site-header', () => ({
+  SiteHeader: ({
+    editNavPane,
+    editNavPanePortalRef,
+  }: {
+    editNavPane?: React.ReactNode
+    editNavPanePortalRef?: (node: HTMLDivElement | null) => void
+  }) => (
+    <div data-testid="site-header">
+      <div data-testid="edit-nav-pane-target" ref={editNavPanePortalRef}>
+        {editNavPane}
+      </div>
+    </div>
+  ),
+}))
+
+vi.mock('../site-file-browser-layout', () => {
+  let nextMountId = 0
+  return {
+    SiteFileBrowserLayout: ({children}: {children: React.ReactNode}) => {
+      const React = require('react')
+      const mountId = React.useRef(++nextMountId)
+      return (
+        <div data-testid="file-browser-layout" data-mount-id={mountId.current}>
+          {children}
+        </div>
+      )
+    },
+  }
+})
+
+vi.mock('@shm/shared/utils/navigation', async () => {
+  const actual = await vi.importActual<typeof import('@shm/shared/utils/navigation')>('@shm/shared/utils/navigation')
+  return {...actual, useNavigate: () => vi.fn()}
+})
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.clearAllMocks()
+})
+
+describe('PageWrapper', () => {
+  it('keeps the file browser layout mounted when keyed route content changes', () => {
+    const siteHomeId = hmId('site')
+    const headerData = {
+      items: [],
+      homeNavigationItems: [],
+      directoryItems: [],
+      isCenterLayout: false,
+      siteHomeDocument: null,
+    }
+
+    act(() => {
+      root.render(
+        <PageWrapper siteHomeId={siteHomeId} docId={hmId('site', {path: ['one']})} headerData={headerData}>
+          <div key="one">Document one</div>
+        </PageWrapper>,
+      )
+    })
+    const firstMountId = container.querySelector('[data-testid="file-browser-layout"]')?.getAttribute('data-mount-id')
+
+    act(() => {
+      root.render(
+        <PageWrapper siteHomeId={siteHomeId} docId={hmId('site', {path: ['two']})} headerData={headerData}>
+          <div key="two">Document two</div>
+        </PageWrapper>,
+      )
+    })
+
+    expect(container.querySelector('[data-testid="file-browser-layout"]')?.getAttribute('data-mount-id')).toBe(
+      firstMountId,
+    )
+    expect(container.textContent).toContain('Document two')
+  })
+})
+
+const TestContext = createContext<string | null>(null)
+
+function ContextReader() {
+  const value = useContext(TestContext)
+  if (!value) throw new Error('missing context')
+  return <span>{value}</span>
+}
+
+function PortalHarness() {
+  const [target, setTarget] = useState<HTMLDivElement | null>(null)
+  const siteHomeId = hmId('site')
+  const headerData = {
+    items: [],
+    homeNavigationItems: [],
+    directoryItems: [],
+    isCenterLayout: false,
+    siteHomeDocument: null,
+  }
+
+  return (
+    <PageWrapper siteHomeId={siteHomeId} docId={hmId('site')} headerData={headerData} editNavPanePortalRef={setTarget}>
+      <TestContext.Provider value="edit nav context">
+        {target ? createPortal(<ContextReader />, target) : null}
+        <div>Document body</div>
+      </TestContext.Provider>
+    </PageWrapper>
+  )
+}
+
+describe('PageWrapper edit navigation pane portal', () => {
+  it('exposes a header portal target so provider-bound panes can render in the header', () => {
+    act(() => {
+      root.render(<PortalHarness />)
+    })
+
+    expect(container.querySelector('[data-testid="edit-nav-pane-target"]')?.textContent).toContain('edit nav context')
+  })
+})

--- a/frontend/packages/ui/src/__tests__/site-file-browser-layout.test.tsx
+++ b/frontend/packages/ui/src/__tests__/site-file-browser-layout.test.tsx
@@ -7,7 +7,8 @@ import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {SiteFileBrowserLayout} from '../site-file-browser-layout'
 ;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
 
-vi.mock('../use-media', () => ({useMedia: () => ({xs: false})}))
+const mediaMock = vi.hoisted(() => ({value: {xs: false}}))
+vi.mock('../use-media', () => ({useMedia: () => mediaMock.value}))
 vi.mock('../site-file-browser', () => ({SiteFileBrowser: () => <div data-testid="site-file-browser" />}))
 vi.mock('../components/scroll-area', () => ({
   ScrollArea: ({children}: {children: React.ReactNode}) => <div data-testid="main-scroll-area">{children}</div>,
@@ -30,6 +31,7 @@ let container: HTMLDivElement
 let root: Root
 
 beforeEach(() => {
+  mediaMock.value = {xs: false}
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
@@ -57,7 +59,7 @@ function renderLayout() {
         onMobileOpenChange={vi.fn()}
         onNavigate={vi.fn()}
       >
-        <div>Document body</div>
+        <div data-testid="document-body">Document body</div>
       </SiteFileBrowserLayout>,
     )
   })
@@ -98,10 +100,36 @@ describe('SiteFileBrowserLayout', () => {
     expect(container.querySelector('[data-testid="folder-tree-icon"]')).toBeTruthy()
   })
 
-  it('leaves desktop main content scrolling to the document body', () => {
+  it('keeps desktop main content in a constrained flex column for document scrolling', () => {
     renderLayout()
 
     expect(container.querySelector('[data-testid="main-scroll-area"]')).toBeNull()
     expect(container.textContent).toContain('Document body')
+    expect(container.querySelector('[data-testid="document-body"]')?.parentElement?.className).toContain('flex-col')
+  })
+
+  it('keeps the mobile drawer pinned to 80 percent of the viewport', () => {
+    mediaMock.value = {xs: true}
+
+    act(() => {
+      root.render(
+        <SiteFileBrowserLayout
+          siteId={hmId('site')}
+          activeDocumentId={hmId('site')}
+          siteName="Site"
+          mobileOpen={true}
+          onMobileOpenChange={vi.fn()}
+          onNavigate={vi.fn()}
+        >
+          <div>Document body</div>
+        </SiteFileBrowserLayout>,
+      )
+    })
+
+    const drawer = document.body.querySelector('aside')
+    expect(drawer?.className).toContain('w-[80dvw]')
+    expect(drawer?.className).toContain('max-w-[80dvw]')
+    expect(drawer?.className).toContain('shrink-0')
+    expect(drawer?.className).toContain('motion-safe:slide-in-from-left')
   })
 })

--- a/frontend/packages/ui/src/__tests__/site-file-browser-layout.test.tsx
+++ b/frontend/packages/ui/src/__tests__/site-file-browser-layout.test.tsx
@@ -79,10 +79,10 @@ describe('SiteFileBrowserLayout', () => {
     )
 
     expect(html).toContain('Document body')
-    expect(html).toContain('site-file-browser')
     expect(html).toContain('Documents')
     expect(html).toContain('w-72')
     expect(html).not.toContain('data-panel-group')
+    expect(html).not.toContain('animate-spin')
   })
 
   it('labels the collapse and reopen controls with tooltips and uses folder tree when collapsed', () => {

--- a/frontend/packages/ui/src/__tests__/site-file-browser-layout.test.tsx
+++ b/frontend/packages/ui/src/__tests__/site-file-browser-layout.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import {hmId} from '@shm/shared'
+import {act} from 'react-dom/test-utils'
+import {createRoot, type Root} from 'react-dom/client'
+import {renderToString} from 'react-dom/server'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {SiteFileBrowserLayout} from '../site-file-browser-layout'
+;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('../use-media', () => ({useMedia: () => ({xs: false})}))
+vi.mock('../site-file-browser', () => ({SiteFileBrowser: () => <div data-testid="site-file-browser" />}))
+vi.mock('../components/scroll-area', () => ({
+  ScrollArea: ({children}: {children: React.ReactNode}) => <div data-testid="main-scroll-area">{children}</div>,
+}))
+vi.mock('../tooltip', () => ({
+  Tooltip: ({content, children}: {content: string; children: React.ReactNode}) => (
+    <div data-tooltip-content={content}>{children}</div>
+  ),
+}))
+vi.mock('lucide-react', async () => {
+  const makeIcon = (testId: string) => (props: React.SVGProps<SVGSVGElement>) => <svg data-testid={testId} {...props} />
+  return {
+    FolderTree: makeIcon('folder-tree-icon'),
+    PanelLeftClose: makeIcon('panel-left-close-icon'),
+    X: makeIcon('x-icon'),
+  }
+})
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  ;(globalThis as typeof globalThis & {ResizeObserver: typeof ResizeObserver}).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.clearAllMocks()
+})
+
+function renderLayout() {
+  act(() => {
+    root.render(
+      <SiteFileBrowserLayout
+        siteId={hmId('site')}
+        activeDocumentId={hmId('site')}
+        siteName="Site"
+        mobileOpen={false}
+        onMobileOpenChange={vi.fn()}
+        onNavigate={vi.fn()}
+      >
+        <div>Document body</div>
+      </SiteFileBrowserLayout>,
+    )
+  })
+}
+
+describe('SiteFileBrowserLayout', () => {
+  it('server-renders a static 288px file explorer before client sizing is known', () => {
+    const html = renderToString(
+      <SiteFileBrowserLayout
+        siteId={hmId('site')}
+        activeDocumentId={hmId('site')}
+        siteName="Site"
+        mobileOpen={false}
+        onMobileOpenChange={vi.fn()}
+        onNavigate={vi.fn()}
+      >
+        <div>Document body</div>
+      </SiteFileBrowserLayout>,
+    )
+
+    expect(html).toContain('Document body')
+    expect(html).toContain('site-file-browser')
+    expect(html).toContain('Documents')
+    expect(html).toContain('w-72')
+    expect(html).not.toContain('data-panel-group')
+  })
+
+  it('labels the collapse and reopen controls with tooltips and uses folder tree when collapsed', () => {
+    renderLayout()
+
+    expect(container.querySelector('[data-tooltip-content="Hide file explorer"]')).toBeTruthy()
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('[aria-label="Collapse file browser"]')?.click()
+    })
+
+    expect(container.querySelector('[data-tooltip-content="Show file explorer"]')).toBeTruthy()
+    expect(container.querySelector('[data-testid="folder-tree-icon"]')).toBeTruthy()
+  })
+
+  it('leaves desktop main content scrolling to the document body', () => {
+    renderLayout()
+
+    expect(container.querySelector('[data-testid="main-scroll-area"]')).toBeNull()
+    expect(container.textContent).toContain('Document body')
+  })
+})

--- a/frontend/packages/ui/src/__tests__/site-file-browser.test.tsx
+++ b/frontend/packages/ui/src/__tests__/site-file-browser.test.tsx
@@ -51,6 +51,11 @@ describe('SiteFileBrowser', () => {
     expect(container.querySelector('[data-slot="scroll-area"]')).toBeTruthy()
     expect(container.querySelector('[aria-label="Private document"]')).toBeTruthy()
     expect(container.querySelector('[aria-current="page"]')?.textContent).toContain('Private guide')
+    const caretButton = container.querySelector('[aria-label="Collapse Guides"]')
+    expect(caretButton?.className).toContain('size-6')
+    expect(caretButton?.className).toContain('p-0')
+    expect(caretButton?.className).not.toContain('min-w-8')
+    expect(container.querySelector('[aria-current="page"]')?.className).toContain('h-6')
   })
 
   it('shows title matches as a flat list and navigates', () => {

--- a/frontend/packages/ui/src/__tests__/site-file-browser.test.tsx
+++ b/frontend/packages/ui/src/__tests__/site-file-browser.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import type {HMDocumentInfo} from '@seed-hypermedia/client/hm-types'
+import {hmId} from '@shm/shared'
+import {act} from 'react-dom/test-utils'
+import {createRoot, type Root} from 'react-dom/client'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {SiteFileBrowser} from '../site-file-browser'
+;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+
+const useDirectoryMock = vi.hoisted(() => vi.fn())
+vi.mock('@shm/shared/models/entity', () => ({useDirectory: useDirectoryMock}))
+
+let container: HTMLDivElement
+let root: Root
+
+function makeDoc(path: string[], name: string, visibility: 'PUBLIC' | 'PRIVATE' = 'PUBLIC') {
+  return {id: hmId('site', {path}), path, metadata: {name}, visibility} as HMDocumentInfo
+}
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.clearAllMocks()
+})
+
+describe('SiteFileBrowser', () => {
+  it('reveals the active document and marks private rows', () => {
+    useDirectoryMock.mockReturnValue({
+      data: [makeDoc(['guides'], 'Guides'), makeDoc(['guides', 'private'], 'Private guide', 'PRIVATE')],
+      isLoading: false,
+      isError: false,
+    })
+
+    act(() => {
+      root.render(
+        <SiteFileBrowser
+          siteId={hmId('site')}
+          activeDocumentId={hmId('site', {path: ['guides', 'private']})}
+          onNavigate={vi.fn()}
+        />,
+      )
+    })
+
+    expect(container.textContent).toContain('Private guide')
+    expect(container.querySelector('[aria-label="Private document"]')).toBeTruthy()
+    expect(container.querySelector('[aria-current="page"]')?.textContent).toContain('Private guide')
+  })
+
+  it('shows title matches as a flat list and navigates', () => {
+    const install = makeDoc(['guides', 'install'], 'Install Seed')
+    const onNavigate = vi.fn()
+    useDirectoryMock.mockReturnValue({data: [makeDoc(['guides'], 'Guides'), install], isLoading: false, isError: false})
+
+    act(() => {
+      root.render(<SiteFileBrowser siteId={hmId('site')} activeDocumentId={null} onNavigate={onNavigate} />)
+    })
+    const input = container.querySelector('input')!
+    act(() => {
+      const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+      setValue?.call(input, 'INSTALL')
+      input.dispatchEvent(new Event('input', {bubbles: true}))
+    })
+
+    expect(container.textContent).not.toContain('Guides')
+    const result = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.includes('Install Seed'),
+    )!
+    act(() => result.click())
+    expect(onNavigate).toHaveBeenCalledWith(install.id)
+  })
+})

--- a/frontend/packages/ui/src/__tests__/site-file-browser.test.tsx
+++ b/frontend/packages/ui/src/__tests__/site-file-browser.test.tsx
@@ -48,6 +48,7 @@ describe('SiteFileBrowser', () => {
     })
 
     expect(container.textContent).toContain('Private guide')
+    expect(container.querySelector('[data-slot="scroll-area"]')).toBeTruthy()
     expect(container.querySelector('[aria-label="Private document"]')).toBeTruthy()
     expect(container.querySelector('[aria-current="page"]')?.textContent).toContain('Private guide')
   })

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -13,6 +13,7 @@ import {
   createInspectNavRoute,
   DocumentPanelRoute,
   findContentBlock,
+  getMetadataName,
   getBlockText,
   getDraftNodesOutline,
   getNodesOutline,
@@ -124,6 +125,7 @@ import {PageLayout} from './page-layout'
 import {PageDeleted, PageDiscovery, PageNotFound, PagePrivate} from './page-message-states'
 import {PanelLayout} from './panel-layout'
 import {SiteHeader} from './site-header'
+import {SiteFileBrowserLayout} from './site-file-browser-layout'
 import {Spinner} from './spinner'
 import {toast} from './toast'
 import {UnreferencedDocuments} from './unreferenced-documents'
@@ -1285,6 +1287,8 @@ export function PageWrapper({
   // Note: IS_DESKTOP (Electron) never uses document scroll regardless of window width
   const media = useMedia()
   const isMobile = media.xs && !IS_DESKTOP
+  const navigate = useNavigate()
+  const [isFileBrowserOpen, setIsFileBrowserOpen] = useState(false)
 
   // Live-preview the in-flight nav while the user edits the home doc, so
   // additions/reorders/deletions in the EditNavPopover show immediately in
@@ -1340,9 +1344,22 @@ export function PageWrapper({
         notifyServiceHost={NOTIFY_SERVICE_HOST}
         rightActions={rightActions}
         editNavPane={editNavPane}
+        onOpenFileBrowser={() => setIsFileBrowserOpen(true)}
       />
       <TransientResourceBanner error={transientResourceError ?? null} />
-      {children}
+      <SiteFileBrowserLayout
+        siteId={hmId(siteHomeId.uid)}
+        activeDocumentId={docId}
+        siteName={getMetadataName(headerData.siteHomeDocument?.metadata) || 'Site documents'}
+        mobileOpen={isFileBrowserOpen}
+        onMobileOpenChange={setIsFileBrowserOpen}
+        onNavigate={(id) => {
+          setIsFileBrowserOpen(false)
+          navigate({key: 'document', id})
+        }}
+      >
+        {children}
+      </SiteFileBrowserLayout>
     </div>
   )
 }

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -98,6 +98,7 @@ import {useIsomorphicLayoutEffect} from '@shm/shared/utils/use-isomorphic-layout
 import {useQuery} from '@tanstack/react-query'
 import {FilePen, Info, Quote, Search} from 'lucide-react'
 import {lazy, ReactNode, Suspense, useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {createPortal} from 'react-dom'
 import {AccountPage} from './account-page'
 import {AllDocumentsPage} from './all-documents-page'
 import {CollaboratorsPage, getRenderedCollaboratorsCount} from './collaborators-page'
@@ -829,6 +830,8 @@ export function ResourcePage({
   const route = useNavRoute()
   const replaceRoute = useNavigate('replace')
   const isSiteProfile = route.key === 'site-profile'
+  const [liveNavigationItems, setLiveNavigationItems] = useState<DocNavigationItem[] | undefined>()
+  const [editNavPanePortalElement, setEditNavPanePortalElement] = useState<HTMLDivElement | null>(null)
 
   const handleResourceRedirect = useCallback(
     ({isDeleted, redirectTarget}: {isDeleted: boolean; redirectTarget: UnpackedHypermediaId | null}) => {
@@ -1129,37 +1132,40 @@ export function ResourcePage({
     : undefined
 
   return (
-    <DocumentMachineProvider
-      // Recreate the machine only when the identity it's bound to changes: the
-      // resolved doc id (path change on first publish) or the ROUTE's pinned
-      // version (?v=). Deliberately NOT the *resolved* latest version — that
-      // bumps on our own publish, which would destroy + recreate the machine
-      // mid-publish and re-load the just-cleared draft, stranding it in editing.
-      key={getDocumentMachineKey(renderedDocId)}
-      input={{
-        documentId: renderedDocId,
-        canEdit: effectiveCanEdit,
-        isLatest,
-        routeVersion: renderedDocId.version ?? null,
-        deps: existingDraftDeps,
-        reservedDraftId: reservedDraftId ?? undefined,
-        editUid: renderedDocId.uid,
-        editPath: renderedDocId.path ?? undefined,
-        signingAccountId,
-        publishAccountUid,
-      }}
-      machine={machine}
-      inspect={inspect}
+    <PageWrapper
+      siteHomeId={siteHomeId}
+      docId={renderedDocId}
+      headerData={headerData}
+      document={document}
+      rightActions={rightActions}
+      editNavPanePortalRef={setEditNavPanePortalElement}
+      transientResourceError={transientResourceError}
+      liveNavigationItems={liveNavigationItems}
     >
-      <PageWrapper
-        siteHomeId={siteHomeId}
-        docId={renderedDocId}
-        headerData={headerData}
-        document={document}
-        rightActions={rightActions}
-        editNavPane={editNavPane}
-        transientResourceError={transientResourceError}
+      <DocumentMachineProvider
+        // Recreate the machine only when the identity it's bound to changes: the
+        // resolved doc id (path change on first publish) or the ROUTE's pinned
+        // version (?v=). Deliberately NOT the *resolved* latest version — that
+        // bumps on our own publish, which would destroy + recreate the machine
+        // mid-publish and re-load the just-cleared draft, stranding it in editing.
+        key={getDocumentMachineKey(renderedDocId)}
+        input={{
+          documentId: renderedDocId,
+          canEdit: effectiveCanEdit,
+          isLatest,
+          routeVersion: renderedDocId.version ?? null,
+          deps: existingDraftDeps,
+          reservedDraftId: reservedDraftId ?? undefined,
+          editUid: renderedDocId.uid,
+          editPath: renderedDocId.path ?? undefined,
+          signingAccountId,
+          publishAccountUid,
+        }}
+        machine={machine}
+        inspect={inspect}
       >
+        <DocumentNavigationItemsBridge docId={renderedDocId} onItemsChange={setLiveNavigationItems} />
+        {editNavPane && editNavPanePortalElement ? createPortal(editNavPane, editNavPanePortalElement) : null}
         <DocumentBody
           routeDocId={docId}
           docId={renderedDocId}
@@ -1203,14 +1209,14 @@ export function ResourcePage({
           linkExtensionOptions={linkExtensionOptions}
           transientResourceError={transientResourceError}
         />
-      </PageWrapper>
-      {machineExtras}
-      {inspect && (
-        <Suspense fallback={null}>
-          <LazyDocumentMachineDebugDrawer store={inspectStore} />
-        </Suspense>
-      )}
-    </DocumentMachineProvider>
+        {machineExtras}
+        {inspect && (
+          <Suspense fallback={null}>
+            <LazyDocumentMachineDebugDrawer store={inspectStore} />
+          </Suspense>
+        )}
+      </DocumentMachineProvider>
+    </PageWrapper>
   )
 }
 
@@ -1259,18 +1265,45 @@ export function computeHeaderData(siteHomeDocument: HMDocument | null): HeaderDa
   }
 }
 
-// Wrapper that renders SiteHeader + content
-export function PageWrapper({
-  siteHomeId,
+function getLiveHeaderNavigationItems(
+  machineNav: ReturnType<typeof useDocumentNavigationOptional>,
+): DocNavigationItem[] | undefined {
+  return machineNav
+    ?.map((n) => {
+      const id = unpackHmId(n.link)
+      return {
+        key: n.id,
+        id: id ?? undefined,
+        webUrl: id ? undefined : n.link,
+        draftId: undefined,
+        metadata: {name: n.text || ''},
+        isPublished: true,
+      } satisfies DocNavigationItem
+    })
+    .filter(isValidSiteHeaderItem)
+}
+
+function DocumentNavigationItemsBridge({
   docId,
-  headerData,
-  document,
-  children,
-  isMainFeedVisible = false,
-  rightActions,
-  editNavPane,
-  transientResourceError,
+  onItemsChange,
 }: {
+  docId: UnpackedHypermediaId
+  onItemsChange: (items: DocNavigationItem[] | undefined) => void
+}) {
+  const machineNav = useDocumentNavigationOptional()
+  const homeDraftOverride = useIsHomeDraftOverride()
+  const isHomeDoc = homeDraftOverride ?? !docId.path?.length
+
+  useEffect(() => {
+    onItemsChange(isHomeDoc ? getLiveHeaderNavigationItems(machineNav) : undefined)
+    return () => onItemsChange(undefined)
+  }, [docId.id, isHomeDoc, machineNav, onItemsChange])
+
+  return null
+}
+
+/** Props for the persistent site page shell. */
+export interface PageShellProps {
   siteHomeId: UnpackedHypermediaId
   docId: UnpackedHypermediaId
   headerData: HeaderData
@@ -1279,9 +1312,27 @@ export function PageWrapper({
   isMainFeedVisible?: boolean
   rightActions?: React.ReactNode
   editNavPane?: React.ReactNode
+  editNavPanePortalRef?: (node: HTMLDivElement | null) => void
   /** Non-fatal resource fetch state rendered as a banner below the header. */
   transientResourceError?: TransientResourceError
-}) {
+  /** In-flight header navigation from an active document machine. */
+  liveNavigationItems?: DocNavigationItem[]
+}
+
+/** Persistent site chrome for the header and file browser around route content. */
+export function PageShell({
+  siteHomeId,
+  docId,
+  headerData,
+  document,
+  children,
+  isMainFeedVisible = false,
+  rightActions,
+  editNavPane,
+  editNavPanePortalRef,
+  transientResourceError,
+  liveNavigationItems,
+}: PageShellProps) {
   // Mobile: let content flow naturally (document scroll)
   // Desktop: fixed height container (element scroll via ScrollArea in children)
   // Note: IS_DESKTOP (Electron) never uses document scroll regardless of window width
@@ -1289,33 +1340,7 @@ export function PageWrapper({
   const isMobile = media.xs && !IS_DESKTOP
   const navigate = useNavigate()
   const [isFileBrowserOpen, setIsFileBrowserOpen] = useState(false)
-
-  // Live-preview the in-flight nav while the user edits the home doc, so
-  // additions/reorders/deletions in the EditNavPopover show immediately in
-  // the visible site header. Mirrors the legacy draft route at
-  // frontend/apps/desktop/src/pages/draft.tsx:880-893. Returns undefined
-  // outside DocumentMachineProvider (loading/error/discovery branches), in
-  // which case we fall back to the published headerData.items.
-  const machineNav = useDocumentNavigationOptional()
-  const homeDraftOverride = useIsHomeDraftOverride()
-  const isHomeDoc = homeDraftOverride ?? !docId.path?.length
-  const liveItems: DocNavigationItem[] | undefined =
-    isHomeDoc && machineNav
-      ? machineNav
-          .map((n) => {
-            const id = unpackHmId(n.link)
-            return {
-              key: n.id,
-              id: id ?? undefined,
-              webUrl: id ? undefined : n.link,
-              draftId: undefined,
-              metadata: {name: n.text || ''},
-              isPublished: true,
-            } satisfies DocNavigationItem
-          })
-          .filter(isValidSiteHeaderItem)
-      : undefined
-  const itemsForHeader = liveItems ?? headerData.items
+  const itemsForHeader = liveNavigationItems ?? headerData.items
 
   return (
     <div
@@ -1343,7 +1368,8 @@ export function PageWrapper({
         isMainFeedVisible={isMainFeedVisible}
         notifyServiceHost={NOTIFY_SERVICE_HOST}
         rightActions={rightActions}
-        editNavPane={editNavPane}
+        editNavPane={editNavPanePortalRef ? undefined : editNavPane}
+        editNavPanePortalRef={editNavPanePortalRef}
         onOpenFileBrowser={() => setIsFileBrowserOpen(true)}
       />
       <TransientResourceBanner error={transientResourceError ?? null} />
@@ -1361,6 +1387,63 @@ export function PageWrapper({
         {children}
       </SiteFileBrowserLayout>
     </div>
+  )
+}
+
+/** Wrapper that renders the persistent site header, file browser, and page content. */
+export function PageWrapper({
+  siteHomeId,
+  docId,
+  headerData,
+  document,
+  children,
+  isMainFeedVisible = false,
+  rightActions,
+  editNavPane,
+  editNavPanePortalRef,
+  transientResourceError,
+  liveNavigationItems,
+}: {
+  siteHomeId: UnpackedHypermediaId
+  docId: UnpackedHypermediaId
+  headerData: HeaderData
+  document?: HMDocument
+  children: React.ReactNode
+  isMainFeedVisible?: boolean
+  rightActions?: React.ReactNode
+  editNavPane?: React.ReactNode
+  editNavPanePortalRef?: (node: HTMLDivElement | null) => void
+  /** Non-fatal resource fetch state rendered as a banner below the header. */
+  transientResourceError?: TransientResourceError
+  /** In-flight header navigation from a document machine mounted inside this wrapper. */
+  liveNavigationItems?: DocNavigationItem[]
+}) {
+  // Live-preview the in-flight nav while the user edits the home doc, so
+  // additions/reorders/deletions in the EditNavPopover show immediately in
+  // the visible site header. Mirrors the legacy draft route at
+  // frontend/apps/desktop/src/pages/draft.tsx:880-893. Returns undefined
+  // outside DocumentMachineProvider (loading/error/discovery branches), in
+  // which case we fall back to the published headerData.items.
+  const machineNav = useDocumentNavigationOptional()
+  const homeDraftOverride = useIsHomeDraftOverride()
+  const isHomeDoc = homeDraftOverride ?? !docId.path?.length
+  const liveItems = liveNavigationItems ?? (isHomeDoc ? getLiveHeaderNavigationItems(machineNav) : undefined)
+
+  return (
+    <PageShell
+      siteHomeId={siteHomeId}
+      docId={docId}
+      headerData={headerData}
+      document={document}
+      isMainFeedVisible={isMainFeedVisible}
+      rightActions={rightActions}
+      editNavPane={editNavPane}
+      editNavPanePortalRef={editNavPanePortalRef}
+      transientResourceError={transientResourceError}
+      liveNavigationItems={liveItems}
+    >
+      {children}
+    </PageShell>
   )
 }
 

--- a/frontend/packages/ui/src/site-file-browser-layout.tsx
+++ b/frontend/packages/ui/src/site-file-browser-layout.tsx
@@ -1,12 +1,12 @@
 import type {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {IS_DESKTOP} from '@shm/shared/constants'
-import {PanelLeftClose, PanelLeftOpen, X} from 'lucide-react'
+import {FolderTree, PanelLeftClose, X} from 'lucide-react'
 import {ReactNode, useEffect, useRef, useState} from 'react'
 import {createPortal} from 'react-dom'
 import {ImperativePanelHandle, Panel, PanelGroup, PanelResizeHandle} from 'react-resizable-panels'
 import {Button} from './button'
-import {ScrollArea} from './components/scroll-area'
 import {SiteFileBrowser} from './site-file-browser'
+import {Tooltip} from './tooltip'
 import {useMedia} from './use-media'
 
 /** Props for the responsive site file browser layout. */
@@ -32,12 +32,17 @@ export function SiteFileBrowserLayout({
 }: SiteFileBrowserLayoutProps) {
   const media = useMedia()
   const isMobile = media.xs && !IS_DESKTOP
+  const [isClient, setIsClient] = useState(false)
   const [collapsed, setCollapsed] = useState(false)
   const desktopContainerRef = useRef<HTMLDivElement>(null)
   const browserPanelRef = useRef<ImperativePanelHandle>(null)
   const [minimumPercent, setMinimumPercent] = useState(20)
   const didSetInitialWidth = useRef(false)
   const browser = <SiteFileBrowser siteId={siteId} activeDocumentId={activeDocumentId} onNavigate={onNavigate} />
+
+  useEffect(() => {
+    setIsClient(true)
+  }, [])
 
   useEffect(() => {
     if (!mobileOpen) return
@@ -69,6 +74,20 @@ export function SiteFileBrowserLayout({
     observer.observe(desktopContainerRef.current)
     return () => observer.disconnect()
   }, [isMobile])
+
+  if (!isClient) {
+    return (
+      <div className="flex min-h-0 flex-1">
+        <aside className="border-border dark:bg-background hidden h-full w-72 shrink-0 flex-col border-r bg-white md:flex">
+          <div className="border-border flex h-12 shrink-0 items-center border-b px-3">
+            <p className="min-w-0 flex-1 truncate text-sm font-semibold">Documents</p>
+          </div>
+          <div className="min-h-0 flex-1">{browser}</div>
+        </aside>
+        <div className="dark:bg-background h-full min-h-0 flex-1 overflow-hidden bg-white">{children}</div>
+      </div>
+    )
+  }
 
   if (isMobile) {
     return (
@@ -112,9 +131,11 @@ export function SiteFileBrowserLayout({
     <div ref={desktopContainerRef} className="flex min-h-0 flex-1">
       {collapsed ? (
         <div className="border-border dark:bg-background shrink-0 border-r bg-white p-2">
-          <Button variant="ghost" size="icon" aria-label="Open file browser" onClick={() => setCollapsed(false)}>
-            <PanelLeftOpen className="size-4" />
-          </Button>
+          <Tooltip content="Show file explorer">
+            <Button variant="ghost" size="icon" aria-label="Open file browser" onClick={() => setCollapsed(false)}>
+              <FolderTree className="size-4" />
+            </Button>
+          </Tooltip>
         </div>
       ) : null}
       <PanelGroup direction="horizontal" className="min-h-0 flex-1">
@@ -131,14 +152,16 @@ export function SiteFileBrowserLayout({
               <aside className="border-border dark:bg-background flex h-full flex-col border-r bg-white">
                 <div className="border-border flex h-12 shrink-0 items-center border-b px-3">
                   <p className="min-w-0 flex-1 truncate text-sm font-semibold">Documents</p>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    aria-label="Collapse file browser"
-                    onClick={() => setCollapsed(true)}
-                  >
-                    <PanelLeftClose className="size-4" />
-                  </Button>
+                  <Tooltip content="Hide file explorer">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label="Collapse file browser"
+                      onClick={() => setCollapsed(true)}
+                    >
+                      <PanelLeftClose className="size-4" />
+                    </Button>
+                  </Tooltip>
                 </div>
                 <div className="min-h-0 flex-1">{browser}</div>
               </aside>
@@ -147,15 +170,7 @@ export function SiteFileBrowserLayout({
           </>
         ) : null}
         <Panel id="site-main-content" order={2} minSize={60}>
-          <div className="dark:bg-background h-full min-h-0 bg-white">
-            <ScrollArea
-              className="scroll-area-full-height h-full"
-              viewportClassName="[&>div]:!block [&>div]:flex [&>div]:min-h-full [&>div]:flex-col"
-              fillViewportContent
-            >
-              {children}
-            </ScrollArea>
-          </div>
+          <div className="dark:bg-background h-full min-h-0 overflow-hidden bg-white">{children}</div>
         </Panel>
       </PanelGroup>
     </div>

--- a/frontend/packages/ui/src/site-file-browser-layout.tsx
+++ b/frontend/packages/ui/src/site-file-browser-layout.tsx
@@ -82,7 +82,14 @@ export function SiteFileBrowserLayout({
           <div className="border-border flex h-12 shrink-0 items-center border-b px-3">
             <p className="min-w-0 flex-1 truncate text-sm font-semibold">Documents</p>
           </div>
-          <div className="min-h-0 flex-1">{browser}</div>
+          <div className="min-h-0 flex-1 p-3">
+            <div className="border-border bg-muted/40 h-9 rounded-md border" />
+            <div className="mt-3 space-y-2">
+              <div className="bg-muted h-4 w-3/4 rounded" />
+              <div className="bg-muted h-4 w-2/3 rounded" />
+              <div className="bg-muted h-4 w-1/2 rounded" />
+            </div>
+          </div>
         </aside>
         <div className="dark:bg-background h-full min-h-0 flex-1 overflow-hidden bg-white">{children}</div>
       </div>

--- a/frontend/packages/ui/src/site-file-browser-layout.tsx
+++ b/frontend/packages/ui/src/site-file-browser-layout.tsx
@@ -91,7 +91,9 @@ export function SiteFileBrowserLayout({
             </div>
           </div>
         </aside>
-        <div className="dark:bg-background h-full min-h-0 flex-1 overflow-hidden bg-white">{children}</div>
+        <div className="dark:bg-background flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-white">
+          {children}
+        </div>
       </div>
     )
   }
@@ -103,7 +105,7 @@ export function SiteFileBrowserLayout({
         {mobileOpen
           ? createPortal(
               <div className="fixed inset-0 z-50 flex" role="dialog" aria-modal="true" aria-label="File browser">
-                <aside className="dark:bg-background flex h-dvh w-4/5 flex-col bg-white shadow-2xl">
+                <aside className="dark:bg-background motion-safe:animate-in motion-safe:slide-in-from-left flex h-dvh w-[80dvw] max-w-[80dvw] shrink-0 flex-col bg-white shadow-2xl motion-safe:duration-200 motion-safe:ease-out">
                   <div className="border-border flex shrink-0 items-center border-b px-3 pt-[max(0.5rem,env(safe-area-inset-top))] pb-2">
                     <div className="min-w-0 flex-1">
                       <p className="font-semibold">Files</p>
@@ -123,7 +125,7 @@ export function SiteFileBrowserLayout({
                 <button
                   type="button"
                   aria-label="Close file browser"
-                  className="h-dvh w-1/5 bg-black/45"
+                  className="motion-safe:animate-in motion-safe:fade-in h-dvh flex-1 bg-black/45 motion-safe:duration-200"
                   onClick={() => onMobileOpenChange(false)}
                 />
               </div>,
@@ -177,7 +179,7 @@ export function SiteFileBrowserLayout({
           </>
         ) : null}
         <Panel id="site-main-content" order={2} minSize={60}>
-          <div className="dark:bg-background h-full min-h-0 overflow-hidden bg-white">{children}</div>
+          <div className="dark:bg-background flex h-full min-h-0 flex-col overflow-hidden bg-white">{children}</div>
         </Panel>
       </PanelGroup>
     </div>

--- a/frontend/packages/ui/src/site-file-browser-layout.tsx
+++ b/frontend/packages/ui/src/site-file-browser-layout.tsx
@@ -1,0 +1,154 @@
+import type {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {IS_DESKTOP} from '@shm/shared/constants'
+import {PanelLeftClose, PanelLeftOpen, X} from 'lucide-react'
+import {ReactNode, useEffect, useRef, useState} from 'react'
+import {createPortal} from 'react-dom'
+import {ImperativePanelHandle, Panel, PanelGroup, PanelResizeHandle} from 'react-resizable-panels'
+import {Button} from './button'
+import {SiteFileBrowser} from './site-file-browser'
+import {useMedia} from './use-media'
+
+/** Props for the responsive site file browser layout. */
+export interface SiteFileBrowserLayoutProps {
+  siteId: UnpackedHypermediaId
+  activeDocumentId: UnpackedHypermediaId | null
+  siteName: string
+  mobileOpen: boolean
+  onMobileOpenChange: (open: boolean) => void
+  onNavigate: (id: UnpackedHypermediaId) => void
+  children: ReactNode
+}
+
+/** Places the site file browser inline on wide layouts and in a left drawer on mobile. */
+export function SiteFileBrowserLayout({
+  siteId,
+  activeDocumentId,
+  siteName,
+  mobileOpen,
+  onMobileOpenChange,
+  onNavigate,
+  children,
+}: SiteFileBrowserLayoutProps) {
+  const media = useMedia()
+  const isMobile = media.xs && !IS_DESKTOP
+  const [collapsed, setCollapsed] = useState(false)
+  const desktopContainerRef = useRef<HTMLDivElement>(null)
+  const browserPanelRef = useRef<ImperativePanelHandle>(null)
+  const [minimumPercent, setMinimumPercent] = useState(20)
+  const didSetInitialWidth = useRef(false)
+  const browser = <SiteFileBrowser siteId={siteId} activeDocumentId={activeDocumentId} onNavigate={onNavigate} />
+
+  useEffect(() => {
+    if (!mobileOpen) return
+    const previousOverflow = document.documentElement.style.overflow
+    document.documentElement.style.overflow = 'hidden'
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onMobileOpenChange(false)
+    }
+    document.addEventListener('keydown', closeOnEscape)
+    return () => {
+      document.documentElement.style.overflow = previousOverflow
+      document.removeEventListener('keydown', closeOnEscape)
+    }
+  }, [mobileOpen, onMobileOpenChange])
+
+  useEffect(() => {
+    if (isMobile || !desktopContainerRef.current) return
+    const updateConstraints = () => {
+      const width = desktopContainerRef.current?.getBoundingClientRect().width ?? 0
+      if (!width) return
+      setMinimumPercent(Math.min(40, (240 / width) * 100))
+      if (!didSetInitialWidth.current) {
+        browserPanelRef.current?.resize(Math.min(40, (288 / width) * 100))
+        didSetInitialWidth.current = true
+      }
+    }
+    updateConstraints()
+    const observer = new ResizeObserver(updateConstraints)
+    observer.observe(desktopContainerRef.current)
+    return () => observer.disconnect()
+  }, [isMobile])
+
+  if (isMobile) {
+    return (
+      <>
+        <div className="min-h-0 flex-1">{children}</div>
+        {mobileOpen
+          ? createPortal(
+              <div className="fixed inset-0 z-50 flex" role="dialog" aria-modal="true" aria-label="File browser">
+                <aside className="bg-background flex h-dvh w-4/5 flex-col shadow-2xl">
+                  <div className="border-border flex shrink-0 items-center border-b px-3 pt-[max(0.5rem,env(safe-area-inset-top))] pb-2">
+                    <div className="min-w-0 flex-1">
+                      <p className="font-semibold">Files</p>
+                      <p className="text-muted-foreground truncate text-xs">{siteName}</p>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label="Close file browser"
+                      onClick={() => onMobileOpenChange(false)}
+                    >
+                      <X className="size-4" />
+                    </Button>
+                  </div>
+                  <div className="min-h-0 flex-1 pb-[env(safe-area-inset-bottom)]">{browser}</div>
+                </aside>
+                <button
+                  type="button"
+                  aria-label="Close file browser"
+                  className="h-dvh w-1/5 bg-black/45"
+                  onClick={() => onMobileOpenChange(false)}
+                />
+              </div>,
+              document.body,
+            )
+          : null}
+      </>
+    )
+  }
+
+  return (
+    <div ref={desktopContainerRef} className="flex min-h-0 flex-1">
+      {collapsed ? (
+        <div className="border-border bg-background shrink-0 border-r p-2">
+          <Button variant="ghost" size="icon" aria-label="Open file browser" onClick={() => setCollapsed(false)}>
+            <PanelLeftOpen className="size-4" />
+          </Button>
+        </div>
+      ) : null}
+      <PanelGroup direction="horizontal" className="min-h-0 flex-1">
+        {!collapsed ? (
+          <>
+            <Panel
+              id="site-file-browser"
+              ref={browserPanelRef}
+              order={1}
+              defaultSize={24}
+              minSize={minimumPercent}
+              maxSize={40}
+            >
+              <aside className="border-border bg-background flex h-full flex-col border-r">
+                <div className="border-border flex h-12 shrink-0 items-center border-b px-3">
+                  <p className="min-w-0 flex-1 truncate text-sm font-semibold">Documents</p>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Collapse file browser"
+                    onClick={() => setCollapsed(true)}
+                  >
+                    <PanelLeftClose className="size-4" />
+                  </Button>
+                </div>
+                <div className="min-h-0 flex-1">{browser}</div>
+              </aside>
+            </Panel>
+            <PanelResizeHandle className="panel-resize-handle" />
+          </>
+        ) : null}
+        <Panel id="site-main-content" order={2} minSize={60}>
+          <div className="h-full min-h-0">{children}</div>
+        </Panel>
+      </PanelGroup>
+    </div>
+  )
+}

--- a/frontend/packages/ui/src/site-file-browser-layout.tsx
+++ b/frontend/packages/ui/src/site-file-browser-layout.tsx
@@ -5,6 +5,7 @@ import {ReactNode, useEffect, useRef, useState} from 'react'
 import {createPortal} from 'react-dom'
 import {ImperativePanelHandle, Panel, PanelGroup, PanelResizeHandle} from 'react-resizable-panels'
 import {Button} from './button'
+import {ScrollArea} from './components/scroll-area'
 import {SiteFileBrowser} from './site-file-browser'
 import {useMedia} from './use-media'
 
@@ -76,7 +77,7 @@ export function SiteFileBrowserLayout({
         {mobileOpen
           ? createPortal(
               <div className="fixed inset-0 z-50 flex" role="dialog" aria-modal="true" aria-label="File browser">
-                <aside className="bg-background flex h-dvh w-4/5 flex-col shadow-2xl">
+                <aside className="dark:bg-background flex h-dvh w-4/5 flex-col bg-white shadow-2xl">
                   <div className="border-border flex shrink-0 items-center border-b px-3 pt-[max(0.5rem,env(safe-area-inset-top))] pb-2">
                     <div className="min-w-0 flex-1">
                       <p className="font-semibold">Files</p>
@@ -110,7 +111,7 @@ export function SiteFileBrowserLayout({
   return (
     <div ref={desktopContainerRef} className="flex min-h-0 flex-1">
       {collapsed ? (
-        <div className="border-border bg-background shrink-0 border-r p-2">
+        <div className="border-border dark:bg-background shrink-0 border-r bg-white p-2">
           <Button variant="ghost" size="icon" aria-label="Open file browser" onClick={() => setCollapsed(false)}>
             <PanelLeftOpen className="size-4" />
           </Button>
@@ -127,7 +128,7 @@ export function SiteFileBrowserLayout({
               minSize={minimumPercent}
               maxSize={40}
             >
-              <aside className="border-border bg-background flex h-full flex-col border-r">
+              <aside className="border-border dark:bg-background flex h-full flex-col border-r bg-white">
                 <div className="border-border flex h-12 shrink-0 items-center border-b px-3">
                   <p className="min-w-0 flex-1 truncate text-sm font-semibold">Documents</p>
                   <Button
@@ -146,7 +147,15 @@ export function SiteFileBrowserLayout({
           </>
         ) : null}
         <Panel id="site-main-content" order={2} minSize={60}>
-          <div className="h-full min-h-0">{children}</div>
+          <div className="dark:bg-background h-full min-h-0 bg-white">
+            <ScrollArea
+              className="scroll-area-full-height h-full"
+              viewportClassName="[&>div]:!block [&>div]:flex [&>div]:min-h-full [&>div]:flex-col"
+              fillViewportContent
+            >
+              {children}
+            </ScrollArea>
+          </div>
         </Panel>
       </PanelGroup>
     </div>

--- a/frontend/packages/ui/src/site-file-browser.tsx
+++ b/frontend/packages/ui/src/site-file-browser.tsx
@@ -1,0 +1,134 @@
+import type {HMDocumentInfo, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {getMetadataName} from '@shm/shared'
+import {useDirectory} from '@shm/shared/models/entity'
+import {
+  buildDocumentTree,
+  filterDocumentsByTitle,
+  flattenTree,
+  getAncestorPathKeys,
+} from '@shm/shared/utils/all-documents-tree'
+import {ChevronDown, ChevronRight, Lock, Search} from 'lucide-react'
+import {useEffect, useMemo, useState} from 'react'
+import {Button} from './button'
+import {Input} from './components/input'
+import {Spinner} from './spinner'
+import {cn} from './utils'
+
+/** Props for the shared site document browser. */
+export interface SiteFileBrowserProps {
+  siteId: UnpackedHypermediaId
+  activeDocumentId: UnpackedHypermediaId | null
+  onNavigate: (id: UnpackedHypermediaId) => void
+}
+
+function titleOf(doc: HMDocumentInfo) {
+  return getMetadataName(doc.metadata) || doc.path?.at(-1) || 'Untitled'
+}
+
+/** Renders the searchable, expandable document hierarchy for a site. */
+export function SiteFileBrowser({siteId, activeDocumentId, onNavigate}: SiteFileBrowserProps) {
+  const directory = useDirectory(siteId, {mode: 'AllDescendants'})
+  const [query, setQuery] = useState('')
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    const activeAncestors = getAncestorPathKeys(activeDocumentId?.path)
+    if (!activeAncestors.length) return
+    setExpandedPaths((current) => new Set([...current, ...activeAncestors]))
+  }, [activeDocumentId?.id])
+
+  const documents = directory.data ?? []
+  const tree = useMemo(() => buildDocumentTree(documents), [documents])
+  const rows = useMemo(() => flattenTree(tree, expandedPaths), [expandedPaths, tree])
+  const matches = useMemo(() => filterDocumentsByTitle(documents, query), [documents, query])
+  const visibleDocuments = query.trim() ? matches : rows.map((row) => row.doc)
+  const rowById = useMemo(() => new Map(rows.map((row) => [row.doc.id.id, row])), [rows])
+
+  function toggle(pathKey: string) {
+    setExpandedPaths((current) => {
+      const next = new Set(current)
+      if (next.has(pathKey)) next.delete(pathKey)
+      else next.add(pathKey)
+      return next
+    })
+  }
+
+  return (
+    <div className="bg-background flex h-full min-h-0 flex-col">
+      <div className="border-border border-b p-3">
+        <div className="relative">
+          <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+          <Input
+            aria-label="Filter documents"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Filter documents…"
+            className="pl-9"
+          />
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        {directory.isLoading ? (
+          <div className="flex h-24 items-center justify-center" aria-label="Loading documents">
+            <Spinner />
+          </div>
+        ) : directory.isError ? (
+          <div className="flex flex-col items-center gap-3 p-6 text-center text-sm">
+            <p>Couldn’t load documents.</p>
+            <Button size="sm" variant="outline" onClick={() => directory.refetch()}>
+              Retry
+            </Button>
+          </div>
+        ) : visibleDocuments.length === 0 ? (
+          <p className="text-muted-foreground p-6 text-center text-sm">
+            {query.trim() ? 'No documents found' : 'No documents to browse'}
+          </p>
+        ) : (
+          <div role={query.trim() ? 'list' : 'tree'} aria-label="Site documents">
+            {visibleDocuments.map((doc) => {
+              const row = rowById.get(doc.id.id)
+              const isFiltered = !!query.trim()
+              const isActive = doc.id.id === activeDocumentId?.id
+              const isExpanded = row ? expandedPaths.has(row.pathKey) : false
+              return (
+                <div
+                  key={doc.id.id}
+                  role={isFiltered ? 'listitem' : 'treeitem'}
+                  aria-expanded={!isFiltered && row?.hasChildren ? isExpanded : undefined}
+                  style={{paddingLeft: isFiltered ? 0 : (row?.depth ?? 0) * 16}}
+                  className={cn('flex min-w-0 items-center rounded-md', isActive && 'bg-accent text-accent-foreground')}
+                >
+                  {!isFiltered && row?.hasChildren ? (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="size-8 shrink-0"
+                      aria-label={isExpanded ? `Collapse ${titleOf(doc)}` : `Expand ${titleOf(doc)}`}
+                      onClick={() => toggle(row.pathKey)}
+                    >
+                      {isExpanded ? <ChevronDown className="size-4" /> : <ChevronRight className="size-4" />}
+                    </Button>
+                  ) : (
+                    <span className="size-8 shrink-0" />
+                  )}
+                  <button
+                    type="button"
+                    aria-current={isActive ? 'page' : undefined}
+                    onClick={() => onNavigate(doc.id)}
+                    className="hover:bg-accent/60 focus-visible:ring-ring flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-2 text-left text-sm outline-none focus-visible:ring-2"
+                  >
+                    {doc.visibility === 'PRIVATE' ? (
+                      <Lock aria-label="Private document" className="size-3.5 shrink-0" />
+                    ) : null}
+                    <span className="truncate">{titleOf(doc)}</span>
+                  </button>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/packages/ui/src/site-file-browser.tsx
+++ b/frontend/packages/ui/src/site-file-browser.tsx
@@ -11,6 +11,7 @@ import {ChevronDown, ChevronRight, Lock, Search} from 'lucide-react'
 import {useEffect, useMemo, useState} from 'react'
 import {Button} from './button'
 import {Input} from './components/input'
+import {ScrollArea} from './components/scroll-area'
 import {Spinner} from './spinner'
 import {cn} from './utils'
 
@@ -34,7 +35,7 @@ export function SiteFileBrowser({siteId, activeDocumentId, onNavigate}: SiteFile
   useEffect(() => {
     const activeAncestors = getAncestorPathKeys(activeDocumentId?.path)
     if (!activeAncestors.length) return
-    setExpandedPaths((current) => new Set([...current, ...activeAncestors]))
+    setExpandedPaths((current) => new Set(Array.from(current).concat(activeAncestors)))
   }, [activeDocumentId?.id])
 
   const documents = directory.data ?? []
@@ -54,7 +55,7 @@ export function SiteFileBrowser({siteId, activeDocumentId, onNavigate}: SiteFile
   }
 
   return (
-    <div className="bg-background flex h-full min-h-0 flex-col">
+    <div className="dark:bg-background flex h-full min-h-0 flex-col bg-white">
       <div className="border-border border-b p-3">
         <div className="relative">
           <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2" />
@@ -68,67 +69,72 @@ export function SiteFileBrowser({siteId, activeDocumentId, onNavigate}: SiteFile
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto p-2">
-        {directory.isLoading ? (
-          <div className="flex h-24 items-center justify-center" aria-label="Loading documents">
-            <Spinner />
-          </div>
-        ) : directory.isError ? (
-          <div className="flex flex-col items-center gap-3 p-6 text-center text-sm">
-            <p>Couldn’t load documents.</p>
-            <Button size="sm" variant="outline" onClick={() => directory.refetch()}>
-              Retry
-            </Button>
-          </div>
-        ) : visibleDocuments.length === 0 ? (
-          <p className="text-muted-foreground p-6 text-center text-sm">
-            {query.trim() ? 'No documents found' : 'No documents to browse'}
-          </p>
-        ) : (
-          <div role={query.trim() ? 'list' : 'tree'} aria-label="Site documents">
-            {visibleDocuments.map((doc) => {
-              const row = rowById.get(doc.id.id)
-              const isFiltered = !!query.trim()
-              const isActive = doc.id.id === activeDocumentId?.id
-              const isExpanded = row ? expandedPaths.has(row.pathKey) : false
-              return (
-                <div
-                  key={doc.id.id}
-                  role={isFiltered ? 'listitem' : 'treeitem'}
-                  aria-expanded={!isFiltered && row?.hasChildren ? isExpanded : undefined}
-                  style={{paddingLeft: isFiltered ? 0 : (row?.depth ?? 0) * 16}}
-                  className={cn('flex min-w-0 items-center rounded-md', isActive && 'bg-accent text-accent-foreground')}
-                >
-                  {!isFiltered && row?.hasChildren ? (
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="size-8 shrink-0"
-                      aria-label={isExpanded ? `Collapse ${titleOf(doc)}` : `Expand ${titleOf(doc)}`}
-                      onClick={() => toggle(row.pathKey)}
-                    >
-                      {isExpanded ? <ChevronDown className="size-4" /> : <ChevronRight className="size-4" />}
-                    </Button>
-                  ) : (
-                    <span className="size-8 shrink-0" />
-                  )}
-                  <button
-                    type="button"
-                    aria-current={isActive ? 'page' : undefined}
-                    onClick={() => onNavigate(doc.id)}
-                    className="hover:bg-accent/60 focus-visible:ring-ring flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-2 text-left text-sm outline-none focus-visible:ring-2"
+      <ScrollArea className="scroll-area-full-height min-h-0 flex-1" viewportClassName="[&>div]:!block">
+        <div className="p-2">
+          {directory.isLoading ? (
+            <div className="flex h-24 items-center justify-center" aria-label="Loading documents">
+              <Spinner />
+            </div>
+          ) : directory.isError ? (
+            <div className="flex flex-col items-center gap-3 p-6 text-center text-sm">
+              <p>Couldn’t load documents.</p>
+              <Button size="sm" variant="outline" onClick={() => directory.refetch()}>
+                Retry
+              </Button>
+            </div>
+          ) : visibleDocuments.length === 0 ? (
+            <p className="text-muted-foreground p-6 text-center text-sm">
+              {query.trim() ? 'No documents found' : 'No documents to browse'}
+            </p>
+          ) : (
+            <div role={query.trim() ? 'list' : 'tree'} aria-label="Site documents">
+              {visibleDocuments.map((doc) => {
+                const row = rowById.get(doc.id.id)
+                const isFiltered = !!query.trim()
+                const isActive = doc.id.id === activeDocumentId?.id
+                const isExpanded = row ? expandedPaths.has(row.pathKey) : false
+                return (
+                  <div
+                    key={doc.id.id}
+                    role={isFiltered ? 'listitem' : 'treeitem'}
+                    aria-expanded={!isFiltered && row?.hasChildren ? isExpanded : undefined}
+                    style={{paddingLeft: isFiltered ? 0 : (row?.depth ?? 0) * 16}}
+                    className={cn(
+                      'flex min-w-0 items-center rounded-md',
+                      isActive && 'bg-accent text-accent-foreground',
+                    )}
                   >
-                    {doc.visibility === 'PRIVATE' ? (
-                      <Lock aria-label="Private document" className="size-3.5 shrink-0" />
-                    ) : null}
-                    <span className="truncate">{titleOf(doc)}</span>
-                  </button>
-                </div>
-              )
-            })}
-          </div>
-        )}
-      </div>
+                    {!isFiltered && row?.hasChildren ? (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-8 shrink-0"
+                        aria-label={isExpanded ? `Collapse ${titleOf(doc)}` : `Expand ${titleOf(doc)}`}
+                        onClick={() => toggle(row.pathKey)}
+                      >
+                        {isExpanded ? <ChevronDown className="size-4" /> : <ChevronRight className="size-4" />}
+                      </Button>
+                    ) : (
+                      <span className="size-8 shrink-0" />
+                    )}
+                    <button
+                      type="button"
+                      aria-current={isActive ? 'page' : undefined}
+                      onClick={() => onNavigate(doc.id)}
+                      className="hover:bg-accent/60 focus-visible:ring-ring flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-2 text-left text-sm outline-none focus-visible:ring-2"
+                    >
+                      {doc.visibility === 'PRIVATE' ? (
+                        <Lock aria-label="Private document" className="size-3.5 shrink-0" />
+                      ) : null}
+                      <span className="truncate">{titleOf(doc)}</span>
+                    </button>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      </ScrollArea>
     </div>
   )
 }

--- a/frontend/packages/ui/src/site-file-browser.tsx
+++ b/frontend/packages/ui/src/site-file-browser.tsx
@@ -105,26 +105,25 @@ export function SiteFileBrowser({siteId, activeDocumentId, onNavigate}: SiteFile
                     )}
                   >
                     {!isFiltered && row?.hasChildren ? (
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="size-8 shrink-0"
+                      <button
+                        type="button"
+                        className="hover:bg-accent/60 focus-visible:ring-ring flex size-6 shrink-0 items-center justify-center rounded-md p-0 outline-none focus-visible:ring-2"
                         aria-label={isExpanded ? `Collapse ${titleOf(doc)}` : `Expand ${titleOf(doc)}`}
                         onClick={() => toggle(row.pathKey)}
                       >
-                        {isExpanded ? <ChevronDown className="size-4" /> : <ChevronRight className="size-4" />}
-                      </Button>
+                        {isExpanded ? <ChevronDown className="size-3.5" /> : <ChevronRight className="size-3.5" />}
+                      </button>
                     ) : (
-                      <span className="size-8 shrink-0" />
+                      <span className="size-6 shrink-0" />
                     )}
                     <button
                       type="button"
                       aria-current={isActive ? 'page' : undefined}
                       onClick={() => onNavigate(doc.id)}
-                      className="hover:bg-accent/60 focus-visible:ring-ring flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-2 text-left text-sm outline-none focus-visible:ring-2"
+                      className="hover:bg-accent/60 focus-visible:ring-ring flex h-6 min-w-0 flex-1 items-center gap-1.5 rounded-md px-1.5 text-left text-xs outline-none focus-visible:ring-2"
                     >
                       {doc.visibility === 'PRIVATE' ? (
-                        <Lock aria-label="Private document" className="size-3.5 shrink-0" />
+                        <Lock aria-label="Private document" className="size-3 shrink-0" />
                       ) : null}
                       <span className="truncate">{titleOf(doc)}</span>
                     </button>

--- a/frontend/packages/ui/src/site-header.tsx
+++ b/frontend/packages/ui/src/site-header.tsx
@@ -17,7 +17,7 @@ import {useResponsiveItems} from './use-responsive-items'
 
 import {IS_DESKTOP} from '@shm/shared/constants'
 import {useIsomorphicLayoutEffect} from '@shm/shared/utils/use-isomorphic-layout-effect'
-import {Activity, Lock} from 'lucide-react'
+import {Activity, Files, Lock} from 'lucide-react'
 import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from './components/dropdown-menu'
 import {useHighlighter} from './highlight-context'
 import {DocNavigationItem, DocumentOutline, DocumentSmallListItem, useNodesOutline} from './navigation'
@@ -51,6 +51,7 @@ export function SiteHeader({
   notifyServiceHost: _notifyServiceHost,
   routeType,
   rightActions,
+  onOpenFileBrowser,
 }: {
   siteHomeId: UnpackedHypermediaId
   docId: UnpackedHypermediaId | null
@@ -72,6 +73,7 @@ export function SiteHeader({
   notifyServiceHost?: string
   routeType?: NavRoute['key']
   rightActions?: React.ReactNode
+  onOpenFileBrowser?: () => void
 }) {
   const [isMobileMenuOpen, _setIsMobileMenuOpen] = useState(false)
   const [isMobileSearchActive, setIsMobileSearchActive] = useState(false)
@@ -92,6 +94,17 @@ export function SiteHeader({
     : {document: siteHomeDocument ?? undefined, id: siteHomeId} // Non-home: use site home (may be undefined while loading)
   const headerSearch = (
     <>
+      {onOpenFileBrowser ? (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="md:hidden"
+          aria-label="Open file browser"
+          onClick={onOpenFileBrowser}
+        >
+          <Files size={20} />
+        </Button>
+      ) : null}
       <Button
         variant="ghost"
         size="icon"

--- a/frontend/packages/ui/src/site-header.tsx
+++ b/frontend/packages/ui/src/site-header.tsx
@@ -17,7 +17,7 @@ import {useResponsiveItems} from './use-responsive-items'
 
 import {IS_DESKTOP} from '@shm/shared/constants'
 import {useIsomorphicLayoutEffect} from '@shm/shared/utils/use-isomorphic-layout-effect'
-import {Activity, Files, Lock} from 'lucide-react'
+import {Activity, FolderTree, Lock} from 'lucide-react'
 import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from './components/dropdown-menu'
 import {useHighlighter} from './highlight-context'
 import {DocNavigationItem, DocumentOutline, DocumentSmallListItem, useNodesOutline} from './navigation'
@@ -102,9 +102,12 @@ export function SiteHeader({
           size="icon"
           className="md:hidden"
           aria-label="Open file browser"
-          onClick={onOpenFileBrowser}
+          onClick={() => {
+            setIsMobileMenuOpen(false)
+            onOpenFileBrowser()
+          }}
         >
-          <Files size={20} />
+          <FolderTree size={20} />
         </Button>
       ) : null}
       <Button

--- a/frontend/packages/ui/src/site-header.tsx
+++ b/frontend/packages/ui/src/site-header.tsx
@@ -46,6 +46,7 @@ export function SiteHeader({
   hideSiteBarClassName,
   isLatest: _isLatest,
   editNavPane,
+  editNavPanePortalRef,
   isMainFeedVisible = false,
   wrapperClassName,
   notifyServiceHost: _notifyServiceHost,
@@ -68,6 +69,7 @@ export function SiteHeader({
   hideSiteBarClassName?: AutoHideSiteHeaderClassName
   isLatest?: boolean
   editNavPane?: React.ReactNode
+  editNavPanePortalRef?: (node: HTMLDivElement | null) => void
   isMainFeedVisible: boolean
   wrapperClassName?: string
   notifyServiceHost?: string
@@ -194,6 +196,7 @@ export function SiteHeader({
           docId={docId}
           isCenterLayout={isCenterLayout}
           editNavPane={editNavPane}
+          editNavPanePortalRef={editNavPanePortalRef}
           isMainFeedVisible={isMainFeedVisible}
           siteHomeId={siteHomeId}
         />
@@ -427,6 +430,7 @@ export function SiteHeaderMenu({
   siteHomeId,
   isCenterLayout = false,
   editNavPane,
+  editNavPanePortalRef,
   isMainFeedVisible = false,
 }: {
   items?: DocNavigationItem[] | null
@@ -434,9 +438,10 @@ export function SiteHeaderMenu({
   siteHomeId: UnpackedHypermediaId
   isCenterLayout?: boolean
   editNavPane?: React.ReactNode
+  editNavPanePortalRef?: (node: HTMLDivElement | null) => void
   isMainFeedVisible?: boolean
 }) {
-  const editNavPaneRef = useRef<HTMLDivElement>(null)
+  const editNavPaneRef = useRef<HTMLDivElement | null>(null)
   const feedLinkButtonRef = useRef<HTMLAnchorElement>(null)
 
   // Calculate reserved width for the dropdown button, edit pane, and feed button
@@ -482,7 +487,16 @@ export function SiteHeaderMenu({
         isCenterLayout ? 'justify-center' : 'justify-end',
       )}
     >
-      {editNavPane && <div ref={editNavPaneRef}>{editNavPane}</div>}
+      {(editNavPane || editNavPanePortalRef) && (
+        <div
+          ref={(node) => {
+            editNavPaneRef.current = node
+            editNavPanePortalRef?.(node)
+          }}
+        >
+          {editNavPane}
+        </div>
+      )}
       {/* Hidden measurement container */}
       <div className="pointer-events-none absolute top-0 left-0 flex items-center gap-5 p-0 opacity-0 md:flex md:p-2">
         {items?.map((item) => {


### PR DESCRIPTION
## Summary

- Add a searchable, expandable site document browser with active-document highlighting and private-document indicators.
- Integrate a resizable, collapsible sidebar on desktop and an 80%-wide drawer on mobile.
- Preserve authorization-aware directory behavior and exclude drafts.
- Add tree filtering and ancestor-path utilities with focused tests.
- Document the feature scope, responsive behavior, accessibility requirements, and implementation plan.

Fixes #936 