### PR TITLE
fix(agents): cancel a timed-out poll cycle instead of only timing it out

### DIFF
--- a/agents/src/activity-monitor.ts
+++ b/agents/src/activity-monitor.ts
@@ -41,7 +41,7 @@ export class ActivityMonitor {
       label: 'Agents Activity',
       intervalMs: options.pollIntervalMs,
       timeoutMs: options.pollTimeoutMs ?? DEFAULT_POLL_TIMEOUT_MS,
-      run: () => this.pollOnce(),
+      run: (signal) => this.pollOnce(signal),
     })
   }
 
@@ -55,14 +55,37 @@ export class ActivityMonitor {
     this.#loop.stop()
   }
 
-  /** Runs one polling cycle for all accounts that have enabled triggers. */
-  async pollOnce(): Promise<void> {
+  /**
+   * Runs one polling cycle for all accounts that have enabled triggers.
+   *
+   * `signal` bounds the whole cycle (see {@link PollLoop}): when it aborts, the cycle stops fetching and
+   * returns instead of grinding through the remaining accounts. Accounts are polled in a stable order, so
+   * a cycle repeatedly cut short still makes progress — the next cycle starts again from the first account.
+   */
+  async pollOnce(signal?: AbortSignal): Promise<void> {
     for (const accountId of this.#enabledTriggerAccounts()) {
-      await this.#pollAccount(accountId)
+      if (signal?.aborted) {
+        console.warn('[Agents Activity] Poll cycle aborted, skipping remaining accounts', {
+          nextAccountId: accountId,
+          serverUrl: this.#options.hmServerUrl,
+        })
+        return
+      }
+      await this.#pollAccount(accountId, signal)
     }
   }
 
-  async #pollAccount(accountId: string): Promise<void> {
+  /**
+   * Per-request deadline for one ListEvents call, combined with the cycle-wide `signal` so a hung request
+   * is cut off by whichever fires first. Without the cycle signal a slow upstream could keep the cycle
+   * alive far past the loop's own timeout, one 20s request at a time.
+   */
+  #requestSignal(cycle?: AbortSignal): AbortSignal {
+    const perRequest = AbortSignal.timeout(this.#options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS)
+    return cycle ? AbortSignal.any([perRequest, cycle]) : perRequest
+  }
+
+  async #pollAccount(accountId: string, signal?: AbortSignal): Promise<void> {
     const startedAt = Date.now()
     const client = this.#options.client ?? createSeedClient(this.#options.hmServerUrl)
     const previous = this.#getWatermark(accountId)
@@ -78,6 +101,7 @@ export class ActivityMonitor {
         previousSuccessAt: previous?.lastSuccessAt,
       })
       for (let page = 0; page < this.#options.maxPagesPerPoll; page += 1) {
+        if (signal?.aborted) break
         const response = await client.request(
           'ListEvents',
           {
@@ -89,7 +113,7 @@ export class ActivityMonitor {
             // instead of being buried at its create-time position where the page walk never reaches it.
             order: 'observed',
           },
-          {signal: AbortSignal.timeout(this.#options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS)},
+          {signal: this.#requestSignal(signal)},
         )
         const events = Array.isArray(response.events) ? (response.events as activityTriggers.ActivityFeedEvent[]) : []
         fetched.push(...events)
@@ -153,6 +177,9 @@ export class ActivityMonitor {
       // separately (planned session auto-restart), not by re-observing the triggering event.
       let cursor = previous.seenKeys
       for (const event of newEvents.reverse()) {
+        // Safe to stop early: the watermark advances after each event below, so an aborted cycle resumes
+        // from the last handled event rather than replaying the batch.
+        if (signal?.aborted) break
         await this.#service.processActivityEvent(accountId, event)
         const key = activityTriggers.activityEventKey(event)
         if (key) cursor = [key, ...cursor.filter((seen) => seen !== key)].slice(0, this.#options.pageSize)
@@ -164,6 +191,16 @@ export class ActivityMonitor {
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
+      if (signal?.aborted) {
+        // The cycle was cancelled (loop timeout or shutdown), not an upstream fault. Recording it as a
+        // watermark error would misreport a healthy server as failing and bury real errors in the noise.
+        console.warn('[Agents Activity] Poll aborted mid-cycle', {
+          accountId,
+          serverUrl: this.#options.hmServerUrl,
+          error: message,
+        })
+        return
+      }
       console.error('[Agents Activity] Poll failed', {accountId, serverUrl: this.#options.hmServerUrl, error: message})
       this.#recordWatermarkError(accountId, startedAt, message)
     }

--- a/agents/src/poll-loop.test.ts
+++ b/agents/src/poll-loop.test.ts
@@ -54,6 +54,54 @@ describe('PollLoop', () => {
     expect(started).toBeGreaterThanOrEqual(3)
   })
 
+  test('aborts the run signal when a run exceeds the timeout', async () => {
+    let aborted = false
+    const loop = new PollLoop({
+      label: 'test',
+      intervalMs: 1000,
+      timeoutMs: 25,
+      run: async (signal) => {
+        signal.addEventListener('abort', () => void (aborted = true))
+        await new Promise(() => {}) // never settles on its own
+      },
+    })
+    loop.start()
+    await sleep(80)
+    loop.stop()
+    expect(aborted).toBe(true)
+  })
+
+  test('a slow upstream cannot stack unbounded concurrent runs', async () => {
+    // Regression: releasing the overlap guard on timeout WITHOUT cancelling the run let every tick add
+    // another still-running cycle, once per timeoutMs, until the event loop was saturated and the process
+    // stopped serving. A run that honours its signal must never leave more than one cycle in flight.
+    let inFlight = 0
+    let maxInFlight = 0
+    let starts = 0
+    const loop = new PollLoop({
+      label: 'test',
+      intervalMs: 5,
+      timeoutMs: 15,
+      run: async (signal) => {
+        starts += 1
+        inFlight += 1
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        // A well-behaved run: slower than the timeout, but it stops when told to.
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) return resolve()
+          signal.addEventListener('abort', () => resolve(), {once: true})
+        })
+        inFlight -= 1
+      },
+    })
+    loop.start()
+    await sleep(120)
+    loop.stop()
+    await sleep(20)
+    expect(starts).toBeGreaterThanOrEqual(3) // loop kept making progress
+    expect(maxInFlight).toBe(1) // and never piled up
+  })
+
   test('keeps ticking after a run throws', async () => {
     let runs = 0
     const loop = new PollLoop({
@@ -79,5 +127,20 @@ describe('withTimeout', () => {
 
   test('rejects after the timeout when the promise hangs', async () => {
     await expect(withTimeout(new Promise(() => {}), 20, 'slow-op')).rejects.toThrow('slow-op timed out after 20ms')
+  })
+
+  test('invokes onTimeout before rejecting so callers can cancel the work', async () => {
+    let cancelled = false
+    await expect(withTimeout(new Promise(() => {}), 20, 'slow-op', () => void (cancelled = true))).rejects.toThrow(
+      'slow-op timed out after 20ms',
+    )
+    expect(cancelled).toBe(true)
+  })
+
+  test('does not invoke onTimeout when the promise settles in time', async () => {
+    let cancelled = false
+    expect(await withTimeout(Promise.resolve('ok'), 1000, 'test', () => void (cancelled = true))).toBe('ok')
+    await sleep(30)
+    expect(cancelled).toBe(false)
   })
 })

--- a/agents/src/poll-loop.ts
+++ b/agents/src/poll-loop.ts
@@ -7,12 +7,17 @@
  * future ticks are scheduled independently of any in-flight run, and:
  *
  *  - overlap-guards: a tick is skipped while the previous run is still in progress (no concurrent runs),
- *  - bounds each run with `timeoutMs`: even a stuck run releases the guard so the next tick proceeds.
+ *  - bounds each run with `timeoutMs`, and **cancels it** by aborting the {@link AbortSignal} handed to
+ *    `run` — so a timed-out run stops doing work instead of merely losing a race.
  *
- * Together these guarantee the loop keeps making progress no matter how a single run misbehaves.
+ * Cancellation is what makes the overlap guard meaningful. Releasing the guard on timeout without
+ * aborting the run lets a slow upstream stack a fresh run on top of every still-running one, once per
+ * `timeoutMs`, forever: unbounded concurrent work on a single-threaded runtime, which saturates the
+ * event loop until the process stops serving anything at all. `run` MUST honour the signal (thread it
+ * into every `fetch`, and check `signal.aborted` between steps) for the bound to hold.
  */
 export class PollLoop {
-  readonly #run: () => Promise<void>
+  readonly #run: (signal: AbortSignal) => Promise<void>
   readonly #intervalMs: number
   readonly #timeoutMs: number
   readonly #label: string
@@ -20,7 +25,12 @@ export class PollLoop {
   #running = false
   #stopped = true
 
-  constructor(opts: {label: string; intervalMs: number; timeoutMs: number; run: () => Promise<void>}) {
+  constructor(opts: {
+    label: string
+    intervalMs: number
+    timeoutMs: number
+    run: (signal: AbortSignal) => Promise<void>
+  }) {
     this.#label = opts.label
     this.#intervalMs = opts.intervalMs
     this.#timeoutMs = opts.timeoutMs
@@ -45,27 +55,44 @@ export class PollLoop {
   async #tick(): Promise<void> {
     if (this.#running || this.#stopped) return
     this.#running = true
+    const controller = new AbortController()
     try {
-      await withTimeout(this.#run(), this.#timeoutMs, this.#label)
+      await withTimeout(this.#run(controller.signal), this.#timeoutMs, this.#label, () =>
+        controller.abort(new Error(`${this.#label} poll cycle exceeded ${this.#timeoutMs}ms`)),
+      )
     } catch (error) {
       console.error(`[${this.#label}] poll tick failed`, error instanceof Error ? error.message : String(error))
     } finally {
+      // The run is cancelled either way: a timeout already aborted it above, and any other exit path
+      // (success or throw) aborts here so nothing the run spawned outlives the tick that owns it.
+      controller.abort(new Error(`${this.#label} poll cycle finished`))
       this.#running = false
     }
   }
 }
 
 /**
- * Resolves/rejects with `promise`, or rejects after `ms` if it has not settled — whichever is first.
- * The losing `promise` keeps running; a noop catch is attached so a late rejection after a timeout does
- * not surface as an unhandled rejection. Callers that need the underlying work to actually stop on
- * timeout must pass their own cancellation (e.g. an AbortSignal to fetch).
+ * Resolves/rejects with `promise`, or rejects after `ms` if it has not settled — whichever is first,
+ * invoking `onTimeout` before rejecting so the caller can cancel the underlying work.
+ *
+ * The losing `promise` keeps running as far as this helper is concerned — a noop catch is attached so a
+ * late rejection after a timeout does not surface as an unhandled rejection. Actually stopping that work
+ * is `onTimeout`'s job (e.g. aborting an {@link AbortController} threaded into every `fetch`); without it
+ * a timeout only hides the run, it does not end it.
  */
-export async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+  onTimeout?: () => void,
+): Promise<T> {
   promise.catch(() => {})
   let timer: ReturnType<typeof setTimeout> | undefined
   const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
+    timer = setTimeout(() => {
+      onTimeout?.()
+      reject(new Error(`${label} timed out after ${ms}ms`))
+    }, ms)
   })
   try {
     return await Promise.race([promise, timeout])

--- a/agents/src/schedule-monitor.ts
+++ b/agents/src/schedule-monitor.ts
@@ -23,6 +23,9 @@ export class ScheduleMonitor {
       timeoutMs: options.pollTimeoutMs ?? DEFAULT_POLL_TIMEOUT_MS,
       run: () => this.pollOnce(),
     })
+    // NOTE: processScheduledTriggers has no cancellation seam yet, so a schedule cycle that overruns
+    // still only loses its race. It fires due triggers from local state (no upstream fetch), so it can't
+    // stall on a slow HM server the way the activity cycle does — see fix note in poll-loop.ts.
   }
 
   /** Starts polling until `stop()` is called. */


### PR DESCRIPTION
## Summary

`PollLoop` bounded each run with `timeoutMs` but never **cancelled** it. On timeout `withTimeout` lost the race and released the overlap guard while the run kept executing. A slow upstream therefore stacked a fresh cycle on top of every still-running one, once per timeout, without bound — on a single-threaded runtime that saturates the event loop until the process stops serving anything.

The existing docstring already named the gap it left open (`poll-loop.ts:58-63`):

> *The losing `promise` keeps running... Callers that need the underlying work to actually stop on timeout must pass their own cancellation (e.g. an AbortSignal to fetch).*

No caller ever did.

## Production impact this fixes

The agent server went down on 2026-08-10. `hyper.media`'s `ListEvents` (a ~1 MB response) slowed past the 60s cycle timeout, cycles piled up for hours, and the service stopped answering `/api/health` entirely — while burning **9.5 CPU-hours on one thread** and leaving **269 inbound connections accepted-but-never-served**. `poll tick failed ... timed out after 60000ms` had fired **407 times over 3 days**, continuously, from the container's first hour.

The agent server should not die because its data source is slow.

## Changes

- **`PollLoop`** owns an `AbortController` per tick, aborts it when the cycle times out — and again on every exit path, so nothing a run spawned outlives the tick that owns it — and hands the signal to `run`.
- **`withTimeout`** takes an optional `onTimeout` hook, invoked before rejecting so callers can cancel.
- **`ActivityMonitor`** honours the signal: the cycle signal is combined with each `ListEvents` request deadline via `AbortSignal.any`, and the account loop, page loop, and per-event loop all stop early when aborted. Advancing the watermark per event already made stopping mid-batch safe.
- A cancelled cycle is **no longer recorded as a watermark error**, so a healthy upstream isn't misreported as failing and real errors aren't buried.
- **`ScheduleMonitor`** keeps its current shape (fires due triggers from local state, no upstream fetch, so it can't stall the same way) — noted in place.

## Scope

This bounds concurrency to one cycle, so a slow upstream degrades polling instead of killing the service. It deliberately does **not** add backoff — a struggling upstream is still retried every interval. That's a worthwhile follow-up, separate from this.

## Testing

- `bun check` clean; full suite passes.
- Two new tests, both of which **fail against the old behaviour** (verified by patching the fix back out): the signal aborts on timeout, and a run that honours its signal never leaves more than one cycle in flight.
- Chased a 2-test flake in `api-service` and confirmed it is **not from this change**: on clean `main`, adding a test that only does `sleep(450)` reproduces the identical failures in 4 of 6 runs. It's a pre-existing latent race where detached trigger-session runs outlive the test and write to a closed DB (`error: Database has closed`), surfaced purely by suite wall-time. Worth its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)