### PR TITLE
fix(agents): route /agents/ws explicitly so prod builds upgrade WebSockets

### DIFF
--- a/agents/src/main.ts
+++ b/agents/src/main.ts
@@ -8,7 +8,7 @@ import * as cbor from '@/cbor'
 import * as config from '@/config'
 import index from '@/frontend/index.html'
 import * as sqlite from '@/sqlite'
-import {type BunRequest, type ServerWebSocket, serve} from 'bun'
+import {type BunRequest, type Server, type ServerWebSocket, serve} from 'bun'
 import type {Database} from 'bun:sqlite'
 import * as fs from 'node:fs'
 import * as filepath from 'node:path'
@@ -520,6 +520,14 @@ async function main(): Promise<void> {
     error: handleError,
     routes: {
       ...createAPIRoutes(svc),
+      // Must be an explicit route: the '/agents/*' catch-all matches function routes before the
+      // fetch() fallback ever runs, so without this the prod build answers upgrade requests with
+      // the SPA HTML instead of a 101.
+      '/agents/ws': (req: BunRequest, srv: Server<WSData>) => {
+        const upgraded = srv.upgrade(req, {data: {connectedAt: Date.now(), subscriptions: new Set<string>()}})
+        if (upgraded) return undefined as unknown as Response
+        return new Response('WebSocket upgrade failed', {status: 400})
+      },
       '/agents/api/status': {
         GET: () => json({...getDebugOverview(db), connections: clients.size}),
       },


### PR DESCRIPTION
## Summary
- `wss://agentic.seed.hyper.media/agents/ws` (and the dev instance) answered WebSocket upgrades with the SPA HTML (HTTP 200) instead of upgrading to 101, so desktop live session streaming was broken against deployed servers — zero `[agents/ws] open` log lines in 48h of prod logs.
- Root cause: in the production build the `'/agents/*'` **function** route matches `/agents/ws` and Bun serves it before the `fetch()` fallback that held the `server.upgrade()` call. In dev the wildcard is an HTML import, which Bun does not apply to upgrade requests — so the bug never reproduced locally.
- Fix: register an explicit `'/agents/ws'` route that performs the upgrade (exact routes take precedence over the wildcard in both modes).

## Testing
- Reproduced against the prod build locally (`bun run build` + `NODE_ENV=production bun dist/main.js`): WS handshake returned 200 before the fix, 101/open after.
- `bun typecheck`, `bun test` (137 pass), `prettier --check` clean.
- Verified `/agents` SPA and `/api/health` still serve after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)