### PR TITLE
feat(ui): compact mobile document header

### DIFF
--- a/frontend/packages/ui/src/__tests__/document-header-breadcrumbs.test.tsx
+++ b/frontend/packages/ui/src/__tests__/document-header-breadcrumbs.test.tsx
@@ -170,7 +170,12 @@ describe('DocumentHeader Breadcrumbs', () => {
         />,
       )
 
-      expect(Array.from(container.querySelectorAll('a')).filter((link) => link.textContent === 'alice')).toHaveLength(1)
+      const desktopByline = Array.from(container.querySelectorAll('div')).find(
+        (element) => element.className.includes('hidden') && element.className.includes('md:flex'),
+      )
+      expect(
+        Array.from(desktopByline?.querySelectorAll('a') ?? []).filter((link) => link.textContent === 'alice'),
+      ).toHaveLength(1)
       expect(errorSpy).not.toHaveBeenCalled()
     } finally {
       errorSpy.mockRestore()
@@ -198,5 +203,32 @@ describe('DocumentHeader Breadcrumbs', () => {
     })
 
     expect(onRemoveIcon).toHaveBeenCalledOnce()
+  })
+
+  it('renders the optional mobile byline action without adding one to read-only headers', () => {
+    const docId = hmId('site', {path: ['doc']})
+    renderWithProvider(
+      <DocumentHeader
+        docId={docId}
+        docMetadata={{name: 'Doc'} as any}
+        authors={[]}
+        updateTime={null}
+        mobileBylineAction={<button type="button">Add</button>}
+      />,
+    )
+    expect(container.querySelector('button')?.textContent).toBe('Add')
+
+    act(() => {
+      root.render(
+        <UniversalAppProvider
+          openRoute={vi.fn()}
+          openUrl={vi.fn()}
+          universalClient={{request: vi.fn(), publish: vi.fn()} as any}
+        >
+          <DocumentHeader docId={docId} docMetadata={{name: 'Doc'} as any} authors={[]} updateTime={null} />
+        </UniversalAppProvider>,
+      )
+    })
+    expect(container.querySelector('button')).toBeNull()
   })
 })

--- a/frontend/packages/ui/src/__tests__/document-metadata-affordances.test.tsx
+++ b/frontend/packages/ui/src/__tests__/document-metadata-affordances.test.tsx
@@ -3,9 +3,26 @@ import React from 'react'
 import {createRoot, type Root} from 'react-dom/client'
 import {act} from 'react-dom/test-utils'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
-import {DocumentMetadataAffordanceButtons} from '../document-metadata-affordances'
+import {
+  DocumentMetadataAffordanceButtons,
+  EditableDocumentMetadataFields,
+  HomeDocumentMetadataAffordanceBar,
+} from '../document-metadata-affordances'
 ;(globalThis as typeof globalThis & {React?: typeof React; IS_REACT_ACT_ENVIRONMENT?: boolean}).React = React
 ;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+
+if (!('PointerEvent' in window)) {
+  ;(window as any).PointerEvent = MouseEvent
+}
+if (!HTMLElement.prototype.hasPointerCapture) {
+  HTMLElement.prototype.hasPointerCapture = () => false
+}
+if (!HTMLElement.prototype.setPointerCapture) {
+  HTMLElement.prototype.setPointerCapture = () => {}
+}
+if (!HTMLElement.prototype.releasePointerCapture) {
+  HTMLElement.prototype.releasePointerCapture = () => {}
+}
 
 let container: HTMLDivElement
 let root: Root
