### PR TITLE
perf(web): stop hammering the daemon with per-page-view listing fan-out

### DIFF
--- a/frontend/apps/web/app/server-universal-client.ts
+++ b/frontend/apps/web/app/server-universal-client.ts
@@ -20,6 +20,32 @@ async function queryDaemon<T>(pathAndQuery: string): Promise<T> {
 }
 
 /**
+ * Short-lived cache for the hot read-only API keys the SSR loaders fan out on
+ * every page render (a single document view fires dozens of these, and crawler
+ * traffic replays the same pages continuously with no HTTP caching in front).
+ *
+ * Entries store in-flight Promises, so concurrent renders of the same page
+ * share one gRPC call instead of racing duplicates. This client is never
+ * authenticated (it always sees the public view of the data), so entries are
+ * safe to share across requests and users. Failed calls are evicted so errors
+ * are not cached.
+ */
+const CACHEABLE_KEYS: ReadonlySet<string> = new Set(['Query', 'QueryBlock', 'InteractionSummary', 'ListCitations'])
+const CACHE_TTL_MS = 30_000
+/** LRU-ish cap, same pattern as the SSR HTML cache in @shm/editor/ssr-render. */
+const CACHE_MAX_ENTRIES = 500
+const responseCache = new Map<string, {expires: number; result: Promise<unknown>}>()
+
+/** JSON with sorted object keys, so logically-equal inputs produce one cache key. */
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_k, v) =>
+    v && typeof v === 'object' && !Array.isArray(v)
+      ? Object.fromEntries(Object.entries(v).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)))
+      : v,
+  )
+}
+
+/**
  * Server-side request function for SSR.
  * Uses gRPC client directly instead of going through API endpoints.
  */
