### PR TITLE
Add collaborative access to agents

### DIFF
--- a/agents/docs/desktop-ui.md
+++ b/agents/docs/desktop-ui.md
@@ -78,6 +78,10 @@ bubble that opens the exact lines the model was given.
 
 ## Server settings and dialogs
 
+The Agents index shows an **Invites** section when the selected account has pending agent invitations, with Accept and
+Decline actions. Accepting opens the agent; accepted shared agents then appear in **All Agents** with a reader/writer
+badge.
+
 The Agents index has two sections: **Agent Servers** (agents grouped by server, each with per-server **Accounts** and
 **Providers** buttons opening `ManageAgentAccountsDialog` and `ModelProvidersDialog`) and **All Agents**, the aggregated
 list across servers with Create Agent. Health reads "Checking… / Offline / Online", and the status dot is suppressed for
@@ -142,7 +146,10 @@ Tabs: **Sessions** (default), **Triggers**, **Memory**, **Tools**, **Prompt**, *
   row deep-links to the file.
 - **Prompt** edits the system prompt with the Seed block editor; edits autosave, convert to markdown before the signed
   `UpdateAgent`, and are normalized server-side.
-- **Settings** edits the name, model, and reasoning level, and shows provider/status/id.
+- **Settings** edits the name, model, and reasoning level and manages agent collaborators. Owners get the same
+  account-search invite control used by document collaborators, with a read/write role picker; the member list includes
+  pending invitations and supports role changes, cancellation, and revocation. Readers see the agent in read-only mode;
+  writers can edit/interact but cannot manage collaborators or delete the agent.
 
 ### Tools tab
 
@@ -195,7 +202,8 @@ message.
 Every row knows its **actor**, and the actor is checked before the role — because the runtime writes to the log as
 `role: 'user'` (the only turn a model takes instruction from) while nobody typed those words:
 
-- **user** messages render as the familiar blue bubble;
+- **user** messages render as the familiar blue bubble with the originator's live Seed account icon on the right (legacy
+  rows without origin metadata use a neutral user glyph);
 - **system** messages render as `SystemMessageRow` — no bubble, no name, quiet grey, set in behind a left rule
   (`assistant-message-rendering.tsx:187`). This is what continuation prompts and unmet-obligation notices look like:
   visibly the machinery talking about the conversation rather than a voice in it;
@@ -207,9 +215,9 @@ Every row can explain itself. A **message** ⓘ opens the exact markdown the mod
 `<server>/agents/<agentId>/sessions/<sessionId>#event=<eventId>`, session/message/seq ids, and any window context that
 rode along hidden. A **tool** row's ⓘ opens `ToolCallDebugDialog` with the raw input and output payloads (and the source
 of a script child, when there is one). Both end in the same **Details** grid, built by `eventMetaRows()`
-(`models/event-meta.ts`): model, provider, duration, and the turn's token breakdown — total, input, output, cache read,
-cache write. The grid is strictly additive: an event recorded before the runtime stamped provenance shows no Details
-section at all rather than labelled blanks.
+(`models/event-meta.ts`): a user message's originator account and exact signer, or an agent event's model, provider,
+duration, and turn token breakdown — total, input, output, cache read, cache write. The grid is strictly additive: an
+event recorded before the runtime stamped provenance shows no Details section at all rather than labelled blanks.
 
 Tool rows dispatch a purpose-built detail view per tool (`assistant-message-rendering.tsx:2034`): `delegate` shows the
 brief and the child's own work, `execute` shows the code with a live output tail, an address-bearing `read` or `write`
@@ -217,7 +225,8 @@ shows the resolved target, and a hypermedia write command gets its own phrasing.
 tool's icon, label, and links, with input paths rebased under `input.` (`getRowToolMetadata`,
 `assistant-message-rendering.tsx:687`) — so it never reads "Call · execute".
 
-Other session-page behavior: optimistic user messages, queued messages while the agent is busy, live assistant partials
+Other session-page behavior: optimistic user messages stamped with the selected account immediately, concurrent sends
+while the agent is busy (the server persists them immediately and serializes their model turns), live assistant partials
 with a streaming cursor, a run status bar (hidden while a pending tool row is already showing its own live status, so
 there are never two spinners), auto-scroll with a scroll-to-latest pill, in-app `hm://` link handling, and signed
 `StopSession` from the stop button including recovery for sessions stuck in `streaming` with no live runner. Retry is

--- a/agents/docs/environments.md
+++ b/agents/docs/environments.md
@@ -1,17 +1,18 @@
 # Environments
 
-The agents server runs in five distinct environments. Same binary logic, very different surroundings: what spawns it,
-what it binds, which HM server it reads and writes through, whether code execution and web tools exist, and how it gets
-updated. This document describes each one and the configuration that makes it work. The full env-var reference lives in
-`operations.md`; this is about which of those knobs each environment turns and why.
+The agents server runs in five distinct kinds of environment (the hosted remote is one kind running as three deployments
+— production, staging, and dev). Same binary logic, very different surroundings: what spawns it, what it binds, which HM
+server it reads and writes through, whether code execution and web tools exist, and how it gets updated. This document
+describes each one and the configuration that makes it work. The full env-var reference lives in `operations.md`; this
+is about which of those knobs each environment turns and why.
 
 A quick orientation table:
 
-|                    | 1 · dev (`./dev up`)              | 2 · CI-built desktop apps    | 3 · `./dev build-desktop`    | 4 · production remote          | 5 · self-hosted remote    |
+|                    | 1 · dev (`./dev up`)              | 2 · CI-built desktop apps    | 3 · `./dev build-desktop`    | 4 · hosted remotes             | 5 · self-hosted remote    |
 | ------------------ | --------------------------------- | ---------------------------- | ---------------------------- | ------------------------------ | ------------------------- |
 | Process            | `bun --hot` under a watcher       | compiled binary, app-spawned | compiled binary, app-spawned | Docker container               | Docker container          |
 | Port               | `3051` (from `.env.vars`)         | `3050` (app default)         | `3050` (app default)         | `3050` behind Caddy `443`      | operator's choice         |
-| HM API / IPFS      | bridge `:58004` / daemon `:58001` | app bridge / app daemon      | app bridge / app daemon      | `https://hyper.media` (both)   | operator's endpoint(s)    |
+| HM API / IPFS      | bridge `:58004` / daemon `:58001` | app bridge / app daemon      | app bridge / app daemon      | `hyper.media` or `dev.` (both) | operator's endpoint(s)    |
 | Code exec          | host microVMs (msb)               | embedded msb runtime         | embedded msb runtime         | `/dev/kvm` plumbed, see gap    | needs KVM + runtime       |
 | web_search/crawler | Docker compose backends           | none (unless configured)     | none (unless configured)     | compose-internal SearXNG/Crawl | optional compose backends |
 | Updates            | file-watch restart                | app release cycle            | rebuild                      | Watchtower auto-pull           | operator pulls            |
@@ -105,19 +106,38 @@ runtime, entitlements, no Docker, daemon-backed HM URL), plus two local-only got
   previously-installed app's binary can hold a port the new build then attaches to. When in doubt, `/api/health` reports
   the running server's version.
 
-## 4. Production remote — `agentic.seed.hyper.media`
+## 4. Hosted remotes — production, staging, and dev
 
-An Ubuntu 24.04 VM (OVH/OpenStack, Terraform Cloud workspace `SHM-Agentic` in the SeedInfra repo, `seed_infra/agentic`).
-Terraform provisions a bare Docker host; the actual service definition is the compose file it writes to
-`/opt/agentic/docker-compose.yml`. The stack:
+One Ubuntu 24.04 VM (OVH/OpenStack, Terraform Cloud workspace `SHM-Agentic` in the SeedInfra repo, `seed_infra/agentic`)
+runs all three hosted agents servers. Terraform provisions a bare Docker host; the actual service definition is the
+compose file it writes to `/opt/agentic/docker-compose.yml`.
 
-- **Caddy** (`caddy:2`) terminates TLS on 80/443 and reverse-proxies two hostnames to two containers:
-  `agentic.seed.hyper.media` → `agents-stable` (image `seedhypermedia/agents:latest`), and
-  `dev.agentic.seed.hyper.media` → `agents-dev` (image `seedhypermedia/agents:dev`), each on internal port `3050`.
-- **agents-stable / agents-dev** run with:
-  - `SEED_AGENTS_HM_SERVER_URL` → `https://hyper.media` (stable) / `https://dev.hyper.media` (dev). Those origins serve
-    both typed `/api/*` and direct `/ipfs/*`, so `SEED_AGENTS_IPFS_SERVER_URL` defaults to the same value. Unlike every
-    local environment, production reads and writes through the public gateway — there is no co-located daemon.
+The three deployments differ in exactly two ways — which image tag they track, and which HM network they read:
+
+| Hostname                           | Container        | Image tag | Code           | Data    |
+| ---------------------------------- | ---------------- | --------- | -------------- | ------- |
+| `agentic.seed.hyper.media`         | `agents-stable`  | `:latest` | newest release | mainnet |
+| `staging.agentic.seed.hyper.media` | `agents-staging` | `:dev`    | `main`         | mainnet |
+| `dev.agentic.seed.hyper.media`     | `agents-dev`     | `:dev`    | `main`         | devnet  |
+
+Staging is the release gate: it runs the _same code_ as dev but against _production data_, so behavior can be validated
+on real mainnet content before a release tag promotes that code to `agents-stable`. Dev keeps devnet data, which is
+where you want to be while a change is still liable to write nonsense.
+
+Each container has its own `agents-*-data` volume, and that separation matters more than it looks: the activity monitor
+only polls for accounts that have enabled triggers **in its own database**, so three servers pointed at the same feed
+stay quiet about each other's agents. Copy prod's DB into staging and both would fire on the same mainnet mention and
+answer twice.
+
+The stack:
+
+- **Caddy** (`caddy:2`) terminates TLS on 80/443 and reverse-proxies each hostname above to its container on internal
+  port `3050`.
+- **agents-stable / agents-staging / agents-dev** run with:
+  - `SEED_AGENTS_HM_SERVER_URL` → `https://hyper.media` (stable, staging) / `https://dev.hyper.media` (dev). Those
+    origins serve both typed `/api/*` and direct `/ipfs/*`, so `SEED_AGENTS_IPFS_SERVER_URL` defaults to the same value.
+    Unlike every local environment, the hosted servers read and write through the public gateway — there is no
+    co-located daemon.
   - `devices: /dev/kvm:/dev/kvm` — hardware virtualization for the execute microVMs. Without the device the service runs
     but every execution fails 502. (This requires an OVH flavor that exposes KVM.)
   - Named volumes: `agents-*-data:/data` (the sqlite DB + agent state; `SEED_AGENTS_DB_PATH=/data/agents.sqlite` and
@@ -128,11 +148,16 @@ Terraform provisions a bare Docker host; the actual service definition is the co
 - **SearXNG** (json format enabled, limiter off — safe only because it is never published outside the compose network)
   and **Crawl4AI** (version-pinned; 0.9.0 changed auth defaults, so it must not float to `:latest`; needs shared memory
   for Chromium) serve the web tools, internal-only.
-- **Watchtower** (label-enabled, short poll interval) auto-pulls both agents images: pushing
-  `seedhypermedia/agents:latest` or `:dev` deploys within minutes. Images are pushed by the three GitHub workflows
-  described in `operations.md` (release tags → `:latest`, main pushes touching `agents/**` → `:dev`, plus a manual
-  hotfix path), or manually via `agents/scripts/build-and-push.sh`. Make sure the Watchtower container itself carries
-  `restart: unless-stopped` — a crashed auto-updater silently stops all deploys.
+- **Watchtower** (label-enabled, short poll interval) auto-pulls the agents images: pushing
+  `seedhypermedia/agents:latest` deploys to `agents-stable`, and pushing `:dev` deploys to **both** `agents-staging` and
+  `agents-dev`, within minutes. Images are pushed by the three GitHub workflows described in `operations.md` (release
+  tags → `:latest`, main pushes touching `agents/**` → `:dev`, plus a manual hotfix path), or manually via
+  `agents/scripts/build-and-push.sh`. Make sure the Watchtower container itself carries `restart: unless-stopped` — a
+  crashed auto-updater silently stops all deploys, and so does a _stopped_ one: `docker stop` on a container with that
+  policy stays stopped across reboots, which is how the host once sat four days without a deploy.
+
+  Watchtower reads `com.centurylinklabs.watchtower.enable` from the **running container**, not from the compose file, so
+  editing that label only takes effect after `docker compose up -d <service>` recreates the container.
 
 Secrets (provider API keys, OAuth credentials) are **not** in the compose environment: they are per-account rows in the
 database, written through the signed `SetSecret` API and encrypted at rest. Subscription OAuth

--- a/agents/docs/implementation-history.md
+++ b/agents/docs/implementation-history.md
@@ -5,6 +5,15 @@ future agents can reconstruct why the system looks the way it does.
 
 ## Recent commit notes
 
+### Agent invitations and collaborators
+
+Agents can now be shared with Seed accounts through explicit pending invitations and accepted reader/writer roles. The
+SQLite membership row never changes ownership: every existing agent/session/run query still executes against the owner's
+account after one centralized access-resolution check. Readers can inspect the complete agent; writers can mutate and
+interact; collaborator management and deletion remain owner-only. Signed WebSocket subscriptions use the same check and
+durable service events fan out to accepted collaborators. Desktop adds pending invites to the Agents index and reuses
+the document collaborator account-search pattern in Agent Settings for invites, roles, revocation, and read-only states.
+
 ### Remote agent content sync hardening
 
 The desktop already discovered `hm://` references from open agent sessions, but the implementation issued one request

--- a/agents/docs/operations.md
+++ b/agents/docs/operations.md
@@ -74,7 +74,9 @@ fall back to `dev`/`unknown`.
   `seedhypermedia/agents:<tag>`. The resolved tag is the version (`latest` for a manual run with no tag);
   `agents-stable` on the host tracks `:latest`.
 - `.github/workflows/dev-docker-images.yml` — on push to `main` touching `agents/**` (or manual dispatch), pushes
-  `seedhypermedia/agents:dev`, which `agents-dev` tracks.
+  `seedhypermedia/agents:dev`, which **both** `agents-staging` and `agents-dev` track. Note the consequence: while this
+  workflow is red on `main`, `:dev` stops moving, and staging silently keeps validating an older commit than the one you
+  are about to release. `/api/version` on staging is the check that catches it.
 - `.github/workflows/hotfix-agents-image.yml` — manual dispatch only, from `main` only. Runs the agents test gate and
   pushes ONLY `seedhypermedia/agents:latest`. Use this to hotfix the production agent server without cutting a full
   release of every image.
@@ -91,23 +93,41 @@ It stamps the current git `HEAD` (commit/branch/date) into the image and pushes 
 
 ### Deploy onto the agent host
 
-`agentic.seed.hyper.media` runs `/opt/agentic/docker-compose.yml` with Watchtower (`nickfedor/watchtower:1.18.1`,
-label-enabled, 5-minute interval) auto-pulling the `agents-stable` (`:latest`) and `agents-dev` (`:dev`) containers.
-After pushing a new image it deploys within the poll interval, or force it immediately:
+One host runs `/opt/agentic/docker-compose.yml` with three agents containers behind Caddy:
+
+| Hostname                           | Container        | Image tag | Code           | Data    |
+| ---------------------------------- | ---------------- | --------- | -------------- | ------- |
+| `agentic.seed.hyper.media`         | `agents-stable`  | `:latest` | newest release | mainnet |
+| `staging.agentic.seed.hyper.media` | `agents-staging` | `:dev`    | `main`         | mainnet |
+| `dev.agentic.seed.hyper.media`     | `agents-dev`     | `:dev`    | `main`         | devnet  |
+
+Staging is the release gate — same code as dev, real mainnet data — so the sequence before cutting a release is: land on
+`main`, wait for `:dev` to deploy, exercise `staging.agentic.seed.hyper.media`, then tag. See `environments.md` for the
+full picture, including why each container needs its own data volume.
+
+Watchtower (`nickfedor/watchtower:1.18.1`, label-enabled, 5-minute interval) auto-pulls the labeled containers. After
+pushing a new image it deploys within the poll interval, or force it immediately:
 
 ```bash
-# Force an update now (proves Watchtower works end to end and pulls labeled containers):
+# Force an update now, with compose (the reliable way):
+ssh ubuntu@agentic.seed.hyper.media \
+  'cd /opt/agentic && docker compose pull agents-stable agents-staging agents-dev && docker compose up -d'
+
+# Or a one-shot Watchtower. Note: only works when the resident Watchtower is stopped — it treats a
+# second instance as an "excess Watchtower container" and SIGTERMs it mid-run.
 ssh ubuntu@agentic.seed.hyper.media \
   'docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
      nickfedor/watchtower:1.18.1 --run-once --label-enable --cleanup'
-
-# Or with compose directly:
-ssh ubuntu@agentic.seed.hyper.media \
-  'cd /opt/agentic && docker compose pull agents-stable agents-dev && docker compose up -d'
 ```
 
-> The host's `docker-compose.yml`/`Caddyfile` are not yet tracked in git (the `seed_infra/agentic` Terraform stack
-> provisions a bare Docker host only). Treat the file on the host as authoritative until that drift is captured.
+Watchtower reads `com.centurylinklabs.watchtower.enable` off the **running container**, so editing that label in the
+compose file changes nothing until `docker compose up -d <service>` recreates the container. That is the knob for
+temporarily pinning a deployment; it does not stop `bootstrap.sh`, whose `docker compose pull` will still move a pinned
+container on the next Terraform apply.
+
+> `/opt/agentic/docker-compose.yml` and `/opt/agentic/Caddyfile` are rendered by `seed_infra/agentic/main.tf` in the
+> SeedInfra repo and pushed over SSH by the `ssh_resource.files` resource. Edits made directly on the host survive until
+> the next apply and then vanish — mirror anything you change there back into `main.tf`.
 
 ## Configuration
 

--- a/agents/docs/persistence.md
+++ b/agents/docs/persistence.md
@@ -127,6 +127,23 @@ Current agent statuses:
 
 Most runtime work currently operates at the session level; agent status is not yet a rich run-state machine.
 
+### `agent_collaborators`
+
+Stores pending invitations and accepted agent-level access grants, keyed by `(agent_id, account_id)`. The `account_id`
+is the invited/collaborating Seed account; the agent's owning account remains on `agents.account_id` and all agent
+content continues to be stored under that owner.
+
+Important columns:
+
+- `role` — `reader` or `writer`;
+- `status` — `pending` or `accepted`;
+- `accepted_at` — acceptance time, NULL while pending;
+- `created_at`, `updated_at`.
+
+Readers may inspect agent settings, memory, tools, triggers, sessions, transcripts, runs, and attachments. Writers may
+also mutate those agent-scoped resources and interact with sessions. Collaborators cannot manage this table or delete
+the agent; those remain owner-only. Deleting an agent deletes its collaboration rows.
+
 ### `agent_triggers`
 
 Stores saved agent-scoped trigger definitions for HM activity triggers and schedule triggers.