@@ -41,6 +58,41 @@ function renderButtons(props: Partial<React.ComponentProps<typeof DocumentMetada
 
 function buttonWithText(text: string): HTMLButtonElement | null {
   return Array.from(container.querySelectorAll('button')).find((button) => button.textContent?.includes(text)) ?? null
+}
+
+function openMobileMenu() {
+  act(() => {
+    container
+      .querySelector<HTMLButtonElement>('button[aria-label="Add document metadata"]')
+      ?.dispatchEvent(new PointerEvent('pointerdown', {bubbles: true, cancelable: true, button: 0, ctrlKey: false}))
+  })
+}
+
+function activateMenuItem(item: HTMLElement) {
+  act(() => {
+    item.dispatchEvent(new PointerEvent('pointerdown', {bubbles: true, cancelable: true, button: 0, ctrlKey: false}))
+    item.dispatchEvent(new PointerEvent('pointerup', {bubbles: true, cancelable: true, button: 0, ctrlKey: false}))
+    item.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))
+    document.body
+      .querySelector<HTMLElement>('[data-radix-menu-content]')
+      ?.dispatchEvent(new Event('animationend', {bubbles: true}))
+  })
+}
+
+function ControlledEditableDocumentMetadataFields(
+  props: Omit<
+    React.ComponentProps<typeof EditableDocumentMetadataFields>,
+    'summaryRequested' | 'onSummaryRequestedChange'
+  >,
+) {
+  const [summaryRequested, setSummaryRequested] = React.useState(false)
+  return (
+    <EditableDocumentMetadataFields
+      {...props}
+      summaryRequested={summaryRequested}
+      onSummaryRequestedChange={setSummaryRequested}
+    />
+  )
 }
 
 describe('DocumentMetadataAffordanceButtons', () => {
@@ -118,6 +170,76 @@ describe('DocumentMetadataAffordanceButtons', () => {
     expect(affordanceRow.className).toContain('opacity-100')
     expect(affordanceRow.className).toContain('md:opacity-0')
   })
+
+  it('shows only the gated actions in the mobile Add menu', () => {
+    renderButtons({mobileOnly: true, fileUpload: vi.fn(), metadata: {icon: 'ipfs://icon-cid'}})
+
+    expect(container.querySelectorAll('button')).toHaveLength(1)
+    openMobileMenu()
+
+    const items = Array.from(document.body.querySelectorAll('[role="menuitem"]')).map(
+      (item) => item.textContent?.trim(),
+    )
+    expect(items).toEqual(['Add Summary', 'Add cover image'])
+  })
+
+  it('renders no mobile Add trigger when every action is gated off', () => {
+    renderButtons({
+      mobileOnly: true,
+      fileUpload: vi.fn(),
+      metadata: {icon: 'ipfs://icon-cid', cover: 'ipfs://cover-cid', summary: 'A summary'},
+    })
+
+    expect(container.querySelector('button[aria-label="Add document metadata"]')).toBeNull()
+  })
+
+  it('uploads an icon selected from the mobile Add menu', async () => {
+    const fileUpload = vi.fn(async () => 'bafyicon')
+    const onMetadata = vi.fn()
+    renderButtons({mobileOnly: true, fileUpload, onMetadata})
+    const input = container.querySelector<HTMLInputElement>('input[aria-label="Choose document icon"]')!
+    const clickSpy = vi.spyOn(input, 'click')
+    openMobileMenu()
+
+    act(() => {
+      Array.from(document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'))
+        .find((item) => item.textContent?.includes('Add icon'))
+        ?.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))
+    })
+    expect(clickSpy).toHaveBeenCalledOnce()
+    const file = new File(['icon'], 'icon.png', {type: 'image/png'})
+    await act(async () => {
+      Object.defineProperty(input, 'files', {value: [file], configurable: true})
+      input.dispatchEvent(new Event('change', {bubbles: true}))
+    })
+
+    expect(fileUpload).toHaveBeenCalledWith(file)
+    expect(onMetadata).toHaveBeenCalledWith({icon: 'ipfs://bafyicon'})
+  })
+
+  it('uploads a cover selected from the mobile Add menu', async () => {
+    const fileUpload = vi.fn(async () => 'ipfs://bafycover')
+    const onMetadata = vi.fn()
+    renderButtons({mobileOnly: true, fileUpload, onMetadata, metadata: {icon: 'ipfs://icon-cid'}})
+    const input = container.querySelector<HTMLInputElement>('input[aria-label="Choose document cover image"]')!
+    const clickSpy = vi.spyOn(input, 'click')
+    openMobileMenu()
+
+    act(() => {
+      Array.from(document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'))
+        .find((item) => item.textContent?.includes('Add cover image'))
+        ?.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}))
+    })
+    expect(clickSpy).toHaveBeenCalledOnce()
+    const file = new File(['cover'], 'cover.png', {type: 'image/png'})
+    await act(async () => {
+      Object.defineProperty(input, 'files', {value: [file], configurable: true})
+      input.dispatchEvent(new Event('change', {bubbles: true}))
+    })
+
+    expect(fileUpload).toHaveBeenCalledWith(file)
+    expect(onMetadata).toHaveBeenCalledWith({cover: 'ipfs://bafycover'})
+  })
 })
 
 describe('EditableDocumentMetadataFields', () => {
@@ -126,11 +248,10 @@ describe('EditableDocumentMetadataFields', () => {
       React.ComponentProps<typeof import('../document-metadata-affordances').EditableDocumentMetadataFields>
     > = {},
   ) {
-    const module = await import('../document-metadata-affordances')
     const onMetadata = props.onMetadata ?? vi.fn()
     act(() => {
       root.render(
-        <module.EditableDocumentMetadataFields
+        <ControlledEditableDocumentMetadataFields
           name="New page"
           summary=""
           metadata={{}}
@@ -236,6 +357,29 @@ describe('EditableDocumentMetadataFields', () => {
     expect(buttonWithText('Add Summary')).not.toBeNull()
   })
 
+  it('keeps an empty summary editor mounted when focus moves into a menu', async () => {
+    await renderFields()
+
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('button[aria-label="Add document summary"]')
+        ?.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+    })
+
+    const summary = container.querySelector<HTMLTextAreaElement>('textarea[aria-label="Document summary"]')
+    expect(summary).not.toBeNull()
+    const menu = document.createElement('div')
+    menu.setAttribute('role', 'menu')
+    document.body.appendChild(menu)
+
+    act(() => {
+      summary?.dispatchEvent(new FocusEvent('blur', {bubbles: true, relatedTarget: menu}))
+    })
+
+    expect(container.querySelector<HTMLTextAreaElement>('textarea[aria-label="Document summary"]')).toBe(summary)
+    menu.remove()
+  })
+
   it('saves summary text as metadata and keeps the editor visible after blur', async () => {
     const onMetadata = vi.fn()
     await renderFields({onMetadata})
@@ -254,12 +398,11 @@ describe('EditableDocumentMetadataFields', () => {
   })
 
   it('keeps the Add Summary button until the summary textarea blurs', async () => {
-    const module = await import('../document-metadata-affordances')
     const onMetadata = vi.fn()
 
     act(() => {
       root.render(
-        <module.EditableDocumentMetadataFields
+        <ControlledEditableDocumentMetadataFields
           name="New page"
           summary=""
           metadata={{}}
@@ -275,7 +418,7 @@ describe('EditableDocumentMetadataFields', () => {
 
     act(() => {
       root.render(
-        <module.EditableDocumentMetadataFields
+        <ControlledEditableDocumentMetadataFields
           name="New page"
           summary="A concise summary"
           metadata={{summary: 'A concise summary'}}
@@ -295,12 +438,11 @@ describe('EditableDocumentMetadataFields', () => {
   })
 
   it('keeps an emptied existing summary textarea visible until blur', async () => {
-    const module = await import('../document-metadata-affordances')
     const onMetadata = vi.fn()
 
     act(() => {
       root.render(
-        <module.EditableDocumentMetadataFields
+        <ControlledEditableDocumentMetadataFields
           name="New page"
           summary="A concise summary"
           metadata={{summary: 'A concise summary'}}
@@ -319,7 +461,7 @@ describe('EditableDocumentMetadataFields', () => {
 
     act(() => {
       root.render(
-        <module.EditableDocumentMetadataFields
+        <ControlledEditableDocumentMetadataFields
           name="New page"
           summary=""
           metadata={{}}
@@ -339,6 +481,99 @@ describe('EditableDocumentMetadataFields', () => {
     expect(container.querySelector<HTMLTextAreaElement>('textarea[aria-label="Document summary"]')).toBeNull()
     expect(buttonWithText('Add Summary')).not.toBeNull()
   })
+
+  it('keeps the summary textarea focused after Add Summary closes the mobile menu', async () => {
+    function MobileSummaryHarness() {
+      const [summaryRequested, setSummaryRequested] = React.useState(false)
+      return (
+        <>
+          <DocumentMetadataAffordanceButtons
+            metadata={{}}
+            visible
+            mobileOnly
+            fileUpload={vi.fn()}
+            onMetadata={vi.fn()}
+            onRequestSummary={() => setSummaryRequested(true)}
+          />
+          <EditableDocumentMetadataFields
+            name="New page"
+            summary=""
+            metadata={{}}
+            onMetadata={vi.fn()}
+            onBeginEdit={vi.fn()}
+            summaryRequested={summaryRequested}
+            onSummaryRequestedChange={setSummaryRequested}
+          />
+        </>
+      )
+    }
+
+    act(() => {
+      root.render(<MobileSummaryHarness />)
+    })
+    openMobileMenu()
+    activateMenuItem(
+      Array.from(document.body.querySelectorAll<HTMLElement>('[role="menuitem"]')).find(
+        (item) => item.textContent?.includes('Add Summary'),
+      )!,
+    )
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    const summary = container.querySelector<HTMLTextAreaElement>('textarea[aria-label="Document summary"]')
+    expect(summary).not.toBeNull()
+    expect(document.activeElement).toBe(summary)
+  })
+
+  it('keeps the summary textarea focused after keyboard Add Summary activation', async () => {
+    function MobileSummaryHarness() {
+      const [summaryRequested, setSummaryRequested] = React.useState(false)
+      return (
+        <>
+          <DocumentMetadataAffordanceButtons
+            metadata={{}}
+            visible
+            mobileOnly
+            fileUpload={vi.fn()}
+            onMetadata={vi.fn()}
+            onRequestSummary={() => setSummaryRequested(true)}
+          />
+          <EditableDocumentMetadataFields
+            name="New page"
+            summary=""
+            metadata={{}}
+            onMetadata={vi.fn()}
+            onBeginEdit={vi.fn()}
+            summaryRequested={summaryRequested}
+            onSummaryRequestedChange={setSummaryRequested}
+          />
+        </>
+      )
+    }
+
+    act(() => {
+      root.render(<MobileSummaryHarness />)
+    })
+    const trigger = container.querySelector<HTMLButtonElement>('button[aria-label="Add document metadata"]')!
+    act(() => {
+      trigger.focus()
+      trigger.dispatchEvent(new KeyboardEvent('keydown', {key: 'ArrowDown', bubbles: true}))
+    })
+    const summaryItem = Array.from(document.body.querySelectorAll<HTMLElement>('[role="menuitem"]')).find(
+      (item) => item.textContent?.includes('Add Summary'),
+    )!
+    act(() => {
+      summaryItem.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter', bubbles: true}))
+    })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    const summary = container.querySelector<HTMLTextAreaElement>('textarea[aria-label="Document summary"]')
+    expect(summary).not.toBeNull()
+    expect(document.activeElement).toBe(summary)
+  })
 })
 
 describe('HomeDocumentMetadataAffordanceBar', () => {
@@ -347,16 +582,10 @@ describe('HomeDocumentMetadataAffordanceBar', () => {
       React.ComponentProps<typeof import('../document-metadata-affordances').HomeDocumentMetadataAffordanceBar>
     > = {},
   ) {
-    const module = await import('../document-metadata-affordances')
     const onMetadata = props.onMetadata ?? vi.fn()
     act(() => {
       root.render(
-        <module.HomeDocumentMetadataAffordanceBar
-          metadata={{}}
-          onMetadata={onMetadata}
-          onBeginEdit={vi.fn()}
-          {...props}
-        />,
+        <HomeDocumentMetadataAffordanceBar metadata={{}} onMetadata={onMetadata} onBeginEdit={vi.fn()} {...props} />,
       )
     })
     return {onMetadata}

--- a/frontend/packages/ui/src/document-header.tsx
+++ b/frontend/packages/ui/src/document-header.tsx
@@ -24,6 +24,7 @@ import {PrivateBadge} from './private-badge'
 import {Spinner} from './spinner'
 import {SizableText} from './text'
 import {Tooltip} from './tooltip'
+import {cn} from './utils'
 
 export type AuthorPayload = HMMetadataPayload
 
@@ -55,6 +56,7 @@ export function DocumentHeader({
   showTitle = true,
   children,
   onRemoveIcon,
+  mobileBylineAction,
 }: {
   docId: UnpackedHypermediaId | null
   docMetadata: HMMetadata | null
@@ -67,6 +69,7 @@ export function DocumentHeader({
   showTitle?: boolean
   children?: React.ReactNode
   onRemoveIcon?: () => void
+  mobileBylineAction?: React.ReactNode
 }) {
   const hasCover = useMemo(() => !!docMetadata?.cover, [docMetadata])
   const hasIcon = useMemo(() => !!docMetadata?.icon, [docMetadata])
@@ -86,13 +89,12 @@ export function DocumentHeader({
 
   return (
     <Container
-      className="dark:bg-background relative w-full rounded-lg bg-white"
+      className={cn('dark:bg-background relative w-full rounded-lg bg-white', hasCover ? 'pt-6' : 'pt-4 md:pt-15')}
       style={{
         marginTop: hasCover ? -40 : 0,
-        paddingTop: !hasCover ? 60 : 24,
       }}
     >
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2 md:gap-4">
         {!isHomeDoc && docId && hasIcon ? (
           <div
             className="group/icon relative flex w-fit"
@@ -130,7 +132,11 @@ export function DocumentHeader({
         ) : (
           <>
             {showTitle && (
-              <SizableText className="text-3xl md:text-4xl lg:text-5xl" weight="bold" {...highlighter(docId)}>
+              <SizableText
+                className="text-2xl max-md:leading-tight md:text-4xl lg:text-5xl"
+                weight="bold"
+                {...highlighter(docId)}
+              >
                 {isHomeDoc ? 'Home' : docMetadata?.name}
               </SizableText>
             )}
@@ -139,10 +145,10 @@ export function DocumentHeader({
             ) : null}
           </>
         )}
-        <div className="border-border flex flex-col gap-2 border-b pb-4">
+        <div className="border-border flex flex-col gap-2 border-b pb-2 md:pb-4">
           {siteUrl ? <SiteURLButton siteUrl={siteUrl} /> : null}
           <div className="flex flex-1 items-center justify-between gap-3">
-            <div className="flex flex-1 flex-wrap items-center gap-3">
+            <div className="hidden flex-1 flex-wrap items-center gap-3 md:flex">
               {displayAuthors.length ? (
                 <>
                   <p className="text-sm font-bold">
@@ -168,6 +174,33 @@ export function DocumentHeader({
               ) : null}
               {updateTime ? <DocumentDate metadata={docMetadata || undefined} updateTime={updateTime} /> : null}
             </div>
+            <div className="flex min-w-0 flex-1 items-center gap-2 md:hidden">
+              {displayAuthors.length ? (
+                <>
+                  <div className="flex shrink-0 items-center -space-x-2">
+                    {displayAuthors.slice(0, 3).map((author) => (
+                      <div
+                        key={author.id.id}
+                        className="dark:border-background dark:bg-background size-5 overflow-hidden rounded-full border-2 border-white bg-white"
+                      >
+                        <HMIcon id={author.id} name={author.metadata?.name} icon={author.metadata?.icon} size={20} />
+                      </div>
+                    ))}
+                  </div>
+                  <p className="min-w-0 truncate text-xs font-medium">
+                    <AuthorLink id={displayAuthors[0]!.id} siteUid={docId?.uid} />
+                    {displayAuthors.length > 1 ? ` & ${displayAuthors.length - 1} others` : null}
+                  </p>
+                </>
+              ) : null}
+              {displayAuthors.length && updateTime ? (
+                <SizableText size="xs" className="shrink-0" aria-hidden="true">
+                  ·
+                </SizableText>
+              ) : null}
+              {updateTime ? <DocumentDate metadata={docMetadata || undefined} updateTime={updateTime} /> : null}
+            </div>
+            {mobileBylineAction}
           </div>
         </div>
       </div>
@@ -201,14 +234,14 @@ function AuthorLink({id, siteUid}: {id: UnpackedHypermediaId; siteUid?: string})
  * Renders the document's location trail, ending with the current document as
  * non-navigable text. A lone crumb still renders: it is the home document.
  */
-export function Breadcrumbs({breadcrumbs}: {breadcrumbs: BreadcrumbEntry[]}) {
+export function Breadcrumbs({breadcrumbs, className}: {breadcrumbs: BreadcrumbEntry[]; className?: string}) {
   if (breadcrumbs.length === 0) return null
 
   const [first, ...rest] = breadcrumbs
   const lastIndex = breadcrumbs.length - 1
 
   return (
-    <nav aria-label="Breadcrumb" className="text-muted-foreground flex min-w-0 flex-1 items-center">
+    <nav aria-label="Breadcrumb" className={cn('text-muted-foreground flex min-w-0 flex-1 items-center', className)}>
       <ol className="flex min-w-0 flex-1 items-center gap-2">
         {first && 'id' in first ? (
           <li className="flex shrink-0 items-center">

--- a/frontend/packages/ui/src/document-metadata-affordances.tsx
+++ b/frontend/packages/ui/src/document-metadata-affordances.tsx
@@ -1,7 +1,8 @@
 import type {HMMetadata} from '@seed-hypermedia/client/hm-types'
-import {FileText, ImagePlus, Smile} from 'lucide-react'
+import {FileText, ImagePlus, Plus, Smile} from 'lucide-react'
 import {ChangeEvent, useCallback, useEffect, useRef, useState} from 'react'
 import {Button} from './button'
+import {MenuItemType, OptionsDropdown} from './options-dropdown'
 import {cn} from './utils'
 
 type MetadataAffordanceKey = 'icon' | 'cover'
@@ -18,6 +19,7 @@ export type DocumentMetadataAffordanceButtonsProps = {
   keepSummaryButtonVisible?: boolean
   hideSummaryButton?: boolean
   alwaysVisibleOnMobile?: boolean
+  mobileOnly?: boolean
 }
 
 export type EditableDocumentMetadataFieldsProps = {
@@ -33,6 +35,8 @@ export type EditableDocumentMetadataFieldsProps = {
   focusTitleOnMount?: boolean
   onCancelEdit?: () => void
   onSummaryEnter?: () => void
+  summaryRequested: boolean
+  onSummaryRequestedChange: (requested: boolean) => void
 }
 
 export type HomeDocumentMetadataAffordanceBarProps = {
@@ -60,9 +64,11 @@ export function DocumentMetadataAffordanceButtons({
   keepSummaryButtonVisible = false,
   hideSummaryButton = false,
   alwaysVisibleOnMobile = false,
+  mobileOnly = false,
 }: DocumentMetadataAffordanceButtonsProps) {
   const iconInputRef = useRef<HTMLInputElement>(null)
   const coverInputRef = useRef<HTMLInputElement>(null)
+  const summaryMenuRequestedRef = useRef(false)
   const [uploading, setUploading] = useState<MetadataAffordanceKey | null>(null)
   const hasIcon = !!metadata?.icon
   const hasCover = !!metadata?.cover
@@ -97,6 +103,89 @@ export function DocumentMetadataAffordanceButtons({
 
   if (!showIconButton && !showSummaryButton && !showCoverButton) {
     return null
+  }
+
+  if (mobileOnly) {
+    const menuItems: (MenuItemType | null)[] = [
+      showIconButton
+        ? {
+            key: 'icon',
+            label: 'Add icon',
+            icon: <Smile className="size-3.5" />,
+            onClick: () => iconInputRef.current?.click(),
+          }
+        : null,
+      showSummaryButton
+        ? {
+            key: 'summary',
+            label: 'Add Summary',
+            icon: <FileText className="size-3.5" />,
+            onClick: () => {
+              summaryMenuRequestedRef.current = true
+              onBeforeMetadataChange?.()
+            },
+          }
+        : null,
+      showCoverButton
+        ? {
+            key: 'cover',
+            label: 'Add cover image',
+            icon: <ImagePlus className="size-3.5" />,
+            onClick: () => coverInputRef.current?.click(),
+          }
+        : null,
+    ]
+
+    return (
+      <div className="md:hidden">
+        {showIconButton ? (
+          <input
+            ref={iconInputRef}
+            type="file"
+            accept="image/*"
+            aria-label="Choose document icon"
+            className="sr-only"
+            tabIndex={-1}
+            onChange={(event) => void handleFileChange('icon', event)}
+          />
+        ) : null}
+        {showCoverButton ? (
+          <input
+            ref={coverInputRef}
+            type="file"
+            accept="image/*"
+            aria-label="Choose document cover image"
+            className="sr-only"
+            tabIndex={-1}
+            onChange={(event) => void handleFileChange('cover', event)}
+          />
+        ) : null}
+        <OptionsDropdown
+          menuItems={menuItems}
+          align="end"
+          side="bottom"
+          button={
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              className="text-muted-foreground hover:text-foreground h-7 shrink-0 rounded-full px-2 text-xs font-medium opacity-80 hover:bg-black/5 hover:opacity-100 active:scale-[0.98] dark:hover:bg-white/10"
+              aria-label="Add document metadata"
+            >
+              <Plus className="size-3.5" />
+              <span>Add</span>
+            </Button>
+          }
+          onCloseAutoFocus={(event) => {
+            if (summaryMenuRequestedRef.current) {
+              event.preventDefault()
+              onRequestSummary()
+            }
+            summaryMenuRequestedRef.current = false
+          }}
+        />
+      </div>
+    )
   }
 
   return (
@@ -184,11 +273,12 @@ export function EditableDocumentMetadataFields({
   focusTitleOnMount,
   onCancelEdit,
   onSummaryEnter,
+  summaryRequested,
+  onSummaryRequestedChange,
 }: EditableDocumentMetadataFieldsProps) {
   const titleRef = useRef<HTMLTextAreaElement | null>(null)
   const summaryRef = useRef<HTMLTextAreaElement | null>(null)
   const [hovered, setHovered] = useState(false)
-  const [summaryRequested, setSummaryRequested] = useState(false)
   const [summaryFocused, setSummaryFocused] = useState(false)
   const summaryText = summary ?? ''
   const showSummaryInput = !!summaryText || summaryRequested || summaryFocused
@@ -208,6 +298,17 @@ export function EditableDocumentMetadataFields({
   useEffect(() => {
     if (titleRef.current) resizeTextarea(titleRef.current)
   }, [name])
+
+  useEffect(() => {
+    const resizeTextareas = () => {
+      if (titleRef.current) resizeTextarea(titleRef.current)
+      if (summaryRef.current) resizeTextarea(summaryRef.current)
+    }
+
+    resizeTextareas()
+    window.addEventListener('resize', resizeTextareas)
+    return () => window.removeEventListener('resize', resizeTextareas)
+  }, [])
 
   useEffect(() => {
     if (focusTitleOnMount) titleRef.current?.focus()
@@ -237,7 +338,7 @@ export function EditableDocumentMetadataFields({
   }, [summaryRequested])
 
   function requestSummary() {
-    setSummaryRequested(true)
+    onSummaryRequestedChange(true)
   }
 
   return (
@@ -250,7 +351,7 @@ export function EditableDocumentMetadataFields({
         metadata={metadata}
         visible={showAffordances}
         fileUpload={fileUpload}
-        className="-ml-2"
+        className="-ml-2 max-md:hidden"
         onBeforeMetadataChange={onBeginEdit}
         onMetadata={onMetadata}
         onRequestSummary={requestSummary}
@@ -263,7 +364,7 @@ export function EditableDocumentMetadataFields({
         rows={1}
         aria-label="Document title"
         className={cn(
-          'w-full resize-none border-none border-transparent bg-transparent text-4xl font-bold shadow-none ring-0 ring-transparent outline-none focus:ring-0',
+          'w-full resize-none border-none border-transparent bg-transparent text-2xl font-bold shadow-none ring-0 ring-transparent outline-none focus:ring-0 max-md:leading-tight md:text-4xl',
           titleClassName,
         )}
         value={name}
@@ -304,8 +405,15 @@ export function EditableDocumentMetadataFields({
             resizeTextarea(event.currentTarget)
             onMetadata({summary: nextSummary})
           }}
-          onBlur={() => {
-            setSummaryRequested(false)
+          onBlur={(event) => {
+            const relatedTarget = event.relatedTarget
+            if (
+              relatedTarget instanceof Element &&
+              relatedTarget.closest('[role="menu"], [data-radix-menu-content], [data-radix-popover-content]')
+            ) {
+              return
+            }
+            onSummaryRequestedChange(false)
             setSummaryFocused(false)
           }}
           onKeyDown={(event) => {

--- a/frontend/packages/ui/src/options-dropdown.tsx
+++ b/frontend/packages/ui/src/options-dropdown.tsx
@@ -144,6 +144,7 @@ export function OptionsDropdown({
   triggerClassName,
   contentClassName,
   ariaLabel = 'Open options',
+  onCloseAutoFocus,
 }: {
   menuItems: (MenuItemType | null)[]
   hiddenUntilItemHover?: boolean
@@ -156,6 +157,7 @@ export function OptionsDropdown({
   triggerClassName?: string
   contentClassName?: string
   ariaLabel?: string
+  onCloseAutoFocus?: DropdownMenuContentProps['onCloseAutoFocus']
 }) {
   const popoverState = usePopoverState()
   const {ordered, firstDestructiveIndex} = orderMenuItems(menuItems)
@@ -183,7 +185,12 @@ export function OptionsDropdown({
             <MoreHorizontal className="size-3.5" />
           </DropdownMenuTrigger>
         )}
-        <DropdownMenuContent className={cn('p-1', contentClassName)} side={side} align={align}>
+        <DropdownMenuContent
+          className={cn('p-1', contentClassName)}
+          side={side}
+          align={align}
+          onCloseAutoFocus={onCloseAutoFocus}
+        >
           <div className="flex flex-col">
             {ordered.map((item, index) => (
               <div key={item.key}>

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -111,7 +111,11 @@ import {DirectoryPageContent} from './directory-page'
 import {DiscussionsPageContent} from './discussions-page'
 import {DocumentCover} from './document-cover'
 import {AuthorPayload, BreadcrumbEntry, DocumentHeader} from './document-header'
-import {EditableDocumentMetadataFields, HomeDocumentMetadataAffordanceBar} from './document-metadata-affordances'
+import {
+  DocumentMetadataAffordanceButtons,
+  EditableDocumentMetadataFields,
+  HomeDocumentMetadataAffordanceBar,
+} from './document-metadata-affordances'
 import {DocumentMetadataView} from './document-metadata-view'
 import {DocumentTopBar} from './document-top-bar'
 import {DocumentTools} from './document-tools'
@@ -2723,6 +2727,7 @@ function EditableDocumentHeader({
   const isEditing = useDocumentSelector(selectIsEditing)
   const focusTitleOnMount = useDocumentSelector(selectShouldFocusDraftTitle)
   const send = useDocumentSend()
+  const [summaryRequested, setSummaryRequested] = useState(false)
 
   // Use machine context metadata if it has been changed, otherwise fall back to document metadata
   const name = ctx.metadata?.name ?? docMetadata?.name ?? ''
@@ -2737,6 +2742,23 @@ function EditableDocumentHeader({
       updateTime={updateTime}
       visibility={visibility as any}
       version={version}
+      mobileBylineAction={
+        <DocumentMetadataAffordanceButtons
+          metadata={metadata}
+          visible
+          mobileOnly
+          fileUpload={fileUpload}
+          onBeforeMetadataChange={() => {
+            if (!isEditing) send({type: 'edit.start'})
+          }}
+          onMetadata={(metadata) => {
+            send({type: 'change', metadata})
+          }}
+          onRequestSummary={() => {
+            setSummaryRequested(true)
+          }}
+        />
+      }
       showTitle={false}
       onRemoveIcon={
         metadata.icon
@@ -2750,7 +2772,7 @@ function EditableDocumentHeader({
       <EditableDocumentMetadataFields
         name={name}
         summary={summary}
-        metadata={metadata as any}
+        metadata={metadata}
         fileUpload={fileUpload}
         focusTitleOnMount={focusTitleOnMount}
         onBeginEdit={() => {
@@ -2767,6 +2789,8 @@ function EditableDocumentHeader({
         onSummaryEnter={() => {
           send({type: 'edit.start', cursorPosition: 'end'})
         }}
+        summaryRequested={summaryRequested}
+        onSummaryRequestedChange={setSummaryRequested}
       />
     </DocumentHeader>
   )


### PR DESCRIPTION
## Summary

On mobile web the document header ate ~525px of a 760px viewport, so body content started below the fold on first render. This shrinks it to ~240px. Everything is scoped to below Tailwind `md`; desktop rendering is unchanged.

Approved mockup (left: today, right: this PR):

![mobile document header — current vs compact](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctMGNmMGNhNTZjODljNDA0OGFjZWM2ODg1OWUzYTM1NjQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctMGNmMGNhNTZjODljNDA0OGFjZWM2ODg1OWUzYTM1NjQvNDdiMDIyNGItNjQ0Ny00YWVkLWE3YmUtMjdlZDkwZmUwMDY2IiwiaWF0IjoxNzg2NTIzMjg5LCJleHAiOjE3ODcxMjgwODksImZpbGVuYW1lIjoibW9iaWxlLWhlYWRlci5wbmcifQ.lgxfDwbgmJFkrkzIIwiIfrqOXnx6kcTSkQ6c6mReSik)

The biggest offender was not the breadcrumbs but the header's reserved top padding, so the `Container` inline style becomes responsive classes:

```diff
-style={{marginTop: hasCover ? -40 : 0, paddingTop: !hasCover ? 60 : 24}}
+className={cn(..., hasCover ? 'pt-6' : 'pt-4 md:pt-[60px]')}
+style={{marginTop: hasCover ? -40 : 0}}
```

Then: title `text-2xl max-md:leading-tight md:text-4xl` (the tight leading is `max-md:`-scoped on purpose — an unprefixed `leading-*` would leak past `md` and override the line-height bundled with `text-4xl`/`text-5xl`), header `gap-2 md:gap-4`, byline `pb-2 md:pb-4`, breadcrumbs `max-md:hidden`.

The byline gets a mobile-only variant rendered next to the existing desktop one: a `-space-x-2` stack of up to 3 author `HMIcon`s, then `<first author> & N others · <date>` on one truncating `text-xs` line, instead of the full comma-separated author list plus divider plus date.

The three `Add icon` / `Add Summary` / `Add cover image` buttons collapse into one `+ Add` chip backed by `OptionsDropdown`, via a new `mobileOnly` branch of `DocumentMetadataAffordanceButtons` that reuses the same `showIconButton`/`showSummaryButton`/`showCoverButton` gating, the same handlers, and the same hidden file inputs — so nothing new is reachable, and the chip renders nothing when no action applies. Per the mockup it sits at the end of the byline row rather than on its own line, which is why `DocumentHeader` gains an optional `mobileBylineAction` slot that `EditableDocumentHeader` fills; the read-only path is untouched.

Two supporting changes fall out of that split:

- `summaryRequested` moves up into `EditableDocumentHeader` as controlled state (`summaryRequested` + `onSummaryRequestedChange`) so the mobile menu item and the desktop button drive the same reveal-and-focus path instead of the mobile chip needing a callback ref into the child.
- `resizeTextarea` now also runs on mount and on `window` resize. The title textarea's height is set in px from `scrollHeight`, so it went stale whenever the font size changed at the breakpoint or the title re-wrapped.

Out of scope: removing breadcrumbs outright (hidden on mobile here, since that removal is happening separately), and activating the existing `useAutoHideSiteHeader` on the web document route, which would reclaim another ~48px.


Link to Devin session: https://app.devin.ai/sessions/8b8eefeef27b45dbbe2ed9f9bef37e3b
Requested by: @horacioh
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/horacioh/seed/pull/22" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Runtime evidence and screenshots

## Runtime test at 390×844 touch: mobile "Add Summary" fixed in `28f58da` ✅

Tested against the real web app (prod build of `frontend/apps/web` + local daemon + local vault identity), writable and read-only published documents, measured with `getBoundingClientRect()`, plus a 1440px desktop pass. Verified the served chunk contains `onCloseAutoFocus:M=>{x.current&&(M.preventDefault(),r()),x.current=!1}`.

### The Add Summary blocker and what actually caused it

The first two attempts failed in the browser while passing in jsdom. A capturing `focusin`/`focusout` log with `relatedTarget` showed the real mechanism: focus was pulled back into the **still-mounted** `DropdownMenuContent` by Radix's `FocusScope` ~20ms after we focused the textarea, and `onCloseAutoFocus` only ran ~130ms later — long after the field's `onBlur` had already unmounted it. So `preventDefault()` in `onCloseAutoFocus` could never fix it, with state or with a ref.

`28f58da` moves the reveal itself into `onCloseAutoFocus` (menu unmount time) instead of the item's `onClick`, and independently stops the empty-summary field from collapsing on a blur whose `relatedTarget` is inside a menu/popover surface.

```
before: 17884 focusout TEXTAREA[Document Summary] related=DIV{menu}.bg-popover   <-- steal
after:  72696 focusout DIV{menuitem}              related=null                   <-- menu unmounted
        72706 focusin  TEXTAREA[Document Summary] related=null                   <-- field keeps focus
```

No `has:false` transition in any MutationObserver trace (5ms poll, checked 2–3s after close): 3/3 mouse clicks, 3/3 real `Input.dispatchTouchEvent` taps, keyboard, and the already-in-edit-mode-with-dirty-title case — each from a fresh reload.

| Mouse click → field open + focused | Real touch tap → field open + focused |
| --- | --- |
| ![mouse](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctMGNmMGNhNTZjODljNDA0OGFjZWM2ODg1OWUzYTM1NjQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctMGNmMGNhNTZjODljNDA0OGFjZWM2ODg1OWUzYTM1NjQvZGU2OTY5NDktNGNlZC00MTVmLTgwN2QtMGRkMGYzZjFlZjk1IiwiaWF0IjoxNzg2NTI4OTg4LCJleHAiOjE3ODcxMzM3ODgsImZpbGVuYW1lIjoic3NfNzVmMTdmM2IucG5nIn0.AZ2pZ8n9jEuCrSwoyBgI0Uzqs55yTC8j_AfU-iS1AxU) | ![touch](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctMGNmMGNhNTZjODljNDA0OGFjZWM2ODg1OWUzYTM1NjQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctMGNmMGNhNTZjODljNDA0OGFjZWM2ODg1OWUzYTM1NjQvNmQyM2VkMDYtZmZhMy00NjdlLWEzMjItZjA4MWZhY2UxYjUwIiwiaWF0IjoxNzg2NTI4OTg4LCJleHAiOjE3ODcxMzM3ODgsImZpbGVuYW1lIjoic3NfMDdmMDM4YTYucG5nIn0.WXyw9bXDyIeW5n_09PZHctx2eAOFZnDh8bVYsARChKE) |

![recording](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctMGNmMGNhNTZjODljNDA0OGFjZWM2ODg1OWUzYTM1NjQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctMGNmMGNhNTZjODljNDA0OGFjZWM2ODg1OWUzYTM1NjQvMjRhYWQ1OTEtZTNjZC00MDEyLTk0OTMtMWI4NGNhZDY1OTMyIiwiaWF0IjoxNzg2NTI4OTg4LCJleHAiOjE3ODcxMzM3ODgsImZpbGVuYW1lIjoicHJldmlldy53ZWJwIn0.DKiKJVaNVa8O8dGumKc8TSK1FA6E02JCAUYxj4MLVmo)

### Everything else

<details open>
<summary>Compact header + measured offsets</summary>

| Mobile, no cover | Mobile with cover + icon | Read-only (no <code>+ Add</code>) |
| --- | --- | --- |
| ![mobile no cover](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctMGNmMGNhNTZjODljNDA0OGFjZWM2ODg1OWUzYTM1NjQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctMGNmMGNhNTZjODljNDA0OGFjZWM2ODg1OWUzYTM1NjQvY2M5NjgyNjMtNDAwMi00MTFiLTg2ZmEtMmNmZmQ3ZTE3ODk5IiwiaWF0IjoxNzg2NTI4OTg4LCJleHAiOjE3ODcxMzM3ODgsImZpbGVuYW1lIjoic3NfNjJkMzJlNDAucG5nIn0.YyctJKe_ji80FjDJis-Zba_xRdX1OokJW0dSl9qOcmU) | ![mobile cover](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctMGNmMGNhNTZjODljNDA0OGFjZWM2ODg1OWUzYTM1NjQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctMGNmMGNhNTZjODljNDA0OGFjZWM2ODg1OWUzYTM1NjQvYTNiZTY2OGQtMTc5MC00Mzc4LWE0NzktNGY5NjRmNTA3NmFiIiwiaWF0IjoxNzg2NTI4OTg4LCJleHAiOjE3ODcxMzM3ODgsImZpbGVuYW1lIjoic3Nfem9vbV8xZTI5YmRjZC5wbmcifQ.BmGgvg1Wk4WnxEy-Kb-fcHnuOCOlZYSiMpJqJQtMBU8) | ![read only](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctMGNmMGNhNTZjODljNDA0OGFjZWM2ODg1OWUzYTM1NjQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctMGNmMGNhNTZjODljNDA0OGFjZWM2ODg1OWUzYTM1NjQvY2FlZjY3ZTUtOWI3YS00ZTNkLWJlMTUtMDM0NjEyYzFkZjE5IiwiaWF0IjoxNzg2NTI4OTg5LCJleHAiOjE3ODcxMzM3ODksImZpbGVuYW1lIjoic3Nfem9vbV9hNGJkZjc4OC5wbmcifQ.Tr8pN3lJnKF6cdzhiafx9wfTMRil1Kxg0RMaojrSpp8) |

- Breadcrumbs hidden at 390px; container `padding-top: 16px` (`pt-4`), desktop `60px` (`md:pt-15`), cover case `24px` (`pt-6`) at both widths.
- Body content starts at **268px** (3-line title, writable) / **234px** (read-only) / 358px with an extreme 6-line title; a 2-line title extrapolates to ~238px against the ~240px design target. ~52px of that offset is the Content/People/Comments/Citations tab row, which this PR doesn't touch.
</details>

<details>
<summary>Uploads, title textarea, collapse paths, desktop, hydration</summary>

- **Add icon** / **Add cover image** open the picker, the upload lands on the document, and the menu correctly drops already-set items.
- Empty summary still collapses when clicking into the document body (blur `relatedTarget` = the editor, so the new guard doesn't swallow it) and when focusing the title textarea.
- Title `<textarea>`: `scrollHeight === clientHeight` while typing a 6-line title and across 390 → 1440 → 390 resizes (180/160/180px); no clipping, no inner scrollbar. Typed summary autosized 28 → 168px and survived a reload.
- Desktop 1440px: breadcrumbs visible, author + vertical divider + date, title `36px/40px`, cover spacing correct. ![desktop](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctMGNmMGNhNTZjODljNDA0OGFjZWM2ODg1OWUzYTM1NjQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctMGNmMGNhNTZjODljNDA0OGFjZWM2ODg1OWUzYTM1NjQvOTkyZjg5YTQtNjQ2My00OTRlLTg5MjctODRlODEyMzczNTk5IiwiaWF0IjoxNzg2NTI4OTg5LCJleHAiOjE3ODcxMzM3ODksImZpbGVuYW1lIjoic3Nfem9vbV83ZWU0NjBkZS5wbmcifQ.d0Qlz50un5wyUL1bzg7hSfe6fLekJtLwNkl0I1IcPuw)
- No hydration-mismatch warnings; breadcrumbs SSR'd with `max-md:hidden` behind blocking CSS, no desktop-header flash. (Pre-existing unrelated `Function components cannot be given refs` warning from `web-site-header`, and notify-service connection errors because :3060 wasn't running.)

**Not tested:** the multi-author byline (3 stacked avatars + "& N others") — every document the local stack could produce has a single author; that needs a second vault identity with a writer capability.
</details>

[Source runtime-test comment](https://github.com/horacioh/seed/pull/22#issuecomment-5265237068)