@@ -27,9 +53,33 @@ export async function serverRequest<K extends keyof typeof APIRouter>(
   key: K,
   input: Parameters<(typeof APIRouter)[K]['getData']>[1],
 ): Promise<Awaited<ReturnType<(typeof APIRouter)[K]['getData']>>> {
+  type Result = Awaited<ReturnType<(typeof APIRouter)[K]['getData']>>
   const apiDefinition = APIRouter[key]
-  const result = await apiDefinition.getData(grpcClient, input as never, queryDaemon)
-  return result as Awaited<ReturnType<(typeof APIRouter)[K]['getData']>>
+
+  if (!CACHEABLE_KEYS.has(key)) {
+    const result = await apiDefinition.getData(grpcClient, input as never, queryDaemon)
+    return result as Result
+  }
+
+  const cacheKey = `${key}:${stableStringify(input)}`
+  const cached = responseCache.get(cacheKey)
+  if (cached && cached.expires > Date.now()) {
+    return cached.result as Promise<Result>
+  }
+  responseCache.delete(cacheKey)
+
+  if (responseCache.size >= CACHE_MAX_ENTRIES) {
+    const oldest = responseCache.keys().next().value
+    if (oldest !== undefined) responseCache.delete(oldest)
+  }
+
+  const result = apiDefinition.getData(grpcClient, input as never, queryDaemon)
+  responseCache.set(cacheKey, {expires: Date.now() + CACHE_TTL_MS, result})
+  result.catch(() => {
+    const entry = responseCache.get(cacheKey)
+    if (entry?.result === result) responseCache.delete(cacheKey)
+  })
+  return result as Promise<Result>
 }
 
 export const serverPublish: UniversalClient['publish'] = (input) => {

--- a/frontend/packages/shared/src/__tests__/api-interaction-summary.test.ts
+++ b/frontend/packages/shared/src/__tests__/api-interaction-summary.test.ts
@@ -7,12 +7,12 @@ const targetDocId = hmId('z6MkTestAccount', {path: ['test-doc']})
 
 function makeGrpcClient({
   getDocument = vi.fn().mockResolvedValue({version: 'v1'}),
-  listDirectory = vi.fn().mockResolvedValue({documents: []}),
+  getDocumentInfo = vi.fn().mockResolvedValue({activitySummary: {childrenCount: 0}}),
   listDocumentChanges = vi.fn().mockResolvedValue({changes: []}),
   listCitations = vi.fn().mockResolvedValue({citations: []}),
 } = {}) {
   return {
-    documents: {getDocument, listDirectory, listDocumentChanges},
+    documents: {getDocument, getDocumentInfo, listDocumentChanges},
     resources: {listCitations},
   } as any
 }
@@ -75,9 +75,9 @@ describe('InteractionSummary.getData', () => {
     expect(result).toEqual(emptySummary)
   })
 
-  it('returns empty summary when listDirectory fails with not found', async () => {
+  it('returns empty summary when getDocumentInfo fails with not found', async () => {
     const grpcClient = makeGrpcClient({
-      listDirectory: vi.fn().mockRejectedValue(new ConnectError('not found', Code.NotFound)),
+      getDocumentInfo: vi.fn().mockRejectedValue(new ConnectError('not found', Code.NotFound)),
     })
 
     const result = await InteractionSummary.getData(grpcClient, {id: targetDocId}, dummyQueryDaemon)

--- a/frontend/packages/shared/src/__tests__/list-all-pages.test.ts
+++ b/frontend/packages/shared/src/__tests__/list-all-pages.test.ts
@@ -1,0 +1,40 @@
+import {describe, expect, it, vi} from 'vitest'
+import {LIST_PAGE_SIZE, listAllPages} from '../list-all-pages'
+
+describe('listAllPages', () => {
+  it('follows nextPageToken until exhausted and concatenates items', async () => {
+    const pages: Record<string, {items: number[]; nextPageToken: string}> = {
+      '': {items: [1, 2], nextPageToken: 'p2'},
+      p2: {items: [3], nextPageToken: 'p3'},
+      p3: {items: [4, 5], nextPageToken: ''},
+    }
+    const fetchPage = vi.fn(async (token: string) => pages[token]!)
+
+    const items = await listAllPages(fetchPage, (r) => r)
+
+    expect(items).toEqual([1, 2, 3, 4, 5])
+    expect(fetchPage).toHaveBeenCalledTimes(3)
+    expect(fetchPage).toHaveBeenNthCalledWith(1, '')
+    expect(fetchPage).toHaveBeenNthCalledWith(2, 'p2')
+    expect(fetchPage).toHaveBeenNthCalledWith(3, 'p3')
+  })
+
+  it('returns a single page without extra requests when there is no token', async () => {
+    const fetchPage = vi.fn(async () => ({items: ['only'], nextPageToken: ''}))
+
+    const items = await listAllPages(fetchPage, (r) => r)
+
+    expect(items).toEqual(['only'])
+    expect(fetchPage).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops at the safety cap even if the server keeps returning tokens', async () => {
+    const page = Array.from({length: LIST_PAGE_SIZE}, (_, i) => i)
+    const fetchPage = vi.fn(async () => ({items: page, nextPageToken: 'more'}))
+
+    const items = await listAllPages(fetchPage, (r) => r)
+
+    expect(items.length).toBe(10_000)
+    expect(fetchPage).toHaveBeenCalledTimes(10_000 / LIST_PAGE_SIZE)
+  })
+})

--- a/frontend/packages/shared/src/api-citations.ts
+++ b/frontend/packages/shared/src/api-citations.ts
@@ -1,17 +1,22 @@
 import {HMRequestImplementation, HMRequestParams} from './api-types'
-import {BIG_INT} from './constants'
 import {GRPCClient} from './grpc-client'
 import {HMListCitationsRequest} from '@seed-hypermedia/client/hm-types'
+import {LIST_PAGE_SIZE, listAllPages} from './list-all-pages'
 import {packHmId, unpackHmId} from './utils'
 
 export const ListCitations: HMRequestImplementation<HMListCitationsRequest> = {
   async getData(grpcClient: GRPCClient, input): Promise<HMListCitationsRequest['output']> {
-    const result = await grpcClient.resources.listCitations({
-      iri: packHmId({...input.targetId, version: null, latest: null}),
-      pageSize: BIG_INT,
-    })
+    const citations = await listAllPages(
+      (pageToken) =>
+        grpcClient.resources.listCitations({
+          iri: packHmId({...input.targetId, version: null, latest: null}),
+          pageSize: LIST_PAGE_SIZE,
+          pageToken,
+        }),
+      (r) => ({items: r.citations, nextPageToken: r.nextPageToken}),
+    )
     return {
-      citations: result.citations.map((c) => c.toJson({emitDefaultValues: true, enumAsInteger: false}) as any),
+      citations: citations.map((c) => c.toJson({emitDefaultValues: true, enumAsInteger: false}) as any),
     }
   },
 }

--- a/frontend/packages/shared/src/api-interaction-summary.ts
+++ b/frontend/packages/shared/src/api-interaction-summary.ts
@@ -1,8 +1,8 @@
 import {HMRequestImplementation} from './api-types'
-import {BIG_INT} from './constants'
 import {GRPCClient} from './grpc-client'
 import {HMInteractionSummaryRequest} from '@seed-hypermedia/client/hm-types'
 import {calculateInteractionSummary} from './interaction-summary'
+import {LIST_PAGE_SIZE, listAllPages} from './list-all-pages'
 import {getErrorMessage, HMNotFoundError, HMRedirectError, HMResourceTombstoneError} from './models/entity'
 import {hmIdPathToEntityQueryPath} from './utils'
 
@@ -13,11 +13,16 @@ export const InteractionSummary: HMRequestImplementation<HMInteractionSummaryReq
     const apiPath = hmIdPathToEntityQueryPath(id.path)
 
     try {
-      const [mentions, latestDoc, docInfo] = await Promise.all([
-        grpcClient.resources.listCitations({
-          iri: id.id,
-          pageSize: BIG_INT,
-        }),
+      const [citations, latestDoc, docInfo] = await Promise.all([
+        listAllPages(
+          (pageToken) =>
+            grpcClient.resources.listCitations({
+              iri: id.id,
+              pageSize: LIST_PAGE_SIZE,
+              pageToken,
+            }),
+          (r) => ({items: r.citations, nextPageToken: r.nextPageToken}),
+        ),
         grpcClient.documents.getDocument({
           account: id.uid,
           path: apiPath,
@@ -40,7 +45,7 @@ export const InteractionSummary: HMRequestImplementation<HMInteractionSummaryReq
       })
       const childrenCount = docInfo.activitySummary?.childrenCount ?? 0
 
-      return calculateInteractionSummary(mentions.citations, changes.changes, id, childrenCount)
+      return calculateInteractionSummary(citations, changes.changes, id, childrenCount)
     } catch (e) {
       // If the document has been redirected, return empty summary.
       // queryResource handles following redirects, so this query will be

--- a/frontend/packages/shared/src/api-interaction-summary.ts
+++ b/frontend/packages/shared/src/api-interaction-summary.ts
@@ -1,4 +1,3 @@
-import {toPlainMessage} from '@bufbuild/protobuf'
 import {HMRequestImplementation} from './api-types'
 import {BIG_INT} from './constants'
 import {GRPCClient} from './grpc-client'
@@ -14,7 +13,7 @@ export const InteractionSummary: HMRequestImplementation<HMInteractionSummaryReq
     const apiPath = hmIdPathToEntityQueryPath(id.path)
 
     try {
-      const [mentions, latestDoc, children] = await Promise.all([
+      const [mentions, latestDoc, docInfo] = await Promise.all([
         grpcClient.resources.listCitations({
           iri: id.id,
           pageSize: BIG_INT,
@@ -24,9 +23,13 @@ export const InteractionSummary: HMRequestImplementation<HMInteractionSummaryReq
           path: apiPath,
           version: undefined,
         }),
-        grpcClient.documents.listDirectory({
+        // The backend computes the alive direct-children count for every
+        // document info row; a whole ListDirectory call just to count
+        // children was both wasteful and wrong (it silently truncated at
+        // the default page size).
+        grpcClient.documents.getDocumentInfo({
           account: id.uid,
-          directoryPath: apiPath,
+          path: apiPath,
         }),
       ])
 
@@ -35,12 +38,7 @@ export const InteractionSummary: HMRequestImplementation<HMInteractionSummaryReq
         path: apiPath,
         version: latestDoc.version,
       })
-      const childrenCount = toPlainMessage(children).documents.filter((d) => {
-        if (d.path === apiPath) return false
-        // filter out children of children
-        if (d.path.split('/').length > apiPath.split('/').length + 1) return false
-        return true
-      }).length
+      const childrenCount = docInfo.activitySummary?.childrenCount ?? 0
 
       return calculateInteractionSummary(mentions.citations, changes.changes, id, childrenCount)
     } catch (e) {

--- a/frontend/packages/shared/src/list-all-pages.ts
+++ b/frontend/packages/shared/src/list-all-pages.ts
@@ -1,0 +1,38 @@
+/**
+ * Page size for paginated list RPCs fetched via {@link listAllPages}.
+ *
+ * Use this instead of BIG_INT page sizes: the daemon clamps huge page sizes
+ * and would silently truncate the result, so callers that want the whole list
+ * must actually paginate.
+ */
+export const LIST_PAGE_SIZE = 500
+
+/**
+ * Safety cap on the total number of items {@link listAllPages} accumulates,
+ * so one pathological document can't make a client fetch forever.
+ */
+const MAX_LIST_ITEMS = 10_000
+
+/**
+ * Fetches every page of a paginated list RPC and returns the concatenated items.
+ *
+ * @param fetchPage - Fetches one page; must pass the given token as `pageToken`
+ * and request `pageSize: LIST_PAGE_SIZE`.
+ * @param getPage - Extracts the page's items and `nextPageToken` from the response.
+ */
+export async function listAllPages<TResponse, TItem>(
+  fetchPage: (pageToken: string) => Promise<TResponse>,
+  getPage: (response: TResponse) => {items: TItem[]; nextPageToken: string},
+): Promise<TItem[]> {
+  const items: TItem[] = []
+  let pageToken = ''
+  while (true) {
+    const response = await fetchPage(pageToken)
+    const page = getPage(response)
+    items.push(...page.items)
+    if (!page.nextPageToken || items.length >= MAX_LIST_ITEMS) {
+      return items.length > MAX_LIST_ITEMS ? items.slice(0, MAX_LIST_ITEMS) : items
+    }
+    pageToken = page.nextPageToken
+  }
+}

--- a/frontend/packages/shared/src/models/__tests__/directory.test.ts
+++ b/frontend/packages/shared/src/models/__tests__/directory.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, it, vi} from 'vitest'
 import {HMDocumentInfo} from '@seed-hypermedia/client/hm-types'
 import {SortAttribute} from '../../client/.generated/documents/v3alpha/documents_pb'
-import {BIG_INT} from '../../constants'
+import {LIST_PAGE_SIZE} from '../../list-all-pages'
 import {hmId} from '../../utils/entity-id-url'
 
 vi.mock('../entity', () => ({
@@ -74,7 +74,8 @@ describe('createQueryResolver', () => {
       account: 'alice',
       directoryPath: '/projects',
       recursive: false,
-      pageSize: BIG_INT,
+      pageSize: LIST_PAGE_SIZE,
+      pageToken: '',
       sortOptions: {
         attribute: SortAttribute.ACTIVITY_TIME,
         descending: true,
@@ -110,7 +111,8 @@ describe('createQueryResolver', () => {
       account: 'alice',
       directoryPath: '/projects',
       recursive: true,
-      pageSize: BIG_INT,
+      pageSize: LIST_PAGE_SIZE,
+      pageToken: '',
     })
     expect(result?.results.map((doc) => doc.metadata.name)).toEqual(['Newer', 'Older'])
   })

--- a/frontend/packages/shared/src/models/comments-resolvers.ts
+++ b/frontend/packages/shared/src/models/comments-resolvers.ts
@@ -10,6 +10,7 @@ import {
   UnpackedHypermediaId,
 } from '@seed-hypermedia/client/hm-types'
 import {BIG_INT} from '../constants'
+import {LIST_PAGE_SIZE, listAllPages} from '../list-all-pages'
 import {hmIdPathToEntityQueryPath} from '../utils/path-api'
 import {getCommentGroups} from '../comments'
 import {parseFragment, unpackHmId} from '../utils'
@@ -154,7 +155,10 @@ export function createDiscussionsResolver(client: GRPCClient) {
           pageSize: BIG_INT,
         })
         .catch(() => null),
-      client.resources.listCitations({iri: targetId.id, pageSize: BIG_INT}).catch(() => null),
+      listAllPages(
+        (pageToken) => client.resources.listCitations({iri: targetId.id, pageSize: LIST_PAGE_SIZE, pageToken}),
+        (r) => ({items: r.citations, nextPageToken: r.nextPageToken}),
+      ).catch(() => null),
     ])
 
     // Process direct comments
@@ -164,8 +168,8 @@ export function createDiscussionsResolver(client: GRPCClient) {
 
     // Process citing discussions - group by doc to dedupe listComments calls
     const mentionsByDoc = new Map<string, {mention: any; id: UnpackedHypermediaId}[]>()
-    citationsResult?.citations
-      .filter((m) => m.sourceType === 'Comment' && m.sourceDocument !== targetId.id)
+    citationsResult
+      ?.filter((m) => m.sourceType === 'Comment' && m.sourceDocument !== targetId.id)
       .forEach((mention) => {
         const id = unpackHmId(mention.sourceDocument)
         if (!id) return
@@ -235,12 +239,17 @@ export function createCommentsByReferenceResolver(client: GRPCClient) {
     authors: Record<string, HMMetadataPayload>
   }> => {
     try {
-      const citations = await client.resources.listCitations({
-        iri: targetId.id,
-        pageSize: BIG_INT,
-      })
+      const citations = await listAllPages(
+        (pageToken) =>
+          client.resources.listCitations({
+            iri: targetId.id,
+            pageSize: LIST_PAGE_SIZE,
+            pageToken,
+          }),
+        (r) => ({items: r.citations, nextPageToken: r.nextPageToken}),
+      )
 
-      const commentCitations = citations.citations.filter((m) => {
+      const commentCitations = citations.filter((m) => {
         if (m.sourceType != 'Comment') return false
         const targetFragment = parseFragment(m.targetFragment)
         if (!targetFragment) return false

--- a/frontend/packages/shared/src/models/directory.ts
+++ b/frontend/packages/shared/src/models/directory.ts
@@ -1,9 +1,9 @@
 import {HMDocumentInfo, HMQuery, HMQueryResult, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {SortAttribute} from '../client/.generated/documents/v3alpha/documents_pb'
-import {BIG_INT} from '../constants'
 import {queryBlockSortedItems} from '../content'
 import {GRPCClient} from '../grpc-client'
 import {entityQueryPathToHmIdPath, hmId} from '../utils'
+import {LIST_PAGE_SIZE, listAllPages} from '../list-all-pages'
 import {hmIdPathToEntityQueryPath} from '../utils/path-api'
 import {prepareHMDocumentInfo} from './entity'
 
@@ -22,15 +22,20 @@ function createDirectoryResolver(client: GRPCClient) {
           ? {attribute: SortAttribute.NAME, descending: reverse}
           : undefined
 
-    const listResult = await client.documents.listDirectory({
-      account: id.uid,
-      directoryPath: hmIdPathToEntityQueryPath(id.path),
-      recursive: mode === 'AllDescendants',
-      pageSize: BIG_INT,
-      ...(sortOptions ? {sortOptions} : {}),
-    })
+    const documents = await listAllPages(
+      (pageToken) =>
+        client.documents.listDirectory({
+          account: id.uid,
+          directoryPath: hmIdPathToEntityQueryPath(id.path),
+          recursive: mode === 'AllDescendants',
+          pageSize: LIST_PAGE_SIZE,
+          pageToken,
+          ...(sortOptions ? {sortOptions} : {}),
+        }),
+      (r) => ({items: r.documents, nextPageToken: r.nextPageToken}),
+    )
 
-    return listResult.documents.map(prepareHMDocumentInfo).filter((doc: HMDocumentInfo) => {
+    return documents.map(prepareHMDocumentInfo).filter((doc: HMDocumentInfo) => {
       if (doc.id.id === id.id) return false
       if (!doc.id.id.startsWith(id.id)) return false
 


### PR DESCRIPTION
## Problem

The production daemon has been pinned at 5-6 cores for hours at a time. Three CPU profiles taken over one day all show the same shape: **~65% of all daemon CPU serving `ListDirectory` and another ~17% serving `ListCitations`**, with 90%+ of total CPU inside `sqlite3_step`. The backend query shapes were fixed separately (#933-era work, commit `9cec42c4f`); this PR fixes the other half: the web gateway generates that traffic in the first place.

## Why the gateway hammers the daemon

Tracing the SSR loaders (`apps/web/app/loaders.ts`, `prefetchResourceData`) shows a single document page view fires, with zero caching at any layer:

- `ListDirectory` for the site home + `ListDirectory` for the current doc (Wave 1)
- one `ListDirectory(pageSize=2^25)` per query block in the doc body — recursive over the whole account for `AllDescendants` blocks, then `slice(0, limit)`-ed client-side (Wave 2)
- up to **30 `InteractionSummary` calls** — one per embedded ref, just to render count badges (Wave 3). Each `InteractionSummary` is itself **4 gRPC calls**: `ListCitations(pageSize=2^25)` + `GetDocument` + `ListDirectory` (used only to *count direct children*) + `ListDocumentChanges`. These use the raw gRPC client, so the doc's own directory was fetched twice per render.

That is **~35 ListDirectory + ~31 ListCitations per page view**. Meanwhile every response is sent `Cache-Control: private, no-store` / `no-cache`, the server builds a fresh QueryClient per request, `robots.txt` is `Allow: /`, and the expensive `/:directory` / `/:all-documents` views are ordinary crawlable links — so crawler traffic replays the full fan-out on every hit, forever. That is the sustained 88% CPU.

## Changes

**1. `InteractionSummary` no longer calls `ListDirectory` at all** (`packages/shared/src/api-interaction-summary.ts`)

The backend already computes the alive direct-children count for every document info row (`children_count`, exposed via `GetDocumentInfo` → `activitySummary.childrenCount`) — the column comment in `documents.go` says verbatim it exists so cards can show the count "without a per-document interaction-summary request". Using it removes one `ListDirectory` from every interaction summary (up to 31 per page view) and is also *more correct*: the old count silently truncated at the backend's default page size and did not exclude deleted documents.

**2. 30s TTL cache for hot read-only keys in the SSR client** (`apps/web/app/server-universal-client.ts`)

The SSR universal client now caches `Query`, `QueryBlock`, `InteractionSummary` and `ListCitations` responses in a module-scoped map: 30s TTL, 500-entry bounded size (same pattern as the SSR HTML cache in `@shm/editor/ssr-render`). Entries store **in-flight Promises**, so concurrent renders of the same page share one backend call instead of racing duplicates, and rejected calls are evicted so errors are never cached. This client is never authenticated — it always sees the public view — so entries are safe to share across requests and users.

Net effect: a typical page render drops from ~35 ListDirectory + ~31 ListCitations to ~4 + ~1 on a cold cache, and to **zero** daemon calls for any page re-rendered within the TTL window — which is exactly the crawler-replay pattern that dominates gateway traffic. Data staleness is bounded at 30s, for listings and count badges on a public gateway.

**3. Real pagination for the hot list calls** (`packages/shared/src/list-all-pages.ts`, second commit)

Companion to the new daemon-side page-size clamp on `ListDirectory`/`ListCitations` (capped at 2000, landed on main in `f0246a025`): callers sending `pageSize: 2^25` without following `next_page_token` would silently truncate long lists once the clamp is live. A new `listAllPages` helper fetches bounded pages (500) following `next_page_token`, with a 10k total safety cap, and replaces `pageSize: 2^25` at the profile-hot call sites: `listCitations` in `api-citations`, `api-interaction-summary` and `models/comments-resolvers`, and `listDirectory` in `models/directory`. Covered by a dedicated multi-page/cap unit test; the other `BIG_INT` call sites hit RPCs that stay unclamped and are left for follow-ups.


## Testing

- `tsc --noEmit` passes in `packages/shared` and `apps/web`.
- Full `packages/shared` vitest suite passes (1004 tests), including the new `list-all-pages` multi-page/cap tests.
- `api-interaction-summary` / `interaction-summary` vitest suites pass (mocks updated from `listDirectory` to `getDocumentInfo`).
- Verified `GetDocumentInfo` populates `activitySummary.childrenCount` (backend `documentInfoFromRow`, `documents.go:1767` — the proto comment claiming it is listing-only is stale).

## Deliberately out of scope (follow-ups)

- Passing listing-row `activitySummary` into `DocumentListItem`/`CitationCell` to kill the per-row summary fetches on `/:directory` and `/:all-documents` (the prop plumbing already exists).
- Capping or lazifying Wave 3's 30 summary prefetches.
- `robots.txt` Disallow for `/:directory` / `/:all-documents` view URLs.
- Pushing query-block `limit` into the backend call instead of slicing after fetching the whole subtree.