@@ -348,6 +365,8 @@ Current event payloads:
 type SessionActor = 'user' | 'agent' | 'system' | 'trigger'
 
 type SessionEventMeta = {
+  accountId?: string // Seed account that originated a user message
+  signerId?: string // exact cryptographic signer from its verified action envelope
   model?: string // model that produced the message
   provider?: string // provider it ran on
   usage?: AgentRunUsage // this turn's tokens, not the run's cumulative total
@@ -384,7 +403,8 @@ type SessionEventPayload =
 `actor` and `meta` are both optional because events predating them exist. Never treat either as required structure:
 `sessionEventActor()` in the protocol package derives the actor of an older event from its shape (a user-role message is
 `user`, an error is `system`, everything else is `agent`), and `meta` is display detail that is simply absent on older
-rows.
+rows. New signed user messages always stamp both the acting Seed `accountId` and exact `signerId`; they may differ when
+the account uses an authorized device/delegate signer.
 
 Plan updates are **not** durable events — the `plan` verb writes `sessions.plan_cbor` in place, which is why the plan
 snapshot carries its own `settledAt` timestamp.
@@ -436,12 +456,14 @@ Session WebSocket subscriptions use the same replay logic when `afterSeq` is sup
 Do not hold write transactions during provider/tool network calls.
 
 `CreateAgent` and `CreateSession` can use short idempotent transactions. `MessageSession` must avoid long SQLite
-transactions because it performs model/network work.
+transactions because it performs model/network work. Concurrent collaborators append synchronously through the single
+service process, then enqueue independently; the run queue serializes model turns per session without delaying event
+persistence.
 
 ## Improvement areas
 
-- Move from `MAX(seq)+1` event sequence allocation to a stronger per-session sequence allocator if concurrent appends
-  become possible.
+- Move from `MAX(seq)+1` event sequence allocation to a stronger per-session sequence allocator before supporting
+  multiple service processes writing the same database.
 - Add retention/pruning for old events, runs, journals, and idempotency rows.
 - Add secret versioning/rotation metadata.
 - Add audit log tables for provider/secret/tool/security events.

--- a/agents/docs/readme.md
+++ b/agents/docs/readme.md
@@ -34,6 +34,7 @@ Completed and usable locally:
 - encrypted secrets and redacted provider/secret responses;
 - model-provider CRUD, provider listing, and provider-backed model listing for model dropdowns;
 - agent CRUD and session CRUD, including inline session-title editing;
+- pending agent invitations plus accepted reader/writer collaborators, with agent-wide read/write enforcement;
 - durable session event replay;
 - schedule triggers for interval, weekly, and one-time proactive sessions;
 - Pi SDK-backed chat execution;

--- a/agents/docs/roadmap.md
+++ b/agents/docs/roadmap.md
@@ -12,8 +12,8 @@ Complete enough to build on; treat as baseline functionality:
   gate; encrypted provider secrets;
 - registry-driven providers (OpenAI, Anthropic, Google, OpenRouter, DeepSeek, Groq, xAI, Ollama, Custom) executing
   through the Pi SDK, with per-agent reasoning levels and ChatGPT/Codex subscription auth;
-- agent and session CRUD, durable event replay, live WebSocket subscriptions, streaming assistant partials, desktop
-  streaming markdown;
+- agent and session CRUD, pending invitations and accepted reader/writer agent collaborators, durable event replay,
+  collaborator-aware WebSocket subscriptions, streaming assistant partials, desktop streaming markdown;
 - the local agents server as a desktop subprocess, with the assistant sidebar unified onto agent sessions across every
   configured server;
 - **the runs tree** — every turn, child, and script is a run row and the table is the dispatch queue (leases, boot-sweep

--- a/agents/docs/security.md
+++ b/agents/docs/security.md
@@ -1,7 +1,8 @@
 # Security model
 
-The Agents security model centers on signed account-scoped actions, server-side ownership checks, encrypted/redacted
-secrets, signed WebSocket subscriptions, and a model-facing tool surface whose authority is fixed at five verbs.
+The Agents security model centers on signed account-scoped actions, server-side owner/collaborator checks,
+encrypted/redacted secrets, signed WebSocket subscriptions, and a model-facing tool surface whose authority is fixed at
+five verbs.
 
 ## Trust boundaries
 
@@ -38,6 +39,23 @@ A socket cannot switch accounts after a successful subscription.
 
 Server-to-client events are not individually signed.
 
+## Agent collaboration authorization
+
+An agent remains owned by `agents.account_id`. `agent_collaborators` adds explicit per-agent access for another signed
+Seed account, first as a pending invitation and then as an accepted `reader` or `writer` row:
+
+- pending invitees see only invitation metadata and cannot access agent contents;
+- readers can inspect all agent-scoped state, including memory, tools, prompts, sessions, transcripts, attachments, and
+  runs;
+- writers can additionally mutate agent-scoped state and interact with sessions;
+- only the owner can invite/revoke members or delete the agent;
+- provider, secret, OAuth, and signing-identity mutations remain scoped to the collaborator's own account. Optional
+  `agentId` on provider/identity list actions exposes only the owner's redacted records needed to render/edit that
+  shared agent.
+
+Agent/session/run WebSocket subscriptions use the same access check. Service events are fanned out to every accepted
+collaborator's account subscription; revocation takes effect before subsequent requests or subscriptions.
+
 ## Account isolation
 
 Account-owned tables include `account_id`:
@@ -45,6 +63,7 @@ Account-owned tables include `account_id`:
 - model providers;
 - secrets;
 - agents;
+- agent collaborators (the invited account is also stored explicitly);
 - sessions;
 - runs;
 - tool documents;
@@ -356,7 +375,8 @@ For every new action:
 3. Normalize inputs at the boundary.
 4. Scope DB queries by account ownership.
 5. Redact sensitive data.
-6. Add unauthorized/cross-account tests.
+6. Add unauthorized/cross-account tests, including reader-vs-writer and pending-vs-accepted behavior for agent-scoped
+   actions.
 7. Decide idempotency/replay semantics.
 8. Decide WebSocket fanout policy.
 9. Update docs.

--- a/agents/docs/signed-api.md
+++ b/agents/docs/signed-api.md
@@ -67,6 +67,12 @@ Current `AgentAction` union (`UnsignedAgentAction` in `agents/protocol/src/index
 `Service.message()`):
 
 - `ListAgents`
+- `ListAgentInvites`
+- `ListAgentCollaborators`
+- `InviteAgentCollaborator`
+- `RemoveAgentCollaborator`
+- `AcceptAgentInvite`
+- `DeclineAgentInvite`
 - `CreateAgent`
 - `ListModelProviders`
 - `ListProviderModels`
@@ -151,7 +157,25 @@ Response:
 {_: 'ListAgentsResponse'; agents: AgentInfo[]}
 ```
 
-Lists agents for the verified account, ordered by update time descending.
+Lists agents owned by the verified account plus agents on which it is an accepted reader or writer, ordered by update
+time descending. Each `AgentInfo.accessRole` is `owner`, `reader`, or `writer`; pending invitations are deliberately not
+returned here.
+
+### Agent invitations and collaborators
+
+- `ListAgentInvites {}` returns pending `AgentInviteInfo` rows for the signed account. An invite discloses only the
+  agent id/name, owner account, role, and timestamps; agent contents remain unavailable until acceptance.
+- `ListAgentCollaborators {agentId}` returns the owner and accepted members. The owner also sees pending invitations.
+- `InviteAgentCollaborator {agentId, accountId, role}` creates an invitation (`reader` or `writer`) or updates an
+  existing member's role. Owner-only.
+- `RemoveAgentCollaborator {agentId, accountId}` revokes an accepted member or cancels a pending invitation. Owner-only.
+- `AcceptAgentInvite {agentId}` accepts the signed account's pending invitation and returns the now-accessible agent.
+- `DeclineAgentInvite {agentId}` deletes the signed account's pending invitation.
+
+Readers can inspect all agent-scoped state. Writers can additionally create/update/delete agent-scoped resources and
+interact with sessions. Managing collaborators and deleting the agent remain owner-only. Account-scoped provider and
+secret mutations are never inherited from an agent collaboration; agent settings may list the owner's redacted
+providers/signing identities through optional `agentId` fields.
 
 ### `CreateAgent`
 
@@ -369,7 +393,7 @@ Response:
 {_: 'GetAgentResponse'; agent: AgentInfo; sessions: SessionInfo[]}
 ```
 
-Requires the agent to belong to the verified account.
+Requires owner, reader, or writer access to the agent.
 
 ### `UpdateAgent`
 
@@ -383,7 +407,8 @@ Request:
 }
 ```
 
-Updates definition after validating account ownership and provider existence.
+Updates the definition for the owner or an accepted writer after validating the owning account's provider and signing
+identities.
 
 ### `DeleteAgent`
 
@@ -722,21 +747,25 @@ deleted with the session.
 
 Flow:
 
-1. verify session belongs to account;
-2. reject if session is already `streaming`;
-3. append durable user message with `content`/`rawMarkdown` set to the model-facing markdown and optional `blocks`
-   preserved for rich UI replay;
-4. set session `streaming`;
-5. run model loop;
+1. verify the signed account has write access to the session's agent;
+2. append the durable user message immediately, with `content`/`rawMarkdown`, optional rich `blocks`, and
+   `meta.accountId` plus the exact cryptographic `meta.signerId` from the verified envelope;
+3. enqueue a durable run for that message;
+4. claim it inline when no other turn owns the session, otherwise leave it queued behind the current turn;
+5. run the model loop with one model turn at a time per session;
 6. emit live partials over WebSocket;
 7. append tool events and final assistant/error event;
-8. set session `idle` or `error`.
+8. start the next queued collaborator turn, if any.
 
-Internally the turn is a durable run row claimed inline from the dispatch queue (`agents/src/runs.ts`); the "already
-streaming" guard checks live runs, not the status column, so a crash cannot wedge it.
+Multiple writers may therefore submit to one session concurrently. Their messages are saved and broadcast in append
+order instead of receiving `409` while the agent is streaming; model turns remain serialized. A queued turn gets an
+in-memory handoff identifying the exact message events that arrived during the preceding response, so later assistant
+events from that preceding turn are not mistaken for answers to the newly queued messages.
+
+Internally each turn is a durable run row in the dispatch queue (`agents/src/runs.ts`).
 `MessageSessionResponse.assistantEventId` is an **empty string** when the request returned before a final assistant
-event existed: background enqueues (triggers, agent-started sessions) and turns that parked on children spawned with
-`delegate` — the rest of the turn streams over WebSocket.
+event existed: concurrent/background enqueues (including triggers and agent-started sessions) and turns that parked on
+children spawned with `delegate` — the rest of the turn streams over WebSocket.
 
 Idempotent through `clientMessageId`, but intentionally avoids one long SQLite transaction around network calls.
 

--- a/agents/docs/system-overview.md
+++ b/agents/docs/system-overview.md
@@ -7,7 +7,8 @@ inspect everything that executed.
 ## Design principles
 
 1. **Signed control plane** — every HTTP action is wrapped in a signed DAG-CBOR envelope.
-2. **Account isolation** — persisted state belongs to one Seed account and server queries must prove ownership.
+2. **Account isolation** — persisted state belongs to one Seed account; access requires ownership or an accepted
+   agent-level reader/writer collaboration.
 3. **Durable sessions** — sessions are append-only event logs with replay by sequence number.
 4. **Live clients** — desktop clients subscribe over a signed WebSocket protocol and receive live changes.
 5. **Secret redaction** — API keys are encrypted at rest and never returned in API responses.
@@ -71,9 +72,11 @@ Shared Seed libraries
 8. Server persists the agent and broadcasts account changes.
 9. User opens agent detail and creates/opens a session.
 10. Desktop subscribes to `sessions/<sessionId>` over WebSocket.
-11. User sends a message with signed `MessageSession`.
-12. Server appends a durable user message and creates a `runs` row for the turn, claimed inline on the `interactive`
-    queue. Session status is a derived mirror of run state, so it reads `streaming` from here on.
+11. A writer sends a message with signed `MessageSession`; other accepted writers may send at the same time.
+12. Server immediately appends each durable user message with its acting account and exact signer, broadcasts it, and
+    creates a `runs` row. The first turn is claimed inline on the `interactive` queue; concurrent turns remain queued in
+    append order because only one model turn may own a session. Session status is a derived mirror of run state, so it
+    reads `streaming` while any of those turns remain live.
 13. Server creates an in-memory Pi SDK session configured from the Seed provider record, encrypted secret, the agent's
     system prompt (its own instructions plus the shared runtime prompt and its `<space>` index), and the tool set: the
     five verbs, plus any callables the transcript shows this thread has already expanded.
@@ -118,6 +121,8 @@ Shared Seed libraries
 ### Agent runtime
 
 - Agent create/list/get/update/delete.
+- Agent invitations, acceptance/decline, revocation, and reader/writer collaborator roles. Readers can inspect the
+  complete agent; writers can additionally mutate and interact, but only owners manage access or delete the agent.
 - Session create/get/list/message/stop/retry/delete.
 - Cross-agent session listing (`ListSessions`) with composite keyset pagination.
 - Pi SDK-backed model execution for OpenAI-compatible, Anthropic, and Google provider mappings.
@@ -139,7 +144,7 @@ Shared Seed libraries
 - Default and multi-server settings.
 - Provider management dialog for OpenAI/Anthropic/Google records/secrets.
 - Create-agent dialog with configured-provider selection.
-- Agent detail page with editable name/model/system prompt.
+- Agent detail page with editable name/model/system prompt and a Settings collaborator invite/member panel.
 - Session page with debounced inline title editing, optimistic user messages, durable events, live assistant partials,
   and shared chat rendering.
 - A mounted remote session page or currently selected Assistant-sidebar session keeps agent-created/referenced `hm://`

--- a/agents/docs/websocket-subscriptions.md
+++ b/agents/docs/websocket-subscriptions.md
@@ -116,9 +116,11 @@ this stream only for liveness.
 Rules:
 
 - `account/<accountId>` must equal verified account ID.
-- `agents/<agentId>` must be owned by verified account.
-- `sessions/<sessionId>` must be owned by verified account.
-- `runs/<rootRunId>` must reference a run owned by the verified account.
+- `agents/<agentId>` requires owner or accepted reader/writer access.
+- `sessions/<sessionId>` requires owner or accepted reader/writer access to its agent.
+- `runs/<rootRunId>` requires owner or accepted reader/writer access to its agent.
+- Accepted collaborators receive the agent's live service events under their own account subscription; pending and
+  revoked collaborators do not.
 - A socket may not switch accounts after a successful subscription.
 
 ## Replay

--- a/agents/e2e/obligations-live-check.ts
+++ b/agents/e2e/obligations-live-check.ts
@@ -17,7 +17,7 @@ async function action(input: Record<string, unknown>, timeoutMs = 120_000): Prom
   const response = await fetch(`${BASE}/api/message`, {
     method: 'POST',
     headers: {'Content-Type': 'application/cbor'},
-    body: cbor.encode(envelope),
+    body: cbor.encode(envelope) as BodyInit,
     signal: AbortSignal.timeout(timeoutMs),
   })
   const body = cbor.decode<any>(new Uint8Array(await response.arrayBuffer()))

--- a/agents/protocol/src/index.ts
+++ b/agents/protocol/src/index.ts
@@ -127,6 +127,12 @@ export type AgentAction = UnsignedAgentAction & {
 /** Supported agent service actions before the signing timestamp is attached. */
 export type UnsignedAgentAction =
   | ListAgents
+  | ListAgentInvites
+  | ListAgentCollaborators
+  | InviteAgentCollaborator
+  | RemoveAgentCollaborator
+  | AcceptAgentInvite
+  | DeclineAgentInvite
   | CreateAgent
   | ListModelProviders
   | ListProviderModels
@@ -184,6 +190,44 @@ export type ListAgents = {
   _: 'ListAgents'
 }
 
+/** Lists pending invitations sent to the signed account. */
+export type ListAgentInvites = {
+  _: 'ListAgentInvites'
+}
+
+/** Lists the owner and collaborators who can access one agent. */
+export type ListAgentCollaborators = {
+  _: 'ListAgentCollaborators'
+  agentId: string
+}
+
+/** Invites an account to read or write one owned agent. */
+export type InviteAgentCollaborator = {
+  _: 'InviteAgentCollaborator'
+  agentId: string
+  accountId: string
+  role: AgentCollaboratorRole
+}
+
+/** Revokes an accepted collaborator or cancels a pending invitation. */
+export type RemoveAgentCollaborator = {
+  _: 'RemoveAgentCollaborator'
+  agentId: string
+  accountId: string
+}
+
+/** Accepts a pending invitation sent to the signed account. */
+export type AcceptAgentInvite = {
+  _: 'AcceptAgentInvite'
+  agentId: string
+}
+
+/** Declines a pending invitation sent to the signed account. */
+export type DeclineAgentInvite = {
+  _: 'DeclineAgentInvite'
+  agentId: string
+}
+
 /** Creates a new agent definition. */
 export type CreateAgent = {
   _: 'CreateAgent'
@@ -194,17 +238,23 @@ export type CreateAgent = {
 /** Lists configured model providers for the signed account. */
 export type ListModelProviders = {
   _: 'ListModelProviders'
+  /** Lists the owning account's providers when viewing a shared agent. */
+  agentId?: string
 }
 
 /** Lists remote models available from one configured provider. */
 export type ListProviderModels = {
   _: 'ListProviderModels'
   provider: string
+  /** Resolves the provider against the owning account of a shared agent. */
+  agentId?: string
 }
 
 /** Lists uploaded Seed account keys available to the signed account. */
 export type ListSigningIdentities = {
   _: 'ListSigningIdentities'
+  /** Lists the owning account's redacted identities when viewing a shared agent. */
+  agentId?: string
 }
 
 /** Generates a new server-side Seed account key for future signing tools. */
@@ -752,6 +802,31 @@ export type ModelProviderConfig = {
   authMode?: 'api-key' | 'subscription'
 }
 
+/** A collaborator's access level on an agent. */
+export type AgentCollaboratorRole = 'reader' | 'writer'
+
+/** The signed account's relationship to an agent. */
+export type AgentAccessRole = 'owner' | AgentCollaboratorRole
+
+/** One owner, accepted collaborator, or pending invitation on an agent. */
+export type AgentCollaboratorInfo = {
+  accountId: string
+  role: AgentAccessRole
+  status: 'accepted' | 'pending'
+  createdAt: number
+  updatedAt: number
+}
+
+/** A pending agent invitation visible to its recipient before agent contents are disclosed. */
+export type AgentInviteInfo = {
+  agentId: string
+  agentName: string
+  ownerAccountId: string
+  role: AgentCollaboratorRole
+  createdAt: number
+  updatedAt: number
+}
+
 /** Public metadata returned for an agent. */
 export type AgentInfo = {
   id: string
@@ -761,6 +836,8 @@ export type AgentInfo = {
   status: 'idle' | 'running' | 'stopped' | 'error'
   createdAt: number
   updatedAt: number
+  /** Permissions of the signed account that requested this value. */
+  accessRole?: AgentAccessRole
 }
 
 /** Public metadata returned for an agent trigger. */
@@ -995,12 +1072,17 @@ export function sessionEventActor(payload: SessionEventPayload): SessionActor {
 }
 
 /**
- * Provenance stamped on runtime-produced events at append time: what produced it, what it cost, how
- * long it took. Written once, so an event still explains itself long after the run that made it is
- * gone. Events recorded before this field existed simply have none — every reader treats it as
- * optional detail, never as required structure.
+ * Provenance stamped on events at append time: which account and signer authored a user event, or
+ * which runtime produced an agent event, what it cost, and how long it took. Written once, so an
+ * event still explains itself long after its request or run is gone. Events recorded before this
+ * field existed simply have none — every reader treats it as optional detail, never as required
+ * structure.
  */
 export type SessionEventMeta = {
+  /** Seed account that originated a user-authored event. */
+  accountId?: string
+  /** Exact cryptographic signer of the signed action that originated a user-authored event. */
+  signerId?: string
   /** Model that produced the message, e.g. `gpt-5-mini`. */
   model?: string
   /** Provider the model ran on, e.g. `openai`. */
@@ -1033,7 +1115,7 @@ export type SessionEventPayload =
        */
       clientMessageId?: string
       actor?: SessionActor
-      /** Model/provider/usage/timing behind an assistant message. Absent on user and legacy events. */
+      /** Origin metadata for user messages, or model/provider/usage/timing for assistant messages. */
       meta?: SessionEventMeta
     }
   | {type: 'tool_call'; id: string; name: string; input: unknown; actor?: SessionActor}
@@ -1166,6 +1248,44 @@ export type SigningIdentity = {
 export type ListAgentsResponse = {
   _: 'ListAgentsResponse'
   agents: AgentInfo[]
+}
+
+/** Successful response for `ListAgentInvites`. */
+export type ListAgentInvitesResponse = {
+  _: 'ListAgentInvitesResponse'
+  invites: AgentInviteInfo[]
+}
+
+/** Successful response for `ListAgentCollaborators`. */
+export type ListAgentCollaboratorsResponse = {
+  _: 'ListAgentCollaboratorsResponse'
+  agentId: string
+  collaborators: AgentCollaboratorInfo[]
+}
+
+/** Successful response for an agent collaborator upsert. */
+export type InviteAgentCollaboratorResponse = {
+  _: 'InviteAgentCollaboratorResponse'
+  collaborator: AgentCollaboratorInfo
+}
+
+/** Successful response for revoking or canceling agent access. */
+export type RemoveAgentCollaboratorResponse = {
+  _: 'RemoveAgentCollaboratorResponse'
+  agentId: string
+  accountId: string
+}
+
+/** Successful response for accepting an agent invitation. */
+export type AcceptAgentInviteResponse = {
+  _: 'AcceptAgentInviteResponse'
+  agent: AgentInfo
+}
+
+/** Successful response for declining an agent invitation. */
+export type DeclineAgentInviteResponse = {
+  _: 'DeclineAgentInviteResponse'
+  agentId: string
 }
 
 /** Successful response for `CreateAgent`. */
@@ -1555,6 +1675,12 @@ export type ErrorResponse = {
 /** Response values for the Agents API. */
 export type AgentResponse =
   | ListAgentsResponse
+  | ListAgentInvitesResponse
+  | ListAgentCollaboratorsResponse
+  | InviteAgentCollaboratorResponse
+  | RemoveAgentCollaboratorResponse
+  | AcceptAgentInviteResponse
+  | DeclineAgentInviteResponse
   | ListModelProvidersResponse
   | ListProviderModelsResponse
   | ListSigningIdentitiesResponse

--- a/agents/src/api-service.test.ts
+++ b/agents/src/api-service.test.ts
@@ -1,6 +1,7 @@
 import {Database} from 'bun:sqlite'
 import {describe, expect, mock, test} from 'bun:test'
 import * as apisvc from '@/api-service'
+import * as auth from '@/auth'
 import * as cbor from '@/cbor'
 import * as sqlite from '@/sqlite'
 import {ProviderOAuthManager} from '@/provider-oauth'
@@ -187,6 +188,289 @@ describe('api service', () => {
       })
       expect(agentPromptText(list.agents[0]?.definition.systemPrompt)).toBe('You are helpful.')
     } finally {
+      db.close()
+      cleanup()
+    }
+  })
+
+  test('invites read and write collaborators and enforces their roles', async () => {
+    const {db, dataDir, cleanup} = createTestState()
+    try {
+      const owner = blobs.generateNobleKeyPair()
+      const collaborator = blobs.generateNobleKeyPair()
+      const collaboratorAccountId = blobs.principalToString(collaborator.principal)
+      const events: apisvc.ServiceEvent[] = []
+      const svc = new apisvc.Service(db, dataDir, {onEvent: (event) => events.push(event)})
+      await setDefaultProvider(svc, owner)
+      const created = await svc.message(
+        await apisvc.createSignedEnvelope(owner, {
+          action: {
+            _: 'CreateAgent',
+            definition: {name: 'Shared Agent', systemPrompt: 'Share carefully.', modelProvider: 'openai', model: 'gpt'},
+          },
+        }),
+      )
+      if (created._ !== 'CreateAgentResponse') throw new Error('unexpected response')
+      const agentId = created.agentId
+
+      await svc.message(
+        await apisvc.createSignedEnvelope(owner, {
+          action: {_: 'InviteAgentCollaborator', agentId, accountId: collaboratorAccountId, role: 'reader'},
+        }),
+      )
+      const invites = await svc.message(
+        await apisvc.createSignedEnvelope(collaborator, {action: {_: 'ListAgentInvites'}}),
+      )
+      expect(invites).toMatchObject({
+        _: 'ListAgentInvitesResponse',
+        invites: [{agentId, agentName: 'Shared Agent', role: 'reader'}],
+      })
+      const pendingList = await svc.message(
+        await apisvc.createSignedEnvelope(collaborator, {action: {_: 'ListAgents'}}),
+      )
+      expect(pendingList).toMatchObject({_: 'ListAgentsResponse', agents: []})
+      await expect(
+        svc.message(await apisvc.createSignedEnvelope(collaborator, {action: {_: 'GetAgent', agentId}})),
+      ).rejects.toThrow('Agent not found')
+
+      const accepted = await svc.message(
+        await apisvc.createSignedEnvelope(collaborator, {action: {_: 'AcceptAgentInvite', agentId}}),
+      )
+      expect(accepted).toMatchObject({_: 'AcceptAgentInviteResponse', agent: {id: agentId, accessRole: 'reader'}})
+      const readerList = await svc.message(await apisvc.createSignedEnvelope(collaborator, {action: {_: 'ListAgents'}}))
+      expect(readerList).toMatchObject({
+        _: 'ListAgentsResponse',
+        agents: [{id: agentId, accessRole: 'reader'}],
+      })
+      await expect(
+        svc.verifySubscription(
+          await apisvc.createSignedEnvelope(collaborator, {
+            action: {_: 'Subscribe', key: `agents/${agentId}`},
+          }),
+        ),
+      ).resolves.toMatchObject({accountId: collaboratorAccountId, key: `agents/${agentId}`})
+      await expect(
+        svc.message(
+          await apisvc.createSignedEnvelope(collaborator, {
+            action: {_: 'WriteAgentMemoryFile', agentId, path: 'reader.txt', content: 'no'},
+          }),
+        ),
+      ).rejects.toThrow('Write access is required')
+      await expect(
+        svc.message(await apisvc.createSignedEnvelope(collaborator, {action: {_: 'CreateSession', agentId}})),
+      ).rejects.toThrow('Write access is required')
+
+      const promoted = await svc.message(
+        await apisvc.createSignedEnvelope(owner, {
+          action: {_: 'InviteAgentCollaborator', agentId, accountId: collaboratorAccountId, role: 'writer'},
+        }),
+      )
+      expect(promoted).toMatchObject({collaborator: {status: 'accepted', role: 'writer'}})
+      await expect(
+        svc.message(
+          await apisvc.createSignedEnvelope(collaborator, {
+            action: {_: 'WriteAgentMemoryFile', agentId, path: 'writer.txt', content: 'yes'},
+          }),
+        ),
+      ).resolves.toMatchObject({_: 'WriteAgentMemoryFileResponse'})
+      expect(
+        events.some(
+          (event) =>
+            event.type === 'account-change' &&
+            event.accountId === collaboratorAccountId &&
+            event.reason === 'agent-memory-changed',
+        ),
+      ).toBe(true)
+      await expect(
+        svc.message(
+          await apisvc.createSignedEnvelope(collaborator, {
+            action: {
+              _: 'InviteAgentCollaborator',
+              agentId,
+              accountId: blobs.principalToString(blobs.generateNobleKeyPair().principal),
+              role: 'reader',
+            },
+          }),
+        ),
+      ).rejects.toThrow('Only the agent owner can do this')
+      await expect(
+        svc.message(await apisvc.createSignedEnvelope(collaborator, {action: {_: 'DeleteAgent', agentId}})),
+      ).rejects.toThrow('Only the agent owner can do this')
+
+      const members = await svc.message(
+        await apisvc.createSignedEnvelope(owner, {action: {_: 'ListAgentCollaborators', agentId}}),
+      )
+      expect(members).toMatchObject({
+        _: 'ListAgentCollaboratorsResponse',
+        collaborators: [
+          {accountId: blobs.principalToString(owner.principal), role: 'owner', status: 'accepted'},
+          {accountId: collaboratorAccountId, role: 'writer', status: 'accepted'},
+        ],
+      })
+      await svc.message(
+        await apisvc.createSignedEnvelope(owner, {
+          action: {_: 'RemoveAgentCollaborator', agentId, accountId: collaboratorAccountId},
+        }),
+      )
+      await expect(
+        svc.message(await apisvc.createSignedEnvelope(collaborator, {action: {_: 'GetAgent', agentId}})),
+      ).rejects.toThrow('Agent not found')
+    } finally {
+      db.close()
+      cleanup()
+    }
+  })
+
+  test('persists each concurrent collaborator message with its account and exact signer', async () => {
+    const {db, dataDir, cleanup} = createTestState()
+    const originalFetch = globalThis.fetch
+    const liveEvents: apisvc.ServiceEvent[] = []
+    const svc = new apisvc.Service(db, dataDir, {onEvent: (event) => liveEvents.push(event)})
+    let releaseFirstResponse = () => {}
+    try {
+      const owner = blobs.generateNobleKeyPair()
+      const collaborator = blobs.generateNobleKeyPair()
+      const collaboratorSigner = blobs.generateNobleKeyPair()
+      const ownerAccountId = blobs.principalToString(owner.principal)
+      const collaboratorAccountId = blobs.principalToString(collaborator.principal)
+      const collaboratorSignerId = blobs.principalToString(collaboratorSigner.principal)
+      auth.setLocalAuthorization(db, {
+        accountId: collaboratorAccountId,
+        signerId: collaboratorSignerId,
+        role: 'AGENT',
+      })
+
+      await svc.message(
+        await apisvc.createSignedEnvelope(owner, {
+          action: {_: 'SetSecret', name: 'openai-key', value: new TextEncoder().encode('sk-test')},
+        }),
+      )
+      await svc.message(
+        await apisvc.createSignedEnvelope(owner, {
+          action: {
+            _: 'SetModelProvider',
+            name: 'openai',
+            provider: {type: 'openai', secretRefs: {apiKey: 'openai-key'}},
+          },
+        }),
+      )
+      const createdAgent = await svc.message(
+        await apisvc.createSignedEnvelope(owner, {
+          action: {
+            _: 'CreateAgent',
+            definition: {name: 'Shared Agent', systemPrompt: 'Reply.', modelProvider: 'openai', model: 'gpt'},
+          },
+        }),
+      )
+      if (createdAgent._ !== 'CreateAgentResponse') throw new Error('unexpected response')
+      const createdSession = await svc.message(
+        await apisvc.createSignedEnvelope(owner, {
+          action: {_: 'CreateSession', agentId: createdAgent.agentId},
+        }),
+      )
+      if (createdSession._ !== 'CreateSessionResponse') throw new Error('unexpected response')
+      await svc.message(
+        await apisvc.createSignedEnvelope(owner, {
+          action: {
+            _: 'InviteAgentCollaborator',
+            agentId: createdAgent.agentId,
+            accountId: collaboratorAccountId,
+            role: 'writer',
+          },
+        }),
+      )
+      await svc.message(
+        await apisvc.createSignedEnvelope(collaborator, {
+          action: {_: 'AcceptAgentInvite', agentId: createdAgent.agentId},
+        }),
+      )
+
+      const firstResponseGate = new Promise<void>((resolve) => {
+        releaseFirstResponse = resolve
+      })
+      let markFirstRequestStarted!: () => void
+      const firstRequestStarted = new Promise<void>((resolve) => {
+        markFirstRequestStarted = resolve
+      })
+      const requestBodies: string[] = []
+      globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
+        requestBodies.push(String(init?.body))
+        const call = requestBodies.length
+        if (call === 1) {
+          markFirstRequestStarted()
+          await firstResponseGate
+        }
+        return openAIStreamResponse([
+          {id: `chat-${call}`, choices: [{delta: {content: `Reply ${call}`}}]},
+          {id: `chat-${call}`, choices: [{delta: {}, finish_reason: 'stop'}], usage: openAIUsage()},
+        ])
+      }) as unknown as typeof fetch
+
+      const ownerTurn = svc.message(
+        await apisvc.createSignedEnvelope(owner, {
+          action: {
+            _: 'MessageSession',
+            sessionId: createdSession.sessionId,
+            content: [{type: 'text', text: 'Owner message'}],
+            clientMessageId: 'shared-client-local-id',
+          },
+        }),
+      )
+      await firstRequestStarted
+
+      const collaboratorTurn = await svc.message(
+        await apisvc.createSignedEnvelope(collaboratorSigner, {
+          account: collaborator.principal,
+          action: {
+            _: 'MessageSession',
+            sessionId: createdSession.sessionId,
+            content: [{type: 'text', text: 'Collaborator message'}],
+            clientMessageId: 'shared-client-local-id',
+          },
+        }),
+      )
+      expect(collaboratorTurn).toMatchObject({_: 'MessageSessionResponse', assistantEventId: ''})
+
+      releaseFirstResponse()
+      await ownerTurn
+      await svc.awaitQueueIdle()
+
+      const session = await svc.message(
+        await apisvc.createSignedEnvelope(collaborator, {
+          action: {_: 'GetSession', sessionId: createdSession.sessionId},
+        }),
+      )
+      if (session._ !== 'GetSessionResponse') throw new Error('unexpected response')
+      const userMessages = session.events
+        .map((event) => event.event)
+        .filter(
+          (event): event is Extract<typeof event, {type: 'message'}> =>
+            event.type === 'message' && event.role === 'user',
+        )
+      expect(userMessages).toHaveLength(2)
+      expect(userMessages[0]).toMatchObject({
+        content: 'Owner message',
+        meta: {accountId: ownerAccountId, signerId: ownerAccountId},
+      })
+      expect(userMessages[1]).toMatchObject({
+        content: 'Collaborator message',
+        meta: {accountId: collaboratorAccountId, signerId: collaboratorSignerId},
+      })
+      const collaboratorMessageAudience = liveEvents
+        .filter(
+          (event): event is Extract<apisvc.ServiceEvent, {type: 'session-event'}> =>
+            event.type === 'session-event' &&
+            (event.event.event as {meta?: {accountId?: string}}).meta?.accountId === collaboratorAccountId,
+        )
+        .map((event) => event.accountId)
+      expect(new Set(collaboratorMessageAudience)).toEqual(new Set([ownerAccountId, collaboratorAccountId]))
+      expect(requestBodies).toHaveLength(2)
+      expect(requestBodies[1]).toContain('concurrent_user_messages')
+      expect(requestBodies[1]).toContain('Collaborator message')
+    } finally {
+      releaseFirstResponse()
+      globalThis.fetch = originalFetch
+      svc.stopRunQueue()
       db.close()
       cleanup()
     }
@@ -4871,12 +5155,14 @@ describe('api service', () => {
       expect(session._).toBe('GetSessionResponse')
       if (session._ !== 'GetSessionResponse') throw new Error('unexpected response')
       expect(session.session.status).toBe('error')
+      const accountId = blobs.principalToString(account.principal)
       expect(session.events.map((event) => event.event)).toEqual([
         {
           type: 'message',
           role: 'user',
           content: 'Will this persist?',
           rawMarkdown: 'Will this persist?',
+          meta: {accountId, signerId: accountId},
         },
         {type: 'error', message: '500 nope'},
       ])
@@ -6318,6 +6604,7 @@ describe('obligations: what a run owes before it may end', () => {
       account,
       calls: () => calls,
       close: () => {
+        svc.stopRunQueue()
         db.close()
         cleanup()
       },

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -573,6 +573,8 @@ export class Service {
   readonly #web: WebToolsConfig
   readonly #codeExec: CodeExecutor
   readonly #runningSessions = new Map<string, RunningSession>()
+  /** Accepted collaborator audiences, cached because partial text events can arrive per token. */
+  readonly #collaboratorAudience = new Map<string, Array<{account_id: string; role: api.AgentCollaboratorRole}>>()
   /** In-flight background dispatch setup (trigger prompt builds + enqueues); the runs themselves live in the queue. */
   readonly #pendingTriggerSessions = new Set<Promise<void>>()
   /** Sessions with a user verb mid-execution: agent runs must not start under them (reverse 409). */
@@ -721,17 +723,36 @@ export class Service {
       throw new APIError(401, message)
     }
 
+    const accountId = this.#actionAccountId(verified.accountId, envelope.action)
+
     switch (envelope.action._) {
       case 'ListAgents':
         return this.#listAgents(verified.accountId)
+      case 'ListAgentInvites':
+        return this.#listAgentInvites(verified.accountId)
+      case 'ListAgentCollaborators':
+        return this.#listAgentCollaborators(verified.accountId, envelope.action.agentId)
+      case 'InviteAgentCollaborator':
+        return this.#inviteAgentCollaborator(
+          verified.accountId,
+          envelope.action.agentId,
+          envelope.action.accountId,
+          envelope.action.role,
+        )
+      case 'RemoveAgentCollaborator':
+        return this.#removeAgentCollaborator(verified.accountId, envelope.action.agentId, envelope.action.accountId)
+      case 'AcceptAgentInvite':
+        return this.#acceptAgentInvite(verified.accountId, envelope.action.agentId)
+      case 'DeclineAgentInvite':
+        return this.#declineAgentInvite(verified.accountId, envelope.action.agentId)
       case 'CreateAgent':
         return this.#createAgent(verified.accountId, envelope.action.definition, envelope.action.clientRequestId)
       case 'ListModelProviders':
-        return this.#listModelProviders(verified.accountId)
+        return this.#listModelProviders(accountId)
       case 'ListProviderModels':
-        return this.#listProviderModels(verified.accountId, envelope.action.provider)
+        return this.#listProviderModels(accountId, envelope.action.provider)
       case 'ListSigningIdentities':
-        return this.#listSigningIdentities(verified.accountId)
+        return this.#listSigningIdentities(accountId)
       case 'CreateSigningIdentity':
         return this.#createSigningIdentity(verified.accountId, envelope.action.label, envelope.action.clientRequestId)
       case 'ImportSigningIdentity':
@@ -770,53 +791,53 @@ export class Service {
           envelope.action.metadata,
         )
       case 'GetAgent':
-        return this.#getAgent(verified.accountId, envelope.action.agentId)
+        return this.#getAgent(accountId, envelope.action.agentId, verified.accountId)
       case 'UpdateAgent':
-        return this.#updateAgent(verified.accountId, envelope.action.agentId, envelope.action.definition)
+        return this.#updateAgent(accountId, envelope.action.agentId, envelope.action.definition, verified.accountId)
       case 'DeleteAgent':
-        return this.#deleteAgent(verified.accountId, envelope.action.agentId)
+        return this.#deleteAgent(accountId, envelope.action.agentId)
       case 'ListAgentTriggers':
-        return this.#listAgentTriggers(verified.accountId, envelope.action.agentId)
+        return this.#listAgentTriggers(accountId, envelope.action.agentId)
       case 'GetAgentTrigger':
-        return this.#getAgentTrigger(verified.accountId, envelope.action.triggerId)
+        return this.#getAgentTrigger(accountId, envelope.action.triggerId)
       case 'CreateAgentTrigger':
         return this.#createAgentTrigger(
-          verified.accountId,
+          accountId,
           envelope.action.agentId,
           envelope.action.trigger,
           envelope.action.clientRequestId,
         )
       case 'UpdateAgentTrigger':
-        return this.#updateAgentTrigger(verified.accountId, envelope.action.triggerId, envelope.action.patch)
+        return this.#updateAgentTrigger(accountId, envelope.action.triggerId, envelope.action.patch)
       case 'DeleteAgentTrigger':
-        return this.#deleteAgentTrigger(verified.accountId, envelope.action.triggerId)
+        return this.#deleteAgentTrigger(accountId, envelope.action.triggerId)
       case 'ListAgentMemory':
-        return this.#listAgentMemory(verified.accountId, envelope.action.agentId)
+        return this.#listAgentMemory(accountId, envelope.action.agentId)
       case 'ListAgentTools':
-        return this.#listAgentTools(verified.accountId, envelope.action.agentId)
+        return this.#listAgentTools(accountId, envelope.action.agentId)
       case 'ReadAgentMemoryFile':
-        return this.#readAgentMemoryFile(verified.accountId, envelope.action.agentId, envelope.action.path)
+        return this.#readAgentMemoryFile(accountId, envelope.action.agentId, envelope.action.path)
       case 'WriteAgentMemoryFile':
         return this.#writeAgentMemoryFile(
-          verified.accountId,
+          accountId,
           envelope.action.agentId,
           envelope.action.path,
           envelope.action.content,
         )
       case 'DeleteAgentMemoryFile':
-        return this.#deleteAgentMemoryFile(verified.accountId, envelope.action.agentId, envelope.action.path)
+        return this.#deleteAgentMemoryFile(accountId, envelope.action.agentId, envelope.action.path)
       case 'DownloadAgentMemoryFile':
         return this.#downloadAgentMemoryFile(
-          verified.accountId,
+          accountId,
           envelope.action.agentId,
           envelope.action.url,
           envelope.action.path,
         )
       case 'UploadAgentMemoryFileToIpfs':
-        return this.#uploadAgentMemoryFileToIpfs(verified.accountId, envelope.action.agentId, envelope.action.path)
+        return this.#uploadAgentMemoryFileToIpfs(accountId, envelope.action.agentId, envelope.action.path)
       case 'CreateSession':
         return this.#createSession(
-          verified.accountId,
+          accountId,
           envelope.action.agentId,
           envelope.action.title,
           envelope.action.clientRequestId,
@@ -831,67 +852,63 @@ export class Service {
           envelope.action.includeChildren,
         )
       case 'UpdateSession':
-        return this.#updateSession(verified.accountId, envelope.action.sessionId, envelope.action.title)
+        return this.#updateSession(accountId, envelope.action.sessionId, envelope.action.title)
       case 'DeleteSession':
-        return this.#deleteSession(verified.accountId, envelope.action.sessionId)
+        return this.#deleteSession(accountId, envelope.action.sessionId)
       case 'GetSession':
-        return await this.#getSession(verified.accountId, envelope.action.sessionId, envelope.action.afterSeq)
+        return await this.#getSession(accountId, envelope.action.sessionId, envelope.action.afterSeq)
       case 'InvokeSessionTool':
         return this.#invokeSessionTool(
-          verified.accountId,
+          accountId,
           envelope.action.sessionId,
           envelope.action.verb,
           envelope.action.input,
         )
       case 'MessageSession':
         return this.#messageSession(
-          verified.accountId,
+          accountId,
           envelope.action.sessionId,
           envelope.action.content,
           envelope.action.clientMessageId,
+          {accountId: verified.accountId, signerId: verified.signerId},
         )
       case 'UploadSessionAttachment':
         return this.#uploadSessionAttachment(
-          verified.accountId,
+          accountId,
           envelope.action.sessionId,
           envelope.action.name,
           envelope.action.mimeType,
           envelope.action.content,
         )
       case 'ReadSessionAttachment':
-        return this.#readSessionAttachment(verified.accountId, envelope.action.sessionId, envelope.action.attachmentId)
+        return this.#readSessionAttachment(accountId, envelope.action.sessionId, envelope.action.attachmentId)
       case 'BeginFileUpload':
-        return this.#beginFileUpload(verified.accountId, envelope.action.target, envelope.action.size)
+        return this.#beginFileUpload(accountId, envelope.action.target, envelope.action.size)
       case 'AppendFileUploadChunk':
         return this.#appendFileUploadChunk(
-          verified.accountId,
+          accountId,
           envelope.action.uploadId,
           envelope.action.offset,
           envelope.action.content,
         )
       case 'CommitFileUpload':
-        return this.#commitFileUpload(verified.accountId, envelope.action.uploadId)
+        return this.#commitFileUpload(accountId, envelope.action.uploadId)
       case 'AbortFileUpload':
-        return this.#abortFileUpload(verified.accountId, envelope.action.uploadId)
+        return this.#abortFileUpload(accountId, envelope.action.uploadId)
       case 'StopSession':
-        return this.#stopSession(verified.accountId, envelope.action.sessionId)
+        return this.#stopSession(accountId, envelope.action.sessionId)
       case 'RetrySession':
-        return this.#retrySession(verified.accountId, envelope.action.sessionId)
+        return this.#retrySession(accountId, envelope.action.sessionId)
       case 'GetRun':
-        return this.#getRun(verified.accountId, envelope.action.runId)
+        return this.#getRun(accountId, envelope.action.runId)
       case 'ListRuns':
-        return this.#listRuns(verified.accountId, envelope.action)
+        return this.#listRuns(accountId, envelope.action)
       case 'CancelRun':
-        return this.#cancelRun(verified.accountId, envelope.action.runId)
+        return this.#cancelRun(accountId, envelope.action.runId)
       case 'SignalRun':
-        return this.#signalRun(
-          verified.accountId,
-          envelope.action.runId,
-          envelope.action.signal,
-          envelope.action.payload,
-        )
+        return this.#signalRun(accountId, envelope.action.runId, envelope.action.signal, envelope.action.payload)
       case 'GetRunJournal':
-        return this.#getRunJournal(verified.accountId, envelope.action.runId, envelope.action.afterSeq)
+        return this.#getRunJournal(accountId, envelope.action.runId, envelope.action.afterSeq)
       case 'Subscribe':
         throw new APIError(400, 'Subscribe is only supported over WebSocket')
       default:
@@ -899,20 +916,362 @@ export class Service {
     }
   }
 
+  /** Resolves an agent-scoped action to the owning account and enforces read/write access once. */
+  #actionAccountId(actorAccountId: string, action: api.UnsignedAgentAction): string {
+    const fromAgent = (agentId: string, write = false) =>
+      this.#requireAgentAccess(actorAccountId, agentId, write ? 'writer' : 'reader').ownerAccountId
+    const fromSession = (sessionId: string, write = false) => {
+      const row = this.#db
+        .query<{agent_id: string}, [string]>(`SELECT agent_id FROM sessions WHERE id = ?`)
+        .get(sessionId)
+      if (!row) throw new APIError(404, 'Session not found')
+      try {
+        return fromAgent(row.agent_id, write)
+      } catch (error) {
+        if (error instanceof APIError && error.status === 404) throw new APIError(404, 'Session not found')
+        throw error
+      }
+    }
+    const fromTrigger = (triggerId: string, write = false) => {
+      const row = this.#db
+        .query<{agent_id: string}, [string]>(`SELECT agent_id FROM agent_triggers WHERE id = ?`)
+        .get(triggerId)
+      if (!row) throw new APIError(404, 'Agent trigger not found')
+      try {
+        return fromAgent(row.agent_id, write)
+      } catch (error) {
+        if (error instanceof APIError && error.status === 404) throw new APIError(404, 'Agent trigger not found')
+        throw error
+      }
+    }
+    const fromRun = (runId: string, write = false) => {
+      const row = this.#db
+        .query<{agent_id: string | null}, [string]>(`SELECT agent_id FROM runs WHERE id = ?`)
+        .get(runId)
+      if (!row?.agent_id) throw new APIError(404, 'Run not found')
+      try {
+        return fromAgent(row.agent_id, write)
+      } catch (error) {
+        if (error instanceof APIError && error.status === 404) throw new APIError(404, 'Run not found')
+        throw error
+      }
+    }
+    const fromUpload = (uploadId: string, write = false) => {
+      const upload = this.#uploads.get(uploadId)
+      if (!upload) throw new APIError(404, 'Upload not found')
+      return upload.target.kind === 'memory'
+        ? fromAgent(upload.target.agentId, write)
+        : fromSession(upload.target.sessionId, write)
+    }
+
+    switch (action._) {
+      case 'ListModelProviders':
+      case 'ListProviderModels':
+      case 'ListSigningIdentities':
+        return action.agentId ? fromAgent(action.agentId) : actorAccountId
+      case 'GetAgent':
+      case 'ListAgentTriggers':
+      case 'ListAgentMemory':
+      case 'ListAgentTools':
+      case 'ReadAgentMemoryFile':
+        return fromAgent(action.agentId)
+      case 'UpdateAgent':
+      case 'WriteAgentMemoryFile':
+      case 'DeleteAgentMemoryFile':
+      case 'DownloadAgentMemoryFile':
+      case 'UploadAgentMemoryFileToIpfs':
+      case 'CreateAgentTrigger':
+      case 'CreateSession':
+        return fromAgent(action.agentId, true)
+      case 'DeleteAgent':
+        return this.#requireAgentAccess(actorAccountId, action.agentId, 'owner').ownerAccountId
+      case 'GetAgentTrigger':
+        return fromTrigger(action.triggerId)
+      case 'UpdateAgentTrigger':
+      case 'DeleteAgentTrigger':
+        return fromTrigger(action.triggerId, true)
+      case 'ListSessions':
+        if (action.agentId) return fromAgent(action.agentId)
+        if (action.parentSessionId) return fromSession(action.parentSessionId)
+        return actorAccountId
+      case 'GetSession':
+      case 'ReadSessionAttachment':
+        return fromSession(action.sessionId)
+      case 'UpdateSession':
+      case 'DeleteSession':
+      case 'MessageSession':
+      case 'InvokeSessionTool':
+      case 'UploadSessionAttachment':
+      case 'StopSession':
+      case 'RetrySession':
+        return fromSession(action.sessionId, true)
+      case 'BeginFileUpload':
+        return action.target.kind === 'memory'
+          ? fromAgent(action.target.agentId, true)
+          : fromSession(action.target.sessionId, true)
+      case 'AppendFileUploadChunk':
+      case 'CommitFileUpload':
+      case 'AbortFileUpload':
+        return fromUpload(action.uploadId, true)
+      case 'GetRun':
+      case 'GetRunJournal':
+        return fromRun(action.runId)
+      case 'ListRuns':
+        if (action.agentId) return fromAgent(action.agentId)
+        if (action.sessionId) return fromSession(action.sessionId)
+        if (action.rootRunId) return fromRun(action.rootRunId)
+        return actorAccountId
+      case 'CancelRun':
+      case 'SignalRun':
+        return fromRun(action.runId, true)
+      default:
+        return actorAccountId
+    }
+  }
+
+  #requireAgentAccess(
+    actorAccountId: string,
+    agentId: string,
+    required: 'reader' | 'writer' | 'owner',
+  ): {ownerAccountId: string; role: api.AgentAccessRole} {
+    const row = this.#db
+      .query<{owner_account_id: string; role: string | null; status: string | null}, [string, string]>(
+        `SELECT a.account_id AS owner_account_id, c.role, c.status
+         FROM agents a
+         LEFT JOIN agent_collaborators c ON c.agent_id = a.id AND c.account_id = ?
+         WHERE a.id = ?`,
+      )
+      .get(actorAccountId, agentId)
+    if (!row) throw new APIError(404, 'Agent not found')
+    const role: api.AgentAccessRole =
+      row.owner_account_id === actorAccountId
+        ? 'owner'
+        : row.status === 'accepted' && (row.role === 'reader' || row.role === 'writer')
+          ? row.role
+          : (() => {
+              throw new APIError(404, 'Agent not found')
+            })()
+    if (required === 'owner' && role !== 'owner') throw new APIError(403, 'Only the agent owner can do this')
+    if (required === 'writer' && role === 'reader') throw new APIError(403, 'Write access is required')
+    return {ownerAccountId: row.owner_account_id, role}
+  }
+
   #listAgents(accountId: string): api.ListAgentsResponse {
     const rows = this.#db
