### PR TITLE
fix(editor): let image captions be selected as document text

### DIFF
--- a/.agents/skills/testing-editor-harness/SKILL.md
+++ b/.agents/skills/testing-editor-harness/SKILL.md
@@ -1,19 +1,24 @@
 ---
 name: testing-editor-harness
-description: How to run and manually test the editor E2E harness for the @shm/editor package, including mobile viewport emulation, supernumber badges, and mobile comment UX interactions.
+description:
+  How to run and manually test the editor E2E harness for the @shm/editor package, including mobile viewport emulation,
+  supernumber badges, and mobile comment UX interactions.
 ---
 
 # Testing the editor E2E harness
 
 ## Devin Secrets Needed
+
 None.
 
 ## Environment
+
 - Work from `frontend/packages/editor`.
 - Use Node 22.22.x and the pnpm fallback at `/home/ubuntu/.local/bin/pnpm` if `mise`/corepack is rate-limited.
 - The harness uses Vite: `pnpm test:harness` runs `vite --config e2e/vite.config.ts` on `http://localhost:5180`.
 
 ## Running the harness
+
 ```bash
 export PATH="/home/ubuntu/.local/bin:/home/ubuntu/.local/share/mise/installs/node/22.22.0/bin:$PATH"
 cd /home/ubuntu/repos/seed/frontend/packages/editor
@@ -21,6 +26,7 @@ pnpm test:harness
 ```
 
 Open the browser at a real-mode fixture URL, e.g.:
+
 ```
 http://localhost:5180/?real=1&fixture=allBlocks&badges=1
 ```
@@ -30,91 +36,196 @@ http://localhost:5180/?real=1&fixture=allBlocks&badges=1
 - `badges=1` gives every fixture block a mock citation/comment count so supernumber badges render.
 
 ## Mobile viewport emulation
-The Chrome for Testing instance in this environment listens on remote-debugging port `29229`. Use CDP to set a mobile viewport without keeping DevTools open:
+
+The Chrome for Testing instance in this environment listens on remote-debugging port `29229`. Use CDP to set a mobile
+viewport without keeping DevTools open:
 
 ```javascript
 // /tmp/set-mobile-viewport.js
-const http = require('http');
-const WebSocket = require('/home/ubuntu/repos/seed/node_modules/ws');
+const http = require('http')
+const WebSocket = require('/home/ubuntu/repos/seed/node_modules/ws')
 
 http.get('http://localhost:29229/json/list', (res) => {
-  let data = '';
-  res.on('data', (c) => (data += c));
+  let data = ''
+  res.on('data', (c) => (data += c))
   res.on('end', () => {
-    const pages = JSON.parse(data);
-    const page = pages.find((p) => p.type === 'page' && (p.url.includes('localhost:5180') || p.url === 'about:blank'));
-    if (!page) { console.error('No suitable page found'); process.exit(1); }
-    const ws = new WebSocket(page.webSocketDebuggerUrl);
+    const pages = JSON.parse(data)
+    const page = pages.find((p) => p.type === 'page' && (p.url.includes('localhost:5180') || p.url === 'about:blank'))
+    if (!page) {
+      console.error('No suitable page found')
+      process.exit(1)
+    }
+    const ws = new WebSocket(page.webSocketDebuggerUrl)
     ws.on('open', () => {
-      ws.send(JSON.stringify({id: 1, method: 'Page.navigate', params: {url: 'http://localhost:5180/?real=1&fixture=allBlocks&badges=1'}}));
+      ws.send(
+        JSON.stringify({
+          id: 1,
+          method: 'Page.navigate',
+          params: {url: 'http://localhost:5180/?real=1&fixture=allBlocks&badges=1'},
+        }),
+      )
       setTimeout(() => {
-        ws.send(JSON.stringify({id: 2, method: 'Emulation.setDeviceMetricsOverride', params: {
-          width: 390, height: 844, deviceScaleFactor: 2, mobile: true,
-          screenWidth: 390, screenHeight: 844,
-        }}));
-        ws.send(JSON.stringify({id: 3, method: 'Emulation.setTouchEmulationEnabled', params: {enabled: true}}));
-        setTimeout(() => ws.close(), 500);
-      }, 300);
-    });
-  });
-});
+        ws.send(
+          JSON.stringify({
+            id: 2,
+            method: 'Emulation.setDeviceMetricsOverride',
+            params: {
+              width: 390,
+              height: 844,
+              deviceScaleFactor: 2,
+              mobile: true,
+              screenWidth: 390,
+              screenHeight: 844,
+            },
+          }),
+        )
+        ws.send(JSON.stringify({id: 3, method: 'Emulation.setTouchEmulationEnabled', params: {enabled: true}}))
+        setTimeout(() => ws.close(), 500)
+      }, 300)
+    })
+  })
+})
 ```
 
 Verify with `window.innerWidth` and `window.innerHeight` in the console.
 
 ## Key DOM selectors
+
 - Editor container: `[data-testid="editor-container"]`
 - Block nodes: `[data-node-type="blockNode"][data-id]`
 - Paragraph content: `[data-node-type="blockNode"][data-id="p-top"] [data-content-type="paragraph"]`
 - Supernumber badges: `.bn-supernumber-badge`
 - Block hover actions card: `[data-bn-block-hover-actions="true"]`
-- Range selection bubble: buttons with `aria-label="Copy link to selection"` or `aria-label="Comment on selection"`, inside a `bg-popover ... rounded-md border ... shadow-md` element
+- Range selection bubble: buttons with `aria-label="Copy link to selection"` or `aria-label="Comment on selection"`,
+  inside a `bg-popover ... rounded-md border ... shadow-md` element
 
 ## Useful runtime globals
-- `window.TEST_EDITOR` (`?real=1`) — exposes `hoverActionsBlockId()`, `blockToolsBlockId()`, `getSelection()`, `getBlocks()`, etc.
+
+- `window.TEST_EDITOR` (`?real=1`) — exposes `hoverActionsBlockId()`, `blockToolsBlockId()`, `getSelection()`,
+  `getBlocks()`, etc.
 - `window.TEST_MACHINE` (`?real=1`) — exposes `state()` and `send()` for the document machine actor.
-- `window.TEST_BLOCK_TOOL_CALLS` — records `{copyLink, comment}` calls made by the `BlockHoverActions` card in `?real=1`.
+- `window.TEST_BLOCK_TOOL_CALLS` — records `{copyLink, comment}` calls made by the `BlockHoverActions` card in
+  `?real=1`.
 
 ## Triggering touch interactions
-The `BlockHoverActions` plugin only responds to `pointerdown`/`pointerup` events whose `pointerType` is not `mouse`. A real mouse click will not open the mobile card. In a real touch scenario, a tap also produces a `click`, which `useReadOnlyClickToEdit` handles and may start editing. For recording/diagnostic purposes, dispatch synthetic pointer events directly:
+
+The `BlockHoverActions` plugin only responds to `pointerdown`/`pointerup` events whose `pointerType` is not `mouse`. A
+real mouse click will not open the mobile card. In a real touch scenario, a tap also produces a `click`, which
+`useReadOnlyClickToEdit` handles and may start editing. For recording/diagnostic purposes, dispatch synthetic pointer
+events directly:
 
 ```javascript
-const content = document.querySelector('[data-node-type="blockNode"][data-id="p-top"] [data-content-type="paragraph"]');
-const rect = content.getBoundingClientRect();
-const x = rect.left + rect.width / 2;
-const y = rect.top + rect.height / 2;
-content.dispatchEvent(new PointerEvent('pointerdown', {pointerType:'touch', bubbles:true, isPrimary:true, clientX:x, clientY:y}));
-await new Promise(r => setTimeout(r, 30));
-content.dispatchEvent(new PointerEvent('pointerup', {pointerType:'touch', bubbles:true, isPrimary:true, clientX:x, clientY:y}));
+const content = document.querySelector('[data-node-type="blockNode"][data-id="p-top"] [data-content-type="paragraph"]')
+const rect = content.getBoundingClientRect()
+const x = rect.left + rect.width / 2
+const y = rect.top + rect.height / 2
+content.dispatchEvent(
+  new PointerEvent('pointerdown', {pointerType: 'touch', bubbles: true, isPrimary: true, clientX: x, clientY: y}),
+)
+await new Promise((r) => setTimeout(r, 30))
+content.dispatchEvent(
+  new PointerEvent('pointerup', {pointerType: 'touch', bubbles: true, isPrimary: true, clientX: x, clientY: y}),
+)
 ```
 
 ## Triggering RangeSelection
-On a real touch device, long-pressing text and adjusting the selection handles creates the selection, and the `RangeSelection` plugin opens the bubble after `touchend`/10 ms settle.
 
-In the harness under CDP device emulation, a real mouse drag across the read-only `contenteditable=false` editor may leave only a collapsed caret. To demonstrate the bubble reliably, set both the native selection and the ProseMirror selection, then dispatch `mouseup` on the editor DOM:
+On a real touch device, long-pressing text and adjusting the selection handles creates the selection, and the
+`RangeSelection` plugin opens the bubble after `touchend`/10 ms settle.
+
+In the harness under CDP device emulation, a real mouse drag across the read-only `contenteditable=false` editor may
+leave only a collapsed caret. To demonstrate the bubble reliably, set both the native selection and the ProseMirror
+selection, then dispatch `mouseup` on the editor DOM:
 
 ```javascript
-const view = window.TEST_EDITOR.editor._tiptapEditor.view;
-const TextSelection = view.state.selection.constructor;
-view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, 3, 18)));
+const view = window.TEST_EDITOR.editor._tiptapEditor.view
+const TextSelection = view.state.selection.constructor
+view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, 3, 18)))
 
-const content = document.querySelector('[data-node-type="blockNode"][data-id="p-top"] [data-content-type="paragraph"]');
-const textNode = Array.from(content.childNodes).find(n => n.nodeType === Node.TEXT_NODE);
+const content = document.querySelector('[data-node-type="blockNode"][data-id="p-top"] [data-content-type="paragraph"]')
+const textNode = Array.from(content.childNodes).find((n) => n.nodeType === Node.TEXT_NODE)
 if (textNode) {
-  const sel = window.getSelection();
-  sel.removeAllRanges();
-  const range = document.createRange();
-  range.setStart(textNode, 0);
-  range.setEnd(textNode, textNode.length);
-  sel.addRange(range);
+  const sel = window.getSelection()
+  sel.removeAllRanges()
+  const range = document.createRange()
+  range.setStart(textNode, 0)
+  range.setEnd(textNode, textNode.length)
+  sel.addRange(range)
 }
 
-await new Promise(r => setTimeout(r, 20));
-view.dom.dispatchEvent(new MouseEvent('mouseup', {bubbles: true, cancelable: true, clientX: 100, clientY: 100}));
+await new Promise((r) => setTimeout(r, 20))
+view.dom.dispatchEvent(new MouseEvent('mouseup', {bubbles: true, cancelable: true, clientX: 100, clientY: 100}))
 ```
 
+## Testing fragment selections (`#blockId[start:end]`)
+
+Fragment actions (Comment / Copy link on a text range) are gated by `getSelectionFragment()` in
+`src/hm-formatting-toolbar.tsx`, which requires a non-empty single-block text selection **and**
+`getReferenceableRevision(blockNode)`. Fixture blocks in `e2e/test-app/TestEditor.tsx` have no `revision`, so out of the
+box **no** block shows fragment actions and a "feature is broken" conclusion would be bogus. When testing fragment
+behavior:
+
+- Temporarily add `props.revision` to the fixture blocks under test (e.g. `p-top`, `blk-image`), and always keep a
+  plain-paragraph control in the same page state.
+- Read the emitted range from `window.TEST_BLOCK_TOOL_CALLS` (`{copyLink, comment}`), or add a temporary fixed-position
+  log panel in `TestEditor.tsx` so the range is visible in a recording.
+- Typing into a block invalidates its revision — do the fragment assertions before mutating text.
+
+When testing highlight consumers, drive the plugin through the React props used by the real editor (`focusBlockId`,
+`focusBlockRange`, and `citationFragmentHighlights`). Console-dispatched plugin metas such as
+`view.dispatch(tr.setMeta(blockHighlightPluginKey, ...))` are swallowed in this harness and are not a reliable
+substitute for the component path.
+
+The harness resets window scroll to `0` about a second after a scroll. Measure scroll targets synchronously after the
+navigation or scroll action; delayed assertions can observe the harness reset instead of the behavior under test.
+
+## Selection inside media inline content (image captions)
+
+An image caption is the image node's ProseMirror inline content (`<InlineContent className="image-caption">` in
+`src/media-container.tsx`). In edit mode, selecting caption text may highlight in the DOM while ProseMirror sees
+nothing. Verified causes (live DOM dump, harness `?real=1&fixture=allBlocks`):
+
+1. `BlockSelectionWrapper` (rendered from `src/media-render.tsx`) puts a `contentEditable={false}` div between the
+   caption and `view.dom`. The caption's own `contentEditable={true}` therefore becomes a **separate editing host**:
+   `document.activeElement` is the caption div, `view.hasFocus()` is false, and prosemirror-view's
+   `hasFocusAndSelection()` discards every selection change. The formatting toolbar never shows because
+   `FormattingToolbarPlugin.shouldShow` requires `view.hasFocus()` — that gate is a symptom, not a separate bug.
+2. The MediaContainer outer wrapper has `draggable={canAuthor ? 'true' : 'false'}` and wraps the caption, so a caption
+   mouse drag becomes a native HTML5 drag and collapses to a caret.
+
+Diagnostic recipe worth reusing for any "text won't select inside a node view" report — dump the ancestor chain and
+toggle the two attributes at runtime before theorising:
+
+```javascript
+const el = document.querySelector('.image-caption') // or any contentDOM
+const view = window.TEST_EDITOR.editor._tiptapEditor.view
+for (let n = el; n; n = n.parentElement) {
+  console.log(
+    n.tagName,
+    JSON.stringify(n.className),
+    'ce=',
+    n.getAttribute('contenteditable'),
+    'draggable=',
+    n.getAttribute('draggable'),
+    n === view.dom ? '<= view.dom' : '',
+  )
+  if (n === view.dom) break
+}
+// then: ancestor.setAttribute('contenteditable','true'); outer.setAttribute('draggable','false');
+// and re-check: view.hasFocus(), document.activeElement, view.state.selection, and
+// !!document.querySelector('[data-testid="formatting-toolbar"]')
+```
+
+Behaviors that look like regressions but are **pre-existing** in this harness — always re-run them on an unpatched tree
+before blaming a change: dragging an image by its media surface does not reorder the block, Enter inside a caption does
+not exit the caption, and clicking an embed card selects nothing.
+
 ## Common pitfalls
+
 - `?badges=1` is required in the harness to render `.bn-supernumber-badge` widgets.
-- `Emulation.setTouchEmulationEnabled` is deprecated in newer CDP versions; if it stops working, use `Emulation.setEmitTouchEventsForMouse` or a newer `Emulation` domain method.
-- The `allBlocks` fixture intentionally uses a broken web-embed URL and a draft embed; expect `Error loading embed` and `Draft card` content — these are not failures.
-- Do not set a `TextSelection` to block-node boundary positions (e.g. 0, 1, or 19); this produces a `blockChildren`/`blockNode` endpoint warning and may fail to trigger the desired UI.
+- `Emulation.setTouchEmulationEnabled` is deprecated in newer CDP versions; if it stops working, use
+  `Emulation.setEmitTouchEventsForMouse` or a newer `Emulation` domain method.
+- The `allBlocks` fixture intentionally uses a broken web-embed URL and a draft embed; expect `Error loading embed` and
+  `Draft card` content — these are not failures.
+- Do not set a `TextSelection` to block-node boundary positions (e.g. 0, 1, or 19); this produces a
+  `blockChildren`/`blockNode` endpoint warning and may fail to trigger the desired UI.

