### PR TITLE
fix(agents): embed the QuickJS wasm so delegated scripts run in bundles

### DIFF
--- a/agents/bun.lock
+++ b/agents/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@seed-hypermedia/agents",
       "dependencies": {
+        "@jitl/quickjs-singlefile-cjs-release-sync": "0.32.0",
         "@mariozechner/pi-ai": "0.70.6",
         "@mariozechner/pi-coding-agent": "0.70.2",
         "@mozilla/readability": "0.6.0",
@@ -18,7 +19,7 @@
         "lucide-react": "^0.545.0",
         "microsandbox": "0.6.8",
         "multiformats": "^13.4.1",
-        "quickjs-emscripten": "^0.32.0",
+        "quickjs-emscripten-core": "0.32.0",
         "react": "^19",
         "react-dom": "^19",
         "react-router-dom": "^7.13.0",
@@ -202,13 +203,7 @@
 
     "@jitl/quickjs-ffi-types": ["@jitl/quickjs-ffi-types@0.32.0", "", {}, "sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg=="],
 
-    "@jitl/quickjs-wasmfile-debug-asyncify": ["@jitl/quickjs-wasmfile-debug-asyncify@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw=="],
-
-    "@jitl/quickjs-wasmfile-debug-sync": ["@jitl/quickjs-wasmfile-debug-sync@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q=="],
-
-    "@jitl/quickjs-wasmfile-release-asyncify": ["@jitl/quickjs-wasmfile-release-asyncify@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q=="],
-
-    "@jitl/quickjs-wasmfile-release-sync": ["@jitl/quickjs-wasmfile-release-sync@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg=="],
+    "@jitl/quickjs-singlefile-cjs-release-sync": ["@jitl/quickjs-singlefile-cjs-release-sync@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-NjUUcw26PoeJHND6nmflAH8nIvAJvxJ2qkSPi95wfiBqPim80GtcdWommroiWb8hh1/7fVettEwodAsGt2Mrsg=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -931,8 +926,6 @@
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
-
-    "quickjs-emscripten": ["quickjs-emscripten@0.32.0", "", { "dependencies": { "@jitl/quickjs-wasmfile-debug-asyncify": "0.32.0", "@jitl/quickjs-wasmfile-debug-sync": "0.32.0", "@jitl/quickjs-wasmfile-release-asyncify": "0.32.0", "@jitl/quickjs-wasmfile-release-sync": "0.32.0", "quickjs-emscripten-core": "0.32.0" } }, "sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA=="],
 
     "quickjs-emscripten-core": ["quickjs-emscripten-core@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg=="],
 

--- a/agents/package.json
+++ b/agents/package.json
@@ -21,6 +21,7 @@
     "@seed-hypermedia/client": "file:../frontend/packages/client"
   },
   "dependencies": {
+    "@jitl/quickjs-singlefile-cjs-release-sync": "0.32.0",
     "@mariozechner/pi-ai": "0.70.6",
     "@mariozechner/pi-coding-agent": "0.70.2",
     "@mozilla/readability": "0.6.0",
@@ -34,7 +35,7 @@
     "lucide-react": "^0.545.0",
     "microsandbox": "0.6.8",
     "multiformats": "^13.4.1",
-    "quickjs-emscripten": "^0.32.0",
+    "quickjs-emscripten-core": "0.32.0",
     "react": "^19",
     "react-dom": "^19",
     "react-router-dom": "^7.13.0",

--- a/agents/src/main.ts
+++ b/agents/src/main.ts
@@ -414,7 +414,11 @@ async function main(): Promise<void> {
         console.error('exec-selfcheck: staged node_modules present but no msb helper was found in it')
         process.exit(1)
       }
-      console.log(`exec-selfcheck: SDK loaded; msb=${process.env.MSB_PATH ?? '(binding-relative)'}`)
+      // The workflow engine's QuickJS wasm is embedded in the bundle; prove it instantiates so a
+      // bundling regression fails the build instead of the first delegated script in production.
+      const {quickjsSelfcheck} = await import('@/workflow-host')
+      await quickjsSelfcheck()
+      console.log(`exec-selfcheck: SDK loaded; msb=${process.env.MSB_PATH ?? '(binding-relative)'}; quickjs ok`)
       process.exit(0)
     } catch (error) {
       console.error(`exec-selfcheck: ${error instanceof Error ? error.message : String(error)}`)

--- a/agents/src/workflow-host.ts
+++ b/agents/src/workflow-host.ts
@@ -14,7 +14,40 @@
  * them (or replays them from the journal), and delivers results back while pumping the VM microtask
  * queue. This supports true `ctx.parallel` fan-out without asyncify.
  */
-import {getQuickJS, type QuickJSContext, type QuickJSRuntime} from 'quickjs-emscripten'
+// The singlefile variant carries the QuickJS wasm embedded in its JS instead of loading
+// `emscripten-module.wasm` from disk at runtime, which no bundled deployment can serve: the
+// Docker image and the compiled desktop binary both bundle main.js away from node_modules, and
+// the wasmfile variant's loader then dies with ENOENT on the missing file.
+import singlefileVariant from '@jitl/quickjs-singlefile-cjs-release-sync'
+import {
+  newQuickJSWASMModuleFromVariant,
+  type QuickJSContext,
+  type QuickJSRuntime,
+  type QuickJSWASMModule,
+} from 'quickjs-emscripten-core'
+
+// Memoized like quickjs-emscripten's getQuickJS() was; newQuickJSWASMModuleFromVariant
+// instantiates a fresh wasm module per call, which no per-run code path should pay for.
+let quickJSModule: Promise<QuickJSWASMModule> | undefined
+const loadQuickJS = () => (quickJSModule ??= newQuickJSWASMModuleFromVariant(singlefileVariant))
+
+/**
+ * Proves the embedded QuickJS wasm instantiates and evaluates in this build. Part of the
+ * packaging selfcheck (`--exec-selfcheck`): a bundling regression that loses the wasm should
+ * fail the image or binary build, not the first delegated script in production.
+ */
+export async function quickjsSelfcheck(): Promise<void> {
+  const QuickJS = await loadQuickJS()
+  const vm = QuickJS.newContext()
+  try {
+    const handle = vm.unwrapResult(vm.evalCode('6 * 7'))
+    const value = vm.dump(handle)
+    handle.dispose()
+    if (value !== 42) throw new Error(`QuickJS selfcheck evaluated to ${String(value)}`)
+  } finally {
+    vm.dispose()
+  }
+}
 import type {RunPlanState} from '@/runs'
 
 /**
@@ -350,7 +383,7 @@ class WorkflowFailure extends Error {
 export async function runWorkflowVM(adapters: WorkflowAdapters): Promise<WorkflowVMOutcome> {
   const fuelMs = adapters.fuelMs ?? DEFAULT_FUEL_MS
   const parkThresholdMs = adapters.timerParkThresholdMs ?? DEFAULT_TIMER_PARK_THRESHOLD_MS
-  const QuickJS = await getQuickJS()
+  const QuickJS = await loadQuickJS()
   const runtime: QuickJSRuntime = QuickJS.newRuntime()
   runtime.setMemoryLimit(adapters.memoryBytes ?? DEFAULT_MEMORY_BYTES)
   runtime.setMaxStackSize(1024 * 1024)


### PR DESCRIPTION
Every `delegate` on the hosted servers failed with `executor-error: ENOENT /app/emscripten-module.wasm` (seen live on staging). quickjs-emscripten's default wasmfile variant loads its wasm from disk relative to the module — a path that exists under dev's `node_modules` but not where `bun build` puts the bundled JS, and the compiled desktop binary bundles the same way.

- Switch `workflow-host` to `@jitl/quickjs-singlefile-cjs-release-sync` via `quickjs-emscripten-core`: the wasm ships embedded in the JS, so it works wherever the bundle goes. Module load stays memoized like `getQuickJS()` was.
- `--exec-selfcheck` now also instantiates QuickJS and evaluates in it, so the Docker image build (and desktop `--smoke`) fails on any future packaging regression of this class.

Verified: the built image's selfcheck prints `quickjs ok`; workflow-host tests 33/33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5gsc3kpcRoeqA4aUUy4Ft