-      .query<AgentRow, [string]>(
-        `SELECT id, account_id, definition_cbor, state_dir, status, created_at, updated_at
-         FROM agents
-         WHERE account_id = ?
-         ORDER BY updated_at DESC`,
+      .query<AgentRow, [string, string, string]>(
+        `SELECT a.id, a.account_id, a.definition_cbor, a.state_dir, a.status, a.created_at, a.updated_at,
+                CASE WHEN a.account_id = ? THEN 'owner' ELSE c.role END AS access_role
+         FROM agents a
+         LEFT JOIN agent_collaborators c ON c.agent_id = a.id AND c.account_id = ? AND c.status = 'accepted'
+         WHERE a.account_id = ? OR c.account_id IS NOT NULL
+         ORDER BY a.updated_at DESC`,
       )
-      .all(accountId)
+      .all(accountId, accountId, accountId)
 
     return {
       _: 'ListAgentsResponse',
-      agents: rows.map(agentRowToInfo),
+      agents: rows.map((row) => agentRowToInfo(row, row.access_role)),
     }
+  }
+
+  #listAgentInvites(accountId: string): api.ListAgentInvitesResponse {
+    const rows = this.#db
+      .query<
+        {
+          agent_id: string
+          owner_account_id: string
+          definition_cbor: Uint8Array
+          role: api.AgentCollaboratorRole
+          created_at: number
+          updated_at: number
+        },
+        [string]
+      >(
+        `SELECT c.agent_id, a.account_id AS owner_account_id, a.definition_cbor, c.role, c.created_at, c.updated_at
+         FROM agent_collaborators c
+         JOIN agents a ON a.id = c.agent_id
+         WHERE c.account_id = ? AND c.status = 'pending'
+         ORDER BY c.updated_at DESC`,
+      )
+      .all(accountId)
+    return {
+      _: 'ListAgentInvitesResponse',
+      invites: rows.map((row) => ({
+        agentId: row.agent_id,
+        agentName: normalizeDefinition(cbor.decode<api.AgentDefinition>(row.definition_cbor)).name,
+        ownerAccountId: row.owner_account_id,
+        role: row.role,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+      })),
+    }
+  }
+
+  #listAgentCollaborators(accountId: string, agentId: string): api.ListAgentCollaboratorsResponse {
+    const access = this.#requireAgentAccess(accountId, agentId, 'reader')
+    const owner = this.#db
+      .query<{created_at: number; updated_at: number}, [string]>(
+        `SELECT created_at, updated_at FROM agents WHERE id = ?`,
+      )
+      .get(agentId)
+    if (!owner) throw new APIError(404, 'Agent not found')
+    const rows = this.#db
+      .query<
+        {
+          account_id: string
+          role: api.AgentCollaboratorRole
+          status: 'accepted' | 'pending'
+          created_at: number
+          updated_at: number
+        },
+        [string]
+      >(
+        `SELECT account_id, role, status, created_at, updated_at
+         FROM agent_collaborators WHERE agent_id = ? ORDER BY status, updated_at DESC`,
+      )
+      .all(agentId)
+    return {
+      _: 'ListAgentCollaboratorsResponse',
+      agentId,
+      collaborators: [
+        {
+          accountId: access.ownerAccountId,
+          role: 'owner',
+          status: 'accepted',
+          createdAt: owner.created_at,
+          updatedAt: owner.updated_at,
+        },
+        ...rows
+          .filter((row) => access.role === 'owner' || row.status === 'accepted')
+          .map((row) => ({
+            accountId: row.account_id,
+            role: row.role,
+            status: row.status,
+            createdAt: row.created_at,
+            updatedAt: row.updated_at,
+          })),
+      ],
+    }
+  }
+
+  #inviteAgentCollaborator(
+    accountId: string,
+    agentId: string,
+    rawCollaboratorAccountId: string,
+    role: api.AgentCollaboratorRole,
+  ): api.InviteAgentCollaboratorResponse {
+    this.#requireAgentAccess(accountId, agentId, 'owner')
+    if (role !== 'reader' && role !== 'writer') throw new APIError(400, 'Collaborator role must be reader or writer')
+    const collaboratorAccountId = normalizeAccountId(rawCollaboratorAccountId)
+    if (collaboratorAccountId === accountId) throw new APIError(400, 'The agent owner is already a member')
+    const now = Date.now()
+    this.#ensureAccount(collaboratorAccountId, now)
+    this.#db.run(
+      `INSERT INTO agent_collaborators (agent_id, account_id, role, status, created_at, updated_at)
+       VALUES (?, ?, ?, 'pending', ?, ?)
+       ON CONFLICT(agent_id, account_id) DO UPDATE SET
+         role = excluded.role,
+         status = CASE WHEN agent_collaborators.status = 'accepted' THEN 'accepted' ELSE 'pending' END,
+         updated_at = excluded.updated_at`,
+      [agentId, collaboratorAccountId, role, now, now],
+    )
+    const row = this.#db
+      .query<
+        {role: api.AgentCollaboratorRole; status: 'accepted' | 'pending'; created_at: number; updated_at: number},
+        [string, string]
+      >(`SELECT role, status, created_at, updated_at FROM agent_collaborators WHERE agent_id = ? AND account_id = ?`)
+      .get(agentId, collaboratorAccountId)
+    if (!row) throw new APIError(500, 'Collaborator was not saved')
+    this.#collaboratorAudience.delete(agentId)
+    this.#onEvent?.({type: 'account-change', accountId, reason: 'agent-collaborators-changed', agentId})
+    this.#onEvent?.({
+      type: 'account-change',
+      accountId: collaboratorAccountId,
+      reason: 'agent-invites-changed',
+      agentId,
+    })
+    return {
+      _: 'InviteAgentCollaboratorResponse',
+      collaborator: {
+        accountId: collaboratorAccountId,
+        role: row.role,
+        status: row.status,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+      },
+    }
+  }
+
+  #removeAgentCollaborator(
+    accountId: string,
+    agentId: string,
+    rawCollaboratorAccountId: string,
+  ): api.RemoveAgentCollaboratorResponse {
+    this.#requireAgentAccess(accountId, agentId, 'owner')
+    const collaboratorAccountId = normalizeAccountId(rawCollaboratorAccountId)
+    const removed = this.#db.run(`DELETE FROM agent_collaborators WHERE agent_id = ? AND account_id = ?`, [
+      agentId,
+      collaboratorAccountId,
+    ])
+    if (removed.changes === 0) throw new APIError(404, 'Collaborator not found')
+    this.#collaboratorAudience.delete(agentId)
+    this.#onEvent?.({type: 'account-change', accountId, reason: 'agent-collaborators-changed', agentId})
+    this.#onEvent?.({
+      type: 'account-change',
+      accountId: collaboratorAccountId,
+      reason: 'agent-invites-changed',
+      agentId,
+    })
+    return {_: 'RemoveAgentCollaboratorResponse', agentId, accountId: collaboratorAccountId}
+  }
+
+  #acceptAgentInvite(accountId: string, agentId: string): api.AcceptAgentInviteResponse {
+    const now = Date.now()
+    const row = this.#db
+      .query<{owner_account_id: string; role: api.AgentCollaboratorRole}, [string, string]>(
+        `SELECT a.account_id AS owner_account_id, c.role
+         FROM agent_collaborators c JOIN agents a ON a.id = c.agent_id
+         WHERE c.agent_id = ? AND c.account_id = ? AND c.status = 'pending'`,
+      )
+      .get(agentId, accountId)
+    if (!row) throw new APIError(404, 'Agent invitation not found')
+    this.#db.run(
+      `UPDATE agent_collaborators SET status = 'accepted', accepted_at = ?, updated_at = ?
+       WHERE agent_id = ? AND account_id = ? AND status = 'pending'`,
+      [now, now, agentId, accountId],
+    )
+    this.#collaboratorAudience.delete(agentId)
+    this.#onEvent?.({
+      type: 'account-change',
+      accountId: row.owner_account_id,
+      reason: 'agent-collaborators-changed',
+      agentId,
+    })
+    this.#onEvent?.({type: 'account-change', accountId, reason: 'agent-invites-changed', agentId})
+    const agent = this.#getAgentInfo(row.owner_account_id, agentId)
+    if (!agent) throw new APIError(404, 'Agent not found')
+    return {_: 'AcceptAgentInviteResponse', agent: {...agent, accessRole: row.role}}
+  }
+
+  #declineAgentInvite(accountId: string, agentId: string): api.DeclineAgentInviteResponse {
+    const row = this.#db
+      .query<{owner_account_id: string}, [string, string]>(
+        `SELECT a.account_id AS owner_account_id
+         FROM agent_collaborators c JOIN agents a ON a.id = c.agent_id
+         WHERE c.agent_id = ? AND c.account_id = ? AND c.status = 'pending'`,
+      )
+      .get(agentId, accountId)
+    if (!row) throw new APIError(404, 'Agent invitation not found')
+    this.#db.run(`DELETE FROM agent_collaborators WHERE agent_id = ? AND account_id = ?`, [agentId, accountId])
+    this.#collaboratorAudience.delete(agentId)
+    this.#onEvent?.({
+      type: 'account-change',
+      accountId: row.owner_account_id,
+      reason: 'agent-collaborators-changed',
+      agentId,
+    })
+    this.#onEvent?.({type: 'account-change', accountId, reason: 'agent-invites-changed', agentId})
+    return {_: 'DeclineAgentInviteResponse', agentId}
   }
 
   async #createAgent(
