### PR TITLE
fix(daemon): materialize the redirect CTE that saturated production

### DIFF
--- a/backend/api/documents/v3alpha/documents.go
+++ b/backend/api/documents/v3alpha/documents.go
@@ -2110,7 +2110,12 @@ func qListDocsCommentAggScoped(scope string) string {
 	targets AS (
 		SELECT id FROM resources tr WHERE (` + scope + `)
 	),
-	redirected AS (
+	redirected AS MATERIALIZED (
+		-- MATERIALIZED is load-bearing. This CTE is referenced from the recursive
+		-- term of ` + "`chains`" + ` below, and without the hint SQLite re-derives it for
+		-- every row the recursion visits, paying the correlated MAX(generation)
+		-- subquery each time: ~2.2k rows x ~2.5ms = 5.5s of CPU per listing call,
+		-- which saturated production on 2026-08-11. Materialized it's ~40ms.
 		SELECT
 			dg.resource AS resource,
 			da.value AS redirect_iri

--- a/backend/api/documents/v3alpha/documents.go
+++ b/backend/api/documents/v3alpha/documents.go
@@ -2102,8 +2102,15 @@ var (
 // targets)` was quadratic: `chains` is a recursive CTE consumed as a co-routine, so SQLite
 // re-evaluated the IN list per row instead of materializing it once (~2k chain rows × ~7k
 // target rows ≈ 15M scans ≈ 2.5s on a real database, and MATERIALIZED hints on `targets`,
-// `redirected` or `chains` did not help). Applying the predicate directly to `tr.iri`
-// makes it a filter on a row already in hand: same rows, ~0.07s instead of ~2.5s.
+// `redirected` or `chains` did not fix THAT problem). Applying the predicate directly to
+// `tr.iri` makes it a filter on a row already in hand: same rows, ~0.07s instead of ~2.5s.
+//
+// The parenthetical above used to read "did not help", full stop. It is scoped to the
+// IN-list pathology, and reading it more broadly steered the 2026-08-11 outage response
+// away from the actual fix: `redirected` is also referenced from the recursive term of
+// `chains`, where it was re-derived once per visited row at ~5.5s per listing call. It now
+// carries a MATERIALIZED hint for that separate reason (see the comment on it below). That
+// win was invisible when the note was written, because the 2.5s IN-list scan dominated.
 func qListDocsCommentAggScoped(scope string) string {
 	return `(
 	WITH RECURSIVE


### PR DESCRIPTION
## Incident

hyper.media and all hosted sites went down on 2026-08-11. `daemon_gateway` sat at 7.4 of 8 cores; a CPU profile put **92.5%** of all time in `ListDirectory`, inside SQLite.

It was not traffic volume. Only **11 ListDirectory calls arrived in 20 seconds** (~0.5/s) — each was burning ~12 CPU-seconds. Blocking crawlers and the two heaviest client IPs changed nothing; stopping `web_gateway` dropped the daemon from 761% to 37%, confirming the calls were the entire load.

## Cause

`qListDocsCommentAggScoped` builds a `redirected` CTE and references it from the **recursive term** of `chains`. Without an explicit hint SQLite declines to materialize it, so it is re-derived for every row the recursion visits — and each derivation pays a correlated `MAX(generation)` subquery over `document_generations`. About 2,222 visited rows × ~2.5ms each ≈ the 5.5s we measured.

Every listing carries this aggregation, and SSR prefetches one recursive whole-subtree listing per query block per page view (`loaders.ts:295-310`), so roughly half a page view per second was enough to saturate the box.

## Fix

One keyword: `redirected AS MATERIALIZED (...)`.

Measured against a copy of the production database (8GB, 91,951 structural blobs, 13,921 comments):

| Query | Before | After |
|---|---|---|
| `chains` CTE alone | 5.166s | 0.009s |
| Full comment aggregation | 5.520s | 0.041s |

Results are byte-identical (2222 rows, max depth 16). Requires SQLite ≥ 3.35; the bundled version is 3.45.2.

## Testing

- `go build ./backend/api/documents/...` clean
- `go test ./backend/api/documents/v3alpha/ -run "TestListDirectory|TestComment|TestListDocuments"` passes
- Timings above measured directly against the production DB, read-only

## Follow-ups (not in this PR)

- `chains` guards only immediate self-redirects (`rd.redirect_iri != c.target_iri`), so A→B→A cycles still walk to the depth-16 cap. Three documents do this today. Cheap now, but worth real cycle detection.
- SSR prefetching a recursive whole-subtree listing per query block per page view is inherently costly; `listAllPages` re-runs this aggregation for every 500-doc page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)