--- a/.agents/skills/testing-editor-harness/SKILL.md
+++ b/.agents/skills/testing-editor-harness/SKILL.md
@@ -217,8 +217,27 @@ for (let n = el; n; n = n.parentElement) {
 ```
 
 Behaviors that look like regressions but are **pre-existing** in this harness — always re-run them on an unpatched tree
-before blaming a change: dragging an image by its media surface does not reorder the block, Enter inside a caption does
-not exit the caption, and clicking an embed card selects nothing.
+before blaming a change: dragging an image by its media surface does not reorder the block (a native drag starts and
+drop indicators appear, but the block order is unchanged on release), and clicking an embed card selects nothing.
+
+### Enter / Shift+Enter inside an image caption
+
+Enter in a caption is handled by the ProseMirror keymap (`KeyboardShortcuts/KeyboardShortcutsExtension.ts`), not by a
+React `onKeyDown` on the caption. Expected behavior when testing it:
+
+- Enter moves the selection out of the caption to the block after the image; the caption text is unchanged and the image
+  block is never split.
+- If the next block is an **atom** (video / file / embed / web-embed), the resulting selection is a `NodeSelection` on
+  that node, not a text caret — assert `pmSelection().kind === 'NodeSelection'`. Re-wrapping
+  `TextSelection.near(...).from` in `TextSelection.create()` is the bug shape to watch for; it produces an invalid caret
+  / `RangeError` for atoms.
+- If the image is the last block, Enter appends a paragraph and puts the caret in it. This case is hard to reach
+  manually because the editor keeps an empty trailing paragraph at the end of the document; prefer the Playwright spec
+  (`e2e/tests/image-caption.e2e.ts`) for it.
+- Shift+Enter stays inside the caption and inserts a line break (caption text gains `\n`, block count unchanged).
+
+If a future change reverts the caption to a separate editing host, the symptom is Enter/typing/selection silently doing
+nothing in the caption — dump the ancestor chain (recipe above) before anything else.
 
 ## Common pitfalls
 
@@ -227,5 +246,16 @@ not exit the caption, and clicking an embed card selects nothing.
   `Emulation.setEmitTouchEventsForMouse` or a newer `Emulation` domain method.
 - The `allBlocks` fixture intentionally uses a broken web-embed URL and a draft embed; expect `Error loading embed` and
   `Draft card` content — these are not failures.
+- External `<img>` / `<figure><img><figcaption>` HTML pastes are handled by `handle-local-media-paste-plugin.ts`, which
+  `fetch`es the image URL and uploads it. In an offline box this logs
+  `Error processing pasted HTML image: TypeError: Failed to fetch` and inserts nothing — that is an environment
+  limitation, not a parsing bug. Use a `data:` URL or a locally served image if you need this path to succeed.
+- CDP `Emulation.setDeviceMetricsOverride` survives page reloads and is **not** undone when the websocket closes right
+  after `clearDeviceMetricsOverride`; keep the CDP connection open for a moment after clearing, or check
+  `window.innerWidth` to confirm the override is gone before continuing desktop tests. Chrome also rejects CDP
+  websockets with `403` unless the client suppresses the `Origin` header
+  (`websocket.create_connection(..., suppress_origin=True)`).
+- On a touch viewport, a plain long-press does not create a text selection; long-press, then move the pointer a few
+  pixels before releasing to get a real range. A double-tap on an image opens the gallery lightbox instead.
 - Do not set a `TextSelection` to block-node boundary positions (e.g. 0, 1, or 19); this produces a
   `blockChildren`/`blockNode` endpoint warning and may fail to trigger the desired UI.

--- a/.github/workflows/custom-ghcr-images.yml
+++ b/.github/workflows/custom-ghcr-images.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - custom-images
+    tags:
+      - '*.*.*-custom'
 
 permissions:
   contents: read
@@ -30,7 +32,13 @@ jobs:
         id: resolve
         shell: bash
         run: |
-          tag="main"
+          # Branch pushes publish the rolling `main` tag; `<version>-custom` tags,
+          # created when the fork mirrors an upstream release, publish `<version>`.
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            tag="${GITHUB_REF_NAME%-custom}"
+          else
+            tag="main"
+          fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "Resolved Docker image tag: $tag"
 

--- a/.github/workflows/custom-ghcr-images.yml
+++ b/.github/workflows/custom-ghcr-images.yml
@@ -1,0 +1,255 @@
+name: Custom - GHCR Images
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - custom-images
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  AWS_REGION: us-east-1
+  REGISTRY: ghcr.io
+  WEB_IMAGE: ghcr.io/horacioh/seed-web
+  SITE_IMAGE: ghcr.io/horacioh/seed-site
+
+jobs:
+  image-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+    steps:
+      - name: Resolve Docker image tag
+        id: resolve
+        shell: bash
+        run: |
+          tag="main"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Resolved Docker image tag: $tag"
+
+  frontend-tests:
+    uses: ./.github/workflows/test-frontend-parallel.yml
+
+  backend-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Cache GGUF model
+        uses: actions/cache@v4
+        with:
+          path: backend/llm/backends/llamacpp/models/*.gguf
+          key: gguf-model-granite-v2
+          enableCrossOsArchive: true
+
+      - name: Download GGUF model
+        run: |
+          if [ ! -f backend/llm/backends/llamacpp/models/granite-embedding-107m-multilingual-Q8_0.gguf ]; then
+            mkdir -p backend/llm/backends/llamacpp/models
+            curl -fSL -o backend/llm/backends/llamacpp/models/granite-embedding-107m-multilingual-Q8_0.gguf \
+              "https://huggingface.co/keisuke-miyako/granite-embedding-107m-multilingual-gguf-q8_0/resolve/main/granite-embedding-107m-multilingual-Q8_0.gguf?download=true"
+          fi
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.2'
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ libvulkan-dev glslc
+
+      - name: Compute llama-go submodule sha
+        id: llama-sha
+        run: echo "sha=$(git -C backend/util/llama-go rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache llama.cpp build (Vulkan)
+        id: llama-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            backend/util/llama-go/libbinding.a
+            backend/util/llama-go/libllama.a
+            backend/util/llama-go/libggml*.a
+            backend/util/llama-go/libcommon.a
+            backend/util/llama-go/build
+          key: llama-vulkan-linux-portable-${{ steps.llama-sha.outputs.sha }}
+
+      - name: Build llama.cpp (with Vulkan GPU support)
+        if: steps.llama-cache.outputs.cache-hit != 'true'
+        run: |
+          cd backend/util/llama-go
+          BUILD_TYPE=vulkan CMAKE_ARGS="-DBUILD_SHARED_LIBS=OFF -DGGML_NATIVE=OFF" make libbinding.a
+
+      - name: Run tests
+        run: go test --count 1 ./backend/...
+        env:
+          CGO_ENABLED: 1
+          LIBRARY_PATH: ${{ github.workspace }}/backend/util/llama-go
+          C_INCLUDE_PATH: ${{ github.workspace }}/backend/util/llama-go
+          LLAMA_LOG: error
+
+      - name: Run tests with race detector
+        run: go test --count 1 -race ./backend/...
+        env:
+          CGO_ENABLED: 1
+          LIBRARY_PATH: ${{ github.workspace }}/backend/util/llama-go
+          C_INCLUDE_PATH: ${{ github.workspace }}/backend/util/llama-go
+          LLAMA_LOG: error
+
+  build-and-perf-test:
+    runs-on: ubuntu-latest
+    needs: [frontend-tests, backend-tests]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Build Web App
+        run: pnpm web:prod
+
+      - name: Run Notify Tests
+        run: pnpm --filter @shm/notify test
+
+      - name: Build Notify App
+        run: pnpm notify:build
+
+      - name: Start Web Server
+        run: |
+          pnpm web:start &
+          sleep 5 # Wait for server to start
+
+      - name: Run Performance Tests
+        run: |
+          cd frontend/apps/perf-web
+          pnpm start --url http://localhost:3000 --app web
+
+      - name: Upload web build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-build
+          path: frontend/apps/web/build/
+          retention-days: 1
+
+  docker-web:
+    runs-on: ubuntu-latest
+    needs: [image-tag, build-and-perf-test]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get commit date
+        run: |
+          COMMIT_DATE=$(git show -s --format="%cd" ${{ github.sha }})
+          echo "COMMIT_DATE=$COMMIT_DATE" >> $GITHUB_ENV
+
+      - name: Download web build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: web-build
+          path: frontend/apps/web/build/
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: GHCR Release ${{ env.WEB_IMAGE }}:${{ needs.image-tag.outputs.tag }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          file: frontend/apps/web/Dockerfile
+          tags: |
+            ${{ env.WEB_IMAGE }}:${{ needs.image-tag.outputs.tag }}
+            ${{ env.WEB_IMAGE }}:sha-${{ github.sha }}
+          build-args: |
+            PREBUILT=true
+            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+            SITE_SENTRY_DSN=${{ secrets.SITE_SENTRY_DSN }}
+            COMMIT_HASH=${{ github.sha }}
+            BRANCH=${{ github.ref }}
+            DATE=${{ env.COMMIT_DATE }}
+          cache-from: type=gha,scope=docker-web-custom-ghcr
+          cache-to: type=gha,mode=max,scope=docker-web-custom-ghcr
+
+  docker-site:
+    runs-on: ubuntu-latest
+    needs: [image-tag, frontend-tests, backend-tests]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Get commit date
+        run: |
+          COMMIT_DATE=$(git show -s --format="%cd" ${{ github.sha }})
+          echo "COMMIT_DATE=$COMMIT_DATE" >> $GITHUB_ENV
+
+      - name: Cache GGUF model
+        uses: actions/cache@v4
+        with:
+          path: backend/llm/backends/llamacpp/models/*.gguf
+          key: gguf-model-granite-v2
+          enableCrossOsArchive: true
+
+      - name: Download GGUF model
+        run: |
+          if [ ! -f backend/llm/backends/llamacpp/models/granite-embedding-107m-multilingual-Q8_0.gguf ]; then
+            mkdir -p backend/llm/backends/llamacpp/models
+            curl -fSL -o backend/llm/backends/llamacpp/models/granite-embedding-107m-multilingual-Q8_0.gguf \
+              "https://huggingface.co/keisuke-miyako/granite-embedding-107m-multilingual-gguf-q8_0/resolve/main/granite-embedding-107m-multilingual-Q8_0.gguf?download=true"
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: GHCR Release ${{ env.SITE_IMAGE }}:${{ needs.image-tag.outputs.tag }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          file: backend/cmd/seed-daemon/Dockerfile
+          tags: |
+            ${{ env.SITE_IMAGE }}:${{ needs.image-tag.outputs.tag }}
+            ${{ env.SITE_IMAGE }}:sha-${{ github.sha }}
+          build-args: |
+            COMMIT_HASH=${{ github.sha }}
+            BRANCH=${{ github.ref }}
+            DATE=${{ env.COMMIT_DATE }}
+          cache-from: type=gha,scope=docker-site-custom-ghcr
+          cache-to: type=gha,mode=max,scope=docker-site-custom-ghcr

--- a/.github/workflows/custom-rebase-main.yml
+++ b/.github/workflows/custom-rebase-main.yml
@@ -16,14 +16,14 @@ concurrency:
 
 jobs:
   sync-main:
-    name: Rebase main onto upstream/main
+    name: Mirror upstream/main into main
     runs-on: ubuntu-latest
     if: github.repository == 'horacioh/seed'
     steps:
-      - name: Checkout main
+      - name: Checkout custom-images
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: custom-images
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -32,26 +32,17 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-      - name: Record starting HEAD
-        id: before
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
       - name: Add and fetch upstream
         run: |
           git remote add upstream https://github.com/seed-hypermedia/seed.git
           git fetch --prune upstream main
           git fetch upstream '+refs/tags/*:refs/tags/*'
 
-      - name: Rebase main onto upstream/main
-        run: git rebase upstream/main
-
-      - name: Record rebased HEAD
-        id: after
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Push rebased main
-        if: steps.after.outputs.sha != steps.before.outputs.sha
-        run: git push --force-with-lease origin HEAD:main
+      - name: Mirror upstream/main into main
+        run: |
+          # main is a verbatim mirror of upstream: never carry fork commits, so a plain
+          # force push is enough and `git pull` on a fork clone always fast-forwards.
+          git push --force origin refs/remotes/upstream/main:refs/heads/main
 
       - name: Mirror new upstream tags
         run: |
@@ -76,7 +67,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           title='Upstream sync of main failed'
-          body="The scheduled sync with \`seed-hypermedia/seed\` failed — either the rebase of \`main\` or the mirroring of upstream tags. Check the failed step in the run below, resolve it manually, then re-run the workflow.
+          body="The scheduled sync with \`seed-hypermedia/seed\` failed — either the mirroring of \`main\` or of the upstream tags. Check the failed step in the run below, resolve it manually, then re-run the workflow.
 
           Failed run: $RUN_URL"
           existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "in:title \"$title\"" --json number --jq '.[0].number')

--- a/.github/workflows/custom-rebase-main.yml
+++ b/.github/workflows/custom-rebase-main.yml
@@ -58,11 +58,10 @@ jobs:
       - name: Mirror new upstream tags
         id: tags
         run: |
-          list_tags() {
-            git ls-remote --tags "$1" | awk '{print $2}' | sed 's#^refs/tags/##' | { grep -v '\^{}$' || true; } | sort -u
-          }
-          list_tags upstream > /tmp/upstream-tags
-          list_tags origin > /tmp/origin-tags
+          # Compare local tags (the snapshot fetched from upstream) against origin, so every
+          # tag pushed below is guaranteed to exist locally even if upstream tags mid-run.
+          git tag --list | sort -u > /tmp/upstream-tags
+          git ls-remote --tags origin | awk '{print $2}' | sed 's#^refs/tags/##' | { grep -v '\^{}$' || true; } | sort -u > /tmp/origin-tags
           new_tags=$(comm -23 /tmp/upstream-tags /tmp/origin-tags)
           if [ -z "$new_tags" ]; then
             echo 'No new upstream tags.'

--- a/.github/workflows/custom-rebase-main.yml
+++ b/.github/workflows/custom-rebase-main.yml
@@ -59,7 +59,7 @@ jobs:
         id: tags
         run: |
           list_tags() {
-            git ls-remote --tags "$1" | awk '{print $2}' | sed 's#^refs/tags/##' | grep -v '\^{}$' | sort -u
+            git ls-remote --tags "$1" | awk '{print $2}' | sed 's#^refs/tags/##' | { grep -v '\^{}$' || true; } | sort -u
           }
           list_tags upstream > /tmp/upstream-tags
           list_tags origin > /tmp/origin-tags

--- a/.github/workflows/custom-rebase-main.yml
+++ b/.github/workflows/custom-rebase-main.yml
@@ -19,6 +19,8 @@ jobs:
     name: Rebase main onto upstream/main
     runs-on: ubuntu-latest
     if: github.repository == 'horacioh/seed'
+    outputs:
+      latest_new_tag: ${{ steps.tags.outputs.latest_new_tag }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -40,6 +42,7 @@ jobs:
         run: |
           git remote add upstream https://github.com/seed-hypermedia/seed.git
           git fetch --prune upstream main
+          git fetch upstream '+refs/tags/*:refs/tags/*'
 
       - name: Rebase main onto upstream/main
         run: git rebase upstream/main
@@ -51,6 +54,25 @@ jobs:
       - name: Push rebased main
         if: steps.after.outputs.sha != steps.before.outputs.sha
         run: git push --force-with-lease origin HEAD:main
+
+      - name: Mirror new upstream tags
+        id: tags
+        run: |
+          list_tags() {
+            git ls-remote --tags "$1" | awk '{print $2}' | sed 's#^refs/tags/##' | grep -v '\^{}$' | sort -u
+          }
+          list_tags upstream > /tmp/upstream-tags
+          list_tags origin > /tmp/origin-tags
+          new_tags=$(comm -23 /tmp/upstream-tags /tmp/origin-tags)
+          if [ -z "$new_tags" ]; then
+            echo 'No new upstream tags.'
+            exit 0
+          fi
+          echo "New upstream tags:"
+          echo "$new_tags"
+          # shellcheck disable=SC2046
+          git push origin $(echo "$new_tags" | sed 's#^#refs/tags/#')
+          echo "latest_new_tag=$(echo "$new_tags" | sort -V | tail -1)" >> "$GITHUB_OUTPUT"
 
       - name: Open or update failure issue
         if: failure()
@@ -104,6 +126,18 @@ jobs:
       - name: Push rebased custom-images
         if: steps.after.outputs.sha != steps.before.outputs.sha
         run: git push --force-with-lease origin HEAD:custom-images
+
+      - name: Tag custom-images for the newest mirrored tag
+        if: needs.sync-main.outputs.latest_new_tag != ''
+        env:
+          TAG: ${{ needs.sync-main.outputs.latest_new_tag }}-custom
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists on origin."
+            exit 0
+          fi
+          git tag -a "$TAG" -m "custom-images rebased onto ${{ needs.sync-main.outputs.latest_new_tag }}"
+          git push origin "refs/tags/$TAG"
 
       - name: Open or update failure issue
         if: failure()

--- a/.github/workflows/custom-rebase-main.yml
+++ b/.github/workflows/custom-rebase-main.yml
@@ -19,8 +19,6 @@ jobs:
     name: Rebase main onto upstream/main
     runs-on: ubuntu-latest
     if: github.repository == 'horacioh/seed'
-    outputs:
-      latest_new_tag: ${{ steps.tags.outputs.latest_new_tag }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -56,7 +54,6 @@ jobs:
         run: git push --force-with-lease origin HEAD:main
 
       - name: Mirror new upstream tags
-        id: tags
         run: |
           # Compare local tags (the snapshot fetched from upstream) against origin, so every
           # tag pushed below is guaranteed to exist locally even if upstream tags mid-run.
@@ -71,7 +68,6 @@ jobs:
           echo "$new_tags"
           # shellcheck disable=SC2046
           git push origin $(echo "$new_tags" | sed 's#^#refs/tags/#')
-          echo "latest_new_tag=$(echo "$new_tags" | sort -V | tail -1)" >> "$GITHUB_OUTPUT"
 
       - name: Open or update failure issue
         if: failure()
@@ -126,17 +122,22 @@ jobs:
         if: steps.after.outputs.sha != steps.before.outputs.sha
         run: git push --force-with-lease origin HEAD:custom-images
 
-      - name: Tag custom-images for the newest mirrored tag
-        if: needs.sync-main.outputs.latest_new_tag != ''
-        env:
-          TAG: ${{ needs.sync-main.outputs.latest_new_tag }}-custom
+      - name: Tag custom-images for the newest mirrored release
         run: |
-          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists on origin."
+          # Derived from origin rather than from what this run mirrored, so a failed run
+          # is recovered by the next scheduled one instead of losing the marker forever.
+          tags=$(git ls-remote --tags origin | awk '{print $2}' | sed 's#^refs/tags/##' | { grep -v '\^{}$' || true; })
+          latest=$(echo "$tags" | { grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true; } | sort -V | tail -1)
+          if [ -z "$latest" ]; then
+            echo 'No release tags on origin yet.'
             exit 0
           fi
-          git tag -a "$TAG" -m "custom-images rebased onto ${{ needs.sync-main.outputs.latest_new_tag }}"
-          git push origin "refs/tags/$TAG"
+          if echo "$tags" | grep -qFx "$latest-custom"; then
+            echo "Tag $latest-custom already exists on origin."
+            exit 0
+          fi
+          git tag -a "$latest-custom" -m "custom-images rebased onto $latest"
+          git push origin "refs/tags/$latest-custom"
 
       - name: Open or update failure issue
         if: failure()

--- a/.github/workflows/custom-rebase-main.yml
+++ b/.github/workflows/custom-rebase-main.yml
@@ -1,0 +1,123 @@
+name: Custom - Sync Fork From Upstream
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Keep the fork close to upstream every 6 hours.
+    - cron: '17 */6 * * *'
+
+permissions:
+  contents: write
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  sync-main:
+    name: Rebase main onto upstream/main
+    runs-on: ubuntu-latest
+    if: github.repository == 'horacioh/seed'
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure actions bot identity
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Record starting HEAD
+        id: before
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Add and fetch upstream
+        run: |
+          git remote add upstream https://github.com/seed-hypermedia/seed.git
+          git fetch --prune upstream main
+
+      - name: Rebase main onto upstream/main
+        run: git rebase upstream/main
+
+      - name: Record rebased HEAD
+        id: after
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Push rebased main
+        if: steps.after.outputs.sha != steps.before.outputs.sha
+        run: git push --force-with-lease origin HEAD:main
+
+      - name: Open or update failure issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title='Upstream sync of main failed'
+          body="The scheduled rebase of \`main\` onto \`seed-hypermedia/seed:main\` failed. Resolve it manually, then re-run the workflow.
+
+          Failed run: $RUN_URL"
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "in:title \"$title\"" --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "Sync failed again: $RUN_URL"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body "$body"
+          fi
+
+  rebase-custom-images:
+    name: Rebase custom-images onto main
+    needs: sync-main
+    runs-on: ubuntu-latest
+    if: github.repository == 'horacioh/seed'
+    steps:
+      - name: Checkout custom-images
+        uses: actions/checkout@v4
+        with:
+          ref: custom-images
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure actions bot identity
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Fetch updated main
+        run: git fetch --prune origin main
+
+      - name: Record starting HEAD
+        id: before
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Rebase custom-images onto origin/main
+        run: git rebase origin/main
+
+      - name: Record rebased HEAD
+        id: after
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Push rebased custom-images
+        if: steps.after.outputs.sha != steps.before.outputs.sha
+        run: git push --force-with-lease origin HEAD:custom-images
+
+      - name: Open or update failure issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title='Rebase of custom-images failed'
+          body="The scheduled rebase of \`custom-images\` onto the freshly synced \`main\` failed, most likely due to a conflict with the fork's custom commits. Resolve it manually, then re-run the workflow.
+
+          Failed run: $RUN_URL"
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "in:title \"$title\"" --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "Rebase failed again: $RUN_URL"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body "$body"
+          fi

--- a/.github/workflows/custom-rebase-main.yml
+++ b/.github/workflows/custom-rebase-main.yml
@@ -80,7 +80,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           title='Upstream sync of main failed'
-          body="The scheduled rebase of \`main\` onto \`seed-hypermedia/seed:main\` failed. Resolve it manually, then re-run the workflow.
+          body="The scheduled sync with \`seed-hypermedia/seed\` failed — either the rebase of \`main\` or the mirroring of upstream tags. Check the failed step in the run below, resolve it manually, then re-run the workflow.
 
           Failed run: $RUN_URL"
           existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "in:title \"$title\"" --json number --jq '.[0].number')
@@ -145,7 +145,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           title='Rebase of custom-images failed'
-          body="The scheduled rebase of \`custom-images\` onto the freshly synced \`main\` failed, most likely due to a conflict with the fork's custom commits. Resolve it manually, then re-run the workflow.
+          body="The scheduled rebase of \`custom-images\` onto the freshly synced \`main\` failed (most likely a conflict with the fork's custom commits), or the \`<version>-custom\` tag could not be pushed. Check the failed step in the run below, resolve it manually, then re-run the workflow.
 
           Failed run: $RUN_URL"
           existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "in:title \"$title\"" --json number --jq '.[0].number')

--- a/.github/workflows/custom-sync-upstream.yml
+++ b/.github/workflows/custom-sync-upstream.yml
@@ -12,6 +12,7 @@ on:
     - cron: '17 5 * * *'
 
 permissions:
+  actions: write
   contents: write
   issues: write
 
@@ -134,13 +135,21 @@ jobs:
 
       - name: Tag custom-images for the release
         run: |
-          # The tag is what triggers the GHCR image build, so a manual re-run of an already
-          # mirrored release has to move it onto the freshly rebased commit.
+          # A manual re-run of an already mirrored release has to move the tag onto the
+          # freshly rebased commit.
           if git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG-custom" >/dev/null 2>&1; then
             git push --delete origin "refs/tags/$RELEASE_TAG-custom"
           fi
           git tag -f -a "$RELEASE_TAG-custom" -m "custom-images rebased onto $RELEASE_TAG"
           git push origin "refs/tags/$RELEASE_TAG-custom"
+
+      - name: Build the images for the tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Pushes made with GITHUB_TOKEN never trigger workflows, so the tag push above
+          # cannot start the image build on its own; dispatch it explicitly at the tag.
+          gh workflow run custom-ghcr-images.yml --repo "$GITHUB_REPOSITORY" --ref "$RELEASE_TAG-custom"
 
       - name: Open or update failure issue
         if: failure()

--- a/.github/workflows/custom-sync-upstream.yml
+++ b/.github/workflows/custom-sync-upstream.yml
@@ -2,9 +2,14 @@ name: Custom - Sync Fork From Upstream
 
 on:
   workflow_dispatch:
+    inputs:
+      rebase_tag:
+        description: 'Release tag to rebase custom-images onto, even if it was already mirrored (e.g. 2026.7.1).'
+        required: false
+        type: string
   schedule:
-    # Keep the fork close to upstream every 6 hours.
-    - cron: '17 */6 * * *'
+    # Mirror upstream once a day.
+    - cron: '17 5 * * *'
 
 permissions:
   contents: write
@@ -19,6 +24,8 @@ jobs:
     name: Mirror upstream/main into main
     runs-on: ubuntu-latest
     if: github.repository == 'horacioh/seed'
+    outputs:
+      release_tag: ${{ steps.mirror-tags.outputs.release_tag }}
     steps:
       - name: Checkout custom-images
         uses: actions/checkout@v4
@@ -45,20 +52,30 @@ jobs:
           git push --force origin refs/remotes/upstream/main:refs/heads/main
 
       - name: Mirror new upstream tags
+        id: mirror-tags
+        env:
+          FORCED_TAG: ${{ inputs.rebase_tag }}
         run: |
           # Compare local tags (the snapshot fetched from upstream) against origin, so every
           # tag pushed below is guaranteed to exist locally even if upstream tags mid-run.
           git tag --list | sort -u > /tmp/upstream-tags
           git ls-remote --tags origin | awk '{print $2}' | sed 's#^refs/tags/##' | { grep -v '\^{}$' || true; } | sort -u > /tmp/origin-tags
           new_tags=$(comm -23 /tmp/upstream-tags /tmp/origin-tags)
-          if [ -z "$new_tags" ]; then
+          if [ -n "$new_tags" ]; then
+            echo "New upstream tags:"
+            echo "$new_tags"
+            # shellcheck disable=SC2046
+            git push origin $(echo "$new_tags" | sed 's#^#refs/tags/#')
+          else
             echo 'No new upstream tags.'
-            exit 0
           fi
-          echo "New upstream tags:"
-          echo "$new_tags"
-          # shellcheck disable=SC2046
-          git push origin $(echo "$new_tags" | sed 's#^#refs/tags/#')
+          # custom-images tracks releases, not every upstream commit, so only a newly
+          # mirrored X.Y.Z tag (or one named on a manual run) triggers the rebase below.
+          release_tag=$(echo "$new_tags" | { grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true; } | sort -V | tail -1)
+          if [ -n "$FORCED_TAG" ]; then
+            release_tag=$FORCED_TAG
+          fi
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
 
       - name: Open or update failure issue
         if: failure()
@@ -78,10 +95,12 @@ jobs:
           fi
 
   rebase-custom-images:
-    name: Rebase custom-images onto main
+    name: Rebase custom-images onto the new release
     needs: sync-main
     runs-on: ubuntu-latest
-    if: github.repository == 'horacioh/seed'
+    if: github.repository == 'horacioh/seed' && needs.sync-main.outputs.release_tag != ''
+    env:
+      RELEASE_TAG: ${{ needs.sync-main.outputs.release_tag }}
     steps:
       - name: Checkout custom-images
         uses: actions/checkout@v4
@@ -95,15 +114,15 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-      - name: Fetch updated main
-        run: git fetch --prune origin main
+      - name: Fetch the release tag
+        run: git fetch --prune origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
 
       - name: Record starting HEAD
         id: before
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Rebase custom-images onto origin/main
-        run: git rebase origin/main
+      - name: Rebase custom-images onto the release tag
+        run: git rebase "$RELEASE_TAG"
 
       - name: Record rebased HEAD
         id: after
@@ -113,22 +132,15 @@ jobs:
         if: steps.after.outputs.sha != steps.before.outputs.sha
         run: git push --force-with-lease origin HEAD:custom-images
 
-      - name: Tag custom-images for the newest mirrored release
+      - name: Tag custom-images for the release
         run: |
-          # Derived from origin rather than from what this run mirrored, so a failed run
-          # is recovered by the next scheduled one instead of losing the marker forever.
-          tags=$(git ls-remote --tags origin | awk '{print $2}' | sed 's#^refs/tags/##' | { grep -v '\^{}$' || true; })
-          latest=$(echo "$tags" | { grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true; } | sort -V | tail -1)
-          if [ -z "$latest" ]; then
-            echo 'No release tags on origin yet.'
-            exit 0
+          # The tag is what triggers the GHCR image build, so a manual re-run of an already
+          # mirrored release has to move it onto the freshly rebased commit.
+          if git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG-custom" >/dev/null 2>&1; then
+            git push --delete origin "refs/tags/$RELEASE_TAG-custom"
           fi
-          if echo "$tags" | grep -qFx "$latest-custom"; then
-            echo "Tag $latest-custom already exists on origin."
-            exit 0
-          fi
-          git tag -a "$latest-custom" -m "custom-images rebased onto $latest"
-          git push origin "refs/tags/$latest-custom"
+          git tag -f -a "$RELEASE_TAG-custom" -m "custom-images rebased onto $RELEASE_TAG"
+          git push origin "refs/tags/$RELEASE_TAG-custom"
 
       - name: Open or update failure issue
         if: failure()
@@ -137,7 +149,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           title='Rebase of custom-images failed'
-          body="The scheduled rebase of \`custom-images\` onto the freshly synced \`main\` failed (most likely a conflict with the fork's custom commits), or the \`<version>-custom\` tag could not be pushed. Check the failed step in the run below, resolve it manually, then re-run the workflow.
+          body="The rebase of \`custom-images\` onto the newly mirrored release tag failed (most likely a conflict with the fork's custom commits), or the \`<version>-custom\` tag could not be pushed. Check the failed step in the run below, resolve it manually, then re-run the workflow.
 
           Failed run: $RUN_URL"
           existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "in:title \"$title\"" --json number --jq '.[0].number')

--- a/docs/custom-docker-web-deploy.md
+++ b/docs/custom-docker-web-deploy.md
@@ -6,10 +6,11 @@ Operator notes for running the Horacio fork deployment while tracking upstream S
 
 Two branches keep the fork clean while still shipping custom images:
 
-- `main`: a clean mirror of `seed-hypermedia/seed:main` plus a single sync workflow commit. It carries no product
-  customizations, so pulling upstream stays trivial.
-- `custom-images`: rebased on top of `main`, it holds every fork customization (custom web/site images, the
-  fork-hosted `deploy.js` updater, and the query-block filters). The GHCR image build runs from this branch.
+- `main`: a verbatim mirror of `seed-hypermedia/seed:main`, commit for commit. It carries nothing of the fork's own —
+  not even the sync workflow — so `git pull` always fast-forwards to the exact upstream state.
+- `custom-images`: the fork's default branch, rebased on top of `main`. It holds every fork customization (the sync and
+  GHCR workflows, custom web/site images, the fork-hosted `deploy.js` updater, and the query-block filters). The GHCR
+  image build runs from this branch.
 
 Other pointers:
 
@@ -26,34 +27,34 @@ rollback targets.
 
 ## Upstream sync (automated)
 
-The `Custom - Sync Fork From Upstream` workflow (`.github/workflows/custom-rebase-main.yml`) runs every 6 hours (and on
-demand) from `main`. It:
+The `Custom - Sync Fork From Upstream` workflow (`.github/workflows/custom-rebase-main.yml`) lives on `custom-images`
+and runs every 6 hours (and on demand). Scheduled workflows only run from the default branch, which is why
+`custom-images` — not `main` — is the fork's default branch. It:
 
-1. Rebases `main` onto `seed-hypermedia/seed:main` and force-with-lease pushes `main`.
-2. Rebases `custom-images` onto the freshly synced `main` and force-with-lease pushes `custom-images`.
-3. Dispatches the GHCR image build for `custom-images`.
+1. Force pushes `upstream/main` onto `main`, so `main` is byte-identical to upstream.
+2. Mirrors new upstream tags.
+3. Rebases `custom-images` onto the freshly mirrored `main` and force-with-lease pushes `custom-images`.
+4. Tags `custom-images` as `<version>-custom` for the newest mirrored release, which triggers the GHCR image build.
 
-If either rebase hits a conflict, the workflow opens (or comments on) a tracking issue and stops so it can be resolved
+If the rebase hits a conflict, the workflow opens (or comments on) a tracking issue and stops so it can be resolved
 manually.
 
 To reproduce it locally:
 
 ```sh
 git fetch upstream main
-git switch main
-git rebase upstream/main
-git push --force-with-lease origin main
+git push --force origin refs/remotes/upstream/main:refs/heads/main
 
 git switch custom-images
 git rebase origin/main
 git push --force-with-lease origin custom-images
 ```
 
-If rebase conflicts occur, stop and resolve them manually. Do not push a conflicted or unverified rebase. After the push,
-confirm the image build workflow publishes fresh `main` and SHA tags before expecting servers to update.
+If rebase conflicts occur, stop and resolve them manually. Do not push a conflicted or unverified rebase. After the
+push, confirm the image build workflow publishes fresh `main` and SHA tags before expecting servers to update.
 
-Caveat: branch protection that blocks force pushes is incompatible with this rebase model. Allow the actions bot to
-force-with-lease push `main` and `custom-images`.
+Caveat: branch protection that blocks force pushes is incompatible with this model. Allow the actions bot to force push
+`main` and force-with-lease push `custom-images`.
 
 ## One-time branch migration
 
@@ -80,17 +81,17 @@ curl -fsSL https://raw.githubusercontent.com/horacioh/seed/custom-images/ops/dep
 
 For an existing install, first take a backup, then re-run the fork bootstrap. The deploy script stores state under the
 seed directory, installs/updates `/usr/local/bin/seed-deploy` when allowed, detects legacy installs, writes
-`config.json`, and runs the deploy wizard when configuration is missing or `--reconfigure` is requested.
-The persisted `deploy_url` also controls `deploy.js` self-updates, so cron keeps the fork-specific custom image support
-instead of replacing it with upstream's S3 build.
+`config.json`, and runs the deploy wizard when configuration is missing or `--reconfigure` is requested. The persisted
+`deploy_url` also controls `deploy.js` self-updates, so cron keeps the fork-specific custom image support instead of
+replacing it with upstream's S3 build.
 
 ```sh
 seed-deploy backup
 SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/custom-images/ops seed-deploy deploy --reconfigure
 ```
 
-When prompted for a custom Docker image tag, use `main` for the normal moving channel. Full GHCR image refs are
-stored in `config.json` as shown below.
+When prompted for a custom Docker image tag, use `main` for the normal moving channel. Full GHCR image refs are stored
+in `config.json` as shown below.
 
 ## Custom image references
 

--- a/docs/custom-docker-web-deploy.md
+++ b/docs/custom-docker-web-deploy.md
@@ -1,0 +1,191 @@
+# Custom Docker Web Deploy Runbook
+
+Operator notes for running the Horacio fork deployment while tracking upstream Seed.
+
+## Model
+
+- Fork remote: `origin` = `horacioh/seed`.
+- Deployment branch: `origin/main`.
+- Upstream: `seed-hypermedia/seed:main`.
+- Server deploy source: `https://raw.githubusercontent.com/horacioh/seed/main/ops`.
+- Custom images:
+  - Web: `ghcr.io/horacioh/seed-web:main` and `ghcr.io/horacioh/seed-web:sha-<sha>`.
+  - Daemon/site: `ghcr.io/horacioh/seed-site:main` and `ghcr.io/horacioh/seed-site:sha-<sha>`.
+
+`main` is the moving deployment channel. `sha-<sha>` tags are immutable rollback targets.
+
+## Daily upstream rebase
+
+Run from a clean local checkout of the fork:
+
+```sh
+git fetch upstream main
+git fetch origin main
+git switch main
+git rebase upstream/main
+git push --force-with-lease origin main
+```
+
+If rebase conflicts occur, stop and resolve them manually. Do not push a conflicted or unverified rebase. After the push,
+confirm the image build workflow publishes fresh `main` and SHA tags before expecting servers to update.
+
+Caveat: branch protection that blocks force pushes is incompatible with this exact rebase model. Either allow
+administrator/maintainer force-with-lease pushes for `main`, or use a separate deployment branch with matching build and
+server configuration.
+
+## Server bootstrap or migration
+
+Use the Horacio fork as the deploy source, not the upstream hosted installer:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/horacioh/seed/main/ops/deploy.sh | \
+  SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/main/ops sh
+```
+
+For an existing install, first take a backup, then re-run the fork bootstrap. The deploy script stores state under the
+seed directory, installs/updates `/usr/local/bin/seed-deploy` when allowed, detects legacy installs, writes
+`config.json`, and runs the deploy wizard when configuration is missing or `--reconfigure` is requested.
+The persisted `deploy_url` also controls `deploy.js` self-updates, so cron keeps the fork-specific custom image support
+instead of replacing it with upstream's S3 build.
+
+```sh
+seed-deploy backup
+SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/main/ops seed-deploy deploy --reconfigure
+```
+
+When prompted for a custom Docker image tag, use `main` for the normal moving channel. Full GHCR image refs are
+stored in `config.json` as shown below.
+
+## Custom image references
+
+The server compose file must run the GHCR images, not the upstream defaults. Using the fork deploy source alone is not
+enough if that branch's `ops/docker-compose.yml` still references `seedhypermedia/*`; verify the raw compose file before
+rollout.
+
+Required image refs:
+
+```text
+ghcr.io/horacioh/seed-web:main
+ghcr.io/horacioh/seed-site:main
+```
+
+For rollback or pinned deploys, use matching SHA tags:
+
+```text
+ghcr.io/horacioh/seed-web:sha-<sha>
+ghcr.io/horacioh/seed-site:sha-<sha>
+```
+
+Persist these refs in the server config. After bootstrap or reconfigure, inspect and edit `config.json` if needed:
+
+```sh
+seed-deploy config
+sudo ${EDITOR:-vi} /opt/seed/config.json
+```
+
+The relevant fields should be:
+
+```json
+{
+  "deploy_url": "https://raw.githubusercontent.com/horacioh/seed/main/ops",
+  "compose_url": "https://raw.githubusercontent.com/horacioh/seed/main/ops/docker-compose.yml",
+  "release_channel": "main",
+  "web_image": "ghcr.io/horacioh/seed-web:main",
+  "site_image": "ghcr.io/horacioh/seed-site:main"
+}
+```
+
+Keep web and site on the same tag. Mixing SHAs can produce API or data compatibility surprises.
+
+Private registry caveat: if the GHCR packages are private, the server must authenticate before pulling:
+
+```sh
+echo "$GHCR_TOKEN" | docker login ghcr.io -u horacioh --password-stdin
+```
+
+Use a token with package read permission. Public GHCR packages do not need this step.
+
+## Automatic and manual deploys
+
+Install cron after bootstrap if it is not already present:
+
+```sh
+seed-deploy cron
+```
+
+Current deploy tooling installs a `# seed-deploy` cron entry that runs `upgrade` and `deploy` every 10 minutes, plus a
+`# seed-cleanup` entry that prunes old Docker images hourly. Check the exact schedule on the server with:
+
+```sh
+crontab -l | grep 'seed-'
+```
+
+Manual deploy:
+
+```sh
+SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/main/ops seed-deploy deploy
+```
+
+Reconfigure deploy settings:
+
+```sh
+SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/main/ops seed-deploy deploy --reconfigure
+```
+
+Start, stop, restart, and logs:
+
+```sh
+seed-deploy start
+seed-deploy stop
+seed-deploy restart
+seed-deploy logs web
+seed-deploy logs daemon
+seed-deploy logs proxy
+```
+
+## Rollback to a SHA tag
+
+1. Pick a known-good image SHA tag that exists for both images.
+2. Reconfigure the server to that tag:
+
+   ```sh
+   SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/main/ops seed-deploy deploy --reconfigure
+   ```
+
+3. Edit `/opt/seed/config.json` so `web_image` and `site_image` point at matching `sha-<sha>` tags.
+4. Deploy and verify:
+
+   ```sh
+   seed-deploy deploy
+   seed-deploy doctor
+   docker inspect seed-web --format '{{.Config.Image}}'
+   docker inspect seed-daemon --format '{{.Config.Image}}'
+   ```
+
+Return to the moving channel by reconfiguring back to `main`.
+
+## Verification
+
+After bootstrap, rebase, deploy, or rollback:
+
+```sh
+seed-deploy doctor
+seed-deploy config
+docker inspect seed-web --format '{{.State.Status}} {{.Config.Image}} {{.State.StartedAt}}'
+docker inspect seed-daemon --format '{{.State.Status}} {{.Config.Image}} {{.State.StartedAt}}'
+docker inspect seed-proxy --format '{{.State.Status}} {{.Config.Image}} {{.State.StartedAt}}'
+seed-deploy logs web
+seed-deploy logs daemon
+seed-deploy logs proxy
+```
+
+Expected:
+
+- `seed-web`, `seed-daemon`, and `seed-proxy` are `running`.
+- `seed-web` uses `ghcr.io/horacioh/seed-web:<tag>`.
+- `seed-daemon` uses `ghcr.io/horacioh/seed-site:<tag>`.
+- `seed-deploy doctor` has no unexpected env, disk, network, image, or cron failures.
+- Logs show normal startup and no repeated crash/restart loop.
+
+If `docker inspect` reports upstream `seedhypermedia/*` images, the server is not using the intended custom image refs;
+fix the deploy source/configuration and redeploy before considering the rollout complete.

--- a/docs/custom-docker-web-deploy.md
+++ b/docs/custom-docker-web-deploy.md
@@ -34,7 +34,8 @@ and runs daily (and on demand). Scheduled workflows only run from the default br
 1. Force pushes `upstream/main` onto `main`, so `main` is byte-identical to upstream.
 2. Mirrors new upstream tags.
 3. Only when a new `X.Y.Z` release tag was mirrored: rebases `custom-images` onto that tag, force-with-lease pushes it,
-   and tags it `<version>-custom`, which triggers the GHCR image build.
+   tags it `<version>-custom`, and dispatches the GHCR image build at that tag. (The dispatch is explicit because pushes
+   made with `GITHUB_TOKEN` never trigger workflows.)
 
 So `main` follows upstream continuously while `custom-images` moves release by release. A manual run can name a
 `rebase_tag` to redo the rebase for an already mirrored release.

--- a/docs/custom-docker-web-deploy.md
+++ b/docs/custom-docker-web-deploy.md
@@ -27,14 +27,17 @@ rollback targets.
 
 ## Upstream sync (automated)
 
-The `Custom - Sync Fork From Upstream` workflow (`.github/workflows/custom-rebase-main.yml`) lives on `custom-images`
-and runs every 6 hours (and on demand). Scheduled workflows only run from the default branch, which is why
-`custom-images` — not `main` — is the fork's default branch. It:
+The `Custom - Sync Fork From Upstream` workflow (`.github/workflows/custom-sync-upstream.yml`) lives on `custom-images`
+and runs daily (and on demand). Scheduled workflows only run from the default branch, which is why `custom-images` — not
+`main` — is the fork's default branch. It:
 
 1. Force pushes `upstream/main` onto `main`, so `main` is byte-identical to upstream.
 2. Mirrors new upstream tags.
-3. Rebases `custom-images` onto the freshly mirrored `main` and force-with-lease pushes `custom-images`.
-4. Tags `custom-images` as `<version>-custom` for the newest mirrored release, which triggers the GHCR image build.
+3. Only when a new `X.Y.Z` release tag was mirrored: rebases `custom-images` onto that tag, force-with-lease pushes it,
+   and tags it `<version>-custom`, which triggers the GHCR image build.
+
+So `main` follows upstream continuously while `custom-images` moves release by release. A manual run can name a
+`rebase_tag` to redo the rebase for an already mirrored release.
 
 If the rebase hits a conflict, the workflow opens (or comments on) a tracking issue and stops so it can be resolved
 manually.
@@ -42,12 +45,14 @@ manually.
 To reproduce it locally:
 
 ```sh
-git fetch upstream main
+git fetch upstream main '+refs/tags/*:refs/tags/*'
 git push --force origin refs/remotes/upstream/main:refs/heads/main
 
 git switch custom-images
-git rebase origin/main
+git rebase <version>
 git push --force-with-lease origin custom-images
+git tag -a <version>-custom -m "custom-images rebased onto <version>"
+git push origin refs/tags/<version>-custom
 ```
 
 If rebase conflicts occur, stop and resolve them manually. Do not push a conflicted or unverified rebase. After the

--- a/docs/custom-docker-web-deploy.md
+++ b/docs/custom-docker-web-deploy.md
@@ -4,42 +4,64 @@ Operator notes for running the Horacio fork deployment while tracking upstream S
 
 ## Model
 
+Two branches keep the fork clean while still shipping custom images:
+
+- `main`: a clean mirror of `seed-hypermedia/seed:main` plus a single sync workflow commit. It carries no product
+  customizations, so pulling upstream stays trivial.
+- `custom-images`: rebased on top of `main`, it holds every fork customization (custom web/site images, the
+  fork-hosted `deploy.js` updater, and the query-block filters). The GHCR image build runs from this branch.
+
+Other pointers:
+
 - Fork remote: `origin` = `horacioh/seed`.
-- Deployment branch: `origin/main`.
+- Deployment branch: `origin/custom-images`.
 - Upstream: `seed-hypermedia/seed:main`.
-- Server deploy source: `https://raw.githubusercontent.com/horacioh/seed/main/ops`.
+- Server deploy source: `https://raw.githubusercontent.com/horacioh/seed/custom-images/ops`.
 - Custom images:
   - Web: `ghcr.io/horacioh/seed-web:main` and `ghcr.io/horacioh/seed-web:sha-<sha>`.
   - Daemon/site: `ghcr.io/horacioh/seed-site:main` and `ghcr.io/horacioh/seed-site:sha-<sha>`.
 
-`main` is the moving deployment channel. `sha-<sha>` tags are immutable rollback targets.
+The `main` image tag is the moving deployment channel (built from `custom-images`); `sha-<sha>` tags are immutable
+rollback targets.
 
-## Daily upstream rebase
+## Upstream sync (automated)
 
-Run from a clean local checkout of the fork:
+The `Custom - Sync Fork From Upstream` workflow (`.github/workflows/custom-rebase-main.yml`) runs every 6 hours (and on
+demand) from `main`. It:
+
+1. Rebases `main` onto `seed-hypermedia/seed:main` and force-with-lease pushes `main`.
+2. Rebases `custom-images` onto the freshly synced `main` and force-with-lease pushes `custom-images`.
+3. Dispatches the GHCR image build for `custom-images`.
+
+If either rebase hits a conflict, the workflow opens (or comments on) a tracking issue and stops so it can be resolved
+manually.
+
+To reproduce it locally:
 
 ```sh
 git fetch upstream main
-git fetch origin main
 git switch main
 git rebase upstream/main
 git push --force-with-lease origin main
+
+git switch custom-images
+git rebase origin/main
+git push --force-with-lease origin custom-images
 ```
 
 If rebase conflicts occur, stop and resolve them manually. Do not push a conflicted or unverified rebase. After the push,
 confirm the image build workflow publishes fresh `main` and SHA tags before expecting servers to update.
 
-Caveat: branch protection that blocks force pushes is incompatible with this exact rebase model. Either allow
-administrator/maintainer force-with-lease pushes for `main`, or use a separate deployment branch with matching build and
-server configuration.
+Caveat: branch protection that blocks force pushes is incompatible with this rebase model. Allow the actions bot to
+force-with-lease push `main` and `custom-images`.
 
 ## Server bootstrap or migration
 
 Use the Horacio fork as the deploy source, not the upstream hosted installer:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/horacioh/seed/main/ops/deploy.sh | \
-  SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/main/ops sh
+curl -fsSL https://raw.githubusercontent.com/horacioh/seed/custom-images/ops/deploy.sh | \
+  SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/custom-images/ops sh
 ```
 
 For an existing install, first take a backup, then re-run the fork bootstrap. The deploy script stores state under the
@@ -50,7 +72,7 @@ instead of replacing it with upstream's S3 build.
 
 ```sh
 seed-deploy backup
-SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/main/ops seed-deploy deploy --reconfigure
+SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/custom-images/ops seed-deploy deploy --reconfigure
 ```
 
 When prompted for a custom Docker image tag, use `main` for the normal moving channel. Full GHCR image refs are
@@ -87,8 +109,8 @@ The relevant fields should be:
 
 ```json
 {
-  "deploy_url": "https://raw.githubusercontent.com/horacioh/seed/main/ops",
-  "compose_url": "https://raw.githubusercontent.com/horacioh/seed/main/ops/docker-compose.yml",
+  "deploy_url": "https://raw.githubusercontent.com/horacioh/seed/custom-images/ops",
+  "compose_url": "https://raw.githubusercontent.com/horacioh/seed/custom-images/ops/docker-compose.yml",
   "release_channel": "main",
   "web_image": "ghcr.io/horacioh/seed-web:main",
   "site_image": "ghcr.io/horacioh/seed-site:main"
@@ -123,13 +145,13 @@ crontab -l | grep 'seed-'
 Manual deploy:
 
 ```sh
-SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/main/ops seed-deploy deploy
+SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/custom-images/ops seed-deploy deploy
 ```
 
 Reconfigure deploy settings:
 
 ```sh
-SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/main/ops seed-deploy deploy --reconfigure
+SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/custom-images/ops seed-deploy deploy --reconfigure
 ```
 
 Start, stop, restart, and logs:
@@ -149,7 +171,7 @@ seed-deploy logs proxy
 2. Reconfigure the server to that tag:
 
    ```sh
-   SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/main/ops seed-deploy deploy --reconfigure
+   SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/custom-images/ops seed-deploy deploy --reconfigure
    ```
 
 3. Edit `/opt/seed/config.json` so `web_image` and `site_image` point at matching `sha-<sha>` tags.

--- a/docs/custom-docker-web-deploy.md
+++ b/docs/custom-docker-web-deploy.md
@@ -55,6 +55,20 @@ confirm the image build workflow publishes fresh `main` and SHA tags before expe
 Caveat: branch protection that blocks force pushes is incompatible with this rebase model. Allow the actions bot to
 force-with-lease push `main` and `custom-images`.
 
+## One-time branch migration
+
+Before replacing the fork's old `main`, repoint every existing custom node at `custom-images` while the currently
+installed fork deploy tool is still available:
+
+```sh
+seed-deploy backup
+SEED_DEPLOY_URL=https://raw.githubusercontent.com/horacioh/seed/custom-images/ops \
+  seed-deploy deploy --reconfigure
+```
+
+Confirm each node's `config.json` stores both `deploy_url` and `compose_url` under
+`https://raw.githubusercontent.com/horacioh/seed/custom-images/ops`. Only then replace `main` with the clean branch.
+
 ## Server bootstrap or migration
 
 Use the Horacio fork as the deploy source, not the upstream hosted installer:

--- a/docs/projects/image-caption-selection.md
+++ b/docs/projects/image-caption-selection.md
@@ -1,0 +1,268 @@
+# Image Caption Selection
+
+## Problem
+
+You cannot select text inside an image caption in the document editor. Selecting caption text in edit mode produces a
+browser highlight but no ProseMirror selection, so nothing that depends on selection works there: no formatting toolbar,
+no bold/italic/link on caption text, and no fragment actions (Copy Link, Comment) targeting a caption range. Dragging
+with the mouse inside a caption collapses to a caret instead of selecting.
+
+The same caption is fully selectable for a read-only reader, which makes the gap visible in practice: a reader can
+comment on a phrase in a caption, but the author who wrote it cannot select that phrase at all — and an author viewing
+their own published document cannot either, because the drag flips the document into edit mode instead.
+
+Verified in the `@shm/editor` E2E harness (`?real=1&fixture=allBlocks`, real `DocumentEditor`), with a plain paragraph
+as the control in every case:
+
+| Mode                                 | Caption fragment selection             |
+| ------------------------------------ | -------------------------------------- |
+| Edit mode                            | Broken — no PM selection, no toolbar   |
+| Read-only, reader (`canEdit=false`)  | Works — emits `blk-image[0:9]`         |
+| Read-only, user with edit permission | Broken — drag enters edit mode instead |
+
+### Root cause
+
+Two independent causes. Both must be fixed; neither alone is sufficient.
+
+**1. The caption is a separate editing host (primary).** The runtime DOM chain from `.image-caption` up to `view.dom`:
+
+| #   | Element                                               | `contenteditable` | `draggable` |
+| --- | ----------------------------------------------------- | ----------------- | ----------- |
+| 0   | `.image-caption`                                      | **true**          | –           |
+| 1   | MediaContainer outer wrapper (`media-container.tsx`)  | –                 | **true**    |
+| 2   | `div.flex.w-full.flex-col` (`media-render.tsx`)       | –                 | –           |
+| 3   | **`BlockSelectionWrapper`** (`media-render.tsx`)      | **false**         | –           |
+| 4–7 | blockContent / node-image / blockNode / blockChildren | –                 | –           |
+| 8   | `div.ProseMirror` = `view.dom`                        | **true**          | –           |
+
+`BlockSelectionWrapper` renders `contentEditable={false}` around the whole media subtree, caption included. The
+caption's own `contentEditable={true}` therefore creates a nested editing host: `document.activeElement` becomes the
+caption div, `view.hasFocus()` is `false`, and prosemirror-view's `hasFocusAndSelection()` discards every selection made
+inside it. This is the case ProseMirror's author warns about directly — "A single ProseMirror editor can only manage a
+single contenteditable range, so there can't be uneditable elements with editable islands in them"
+([discuss.prosemirror.net](https://discuss.prosemirror.net/t/nodeview-rendering-child-nodes-without-contentdom/5014)).
+
+The `FormattingToolbarPlugin.shouldShow` → `view.hasFocus()` gate is a **symptom of this**, not a separate blocker. It
+passes on its own once the editing host is fixed.
+
+**2. A `draggable` ancestor swallows mouse drags.** The MediaContainer outer wrapper is `draggable=true`, so a
+mousedown-and-move inside the caption starts a native HTML5 drag rather than a text selection. Fixing this alone makes
+the DOM selection appear but PM still sees nothing; fixing cause 1 alone leaves keyboard selection working and mouse
+drag broken.
+
+### How other editors model this
+
+Every editor that supports caption formatting **and** unified selection makes the caption ordinary document content in
+the same contenteditable:
+
+- **Atlassian ADF** — `mediaSingle` contains a `media` node and a sibling `caption` node with inline content and marks.
+- **Tiptap figure/figcaption** — `content: 'image figcaption'`, rendered via `renderHTML` with no React node view and no
+  `contenteditable=false` wrapper.
+- **Slate** — `figure` is a normal element with a caption child; only the image itself is void.
+
+The alternative is a nested editor (**Lexical playground**: `ImageNode` is a `DecoratorNode` owning a full nested
+`LexicalEditor` for the caption). That buys rich formatting but permanently gives up document-level selection across or
+into the caption. Seed today has the nested-editor drawbacks without being a nested editor.
+
+Seed's schema is already in the right family: the image block is `containsInlineContent: true` and the caption is the
+image node's inline content, serialized to the block's `text` with annotations. **No schema or data-model change is
+needed.** The bug is purely in how the node view's DOM is wrapped.
+
+## Consuming-side verification
+
+Gap #1 — whether a caption-targeted range resolves and renders — is verified closed for the editor/viewer layer. The
+runtime harness used the real editor and verified:
+
+- `rangeFocus` for `blk-image[0:5]` produces one `.bn-range-highlight-focus` inside `.image-caption` over the expected
+  characters; a paragraph control behaves the same way.
+- Codepoint offsets survive an emoji: for `ab😀cd`, `3:5` selects `cd` and `0:3` selects `ab😀`; no surrogate pair is
+  split.
+- Citation fragment highlighting renders over the caption and is clickable.
+- The read-only quote viewer, using the same props passed by `QuotedDocBlock`, highlights the caption, and the
+  quoted-text preview is non-empty.
+- Unknown block IDs, `3:3`, `7:2`, and `50:80` produce zero decorations without throwing, and the editor recovers for a
+  subsequent valid range.
+- `document.getElementById('blk-image')` is a valid scroll target.
+
+The consuming implementation is generic. `BlockHighlightPlugin` and `CitationFragmentHighlightPlugin` match any
+`blockNode` by ID and walk its inline content; neither assumes a paragraph selector or a particular block type.
+`getBlockText()` returns `block.text` for `Image`, so caption text is also available to quoted-text previews. **No
+consumer-side code change is needed.**
+
+The following app-level paths remain unverified:
+
+- Real URL navigation with a `#blk-image[0:5]` browser hash.
+- Daemon-backed comment creation on a caption range.
+- The real `QuotedDocBlock` path in desktop and web.
+- The quoted-text preview assembled in `frontend/packages/ui/src/resource-page-common.tsx`.
+- Citation `targetBlockRevision` filtering against a published document with revisions.
+
+## Solution
+
+Keep the schema and the data model exactly as they are. Stop the media node view from making the caption's DOM
+non-editable, and move the drag affordance off the caption's ancestors.
+
+A throwaway version of this patch was applied in the harness and confirmed to work end to end:
+
+- Give `BlockSelectionWrapper` an opt-out so it does not force `contentEditable={false}` over a block that has inline
+  content, and use it for image blocks from `media-render.tsx`. The media surface div keeps its own
+  `contentEditable={false}`.
+- Move `draggable` and `onDragStart`/`onDragEnd` from the MediaContainer outer wrapper onto the media-surface div (the
+  one already marked `contentEditable={false}`), so the caption is no longer inside a draggable region.
+- Keep `data-media-container-ignore-select` on the caption and the existing `lastMousedownInCaption` guard in
+  `BlockManipulationExtension` — they are what let caption clicks coexist with whole-node media selection.
+
+Measured with the throwaway patch in place:
+
+- Caption keyboard selection produces a non-empty PM `TextSelection` inside the image node, with `view.hasFocus()` true
+  and the formatting toolbar showing Comment and Copy Link.
+- Copy Link on a caption selection emits `blockId=blk-image`, `start:0`, `end:11`.
+- Real mouse drag inside the caption selects and opens the toolbar.
+- Paragraph control still emits `p-top` `0:15`.
+
+User stories:
+
+- As an author, I can select part of an image caption and make it bold, italic, or a link.
+- As an author, I can select part of my own caption and copy a fragment link or start a comment on it, the same way I
+  can in a paragraph.
+- As a reader, caption fragment selection keeps working exactly as it does today.
+- As an author, I can still click an image to select the whole block, drag it to reorder, and resize it.
+
+### Open decisions
+
+These change the shape of the patch and should be settled before implementation starts:
+
+1. Should `BlockSelectionWrapper` stop wrapping image blocks entirely, or gain an inline-content-aware mode? The
+   inline-content-aware mode is narrower and is what was validated; skipping the wrapper outright is simpler but drops
+   whatever else the wrapper provides for images.
+2. Should block drag for images live only on the media surface? That is the validated shape, and it shrinks the drag
+   affordance area — the caption strip stops being a drag handle. The side-menu drag handle is unaffected.
+
+### Acceptance criteria
+
+Everything below is a runnable check, not a judgement call. The pre-fix state of the Phase 2 tests must be **failing**,
+so they are written first and demonstrate the regression before the fix lands.
+
+## Scope
+
+Five phases. Phases 1–3 are the shippable core; 4 and 5 gate the production push.
+
+**Phase 1 — Failing tests first (0.5 day).** No dependencies.
+
+- Unit (`media-container.test.tsx`): assert the caption's DOM is not inside any `contenteditable=false` ancestor within
+  the node view, and that no ancestor between the caption and the node-view root is `draggable`. These are the two root
+  causes expressed as assertions, so they cannot silently regress.
+- E2E (`e2e/tests/image-caption.e2e.ts`): select a caption substring by keyboard and by mouse drag; assert a non-empty
+  PM `TextSelection` inside the image node; assert the toolbar appears; assert Copy Link emits the image block ID and
+  the expected offsets. Use `window.TEST_BLOCK_TOOL_CALLS` to read the emitted range.
+- Fixture blocks need a `revision` for fragment actions to appear at all — without it the referenceable-revision gate
+  hides them and a caption failure is meaningless. Add it to the harness fixture.
+
+**Phase 2 — The fix (0.5 day).** Depends on Phase 1.
+
+- The three bullets in Solution. Phase 1 tests go green.
+
+**Phase 3 — Media regression sweep (1 day).** Depends on Phase 2.
+
+- E2E over `fixture=allBlocks`: click-to-select for image, video, file, embed, web-embed; arrow traversal across media
+  nodes; Backspace/Delete removal; image and video resize handles; side-menu drag-handle reorder; media selection menu
+  replace/delete; URL input paste (must not reach editor-level paste handlers); file drop upload.
+- Caption behavior that already works and must keep working: typing, Enter navigation, Shift+Enter line break, clicking
+  the caption not producing a `NodeSelection`, clicking the media surface producing one.
+
+  Known **pre-existing** failures — confirmed identical on an unpatched tree, do not treat as regressions and do not fix
+  here: media-surface drag does not reorder the block, Enter inside a caption does not exit it, embed-card click selects
+  nothing. Video click selection is untestable in the current fixture (no source).
+
+**Phase 4 — Clipboard and SSR (1 day).** Depends on Phase 2, parallel with Phase 3.
+
+- Internal copy/paste of an image block with a caption, within one document and between two documents (two pages in one
+  browser context sharing the real clipboard; the fixtures already grant clipboard permissions and expose
+  `setClipboardHTML`/`paste`). Assert the caption survives and the destination block ID is regenerated.
+- External paste: `<img>` alone, and `<figure><img><figcaption>`. Today `handle-local-media-paste-plugin` intercepts the
+  first image source and uploads it, and no rule maps `figcaption` to the caption — so the caption is dropped. Write the
+  test to **document current behavior**; improving it is out of scope (see No Gos).
+- Copy and cut of caption text itself.
+- SSR (`ssr-render.test.tsx`): the relocation logic keys off `[data-node-view-content]` and does not read
+  `contenteditable`, so it should be unaffected — but assert it explicitly: caption text present, caption inside the
+  node-view content slot, `contenteditable` on the intended element only, and server structure matching the live harness
+  DOM.
+
+**Phase 5 — Mobile (1 day).** Depends on Phase 2.
+
+- CDP mobile emulation at 390×844, dsf 2, touch on. Long-press caption text; selection handles; range action bubble
+  appears and is tappable; soft keyboard opening and the resulting visual-viewport resize; caption Enter.
+- Real mouse dragging is unreliable under CDP mobile emulation — set the native DOM selection and the PM selection, then
+  dispatch `mouseup`, as documented in the testing-editor-harness skill.
+
+**Total: ~4 days**, of which ~3 are tests. Phases 3–5 can run in parallel once Phase 2 lands.
+
+### Gate for pushing to production
+
+All of Phase 1, 3, 4, and 5 green, plus one manual pass in the desktop app on a real published document: select caption
+text, apply a mark, copy a fragment link, paste it back, and confirm it resolves to the caption range. The harness does
+not cover the desktop shell, real publishing, or the real clipboard.
+
+### Harness testing guidance
+
+When testing highlight consumers in the harness, drive the plugin through the React props that the real editor uses
+(`focusBlockId`, `focusBlockRange`, and `citationFragmentHighlights`). Console-dispatched plugin metas such as
+`view.dispatch(tr.setMeta(blockHighlightPluginKey, ...))` are swallowed in this harness and are not a reliable
+substitute for the component path.
+
+The harness resets window scroll to `0` about a second after a scroll. Measure scroll targets synchronously after the
+navigation/scroll action; delayed assertions can observe the harness reset rather than the behavior under test.
+
+## Open gaps
+
+- [ ] Edit-mode caption selection and its two DOM root causes — see
+      [#925](https://github.com/seed-hypermedia/seed/issues/925)
+      (`docs/projects/image-caption-selection-issues/01-image-caption-selection-edit-mode.md`).
+- [ ] Author viewing their own published document enters edit mode instead of selecting a caption range — see
+      [#926](https://github.com/seed-hypermedia/seed/issues/926)
+      (`docs/projects/image-caption-selection-issues/02-image-caption-selection-own-published-doc.md`).
+- [ ] Collaboration/Yjs caption editing and range anchoring — see
+      [#927](https://github.com/seed-hypermedia/seed/issues/927)
+      (`docs/projects/image-caption-selection-issues/03-image-caption-collaboration.md`).
+- [ ] Image caption mark serialization round-trip — see [#928](https://github.com/seed-hypermedia/seed/issues/928)
+      (`docs/projects/image-caption-selection-issues/04-image-caption-marks-round-trip.md`).
+- [ ] Product decision and tests for cross-block selections around captions — see
+      [#929](https://github.com/seed-hypermedia/seed/issues/929)
+      (`docs/projects/image-caption-selection-issues/05-image-caption-cross-block-selection.md`).
+- [ ] Undo/redo, IME/composition, spellcheck, and screen-reader behavior — see
+      [#930](https://github.com/seed-hypermedia/seed/issues/930)
+      (`docs/projects/image-caption-selection-issues/06-image-caption-editing-edge-cases.md`).
+- [ ] Project owner, rollout plan, and estimate calibration — see
+      [#931](https://github.com/seed-hypermedia/seed/issues/931)
+      (`docs/projects/image-caption-selection-issues/07-image-caption-project-plan.md`).
+
+## Rabbit Holes
+
+- **Rewriting the schema to `figure`/`figcaption` or an ADF-style `caption` child node.** Tempting because it is what
+  the SOTA editors do, but Seed's `containsInlineContent: true` image already puts the caption in the document as inline
+  content. The bug is DOM wrapping, not schema. A schema change means a data migration and touches every serializer.
+- **Making external `<figcaption>` import into the caption.** A real gap, but it is a separate paste-mapping feature
+  with its own edge cases (multiple images, figure without img, nested figures). Document current behavior in Phase 4
+  and file it separately.
+- **Fixing the pre-existing failures found during diagnosis** — media-surface drag not reordering, Enter not exiting the
+  caption, embed-card click selecting nothing. They are real bugs but predate this work; bundling them makes the
+  regression sweep unreadable.
+- **Adding captions to video, file, or embed.** Only the image block has `containsInlineContent: true`. The others are
+  leaf nodes and adding inline content to them is a schema change, not a wrapping fix.
+- **Refactoring `BlockSelectionWrapper` generally.** It has explicit warnings about media mousedown/click ordering. Add
+  the narrow opt-out; do not restructure it.
+- **Generalizing the "editable island" fix across every node view.** Fix the media path that is broken and covered by
+  tests.
+
+## No Gos
+
+- No schema change, no data migration, no change to how captions serialize into `block.text` and annotations.
+- Do not remove `contentEditable={false}` from the media surface, the upload form, or any native control (file input,
+  URL input, buttons). Only the caption's ancestry changes.
+- Do not remove `data-media-container-ignore-select` or the `lastMousedownInCaption` guard.
+- Do not change read-only reader behavior — caption fragment selection already works there and must be byte-identical
+  after the fix.
+- Do not change fragment-action gating: blocks without a referenceable revision still show no fragment actions.
+- Do not ship on harness evidence alone. The desktop app, real publishing, and the real clipboard are untested by the
+  harness and require the manual pass above.
+- Do not land the fix without the Phase 1 tests demonstrably failing beforehand.

--- a/docs/query-block-filters.md
+++ b/docs/query-block-filters.md
@@ -1,0 +1,47 @@
+# Query Block Filters
+
+## Problem
+
+Query blocks can choose a directory, traversal mode, sort, and limit, but cannot narrow results by document attributes.
+The immediate need is filtering a query block to documents where a given account is one of the document authors.
+
+## Solution
+
+Store filters on the query object as `query.filters`, a sibling to `includes`, `sort`, and `limit`:
+
+```ts
+{
+  includes: [{space, path, mode}],
+  sort: [{term: 'UpdateTime', reverse: false}],
+  limit: 10,
+  filters: [
+    {type: 'Author', uid: '<account-id>'},
+  ],
+}
+```
+
+The shared query resolver fetches the directory, applies filters, then sorts and limits results. Author filters match if
+any stored author UID equals one of the requested account IDs.
+
+## Scope
+
+- Add `HMQueryFilter` schema/type support for `Author` filters.
+- Persist filters through query block editor props and HM block conversion.
+- Add editor controls for multi-select author account autocomplete by profile name.
+- Apply filters in shared query block resolution before sorting and limiting.
+- Cover persistence and resolver behavior with tests.
+
+## Rabbit Holes
+
+- Server-side filtering in `ListDirectory` for pagination-scale efficiency.
+- Multi-include query semantics.
+- Rich account picker/autocomplete for author selection.
+- Date filters, such as publish time, create time, update time, activity time, or exact timestamp source selection.
+- Complex boolean logic UI for nested AND/OR groups.
+
+## No Gos
+
+- Do not place filters inside `includes[]`; include entries remain only `{space, path, mode}`.
+- Do not add one-off top-level fields like `authorFilter`; use the generic `filters` array.
+- Do not store author profile names in filters; store selected account IDs only.
+- Do not change backend proto/API in this iteration unless query block pagination requires server-side filtering later.

--- a/frontend/apps/desktop/src/app-notifications.ts
+++ b/frontend/apps/desktop/src/app-notifications.ts
@@ -116,7 +116,6 @@ async function resolveNotifyHost(notifyServiceHost: string | undefined): Promise
   // same notify server the web vault and the UI use; fall back to the local
   // default (appStore / NOTIFY_SERVICE_HOST, seeded from the renderer).
   const host = explicit || vaultHost || fallback
-  log.error('🔔 NOTIFY resolveNotifyHost', {explicit: explicit ?? null, vaultHost, fallback, chosen: host ?? null})
   if (!host) {
     throw new Error('Notify service host is not configured')
   }
@@ -379,16 +378,7 @@ async function runSync(accountUid: string, notifyServiceHost?: string): Promise<
   const syncStart = Date.now()
 
   try {
-    const localConfigBefore = getOrCreateAccountState(accountUid).snapshot.config
     const remoteState = await getNotificationState(host, signer)
-    log.error('🔔 NOTIFY SYNC remote-state', {
-      accountUid,
-      host,
-      signingKeyName: signingKeyNameCache.get(accountUid) ?? '(unresolved)',
-      localBefore: {email: localConfigBefore.email, verifiedTime: localConfigBefore.verifiedTime},
-      remote: {email: remoteState.config.email, verifiedTime: remoteState.config.verifiedTime},
-      pendingActions: getOrCreateAccountState(accountUid).pendingActions.map((a) => a.type),
-    })
     updateAccountState(accountUid, (current) => ({
       ...current,
       snapshot: reduceNotificationStateActions(
@@ -401,13 +391,6 @@ async function runSync(accountUid: string, notifyServiceHost?: string): Promise<
       lastSyncAtMs: syncStart,
       lastSyncError: null,
     }))
-    log.error('🔔 NOTIFY SYNC after-reduce', {
-      accountUid,
-      config: {
-        email: getOrCreateAccountState(accountUid).snapshot.config.email,
-        verifiedTime: getOrCreateAccountState(accountUid).snapshot.config.verifiedTime,
-      },
-    })
 
     const pendingBeforeApply = getOrCreateAccountState(accountUid).pendingActions
     if (pendingBeforeApply.length > 0) {

--- a/frontend/apps/desktop/src/editor/query-block.tsx
+++ b/frontend/apps/desktop/src/editor/query-block.tsx
@@ -7,7 +7,7 @@ import {entityQueryPathToHmIdPath} from '@shm/shared'
 import {queryQueryBlock} from '@shm/shared/models/queries'
 import {useUniversalClient} from '@shm/shared/routing'
 import {EditorQueryBlock} from '@seed-hypermedia/client/editor-types'
-import {HMBlockQuery, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {HMBlockQuery, parseHMQueryFiltersJSON, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {useResource} from '@shm/shared/models/entity'
 import {NavRoute} from '@shm/shared/routes'
 import {hmId} from '@shm/shared/utils/entity-id-url'
@@ -26,9 +26,11 @@ import {Fragment} from '@tiptap/pm/model'
 import {NodeSelection, TextSelection} from 'prosemirror-state'
 import {FocusEvent, Profiler, useCallback, useEffect, useMemo, useState} from 'react'
 import {HMBlockSchema} from './schema'
+import {QueryAccountFilterInput} from '@shm/editor/query-account-filter-input'
 
 const defaultQueryIncludes = '[{"space":"","path":"","mode":"Children"}]'
 const defaultQuerySort = '[{"term":"UpdateTime","reverse":false}]'
+const defaultQueryFilters = '[]'
 
 export const QueryBlock = createReactBlockSpec({
   type: 'query',
@@ -49,6 +51,9 @@ export const QueryBlock = createReactBlockSpec({
     },
     querySort: {
       default: defaultQuerySort,
+    },
+    queryFilters: {
+      default: defaultQueryFilters,
     },
     banner: {
       default: 'false',
@@ -89,6 +94,10 @@ function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
     return JSON.parse(block.props.querySort || defaultQuerySort)
   }, [block.props.querySort])
 
+  const queryFilters: HMQueryBlockFilters = useMemo(() => {
+    return parseQueryFilters(block.props.queryFilters)
+  }, [block.props.queryFilters])
+
   const banner = useMemo(() => {
     return Boolean(block.props.banner == 'true')
   }, [block.props.banner])
@@ -104,9 +113,10 @@ function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
         includes: queryIncludes,
         sort: querySort,
         limit: queryLimit,
+        filters: queryFilters,
       },
     }
-  }, [queryIncludes, querySort, queryLimit])
+  }, [queryIncludes, querySort, queryLimit, queryFilters])
   const queryBlock = useQuery(queryQueryBlock(client, queryBlockInput))
   const sortedItems = queryBlock.data?.results ?? []
 
@@ -185,7 +195,7 @@ function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
         queryDocName={queryBlock.data?.queryTargetName || ''}
         queryIncludes={queryIncludes}
         querySort={querySort}
-        style={block.props.style as 'Card' | 'List'}
+        queryFilters={queryFilters}
         banner={banner}
         // @ts-expect-error
         block={block}
@@ -243,6 +253,11 @@ function BlankQueryBlockMessage({message}: {message: string}) {
 
 type HMQueryBlockIncludes = HMBlockQuery['attributes']['query']['includes']
 type HMQueryBlockSort = NonNullable<HMBlockQuery['attributes']['query']['sort']>
+type HMQueryBlockFilters = NonNullable<HMBlockQuery['attributes']['query']['filters']>
+
+function parseQueryFilters(rawFilters: string | undefined): HMQueryBlockFilters {
+  return parseHMQueryFiltersJSON(rawFilters || defaultQueryFilters)
+}
 
 function QuerySettings({
   queryDocName = '',
@@ -250,6 +265,7 @@ function QuerySettings({
   onValuesChange,
   queryIncludes,
   querySort,
+  queryFilters,
   editor,
   banner,
 }: {
@@ -257,6 +273,7 @@ function QuerySettings({
   block: EditorQueryBlock
   queryIncludes: HMQueryBlockIncludes
   querySort: HMQueryBlockSort
+  queryFilters: HMQueryBlockFilters
   banner: boolean
   onValuesChange: ({id, props}: {id: UnpackedHypermediaId | null; props: EditorQueryBlock['props']}) => void
   editor: BlockNoteEditor<HMBlockSchema>
@@ -265,6 +282,23 @@ function QuerySettings({
   const popoverState = usePopoverState(block.props.defaultOpen === 'true')
   const [limit, setLimit] = useState(!!block.props.queryLimit)
 
+  const authorFilters = queryFilters.filter((filter) => filter.type === 'Author')
+
+  const saveFilters = (filters: HMQueryBlockFilters) => {
+    const queryFilters = JSON.stringify(filters)
+    queueMicrotask(() => {
+      onValuesChange({
+        id: null,
+        props: {
+          queryFilters,
+        } as EditorQueryBlock['props'],
+      })
+    })
+  }
+
+  const updateAuthorFilters = (uids: string[]) => {
+    saveFilters(uids.map((uid) => ({type: 'Author' as const, uid})))
+  }
   return (
     <>
       <div
@@ -353,6 +387,11 @@ function QuerySettings({
                     value: 'AllDescendants',
                   },
                 ]}
+              />
+
+              <QueryAccountFilterInput
+                selectedUids={authorFilters.map((filter) => filter.uid)}
+                onSelectedUidsChange={updateAuthorFilters}
               />
 
               <SelectField

--- a/frontend/apps/desktop/src/models/blocks.ts
+++ b/frontend/apps/desktop/src/models/blocks.ts
@@ -143,6 +143,9 @@ function isQueryEqual(q1?: HMQuery, q2?: HMQuery): boolean {
   // Compare sorting arrays
   if (!isEqual(q1.sort || [], q2.sort || [])) return false
 
+  // Compare filters arrays
+  if (!isEqual(q1.filters || [], q2.filters || [])) return false
+
   // Compare includes arrays
   if (q1.includes.length !== q2.includes.length) return false
 

--- a/frontend/apps/desktop/src/models/notification-config.ts
+++ b/frontend/apps/desktop/src/models/notification-config.ts
@@ -27,25 +27,11 @@ export function useNotificationConfig(
   const enabled = !!accountUid && (options?.enabled ?? true)
   return useQuery({
     queryKey: [queryKeys.NOTIFICATION_CONFIG, notifyServiceHost, accountUid],
-    queryFn: async () => {
-      const result = await client.notificationConfig.getConfig.query({
+    queryFn: () =>
+      client.notificationConfig.getConfig.query({
         accountUid: accountUid!,
         notifyServiceHost,
-      })
-      // eslint-disable-next-line no-console
-      console.error(
-        '🔔 NOTIFY renderer getConfig ' +
-          JSON.stringify({
-            accountUid,
-            notifyServiceHost,
-            email: result.email,
-            verifiedTime: result.verifiedTime,
-            isNotifyServerConnected: result.isNotifyServerConnected,
-            syncError: result.syncError,
-          }),
-      )
-      return result
-    },
+      }),
     enabled,
     staleTime: 0,
     refetchOnMount: 'always',

--- a/frontend/packages/client/src/blocks-to-markdown.ts
+++ b/frontend/packages/client/src/blocks-to-markdown.ts
@@ -620,12 +620,14 @@ async function resolveQuery(block: HMBlock, depth: number, ctx: ResolveContext):
       | {
           includes?: Array<{space: string; path?: string; mode?: string}>
           sort?: Array<{term: SortTerm; reverse?: boolean}>
+          filters?: Array<{type: 'Author'; uid: string}>
           limit?: number
         }
       | undefined
 
     let includes: Array<{space: string; path?: string; mode: 'Children' | 'AllDescendants'}>
     let sort: Array<{term: SortTerm; reverse: boolean}> | undefined
+    let filters: Array<{type: 'Author'; uid: string}> | undefined
     let limit: number | undefined
 
     if (queryConfig?.includes) {
@@ -635,6 +637,7 @@ async function resolveQuery(block: HMBlock, depth: number, ctx: ResolveContext):
         mode: (inc.mode as 'Children' | 'AllDescendants') || 'Children',
       }))
       sort = queryConfig.sort?.map((s) => ({term: s.term, reverse: s.reverse ?? false}))
+      filters = queryConfig.filters
       limit = queryConfig.limit
     } else {
       const space = (attrs?.space as string) || ''
@@ -652,6 +655,7 @@ async function resolveQuery(block: HMBlock, depth: number, ctx: ResolveContext):
     const results = await ctx.client.request('Query', {
       includes,
       sort: sort || [{term: 'UpdateTime', reverse: true}],
+      filters,
       limit: limit || 10,
     })
 

--- a/frontend/packages/client/src/editor-types.ts
+++ b/frontend/packages/client/src/editor-types.ts
@@ -150,6 +150,7 @@ export type EditorQueryBlock = EditorBaseBlock & {
     queryLimit?: string
     queryIncludes?: string
     querySort?: string
+    queryFilters?: string
     banner?: 'true' | 'false'
   }
   content: Array<HMInlineContent>

--- a/frontend/packages/client/src/editorblock-to-hmblock.ts
+++ b/frontend/packages/client/src/editorblock-to-hmblock.ts
@@ -5,6 +5,7 @@ import {
   HMBlockButtonAlignmentSchema,
   type HMBlockNode,
   HMBlockSchema,
+  parseHMQueryFiltersJSON,
   type HMBlockType,
   toNumber,
 } from './hm-types'
@@ -326,12 +327,15 @@ export function editorBlockToHMBlock(editorBlock: EditorBlock): HMBlock {
   if (blockQuery && editorBlock.type == 'query') {
     blockQuery.attributes.style = editorBlock.props.style
     blockQuery.attributes.columnCount = Number(editorBlock.props.columnCount)
-    const query: {includes: unknown[]; sort: unknown[]; limit?: number} = {
+    const query: {includes: unknown[]; sort: unknown[]; filters?: unknown[]; limit?: number} = {
       includes: [],
       sort: [],
     }
     if (editorBlock.props.queryIncludes) query.includes = JSON.parse(editorBlock.props.queryIncludes)
     if (editorBlock.props.querySort) query.sort = JSON.parse(editorBlock.props.querySort)
+    if (editorBlock.props.queryFilters) {
+      query.filters = parseHMQueryFiltersJSON(editorBlock.props.queryFilters)
+    }
     if (editorBlock.props.queryLimit) query.limit = Number(editorBlock.props.queryLimit)
     blockQuery.attributes.query = query
     blockQuery.attributes.banner = editorBlock.props.banner == 'true'

--- a/frontend/packages/client/src/hm-types.ts
+++ b/frontend/packages/client/src/hm-types.ts
@@ -783,6 +783,41 @@ export const HMQuerySortSchema = z.object({
 })
 export type HMQuerySort = z.infer<typeof HMQuerySortSchema>
 
+export const HMQueryFilterSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('Author'),
+    uid: z.string(),
+  }),
+])
+export type HMQueryFilter = z.infer<typeof HMQueryFilterSchema>
+
+/** Returns only query filters supported by this client, dropping malformed or future filter types. */
+export function getSupportedHMQueryFilters(val: unknown): HMQueryFilter[] {
+  if (!Array.isArray(val)) return []
+  return val.filter(
+    (filter): filter is HMQueryFilter =>
+      filter !== null &&
+      typeof filter === 'object' &&
+      (filter as {type?: unknown}).type === 'Author' &&
+      typeof (filter as {uid?: unknown}).uid === 'string',
+  )
+}
+
+/** Parses stored query filter JSON, returning an empty list for invalid or unsupported payloads. */
+export function parseHMQueryFiltersJSON(rawFilters: string | undefined): HMQueryFilter[] {
+  if (!rawFilters) return []
+  try {
+    return getSupportedHMQueryFilters(JSON.parse(rawFilters))
+  } catch {
+    return []
+  }
+}
+
+function removeUnsupportedQueryFilters(val: unknown) {
+  if (val === undefined) return undefined
+  return getSupportedHMQueryFilters(val)
+}
+
 export const HMQuerySchema = z.object({
   includes: z.array(HMQueryInclusionSchema),
   sort: z.array(HMQuerySortSchema).optional(),
@@ -790,6 +825,7 @@ export const HMQuerySchema = z.object({
     (val) => (val === '' || val === null || val === undefined ? undefined : val),
     z.coerce.number().optional(),
   ),
+  filters: z.preprocess(removeUnsupportedQueryFilters, z.array(HMQueryFilterSchema).optional()),
 })
 export type HMQuery = z.infer<typeof HMQuerySchema>
 

--- a/frontend/packages/client/src/hmblock-to-editorblock.ts
+++ b/frontend/packages/client/src/hmblock-to-editorblock.ts
@@ -9,6 +9,7 @@ import type {
   MediaBlockProps,
 } from './editor-types'
 import {
+  getSupportedHMQueryFilters,
   isSurrogate,
   type HMAnnotation,
   type HMBlock,
@@ -231,6 +232,7 @@ export function hmBlockToEditorBlock(block: HMBlock): EditorBlock {
     queryProps.columnCount = String(block.attributes?.columnCount || '')
     queryProps.queryIncludes = JSON.stringify(block.attributes?.query?.includes || [])
     queryProps.querySort = JSON.stringify(block.attributes?.query?.sort || {})
+    queryProps.queryFilters = JSON.stringify(getSupportedHMQueryFilters(block.attributes?.query?.filters))
     queryProps.banner = block.attributes?.banner ? 'true' : 'false'
     queryProps.queryLimit = String(block.attributes?.query?.limit || '')
   }

--- a/frontend/packages/editor/e2e/tests/image-caption.e2e.ts
+++ b/frontend/packages/editor/e2e/tests/image-caption.e2e.ts
@@ -2,6 +2,120 @@ import {expect, test} from './fixtures'
 
 test.use({clipboardPermissions: false})
 
+async function insertImageBlock(page: any, name: string) {
+  await page.evaluate((fileName: string) => {
+    const editor = window.TEST_EDITOR?.editor
+    const firstBlock = editor?.topLevelBlocks?.[0]
+    if (!editor || !firstBlock) throw new Error('Editor not ready')
+
+    editor.insertBlocks(
+      [
+        {
+          type: 'image',
+          props: {
+            url: 'data:image/gif;base64,R0lGODlhAQABAAAAACw=',
+            name: fileName,
+            alt: 'Caption test image',
+          },
+          content: [],
+        },
+      ],
+      firstBlock.id,
+      'after',
+    )
+  }, name)
+}
+
+/**
+ * The ProseMirror selection, resolved against the block it belongs to — the
+ * same shape the fragment actions read when they build `#blockId[start:end]`.
+ */
+async function getSelectionInfo(page: any) {
+  return page.evaluate(() => {
+    const view = (window.TEST_EDITOR?.editor as any)?._tiptapEditor?.view
+    if (!view) throw new Error('tiptap view not found')
+    const {from, to, empty} = view.state.selection
+    let blockId: string | null = null
+    let blockType: string | null = null
+    view.state.doc.nodesBetween(from, to, (node: any) => {
+      if (node.type.name !== 'blockNode' || blockId) return true
+      blockId = node.attrs?.id ?? null
+      blockType = node.firstChild?.type?.name ?? null
+      return true
+    })
+    return {empty, text: view.state.doc.textBetween(from, to), hasFocus: view.hasFocus(), blockId, blockType}
+  })
+}
+
+test.describe('Image caption selection', () => {
+  test.use({editorEditMode: true})
+
+  test('selects caption text with the keyboard and shows the formatting toolbar', async ({editorHelpers, page}) => {
+    await insertImageBlock(page, 'caption-keyboard.gif')
+
+    const caption = page.locator('.image-caption').first()
+    await expect(caption).toBeVisible()
+    await caption.click()
+    await page.keyboard.type('Caption words')
+
+    await page.keyboard.press('Home')
+    for (let i = 0; i < 7; i++) await page.keyboard.press('Shift+ArrowRight')
+    await page.waitForTimeout(100)
+
+    const selection = await getSelectionInfo(page)
+    expect(selection.hasFocus).toBe(true)
+    expect(selection.empty).toBe(false)
+    expect(selection.text).toBe('Caption')
+    expect(selection.blockType).toBe('image')
+
+    await expect(page.getByTestId('formatting-toolbar')).toBeVisible()
+  })
+
+  test('selects caption text by dragging with the mouse', async ({editorHelpers, page}) => {
+    await insertImageBlock(page, 'caption-mouse.gif')
+
+    const caption = page.locator('.image-caption').first()
+    await expect(caption).toBeVisible()
+    await caption.click()
+    await page.keyboard.type('Caption words')
+    await page.waitForTimeout(100)
+
+    const box = await caption.boundingBox()
+    if (!box) throw new Error('Caption has no bounding box')
+    await page.mouse.move(box.x + 2, box.y + box.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(box.x + box.width - 2, box.y + box.height / 2, {steps: 10})
+    await page.mouse.up()
+    await page.waitForTimeout(100)
+
+    const selection = await getSelectionInfo(page)
+    expect(selection.empty).toBe(false)
+    expect(selection.text.length).toBeGreaterThan(0)
+    expect('Caption words').toContain(selection.text)
+    expect(selection.blockType).toBe('image')
+  })
+
+  test('applies bold to a caption selection', async ({editorHelpers, page}) => {
+    await insertImageBlock(page, 'caption-bold.gif')
+
+    const caption = page.locator('.image-caption').first()
+    await expect(caption).toBeVisible()
+    await caption.click()
+    await page.keyboard.type('Bold caption')
+
+    await page.keyboard.press('Home')
+    await page.keyboard.press('Shift+ControlOrMeta+ArrowRight')
+    await page.waitForTimeout(100)
+    await page.keyboard.press('ControlOrMeta+B')
+    await page.waitForTimeout(100)
+
+    const blocks = await editorHelpers.getAllBlocks()
+    const imageBlock = blocks.find((block: any) => block.type === 'image')
+    expect(imageBlock.content[0]).toMatchObject({text: 'Bold', styles: {bold: true}})
+    expect(imageBlock.content[1]).toMatchObject({text: ' caption'})
+  })
+})
+
 test.describe('Image caption editing', () => {
   test('keeps the cursor in the caption and preserves the image when typing below it', async ({
     editorHelpers,
@@ -40,6 +154,47 @@ test.describe('Image caption editing', () => {
     const imageBlock = blocks.find((block: any) => block.type === 'image')
     expect(imageBlock).toBeTruthy()
     expect(imageBlock.content).toEqual([{type: 'text', text: 'A visible caption', styles: {}}])
+  })
+
+  test('creates a paragraph below the image on Enter when the image is the last block', async ({
+    editorHelpers,
+    page,
+  }) => {
+    await page.evaluate(() => {
+      const editor = window.TEST_EDITOR?.editor
+      const blocks = editor?.topLevelBlocks
+      const lastBlock = blocks?.[blocks.length - 1]
+      if (!editor || !lastBlock) throw new Error('Editor not ready')
+
+      editor.insertBlocks(
+        [
+          {
+            type: 'image',
+            props: {
+              url: 'data:image/gif;base64,R0lGODlhAQABAAAAACw=',
+              name: 'caption-last-block.gif',
+              alt: 'Caption last block image',
+            },
+            content: [],
+          },
+        ],
+        lastBlock.id,
+        'after',
+      )
+    })
+
+    const caption = page.locator('.image-caption').first()
+    await expect(caption).toBeVisible()
+    await caption.click()
+    await page.keyboard.type('Trailing caption')
+    await page.keyboard.press('Enter')
+    await page.keyboard.type('New paragraph')
+
+    const blocks = await editorHelpers.getAllBlocks()
+    const imageIndex = blocks.findIndex((block: any) => block.type === 'image')
+    expect(blocks[imageIndex].content).toEqual([{type: 'text', text: 'Trailing caption', styles: {}}])
+    expect(blocks[imageIndex + 1].type).toBe('paragraph')
+    expect(blocks[imageIndex + 1].content).toEqual([{type: 'text', text: 'New paragraph', styles: {}}])
   })
 
   test('moves from the caption to the next block on Enter', async ({editorHelpers, page}) => {

--- a/frontend/packages/editor/e2e/tests/image-caption.e2e.ts
+++ b/frontend/packages/editor/e2e/tests/image-caption.e2e.ts
@@ -197,6 +197,65 @@ test.describe('Image caption editing', () => {
     expect(blocks[imageIndex + 1].content).toEqual([{type: 'text', text: 'New paragraph', styles: {}}])
   })
 
+  test('selects the next block as a node on Enter when it has no text to hold a cursor', async ({
+    editorHelpers,
+    page,
+  }) => {
+    await page.evaluate(() => {
+      const editor = window.TEST_EDITOR?.editor
+      const firstBlock = editor?.topLevelBlocks?.[0]
+      if (!editor || !firstBlock) throw new Error('Editor not ready')
+
+      editor.insertBlocks(
+        [
+          {
+            type: 'image',
+            props: {
+              url: 'data:image/gif;base64,R0lGODlhAQABAAAAACw=',
+              name: 'caption-before-file.gif',
+              alt: 'Caption before file image',
+            },
+            content: [],
+          },
+          {
+            type: 'file',
+            props: {url: 'ipfs://bafyfile', name: 'attachment.pdf', size: '1024'},
+            content: [],
+          },
+        ],
+        firstBlock.id,
+        'after',
+      )
+    })
+
+    const errors: string[] = []
+    page.on('pageerror', (error: Error) => errors.push(error.message))
+
+    const blocksBefore = await editorHelpers.getAllBlocks()
+
+    const caption = page.locator('.image-caption').first()
+    await expect(caption).toBeVisible()
+    await caption.click()
+    await page.keyboard.type('Caption before a file')
+    await page.keyboard.press('Enter')
+    await page.waitForTimeout(100)
+
+    const selection = await page.evaluate(() => {
+      const view = (window.TEST_EDITOR?.editor as any)?._tiptapEditor?.view
+      const {selection: sel} = view.state
+      return {isNodeSelection: Boolean((sel as any).node), nodeType: (sel as any).node?.type?.name ?? null}
+    })
+    expect(selection.isNodeSelection).toBe(true)
+    expect(selection.nodeType).toBe('file')
+    expect(errors).toEqual([])
+
+    const blocksAfter = await editorHelpers.getAllBlocks()
+    expect(blocksAfter.length).toBe(blocksBefore.length)
+    const imageIndex = blocksAfter.findIndex((block: any) => block.type === 'image')
+    expect(blocksAfter[imageIndex].content).toEqual([{type: 'text', text: 'Caption before a file', styles: {}}])
+    expect(blocksAfter[imageIndex + 1].type).toBe('file')
+  })
+
   test('moves from the caption to the next block on Enter', async ({editorHelpers, page}) => {
     await page.evaluate(() => {
       const editor = window.TEST_EDITOR?.editor

--- a/frontend/packages/editor/src/block-selection-wrapper.tsx
+++ b/frontend/packages/editor/src/block-selection-wrapper.tsx
@@ -60,6 +60,7 @@ export function BlockSelectionWrapper({
   onSelectionChange,
   selectOnMouseDown,
   onSelectMouseDown,
+  keepEditable,
 }: {
   editor: BlockNoteEditor<HMBlockSchema>
   block: Block<HMBlockSchema>
@@ -86,6 +87,16 @@ export function BlockSelectionWrapper({
    * capture handler has already selected the block.
    */
   onSelectMouseDown?: (wasSelected: boolean) => void
+  /**
+   * Opt out of the non-editable wrapper for blocks that render editable
+   * inline content (image captions). A ProseMirror view manages a single
+   * contenteditable range, so a `contenteditable=false` ancestor makes the
+   * caption its own editing host: `view.hasFocus()` stays false and every
+   * caption selection is discarded, which breaks range selection and the
+   * fragment actions built on it. The media surface itself stays
+   * non-editable, so click-to-select is unaffected.
+   */
+  keepEditable?: boolean
 }) {
   const selected = useIsBlockSelected(editor, block)
   useEffect(() => {
@@ -107,7 +118,7 @@ export function BlockSelectionWrapper({
 
   return (
     <div
-      contentEditable={false}
+      contentEditable={keepEditable ? undefined : false}
       className={cn(className, selected && 'bn-media-selected')}
       onMouseDownCapture={selectOnMouseDown ? handleMouseDownCapture : undefined}
     >

--- a/frontend/packages/editor/src/blocknote/core/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
@@ -438,9 +438,12 @@ export const KeyboardShortcutsExtension = Extension.create<{
             if (!dispatch) return true
 
             const afterPos = blockInfo.block.afterPos
-            const nextTextPos = TextSelection.near(state.doc.resolve(afterPos), 1).from
-            if (nextTextPos > afterPos) {
-              tr.setSelection(TextSelection.create(tr.doc, nextTextPos))
+            // `near` returns a NodeSelection when the next block is an atom
+            // (video, file, embed), so it is used as-is instead of being
+            // rewrapped into a TextSelection that has no textblock to live in.
+            const nextSelection = TextSelection.near(state.doc.resolve(afterPos), 1)
+            if (nextSelection.from > afterPos) {
+              tr.setSelection(nextSelection)
             } else {
               // The image is the last block: Enter appends a paragraph to type in.
               const {blockNode, paragraph} = state.schema.nodes

--- a/frontend/packages/editor/src/blocknote/core/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
@@ -428,15 +428,28 @@ export const KeyboardShortcutsExtension = Extension.create<{
 
     const handleEnter = () =>
       this.editor.commands.first(({commands}) => [
-        // When the cursor is inside an image caption, let the React
-        // handler manage Enter behavior — do not create or split blocks.
+        // An image caption is inline content of the image block, so Enter must
+        // never split or create a block there: it moves the cursor to the next
+        // block instead, appending an empty paragraph when the image is last.
         () =>
-          commands.command(({state}) => {
+          commands.command(({state, tr, dispatch}) => {
             const blockInfo = getBlockInfoFromSelection(state)
-            if (blockInfo.blockContentType === 'image' && !(state.selection instanceof NodeSelection)) {
-              return true
+            if (blockInfo.blockContentType !== 'image' || state.selection instanceof NodeSelection) return false
+            if (!dispatch) return true
+
+            const afterPos = blockInfo.block.afterPos
+            const nextTextPos = TextSelection.near(state.doc.resolve(afterPos), 1).from
+            if (nextTextPos > afterPos) {
+              tr.setSelection(TextSelection.create(tr.doc, nextTextPos))
+            } else {
+              // The image is the last block: Enter appends a paragraph to type in.
+              const {blockNode, paragraph} = state.schema.nodes
+              if (!blockNode || !paragraph) return true
+              tr.insert(afterPos, blockNode.create(null, paragraph.create()))
+              tr.setSelection(TextSelection.create(tr.doc, afterPos + 2))
             }
-            return false
+            tr.scrollIntoView()
+            return true
           }),
         // Add a block on top of the current one, if the block is not
         // empty and the selection is at the start of that block,

--- a/frontend/packages/editor/src/blocknote/react/ReactBlockSpec.test.ts
+++ b/frontend/packages/editor/src/blocknote/react/ReactBlockSpec.test.ts
@@ -1,0 +1,44 @@
+import {Schema} from 'prosemirror-model'
+import {describe, expect, it} from 'vitest'
+import {getBlockNodeFromPos} from './block-node-position'
+
+const schema = new Schema({
+  nodes: {
+    doc: {
+      content: 'blockNode+',
+    },
+    blockNode: {
+      group: 'blockNodeChild',
+      attrs: {
+        id: {default: ''},
+      },
+      content: 'block',
+      toDOM: () => ['div', {'data-node-type': 'blockNode'}, 0],
+    },
+    query: {
+      group: 'block',
+      content: 'text*',
+      attrs: {
+        queryFilters: {default: '[]'},
+      },
+      toDOM: () => ['div', {'data-content-type': 'query'}, 0],
+    },
+    text: {
+      group: 'inline',
+    },
+  },
+})
+
+const doc = schema.node('doc', null, [
+  schema.node('blockNode', {id: 'query-block'}, [schema.node('query', {queryFilters: '[]'}, schema.text('x'))]),
+])
+
+describe('getBlockNodeFromPos', () => {
+  it('finds the containing block when the position points at the first block node', () => {
+    expect(getBlockNodeFromPos(doc, 0)?.attrs.id).toBe('query-block')
+  })
+
+  it('finds the containing block when the position resolves inside block content', () => {
+    expect(getBlockNodeFromPos(doc, 2)?.attrs.id).toBe('query-block')
+  })
+})

--- a/frontend/packages/editor/src/blocknote/react/ReactBlockSpec.tsx
+++ b/frontend/packages/editor/src/blocknote/react/ReactBlockSpec.tsx
@@ -16,6 +16,7 @@ import {createTipTapBlock} from '../core/extensions/Blocks/api/block'
 import {TagParseRule} from '@tiptap/pm/model'
 import {NodeViewContent, NodeViewProps, NodeViewWrapper, ReactNodeViewRenderer} from '@tiptap/react'
 import {createContext, ElementType, FC, HTMLProps, useContext} from 'react'
+import {getBlockNodeFromPos} from './block-node-position'
 
 // extend BlockConfig but use a React render function
 export type ReactBlockConfig<
@@ -111,17 +112,19 @@ export function createReactBlockSpec<
         // Gets position of the node
         const pos = typeof props.getPos === 'function' ? props.getPos() : undefined
 
-        if (!pos) return null
+        if (pos == null) return null
         // Gets TipTap editor instance
         const tipTapEditor = editor._tiptapEditor
         // Gets parent blockNode node
 
-        const blockNode = tipTapEditor.state.doc.resolve(pos!).node()
+        const blockNode = getBlockNodeFromPos(tipTapEditor.state.doc, pos)
+        if (!blockNode) return null
 
         // Gets block identifier
         const blockIdentifier = blockNode.attrs.id
         // Get the block
-        const block = editor.getBlock(blockIdentifier)!
+        const block = editor.getBlock(blockIdentifier)
+        if (!block) return null
         if (block.type !== blockConfig.type) {
           throw new Error('Block type does not match')
         }

--- a/frontend/packages/editor/src/blocknote/react/block-node-position.ts
+++ b/frontend/packages/editor/src/blocknote/react/block-node-position.ts
@@ -1,0 +1,17 @@
+import {Node as PMNode} from '@tiptap/pm/model'
+
+/**
+ * Returns the BlockNote wrapper node for a ProseMirror position inside a block.
+ */
+export function getBlockNodeFromPos(doc: PMNode, pos: number): PMNode | undefined {
+  const nodeAtPos = doc.nodeAt(pos)
+  if (nodeAtPos?.type.name === 'blockNode') return nodeAtPos
+
+  const resolvedPos = doc.resolve(pos)
+  for (let depth = resolvedPos.depth; depth >= 0; depth--) {
+    const node = resolvedPos.node(depth)
+    if (node.type.name === 'blockNode') return node
+  }
+
+  return undefined
+}

--- a/frontend/packages/editor/src/media-container.test.tsx
+++ b/frontend/packages/editor/src/media-container.test.tsx
@@ -138,6 +138,43 @@ describe('MediaContainer image caption', () => {
     expect(caption.getAttribute('contentEditable')).toBe('true')
   })
 
+  it('is not nested inside a non-editable ancestor', () => {
+    editorGate.canEdit = true
+    editorGate.isEditing = true
+    const caption = renderImageContainer(makeEditor(true))
+
+    for (let el = caption.parentElement; el && el !== container; el = el.parentElement) {
+      expect(el.getAttribute('contentEditable')).not.toBe('false')
+    }
+  })
+
+  it('is not nested inside a draggable ancestor', () => {
+    editorGate.canEdit = true
+    editorGate.isEditing = true
+    const caption = renderImageContainer(makeEditor(true))
+
+    for (let el = caption.parentElement; el && el !== container; el = el.parentElement) {
+      expect(el.getAttribute('draggable')).not.toBe('true')
+    }
+  })
+
+  it('keeps the media surface non-editable and draggable', () => {
+    editorGate.canEdit = true
+    editorGate.isEditing = true
+    const editor = makeEditor(true, true)
+    act(() => {
+      root.render(
+        <MediaContainer editor={editor} block={makeBlock()} mediaType="image" assign={() => {}}>
+          <div data-testid="media-child" />
+        </MediaContainer>,
+      )
+    })
+
+    const surface = (container.querySelector('[data-testid="media-child"]') as HTMLElement).parentElement!
+    expect(surface.getAttribute('contentEditable')).toBe('false')
+    expect(surface.getAttribute('draggable')).toBe('true')
+  })
+
   it('does not select the image block when the caption is clicked', () => {
     editorGate.canEdit = true
     editorGate.isEditing = true
@@ -205,61 +242,6 @@ describe('MediaContainer image caption', () => {
     expect(editor.__view.state.selection instanceof MultipleNodeSelection).toBe(true)
     const selection = editor.__view.state.selection as MultipleNodeSelection
     expect(selection.nodes.map((node) => node.attrs.id)).toEqual(['block-1', 'block-2', 'block-3'])
-  })
-
-  it('moves to the next block when Enter is pressed in the image caption', () => {
-    editorGate.canEdit = true
-    editorGate.isEditing = true
-    const editor = makeEditor(true)
-    const caption = renderImageContainer(editor)
-
-    const event = new KeyboardEvent('keydown', {key: 'Enter', bubbles: true, cancelable: true})
-    act(() => {
-      caption.dispatchEvent(event)
-    })
-
-    expect(event.defaultPrevented).toBe(true)
-    expect(editor.setTextCursorPosition).toHaveBeenCalledWith({id: 'block-2'}, 'start')
-    expect(editor.insertBlocks).not.toHaveBeenCalled()
-    expect(editor.focus).toHaveBeenCalledOnce()
-  })
-
-  it('creates a paragraph below the image when Enter is pressed in the last image caption', () => {
-    editorGate.canEdit = true
-    editorGate.isEditing = true
-    const editor = makeEditor(true)
-    const insertedBlock = {id: 'inserted-block'}
-    editor.getTextCursorPosition
-      .mockReturnValueOnce({block: {id: 'block-1'}, nextBlock: undefined})
-      .mockReturnValueOnce({block: {id: 'block-1'}, nextBlock: insertedBlock})
-    const caption = renderImageContainer(editor)
-
-    const event = new KeyboardEvent('keydown', {key: 'Enter', bubbles: true, cancelable: true})
-    act(() => {
-      caption.dispatchEvent(event)
-    })
-
-    expect(event.defaultPrevented).toBe(true)
-    expect(editor.insertBlocks).toHaveBeenCalledWith([{type: 'paragraph', content: ''}], 'block-1', 'after')
-    expect(editor.setTextCursorPosition).toHaveBeenCalledWith(insertedBlock, 'start')
-    expect(editor.focus).toHaveBeenCalledOnce()
-  })
-
-  it('lets Shift+Enter create a line break in the image caption', () => {
-    editorGate.canEdit = true
-    editorGate.isEditing = true
-    const editor = makeEditor(true)
-    const caption = renderImageContainer(editor)
-
-    const event = new KeyboardEvent('keydown', {key: 'Enter', shiftKey: true, bubbles: true, cancelable: true})
-    act(() => {
-      caption.dispatchEvent(event)
-    })
-
-    expect(event.defaultPrevented).toBe(false)
-    expect(editor.setTextCursorPosition).not.toHaveBeenCalled()
-    expect(editor.insertBlocks).not.toHaveBeenCalled()
-    expect(editor.focus).not.toHaveBeenCalled()
   })
 
   it('does not render copy or comment actions inside the media selection menu', () => {

--- a/frontend/packages/editor/src/media-container.tsx
+++ b/frontend/packages/editor/src/media-container.tsx
@@ -311,26 +311,6 @@ export const MediaContainer = ({
     view.focus()
   }
 
-  const handleImageCaptionKeyDown = (event: React.KeyboardEvent<ElementType>) => {
-    if (event.key !== 'Enter' || event.shiftKey) return
-
-    event.preventDefault()
-    event.stopPropagation()
-
-    const cursorPosition = editor.getTextCursorPosition()
-    if (cursorPosition.block.id !== block.id) return
-
-    if (cursorPosition.nextBlock) {
-      editor.setTextCursorPosition(cursorPosition.nextBlock, 'start')
-    } else {
-      editor.insertBlocks([{type: 'paragraph', content: ''}], block.id, 'after')
-      const nextBlock = editor.getTextCursorPosition().nextBlock
-      if (nextBlock) editor.setTextCursorPosition(nextBlock, 'start')
-    }
-
-    editor.focus()
-  }
-
   const mediaProps = {
     ...styleProps,
     ...(isEmbed || !canAuthor ? {} : dragProps),
@@ -352,21 +332,6 @@ export const MediaContainer = ({
       //   'relative flex w-full flex-col gap-2 self-center',
       //   mediaType === 'file' ? 'items-stretch' : 'items-center',
       // )}
-      draggable={canAuthor ? 'true' : 'false'}
-      onDragStart={(e: any) => {
-        // Uncomment to allow drag only if block is selected
-        // if (!selected) {
-        //   e.preventDefault()
-        //   return
-        // }
-        e.stopPropagation()
-        beginEditIfNeeded()
-        editor.sideMenu!.blockDragStart(e)
-      }}
-      onDragEnd={(e: any) => {
-        e.stopPropagation()
-        editor.sideMenu!.blockDragEnd()
-      }}
       onClick={
         onPress
           ? (e) => {
@@ -409,6 +374,19 @@ export const MediaContainer = ({
         style={{width}}
         {...mediaProps}
         contentEditable={false}
+        // Block dragging lives on the media surface, never on the wrapper: an
+        // image's caption is a sibling of this element and a draggable
+        // ancestor would turn caption text drags into native drags.
+        draggable={canAuthor ? 'true' : 'false'}
+        onDragStart={(e: any) => {
+          e.stopPropagation()
+          beginEditIfNeeded()
+          editor.sideMenu!.blockDragStart(e)
+        }}
+        onDragEnd={(e: any) => {
+          e.stopPropagation()
+          editor.sideMenu!.blockDragEnd()
+        }}
       >
         {mediaType !== 'embed' && editor.renderType !== 'viewer' && canEdit && (mediaType !== 'file' || isEditing) && (
           <>
@@ -458,7 +436,6 @@ export const MediaContainer = ({
           className="image-caption"
           contentEditable={editor.isEditable}
           data-media-container-ignore-select
-          onKeyDown={handleImageCaptionKeyDown}
         />
       )}
     </div>

--- a/frontend/packages/editor/src/media-render.tsx
+++ b/frontend/packages/editor/src/media-render.tsx
@@ -157,7 +157,7 @@ export const MediaRender: React.FC<RenderProps> = ({
   }
 
   return (
-    <BlockSelectionWrapper editor={editor} block={block}>
+    <BlockSelectionWrapper editor={editor} block={block} keepEditable={mediaType === 'image'}>
       <div className="flex w-full flex-col">
         {hideForm ? (
           <MediaComponent block={block} editor={editor} assign={assignMedia} DisplayComponent={DisplayComponent} />

--- a/frontend/packages/editor/src/query-account-filter-input.tsx
+++ b/frontend/packages/editor/src/query-account-filter-input.tsx
@@ -1,0 +1,93 @@
+import {HMMetadataPayload} from '@seed-hypermedia/client/hm-types'
+import {useRootDocuments} from '@shm/shared/models/entity'
+import {abbreviateUid} from '@shm/shared/utils/abbreviate'
+import {hmId} from '@shm/shared/utils/entity-id-url'
+import {AccountSearchResult, AccountTagInput, AccountTagInputItem} from '@shm/ui/account-tag-input'
+import {SizableText} from '@shm/ui/text'
+import {useMemo, useState} from 'react'
+
+type QueryAccountFilterInputProps = {
+  selectedUids: string[]
+  onSelectedUidsChange: (uids: string[]) => void
+}
+
+function accountLabel(account: HMMetadataPayload | undefined, uid: string) {
+  return account?.metadata?.name || abbreviateUid(uid)
+}
+
+function accountToResult(account: HMMetadataPayload): AccountSearchResult {
+  return {
+    id: account.id,
+    label: accountLabel(account, account.id.uid),
+    metadata: account.metadata ?? undefined,
+  }
+}
+
+export function QueryAccountFilterInput({selectedUids, onSelectedUidsChange}: QueryAccountFilterInputProps) {
+  const [search, setSearch] = useState('')
+  const accounts = useRootDocuments()
+  const accountByUid = useMemo(() => {
+    return new Map((accounts.data?.accounts ?? []).map((account) => [account.id.uid, account]))
+  }, [accounts.data?.accounts])
+  const selectedUidSet = useMemo(() => new Set(selectedUids), [selectedUids])
+  const searchTerm = search.trim().toLowerCase()
+
+  const selectedAccounts = useMemo<AccountSearchResult[]>(() => {
+    return selectedUids.map((uid) => {
+      const account = accountByUid.get(uid)
+      if (account) return accountToResult(account)
+      return {id: hmId(uid), label: abbreviateUid(uid)}
+    })
+  }, [accountByUid, selectedUids])
+
+  const matches = useMemo(() => {
+    if (!searchTerm) return []
+    return (accounts.data?.accounts ?? [])
+      .filter((account) => {
+        if (selectedUidSet.has(account.id.uid)) return false
+        const name = account.metadata?.name?.toLowerCase() ?? ''
+        return name.includes(searchTerm)
+      })
+      .sort((a, b) =>
+        accountLabel(a, a.id.uid).localeCompare(accountLabel(b, b.id.uid), undefined, {sensitivity: 'base'}),
+      )
+      .slice(0, 8)
+      .map(accountToResult)
+  }, [accounts.data?.accounts, searchTerm, selectedUidSet])
+
+  return (
+    <div className="flex flex-col gap-1">
+      <SizableText size="sm" color="muted">
+        Author accounts
+      </SizableText>
+      <div className="border-border bg-background rounded-md border">
+        <AccountTagInput
+          label="Author accounts"
+          value={search}
+          onChange={setSearch}
+          values={selectedAccounts}
+          onValuesChange={(values) => onSelectedUidsChange(values.map((value) => value.id.uid))}
+          placeholder={selectedUids.length ? 'Add author…' : 'Search profile name…'}
+        >
+          {matches.map((account) => (
+            <AccountTagInputItem
+              key={account.id.uid}
+              account={account}
+              onClick={() => {
+                onSelectedUidsChange([...selectedUids, account.id.uid])
+                setSearch('')
+              }}
+            >
+              Add &quot;{account.label}&quot;
+            </AccountTagInputItem>
+          ))}
+          {searchTerm && !matches.length ? (
+            <div className="text-muted-foreground px-3 py-2 text-sm">
+              {accounts.isLoading ? 'Searching accounts…' : 'No accounts match that profile name.'}
+            </div>
+          ) : null}
+        </AccountTagInput>
+      </div>
+    </div>
+  )
+}

--- a/frontend/packages/editor/src/query-block-input.ts
+++ b/frontend/packages/editor/src/query-block-input.ts
@@ -9,18 +9,21 @@
 
 export const defaultQueryIncludes = '[{"space":"","path":"","mode":"Children"}]'
 export const defaultQuerySort = '[{"term":"UpdateTime","reverse":false}]'
+export const defaultQueryFilters = '[]'
 
 export type QueryBlockInputProps = {
   queryIncludes?: string
   querySort?: string
   queryLimit?: string
+  queryFilters?: string
 }
 
 export function getQueryBlockInput(
   props: QueryBlockInputProps,
-): {query: {includes: any[]; sort: any; limit: number | undefined}} | null {
+): {query: {includes: any[]; sort: any; limit: number | undefined; filters: any[]}} | null {
   const queryIncludes = JSON.parse(props.queryIncludes || defaultQueryIncludes)
   const querySort = JSON.parse(props.querySort || defaultQuerySort)
+  const queryFilters = JSON.parse(props.queryFilters || defaultQueryFilters)
   const parsedLimit = parseInt(props.queryLimit || '', 10)
   if (!queryIncludes?.[0]?.space) return null
   return {
@@ -28,6 +31,7 @@ export function getQueryBlockInput(
       includes: queryIncludes,
       sort: querySort,
       limit: parsedLimit > 0 ? parsedLimit : undefined,
+      filters: queryFilters,
     },
   }
 }

--- a/frontend/packages/editor/src/query-block.tsx
+++ b/frontend/packages/editor/src/query-block.tsx
@@ -1,5 +1,5 @@
 import {EditorQueryBlock} from '@seed-hypermedia/client/editor-types'
-import {HMBlockQuery, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {HMBlockQuery, parseHMQueryFiltersJSON, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {entityQueryPathToHmIdPath} from '@shm/shared'
 import {queryQueryBlock} from '@shm/shared/models/queries'
 import {useEditorGate} from '@shm/shared/models/use-editor-gate'
@@ -27,8 +27,9 @@ import {createReactBlockSpec} from './blocknote/react'
 import {buildSlotItems} from './query-block-draft-items'
 import {useQuerySearchInput} from './query-search-context'
 import {HMBlockSchema} from './schema'
+import {QueryAccountFilterInput} from './query-account-filter-input'
 
-import {defaultQueryIncludes, defaultQuerySort, getQueryBlockInput} from './query-block-input'
+import {defaultQueryFilters, defaultQueryIncludes, defaultQuerySort, getQueryBlockInput} from './query-block-input'
 
 export const QueryBlock = createReactBlockSpec({
   type: 'query',
@@ -49,6 +50,9 @@ export const QueryBlock = createReactBlockSpec({
     },
     querySort: {
       default: defaultQuerySort,
+    },
+    queryFilters: {
+      default: defaultQueryFilters,
     },
     banner: {
       default: 'false',
@@ -78,6 +82,11 @@ export const QueryBlock = createReactBlockSpec({
 
 type HMQueryBlockIncludes = HMBlockQuery['attributes']['query']['includes']
 type HMQueryBlockSort = NonNullable<HMBlockQuery['attributes']['query']['sort']>
+type HMQueryBlockFilters = NonNullable<HMBlockQuery['attributes']['query']['filters']>
+
+function parseQueryFilters(rawFilters: string | undefined): HMQueryBlockFilters {
+  return parseHMQueryFiltersJSON(rawFilters || defaultQueryFilters)
+}
 
 function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSchema>) {
   const client = useUniversalClient()
@@ -88,6 +97,10 @@ function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
   const querySort = useMemo(() => {
     return JSON.parse(block.props.querySort || defaultQuerySort)
   }, [block.props.querySort])
+
+  const queryFilters: HMQueryBlockFilters = useMemo(() => {
+    return parseQueryFilters(block.props.queryFilters)
+  }, [block.props.queryFilters])
 
   const banner = block.props.banner === 'true'
   const queryTargetId = useMemo<UnpackedHypermediaId | null>(() => {
@@ -187,7 +200,7 @@ function Render(block: Block<HMBlockSchema>, editor: BlockNoteEditor<HMBlockSche
             queryDocName={queryBlock.data?.queryTargetName || ''}
             queryIncludes={queryIncludes}
             querySort={querySort}
-            style={style}
+            queryFilters={queryFilters}
             banner={banner}
             // @ts-expect-error
             block={block}
@@ -221,6 +234,7 @@ function QuerySettings({
   onValuesChange,
   queryIncludes,
   querySort,
+  queryFilters,
   editor,
   banner,
   beginEditIfNeeded,
@@ -229,6 +243,7 @@ function QuerySettings({
   block: EditorQueryBlock
   queryIncludes: HMQueryBlockIncludes
   querySort: HMQueryBlockSort
+  queryFilters: HMQueryBlockFilters
   banner: boolean
   onValuesChange: ({id, props}: {id: UnpackedHypermediaId | null; props: EditorQueryBlock['props']}) => void
   editor: BlockNoteEditor<HMBlockSchema>
@@ -292,6 +307,23 @@ function QuerySettings({
     }
   }, [popoverState.open, editor, block.id])
 
+  const authorFilters = queryFilters.filter((filter) => filter.type === 'Author')
+
+  const saveFilters = (filters: HMQueryBlockFilters) => {
+    const queryFilters = JSON.stringify(filters)
+    queueMicrotask(() => {
+      onValuesChange({
+        id: null,
+        props: {
+          queryFilters,
+        } as EditorQueryBlock['props'],
+      })
+    })
+  }
+
+  const updateAuthorFilters = (uids: string[]) => {
+    saveFilters(uids.map((uid) => ({type: 'Author' as const, uid})))
+  }
   return (
     <>
       <div className="relative flex justify-end py-1">
@@ -368,6 +400,11 @@ function QuerySettings({
                   {label: 'Show only Direct Children', value: 'Children'},
                   {label: 'Show all Descendants', value: 'AllDescendants'},
                 ]}
+              />
+
+              <QueryAccountFilterInput
+                selectedUids={authorFilters.map((filter) => filter.uid)}
+                onSelectedUidsChange={updateAuthorFilters}
               />
 
               <SelectField

--- a/frontend/packages/shared/src/api-query-block.ts
+++ b/frontend/packages/shared/src/api-query-block.ts
@@ -238,6 +238,7 @@ export const QueryBlock: HMRequestImplementation<HMQueryBlockRequest> = {
             includes: input.query.includes.map(({space, path, mode}) => ({space, path, mode})),
             limit: input.query.limit ?? null,
             sortCount: input.query.sort?.length ?? 0,
+            filterCount: input.query.filters?.length ?? 0,
           },
           resolvedItemCount: perf.resolvedItemCount,
           returnedItemCount: perf.returnedItemCount,

--- a/frontend/packages/shared/src/client/__tests__/editorblock-to-hmblock.test.ts
+++ b/frontend/packages/shared/src/client/__tests__/editorblock-to-hmblock.test.ts
@@ -828,6 +828,7 @@ describe('EditorBlock to HMBlock', () => {
           banner: 'true',
           queryIncludes: '[{"space": "FOO_SPACE", "path": "", "mode": "Children"}]',
           querySort: '[{"term": "UpdateTime", "reverse": false}]',
+          queryFilters: '[{"type": "Author", "uid": "author-a"}]',
           queryLimit: '10',
           style: 'Card',
           columnCount: '1',
@@ -846,6 +847,7 @@ describe('EditorBlock to HMBlock', () => {
           query: {
             includes: [{space: 'FOO_SPACE', path: '', mode: 'Children'}],
             sort: [{term: 'UpdateTime', reverse: false}],
+            filters: [{type: 'Author', uid: 'author-a'}],
             limit: 10,
           },
         },
@@ -854,6 +856,63 @@ describe('EditorBlock to HMBlock', () => {
       const val = editorBlockToHMBlock(editorBlock)
 
       expect(val).toEqual(result)
+    })
+
+    test('query block ignores unsupported or malformed filters', () => {
+      const editorBlock: EditorQueryBlock = {
+        id: 'foo',
+        type: 'query',
+        children: [],
+        content: [
+          {
+            type: 'text',
+            text: '',
+            styles: {},
+          },
+        ],
+        props: {
+          banner: 'false',
+          queryIncludes: '[{"space": "FOO_SPACE", "path": "", "mode": "Children"}]',
+          querySort: '[]',
+          queryFilters:
+            '[{"type":"Author","uid":"author-a"},{"type":"PublishDate","after":"2026-01-01"},{"type":"Author","uid":42}]',
+          queryLimit: '',
+          style: 'Card',
+          columnCount: '1',
+        },
+      }
+
+      const val = editorBlockToHMBlock(editorBlock)
+
+      expect((val as HMBlockQuery).attributes.query.filters).toEqual([{type: 'Author', uid: 'author-a'}])
+    })
+
+    test('query block treats invalid filter JSON as no filters', () => {
+      const editorBlock: EditorQueryBlock = {
+        id: 'foo',
+        type: 'query',
+        children: [],
+        content: [
+          {
+            type: 'text',
+            text: '',
+            styles: {},
+          },
+        ],
+        props: {
+          banner: 'false',
+          queryIncludes: '[{"space": "FOO_SPACE", "path": "", "mode": "Children"}]',
+          querySort: '[]',
+          queryFilters: '{"type":"PublishDate"}',
+          queryLimit: '',
+          style: 'Card',
+          columnCount: '1',
+        },
+      }
+
+      const val = editorBlockToHMBlock(editorBlock)
+
+      expect((val as HMBlockQuery).attributes.query.filters).toEqual([])
     })
 
     // test('nostr', () => {

--- a/frontend/packages/shared/src/client/__tests__/hmblock-to-editorblock.test.ts
+++ b/frontend/packages/shared/src/client/__tests__/hmblock-to-editorblock.test.ts
@@ -876,6 +876,7 @@ describe('HMBlock to EditorBlock', () => {
           query: {
             includes: [{space: 'FOO_SPACE', path: '', mode: 'Children'}],
             sort: [{term: 'UpdateTime', reverse: false}],
+            filters: [{type: 'Author', uid: 'author-a'}],
           },
         },
         revision: 'revision123',
@@ -895,6 +896,7 @@ describe('HMBlock to EditorBlock', () => {
         props: {
           queryIncludes: '[{"space":"FOO_SPACE","path":"","mode":"Children"}]',
           querySort: '[{"term":"UpdateTime","reverse":false}]',
+          queryFilters: '[{"type":"Author","uid":"author-a"}]',
           queryLimit: '',
           style: 'Card',
           columnCount: '1',
@@ -906,6 +908,54 @@ describe('HMBlock to EditorBlock', () => {
       const val = hmBlockToEditorBlock(hmBlock)
 
       expect(val).toEqual(result)
+    })
+
+    test('query block drops unsupported filter attributes while preserving supported filters', () => {
+      const hmBlock = {
+        id: 'foo',
+        type: 'Query',
+        text: ``,
+        annotations: [],
+        attributes: {
+          style: 'Card',
+          columnCount: 1,
+          query: {
+            includes: [{space: 'FOO_SPACE', path: '', mode: 'Children'}],
+            sort: [],
+            filters: [
+              {type: 'Author', uid: 'author-a'},
+              {type: 'PublishDate', after: '2026-01-01'},
+              {type: 'Author', uid: 42},
+            ],
+          },
+        },
+      } as unknown as HMBlockQuery
+
+      const val = hmBlockToEditorBlock(hmBlock)
+
+      expect((val as EditorQueryBlock).props.queryFilters).toBe('[{"type":"Author","uid":"author-a"}]')
+    })
+
+    test('query block treats malformed filter attributes as no filters', () => {
+      const hmBlock = {
+        id: 'foo',
+        type: 'Query',
+        text: ``,
+        annotations: [],
+        attributes: {
+          style: 'Card',
+          columnCount: 1,
+          query: {
+            includes: [{space: 'FOO_SPACE', path: '', mode: 'Children'}],
+            sort: [],
+            filters: {type: 'PublishDate', after: '2026-01-01'},
+          },
+        },
+      } as unknown as HMBlockQuery
+
+      const val = hmBlockToEditorBlock(hmBlock)
+
+      expect((val as EditorQueryBlock).props.queryFilters).toBe('[]')
     })
   })
 

--- a/frontend/packages/shared/src/models/__tests__/directory.test.ts
+++ b/frontend/packages/shared/src/models/__tests__/directory.test.ts
@@ -19,6 +19,8 @@ function makeEntry(
     updateTime: string
     latestChangeTime: string
     latestCommentTime: string
+    authors: string[]
+    displayPublishTime: string
   }>,
 ): HMDocumentInfo {
   const path = overrides.path ?? ['projects', 'a']
@@ -26,7 +28,7 @@ function makeEntry(
     type: 'document',
     id: overrides.id ?? hmId('alice', {path}),
     path,
-    authors: [],
+    authors: overrides.authors ?? [],
     createTime: overrides.createTime ?? '2024-01-01T00:00:00Z',
     updateTime: overrides.updateTime ?? '2024-01-01T00:00:00Z',
     sortTime: new Date(overrides.updateTime ?? '2024-01-01T00:00:00Z'),
@@ -41,7 +43,10 @@ function makeEntry(
       isUnread: false,
     },
     generationInfo: {genesis: '', generation: 0n},
-    metadata: {name: overrides.name ?? path[path.length - 1] ?? 'Untitled'},
+    metadata: {
+      name: overrides.name ?? path[path.length - 1] ?? 'Untitled',
+      displayPublishTime: overrides.displayPublishTime,
+    },
     visibility: 'PUBLIC',
   } as unknown as HMDocumentInfo
 }
@@ -81,6 +86,73 @@ describe('createQueryResolver', () => {
       },
     })
     expect(result?.results.map((doc) => doc.metadata.name)).toEqual(['Newer', 'Older'])
+  })
+
+  it('filters results by author before sorting', async () => {
+    const parent = makeEntry({id: hmId('alice', {path: ['projects']}), path: ['projects'], name: 'Projects'})
+    const authoredByAlice = makeEntry({
+      id: hmId('alice', {path: ['projects', 'alice']}),
+      path: ['projects', 'alice'],
+      name: 'Alice',
+      authors: ['alice-author', 'co-author'],
+      updateTime: '2024-01-01T00:00:00Z',
+    })
+    const authoredByBob = makeEntry({
+      id: hmId('alice', {path: ['projects', 'bob']}),
+      path: ['projects', 'bob'],
+      name: 'Bob',
+      authors: ['bob-author'],
+      updateTime: '2024-03-01T00:00:00Z',
+    })
+
+    const listDirectory = vi.fn().mockResolvedValue({documents: [parent, authoredByBob, authoredByAlice]})
+    const resolver = createQueryResolver({documents: {listDirectory}} as any)
+
+    const result = await resolver({
+      includes: [{space: 'alice', path: '/projects', mode: 'AllDescendants'}],
+      sort: [{term: 'UpdateTime', reverse: false}],
+      filters: [{type: 'Author', uid: 'alice-author'}],
+    })
+
+    expect(result?.results.map((doc) => doc.metadata.name)).toEqual(['Alice'])
+  })
+
+  it('matches any selected author filter before sorting', async () => {
+    const parent = makeEntry({id: hmId('alice', {path: ['projects']}), path: ['projects'], name: 'Projects'})
+    const authoredByAlice = makeEntry({
+      id: hmId('alice', {path: ['projects', 'alice']}),
+      path: ['projects', 'alice'],
+      name: 'Alice',
+      authors: ['alice-author'],
+    })
+    const authoredByBob = makeEntry({
+      id: hmId('alice', {path: ['projects', 'bob']}),
+      path: ['projects', 'bob'],
+      name: 'Bob',
+      authors: ['bob-author'],
+    })
+    const authoredByCarol = makeEntry({
+      id: hmId('alice', {path: ['projects', 'carol']}),
+      path: ['projects', 'carol'],
+      name: 'Carol',
+      authors: ['carol-author'],
+    })
+
+    const listDirectory = vi
+      .fn()
+      .mockResolvedValue({documents: [parent, authoredByCarol, authoredByBob, authoredByAlice]})
+    const resolver = createQueryResolver({documents: {listDirectory}} as any)
+
+    const result = await resolver({
+      includes: [{space: 'alice', path: '/projects', mode: 'AllDescendants'}],
+      sort: [{term: 'Title', reverse: false}],
+      filters: [
+        {type: 'Author', uid: 'alice-author'},
+        {type: 'Author', uid: 'bob-author'},
+      ],
+    })
+
+    expect(result?.results.map((doc) => doc.metadata.name)).toEqual(['Alice', 'Bob'])
   })
 
   it('still uses listDirectory for unsupported server sorts and applies client-side sorting', async () => {

--- a/frontend/packages/shared/src/models/directory.ts
+++ b/frontend/packages/shared/src/models/directory.ts
@@ -1,4 +1,10 @@
-import {HMDocumentInfo, HMQuery, HMQueryResult, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {
+  HMDocumentInfo,
+  HMQuery,
+  HMQueryFilter,
+  HMQueryResult,
+  UnpackedHypermediaId,
+} from '@seed-hypermedia/client/hm-types'
 import {SortAttribute} from '../client/.generated/documents/v3alpha/documents_pb'
 import {BIG_INT} from '../constants'
 import {queryBlockSortedItems} from '../content'
@@ -6,6 +12,15 @@ import {GRPCClient} from '../grpc-client'
 import {entityQueryPathToHmIdPath, hmId} from '../utils'
 import {hmIdPathToEntityQueryPath} from '../utils/path-api'
 import {prepareHMDocumentInfo} from './entity'
+
+function filterQueryResults(entries: HMDocumentInfo[], filters: HMQueryFilter[] | undefined): HMDocumentInfo[] {
+  if (!filters?.length) return entries
+
+  const authorUids = filters.map((filter) => filter.uid).filter(Boolean)
+  if (!authorUids.length) return entries
+
+  return entries.filter((entry) => authorUids.some((uid) => entry.authors.includes(uid)))
+}
 
 function createDirectoryResolver(client: GRPCClient) {
   async function getDirectory(
@@ -48,7 +63,7 @@ function createDirectoryResolver(client: GRPCClient) {
 export function createQueryResolver(client: GRPCClient) {
   const getDirectory = createDirectoryResolver(client)
   async function getQueryResults(query: HMQuery): Promise<HMQueryResult | null> {
-    const {includes, sort} = query
+    const {includes, sort, filters} = query
     if (includes.length !== 1) return null // only support one include for now
     const {path, mode, space} = includes[0]!
     const inId = hmId(space, {
@@ -57,10 +72,11 @@ export function createQueryResolver(client: GRPCClient) {
     const dir = await getDirectory(inId, mode, sort)
     if (!inId) return null
 
+    const filteredDir = filterQueryResults(dir, filters)
     const sortedDir = sort
-      ? queryBlockSortedItems({entries: dir, sort})
+      ? queryBlockSortedItems({entries: filteredDir, sort})
       : queryBlockSortedItems({
-          entries: dir,
+          entries: filteredDir,
           sort: [{term: 'UpdateTime', reverse: false}],
         })
     return {in: inId, results: sortedDir, mode} satisfies HMQueryResult

--- a/frontend/packages/ui/src/account-tag-input.tsx
+++ b/frontend/packages/ui/src/account-tag-input.tsx
@@ -1,0 +1,261 @@
+import * as Ariakit from '@ariakit/react'
+import {CompositeInput} from '@ariakit/react-core/composite/composite-input'
+import {HMMetadata, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {useAccount, useResource} from '@shm/shared/models/entity'
+import {abbreviateUid} from '@shm/shared/utils/abbreviate'
+import {forwardRef, useEffect, useId, useRef} from 'react'
+import './combobox.css'
+import {HMIcon, LoadedHMIcon} from './hm-icon'
+import {X} from './icons'
+import {SizableText} from './text'
+
+export type AccountSearchResult = {
+  id: UnpackedHypermediaId
+  label: string
+  unresolved?: boolean
+  metadata?: HMMetadata
+}
+
+interface AccountTagInputProps extends Omit<Ariakit.ComboboxProps, 'onChange'> {
+  label: string
+  value?: string
+  onChange?: (value: string) => void
+  defaultValue?: string
+  values?: Array<AccountSearchResult>
+  onValuesChange?: (values: Array<AccountSearchResult>) => void
+  defaultValues?: Array<AccountSearchResult>
+}
+
+export const AccountTagInput = forwardRef<HTMLInputElement, AccountTagInputProps>(function AccountTagInput(props, ref) {
+  const {
+    label,
+    defaultValue,
+    value,
+    onChange,
+    defaultValues,
+    values,
+    onValuesChange,
+    children,
+    className,
+    ...comboboxProps
+  } = props
+
+  const comboboxRef = useRef<HTMLInputElement>(null)
+  const defaultComboboxId = useId()
+  const comboboxId = comboboxProps.id || defaultComboboxId
+
+  const combobox = Ariakit.useComboboxStore({
+    value,
+    defaultValue,
+    setValue: onChange,
+    resetValueOnHide: true,
+  })
+
+  // @ts-expect-error Ariakit's generic Select store value works here but TS cannot infer the array type.
+  const select = Ariakit.useSelectStore<AccountSearchResult>({
+    combobox,
+    value: values,
+    defaultValue: defaultValues,
+    setValue: onValuesChange,
+  })
+
+  const composite = Ariakit.useCompositeStore({
+    defaultActiveId: comboboxId,
+  })
+
+  const selectedValues = select.useState('value')
+
+  useEffect(() => combobox.setValue(''), [selectedValues, combobox])
+
+  const toggleValueFromSelectedValues = (value: AccountSearchResult) => {
+    // @ts-expect-error Ariakit supports updater callbacks for controlled values.
+    select.setValue((prevSelectedValues: Array<AccountSearchResult>) => {
+      const index = prevSelectedValues.indexOf(value)
+      if (index !== -1) {
+        return prevSelectedValues.filter((v) => v.id.id != value.id.id)
+      }
+      return [...prevSelectedValues, value]
+    })
+  }
+
+  const onItemClick = (value: AccountSearchResult) => () => {
+    toggleValueFromSelectedValues(value)
+  }
+
+  const onItemKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'Backspace' || event.key === 'Delete') {
+      event.currentTarget.click()
+    }
+  }
+
+  const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== 'Backspace') return
+    const {selectionStart, selectionEnd} = event.currentTarget
+    const isCaretAtTheBeginning = selectionStart === 0 && selectionEnd === 0
+    if (!isCaretAtTheBeginning) return
+    // @ts-expect-error Ariakit supports updater callbacks for controlled values.
+    select.setValue((values: Array<AccountSearchResult>) => {
+      if (!values.length) return values
+      return values.slice(0, values.length - 1)
+    })
+    combobox.hide()
+  }
+
+  return (
+    <Ariakit.Composite
+      store={composite}
+      role="grid"
+      aria-label={label}
+      className="tag-grid"
+      onMouseDown={(event) => event.stopPropagation()}
+      onClick={(event) => {
+        event.stopPropagation()
+        comboboxRef.current?.focus()
+      }}
+      render={<div className="flex flex-1 rounded-md p-1" />}
+    >
+      <Ariakit.CompositeRow role="row" render={<div className="flex w-full flex-wrap gap-1" />}>
+        {/* @ts-expect-error Ariakit selected value state is the AccountSearchResult array configured above. */}
+        {selectedValues.map((selectedValue: AccountSearchResult) => {
+          return (
+            <Ariakit.CompositeItem
+              key={selectedValue.id.id}
+              role="gridcell"
+              onClick={onItemClick(selectedValue)}
+              onKeyDown={onItemKeyDown}
+              onFocus={combobox.hide}
+              render={
+                <div className="bg-background border-border flex min-h-6 items-center gap-1 rounded-md border p-1 px-2 hover:bg-black/10 dark:hover:bg-white/10" />
+              }
+            >
+              <SelectedAccountItem value={selectedValue} />
+              <X size={12} />
+            </Ariakit.CompositeItem>
+          )
+        })}
+        <div role="cell" className="flex min-w-0 flex-1 flex-col">
+          <Ariakit.CompositeItem
+            id={comboboxId}
+            render={
+              <CompositeInput
+                ref={comboboxRef}
+                onKeyDown={onInputKeyDown}
+                render={
+                  <Ariakit.Combobox
+                    ref={ref}
+                    store={combobox}
+                    size={1}
+                    className={`combobox w-full min-w-0 ${className ?? ''}`}
+                    {...comboboxProps}
+                  />
+                }
+              />
+            }
+          />
+        </div>
+        <Ariakit.ComboboxPopover
+          store={combobox}
+          portal
+          sameWidth
+          gutter={8}
+          render={
+            <Ariakit.SelectList
+              // @ts-expect-error Ariakit store value is configured as AccountSearchResult[].
+              store={select}
+              render={<div className="z-100 rounded-sm bg-white dark:bg-black" />}
+            />
+          }
+        >
+          {children}
+        </Ariakit.ComboboxPopover>
+      </Ariakit.CompositeRow>
+    </Ariakit.Composite>
+  )
+})
+
+function SelectedAccountItem({value}: {value: AccountSearchResult}) {
+  if (value.metadata) {
+    return (
+      <>
+        <HMIcon id={value.id} name={value.metadata.name} icon={value.metadata.icon} size={20} />
+        <SizableText>{value.metadata.name || value.label}</SizableText>
+      </>
+    )
+  }
+
+  if (value.unresolved) return <UnresolvedAccountItem value={value} />
+
+  return (
+    <>
+      <LoadedHMIcon id={value.id} size={20} />
+      <SizableText>{value.label}</SizableText>
+    </>
+  )
+}
+
+function UnresolvedAccountItem({value}: {value: AccountSearchResult}) {
+  const account = useAccount(value.id.uid, {subscribe: true})
+  const metadata = account.data?.metadata
+  const label = metadata?.name || abbreviateUid(value.id.uid)
+  return (
+    <>
+      <HMIcon id={value.id} name={metadata?.name} icon={metadata?.icon} size={20} />
+      <SizableText>{label}</SizableText>
+    </>
+  )
+}
+
+interface AccountTagInputItemProps extends Ariakit.SelectItemProps {
+  children?: React.ReactNode
+  account?: AccountSearchResult
+}
+
+export const AccountTagInputItem = forwardRef<HTMLDivElement, AccountTagInputItemProps>(
+  function AccountTagInputItem(props, ref) {
+    const {onMouseDown, onClick, ...itemProps} = props
+    const resource = useResource(props.account?.id)
+    const metadata =
+      props.account?.metadata ?? (resource.data?.type === 'document' ? resource.data.document?.metadata : undefined)
+    return (
+      <Ariakit.SelectItem
+        ref={ref}
+        {...itemProps}
+        onMouseDown={(event) => {
+          event.preventDefault()
+          event.stopPropagation()
+          onMouseDown?.(event)
+        }}
+        onClick={(event) => {
+          event.stopPropagation()
+          onClick?.(event)
+        }}
+        render={
+          <Ariakit.ComboboxItem
+            render={<AccountTagInputItemContent className="combobox-item" render={props.render} />}
+          />
+        }
+      >
+        <div className="flex flex-1 justify-start gap-2">
+          {metadata && props.account?.id ? (
+            <HMIcon size={16} name={metadata.name} icon={metadata.icon} id={props.account.id} />
+          ) : null}
+          <div className="flex flex-1">
+            <SizableText size="sm" className="text-currentColor">
+              {props.children || props.account?.label}
+            </SizableText>
+          </div>
+        </div>
+      </Ariakit.SelectItem>
+    )
+  },
+)
+
+const AccountTagInputItemContent = forwardRef<any, any>(function AccountTagInputItemContent(props, ref) {
+  let {render, children, ...restProps} = props
+
+  return (
+    <div ref={ref} {...restProps} className="combobox-item data-[active-item]:bg-accent flex flex-1 gap-2 p-3">
+      {render ? render : children}
+    </div>
+  )
+})

--- a/frontend/packages/ui/src/collaborators-page.tsx
+++ b/frontend/packages/ui/src/collaborators-page.tsx
@@ -1,9 +1,6 @@
-import * as Ariakit from '@ariakit/react'
-import {CompositeInput} from '@ariakit/react-core/composite/composite-input'
 import {
   HMCapability,
   HMListDocumentCollaboratorsOutput,
-  HMMetadata,
   HMMetadataPayload,
   HMSiteMember,
   UnpackedHypermediaId,
@@ -11,33 +8,22 @@ import {
 import {resolveHypermediaUrl, type DomainResolverFn} from '@seed-hypermedia/client'
 import {useRouteLink} from '@shm/shared'
 import {useAddCapabilities, useSelectedAccountCapability} from '@shm/shared/models/capabilities'
-import {
-  useAccount,
-  useCapabilities,
-  useCollaborators,
-  useResource,
-  useSelectedAccountId,
-  useSiteMembers,
-} from '@shm/shared/models/entity'
+import {useCapabilities, useCollaborators, useSelectedAccountId, useSiteMembers} from '@shm/shared/models/entity'
 import {useSearch} from '@shm/shared/models/search'
 import {abbreviateUid} from '@shm/shared/utils/abbreviate'
 import {hmId, hmIdToURL, unpackHmId} from '@shm/shared/utils/entity-id-url'
 import {Users} from 'lucide-react'
-import {forwardRef, useCallback, useEffect, useId, useMemo, useRef, useState} from 'react'
+import {useCallback, useMemo, useState} from 'react'
 import {Button} from './button'
-import './combobox.css'
-import {HMIcon, LoadedHMIcon} from './hm-icon'
-import {ArrowRight, X} from './icons'
+import {AccountSearchResult, AccountTagInput, AccountTagInputItem} from './account-tag-input'
+import {HMIcon} from './hm-icon'
+import {ArrowRight} from './icons'
 import {Spinner} from './spinner'
 import {SizableText} from './text'
 import {toast} from './toast'
 
-export type SearchResult = {
-  id: UnpackedHypermediaId
-  label: string
-  unresolved?: boolean
-  metadata?: HMMetadata
-}
+/** Account search result used by collaborator search inputs. */
+export type SearchResult = AccountSearchResult
 
 /** Returns the number of people rows rendered by the document People tab. */
 export function getRenderedCollaboratorsCount(
@@ -206,7 +192,7 @@ export function AccountSearchInput({
 
   return (
     <div className="flex flex-1">
-      <TagInput
+      <AccountTagInput
         label={label}
         value={search}
         onChange={handleSearchChange}
@@ -217,19 +203,19 @@ export function AccountSearchInput({
         {matches.map(
           (result) =>
             result && (
-              <TagInputItem
+              <AccountTagInputItem
                 key={result.id.id}
                 onClick={() => {
                   onValuesChange([...values, result])
                 }}
-                member={result}
+                account={result}
               >
                 Add &quot;{result?.label}&quot;
-              </TagInputItem>
+              </AccountTagInputItem>
             ),
         )}
         {search && matches.length == 0 ? (
-          <TagInputItem
+          <AccountTagInputItem
             onClick={async () => {
               // Try resolving bare domains (e.g. "gabo.es")
               if (search.includes('.')) {
@@ -249,9 +235,9 @@ export function AccountSearchInput({
             }}
           >
             Add &quot;{search}&quot;
-          </TagInputItem>
+          </AccountTagInputItem>
         ) : null}
-      </TagInput>
+      </AccountTagInput>
     </div>
   )
 }
@@ -556,209 +542,3 @@ function DocumentCollaborators({
     </div>
   )
 }
-
-interface TagInputProps extends Omit<Ariakit.ComboboxProps, 'onChange'> {
-  label: string
-  value?: string
-  onChange?: (value: string) => void
-  defaultValue?: string
-  values?: Array<SearchResult>
-  onValuesChange?: (values: Array<SearchResult>) => void
-  defaultValues?: Array<SearchResult>
-}
-
-const TagInput = forwardRef<HTMLInputElement, TagInputProps>(function TagInput(props, ref) {
-  const {label, defaultValue, value, onChange, defaultValues, values, onValuesChange, children, ...comboboxProps} =
-    props
-
-  const comboboxRef = useRef<HTMLInputElement>(null)
-  const defaultComboboxId = useId()
-  const comboboxId = comboboxProps.id || defaultComboboxId
-
-  // When this combobox is rendered inside a modal dialog (e.g. Radix Dialog), the dialog disables
-  // pointer events outside its content and dismisses itself on an outside pointerdown. Because the
-  // popover is portalled to the body it counts as "outside", so mouse clicks on options are swallowed
-  // (keyboard selection still works). Re-enable pointer events on the popover and stop its pointerdown
-  // from bubbling to the dialog's document-level dismiss listener. A native listener is used so it runs
-  // regardless of React's synthetic event root.
-  const popoverRef = useCallback((node: HTMLElement | null) => {
-    node?.addEventListener('pointerdown', (event) => event.stopPropagation())
-  }, [])
-
-  const combobox = Ariakit.useComboboxStore({
-    value,
-    defaultValue,
-    setValue: onChange,
-    resetValueOnHide: true,
-  })
-
-  // @ts-expect-error
-  const select = Ariakit.useSelectStore<SearchResult>({
-    combobox,
-    value: values,
-    defaultValue: defaultValues,
-    setValue: onValuesChange,
-  })
-
-  const composite = Ariakit.useCompositeStore({
-    defaultActiveId: comboboxId,
-  })
-
-  const selectedValues = select.useState('value')
-
-  // Reset the combobox value whenever an item is checked or unchecked.
-  useEffect(() => combobox.setValue(''), [selectedValues, combobox])
-
-  const toggleValueFromSelectedValues = (value: SearchResult) => {
-    // @ts-expect-error
-    select.setValue((prevSelectedValues: Array<SearchResult>) => {
-      const index = prevSelectedValues.indexOf(value)
-      if (index !== -1) {
-        return prevSelectedValues.filter((v: SearchResult) => v.id.id != value.id.id)
-      }
-      return [...prevSelectedValues, value]
-    })
-  }
-
-  const onItemClick = (value: SearchResult) => () => {
-    toggleValueFromSelectedValues(value)
-  }
-
-  const onItemKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
-    if (event.key === 'Backspace' || event.key === 'Delete') {
-      event.currentTarget.click()
-    }
-  }
-
-  const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key !== 'Backspace') return
-    const {selectionStart, selectionEnd} = event.currentTarget
-    const isCaretAtTheBeginning = selectionStart === 0 && selectionEnd === 0
-    if (!isCaretAtTheBeginning) return
-    // @ts-expect-error
-    select.setValue((values: Array<SearchResult>) => {
-      if (!values.length) return values
-      return values.slice(0, values.length - 1)
-    })
-    combobox.hide()
-  }
-
-  return (
-    <Ariakit.Composite
-      store={composite}
-      role="grid"
-      aria-label={label}
-      className="tag-grid"
-      onClick={() => comboboxRef.current?.focus()}
-      render={<div className="flex flex-1 rounded-md p-1" />}
-    >
-      <Ariakit.CompositeRow role="row" render={<div className="flex w-full flex-wrap gap-1" />}>
-        {/* @ts-expect-error */}
-        {selectedValues.map((value: SearchResult) => {
-          // TODO: (horacio): Should I cleanup the list from the `unresolved` value?
-          return (
-            <Ariakit.CompositeItem
-              key={value.id.id}
-              role="gridcell"
-              onClick={onItemClick(value)}
-              onKeyDown={onItemKeyDown}
-              onFocus={combobox.hide}
-              render={
-                <div className="bg-background border-border flex min-h-6 items-center gap-1 rounded-md border p-1 px-2 hover:bg-black/10 dark:hover:bg-white/10" />
-              }
-            >
-              {'unresolved' in value && value.unresolved ? (
-                <UnresolvedItem value={value} />
-              ) : (
-                <>
-                  <LoadedHMIcon id={value.id} size={20} />
-                  <SizableText>{value.label}</SizableText>
-                </>
-              )}
-              <X size={12} />
-            </Ariakit.CompositeItem>
-          )
-        })}
-        <div role="cell" className="flex flex-1 flex-col">
-          <Ariakit.CompositeItem
-            id={comboboxId}
-            render={
-              <CompositeInput
-                ref={comboboxRef}
-                onKeyDown={onInputKeyDown}
-                render={<Ariakit.Combobox ref={ref} store={combobox} className="combobox" {...comboboxProps} />}
-              />
-            }
-          />
-        </div>
-        <Ariakit.ComboboxPopover
-          ref={popoverRef}
-          store={combobox}
-          portal
-          sameWidth
-          gutter={8}
-          className="pointer-events-auto"
-          render={
-            <Ariakit.SelectList
-              // @ts-expect-error
-              store={select}
-              render={<div className="z-100 rounded-sm bg-white dark:bg-black" />}
-            />
-          }
-        >
-          {children}
-        </Ariakit.ComboboxPopover>
-      </Ariakit.CompositeRow>
-    </Ariakit.Composite>
-  )
-})
-
-function UnresolvedItem({value}: {value: SearchResult}) {
-  const account = useAccount(value.id.uid, {subscribe: true})
-  const metadata = account.data?.metadata
-  const label = metadata?.name || abbreviateUid(value.id.uid)
-  return (
-    <>
-      <HMIcon id={value.id} name={metadata?.name} icon={metadata?.icon} size={20} />
-      <SizableText>{label}</SizableText>
-    </>
-  )
-}
-
-interface TagInputItemProps extends Ariakit.SelectItemProps {
-  children?: React.ReactNode
-  member?: SearchResult
-}
-
-const TagInputItem = forwardRef<HTMLDivElement, TagInputItemProps>(function TagInputItem(props, ref) {
-  const resource = useResource(props.member?.id)
-  const metadata = resource.data?.type === 'document' ? resource.data.document?.metadata : undefined
-  return (
-    <Ariakit.SelectItem
-      ref={ref}
-      {...props}
-      render={<Ariakit.ComboboxItem render={<TagInputItemContent className="combobox-item" render={props.render} />} />}
-    >
-      <div className="flex flex-1 justify-start gap-2">
-        {metadata && props.member?.id ? (
-          <HMIcon size={16} name={metadata?.name} icon={metadata?.icon} id={props.member?.id} />
-        ) : null}
-        <div className="flex flex-1">
-          <SizableText size="sm" className="text-currentColor">
-            {props.children || props.member?.label}
-          </SizableText>
-        </div>
-      </div>
-    </Ariakit.SelectItem>
-  )
-})
-
-const TagInputItemContent = forwardRef<any, any>(function TagInputItemContent(props, ref) {
-  let {render, children, ...restProps} = props
-
-  return (
-    <div ref={ref} {...restProps} className="combobox-item data-[active-item]:bg-accent flex flex-1 gap-2 p-3">
-      {render ? render : children}
-    </div>
-  )
-})

--- a/ops/deploy.test.ts
+++ b/ops/deploy.test.ts
@@ -40,12 +40,16 @@ import {
   installWrapper,
   getContainerImages,
   checkForNewImages,
+  expectedServiceImages,
+  rollbackImageTargets,
+  rollbackTagRefs,
   checkGpuAcceleration,
   ensureSeedDir,
   environmentPresets,
   configWarnings,
   DEFAULT_RELEASE_CHANNEL,
   validateDockerImageTag,
+  validateDockerImageRef,
   buildCrontab,
   parseArgs,
   extractSeedCronLines,
@@ -322,6 +326,22 @@ describe('validateDockerImageTag', () => {
   })
 })
 
+describe('validateDockerImageRef', () => {
+  test('accepts full image refs with registries and tags', () => {
+    expect(validateDockerImageRef('ghcr.io/horacioh/seed-web:main')).toBeUndefined()
+    expect(validateDockerImageRef('ghcr.io/horacioh/seed-site:sha-abcdef123456')).toBeUndefined()
+    expect(validateDockerImageRef('registry.example.com:5000/ns/image:v1.2.3')).toBeUndefined()
+  })
+
+  test('rejects invalid full image refs', () => {
+    expect(validateDockerImageRef('')).toBeUndefined()
+    expect(validateDockerImageRef(' ghcr.io/horacioh/seed-web:main')).toContain('spaces')
+    expect(validateDockerImageRef('ghcr.io/horacioh/seed-web')).toContain('tag')
+    expect(validateDockerImageRef('ghcr.io/horacioh/seed-web:bad tag')).toContain('spaces')
+    expect(validateDockerImageRef('ghcr.io/horacioh/seed-web:-bad')).toContain('tag')
+  })
+})
+
 // ---------------------------------------------------------------------------
 // generateCaddyfile
 // ---------------------------------------------------------------------------
@@ -580,6 +600,25 @@ describe('buildComposeEnv', () => {
     )
   })
 
+  test('reflects configured full image references', () => {
+    const env = buildComposeEnv(
+      makeTestConfig({
+        web_image: 'ghcr.io/horacioh/seed-web:main',
+        site_image: 'ghcr.io/horacioh/seed-site:main',
+      }),
+      makePaths(),
+    )
+
+    expect(env).toContain('SEED_WEB_IMAGE="ghcr.io/horacioh/seed-web:main"')
+    expect(env).toContain('SEED_SITE_IMAGE="ghcr.io/horacioh/seed-site:main"')
+  })
+
+  test('omits full image references when official defaults are used', () => {
+    const env = buildComposeEnv(makeTestConfig(), makePaths())
+    expect(env).not.toContain('SEED_WEB_IMAGE=')
+    expect(env).not.toContain('SEED_SITE_IMAGE=')
+  })
+
   test('reflects log level', () => {
     expect(
       buildComposeEnv(
@@ -697,16 +736,26 @@ describe('config read/write/exists', () => {
   })
 
   test('config preserves all SeedConfig fields', async () => {
-    await writeConfig(makeTestConfig(), paths)
+    await writeConfig(
+      makeTestConfig({
+        deploy_url: 'https://raw.githubusercontent.com/horacioh/seed/main/ops',
+        web_image: 'ghcr.io/horacioh/seed-web:main',
+        site_image: 'ghcr.io/horacioh/seed-site:main',
+      }),
+      paths,
+    )
     const loaded = await readConfig(paths)
     const expectedKeys: (keyof SeedConfig)[] = [
       'domain',
       'email',
+      'deploy_url',
       'compose_url',
       'compose_sha',
       'compose_envs',
       'environment',
       'release_channel',
+      'web_image',
+      'site_image',
       'testnet',
       'link_secret',
       'analytics',
@@ -716,6 +765,91 @@ describe('config read/write/exists', () => {
     for (const key of expectedKeys) {
       expect(loaded).toHaveProperty(key)
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// docker-compose image refs
+// ---------------------------------------------------------------------------
+
+describe('docker-compose image refs', () => {
+  test('web and site images can be overridden by full image refs while preserving defaults', async () => {
+    const compose = await readFile(join(import.meta.dir, 'docker-compose.yml'), 'utf-8')
+
+    expect(compose).toContain('image: ${SEED_WEB_IMAGE:-seedhypermedia/web:${SEED_SITE_TAG:-latest}}')
+    expect(compose).toContain('image: ${SEED_SITE_IMAGE:-seedhypermedia/site:${SEED_SITE_TAG:-latest}}')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// expectedServiceImages
+// ---------------------------------------------------------------------------
+
+describe('expectedServiceImages', () => {
+  test('uses official image refs for default channels', () => {
+    expect(expectedServiceImages(makeTestConfig({release_channel: 'dev'}))).toEqual([
+      {container: 'seed-web', expectedImage: 'seedhypermedia/web:dev'},
+      {container: 'seed-daemon', expectedImage: 'seedhypermedia/site:dev'},
+    ])
+  })
+
+  test('uses configured full image refs when present', () => {
+    expect(
+      expectedServiceImages(
+        makeTestConfig({
+          web_image: 'ghcr.io/horacioh/seed-web:main',
+          site_image: 'ghcr.io/horacioh/seed-site:main',
+        }),
+      ),
+    ).toEqual([
+      {container: 'seed-web', expectedImage: 'ghcr.io/horacioh/seed-web:main'},
+      {container: 'seed-daemon', expectedImage: 'ghcr.io/horacioh/seed-site:main'},
+    ])
+  })
+})
+
+describe('rollbackImageTargets', () => {
+  test('retags official rollback images to the configured release channel', () => {
+    expect(rollbackImageTargets(makeTestConfig({release_channel: 'dev'}))).toEqual([
+      {base: 'seedhypermedia/web', target: 'seedhypermedia/web:dev'},
+      {base: 'seedhypermedia/site', target: 'seedhypermedia/site:dev'},
+    ])
+  })
+
+  test('retags custom rollback images to the exact full image refs compose uses', () => {
+    expect(
+      rollbackImageTargets(
+        makeTestConfig({
+          web_image: 'ghcr.io/horacioh/seed-web:sha-abcdef123456',
+          site_image: 'ghcr.io/horacioh/seed-site:sha-abcdef123456',
+        }),
+      ),
+    ).toEqual([
+      {base: 'ghcr.io/horacioh/seed-web', target: 'ghcr.io/horacioh/seed-web:sha-abcdef123456'},
+      {base: 'ghcr.io/horacioh/seed-site', target: 'ghcr.io/horacioh/seed-site:sha-abcdef123456'},
+    ])
+  })
+})
+
+describe('rollbackTagRefs', () => {
+  test('tags current and configured image bases when migrating to custom refs', () => {
+    expect(
+      rollbackTagRefs(
+        'seed-web',
+        'seedhypermedia/web:latest',
+        makeTestConfig({web_image: 'ghcr.io/horacioh/seed-web:main'}),
+      ),
+    ).toEqual(['seedhypermedia/web:rollback', 'ghcr.io/horacioh/seed-web:rollback'])
+  })
+
+  test('dedupes rollback tags when image base is unchanged', () => {
+    expect(rollbackTagRefs('seed-web', 'seedhypermedia/web:dev', makeTestConfig({release_channel: 'dev'}))).toEqual([
+      'seedhypermedia/web:rollback',
+    ])
+  })
+
+  test('only tags current base for unmanaged containers', () => {
+    expect(rollbackTagRefs('seed-proxy', 'caddy:2', makeTestConfig())).toEqual(['caddy:rollback'])
   })
 })
 
@@ -1164,6 +1298,32 @@ describe('checkForNewImages', () => {
       "image inspect seedhypermedia/site:feature-branch --format '{{.Id}}'": 'sha256:ccc',
     })
     const result = await checkForNewImages({...config, release_channel: 'feature-branch'}, paths, shell)
+    expect(result).toBe(false)
+  })
+
+  test('uses configured full image refs when cron checks for updates', async () => {
+    const shell = makeMockShell({
+      "inspect seed-proxy --format '{{.Image}}'": 'sha256:aaa',
+      "inspect seed-web --format '{{.Image}}'": 'sha256:bbb',
+      "inspect seed-daemon --format '{{.Image}}'": 'sha256:ccc',
+      'docker compose': '',
+      "inspect seed-proxy --format '{{.Config.Image}}'": 'caddy:2',
+      "inspect seed-web --format '{{.Config.Image}}'": 'ghcr.io/horacioh/seed-web:main',
+      "inspect seed-daemon --format '{{.Config.Image}}'": 'ghcr.io/horacioh/seed-site:main',
+      "image inspect caddy:2 --format '{{.Id}}'": 'sha256:aaa',
+      "image inspect ghcr.io/horacioh/seed-web:main --format '{{.Id}}'": 'sha256:bbb',
+      "image inspect ghcr.io/horacioh/seed-site:main --format '{{.Id}}'": 'sha256:ccc',
+    })
+
+    const result = await checkForNewImages(
+      {
+        ...config,
+        web_image: 'ghcr.io/horacioh/seed-web:main',
+        site_image: 'ghcr.io/horacioh/seed-site:main',
+      },
+      paths,
+      shell,
+    )
     expect(result).toBe(false)
   })
 })
@@ -2058,15 +2218,28 @@ describe('getOpsBaseUrl', () => {
 // ---------------------------------------------------------------------------
 
 describe('getDeployScriptUrl', () => {
-  test('always returns the S3 main-branch URL, independent of image channel', () => {
-    // The script self-updates from main for every node; release_channel
-    // (dev/latest/custom) never changes where the script comes from.
+  test('returns the S3 main-branch URL without a custom deploy source', () => {
     const origDeploy = process.env.SEED_DEPLOY_URL
     const origRepo = process.env.SEED_REPO_URL
     delete process.env.SEED_DEPLOY_URL
     delete process.env.SEED_REPO_URL
     try {
       expect(getDeployScriptUrl()).toBe(DEV_DEPLOY_SCRIPT_URL)
+    } finally {
+      if (origDeploy !== undefined) process.env.SEED_DEPLOY_URL = origDeploy
+      if (origRepo !== undefined) process.env.SEED_REPO_URL = origRepo
+    }
+  })
+
+  test('uses the persisted deploy source for fork-managed nodes', () => {
+    const origDeploy = process.env.SEED_DEPLOY_URL
+    const origRepo = process.env.SEED_REPO_URL
+    delete process.env.SEED_DEPLOY_URL
+    delete process.env.SEED_REPO_URL
+    try {
+      expect(getDeployScriptUrl('https://raw.githubusercontent.com/horacioh/seed/main/ops/')).toBe(
+        'https://raw.githubusercontent.com/horacioh/seed/main/ops/dist/deploy.js',
+      )
     } finally {
       if (origDeploy !== undefined) process.env.SEED_DEPLOY_URL = origDeploy
       if (origRepo !== undefined) process.env.SEED_REPO_URL = origRepo

--- a/ops/deploy.test.ts
+++ b/ops/deploy.test.ts
@@ -738,7 +738,7 @@ describe('config read/write/exists', () => {
   test('config preserves all SeedConfig fields', async () => {
     await writeConfig(
       makeTestConfig({
-        deploy_url: 'https://raw.githubusercontent.com/horacioh/seed/main/ops',
+        deploy_url: 'https://raw.githubusercontent.com/horacioh/seed/custom-images/ops',
         web_image: 'ghcr.io/horacioh/seed-web:main',
         site_image: 'ghcr.io/horacioh/seed-site:main',
       }),
@@ -2237,8 +2237,8 @@ describe('getDeployScriptUrl', () => {
     delete process.env.SEED_DEPLOY_URL
     delete process.env.SEED_REPO_URL
     try {
-      expect(getDeployScriptUrl('https://raw.githubusercontent.com/horacioh/seed/main/ops/')).toBe(
-        'https://raw.githubusercontent.com/horacioh/seed/main/ops/dist/deploy.js',
+      expect(getDeployScriptUrl('https://raw.githubusercontent.com/horacioh/seed/custom-images/ops/')).toBe(
+        'https://raw.githubusercontent.com/horacioh/seed/custom-images/ops/dist/deploy.js',
       )
     } finally {
       if (origDeploy !== undefined) process.env.SEED_DEPLOY_URL = origDeploy

--- a/ops/deploy.ts
+++ b/ops/deploy.ts
@@ -73,6 +73,27 @@ export const NOTIFY_SERVICE_HOST = 'https://notify.seed.hyper.media'
 export const LIGHTNING_URL_MAINNET = 'https://ln.seed.hyper.media'
 export const LIGHTNING_URL_TESTNET = 'https://ln.testnet.seed.hyper.media'
 
+function currentDeployUrl(): string {
+  return getOpsBaseUrl().replace(/\/+$/, '')
+}
+
+function currentComposeUrl(): string {
+  return `${currentDeployUrl()}/docker-compose.yml`
+}
+
+function configuredDeployUrl(existing?: SeedConfig): string {
+  if (process.env.SEED_DEPLOY_URL || process.env.SEED_REPO_URL) return currentDeployUrl()
+  if (existing?.deploy_url) return existing.deploy_url.replace(/\/+$/, '')
+  return currentDeployUrl()
+}
+
+function configuredComposeUrl(existing?: SeedConfig): string {
+  if (process.env.SEED_DEPLOY_URL || process.env.SEED_REPO_URL) return currentComposeUrl()
+  if (existing?.deploy_url) return `${existing.deploy_url.replace(/\/+$/, '')}/docker-compose.yml`
+  if (existing?.compose_url) return existing.compose_url
+  return currentComposeUrl()
+}
+
 // deploy.js distribution URLs.
 // Production: attached as a GitHub Release asset on each tagged release.
 // Dev: uploaded to S3 alongside dev Docker images on each main push.
@@ -82,19 +103,16 @@ export const DEV_DEPLOY_SCRIPT_URL = 'https://seedappdev.s3.eu-west-2.amazonaws.
 /**
  * The deploy.js self-update source.
  *
- * Deliberately INDEPENDENT of the image release channel: the deploy script is
- * the orchestration tool, and its bug fixes must reach EVERY node automatically
- * — without cutting a release or switching channels. So we always track the
- * main-branch build published to S3 on each push (CI-gated by
- * check-deploy-script). `release_channel` governs only which *images* a node
- * runs, never which script manages them.
- *
- * A SEED_DEPLOY_URL / SEED_REPO_URL override (testing / branch builds) still
- * redirects the source to that ops base.
+ * A configured deploy source keeps fork-specific orchestration code aligned
+ * with its compose file and images. Environment overrides take priority for
+ * testing and branch builds. Nodes without a custom source use upstream S3.
  */
-export function getDeployScriptUrl(): string {
+export function getDeployScriptUrl(deployUrl?: string): string {
   if (process.env.SEED_DEPLOY_URL || process.env.SEED_REPO_URL) {
     return `${getOpsBaseUrl()}/dist/deploy.js`
+  }
+  if (deployUrl) {
+    return `${deployUrl.replace(/\/+$/, '')}/dist/deploy.js`
   }
   return DEV_DEPLOY_SCRIPT_URL
 }
@@ -225,6 +243,8 @@ export interface SeedConfig {
   domain: string
   /** Contact email — used to reach the operator about security updates */
   email: string
+  /** URL to fetch deploy assets from, usually the raw GitHub ops directory */
+  deploy_url?: string
   /** URL to fetch the docker-compose.yml from */
   compose_url: string
   /** SHA-256 of the last deployed docker-compose.yml — used to detect changes */
@@ -246,6 +266,10 @@ export interface SeedConfig {
    * Orthogonal to `testnet`: the image channel never changes the P2P network.
    */
   release_channel: 'latest' | 'dev' | string
+  /** Full Docker image ref for the web service; overrides release_channel when set */
+  web_image?: string
+  /** Full Docker image ref for the daemon/site service; overrides release_channel when set */
+  site_image?: string
   /**
    * Whether to connect to the testnet (devnet) P2P network instead of mainnet.
    * This is the sole source of truth for the network and is chosen explicitly
@@ -319,6 +343,26 @@ export function validateDockerImageTag(tag: string): string | undefined {
   if (!/^[A-Za-z0-9_][A-Za-z0-9_.-]*$/.test(tag)) {
     return 'Use a Docker image tag: letters, numbers, _, . or -; must start with a letter, number or _'
   }
+}
+
+/** Validate an optional full Docker image reference entered at the setup/reconfigure boundary. */
+export function validateDockerImageRef(ref: string): string | undefined {
+  if (!ref) return undefined
+  if (ref.trim() !== ref) return 'Remove leading or trailing spaces'
+  if (/\s/.test(ref)) return 'Docker image refs cannot contain spaces'
+
+  const lastSlash = ref.lastIndexOf('/')
+  const lastColon = ref.lastIndexOf(':')
+  if (lastColon <= lastSlash) return 'Include an explicit image tag, for example ghcr.io/horacioh/seed-web:main'
+
+  const name = ref.slice(0, lastColon)
+  const tag = ref.slice(lastColon + 1)
+  if (!name || !/^[A-Za-z0-9][A-Za-z0-9._:/-]*$/.test(name) || name.includes('://')) {
+    return 'Use a Docker image ref such as ghcr.io/horacioh/seed-web:main'
+  }
+
+  const tagError = validateDockerImageTag(tag)
+  if (tagError) return `Invalid image tag: ${tagError}`
 }
 
 async function promptReleaseChannel(options: {
@@ -837,6 +881,18 @@ async function runMigrationWizard(
           initialTag: old.imageTag,
           advanced,
         }),
+      web_image: () =>
+        p.text({
+          message: 'Full web image ref (optional)',
+          placeholder: 'ghcr.io/horacioh/seed-web:main',
+          validate: validateDockerImageRef,
+        }),
+      site_image: () =>
+        p.text({
+          message: 'Full site/daemon image ref (optional)',
+          placeholder: 'ghcr.io/horacioh/seed-site:main',
+          validate: validateDockerImageRef,
+        }),
       log_level: () =>
         p.select({
           message: 'Log level',
@@ -894,7 +950,8 @@ async function runMigrationWizard(
   const config: SeedConfig = {
     domain: answers.domain as string,
     email: (answers.email as string) || '',
-    compose_url: DEFAULT_COMPOSE_URL,
+    deploy_url: currentDeployUrl(),
+    compose_url: currentComposeUrl(),
     compose_sha: '',
     compose_env_sha: '',
     compose_envs: {
@@ -902,6 +959,8 @@ async function runMigrationWizard(
     },
     environment: env,
     release_channel: answers.release_channel as string,
+    web_image: (answers.web_image as string) || undefined,
+    site_image: (answers.site_image as string) || undefined,
     testnet,
     link_secret: secret,
     analytics: old.trafficStats,
@@ -997,6 +1056,20 @@ async function runFreshWizard(paths: DeployPaths, existing?: SeedConfig, advance
           initialTag: existing?.release_channel,
           advanced,
         }),
+      web_image: () =>
+        p.text({
+          message: 'Full web image ref (optional)',
+          initialValue: existing?.web_image,
+          placeholder: 'ghcr.io/horacioh/seed-web:main',
+          validate: validateDockerImageRef,
+        }),
+      site_image: () =>
+        p.text({
+          message: 'Full site/daemon image ref (optional)',
+          initialValue: existing?.site_image,
+          placeholder: 'ghcr.io/horacioh/seed-site:main',
+          validate: validateDockerImageRef,
+        }),
       log_level: () =>
         p.select({
           message: 'Log level for Seed services',
@@ -1050,7 +1123,8 @@ async function runFreshWizard(paths: DeployPaths, existing?: SeedConfig, advance
   const config: SeedConfig = {
     domain: answers.domain as string,
     email: (answers.email as string) || '',
-    compose_url: DEFAULT_COMPOSE_URL,
+    deploy_url: configuredDeployUrl(existing),
+    compose_url: configuredComposeUrl(existing),
     compose_sha: existing?.compose_sha ?? '',
     compose_env_sha: existing?.compose_env_sha ?? '',
     compose_envs: {
@@ -1058,6 +1132,8 @@ async function runFreshWizard(paths: DeployPaths, existing?: SeedConfig, advance
     },
     environment: env,
     release_channel: answers.release_channel as string,
+    web_image: (answers.web_image as string) || undefined,
+    site_image: (answers.site_image as string) || undefined,
     testnet,
     link_secret: secret,
     // TODO: When re-enabling wizard analytics, publish a post/changelog
@@ -1072,6 +1148,8 @@ async function runFreshWizard(paths: DeployPaths, existing?: SeedConfig, advance
     ['email', config.email],
     ['network', config.testnet ? 'testnet (devnet)' : 'mainnet'],
     ['release_channel', config.release_channel],
+    ['web_image', config.web_image || '(default)'],
+    ['site_image', config.site_image || '(default)'],
     ['log_level', config.compose_envs.LOG_LEVEL],
     ['gateway', String(config.gateway)],
   ]
@@ -1081,6 +1159,8 @@ async function runFreshWizard(paths: DeployPaths, existing?: SeedConfig, advance
         email: existing.email,
         network: existing.testnet ? 'testnet (devnet)' : 'mainnet',
         release_channel: existing.release_channel,
+        web_image: existing.web_image || '(default)',
+        site_image: existing.site_image || '(default)',
         log_level: existing.compose_envs?.LOG_LEVEL ?? 'info',
         gateway: String(existing.gateway),
       }
@@ -1306,6 +1386,40 @@ export async function getContainerImages(shell: ShellRunner): Promise<Map<string
   return images
 }
 
+/** Return the expected Docker image refs for services managed by Seed compose. */
+export function expectedServiceImages(config: SeedConfig): Array<{container: string; expectedImage: string}> {
+  const tag = config.release_channel || DEFAULT_RELEASE_CHANNEL
+  return [
+    {container: 'seed-web', expectedImage: config.web_image || `seedhypermedia/web:${tag}`},
+    {container: 'seed-daemon', expectedImage: config.site_image || `seedhypermedia/site:${tag}`},
+  ]
+}
+
+function imageBase(ref: string): string {
+  const lastSlash = ref.lastIndexOf('/')
+  const lastColon = ref.lastIndexOf(':')
+  if (lastColon > lastSlash) return ref.slice(0, lastColon)
+  return ref
+}
+
+/** Return rollback tag sources and targets for the configured service image refs. */
+export function rollbackImageTargets(config: SeedConfig): Array<{base: string; target: string}> {
+  return expectedServiceImages(config).map(({expectedImage}) => ({
+    base: imageBase(expectedImage),
+    target: expectedImage,
+  }))
+}
+
+/** Return rollback tag refs to apply to a running image before deploying a new config. */
+export function rollbackTagRefs(container: string, runningImage: string, config: SeedConfig): string[] {
+  const tags = new Set<string>([`${imageBase(runningImage)}:rollback`])
+  const expected = expectedServiceImages(config).find((image) => image.container === container)
+  if (expected) {
+    tags.add(`${imageBase(expected.expectedImage)}:rollback`)
+  }
+  return [...tags]
+}
+
 /**
  * Pull latest images and check if any differ from what's currently running.
  * Returns true if new images were pulled that differ from running containers.
@@ -1404,6 +1518,13 @@ export function buildComposeEnv(config: SeedConfig, paths: DeployPaths): string 
     SEED_SITE_MONITORING_WORKDIR: join(paths.seedDir, 'monitoring'),
   }
 
+  if (config.web_image) {
+    vars.SEED_WEB_IMAGE = config.web_image
+  }
+  if (config.site_image) {
+    vars.SEED_SITE_IMAGE = config.site_image
+  }
+
   return Object.entries(vars)
     .map(([k, v]) => `${k}="${v}"`)
     .join(' ')
@@ -1451,14 +1572,13 @@ async function rollback(
   shell: ShellRunner,
 ): Promise<void> {
   log('Deployment failed — rolling back to previous images...')
-  const tag = config.release_channel || 'latest'
 
-  // Re-tag rollback images back to the release channel tag so compose uses them.
-  for (const base of ['seedhypermedia/site', 'seedhypermedia/web']) {
+  // Re-tag rollback images back to the exact image refs compose uses.
+  for (const {base, target} of rollbackImageTargets(config)) {
     const hasRollback = shell.runSafe(`docker image inspect ${base}:rollback >/dev/null 2>&1 && echo yes`)
     if (hasRollback === 'yes') {
-      shell.runSafe(`docker tag ${base}:rollback ${base}:${tag}`)
-      log(`  Restored ${base}:${tag} from rollback image`)
+      shell.runSafe(`docker tag ${base}:rollback ${target}`)
+      log(`  Restored ${target} from rollback image`)
     }
   }
 
@@ -1479,7 +1599,7 @@ async function rollback(
 // with the code already loaded in memory.
 // ---------------------------------------------------------------------------
 
-export async function selfUpdate(scriptPath: string = process.argv[1] || ''): Promise<void> {
+export async function selfUpdate(scriptPath: string = process.argv[1] || '', deployUrl?: string): Promise<void> {
   const report = (msg: string) => {
     if (process.stdout.isTTY) {
       console.log(msg)
@@ -1498,7 +1618,7 @@ export async function selfUpdate(scriptPath: string = process.argv[1] || ''): Pr
   }
 
   try {
-    const url = getDeployScriptUrl()
+    const url = getDeployScriptUrl(deployUrl)
     const response = await fetch(url)
     if (!response.ok) {
       report(`Upgrade: failed to fetch ${url}: ${response.status}`)
@@ -1559,7 +1679,11 @@ export async function deploy(
   // Use env-based URL override when present (testing / branch builds),
   // otherwise fall back to the compose_url stored in config.json.
   const hasEnvOverride = process.env.SEED_DEPLOY_URL || process.env.SEED_REPO_URL
-  const composeUrl = hasEnvOverride ? `${getOpsBaseUrl()}/docker-compose.yml` : config.compose_url
+  const composeUrl = hasEnvOverride
+    ? `${getOpsBaseUrl()}/docker-compose.yml`
+    : config.deploy_url
+      ? `${config.deploy_url.replace(/\/+$/, '')}/docker-compose.yml`
+      : config.compose_url
   const composeResponse = await fetch(composeUrl)
   if (!composeResponse.ok) {
     spinner?.stop('Failed to fetch docker-compose.yml')
@@ -1672,8 +1796,9 @@ export async function deploy(
   for (const [name, imageId] of previousImages) {
     const imageName = shell.runSafe(`docker inspect ${name} --format '{{.Config.Image}}' 2>/dev/null`)
     if (imageName) {
-      const base = imageName.split(':')[0]
-      shell.runSafe(`docker tag ${imageId} ${base}:rollback 2>/dev/null`)
+      for (const tagRef of rollbackTagRefs(name, imageName, config)) {
+        shell.runSafe(`docker tag ${imageId} ${tagRef} 2>/dev/null`)
+      }
     }
   }
 
@@ -1752,7 +1877,8 @@ export async function deploy(
   await writeConfig(config, paths)
 
   // New images are healthy — remove rollback tags so old images can be pruned.
-  for (const base of ['seedhypermedia/site', 'seedhypermedia/web']) {
+  for (const {expectedImage} of expectedServiceImages(config)) {
+    const base = imageBase(expectedImage)
     shell.runSafe(`docker rmi ${base}:rollback 2>/dev/null`)
   }
 
@@ -2089,10 +2215,16 @@ async function cmdDeploy(paths: DeployPaths, shell: ShellRunner, reconfigure = f
   p.outro(`Setup complete! Your Seed node is running.\n${MANAGE_HINT}`)
 }
 
-async function cmdUpgrade(): Promise<void> {
-  // The script updates itself in place, from main, for every node — independent
-  // of both the data dir and release_channel.
-  await selfUpdate()
+async function cmdUpgrade(paths: DeployPaths): Promise<void> {
+  let deployUrl: string | undefined
+  try {
+    if (await configExists(paths)) {
+      deployUrl = (await readConfig(paths)).deploy_url
+    }
+  } catch {
+    // If config can't be read, use the upstream updater.
+  }
+  await selfUpdate(undefined, deployUrl)
 }
 
 async function cmdStop(paths: DeployPaths, shell: ShellRunner): Promise<void> {
@@ -2137,6 +2269,9 @@ async function cmdDoctor(paths: DeployPaths, shell: ShellRunner): Promise<void> 
     console.log(`  Domain:      ${config.domain}`)
     console.log(`  Network:     ${config.testnet ? 'Testnet (devnet)' : 'Mainnet'}`)
     console.log(`  Channel:     ${config.release_channel}`)
+    if (config.deploy_url) console.log(`  Deploy URL:  ${config.deploy_url}`)
+    if (config.web_image) console.log(`  Web image:   ${config.web_image}`)
+    if (config.site_image) console.log(`  Site image:  ${config.site_image}`)
     console.log(`  Gateway:     ${config.gateway ? 'Yes' : 'No'}`)
     console.log(`  Config:      ${paths.configPath}`)
     for (const warning of configWarnings(config)) {
@@ -2189,7 +2324,6 @@ async function cmdDoctor(paths: DeployPaths, shell: ShellRunner): Promise<void> 
 
   // Configuration sync — compare running container state against config
   if (config) {
-    const expectedTag = config.release_channel
     const expectedLightning = config.testnet ? LIGHTNING_URL_TESTNET : LIGHTNING_URL_MAINNET
     const expectedTestnetName = config.testnet ? 'dev' : ''
 
@@ -2211,10 +2345,7 @@ async function cmdDoctor(paths: DeployPaths, shell: ShellRunner): Promise<void> 
     }
 
     // Check image tags
-    const imageChecks: Array<{container: string; expectedImage: string}> = [
-      {container: 'seed-web', expectedImage: `seedhypermedia/web:${expectedTag}`},
-      {container: 'seed-daemon', expectedImage: `seedhypermedia/site:${expectedTag}`},
-    ]
+    const imageChecks = expectedServiceImages(config)
 
     let hasMismatch = false
     const mismatches: string[] = []
@@ -2734,7 +2865,7 @@ async function main(): Promise<void> {
     case 'deploy':
       return cmdDeploy(paths, shell, reconfigure, advanced)
     case 'upgrade':
-      return cmdUpgrade()
+      return cmdUpgrade(paths)
     case 'stop':
       return cmdStop(paths, shell)
     case 'start':

--- a/ops/dist/deploy.js
+++ b/ops/dist/deploy.js
@@ -835,11 +835,36 @@ var DEFAULT_COMPOSE_URL = `${OPS_BASE_URL}/docker-compose.yml`;
 var NOTIFY_SERVICE_HOST = "https://notify.seed.hyper.media";
 var LIGHTNING_URL_MAINNET = "https://ln.seed.hyper.media";
 var LIGHTNING_URL_TESTNET = "https://ln.testnet.seed.hyper.media";
+function currentDeployUrl() {
+  return getOpsBaseUrl().replace(/\/+$/, "");
+}
+function currentComposeUrl() {
+  return `${currentDeployUrl()}/docker-compose.yml`;
+}
+function configuredDeployUrl(existing) {
+  if (process.env.SEED_DEPLOY_URL || process.env.SEED_REPO_URL)
+    return currentDeployUrl();
+  if (existing?.deploy_url)
+    return existing.deploy_url.replace(/\/+$/, "");
+  return currentDeployUrl();
+}
+function configuredComposeUrl(existing) {
+  if (process.env.SEED_DEPLOY_URL || process.env.SEED_REPO_URL)
+    return currentComposeUrl();
+  if (existing?.deploy_url)
+    return `${existing.deploy_url.replace(/\/+$/, "")}/docker-compose.yml`;
+  if (existing?.compose_url)
+    return existing.compose_url;
+  return currentComposeUrl();
+}
 var GITHUB_RELEASES_API = "https://api.github.com/repos/seed-hypermedia/seed/releases/latest";
 var DEV_DEPLOY_SCRIPT_URL = "https://seedappdev.s3.eu-west-2.amazonaws.com/dev/latest/deploy.js";
-function getDeployScriptUrl() {
+function getDeployScriptUrl(deployUrl) {
   if (process.env.SEED_DEPLOY_URL || process.env.SEED_REPO_URL) {
     return `${getOpsBaseUrl()}/dist/deploy.js`;
+  }
+  if (deployUrl) {
+    return `${deployUrl.replace(/\/+$/, "")}/dist/deploy.js`;
   }
   return DEV_DEPLOY_SCRIPT_URL;
 }
@@ -944,6 +969,26 @@ function validateDockerImageTag(tag) {
   if (!/^[A-Za-z0-9_][A-Za-z0-9_.-]*$/.test(tag)) {
     return "Use a Docker image tag: letters, numbers, _, . or -; must start with a letter, number or _";
   }
+}
+function validateDockerImageRef(ref) {
+  if (!ref)
+    return;
+  if (ref.trim() !== ref)
+    return "Remove leading or trailing spaces";
+  if (/\s/.test(ref))
+    return "Docker image refs cannot contain spaces";
+  const lastSlash = ref.lastIndexOf("/");
+  const lastColon = ref.lastIndexOf(":");
+  if (lastColon <= lastSlash)
+    return "Include an explicit image tag, for example ghcr.io/horacioh/seed-web:main";
+  const name = ref.slice(0, lastColon);
+  const tag = ref.slice(lastColon + 1);
+  if (!name || !/^[A-Za-z0-9][A-Za-z0-9._:/-]*$/.test(name) || name.includes("://")) {
+    return "Use a Docker image ref such as ghcr.io/horacioh/seed-web:main";
+  }
+  const tagError = validateDockerImageTag(tag);
+  if (tagError)
+    return `Invalid image tag: ${tagError}`;
 }
 async function promptReleaseChannel(options) {
   const initialTag = options.initialTag ?? DEFAULT_RELEASE_CHANNEL;
@@ -1291,6 +1336,16 @@ async function runMigrationWizard(old, paths, shell, advanced = false) {
       initialTag: old.imageTag,
       advanced
     }),
+    web_image: () => ue({
+      message: "Full web image ref (optional)",
+      placeholder: "ghcr.io/horacioh/seed-web:main",
+      validate: validateDockerImageRef
+    }),
+    site_image: () => ue({
+      message: "Full site/daemon image ref (optional)",
+      placeholder: "ghcr.io/horacioh/seed-site:main",
+      validate: validateDockerImageRef
+    }),
     log_level: () => de({
       message: "Log level",
       initialValue: old.logLevel ?? "info",
@@ -1341,7 +1396,8 @@ async function runMigrationWizard(old, paths, shell, advanced = false) {
   const config = {
     domain: answers.domain,
     email: answers.email || "",
-    compose_url: DEFAULT_COMPOSE_URL,
+    deploy_url: currentDeployUrl(),
+    compose_url: currentComposeUrl(),
     compose_sha: "",
     compose_env_sha: "",
     compose_envs: {
@@ -1349,6 +1405,8 @@ async function runMigrationWizard(old, paths, shell, advanced = false) {
     },
     environment: env,
     release_channel: answers.release_channel,
+    web_image: answers.web_image || undefined,
+    site_image: answers.site_image || undefined,
     testnet,
     link_secret: secret,
     analytics: old.trafficStats,
@@ -1424,6 +1482,18 @@ async function runFreshWizard(paths, existing, advanced = false) {
       initialTag: existing?.release_channel,
       advanced
     }),
+    web_image: () => ue({
+      message: "Full web image ref (optional)",
+      initialValue: existing?.web_image,
+      placeholder: "ghcr.io/horacioh/seed-web:main",
+      validate: validateDockerImageRef
+    }),
+    site_image: () => ue({
+      message: "Full site/daemon image ref (optional)",
+      initialValue: existing?.site_image,
+      placeholder: "ghcr.io/horacioh/seed-site:main",
+      validate: validateDockerImageRef
+    }),
     log_level: () => de({
       message: "Log level for Seed services",
       initialValue: existing?.compose_envs?.LOG_LEVEL ?? "info",
@@ -1467,7 +1537,8 @@ async function runFreshWizard(paths, existing, advanced = false) {
   const config = {
     domain: answers.domain,
     email: answers.email || "",
-    compose_url: DEFAULT_COMPOSE_URL,
+    deploy_url: configuredDeployUrl(existing),
+    compose_url: configuredComposeUrl(existing),
     compose_sha: existing?.compose_sha ?? "",
     compose_env_sha: existing?.compose_env_sha ?? "",
     compose_envs: {
@@ -1475,6 +1546,8 @@ async function runFreshWizard(paths, existing, advanced = false) {
     },
     environment: env,
     release_channel: answers.release_channel,
+    web_image: answers.web_image || undefined,
+    site_image: answers.site_image || undefined,
     testnet,
     link_secret: secret,
     analytics: existing?.analytics ?? false,
@@ -1486,6 +1559,8 @@ async function runFreshWizard(paths, existing, advanced = false) {
     ["email", config.email],
     ["network", config.testnet ? "testnet (devnet)" : "mainnet"],
     ["release_channel", config.release_channel],
+    ["web_image", config.web_image || "(default)"],
+    ["site_image", config.site_image || "(default)"],
     ["log_level", config.compose_envs.LOG_LEVEL],
     ["gateway", String(config.gateway)]
   ];
@@ -1494,6 +1569,8 @@ async function runFreshWizard(paths, existing, advanced = false) {
     email: existing.email,
     network: existing.testnet ? "testnet (devnet)" : "mainnet",
     release_channel: existing.release_channel,
+    web_image: existing.web_image || "(default)",
+    site_image: existing.site_image || "(default)",
     log_level: existing.compose_envs?.LOG_LEVEL ?? "info",
     gateway: String(existing.gateway)
   } : undefined;
@@ -1633,6 +1710,34 @@ async function getContainerImages(shell) {
   }
   return images;
 }
+function expectedServiceImages(config) {
+  const tag = config.release_channel || DEFAULT_RELEASE_CHANNEL;
+  return [
+    { container: "seed-web", expectedImage: config.web_image || `seedhypermedia/web:${tag}` },
+    { container: "seed-daemon", expectedImage: config.site_image || `seedhypermedia/site:${tag}` }
+  ];
+}
+function imageBase(ref) {
+  const lastSlash = ref.lastIndexOf("/");
+  const lastColon = ref.lastIndexOf(":");
+  if (lastColon > lastSlash)
+    return ref.slice(0, lastColon);
+  return ref;
+}
+function rollbackImageTargets(config) {
+  return expectedServiceImages(config).map(({ expectedImage }) => ({
+    base: imageBase(expectedImage),
+    target: expectedImage
+  }));
+}
+function rollbackTagRefs(container, runningImage, config) {
+  const tags = new Set([`${imageBase(runningImage)}:rollback`]);
+  const expected = expectedServiceImages(config).find((image) => image.container === container);
+  if (expected) {
+    tags.add(`${imageBase(expected.expectedImage)}:rollback`);
+  }
+  return [...tags];
+}
 async function checkForNewImages(config, paths, shell) {
   const env = buildComposeEnv(config, paths);
   const beforeImages = await getContainerImages(shell);
@@ -1707,6 +1812,12 @@ function buildComposeEnv(config, paths) {
     NOTIFY_SERVICE_HOST,
     SEED_SITE_MONITORING_WORKDIR: join(paths.seedDir, "monitoring")
   };
+  if (config.web_image) {
+    vars.SEED_WEB_IMAGE = config.web_image;
+  }
+  if (config.site_image) {
+    vars.SEED_SITE_IMAGE = config.site_image;
+  }
   return Object.entries(vars).map(([k3, v3]) => `${k3}="${v3}"`).join(" ");
 }
 function getWorkspaceDirs(paths) {
@@ -1736,12 +1847,11 @@ async function ensureSeedDir(paths, shell) {
 }
 async function rollback(previousImages, config, paths, shell) {
   log("Deployment failed \u2014 rolling back to previous images...");
-  const tag = config.release_channel || "latest";
-  for (const base of ["seedhypermedia/site", "seedhypermedia/web"]) {
+  for (const { base, target } of rollbackImageTargets(config)) {
     const hasRollback = shell.runSafe(`docker image inspect ${base}:rollback >/dev/null 2>&1 && echo yes`);
     if (hasRollback === "yes") {
-      shell.runSafe(`docker tag ${base}:rollback ${base}:${tag}`);
-      log(`  Restored ${base}:${tag} from rollback image`);
+      shell.runSafe(`docker tag ${base}:rollback ${target}`);
+      log(`  Restored ${target} from rollback image`);
     }
   }
   for (const [name] of previousImages) {
@@ -1753,7 +1863,7 @@ async function rollback(previousImages, config, paths, shell) {
   shell.runSafe(`${env} docker compose -f ${paths.composePath} up -d --quiet-pull 2>&1`);
   log("Rollback complete. Check container status with: docker ps");
 }
-async function selfUpdate(scriptPath = process.argv[1] || "") {
+async function selfUpdate(scriptPath = process.argv[1] || "", deployUrl) {
   const report = (msg) => {
     if (process.stdout.isTTY) {
       console.log(msg);
@@ -1766,7 +1876,7 @@ async function selfUpdate(scriptPath = process.argv[1] || "") {
     return;
   }
   try {
-    const url = getDeployScriptUrl();
+    const url = getDeployScriptUrl(deployUrl);
     const response = await fetch(url);
     if (!response.ok) {
       report(`Upgrade: failed to fetch ${url}: ${response.status}`);
@@ -1808,7 +1918,7 @@ async function deploy(config, paths, shell, takeoverApproved = false) {
   spinner?.start("Fetching docker-compose.yml...");
   step("Fetching docker-compose.yml...");
   const hasEnvOverride = process.env.SEED_DEPLOY_URL || process.env.SEED_REPO_URL;
-  const composeUrl = hasEnvOverride ? `${getOpsBaseUrl()}/docker-compose.yml` : config.compose_url;
+  const composeUrl = hasEnvOverride ? `${getOpsBaseUrl()}/docker-compose.yml` : config.deploy_url ? `${config.deploy_url.replace(/\/+$/, "")}/docker-compose.yml` : config.compose_url;
   const composeResponse = await fetch(composeUrl);
   if (!composeResponse.ok) {
     spinner?.stop("Failed to fetch docker-compose.yml");
@@ -1904,8 +2014,9 @@ async function deploy(config, paths, shell, takeoverApproved = false) {
   for (const [name, imageId] of previousImages) {
     const imageName = shell.runSafe(`docker inspect ${name} --format '{{.Config.Image}}' 2>/dev/null`);
     if (imageName) {
-      const base = imageName.split(":")[0];
-      shell.runSafe(`docker tag ${imageId} ${base}:rollback 2>/dev/null`);
+      for (const tagRef of rollbackTagRefs(name, imageName, config)) {
+        shell.runSafe(`docker tag ${imageId} ${tagRef} 2>/dev/null`);
+      }
     }
   }
   const env = buildComposeEnv(config, paths);
@@ -1962,7 +2073,8 @@ async function deploy(config, paths, shell, takeoverApproved = false) {
   config.compose_env_sha = envSha;
   config.last_script_run = new Date().toISOString();
   await writeConfig(config, paths);
-  for (const base of ["seedhypermedia/site", "seedhypermedia/web"]) {
+  for (const { expectedImage } of expectedServiceImages(config)) {
+    const base = imageBase(expectedImage);
     shell.runSafe(`docker rmi ${base}:rollback 2>/dev/null`);
   }
   step("Cleaning up unused images...");
@@ -2202,8 +2314,14 @@ ${MANAGE_HINT}`);
   fe(`Setup complete! Your Seed node is running.
 ${MANAGE_HINT}`);
 }
-async function cmdUpgrade() {
-  await selfUpdate();
+async function cmdUpgrade(paths) {
+  let deployUrl;
+  try {
+    if (await configExists(paths)) {
+      deployUrl = (await readConfig(paths)).deploy_url;
+    }
+  } catch {}
+  await selfUpdate(undefined, deployUrl);
 }
 async function cmdStop(paths, shell) {
   checkDockerAccess(shell);
@@ -2241,6 +2359,12 @@ Configuration:`);
     console.log(`  Domain:      ${config.domain}`);
     console.log(`  Network:     ${config.testnet ? "Testnet (devnet)" : "Mainnet"}`);
     console.log(`  Channel:     ${config.release_channel}`);
+    if (config.deploy_url)
+      console.log(`  Deploy URL:  ${config.deploy_url}`);
+    if (config.web_image)
+      console.log(`  Web image:   ${config.web_image}`);
+    if (config.site_image)
+      console.log(`  Site image:  ${config.site_image}`);
     console.log(`  Gateway:     ${config.gateway ? "Yes" : "No"}`);
     console.log(`  Config:      ${paths.configPath}`);
     for (const warning of configWarnings(config)) {
@@ -2284,7 +2408,6 @@ Containers:`);
   Tip: Check logs with '${cmd("logs daemon|web|proxy")}'`);
   }
   if (config) {
-    const expectedTag = config.release_channel;
     const expectedLightning = config.testnet ? LIGHTNING_URL_TESTNET : LIGHTNING_URL_MAINNET;
     const expectedTestnetName = config.testnet ? "dev" : "";
     const checks = [
@@ -2301,10 +2424,7 @@ Containers:`);
       "seed-daemon": daemonEnvs,
       "seed-web": webEnvs
     };
-    const imageChecks = [
-      { container: "seed-web", expectedImage: `seedhypermedia/web:${expectedTag}` },
-      { container: "seed-daemon", expectedImage: `seedhypermedia/site:${expectedTag}` }
-    ];
+    const imageChecks = expectedServiceImages(config);
     let hasMismatch = false;
     const mismatches = [];
     for (const { container, envVar, expected, label } of checks) {
@@ -2720,7 +2840,7 @@ async function main() {
     case "deploy":
       return cmdDeploy(paths, shell, reconfigure, advanced);
     case "upgrade":
-      return cmdUpgrade();
+      return cmdUpgrade(paths);
     case "stop":
       return cmdStop(paths, shell);
     case "start":
@@ -2754,11 +2874,14 @@ if (import.meta.main) {
 export {
   writeConfig,
   validateDockerImageTag,
+  validateDockerImageRef,
   takeOverHost,
   stopStackByProject,
   sha256,
   setupCron,
   selfUpdate,
+  rollbackTagRefs,
+  rollbackImageTargets,
   removeSeedCronLines,
   removeLegacyHostCronLines,
   removeLegacyHostCron,
@@ -2786,6 +2909,7 @@ export {
   freeConflictingPortBindings,
   extractSeedCronLines,
   extractDns,
+  expectedServiceImages,
   environmentPresets,
   ensureSeedDir,
   detectOldInstall,

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -27,7 +27,7 @@ services:
 
   seed-web:
     container_name: seed-web
-    image: seedhypermedia/web:${SEED_SITE_TAG:-latest}
+    image: ${SEED_WEB_IMAGE:-seedhypermedia/web:${SEED_SITE_TAG:-latest}}
     user: "${SEED_UID}:${SEED_GID}"
     depends_on:
       - seed-daemon
@@ -49,7 +49,7 @@ services:
 
   seed-daemon:
     container_name: seed-daemon
-    image: seedhypermedia/site:${SEED_SITE_TAG:-latest}
+    image: ${SEED_SITE_IMAGE:-seedhypermedia/site:${SEED_SITE_TAG:-latest}}
     user: "${SEED_UID}:${SEED_GID}"
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary

Fixes seed-hypermedia/seed#925: caption text could not be range-selected in edit mode, so the fragment actions built on selections (Copy Link, Comment → `#blk-image[start:end]`) were unreachable for captions.

Two independent causes, both in the image render path:

1. `BlockSelectionWrapper` wrapped the whole image subtree in `contentEditable={false}`. A ProseMirror view manages a single contenteditable range, so the caption (which is real inline content of the image block) became its own editing host: `view.hasFocus()` stayed false and prosemirror-view discarded every caption selection.
2. `MediaContainer`'s outer wrapper was `draggable=true`, so caption mouse drags became native drags instead of text selection.

```diff
-<BlockSelectionWrapper editor={editor} block={block}>
+<BlockSelectionWrapper editor={editor} block={block} keepEditable={mediaType === 'image'}>

 // media-container.tsx: draggable moves off the wrapper (the caption's ancestor)
-<div className="…flex-col…" draggable={canAuthor} onDragStart={…} onDragEnd={…}>
+<div className="…flex-col…">
   <div {...mediaProps} contentEditable={false}
+       draggable={canAuthor} onDragStart={…} onDragEnd={…}>
```

The media surface itself stays `contentEditable={false}` and draggable, so click-to-select, side-menu drag, and reorder are unchanged.

Third change, a consequence of the first: Enter in a caption was handled by a React `onKeyDown` on the caption element, and the Enter keymap explicitly no-op'd for image blocks to defer to it. Now that the caption is part of the outer editing host, keydown targets `div.ProseMirror` and never reaches that React handler — Enter silently did nothing. The behavior moves into the keymap branch that used to be the no-op:

```ts
// KeyboardShortcutsExtension, handleEnter
if (blockContentType === 'image' && !(selection instanceof NodeSelection)) {
  const nextTextPos = TextSelection.near(doc.resolve(block.afterPos), 1).from
  nextTextPos > block.afterPos
    ? tr.setSelection(TextSelection.create(tr.doc, nextTextPos))   // move to next block
    : tr.insert(block.afterPos, blockNode.create(null, paragraph.create()))  // image is last
}
```

## Tests

- `media-container.test.tsx`: new assertions that no caption ancestor is `contenteditable=false` or `draggable=true`, and that the media surface keeps both. Both failed before the fix. The three unit tests covering the removed React Enter handler are deleted — that behavior now lives in the keymap and is covered end-to-end instead.
- `image-caption.e2e.ts`: keyboard selection (asserting a non-empty `TextSelection` inside the image block, `view.hasFocus()`, and the formatting toolbar appearing), mouse drag selection, bold on a caption range, and Enter with the image as the last block.
- Full editor E2E suite passes (103 passed / 12 skipped). The 9 pre-existing unit failures in `embed-editor`, `readonly-viewer-gallery` and `BlockManipulationExtension` reproduce unchanged on the base branch.

`docs/projects/image-caption-selection.md` holds the investigation and the remaining phased test plan (media regression sweep, clipboard/SSR, mobile), plus links to the follow-up issues seed-hypermedia/seed#926–#931.


Link to Devin session: https://app.devin.ai/sessions/923dddc749c646c8965bc2110a7d9ab4
Requested by: @horacioh
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/horacioh/seed/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->