@@ -1555,7 +1914,7 @@ export class Service {
     }
   }
 
-  #getAgent(accountId: string, agentId: string): api.GetAgentResponse {
+  #getAgent(accountId: string, agentId: string, viewerAccountId = accountId): api.GetAgentResponse {
     const agent = this.#db
       .query<AgentRow, [string, string]>(
         `SELECT id, account_id, definition_cbor, state_dir, status, created_at, updated_at
@@ -1573,7 +1932,12 @@ export class Service {
       )
       .all(accountId, agentId)
 
-    return {_: 'GetAgentResponse', agent: agentRowToInfo(agent), sessions: this.#sessionRowsToInfo(accountId, sessions)}
+    const access = this.#requireAgentAccess(viewerAccountId, agentId, 'reader')
+    return {
+      _: 'GetAgentResponse',
+      agent: agentRowToInfo(agent, access.role),
+      sessions: this.#sessionRowsToInfo(accountId, sessions),
+    }
   }
 
   /**
@@ -1595,8 +1959,18 @@ export class Service {
     includeChildren?: boolean,
   ): api.ListSessionsResponse {
     const pageSize = boundedInteger(limit, DEFAULT_SESSION_PAGE_SIZE, 1, MAX_SESSION_PAGE_SIZE)
-    const conditions = ['account_id = ?']
-    const params: (string | number)[] = [accountId]
+    const conditions = [
+      `EXISTS (
+        SELECT 1 FROM agents visible_agent
+        LEFT JOIN agent_collaborators visible_collaborator
+          ON visible_collaborator.agent_id = visible_agent.id
+          AND visible_collaborator.account_id = ?
+          AND visible_collaborator.status = 'accepted'
+        WHERE visible_agent.id = sessions.agent_id
+          AND (visible_agent.account_id = ? OR visible_collaborator.account_id IS NOT NULL)
+      )`,
+    ]
+    const params: (string | number)[] = [accountId, accountId]
     if (agentId !== undefined) {
       conditions.push('agent_id = ?')
       params.push(normalizeBoundedString(agentId, 'Agent ID', MAX_NAME_BYTES))
@@ -1632,7 +2006,9 @@ export class Service {
 
     const hasMore = rows.length > pageSize
     const page = hasMore ? rows.slice(0, pageSize) : rows
-    const sessions = this.#sessionRowsToInfo(accountId, page)
+    const sessions = page.map((session) =>
+      sessionRowToInfo(session, this.#getSessionTriggerContext(session.account_id, session.id) ?? undefined),
+    )
     const referencedAgentIds = new Set(sessions.map((session) => session.agentId))
     const agents = this.#listAgents(accountId).agents.filter((agent) => referencedAgentIds.has(agent.id))
     const last = page[page.length - 1]
@@ -1645,7 +2021,12 @@ export class Service {
     }
   }
 
-  #updateAgent(accountId: string, agentId: string, rawDefinition: api.AgentDefinition): api.GetAgentResponse {
+  #updateAgent(
+    accountId: string,
+    agentId: string,
+    rawDefinition: api.AgentDefinition,
+    viewerAccountId = accountId,
+  ): api.GetAgentResponse {
     const definition = normalizeDefinition(rawDefinition)
     const existing = this.#db
       .query<{id: string}, [string, string]>(`SELECT id FROM agents WHERE account_id = ? AND id = ?`)
@@ -1667,7 +2048,7 @@ export class Service {
       accountId,
       agentId,
     ])
-    const response = this.#getAgent(accountId, agentId)
+    const response = this.#getAgent(accountId, agentId, viewerAccountId)
     this.#emit({type: 'agent-change', accountId, agent: response.agent})
     invalidateSpaceIndex(accountId, agentId)
     this.#emit({type: 'account-change', accountId, reason: 'agent-updated', agentId})
@@ -1678,6 +2059,12 @@ export class Service {
     const existing = this.#getAgentInfo(accountId, agentId)
     if (!existing) throw new APIError(404, 'Agent not found')
 
+    const collaboratorAccountIds = this.#db
+      .query<{account_id: string}, [string]>(
+        `SELECT account_id FROM agent_collaborators WHERE agent_id = ? AND status = 'accepted'`,
+      )
+      .all(agentId)
+      .map((row) => row.account_id)
     const sessions = this.#db
       .query<{id: string}, [string, string]>(`SELECT id FROM sessions WHERE account_id = ? AND agent_id = ?`)
       .all(accountId, agentId)
@@ -1718,6 +2105,7 @@ export class Service {
       this.#db.run(`DELETE FROM agent_triggers WHERE account_id = ? AND agent_id = ?`, [accountId, agentId])
       this.#db.run(`DELETE FROM agent_drafts WHERE account_id = ? AND agent_id = ?`, [accountId, agentId])
       this.#db.run(`DELETE FROM tool_documents WHERE account_id = ? AND agent_id = ?`, [accountId, agentId])
+      this.#db.run(`DELETE FROM agent_collaborators WHERE agent_id = ?`, [agentId])
       this.#db.run(`DELETE FROM agents WHERE account_id = ? AND id = ?`, [accountId, agentId])
     })
     transaction()
@@ -1733,7 +2121,11 @@ export class Service {
     }
 
     invalidateSpaceIndex(accountId, agentId)
+    this.#collaboratorAudience.delete(agentId)
     this.#emit({type: 'account-change', accountId, reason: 'agent-deleted', agentId})
+    for (const collaboratorAccountId of collaboratorAccountIds) {
+      this.#onEvent?.({type: 'account-change', accountId: collaboratorAccountId, reason: 'agent-deleted', agentId})
+    }
     return {_: 'DeleteAgentResponse', agentId}
   }
 
@@ -2540,18 +2932,22 @@ export class Service {
     sessionId: string,
     content: api.MessageSession['content'],
     clientMessageId?: string,
+    origin?: {accountId: string; signerId: string},
   ): Promise<api.MessageSessionResponse> {
     const normalizedId =
       clientMessageId === undefined
         ? undefined
         : normalizeBoundedString(clientMessageId, 'Client message ID', MAX_NAME_BYTES)
     const requestCBOR = normalizedId === undefined ? undefined : cbor.encode({sessionId, content})
+    // Idempotency belongs to the acting account, not the agent owner's storage account: two
+    // collaborators may legitimately generate the same client-local id.
+    const idempotencyAccountId = origin?.accountId ?? accountId
     if (normalizedId !== undefined && requestCBOR !== undefined) {
       const existing = this.#db
         .query<{request_cbor: Uint8Array; response_cbor: Uint8Array}, [string, string, string]>(
           `SELECT request_cbor, response_cbor FROM action_idempotency WHERE account_id = ? AND action = ? AND client_request_id = ?`,
         )
-        .get(accountId, 'MessageSession', normalizedId)
+        .get(idempotencyAccountId, 'MessageSession', normalizedId)
       if (existing) {
         if (!bytesEqual(existing.request_cbor, requestCBOR))
           throw new APIError(409, 'Client message ID payload mismatch')
@@ -2559,12 +2955,12 @@ export class Service {
       }
     }
 
-    const response = await this.#messageSessionOnce(accountId, sessionId, content)
+    const response = await this.#messageSessionOnce(accountId, sessionId, content, origin ? {userOrigin: origin} : {})
     if (normalizedId !== undefined && requestCBOR !== undefined) {
       this.#db.run(
         `INSERT INTO action_idempotency (account_id, action, client_request_id, request_cbor, response_cbor, created_at)
          VALUES (?, ?, ?, ?, ?, ?)`,
-        [accountId, 'MessageSession', normalizedId, requestCBOR, cbor.encode(response), Date.now()],
+        [idempotencyAccountId, 'MessageSession', normalizedId, requestCBOR, cbor.encode(response), Date.now()],
       )
     }
     return response
@@ -2583,6 +2979,8 @@ export class Service {
       parentRunId?: string
       /** Human label for the run, shown in the progress card's children strip. */
       title?: string
+      /** Signed Seed account and exact signer behind an interactive user message. */
+      userOrigin?: {accountId: string; signerId: string}
     } = {},
   ): Promise<api.MessageSessionResponse> {
     const messages = normalizeMessageContent(rawContent)
@@ -2595,8 +2993,6 @@ export class Service {
       )
       .get(accountId, sessionId)
     if (!session) throw new APIError(404, 'Session not found')
-    // Liveness is lease-based (run rows), not the status column, so a crash can never wedge this guard.
-    if (runs.sessionHasLiveRun(this.#db, sessionId)) throw new APIError(409, 'Session is already streaming')
     if (this.#liveUserVerbs.has(sessionId)) {
       throw new APIError(409, 'A user tool action is still running in this thread; wait for it to finish')
     }
@@ -2624,25 +3020,10 @@ export class Service {
       if (!info) throw new APIError(404, `Attachment not found: ${attachmentId}`)
       return info
     })
-    this.#appendSessionEvent(
-      accountId,
-      session.agent_id,
-      sessionId,
-      {
-        type: 'message',
-        role: 'user',
-        content: modelTexts[0]!,
-        rawMarkdown: firstMessage.text,
-        ...(firstMessage.blocks ? {blocks: firstMessage.blocks} : {}),
-        ...(firstMessage.contextLines ? {contextLines: firstMessage.contextLines} : {}),
-        ...(attachments.length > 0 ? {attachments} : {}),
-        // Echoed so the sending client can replace its optimistic pending row by identity — the
-        // stored `content` is re-serialized and cannot be matched by text.
-        ...(firstMessage.clientMessageId ? {clientMessageId: firstMessage.clientMessageId} : {}),
-      },
-      now,
-    )
-    for (const [index, message] of messages.slice(1).entries()) {
+    const userMeta: api.SessionEventMeta | undefined = opts.userOrigin
+      ? {accountId: opts.userOrigin.accountId, signerId: opts.userOrigin.signerId}
+      : undefined
+    const userEvents = [
       this.#appendSessionEvent(
         accountId,
         session.agent_id,
@@ -2650,14 +3031,42 @@ export class Service {
         {
           type: 'message',
           role: 'user',
-          content: modelTexts[index + 1]!,
-          rawMarkdown: message.text,
-          ...(message.blocks ? {blocks: message.blocks} : {}),
-          ...(message.clientMessageId ? {clientMessageId: message.clientMessageId} : {}),
+          content: modelTexts[0]!,
+          rawMarkdown: firstMessage.text,
+          ...(firstMessage.blocks ? {blocks: firstMessage.blocks} : {}),
+          ...(firstMessage.contextLines ? {contextLines: firstMessage.contextLines} : {}),
+          ...(attachments.length > 0 ? {attachments} : {}),
+          // Echoed so the sending client can replace its optimistic pending row by identity — the
+          // stored `content` is re-serialized and cannot be matched by text.
+          ...(firstMessage.clientMessageId ? {clientMessageId: firstMessage.clientMessageId} : {}),
+          ...(userMeta ? {meta: userMeta} : {}),
         },
-        Date.now(),
+        now,
+      ),
+    ]
+    for (const [index, message] of messages.slice(1).entries()) {
+      userEvents.push(
+        this.#appendSessionEvent(
+          accountId,
+          session.agent_id,
+          sessionId,
+          {
+            type: 'message',
+            role: 'user',
+            content: modelTexts[index + 1]!,
+            rawMarkdown: message.text,
+            ...(message.blocks ? {blocks: message.blocks} : {}),
+            ...(message.clientMessageId ? {clientMessageId: message.clientMessageId} : {}),
+            ...(userMeta ? {meta: userMeta} : {}),
+          },
+          Date.now(),
+        ),
       )
     }
+    // A user message is durable before its run is scheduled. If another turn already owns this
+    // session, leave this run queued instead of rejecting the writer; the per-session run claim
+    // serializes model work while every collaborator remains free to contribute to the shared log.
+    const queuedBehindAnotherTurn = runs.sessionHasLiveRun(this.#db, sessionId)
     const origin = opts.origin ?? 'user'
     const run = this.#runQueue.enqueue({
       id: opts.runId,
@@ -2670,24 +3079,30 @@ export class Service {
       parentRunId: opts.parentRunId,
       // Titles are mandatory: a plain chat turn is named by what the user asked.
       title: opts.title ?? sessionTitleFromPrompt(firstMessage.text),
-      input: {kind: 'session-message'},
+      input: {
+        kind: 'session-message',
+        userEventIds: userEvents.map((event) => event.id),
+        queuedBehindAnotherTurn,
+      },
       queue: opts.background ? 'background' : 'interactive',
       // Background turns ride out a flaky provider; a turn the user is watching fails fast instead,
       // because retrying holds the session lock through the backoff — the error would never reach
       // them and their next message would bounce off "already streaming". They have Retry.
       maxAttempts: opts.background ? AGENT_RUN_MAX_ATTEMPTS : 1,
-      dispatch: opts.background === true,
+      dispatch: opts.background === true || queuedBehindAnotherTurn,
     })
-    // Background callers (triggers, agent-started sessions) return as soon as the run is durably
-    // queued; the dispatch loop picks it up and completion is observable via awaitQueueIdle/WS.
-    if (opts.background) return {_: 'MessageSessionResponse', sessionId, assistantEventId: ''}
+    // Background callers and concurrent collaborators return as soon as both their message and its
+    // serialized follow-up run are durable. Completion remains observable through the session WS.
+    if (opts.background || queuedBehindAnotherTurn) {
+      return {_: 'MessageSessionResponse', sessionId, assistantEventId: ''}
+    }
 
     const final = await this.#runQueue.runInline(run.id)
-    if (final.status === 'queued') {
-      // The inline claim was refused: another live run owns this session (a concurrent send won the
-      // race while this request resolved message embeds). Withdraw our duplicate run and 409.
-      this.#runQueue.cancelTree(accountId, run.id)
-      throw new APIError(409, 'Session is already streaming')
+    if (final.status === 'queued' || final.status === 'claimed' || final.status === 'running') {
+      // A concurrent request may wake the dispatcher between our enqueue and inline claim. The
+      // message is already durable and this run is still the unique work item for it, so leave it
+      // serialized in the queue and let every writer return successfully.
+      return {_: 'MessageSessionResponse', sessionId, assistantEventId: ''}
     }
     if (final.status === 'succeeded' || final.status === 'canceled') {
       const output = (final.output ?? {}) as {assistantEventId?: string}
@@ -4529,18 +4944,61 @@ export class Service {
       return next
     }
     const replayMessages = this.#piMessages(sessionId)
-    // A park-resume after interleaved conversation can end on an assistant message (the late tool
-    // results attach adjacent to their calls, earlier in the transcript). Pi cannot continue from
-    // an assistant turn, and the model needs direction anyway: hand it back the floor explicitly.
-    // In-memory only — never persisted to the transcript.
-    const lastReplayed = replayMessages.at(-1) as {role?: string} | undefined
-    if (lastReplayed?.role === 'assistant') {
+    const runInput = run && isRecord(run.input) ? run.input : undefined
+    const queuedUserEventIds =
+      runInput?.queuedBehindAnotherTurn === true && Array.isArray(runInput.userEventIds)
+        ? runInput.userEventIds.filter((id): id is string => typeof id === 'string')
+        : []
+    // A concurrent collaborator's message is appended immediately, even while the preceding
+    // assistant response is still streaming. That means durable ordering can be user B, then the
+    // tail of assistant A. Put an in-memory handoff last so the serialized follow-up turn cannot
+    // mistake A's later event for an answer to B. The original messages remain the only durable
+    // copies; this is provider guidance, not another transcript event.
+    if (queuedUserEventIds.length) {
+      const wanted = new Set(queuedUserEventIds)
+      const concurrentMessages = this.#db
+        .query<SessionEventRow, [string]>(
+          `SELECT id, session_id, seq, event_cbor, created_at FROM session_events WHERE session_id = ? ORDER BY seq ASC`,
+        )
+        .all(sessionId)
+        .filter((row) => wanted.has(row.id))
+        .map((row) => {
+          const payload = cbor.decode<api.SessionEventPayload>(row.event_cbor) as {
+            type?: string
+            role?: string
+            content?: string
+            meta?: api.SessionEventMeta
+          }
+          return {
+            eventId: row.id,
+            accountId: payload.meta?.accountId,
+            content: payload.type === 'message' && payload.role === 'user' ? payload.content : undefined,
+          }
+        })
+        .filter((message): message is {eventId: string; accountId: string | undefined; content: string} =>
+          Boolean(message.content),
+        )
       replayMessages.push({
         role: 'user',
-        content:
-          '<background_work_update>\nThe background sub-sessions/workflows you were waiting on have finished; their results are attached to their tool calls above. Continue now: act on those results and reply to the user, including anything you promised to deliver once they completed.\n</background_work_update>',
+        content: `<concurrent_user_messages>\nThese user messages arrived while the previous response was already in progress. Any assistant event that follows them in the durable transcript belongs to that earlier turn and does not answer them. Respond to these messages now:\n${JSON.stringify(
+          concurrentMessages,
+        )}\n</concurrent_user_messages>`,
         timestamp: Date.now(),
       })
+    } else {
+      // A park-resume after interleaved conversation can end on an assistant message (the late tool
+      // results attach adjacent to their calls, earlier in the transcript). Pi cannot continue from
+      // an assistant turn, and the model needs direction anyway: hand it back the floor explicitly.
+      // In-memory only — never persisted to the transcript.
+      const lastReplayed = replayMessages.at(-1) as {role?: string} | undefined
+      if (lastReplayed?.role === 'assistant') {
+        replayMessages.push({
+          role: 'user',
+          content:
+            '<background_work_update>\nThe background sub-sessions/workflows you were waiting on have finished; their results are attached to their tool calls above. Continue now: act on those results and reply to the user, including anything you promised to deliver once they completed.\n</background_work_update>',
+          timestamp: Date.now(),
+        })
+      }
     }
     // The checklist, handed back every turn.
     //
@@ -5114,7 +5572,45 @@ export class Service {
   }
 
   #emit(event: ServiceEvent): void {
-    this.#onEvent?.(event)
+    const onEvent = this.#onEvent
+    if (!onEvent) return
+    onEvent(event)
+    const agentId =
+      event.type === 'agent-change'
+        ? event.agent.id
+        : event.type === 'session-change'
+          ? event.session.agentId
+          : event.type === 'session-event' || event.type === 'session-partial'
+            ? event.agentId
+            : event.type === 'account-change'
+              ? event.agentId
+              : event.type === 'run-change'
+                ? event.run.agentId
+                : event.type === 'run-append' || event.type === 'run-partial'
+                  ? this.#db
+                      .query<{agent_id: string | null}, [string]>(
+                        `SELECT agent_id FROM runs WHERE root_run_id = ? LIMIT 1`,
+                      )
+                      .get(event.rootRunId)?.agent_id
+                  : undefined
+    if (!agentId) return
+    let collaborators = this.#collaboratorAudience.get(agentId)
+    if (!collaborators) {
+      collaborators = this.#db
+        .query<{account_id: string; role: api.AgentCollaboratorRole}, [string]>(
+          `SELECT account_id, role FROM agent_collaborators WHERE agent_id = ? AND status = 'accepted'`,
+        )
+        .all(agentId)
+      this.#collaboratorAudience.set(agentId, collaborators)
+    }
+    for (const collaborator of collaborators) {
+      if (collaborator.account_id === event.accountId) continue
+      const sharedEvent =
+        event.type === 'agent-change'
+          ? {...event, accountId: collaborator.account_id, agent: {...event.agent, accessRole: collaborator.role}}
+          : {...event, accountId: collaborator.account_id}
+      onEvent(sharedEvent as ServiceEvent)
+    }
   }
 
   async #getSession(accountId: string, sessionId: string, afterSeq?: number): Promise<api.GetSessionResponse> {
@@ -5223,28 +5719,29 @@ export class Service {
     if (agentMatch) {
       const agentId = agentMatch[1]
       if (!agentId) throw new APIError(400, 'Subscription key is invalid')
-      const agent = this.#getAgentInfo(verified.accountId, agentId)
-      if (!agent) throw new APIError(404, 'Agent not found')
+      this.#requireAgentAccess(verified.accountId, agentId, 'reader')
       return {accountId: verified.accountId, key}
     }
     const sessionMatch = /^sessions\/([^/]+)$/.exec(key)
     if (sessionMatch) {
       const sessionId = sessionMatch[1]
       if (!sessionId) throw new APIError(400, 'Subscription key is invalid')
-      const replay = await this.#getSession(verified.accountId, sessionId, envelope.action.afterSeq)
+      const ownerAccountId = this.#actionAccountId(verified.accountId, {_: 'GetSession', sessionId})
+      const replay = await this.#getSession(ownerAccountId, sessionId, envelope.action.afterSeq)
       return {accountId: verified.accountId, key, replay}
     }
     const runMatch = /^runs\/([^/]+)$/.exec(key)
     if (runMatch) {
       const rootRunId = runMatch[1]
       if (!rootRunId) throw new APIError(400, 'Subscription key is invalid')
-      const root = runs.getRun(this.#db, verified.accountId, rootRunId)
+      const ownerAccountId = this.#actionAccountId(verified.accountId, {_: 'GetRun', runId: rootRunId})
+      const root = runs.getRun(this.#db, ownerAccountId, rootRunId)
       if (!root) throw new APIError(404, 'Run not found')
-      const tree = runs.listRunTree(this.#db, verified.accountId, root.rootRunId)
+      const tree = runs.listRunTree(this.#db, ownerAccountId, root.rootRunId)
       const afterSeq = envelope.action.afterSeq
       const entries: api.RunJournalEntryInfo[] = []
       for (const run of tree) {
-        entries.push(...this.#getRunJournal(verified.accountId, run.id, afterSeq).entries)
+        entries.push(...this.#getRunJournal(ownerAccountId, run.id, afterSeq).entries)
       }
       return {
         accountId: verified.accountId,
@@ -5829,6 +6326,7 @@ type AgentRow = {
   status: api.AgentInfo['status']
   created_at: number
   updated_at: number
+  access_role?: api.AgentAccessRole
 }
 
 type AgentTriggerRow = {
@@ -6109,7 +6607,7 @@ function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
   return true
 }
 
-function agentRowToInfo(row: AgentRow): api.AgentInfo {
+function agentRowToInfo(row: AgentRow, accessRole: api.AgentAccessRole = 'owner'): api.AgentInfo {
   return {
     id: row.id,
     account: row.account_id,
@@ -6118,6 +6616,7 @@ function agentRowToInfo(row: AgentRow): api.AgentInfo {
     status: row.status,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+    accessRole,
   }
 }
 
@@ -9949,6 +10448,18 @@ function getOrCreateSecretEncryptionKey(db: Database): Uint8Array {
   const key = crypto.getRandomValues(new Uint8Array(32))
   db.run(`INSERT INTO server_config (key, value) VALUES (?, ?)`, [SECRET_KEY_CONFIG_KEY, key])
   return key
+}
+
+function normalizeAccountId(value: unknown): string {
+  const accountId = normalizeBoundedString(value, 'Collaborator account', MAX_NAME_BYTES)
+  try {
+    const principal = blobs.principalFromString(accountId)
+    const canonical = blobs.principalToString(principal)
+    if (canonical !== accountId) throw new Error('not canonical')
+    return canonical
+  } catch {
+    throw new APIError(400, 'Collaborator account must be a valid Seed account ID')
+  }
 }
 
 function normalizeBoundedString(value: unknown, label: string, maxBytes: number): string {

--- a/agents/src/main.ts
+++ b/agents/src/main.ts
@@ -326,6 +326,7 @@ function agentRowToInfo(row: AgentRow): api.AgentInfo {
     status: row.status,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+    accessRole: 'owner',
   }
 }
 
@@ -518,9 +519,10 @@ async function main(): Promise<void> {
           key: `account/${event.accountId}`,
           value: {reason: event.reason, agentId: event.agentId, sessionId: event.sessionId},
         })
-        // Memory writes happen mid-session with no agent-change event, so also notify
-        // agent-page subscribers watching the Memory tab.
-        if (event.reason === 'agent-memory-changed' && event.agentId) {
+        // Agent-scoped account changes also reach the open agent page. This covers memory writes
+        // (which have no agent-change event), collaborator changes, and an owner deleting an agent
+        // while a collaborator still has its detail page open.
+        if (event.agentId) {
           sendIfSubscribed(ws, `agents/${event.agentId}`, {
             _: 'change',
             key: `account/${event.accountId}`,

--- a/agents/src/sqlite-schema.sql
+++ b/agents/src/sqlite-schema.sql
@@ -48,6 +48,19 @@ CREATE TABLE agents (
 
 CREATE INDEX agents_by_account ON agents (account_id, updated_at DESC);
 
+CREATE TABLE agent_collaborators (
+    agent_id TEXT NOT NULL REFERENCES agents (id),
+    account_id TEXT NOT NULL REFERENCES accounts (id),
+    role TEXT NOT NULL,
+    status TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    accepted_at INTEGER,
+    PRIMARY KEY (agent_id, account_id)
+) WITHOUT ROWID;
+
+CREATE INDEX agent_collaborators_by_account ON agent_collaborators (account_id, status, updated_at DESC);
+
 CREATE TABLE agent_triggers (
     id TEXT PRIMARY KEY,
     account_id TEXT NOT NULL REFERENCES accounts (id),

--- a/agents/src/sqlite.test.ts
+++ b/agents/src/sqlite.test.ts
@@ -10,6 +10,7 @@ describe('sqlite', () => {
       expect(result.ok).toBe(true)
       expect(getConfigValue(db, sqlite.SCHEMA_MIGRATION_VERSION_KEY)).toBe(String(sqlite.desiredVersion))
       expect(tableExists(db, 'agents')).toBe(true)
+      expect(tableExists(db, 'agent_collaborators')).toBe(true)
       expect(tableExists(db, 'session_events')).toBe(true)
       expect(tableExists(db, 'action_idempotency')).toBe(true)
       expect(tableExists(db, 'agent_triggers')).toBe(true)
@@ -56,6 +57,10 @@ describe('sqlite', () => {
             '',
           )
           .replace(/CREATE INDEX sessions_by_parent ON sessions \(parent_session_id, created_at\);\n\n/u, '')
+          .replace(
+            /CREATE TABLE agent_collaborators[\s\S]*?CREATE TABLE agent_triggers/u,
+            'CREATE TABLE agent_triggers',
+          )
           .replace(/CREATE TABLE runs[\s\S]*?CREATE TABLE agent_drafts/u, 'CREATE TABLE agent_drafts')
           .replace(/CREATE TABLE tool_documents[\s\S]*?CREATE TABLE server_config/u, 'CREATE TABLE server_config')
           .replace(/CREATE TABLE agent_triggers[\s\S]*?CREATE TABLE sessions/u, 'CREATE TABLE sessions')
@@ -77,6 +82,7 @@ describe('sqlite', () => {
       expect(tableExists(db, 'trigger_firings')).toBe(true)
       expect(tableExists(db, 'activity_watermarks')).toBe(true)
       expect(tableExists(db, 'agent_drafts')).toBe(true)
+      expect(tableExists(db, 'agent_collaborators')).toBe(true)
       expect(tableExists(db, 'runs')).toBe(true)
       expect(tableExists(db, 'run_journal')).toBe(true)
       expect(tableExists(db, 'tool_documents')).toBe(true)

--- a/agents/src/sqlite.ts
+++ b/agents/src/sqlite.ts
@@ -13,6 +13,20 @@ export const BASELINE_SCHEMA_MIGRATION_VERSION = 0
 /** Prepend-only database migrations. */
 export const migrations: string[] = [
   // ======= IMPORTANT: Add new migrations below this line. =======
+  // Agent-level invitations and accepted read/write collaborators. The invited account is a real
+  // Seed principal and gets an accounts row before this membership row is inserted.
+  `CREATE TABLE agent_collaborators (
+      agent_id TEXT NOT NULL REFERENCES agents (id),
+      account_id TEXT NOT NULL REFERENCES accounts (id),
+      role TEXT NOT NULL,
+      status TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      accepted_at INTEGER,
+      PRIMARY KEY (agent_id, account_id)
+  ) WITHOUT ROWID;
+
+  CREATE INDEX agent_collaborators_by_account ON agent_collaborators (account_id, status, updated_at DESC);`,
   // Run titles became mandatory: every enqueue site now derives a real one, so the display layer
   // never invents a label. Rows from before the requirement get the exact text the UI used to
   // fall back to, so their cards read the same as they always did.

--- a/agents/tsconfig.json
+++ b/agents/tsconfig.json
@@ -32,5 +32,5 @@
     "noPropertyAccessFromIndexSignature": false
   },
 
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["data", "dist", "node_modules"]
 }

--- a/frontend/apps/desktop/src/__tests__/agents-list-local-server.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/agents-list-local-server.test.tsx
@@ -14,6 +14,14 @@ const mockState = vi.hoisted(() => ({
   healths: [] as Array<{isLoading: boolean; isError: boolean; data?: {uptime: number}}>,
   selectedAccountId: 'account-1' as string | null,
   accountIds: ['account-1'] as string[],
+  invites: [] as Array<{
+    agentId: string
+    agentName: string
+    ownerAccountId: string
+    role: 'reader' | 'writer'
+    createdAt: number
+    updatedAt: number
+  }>,
 }))
 
 vi.mock('@/models/agents', () => ({
@@ -24,6 +32,14 @@ vi.mock('@/models/agents', () => ({
   useLocalAgentServerUrl: () => ({data: mockState.localServerUrl}),
   useAgentServerHealths: () => mockState.healths,
   useAgentLists: () => mockState.serverUrls.map(() => ({data: [], isFetching: false, isError: false})),
+  useAgentInviteLists: () =>
+    mockState.serverUrls.map((_, index) => ({
+      data: index === 0 ? mockState.invites : [],
+      isFetching: false,
+      isError: false,
+    })),
+  useAcceptAgentInvite: () => ({isLoading: false, mutate: vi.fn()}),
+  useDeclineAgentInvite: () => ({isLoading: false, mutate: vi.fn()}),
   useAgentWebSocketSubscription: () => ({text: ''}),
 }))
 
@@ -108,10 +124,33 @@ describe('agents list — local server presentation', () => {
     ]
     mockState.selectedAccountId = 'account-1'
     mockState.accountIds = ['account-1']
+    mockState.invites = []
   })
 
   afterEach(() => {
     document.body.innerHTML = ''
+  })
+
+  it('shows pending agent invitations with their role and actions', () => {
+    mockState.invites = [
+      {
+        agentId: 'shared-agent',
+        agentName: 'Research partner',
+        ownerAccountId: 'z6MkOwnerAccount',
+        role: 'writer',
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ]
+    const {container, root} = renderList()
+
+    expect(container.textContent).toContain('Invites')
+    expect(container.textContent).toContain('Research partner')
+    expect(container.textContent).toContain('Write collaborator')
+    expect(container.textContent).toContain('Accept')
+    expect(container.textContent).toContain('Decline')
+
+    cleanupRendered(root, container)
   })
 
   it('names the local server instead of showing its URL', () => {

--- a/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
@@ -60,6 +60,13 @@ vi.mock('../components/markdown', () => ({
 
 vi.mock('@shm/shared/models/entity', () => ({
   useResource: () => ({data: null}),
+  useAccount: (accountId?: string) => ({
+    data: accountId ? {metadata: {name: accountId === 'z6MkAlice' ? 'Alice' : 'Account'}} : null,
+  }),
+}))
+
+vi.mock('@shm/ui/hm-icon', () => ({
+  HMIcon: ({name}: {name?: string}) => React.createElement('div', {'data-testid': 'account-icon'}, name),
 }))
 
 // models/agents creates the tRPC client at import time, which needs the electronTRPC preload global.
@@ -153,6 +160,33 @@ describe('assistant message rendering', () => {
     expect(document.body.textContent).toContain('Context shared with the agent')
     expect(document.body.textContent).toContain('URL: hm://z6MkDoc/plan')
     expect(document.body.textContent).toContain('View: document')
+
+    cleanupRendered(root, container)
+  })
+
+  it('shows the originator icon and exact account and signer metadata on user messages', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    act(() => {
+      root.render(
+        <ChatMessageBubble
+          message={{
+            role: 'user',
+            content: 'Shared update',
+            meta: {accountId: 'z6MkAlice', signerId: 'z6MkAliceDeviceSigner'},
+          }}
+        />,
+      )
+    })
+
+    expect(container.querySelector('[data-testid="account-icon"]')?.textContent).toBe('Alice')
+    expect(container.querySelector('[aria-label="Message from Alice"]')).toBeTruthy()
+    click(findButton(container, (element) => element.title === 'Show markdown sent to the LLM'))
+    expect(document.body.textContent).toContain('Originator')
+    expect(document.body.textContent).toContain('z6MkAlice')
+    expect(document.body.textContent).toContain('Signer')
+    expect(document.body.textContent).toContain('z6MkAliceDeviceSigner')
 
     cleanupRendered(root, container)
   })

--- a/frontend/apps/desktop/src/__tests__/assistant-new-session-selection.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/assistant-new-session-selection.test.tsx
@@ -88,9 +88,12 @@ describe('sidebar new-chat selection after CreateSession', () => {
   it('lets the optimistic first message attach to the seeded session', () => {
     addOptimisticSessionToCaches(SERVER, ACCOUNT, session('s-new', 200))
     addOptimisticSessionMessage(SERVER, ACCOUNT, 's-new', [{text: 'hello'}])
-    const cached = queryClient.getQueryData(sessionKey('s-new')) as {events: Array<{event: {content: string}}>}
+    const cached = queryClient.getQueryData(sessionKey('s-new')) as {
+      events: {event: {content: string; meta?: {accountId?: string}}}[]
+    }
     expect(cached.events).toHaveLength(1)
     expect(cached.events[0]!.event.content).toBe('hello')
+    expect(cached.events[0]!.event.meta?.accountId).toBe(ACCOUNT)
   })
 
   it('does not duplicate a session the list already has, nor clobber a real GetSession cache', () => {

--- a/frontend/apps/desktop/src/agents-client.ts
+++ b/frontend/apps/desktop/src/agents-client.ts
@@ -12,6 +12,12 @@ export type AgentMessageBlock = AgentsProtocol.AgentMessageBlock
 export type MessageSessionContentPart = AgentsProtocol.MessageSessionContentPart
 /** Public metadata returned by the agents service. */
 export type AgentInfo = AgentsProtocol.AgentInfo
+/** A read or write role granted to an agent collaborator. */
+export type AgentCollaboratorRole = AgentsProtocol.AgentCollaboratorRole
+/** One owner, collaborator, or pending invitation on an agent. */
+export type AgentCollaboratorInfo = AgentsProtocol.AgentCollaboratorInfo
+/** A pending agent invitation shown to its recipient. */
+export type AgentInviteInfo = AgentsProtocol.AgentInviteInfo
 /** Public metadata returned for a session. */
 export type SessionInfo = AgentsProtocol.SessionInfo
 /** Compact trigger attribution attached to sessions created by triggers. */
@@ -32,7 +38,7 @@ export type SessionEvent = AgentsProtocol.SessionEvent
 export type SessionEventPayload = AgentsProtocol.SessionEventPayload
 /** Who performed a logged action: the log is shared, so every entry says who acted. */
 export type SessionActor = AgentsProtocol.SessionActor
-/** Model/provider/usage/timing stamped on a runtime-produced event at append time. */
+/** User origin or runtime model/provider/usage/timing stamped on a durable event. */
 export type SessionEventMeta = AgentsProtocol.SessionEventMeta
 /** Server-sent WebSocket event after a signed subscription. */
 export type AgentWSEvent = AgentsProtocol.AgentWSEvent

--- a/frontend/apps/desktop/src/components/assistant-message-rendering.tsx
+++ b/frontend/apps/desktop/src/components/assistant-message-rendering.tsx
@@ -28,11 +28,14 @@ import {
 import {useOpenUrl} from '@/open-url'
 import {useRun, useSessionAttachmentDataUrls, useSessionRuns} from '@/models/agents'
 import {descendantsOf, isTerminalRun, RunWorkHierarchy, useRunTreeView} from '@/pages/agents/run-work'
+import {useAccount} from '@shm/shared/models/entity'
+import {hmId} from '@shm/shared/utils/entity-id-url'
 import {ParkedRunActions} from '@/pages/agents/run-parked-actions'
 import {useSelectedAccountId} from '@/selected-account'
 import {useClickNavigate, useNavigate} from '@/utils/useNavigate'
 import type {HMBlockNode} from '@seed-hypermedia/client/hm-types'
 import {Button} from '@shm/ui/button'
+import {HMIcon} from '@shm/ui/hm-icon'
 import {cn} from '@shm/ui/utils'
 import {
   ArrowUpRight,
@@ -45,6 +48,7 @@ import {
   PenLine,
   RotateCcw,
   Search,
+  UserRound,
   Wrench,
 } from 'lucide-react'
 import React, {Suspense, useMemo, useState} from 'react'
@@ -100,6 +104,7 @@ export const ChatMessageBubble = React.memo(function ChatMessageBubble({
             {message.contextLines?.length ? <MessageContextInfo lines={message.contextLines} /> : null}
           </div>
           {rawMarkdown ? <RawMarkdownButton onClick={() => setShowRawMarkdown(true)} /> : null}
+          <UserMessageOrigin meta={message.meta} />
         </div>
       ) : (
         <AssistantMessageParts
@@ -214,10 +219,36 @@ function EventMetaSection({meta}: {meta?: SessionEventMeta}) {
         {rows.map((row) => (
           <div key={row.label} className="flex min-w-0 items-baseline justify-between gap-2 text-xs">
             <span className="text-muted-foreground shrink-0">{row.label}</span>
-            <span className="min-w-0 truncate text-right font-medium">{row.value}</span>
+            <span className="min-w-0 text-right font-medium break-all" title={row.value}>
+              {row.value}
+            </span>
           </div>
         ))}
       </div>
+    </div>
+  )
+}
+
+function UserMessageOrigin({meta}: {meta?: SessionEventMeta}) {
+  const account = useAccount(meta?.accountId, {subscribe: true, enabled: !!meta?.accountId})
+  const metadata = account.data?.metadata
+  const label = metadata?.name || meta?.accountId || 'Unknown user'
+
+  return meta?.accountId ? (
+    <div
+      className="ring-border bg-background mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full ring-1"
+      title={`${label}\n${meta.accountId}`}
+      aria-label={`Message from ${label}`}
+    >
+      <HMIcon id={hmId(meta.accountId)} name={metadata?.name} icon={metadata?.icon} size={26} />
+    </div>
+  ) : (
+    <div
+      className="ring-border bg-muted text-muted-foreground mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full ring-1"
+      title="Unknown user (legacy message)"
+      aria-label="Message from unknown user"
+    >
+      <UserRound className="size-3.5" />
     </div>
   )
 }
@@ -352,7 +383,7 @@ export type ChatBubbleMessage = {
    * model must read as instruction (role 'user') and the reader must not mistake for the user.
    */
   actor?: SessionActor
-  /** Model, provider, per-turn usage, and wall time, as the runtime stamped them. */
+  /** User origin or model/provider/usage/timing, as the writer stamped it. */
   meta?: SessionEventMeta
 }
 

--- a/frontend/apps/desktop/src/components/assistant-panel.tsx
+++ b/frontend/apps/desktop/src/components/assistant-panel.tsx
@@ -75,7 +75,6 @@ import {
 import type {CommentEditorSubmitHandle} from '@shm/editor/comment-editor'
 import {RunRecordCard, SessionRunCard} from '@/pages/agents/run-card'
 import {SessionStatusDot, SubSessionsDisclosure} from './session-children'
-import {QueuedChatMessages, useQueuedChatMessages} from './chat-message-queue'
 
 /**
  * Assistant sidebar.
@@ -313,6 +312,7 @@ export function AssistantPanel({
           agentId={activeAgent.agent.id}
           agentName={activeAgent.agent.definition.name}
           accountUid={accountUid}
+          readOnly={activeAgent.agent.accessRole === 'reader'}
           composerRef={composerRef}
           onSessionCreated={selectSession}
         />
@@ -544,11 +544,13 @@ function AssistantDraftChat({
   accountUid,
   composerRef,
   onSessionCreated,
+  readOnly,
 }: {
   serverUrl: string
   agentId: string
   agentName: string
   accountUid: string | null | undefined
+  readOnly: boolean
   composerRef: React.MutableRefObject<CommentEditorSubmitHandle | null>
   onSessionCreated: (ref: AssistantSessionRef) => void
 }) {
@@ -607,6 +609,7 @@ function AssistantDraftChat({
         isBusy={false}
         isStreaming={false}
         stopPending={false}
+        disabledMessage={readOnly ? 'You have read-only access to this agent.' : undefined}
         serverUrl={serverUrl}
         accountId={accountUid ?? null}
         composerHandleRef={composerRef}
@@ -642,6 +645,7 @@ function AssistantSessionChat({
 
   const autoScroll = useChatAutoScroll()
 
+  const readOnly = agentDetail.data?.agent.accessRole === 'reader'
   const status = session.data?.session.status
   const isStreaming = status === 'streaming'
   const isBusy = messageSession.isPending || isStreaming
@@ -699,11 +703,6 @@ function AssistantSessionChat({
     [accountUid, messageSession, serverUrl, sessionId],
   )
 
-  const {queuedMessages, queueMessage} = useQueuedChatMessages<AgentSessionDraftMessage>({
-    isBusy,
-    onFlush: doSendMessage,
-  })
-
   // Retry is offered on a trailing error only, and survives its own in-flight state: the row goes
   // away when the retried run starts streaming, not when the request is sent.
   const retryableRowKey = retryableErrorRowKey(rows, !!isBusy)
@@ -714,8 +713,7 @@ function AssistantSessionChat({
   }, [retrySession, sessionId])
 
   function handleSend(message: AgentSessionDraftMessage) {
-    if (isBusy) queueMessage(message)
-    else doSendMessage(message)
+    doSendMessage(message)
   }
 
   async function handleStop() {
@@ -807,12 +805,11 @@ function AssistantSessionChat({
         sessionId={sessionId}
         sessionPlan={session.data?.session.plan}
         frozenRunIds={frozenRuns}
+        readOnly={readOnly}
         onOpenSession={(childSessionId, childAgentId) =>
           navigate({key: 'agent-session', agentId: childAgentId, sessionId: childSessionId, serverUrl})
         }
       />
-
-      <QueuedChatMessages messages={queuedMessages} getText={(message) => message.text} />
 
       {/* No focus-on-mount here: session chats mount with the panel itself (e.g. on app launch),
           where stealing focus from the document would be wrong. Focus is imperative, via the
@@ -820,7 +817,13 @@ function AssistantSessionChat({
       <AgentRichMessageComposer
         isBusy={isBusy}
         isStreaming={isStreaming}
-        disabledMessage={isDrivenByParent ? SUB_SESSION_DRIVEN_MESSAGE : undefined}
+        disabledMessage={
+          readOnly
+            ? 'You have read-only access to this agent.'
+            : isDrivenByParent
+              ? SUB_SESSION_DRIVEN_MESSAGE
+              : undefined
+        }
         stopPending={stopSession.isPending}
         serverUrl={serverUrl}
         accountId={accountUid ?? null}

--- a/frontend/apps/desktop/src/models/agents.ts
+++ b/frontend/apps/desktop/src/models/agents.ts
@@ -5,6 +5,7 @@ import {
   normalizeAgentServerUrl,
   sendAgentAction,
   signAgentAction,
+  type AgentCollaboratorRole,
   type AgentDefinition,
   type AgentInfo,
   type AgentMessageBlock,
@@ -400,6 +401,44 @@ export function useAgentList(serverUrl: string | undefined, accountUid: string |
   })
 }
 
+/** Lists pending agent invitations on one configured server. */
+export function useAgentInvites(serverUrl: string | undefined, accountUid: string | null | undefined) {
+  return useQuery({
+    queryKey: ['agents', 'invites', serverUrl, accountUid],
+    queryFn: async () => {
+      if (!serverUrl || !accountUid) return []
+      const res = await sendAgentAction({serverUrl, accountUid, action: {_: 'ListAgentInvites'}})
+      if (res._ !== 'ListAgentInvitesResponse') throw new Error('Unexpected ListAgentInvites response')
+      return res.invites
+    },
+    enabled: !!serverUrl && !!accountUid,
+    refetchInterval: AGENT_BACKGROUND_REFETCH_INTERVAL_MS,
+    refetchIntervalInBackground: true,
+    retry: false,
+    useErrorBoundary: false,
+  })
+}
+
+/** Lists pending invitations for each configured server. */
+export function useAgentInviteLists(serverUrls: string[] | undefined, accountUid: string | null | undefined) {
+  return useQueries({
+    queries: (serverUrls || []).map((serverUrl) => ({
+      queryKey: ['agents', 'invites', serverUrl, accountUid],
+      queryFn: async () => {
+        if (!accountUid) return []
+        const res = await sendAgentAction({serverUrl, accountUid, action: {_: 'ListAgentInvites'}})
+        if (res._ !== 'ListAgentInvitesResponse') throw new Error('Unexpected ListAgentInvites response')
+        return res.invites
+      },
+      enabled: !!accountUid,
+      refetchInterval: AGENT_BACKGROUND_REFETCH_INTERVAL_MS,
+      refetchIntervalInBackground: true,
+      retry: false,
+      useErrorBoundary: false,
+    })),
+  })
+}
+
 /** Lists agents for each configured server. */
 export function useAgentLists(serverUrls: string[] | undefined, accountUid: string | null | undefined) {
   return useQueries({
@@ -453,13 +492,21 @@ export function useHasAnyAgent(serverUrls: string[] | undefined, accountUid: str
   return {hasAgents, isSettled}
 }
 
-/** Lists configured model providers for the selected account on the configured server. */
-export function useModelProviders(serverUrl: string | undefined, accountUid: string | null | undefined) {
+/** Lists configured model providers for the selected account or a shared agent's owner. */
+export function useModelProviders(
+  serverUrl: string | undefined,
+  accountUid: string | null | undefined,
+  agentId?: string,
+) {
   return useQuery({
-    queryKey: ['agents', 'providers', serverUrl, accountUid],
+    queryKey: ['agents', 'providers', serverUrl, accountUid, agentId],
     queryFn: async () => {
       if (!serverUrl || !accountUid) return []
-      const res = await sendAgentAction({serverUrl, accountUid, action: {_: 'ListModelProviders'}})
+      const res = await sendAgentAction({
+        serverUrl,
+        accountUid,
+        action: {_: 'ListModelProviders', ...(agentId ? {agentId} : {})},
+      })
       if (res._ !== 'ListModelProvidersResponse') throw new Error('Unexpected ListModelProviders response')
       return res.providers
     },
@@ -476,12 +523,17 @@ export function useProviderModels(
   serverUrl: string | undefined,
   accountUid: string | null | undefined,
   provider: string | undefined,
+  agentId?: string,
 ) {
   return useQuery({
-    queryKey: ['agents', 'provider-models', serverUrl, accountUid, provider],
+    queryKey: ['agents', 'provider-models', serverUrl, accountUid, provider, agentId],
     queryFn: async () => {
       if (!serverUrl || !accountUid || !provider) return []
-      const res = await sendAgentAction({serverUrl, accountUid, action: {_: 'ListProviderModels', provider}})
+      const res = await sendAgentAction({
+        serverUrl,
+        accountUid,
+        action: {_: 'ListProviderModels', provider, ...(agentId ? {agentId} : {})},
+      })
       if (res._ !== 'ListProviderModelsResponse') throw new Error('Unexpected ListProviderModels response')
       return res.models
     },
@@ -496,13 +548,21 @@ export function useProviderModels(
   })
 }
 
-/** Lists uploaded HM account keys for the selected account on the configured server. */
-export function useSigningIdentities(serverUrl: string | undefined, accountUid: string | null | undefined) {
+/** Lists uploaded HM account keys for the selected account or a shared agent's owner. */
+export function useSigningIdentities(
+  serverUrl: string | undefined,
+  accountUid: string | null | undefined,
+  agentId?: string,
+) {
   return useQuery({
-    queryKey: ['agents', 'signing-identities', serverUrl, accountUid],
+    queryKey: ['agents', 'signing-identities', serverUrl, accountUid, agentId],
     queryFn: async (): Promise<SigningIdentity[]> => {
       if (!serverUrl || !accountUid) return []
-      const res = await sendAgentAction({serverUrl, accountUid, action: {_: 'ListSigningIdentities'}})
+      const res = await sendAgentAction({
+        serverUrl,
+        accountUid,
+        action: {_: 'ListSigningIdentities', ...(agentId ? {agentId} : {})},
+      })
       if (res._ !== 'ListSigningIdentitiesResponse') throw new Error('Unexpected ListSigningIdentities response')
       return res.identities
     },
@@ -839,6 +899,96 @@ export function useCreateAgent(serverUrl: string | undefined, accountUid: string
     },
     onSuccess() {
       invalidateQueries(['agents', 'list'])
+    },
+  })
+}
+
+/** Lists everyone with access to one agent, including pending invitations. */
+export function useAgentCollaborators(
+  serverUrl: string | undefined,
+  accountUid: string | null | undefined,
+  agentId: string | undefined,
+) {
+  return useQuery({
+    queryKey: ['agents', 'collaborators', serverUrl, accountUid, agentId],
+    queryFn: async () => {
+      if (!serverUrl || !accountUid || !agentId) return []
+      const res = await sendAgentAction({serverUrl, accountUid, action: {_: 'ListAgentCollaborators', agentId}})
+      if (res._ !== 'ListAgentCollaboratorsResponse') throw new Error('Unexpected collaborator list response')
+      return res.collaborators
+    },
+    enabled: !!serverUrl && !!accountUid && !!agentId,
+    refetchInterval: AGENT_BACKGROUND_REFETCH_INTERVAL_MS,
+    refetchIntervalInBackground: true,
+    retry: false,
+    useErrorBoundary: false,
+  })
+}
+
+/** Invites an account or updates an existing collaborator's role. */
+export function useInviteAgentCollaborator(serverUrl: string | undefined, accountUid: string | null | undefined) {
+  return useMutation({
+    mutationFn: async ({
+      agentId,
+      collaboratorAccountId,
+      role,
+    }: {
+      agentId: string
+      collaboratorAccountId: string
+      role: AgentCollaboratorRole
+    }) => {
+      if (!serverUrl || !accountUid) throw new Error('Select an account and agent server first')
+      return sendAgentAction({
+        serverUrl,
+        accountUid,
+        action: {_: 'InviteAgentCollaborator', agentId, accountId: collaboratorAccountId, role},
+      })
+    },
+    onSuccess() {
+      invalidateQueries(['agents'])
+    },
+  })
+}
+
+/** Revokes a collaborator or cancels their pending invitation. */
+export function useRemoveAgentCollaborator(serverUrl: string | undefined, accountUid: string | null | undefined) {
+  return useMutation({
+    mutationFn: async ({agentId, collaboratorAccountId}: {agentId: string; collaboratorAccountId: string}) => {
+      if (!serverUrl || !accountUid) throw new Error('Select an account and agent server first')
+      return sendAgentAction({
+        serverUrl,
+        accountUid,
+        action: {_: 'RemoveAgentCollaborator', agentId, accountId: collaboratorAccountId},
+      })
+    },
+    onSuccess() {
+      invalidateQueries(['agents'])
+    },
+  })
+}
+
+/** Accepts one pending agent invitation. */
+export function useAcceptAgentInvite(serverUrl: string | undefined, accountUid: string | null | undefined) {
+  return useMutation({
+    mutationFn: async (agentId: string) => {
+      if (!serverUrl || !accountUid) throw new Error('Select an account and agent server first')
+      return sendAgentAction({serverUrl, accountUid, action: {_: 'AcceptAgentInvite', agentId}})
+    },
+    onSuccess() {
+      invalidateQueries(['agents'])
+    },
+  })
+}
+
+/** Declines one pending agent invitation. */
+export function useDeclineAgentInvite(serverUrl: string | undefined, accountUid: string | null | undefined) {
+  return useMutation({
+    mutationFn: async (agentId: string) => {
+      if (!serverUrl || !accountUid) throw new Error('Select an account and agent server first')
+      return sendAgentAction({serverUrl, accountUid, action: {_: 'DeclineAgentInvite', agentId}})
+    },
+    onSuccess() {
+      invalidateQueries(['agents'])
     },
   })
 }
@@ -2047,6 +2197,9 @@ export function addOptimisticSessionMessage(
             // Stamped rather than inferred: `role: 'user'` is a shape the runtime writes too, and
             // this row is the one case where the app knows for certain a person typed it.
             actor: 'user',
+            // The exact signer arrives with the durable echo; the acting account is already known
+            // locally, so its profile icon can render without waiting for the round trip.
+            meta: {accountId: accountUid},
             content: message.text,
             rawMarkdown: message.text,
             clientMessageId: message.clientMessageId,

--- a/frontend/apps/desktop/src/models/event-meta.ts
+++ b/frontend/apps/desktop/src/models/event-meta.ts
@@ -1,8 +1,8 @@
 import type {AgentRunUsage, SessionEventMeta} from '@/agents-client'
 
 /**
- * What a logged event can say about itself — how long it took, what it cost, which model produced
- * it — reduced to display rows.
+ * What a logged event can say about itself — who originated and signed it, how long it took, what
+ * it cost, which model produced it — reduced to display rows.
  *
  * The runtime stamps this at append time, so most of it is simply read back. But the log is older
  * than the stamp: every event recorded before `meta` existed has none, and even a stamped event may
@@ -44,6 +44,8 @@ function usageTotal(usage: AgentRunUsage): number {
 export function eventMetaRows(meta: SessionEventMeta | undefined): EventMetaRow[] {
   if (!meta) return []
   const rows: EventMetaRow[] = []
+  if (meta.accountId) rows.push({label: 'Originator', value: meta.accountId})
+  if (meta.signerId) rows.push({label: 'Signer', value: meta.signerId})
   if (meta.model) rows.push({label: 'Model', value: meta.model})
   if (meta.provider) rows.push({label: 'Provider', value: meta.provider})
   if (typeof meta.durationMs === 'number' && meta.durationMs >= 0) {

--- a/frontend/apps/desktop/src/pages/agents/__tests__/run-work.test.tsx
+++ b/frontend/apps/desktop/src/pages/agents/__tests__/run-work.test.tsx
@@ -78,6 +78,7 @@ vi.mock('@/components/markdown', () => ({
 
 vi.mock('@shm/shared/models/entity', () => ({
   useResource: () => ({data: null}),
+  useAccount: () => ({data: null}),
 }))
 
 function makeRun(overrides: Partial<RunInfo> & Pick<RunInfo, 'id' | 'status'>): RunInfo {

--- a/frontend/apps/desktop/src/pages/agents/agent-row.tsx
+++ b/frontend/apps/desktop/src/pages/agents/agent-row.tsx
@@ -23,11 +23,13 @@ export function AgentListRow({
   name,
   status,
   serverUrl,
+  accessRole,
 }: {
   agentId: string
   name: string
   status: string
   serverUrl: string
+  accessRole?: 'owner' | 'reader' | 'writer'
 }) {
   const navigate = useNavigate()
   const statusIndicator = getAgentStatusIndicator(status)
@@ -36,9 +38,16 @@ export function AgentListRow({
       className="border-border hover:bg-muted/60 flex cursor-pointer items-center justify-between gap-4 rounded-lg border p-3 transition-colors"
       onClick={() => navigate({key: 'agent', agentId, serverUrl})}
     >
-      <SizableText weight="bold" className="min-w-0 truncate">
-        {name}
-      </SizableText>
+      <div className="flex min-w-0 items-center gap-2">
+        <SizableText weight="bold" className="min-w-0 truncate">
+          {name}
+        </SizableText>
+        {accessRole && accessRole !== 'owner' ? (
+          <span className="bg-muted text-muted-foreground flex-none rounded-full px-2 py-0.5 text-[10px] font-medium tracking-wide uppercase">
+            {accessRole}
+          </span>
+        ) : null}
+      </div>
       <Tooltip content={statusIndicator.label} asChild>
         <span className={`size-2.5 shrink-0 rounded-full ${statusIndicator.className}`} />
       </Tooltip>

--- a/frontend/apps/desktop/src/pages/agents/detail.tsx
+++ b/frontend/apps/desktop/src/pages/agents/detail.tsx
@@ -1,4 +1,6 @@
 import {
+  type AgentCollaboratorInfo,
+  type AgentCollaboratorRole,
   type AgentDefinition,
   type AgentToolInfo,
   type AgentTriggerInfo,
@@ -10,6 +12,7 @@ import {
 import {
   DEFAULT_AGENT_SERVER_URL,
   isLocalAgentServer,
+  useAgentCollaborators,
   useAgentDetail,
   useAgentList,
   useAgentServerHealth,
@@ -24,8 +27,10 @@ import {
   useCreateSigningIdentity,
   useDeleteAgent,
   useDeleteAgentTrigger,
+  useInviteAgentCollaborator,
   useModelProviders,
   useProviderModels,
+  useRemoveAgentCollaborator,
   useSigningIdentities,
   useUpdateAgent,
   useUpdateAgentTrigger,
@@ -37,7 +42,10 @@ import {useClickNavigate, useNavigate} from '@/utils/useNavigate'
 import {markdownBlockNodesToHMBlockNodes, parseMarkdown} from '@seed-hypermedia/client'
 import type {HMBlockNode} from '@seed-hypermedia/client/hm-types'
 import {formattedDateMedium} from '@shm/shared/utils/date'
+import {abbreviateUid} from '@shm/shared/utils/abbreviate'
+import {useAccount} from '@shm/shared/models/entity'
 import {useNavRoute} from '@shm/shared/utils/navigation'
+import {hmId} from '@shm/shared/utils/entity-id-url'
 import {Button} from '@shm/ui/button'
 import {copyTextToClipboard} from '@shm/ui/copy-to-clipboard'
 import {
@@ -49,13 +57,15 @@ import {
 } from '@shm/ui/components/alert-dialog'
 import {DialogDescription, DialogTitle} from '@shm/ui/components/dialog'
 import {Input} from '@shm/ui/components/input'
+import {AccountSearchInput, type SearchResult} from '@shm/ui/collaborators-page'
 import {Container, PanelContainer} from '@shm/ui/container'
 import {OptionsDropdown} from '@shm/ui/options-dropdown'
 import {SizableText} from '@shm/ui/text'
 import {Spinner} from '@shm/ui/spinner'
 import {toast} from '@shm/ui/toast'
 import {useAppDialog} from '@shm/ui/universal-dialog'
-import {Info, KeyRound, Plus, Trash2} from 'lucide-react'
+import {Info, KeyRound, Plus, Trash2, UserPlus, Users, X} from 'lucide-react'
+import {HMIcon} from '@shm/ui/hm-icon'
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {getSeedTool} from '../../../../../../agents/protocol/src/tool-registry'
 import {
@@ -81,7 +91,7 @@ import {modelReasoningSupport, type ReasoningLevel} from '@seed-hypermedia/agent
 import {ModelSelect} from './model-select'
 import {coerceReasoningLevel, ReasoningSelect} from './reasoning-select'
 import {curateProviderModels, pickDefaultProviderModel} from './model-utils'
-import {AgentPromptEditor, promptBlocksForRequest} from './prompt-editor'
+import {AgentPromptEditor, promptBlocksForRequest, promptBlocksToMarkdown} from './prompt-editor'
 import {AgentsNoAccountPage} from './no-account'
 import {ProviderSelect} from './provider-select'
 
@@ -118,19 +128,23 @@ function AgentDetailPage({
   const updateAgent = useUpdateAgent(serverUrl, selectedAccountId)
   const updateSigningIdentity = useUpdateSigningIdentity(serverUrl, selectedAccountId)
   const deleteAgentDialog = useAppDialog(DeleteAgentDialog, {isAlert: true})
-  const signingIdentities = useSigningIdentities(serverUrl, selectedAccountId)
+  const signingIdentities = useSigningIdentities(serverUrl, selectedAccountId, agentId)
   const createSigningIdentity = useCreateSigningIdentity(serverUrl, selectedAccountId)
   const createTriggerDialog = useAppDialog(CreateAgentTriggerDialog)
   const editNameDialog = useAppDialog(EditAgentNameDialog)
-  const modelProviders = useModelProviders(serverUrl, selectedAccountId)
+  const modelProviders = useModelProviders(serverUrl, selectedAccountId, agentId)
+  const collaborators = useAgentCollaborators(serverUrl, selectedAccountId, agentId)
   const allAgents = useAgentList(serverUrl, selectedAccountId)
   const addProviderDialog = useAppDialog(AddModelProviderDialog)
   useAgentWebSocketSubscription(serverUrl, selectedAccountId, `agents/${agentId}`)
+  const accessRole = agent.data?.agent.accessRole ?? 'owner'
+  const canWrite = accessRole === 'owner' || accessRole === 'writer'
+  const isOwner = accessRole === 'owner'
   const [name, setName] = useState('')
   const [modelProvider, setModelProvider] = useState('')
   const [model, setModel] = useState('')
   const [reasoningLevel, setReasoningLevel] = useState<ReasoningLevel | undefined>(undefined)
-  const providerModels = useProviderModels(serverUrl, selectedAccountId, modelProvider)
+  const providerModels = useProviderModels(serverUrl, selectedAccountId, modelProvider, agentId)
   const selectedProviderType = modelProviders.data?.find((provider) => provider.name === modelProvider)?.type
   const [systemPrompt, setSystemPrompt] = useState<HMBlockNode[]>([])
   const [promptEditorKey, setPromptEditorKey] = useState(0)
@@ -201,7 +215,7 @@ function AgentDetailPage({
     const result = await updateAgent.mutateAsync({agentId, definition: {...definition, name: trimmed}})
     if (result._ !== 'GetAgentResponse') throw new Error('Unexpected update response')
     // Keep the dedicated account's profile name in sync; leave shared accounts alone.
-    if (agentSigningKey && !isAccountShared) {
+    if (isOwner && agentSigningKey && !isAccountShared) {
       await updateSigningIdentity.mutateAsync({name: agentSigningKey, label: trimmed})
     }
     if (!nameModelDirty) setName(trimmed)
@@ -292,7 +306,7 @@ function AgentDetailPage({
     updateAgent.mutateAsync,
   ])
 
-  const promptEditorDisabled = !selectedAccountId || serverHealth.isError || agent.isError
+  const promptEditorDisabled = !selectedAccountId || serverHealth.isError || agent.isError || !canWrite
 
   useEffect(() => {
     if (!agent.data || !promptDirty || promptEditorDisabled) return
@@ -368,22 +382,27 @@ function AgentDetailPage({
               <AgentHeader
                 agent={agent.data.agent}
                 agentName={name}
-                onEditName={() =>
-                  editNameDialog.open({
-                    currentName: name,
-                    accountStatus: agentAccountStatus,
-                    onRename: handleRenameAgent,
-                  })
+                onEditName={
+                  canWrite
+                    ? () =>
+                        editNameDialog.open({
+                          currentName: name,
+                          accountStatus: agentAccountStatus,
+                          onRename: handleRenameAgent,
+                        })
+                    : undefined
                 }
                 agentId={agentId}
                 serverUrl={serverUrl}
                 activeTab={tab}
                 sessionsCount={topLevelSessions.length}
                 triggersCount={triggers.data?.length}
-                onCreateSession={() => void handleCreateSession()}
+                onCreateSession={canWrite ? () => void handleCreateSession() : undefined}
                 creatingSession={createSession.isLoading}
-                onCreateTrigger={() => createTriggerDialog.open({serverUrl, selectedAccountId, agentId})}
-                canCreateTrigger={!!selectedAccountId}
+                onCreateTrigger={
+                  canWrite ? () => createTriggerDialog.open({serverUrl, selectedAccountId, agentId}) : undefined
+                }
+                canCreateTrigger={!!selectedAccountId && canWrite}
                 breadcrumbItems={breadcrumbItems}
               />
 
@@ -425,11 +444,13 @@ function AgentDetailPage({
                       />
                     ))}
                   </div>
-                  <StartSessionInput
-                    creating={createSession.isLoading}
-                    disabled={!selectedAccountId}
-                    onCreate={() => void handleCreateSession()}
-                  />
+                  {canWrite ? (
+                    <StartSessionInput
+                      creating={createSession.isLoading}
+                      disabled={!selectedAccountId}
+                      onCreate={() => void handleCreateSession()}
+                    />
+                  ) : null}
                 </section>
               ) : null}
 
@@ -441,6 +462,7 @@ function AgentDetailPage({
                   selectedTriggerId={triggerId}
                   triggers={triggers.data || []}
                   isLoading={triggers.isLoading}
+                  readOnly={!canWrite}
                 />
               ) : null}
 
@@ -450,6 +472,7 @@ function AgentDetailPage({
                   accountUid={selectedAccountId ?? null}
                   agentId={agentId}
                   openPath={memoryPath}
+                  readOnly={!canWrite}
                 />
               ) : null}
 
@@ -475,6 +498,8 @@ function AgentDetailPage({
                   onSave={(definition) => updateAgent.mutateAsync({agentId, definition})}
                   onCreateIdentity={(label) => createSigningIdentity.mutateAsync(label)}
                   saving={updateAgent.isLoading || createSigningIdentity.isLoading}
+                  readOnly={!canWrite}
+                  canCreateIdentity={isOwner}
                 />
               ) : null}
 
@@ -497,9 +522,11 @@ function AgentDetailPage({
                     </SizableText>
                   </div>
                   {promptEditorDisabled ? (
-                    <div className="border-input bg-muted/40 text-muted-foreground min-h-80 rounded-lg border p-4 text-sm">
-                      Connect to the agent server to edit this prompt.
-                    </div>
+                    <pre className="border-input bg-muted/40 text-muted-foreground min-h-80 rounded-lg border p-4 text-sm whitespace-pre-wrap">
+                      {!canWrite
+                        ? promptBlocksToMarkdown(systemPrompt) || 'No system prompt configured.'
+                        : 'Connect to the agent server to edit this prompt.'}
+                    </pre>
                   ) : (
                     <div className="min-h-0 flex-1 overflow-y-auto pr-1 pb-4">
                       <AgentPromptEditor
@@ -524,9 +551,12 @@ function AgentDetailPage({
                       </SizableText>
                       <ProviderSelect
                         providers={modelProviders.data}
+                        disabled={!canWrite}
                         value={modelProvider}
                         onChange={handleProviderChange}
-                        onAddProvider={() => addProviderDialog.open({serverUrl, selectedAccountId})}
+                        onAddProvider={
+                          isOwner ? () => addProviderDialog.open({serverUrl, selectedAccountId}) : undefined
+                        }
                       />
                     </label>
                     <label className="flex flex-col gap-1">
@@ -535,6 +565,7 @@ function AgentDetailPage({
                       </SizableText>
                       <ModelSelect
                         models={providerModels.data}
+                        disabled={!canWrite}
                         providerType={selectedProviderType}
                         value={model}
                         onChange={(nextModel) => {
@@ -554,6 +585,7 @@ function AgentDetailPage({
                         </SizableText>
                         <ReasoningSelect
                           providerType={selectedProviderType}
+                          disabled={!canWrite}
                           model={model}
                           value={reasoningLevel}
                           onChange={(level) => {
@@ -564,6 +596,15 @@ function AgentDetailPage({
                       </label>
                     ) : null}
                   </div>
+                  <AgentCollaboratorsSettings
+                    serverUrl={serverUrl}
+                    accountUid={selectedAccountId ?? null}
+                    agentId={agentId}
+                    ownerAccountId={agent.data.agent.account}
+                    collaborators={collaborators.data || []}
+                    loading={collaborators.isLoading}
+                    isOwner={isOwner}
+                  />
                   <div className="flex flex-col gap-2">
                     <SizableText
                       size="xs"
@@ -578,23 +619,25 @@ function AgentDetailPage({
                             ? 'Settings save failed'
                             : ''}
                     </SizableText>
-                    <Button
-                      className="w-fit"
-                      variant="destructive"
-                      onClick={() =>
-                        deleteAgentDialog.open({
-                          serverUrl,
-                          selectedAccountId: selectedAccountId ?? null,
-                          agentId,
-                          agentName: name,
-                          onDeleted: () => navigate({key: 'agents'}),
-                        })
-                      }
-                      disabled={!selectedAccountId}
-                    >
-                      <Trash2 className="size-4" />
-                      Delete agent
-                    </Button>
+                    {isOwner ? (
+                      <Button
+                        className="w-fit"
+                        variant="destructive"
+                        onClick={() =>
+                          deleteAgentDialog.open({
+                            serverUrl,
+                            selectedAccountId: selectedAccountId ?? null,
+                            agentId,
+                            agentName: name,
+                            onDeleted: () => navigate({key: 'agents'}),
+                          })
+                        }
+                        disabled={!selectedAccountId}
+                      >
+                        <Trash2 className="size-4" />
+                        Delete agent
+                      </Button>
+                    ) : null}
                   </div>
                 </section>
               ) : null}
@@ -610,6 +653,7 @@ function AgentDetailPage({
           selectedTriggerId={triggerId}
           triggers={triggers.data || []}
           isLoading={triggers.isLoading}
+          readOnly={!canWrite}
         />
       ) : null}
     </PanelContainer>
@@ -635,6 +679,186 @@ function hasPromptContent(blocks: HMBlockNode[]): boolean {
     if (type && type !== 'paragraph' && type !== 'heading' && type !== 'code' && type !== 'math') return true
     return node.children ? hasPromptContent(node.children) : false
   })
+}
+
+function AgentCollaboratorsSettings({
+  serverUrl,
+  accountUid,
+  agentId,
+  ownerAccountId,
+  collaborators,
+  loading,
+  isOwner,
+}: {
+  serverUrl: string
+  accountUid: string | null
+  agentId: string
+  ownerAccountId: string
+  collaborators: AgentCollaboratorInfo[]
+  loading: boolean
+  isOwner: boolean
+}) {
+  const invite = useInviteAgentCollaborator(serverUrl, accountUid)
+  const remove = useRemoveAgentCollaborator(serverUrl, accountUid)
+  const [selected, setSelected] = useState<SearchResult[]>([])
+  const [role, setRole] = useState<AgentCollaboratorRole>('writer')
+  const excludedAccountIds = [ownerAccountId, ...collaborators.map((member) => member.accountId)]
+
+  async function handleInvite() {
+    if (!selected.length) return
+    try {
+      await Promise.all(
+        selected.map((member) => invite.mutateAsync({agentId, collaboratorAccountId: member.id.uid, role})),
+      )
+      toast.success(selected.length === 1 ? 'Invitation sent' : `${selected.length} invitations sent`)
+      setSelected([])
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Could not invite collaborator')
+    }
+  }
+
+  return (
+    <section className="border-border flex flex-col gap-3 border-t pt-4">
+      <div className="flex items-start gap-3">
+        <div className="bg-primary/10 text-primary flex size-9 flex-none items-center justify-center rounded-lg">
+          <Users className="size-4" />
+        </div>
+        <div>
+          <SizableText size="sm" weight="bold" className="block">
+            Collaborators
+          </SizableText>
+          <SizableText size="xs" color="muted" className="block">
+            Readers can view everything. Writers can also change settings, memory, tools, triggers, and sessions.
+          </SizableText>
+        </div>
+      </div>
+
+      {isOwner ? (
+        <div className="border-border flex overflow-hidden rounded-md border">
+          <AccountSearchInput
+            label="Collaborators"
+            placeholder="Invite collaborators"
+            values={selected}
+            onValuesChange={setSelected}
+            excludeUids={excludedAccountIds}
+          />
+          <select
+            aria-label="Collaborator role"
+            value={role}
+            onChange={(event) => setRole(event.currentTarget.value as AgentCollaboratorRole)}
+            className="border-border bg-background text-foreground border-l px-3 text-sm outline-none"
+          >
+            <option value="reader">Can read</option>
+            <option value="writer">Can write</option>
+          </select>
+          <Button
+            className="h-auto rounded-none"
+            onClick={() => void handleInvite()}
+            disabled={!selected.length || invite.isLoading}
+            aria-label="Send collaborator invitation"
+          >
+            <UserPlus className="size-4" />
+          </Button>
+        </div>
+      ) : null}
+
+      <div className="border-border divide-border divide-y overflow-hidden rounded-lg border">
+        {loading ? (
+          <div className="flex items-center gap-2 p-3">
+            <Spinner />
+            <SizableText size="sm" color="muted">
+              Loading collaborators…
+            </SizableText>
+          </div>
+        ) : (
+          collaborators.map((member) => (
+            <AgentCollaboratorRow
+              key={member.accountId}
+              member={member}
+              isOwner={isOwner}
+              changing={invite.isLoading || remove.isLoading}
+              onRoleChange={(nextRole) =>
+                invite.mutate(
+                  {agentId, collaboratorAccountId: member.accountId, role: nextRole},
+                  {onError: (error) => toast.error(error instanceof Error ? error.message : 'Could not change role')},
+                )
+              }
+              onRemove={() =>
+                remove.mutate(
+                  {agentId, collaboratorAccountId: member.accountId},
+                  {onError: (error) => toast.error(error instanceof Error ? error.message : 'Could not remove member')},
+                )
+              }
+            />
+          ))
+        )}
+      </div>
+    </section>
+  )
+}
+
+function AgentCollaboratorRow({
+  member,
+  isOwner,
+  changing,
+  onRoleChange,
+  onRemove,
+}: {
+  member: AgentCollaboratorInfo
+  isOwner: boolean
+  changing: boolean
+  onRoleChange: (role: AgentCollaboratorRole) => void
+  onRemove: () => void
+}) {
+  const account = useAccount(member.accountId, {subscribe: true})
+  const metadata = account.data?.metadata
+  const canManage = isOwner && member.role !== 'owner'
+
+  return (
+    <div className="bg-card flex items-center gap-3 p-3">
+      <HMIcon id={hmId(member.accountId)} name={metadata?.name} icon={metadata?.icon} size={32} />
+      <div className="min-w-0 flex-1">
+        <SizableText size="sm" weight="bold" className="block truncate">
+          {metadata?.name || abbreviateUid(member.accountId)}
+        </SizableText>
+        <SizableText size="xs" color="muted" className="block truncate font-mono">
+          {member.accountId}
+        </SizableText>
+      </div>
+      {member.status === 'pending' ? (
+        <span className="bg-muted text-muted-foreground rounded-full px-2 py-0.5 text-[10px] font-medium tracking-wide uppercase">
+          Pending
+        </span>
+      ) : null}
+      {canManage ? (
+        <select
+          aria-label={`Role for ${metadata?.name || member.accountId}`}
+          value={member.role}
+          onChange={(event) => onRoleChange(event.currentTarget.value as AgentCollaboratorRole)}
+          disabled={changing}
+          className="border-border bg-background text-foreground rounded-md border px-2 py-1.5 text-xs"
+        >
+          <option value="reader">Can read</option>
+          <option value="writer">Can write</option>
+        </select>
+      ) : (
+        <SizableText size="xs" color="muted" className="capitalize">
+          {member.role}
+        </SizableText>
+      )}
+      {canManage ? (
+        <Button
+          variant="ghost"
+          size="iconSm"
+          onClick={onRemove}
+          disabled={changing}
+          aria-label={member.status === 'pending' ? 'Cancel invitation' : 'Remove collaborator'}
+        >
+          <X className="size-4" />
+        </Button>
+      ) : null}
+    </div>
+  )
 }
 
 function DeleteAgentDialog({
@@ -859,6 +1083,8 @@ function AgentToolsTab({
   onSave,
   onCreateIdentity,
   saving,
+  readOnly = false,
+  canCreateIdentity = false,
 }: {
   serverUrl: string | undefined
   accountUid: string | null
@@ -870,6 +1096,8 @@ function AgentToolsTab({
   onSave: (definition: AgentDefinition) => Promise<unknown>
   onCreateIdentity: (label: string) => Promise<unknown>
   saving: boolean
+  readOnly?: boolean
+  canCreateIdentity?: boolean
 }) {
   const toolInfoDialog = useAppDialog(ToolInfoDialog)
   const authoredToolDialog = useAppDialog(AuthoredToolDialog)
@@ -962,7 +1190,7 @@ function AgentToolsTab({
                   type="checkbox"
                   className="mt-1 size-4"
                   checked={checked}
-                  disabled={!groupAvailable && !setupAction}
+                  disabled={readOnly || (!groupAvailable && !setupAction)}
                   onChange={(event) => {
                     // Enabling an unavailable-but-fixable tool answers with setup help instead of
                     // a save; disabling always saves so users can still remove the tool.
@@ -1123,7 +1351,7 @@ function AgentToolsTab({
                     type="checkbox"
                     className="mt-1 size-4"
                     checked={checked}
-                    disabled={saving || identitiesLoading}
+                    disabled={readOnly || saving || identitiesLoading}
                     onChange={(event) => {
                       const nextSigningKeys = event.target.checked
                         ? Array.from(new Set([...signingKeys, identity.name]))
@@ -1140,7 +1368,7 @@ function AgentToolsTab({
               )
             })}
           </div>
-          {!identitiesLoading && identities.length === 0 ? (
+          {!readOnly && canCreateIdentity && !identitiesLoading && identities.length === 0 ? (
             <div className="border-border bg-background flex flex-col gap-3 rounded-lg border border-dashed p-3">
               <SizableText size="sm" color="muted">
                 No agent accounts are available on this server yet. Create a new server-side HM account key, then enable
@@ -1153,7 +1381,7 @@ function AgentToolsTab({
                 disabled={saving}
               />
             </div>
-          ) : showNewIdentityPanel ? (
+          ) : !readOnly && canCreateIdentity && showNewIdentityPanel ? (
             <NewAgentAccountPanel
               name={newIdentityName}
               onNameChange={setNewIdentityName}
@@ -1161,12 +1389,12 @@ function AgentToolsTab({
               onCancel={() => setShowNewIdentityPanel(false)}
               disabled={saving}
             />
-          ) : (
+          ) : !readOnly && canCreateIdentity ? (
             <Button className="w-fit" variant="ghost" onClick={() => setShowNewIdentityPanel(true)} disabled={saving}>
               <Plus className="size-4" />
               New Agent Account
             </Button>
-          )}
+          ) : null}
         </div>
       ) : null}
 
@@ -1224,6 +1452,7 @@ function AgentTriggersTab({
   selectedTriggerId,
   triggers,
   isLoading,
+  readOnly = false,
 }: {
   agentId: string
   serverUrl: string
@@ -1231,6 +1460,7 @@ function AgentTriggersTab({
   selectedTriggerId?: string
   triggers: AgentTriggerInfo[]
   isLoading: boolean
+  readOnly?: boolean
 }) {
   const navigate = useNavigate()
   const trigger = useAgentTrigger(serverUrl, selectedAccountId, selectedTriggerId)
@@ -1282,7 +1512,7 @@ function AgentTriggersTab({
   }, [nameDirty, selected])
 
   useEffect(() => {
-    if (!selectedTriggerId || !selected || !nameDirty) return
+    if (readOnly || !selectedTriggerId || !selected || !nameDirty) return
     const draftName = name.trim()
     if (!draftName) return
     if (draftName === selected.name) {
@@ -1313,7 +1543,7 @@ function AgentTriggersTab({
         })
     }, 600)
     return () => clearTimeout(timer)
-  }, [name, nameDirty, selected, selectedTriggerId, updateTrigger])
+  }, [name, nameDirty, readOnly, selected, selectedTriggerId, updateTrigger])
 
   async function handleEnabledChange(nextEnabled: boolean) {
     if (!selectedTriggerId || !selected) return
@@ -1329,7 +1559,7 @@ function AgentTriggersTab({
   }
 
   useEffect(() => {
-    if (!selectedTriggerId || !selected || !detailsDirty || detailsSaveState === 'saving') return
+    if (readOnly || !selectedTriggerId || !selected || !detailsDirty || detailsSaveState === 'saving') return
     const detailsKey = currentDetailsKey
     if (detailsKey === lastSavedDetailsKeyRef.current) {
       setDetailsDirty(false)
@@ -1367,7 +1597,7 @@ function AgentTriggersTab({
         })
     }, 800)
     return () => clearTimeout(timer)
-  }, [currentDetailsKey, detailsDirty, detailsSaveState, prompt, selected, selectedTriggerId, source])
+  }, [currentDetailsKey, detailsDirty, detailsSaveState, prompt, readOnly, selected, selectedTriggerId, source])
 
   async function handleDeleteTrigger() {
     if (!selectedTriggerId) return
@@ -1392,22 +1622,24 @@ function AgentTriggersTab({
             setNameDirty(true)
           }}
           saveState={nameSaveState}
-          disabled={!selected}
+          disabled={!selected || readOnly}
           backLabel="Back to agent triggers"
           onBack={() => navigate({key: 'agent', agentId, serverUrl, tab: 'triggers'})}
           actions={
-            <OptionsDropdown
-              align="end"
-              menuItems={[
-                {
-                  key: 'delete-trigger',
-                  icon: <Trash2 className="size-4" />,
-                  label: 'Delete trigger',
-                  variant: 'destructive',
-                  onClick: () => void handleDeleteTrigger(),
-                },
-              ]}
-            />
+            !readOnly ? (
+              <OptionsDropdown
+                align="end"
+                menuItems={[
+                  {
+                    key: 'delete-trigger',
+                    icon: <Trash2 className="size-4" />,
+                    label: 'Delete trigger',
+                    variant: 'destructive',
+                    onClick: () => void handleDeleteTrigger(),
+                  },
+                ]}
+              />
+            ) : null
           }
         />
         <div className="mx-auto flex min-h-0 w-full max-w-4xl flex-1 flex-col gap-5 overflow-y-auto px-4 py-4">
@@ -1419,48 +1651,69 @@ function AgentTriggersTab({
           ) : null}
           {selected ? (
             <>
-              <div className="grid gap-4">
-                <TriggerSourceFields
-                  source={source}
-                  onChange={(nextSource) => {
-                    setSource(nextSource)
-                    setDetailsDirty(true)
-                  }}
-                  trailing={
-                    <label className="flex h-9 items-center gap-2 text-base">
-                      <input
-                        type="checkbox"
-                        checked={enabled}
-                        disabled={updateTrigger.isLoading}
-                        onChange={(event) => void handleEnabledChange(event.target.checked)}
-                      />
-                      Enable Trigger
-                    </label>
-                  }
-                />
-                <div className="flex flex-col gap-1">
-                  <SizableText size="sm" weight="bold">
-                    Prompt
-                  </SizableText>
-                  <AgentPromptEditor
-                    key={selected.id}
-                    initialBlocks={prompt}
-                    onChange={(blocks) => {
-                      setPrompt(blocks)
+              {readOnly ? (
+                <div className="grid gap-4">
+                  <div className="border-border bg-muted/40 rounded-lg border p-3">
+                    <SizableText size="sm" weight="bold" className="block">
+                      Source
+                    </SizableText>
+                    <SizableText size="sm" color="muted">
+                      {summarizeTriggerSource(source)}
+                    </SizableText>
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <SizableText size="sm" weight="bold">
+                      Prompt
+                    </SizableText>
+                    <pre className="border-border bg-muted/40 min-h-40 rounded-lg border p-3 text-sm whitespace-pre-wrap">
+                      {promptBlocksToMarkdown(prompt) || 'No prompt configured.'}
+                    </pre>
+                  </div>
+                </div>
+              ) : (
+                <div className="grid gap-4">
+                  <TriggerSourceFields
+                    source={source}
+                    onChange={(nextSource) => {
+                      setSource(nextSource)
                       setDetailsDirty(true)
                     }}
+                    trailing={
+                      <label className="flex h-9 items-center gap-2 text-base">
+                        <input
+                          type="checkbox"
+                          checked={enabled}
+                          disabled={updateTrigger.isLoading}
+                          onChange={(event) => void handleEnabledChange(event.target.checked)}
+                        />
+                        Enable Trigger
+                      </label>
+                    }
                   />
-                  <SizableText size="xs" color={detailsSaveState === 'error' ? undefined : 'muted'}>
-                    {detailsSaveState === 'saving'
-                      ? 'Saving…'
-                      : detailsSaveState === 'saved'
-                        ? 'Saved.'
-                        : detailsSaveState === 'error'
-                          ? 'Save failed.'
-                          : ''}
-                  </SizableText>
+                  <div className="flex flex-col gap-1">
+                    <SizableText size="sm" weight="bold">
+                      Prompt
+                    </SizableText>
+                    <AgentPromptEditor
+                      key={selected.id}
+                      initialBlocks={prompt}
+                      onChange={(blocks) => {
+                        setPrompt(blocks)
+                        setDetailsDirty(true)
+                      }}
+                    />
+                    <SizableText size="xs" color={detailsSaveState === 'error' ? undefined : 'muted'}>
+                      {detailsSaveState === 'saving'
+                        ? 'Saving…'
+                        : detailsSaveState === 'saved'
+                          ? 'Saved.'
+                          : detailsSaveState === 'error'
+                            ? 'Save failed.'
+                            : ''}
+                    </SizableText>
+                  </div>
                 </div>
-              </div>
+              )}
               <div className="border-border flex flex-col gap-2 border-t pt-5">
                 <SizableText weight="bold">Sessions created by this trigger</SizableText>
                 {!trigger.data?.sessions.length ? (

--- a/frontend/apps/desktop/src/pages/agents/list.tsx
+++ b/frontend/apps/desktop/src/pages/agents/list.tsx
@@ -1,8 +1,11 @@
 import {
   isLocalAgentServer,
   LOCAL_AGENT_SERVER_LABEL,
+  useAcceptAgentInvite,
+  useAgentInviteLists,
   useAgentLists,
   useAgentServerHealths,
+  useDeclineAgentInvite,
   useAgentServerUrls,
   useAgentWebSocketSubscription,
   useLocalAgentServerUrl,
@@ -10,12 +13,13 @@ import {
 import {useSelectedAccountId} from '@/selected-account'
 import {useNavigate} from '@/utils/useNavigate'
 import {hostnameStripProtocol} from '@shm/shared'
+import {abbreviateUid} from '@shm/shared/utils/abbreviate'
 import {Button} from '@shm/ui/button'
 import {Container, PanelContainer} from '@shm/ui/container'
 import {SizableText} from '@shm/ui/text'
 import {Tooltip} from '@shm/ui/tooltip'
 import {useAppDialog} from '@shm/ui/universal-dialog'
-import {Bot, CircleUserRound, Settings} from 'lucide-react'
+import {Bot, Check, CircleUserRound, Mail, Settings, X} from 'lucide-react'
 import React, {useMemo} from 'react'
 import {AgentListRow} from './agent-row'
 import {CreateAgentDialog, ManageAgentAccountsDialog, ModelProvidersDialog} from './dialogs'
@@ -35,6 +39,7 @@ function AgentsListContent({selectedAccountId}: {selectedAccountId: string}) {
   const serverUrls = serverUrlsQuery.data || []
   const localServerUrl = useLocalAgentServerUrl()
   const agentQueries = useAgentLists(serverUrls, selectedAccountId)
+  const inviteQueries = useAgentInviteLists(serverUrls, selectedAccountId)
   const healthQueries = useAgentServerHealths(serverUrls)
   const providersDialog = useAppDialog(ModelProvidersDialog)
   const manageAccountsDialog = useAppDialog(ManageAgentAccountsDialog)
@@ -46,6 +51,13 @@ function AgentsListContent({selectedAccountId}: {selectedAccountId: string}) {
         (agentQueries[index]?.data || []).map((agent) => ({...agent, serverUrl})),
       ),
     [agentQueries, serverUrls],
+  )
+  const invites = useMemo(
+    () =>
+      serverUrls.flatMap((serverUrl, index) =>
+        (inviteQueries[index]?.data || []).map((invite) => ({...invite, serverUrl})),
+      ),
+    [inviteQueries, serverUrls],
   )
   const isLoadingAgents = agentQueries.some((query) => query.isFetching && !query.data)
   const agentError = agentQueries.find((query) => query.isError)?.error
@@ -140,6 +152,27 @@ function AgentsListContent({selectedAccountId}: {selectedAccountId: string}) {
         {manageAccountsDialog.content}
         {createAgentDialog.content}
 
+        {invites.length ? (
+          <section className="flex flex-col gap-3">
+            <div className="flex items-center gap-2">
+              <Mail className="text-muted-foreground size-4" />
+              <SizableText weight="bold">Invites</SizableText>
+              <span className="bg-primary/10 text-primary rounded-full px-2 py-0.5 text-xs font-bold">
+                {invites.length}
+              </span>
+            </div>
+            <div className="flex flex-col gap-2">
+              {invites.map((invite) => (
+                <AgentInviteRow
+                  key={`${invite.serverUrl}:${invite.agentId}`}
+                  invite={invite}
+                  selectedAccountId={selectedAccountId}
+                />
+              ))}
+            </div>
+          </section>
+        ) : null}
+
         <section className="flex flex-col gap-3">
           <div className="flex items-center justify-between gap-4">
             <SizableText weight="bold">All Agents</SizableText>
@@ -170,12 +203,66 @@ function AgentsListContent({selectedAccountId}: {selectedAccountId: string}) {
                 name={agent.definition.name}
                 status={agent.status}
                 serverUrl={agent.serverUrl}
+                accessRole={agent.accessRole}
               />
             ))}
           </div>
         </section>
       </Container>
     </PanelContainer>
+  )
+}
+
+function AgentInviteRow({
+  invite,
+  selectedAccountId,
+}: {
+  invite: {
+    agentId: string
+    agentName: string
+    ownerAccountId: string
+    role: 'reader' | 'writer'
+    serverUrl: string
+  }
+  selectedAccountId: string
+}) {
+  const navigate = useNavigate()
+  const accept = useAcceptAgentInvite(invite.serverUrl, selectedAccountId)
+  const decline = useDeclineAgentInvite(invite.serverUrl, selectedAccountId)
+  const pending = accept.isLoading || decline.isLoading
+
+  return (
+    <div className="border-border bg-card flex items-center gap-3 rounded-lg border p-3">
+      <div className="bg-primary/10 text-primary flex size-9 flex-none items-center justify-center rounded-lg">
+        <Bot className="size-4" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <SizableText weight="bold" className="block truncate">
+          {invite.agentName}
+        </SizableText>
+        <SizableText size="xs" color="muted" className="block">
+          {invite.role === 'writer' ? 'Write collaborator' : 'Read collaborator'} · invited by{' '}
+          {abbreviateUid(invite.ownerAccountId)}
+        </SizableText>
+      </div>
+      <Button
+        size="sm"
+        onClick={() =>
+          accept.mutate(invite.agentId, {
+            onSuccess: (result) => {
+              if (result._ !== 'AcceptAgentInviteResponse') return
+              navigate({key: 'agent', agentId: invite.agentId, serverUrl: invite.serverUrl})
+            },
+          })
+        }
+        disabled={pending}
+      >
+        <Check className="size-4" /> Accept
+      </Button>
+      <Button variant="ghost" size="sm" onClick={() => decline.mutate(invite.agentId)} disabled={pending}>
+        <X className="size-4" /> Decline
+      </Button>
+    </div>
   )
 }
 

--- a/frontend/apps/desktop/src/pages/agents/memory.tsx
+++ b/frontend/apps/desktop/src/pages/agents/memory.tsx
@@ -48,10 +48,13 @@ export function AgentMemoryTab({
   accountUid,
   agentId,
   openPath,
+  readOnly = false,
 }: {
   serverUrl: string
   accountUid: string | null
   agentId: string
+  /** Prevents a reader collaborator from changing the shared memory. */
+  readOnly?: boolean
   /** File the route asked for — a tool row linking to `~/memory/<path>` lands the user on it. */
   openPath?: string
 }) {
@@ -268,47 +271,50 @@ export function AgentMemoryTab({
         <div className="flex flex-col">
           <SizableText weight="bold">Memory</SizableText>
           <SizableText size="xs" color="muted">
-            Private files this agent reads and writes across sessions. You can edit everything here.
+            Private files this agent reads and writes across sessions.{' '}
+            {readOnly ? 'You have read-only access.' : 'You can edit everything here.'}
             {memory.data
               ? ` ${fileCount} file${fileCount === 1 ? '' : 's'}, ${formatBytes(memory.data.totalBytes)}.`
               : ''}
           </SizableText>
         </div>
-        <div className="flex flex-none items-center gap-2">
-          <input
-            ref={uploadInputRef}
-            type="file"
-            multiple
-            className="hidden"
-            onChange={(event) => {
-              const localFiles = Array.from(event.currentTarget.files ?? [])
-              event.currentTarget.value = ''
-              if (localFiles.length) void handleUploadLocalFiles(localFiles.map((file) => ({path: file.name, file})))
-            }}
-          />
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => uploadInputRef.current?.click()}
-            disabled={writeFile.isLoading}
-          >
-            <Upload className="mr-2 size-4" /> Add file
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setAddPanel((current) => (current === 'from-url' ? 'none' : 'from-url'))}
-          >
-            <Globe className="mr-2 size-4" /> From URL
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setAddPanel((current) => (current === 'new-file' ? 'none' : 'new-file'))}
-          >
-            <FilePlus className="mr-2 size-4" /> New file
-          </Button>
-        </div>
+        {!readOnly ? (
+          <div className="flex flex-none items-center gap-2">
+            <input
+              ref={uploadInputRef}
+              type="file"
+              multiple
+              className="hidden"
+              onChange={(event) => {
+                const localFiles = Array.from(event.currentTarget.files ?? [])
+                event.currentTarget.value = ''
+                if (localFiles.length) void handleUploadLocalFiles(localFiles.map((file) => ({path: file.name, file})))
+              }}
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => uploadInputRef.current?.click()}
+              disabled={writeFile.isLoading}
+            >
+              <Upload className="mr-2 size-4" /> Add file
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setAddPanel((current) => (current === 'from-url' ? 'none' : 'from-url'))}
+            >
+              <Globe className="mr-2 size-4" /> From URL
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setAddPanel((current) => (current === 'new-file' ? 'none' : 'new-file'))}
+            >
+              <FilePlus className="mr-2 size-4" /> New file
+            </Button>
+          </div>
+        ) : null}
       </div>
 
       {uploadProgress ? (
@@ -391,7 +397,7 @@ export function AgentMemoryTab({
             dropTarget === '' ? 'ring-primary/50 ring-2 ring-inset' : ''
           }`}
           onDragOver={(event) => {
-            if (!hasDraggedFiles(event)) return
+            if (readOnly || !hasDraggedFiles(event)) return
             event.preventDefault()
             // Dir rows stop propagation while hovered, so reaching here means the root is targeted.
             setDropTarget('')
@@ -401,7 +407,7 @@ export function AgentMemoryTab({
             setDropTarget(null)
           }}
           onDrop={(event) => {
-            if (!hasDraggedFiles(event)) return
+            if (readOnly || !hasDraggedFiles(event)) return
             event.preventDefault()
             setDropTarget(null)
             void handleDroppedItems(event.dataTransfer)
@@ -430,13 +436,13 @@ export function AgentMemoryTab({
                 expanded={entry.type === 'dir' && expandedDirs.has(entry.path)}
                 onToggle={entry.type === 'dir' ? () => toggleDir(entry.path) : undefined}
                 onSelect={() => (entry.type === 'file' ? selectFile(entry.path) : undefined)}
-                onRequestDelete={() => setConfirmDeletePath(entry.path)}
+                onRequestDelete={readOnly ? undefined : () => setConfirmDeletePath(entry.path)}
                 onCancelDelete={() => setConfirmDeletePath(null)}
                 onConfirmDelete={() => void handleDelete(entry.path)}
                 deleting={deleteFile.isLoading && confirmDeletePath === entry.path}
                 dropTargeted={entry.type === 'dir' && dropTarget === entry.path}
                 onDirDragOver={
-                  entry.type === 'dir'
+                  !readOnly && entry.type === 'dir'
                     ? (event) => {
                         if (!hasDraggedFiles(event)) return
                         event.preventDefault()
@@ -446,7 +452,7 @@ export function AgentMemoryTab({
                     : undefined
                 }
                 onDirDrop={
-                  entry.type === 'dir'
+                  !readOnly && entry.type === 'dir'
                     ? (event) => {
                         if (!hasDraggedFiles(event)) return
                         event.preventDefault()
@@ -478,9 +484,11 @@ export function AgentMemoryTab({
                 {formatBytes(selectedEntry.size)}
                 {selectedEntry.mimeType ? ` · ${selectedEntry.mimeType}` : ''} — too large to preview here.
               </SizableText>
-              <Button variant="outline" size="sm" onClick={() => setConfirmDeletePath(selectedPath)} className="mt-2">
-                <Trash2 className="mr-1 size-3.5" /> Delete
-              </Button>
+              {!readOnly ? (
+                <Button variant="outline" size="sm" onClick={() => setConfirmDeletePath(selectedPath)} className="mt-2">
+                  <Trash2 className="mr-1 size-3.5" /> Delete
+                </Button>
+              ) : null}
             </div>
           ) : file.isLoading ? (
             <div className="flex flex-1 items-center justify-center p-6">
@@ -504,7 +512,7 @@ export function AgentMemoryTab({
                   {file.data.mimeType ? ` · ${file.data.mimeType}` : ''}
                   {file.data.updatedAt ? ` · ${formattedDateMedium(new Date(file.data.updatedAt))}` : ''}
                 </SizableText>
-                {file.data.encoding === 'utf8' && dirty ? (
+                {!readOnly && file.data.encoding === 'utf8' && dirty ? (
                   <>
                     <Button
                       variant="ghost"
@@ -538,7 +546,7 @@ export function AgentMemoryTab({
                       key: 'publish-ipfs',
                       icon: <UploadCloud className="size-4" />,
                       label: uploadToIpfs.isLoading ? 'Publishing…' : 'Publish to IPFS',
-                      disabled: uploadToIpfs.isLoading,
+                      disabled: readOnly || uploadToIpfs.isLoading,
                       onClick: () => void handlePublishToIpfs(),
                     },
                   ]}
@@ -569,6 +577,7 @@ export function AgentMemoryTab({
                   className="focus:ring-primary/25 min-h-0 flex-1 resize-none bg-transparent p-3 font-mono text-sm outline-none focus:ring-2"
                   value={draftText ?? file.data.content ?? ''}
                   onChange={(event) => setDraftText(event.currentTarget.value)}
+                  readOnly={readOnly}
                   spellCheck={false}
                 />
               ) : (
@@ -681,7 +690,7 @@ function MemoryEntryRow({
   /** Collapses/expands this directory. */
   onToggle?: () => void
   onSelect: () => void
-  onRequestDelete: () => void
+  onRequestDelete?: () => void
   onCancelDelete: () => void
   onConfirmDelete: () => void
   /** True while dragged files hover this directory row. */
@@ -728,7 +737,7 @@ function MemoryEntryRow({
             Cancel
           </Button>
         </span>
-      ) : (
+      ) : onRequestDelete ? (
         <Button
           variant="ghost"
           size="iconSm"
@@ -738,7 +747,7 @@ function MemoryEntryRow({
         >
           <Trash2 className="size-3.5" />
         </Button>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/frontend/apps/desktop/src/pages/agents/provider-select.tsx
+++ b/frontend/apps/desktop/src/pages/agents/provider-select.tsx
@@ -19,7 +19,7 @@ export function ProviderSelect({
   providers: ModelProviderInfo[] | undefined
   value: string
   onChange: (name: string) => void
-  onAddProvider: () => void
+  onAddProvider?: () => void
   disabled?: boolean
 }) {
   const hasValueOption = !value || providers?.some((provider) => provider.name === value)
@@ -27,7 +27,7 @@ export function ProviderSelect({
     <Select
       value={value}
       onValueChange={(next) => {
-        if (next === ADD_PROVIDER_VALUE) onAddProvider()
+        if (next === ADD_PROVIDER_VALUE) onAddProvider?.()
         else onChange(next)
       }}
       disabled={disabled}
@@ -46,7 +46,7 @@ export function ProviderSelect({
             </span>
           </SelectItem>
         ))}
-        <SelectItem value={ADD_PROVIDER_VALUE}>+ Add provider…</SelectItem>
+        {onAddProvider ? <SelectItem value={ADD_PROVIDER_VALUE}>+ Add provider…</SelectItem> : null}
       </SelectContent>
     </Select>
   )

--- a/frontend/apps/desktop/src/pages/agents/rich-message-composer.tsx
+++ b/frontend/apps/desktop/src/pages/agents/rich-message-composer.tsx
@@ -179,7 +179,7 @@ export function AgentRichMessageComposer({
             <Button
               size="sm"
               onClick={() => submitHandleRef.current?.submit()}
-              title={isBusy ? 'Queue message' : 'Send'}
+              title={isBusy ? 'Send while the agent is working' : 'Send'}
             >
               <Send className="size-3.5" />
             </Button>

--- a/frontend/apps/desktop/src/pages/agents/run-card.tsx
+++ b/frontend/apps/desktop/src/pages/agents/run-card.tsx
@@ -82,6 +82,7 @@ export function SessionRunCard({
   compact,
   frozenRunIds,
   onOpenSession,
+  readOnly = false,
 }: {
   serverUrl: string
   accountUid: string | null | undefined
@@ -98,6 +99,8 @@ export function SessionRunCard({
   frozenRunIds?: ReadonlySet<string>
   /** Opens the transcript of an agent child run. */
   onOpenSession?: (sessionId: string, agentId?: string) => void
+  /** Hides run controls for reader collaborators while preserving live progress. */
+  readOnly?: boolean
 }) {
   const runs = useSessionRuns(serverUrl, accountUid, sessionId)
   const cancelRun = useCancelRun(serverUrl, accountUid)
@@ -141,6 +144,7 @@ export function SessionRunCard({
           onOpenSession={onOpenSession}
           onCancelRun={(runId) => cancelRun.mutate(runId)}
           cancelPending={cancelRun.isPending}
+          readOnly={readOnly}
         />
       </RunCardShell>
     )
@@ -229,6 +233,7 @@ function RunCardBody({
   onOpenSession,
   onCancelRun,
   cancelPending,
+  readOnly = false,
 }: {
   /** Agent server this run lives on, so its tool rows can link into the agent's own pages. */
   serverUrl: string
@@ -241,6 +246,7 @@ function RunCardBody({
   onOpenSession?: (sessionId: string, agentId?: string) => void
   onCancelRun: (runId: string) => void
   cancelPending: boolean
+  readOnly?: boolean
 }) {
   const [confirmingCancel, setConfirmingCancel] = useState(false)
   const isTerminal = isTerminalRun(run.status)
@@ -271,7 +277,7 @@ function RunCardBody({
         >
           {isParked ? parkedLabel(run, childRuns, doneChildren) : runTitle(run)}
         </span>
-        {isTerminal ? null : confirmingCancel ? (
+        {isTerminal || readOnly ? null : confirmingCancel ? (
           <span className="flex flex-none items-center gap-1">
             <Button
               size="sm"
@@ -309,7 +315,7 @@ function RunCardBody({
       ) : null}
 
       {/* The run has stopped and is asking; the answer belongs where the question is. */}
-      <ParkedRunActions run={run} serverUrl={serverUrl} accountUid={accountUid} />
+      {!readOnly ? <ParkedRunActions run={run} serverUrl={serverUrl} accountUid={accountUid} /> : null}
 
       {progress && !isTerminal ? (
         <div className="flex flex-col gap-1">
@@ -333,7 +339,7 @@ function RunCardBody({
         liveState={liveState}
         compact={compact}
         onOpenSession={onOpenSession}
-        onCancelRun={onCancelRun}
+        onCancelRun={readOnly ? undefined : onCancelRun}
         cancelPending={cancelPending}
         renderToolPart={(part) => (
           <ToolCallLine item={part} serverUrl={serverUrl} accountUid={accountUid} agentId={run.agentId} />

--- a/frontend/apps/desktop/src/pages/agents/server.tsx
+++ b/frontend/apps/desktop/src/pages/agents/server.tsx
@@ -94,6 +94,7 @@ function AgentServerContent({routeServerUrl, selectedAccountId}: {routeServerUrl
                 name={agent.definition.name}
                 status={agent.status}
                 serverUrl={serverUrl}
+                accessRole={agent.accessRole}
               />
             ))}
           </div>

--- a/frontend/apps/desktop/src/pages/agents/session.tsx
+++ b/frontend/apps/desktop/src/pages/agents/session.tsx
@@ -12,7 +12,6 @@ import {
   ChatMessageBubble,
   type ChatBubbleMessage,
 } from '@/components/assistant-message-rendering'
-import {QueuedChatMessages, useQueuedChatMessages} from '@/components/chat-message-queue'
 import {
   addOptimisticSessionMessage,
   type AgentSessionDraftMessage,
@@ -268,12 +267,13 @@ function AgentSessionPage({
   )
   // Which runs the scroll already owns, so the pinned slot does not tell the same story twice.
   const frozenRuns = useMemo(() => frozenRunIds(chatRows), [chatRows])
+  const canWrite = !!agent.data && agent.data.agent.accessRole !== 'reader'
   const isAgentStreaming = session.data?.session.status === 'streaming'
   const isAgentBusy = messageSession.isPending || isAgentStreaming
   const retrySession = useRetrySession(serverUrl, selectedAccountId)
   // Deliberately not gated on the mutation being in flight: the button stays put and shows its
   // pending state until the retried run actually starts streaming, which is what removes the row.
-  const retryableRowKey = retryableErrorRowKey(chatRows, !!isAgentBusy)
+  const retryableRowKey = canWrite ? retryableErrorRowKey(chatRows, !!isAgentBusy) : undefined
   const runStartedAt = useRunStartedAt(isAgentBusy)
   // Sub-session affordances: the parent is loaded only for its title/route, and the child's own run
   // to tell "still being driven by the parent" from "finished, yours to continue". That run is a
@@ -374,14 +374,8 @@ function AgentSessionPage({
     [messageSession, selectedAccountId, serverUrl, sessionId],
   )
 
-  const {queuedMessages, queueMessage} = useQueuedChatMessages<AgentSessionDraftMessage>({
-    isBusy: isAgentBusy,
-    onFlush: doSendAgentMessage,
-  })
-
   async function handleSendMessage(message: AgentSessionDraftMessage) {
-    if (isAgentBusy) queueMessage(message)
-    else await doSendAgentMessage(message)
+    await doSendAgentMessage(message)
   }
 
   const handleRetrySession = useCallback(() => {
@@ -424,7 +418,7 @@ function AgentSessionPage({
         placeholder="Untitled session"
         onTitleChange={setTitleDraft}
         saveState={titleSaveState}
-        disabled={!session.data}
+        disabled={!session.data || !canWrite}
         backLabel="Back to agent sessions"
         onBack={() => {
           const agentId = session.data?.session.agentId
@@ -463,13 +457,17 @@ function AgentSessionPage({
                     toast.success('Session URL copied')
                   },
                 },
-                {
-                  key: 'delete-session',
-                  icon: <Trash2 className="size-4" />,
-                  label: 'Delete session',
-                  variant: 'destructive',
-                  onClick: openDeleteSessionDialog,
-                },
+                ...(canWrite
+                  ? [
+                      {
+                        key: 'delete-session',
+                        icon: <Trash2 className="size-4" />,
+                        label: 'Delete session',
+                        variant: 'destructive' as const,
+                        onClick: openDeleteSessionDialog,
+                      },
+                    ]
+                  : []),
               ]}
             />
           </>
@@ -577,15 +575,21 @@ function AgentSessionPage({
               sessionId={sessionId}
               sessionPlan={session.data.session.plan}
               frozenRunIds={frozenRuns}
+              readOnly={!canWrite}
               onOpenSession={(childSessionId, childAgentId) =>
                 navigate({key: 'agent-session', agentId: childAgentId, sessionId: childSessionId, serverUrl})
               }
             />
-            <QueuedChatMessages messages={queuedMessages} getText={(message) => message.text} />
             <AgentRichMessageComposer
               isBusy={isAgentBusy}
               isStreaming={isAgentStreaming}
-              disabledMessage={isDrivenByParent ? SUB_SESSION_DRIVEN_MESSAGE : undefined}
+              disabledMessage={
+                !canWrite
+                  ? 'You have read-only access to this agent.'
+                  : isDrivenByParent
+                    ? SUB_SESSION_DRIVEN_MESSAGE
+                    : undefined
+              }
               stopPending={stopSession.isPending}
               serverUrl={serverUrl}
               accountId={selectedAccountId ?? null}


### PR DESCRIPTION
## Summary

- Add reader and writer invitations, acceptance/decline flows, role management, revocation, and owner-only collaborator controls.
- Enforce agent-scoped access across signed API actions, sessions, triggers, runs, attachments, WebSocket subscriptions, and event fanout.
- Attribute collaborative messages to both the acting Seed account and exact signer while durably accepting concurrent writes and serializing model turns.
- Add desktop invitation, collaborator settings, role badges, read-only states, live updates, account avatars, and provenance details.
- Document collaboration behavior and clarify the hosted staging/deployment environment.

## Validation

- `pnpm typecheck`
- `pnpm test` (web 139 passed/1 skipped, shared 1046 passed/1 skipped, desktop 682 passed)
- `cd agents && bun check && bun test && bun run format:check` (309 tests passed)
- `./dev build-desktop && pnpm web:prod`
- Frontend and agents formatting checks
- `git diff --check`
- `pnpm audit` (6 configured ignored vulnerabilities: 3 moderate, 3 high)