### PR TITLE
refactor(client): accept either signer shape, dedupe capability and principal helpers

### DIFF
--- a/frontend/packages/client/src/auto-link.ts
+++ b/frontend/packages/client/src/auto-link.ts
@@ -10,7 +10,8 @@
  * - Full I/O convenience: fetch parent, check, build ops, sign, publish
  */
 
-import type {HMBlockNode, HMDocument, HMSigner, UnpackedHypermediaId} from './hm-types'
+import type {HMBlockNode, HMDocument, UnpackedHypermediaId} from './hm-types'
+import type {AnySigner} from './signer'
 import {entityQueryPathToHmIdPath, packHmId, unpackHmId} from './hm-types'
 import type {SeedClient} from './client'
 import type {DocumentOperation} from './change'
@@ -155,7 +156,7 @@ export type AutoLinkChildToParentOptions = {
   /** hm:// URL of the published child document (without version). */
   childHmUrl: string
   /** Signer for the parent document change. */
-  signer: HMSigner
+  signer: AnySigner
 }
 
 /**

--- a/frontend/packages/client/src/blobs.ts
+++ b/frontend/packages/client/src/blobs.ts
@@ -14,6 +14,9 @@ import {CID} from 'multiformats/cid'
 import * as Digest from 'multiformats/hashes/digest'
 import {sha256 as sha256hasher} from 'multiformats/hashes/sha2'
 import * as cbor from './cbor'
+import {type AnySigner, toPrincipalSigner} from './signer'
+
+export type {AnySigner}
 
 // Ed25519 multicodec (0xed) varint prefix. No existing JS library exports this constant.
 export const ED25519_VARINT_PREFIX = new Uint8Array([0xed, 0x01])
@@ -203,7 +206,7 @@ export interface Profile extends Blob {
 
 /** Create a signed and encoded Profile blob. */
 export async function createProfile(
-  signer: Signer,
+  anySigner: AnySigner,
   opts: {
     /** Display name (required for non-alias profiles). */
     name: string
@@ -216,6 +219,7 @@ export async function createProfile(
   },
   ts: Timestamp,
 ): Promise<Encoded<Profile>> {
+  const signer = await toPrincipalSigner(anySigner)
   opts = {...opts} // Copying opts to avoid mutating the original object.
 
   if (opts.account && principalEqual(opts.account, signer.principal)) {
@@ -242,7 +246,12 @@ export async function createProfile(
 }
 
 /** Create a signed and encoded alias Profile blob (identity redirect). */
-export async function createProfileAlias(signer: Signer, alias: Principal, ts: Timestamp): Promise<Encoded<Profile>> {
+export async function createProfileAlias(
+  anySigner: AnySigner,
+  alias: Principal,
+  ts: Timestamp,
+): Promise<Encoded<Profile>> {
+  const signer = await toPrincipalSigner(anySigner)
   const blob: Profile = {
     type: 'Profile',
     signer: signer.principal,
@@ -271,7 +280,7 @@ export interface Capability extends Blob {
 
 /** Create a signed and encoded Capability blob. */
 export async function createCapability(
-  issuer: Signer,
+  anyIssuer: AnySigner,
   delegate: Principal,
   role: Role,
   ts: Timestamp,
@@ -284,6 +293,16 @@ export async function createCapability(
     audience?: Principal
   } = {},
 ): Promise<Encoded<Capability>> {
+  const issuer = await toPrincipalSigner(anyIssuer)
+
+  // Spreading opts directly would put explicit `undefined` values on the blob,
+  // which the DAG-CBOR encoder writes as null rather than omitting. Only carry
+  // over keys that were actually set.
+  const present: {-readonly [K in 'path' | 'label' | 'audience']?: Capability[K]} = {}
+  if (opts.path !== undefined) present.path = opts.path
+  if (opts.label !== undefined) present.label = opts.label
+  if (opts.audience !== undefined) present.audience = opts.audience
+
   const blob: Capability = {
     type: 'Capability',
     signer: issuer.principal,
@@ -291,7 +310,7 @@ export async function createCapability(
     ts,
     delegate,
     role,
-    ...opts,
+    ...present,
   }
 
   return encode(await sign(issuer, blob))
@@ -312,10 +331,10 @@ export interface Encoded<T extends Blob> extends Decoded<T> {
  * Sign a blob with a Signer.
  * Fills sig with zeros, CBOR-encodes, signs, replaces sig.
  */
-export async function sign<T extends Blob>(signer: Signer, blob: T): Promise<T> {
+export async function sign<T extends Blob>(signer: AnySigner, blob: T): Promise<T> {
   const unsigned = {...blob, sig: new Uint8Array(ED25519_SIGNATURE_SIZE)}
   const data = new Uint8Array(cbor.encode(unsigned))
-  const sig = await signer.sign(data)
+  const sig = await (await toPrincipalSigner(signer)).sign(data)
   return {...unsigned, sig}
 }
 

--- a/frontend/packages/client/src/capability.ts
+++ b/frontend/packages/client/src/capability.ts
@@ -2,11 +2,12 @@
  * Capability SDK — create and resolve capabilities (delegate access to other accounts).
  */
 
-import {encode as cborEncode} from '@ipld/dag-cbor'
-import type {HMPublishBlobsInput, HMSigner} from './hm-types'
+import type {HMPublishBlobsInput} from './hm-types'
 import {entityQueryPathToHmIdPath, packBaseId} from './hm-types'
 import {base58btc} from 'multiformats/bases/base58'
-import {signObject, toPublishInput} from './signing'
+import {createCapability as createCapabilityBlob} from './blobs'
+import type {AnySigner} from './signer'
+import {toPublishInput} from './signing'
 import type {SeedClient} from './client'
 
 /** Role values for capability blobs. */
@@ -26,30 +27,20 @@ export type CreateCapabilityInput = {
 /**
  * Create a signed capability blob ready for publishing.
  * The signer is the issuer granting access to the delegate.
+ *
+ * Wraps the blob primitive in `./blobs`, which is the single implementation of
+ * the Capability wire format; this adds the string-keyed input shape and the
+ * publish envelope the rest of the SDK expects.
  */
-export async function createCapability(input: CreateCapabilityInput, signer: HMSigner): Promise<HMPublishBlobsInput> {
-  const signerKey = await signer.getPublicKey()
-  const ts = BigInt(Date.now())
-
-  const unsigned: Record<string, unknown> = {
-    type: 'Capability',
-    signer: new Uint8Array(signerKey),
-    sig: new Uint8Array(64),
-    ts,
-    delegate: new Uint8Array(base58btc.decode(input.delegateUid)),
-    role: input.role,
-  }
-
-  if (input.path) {
-    unsigned.path = input.path
-  }
-  if (input.label) {
-    unsigned.label = input.label
-  }
-
-  unsigned.sig = await signObject(signer, unsigned)
-
-  return toPublishInput(cborEncode(unsigned))
+export async function createCapability(input: CreateCapabilityInput, signer: AnySigner): Promise<HMPublishBlobsInput> {
+  const encoded = await createCapabilityBlob(
+    signer,
+    new Uint8Array(base58btc.decode(input.delegateUid)),
+    input.role,
+    Date.now(),
+    {path: input.path || undefined, label: input.label || undefined},
+  )
+  return toPublishInput(encoded.data)
 }
 
 /**

--- a/frontend/packages/client/src/change.ts
+++ b/frontend/packages/client/src/change.ts
@@ -9,12 +9,13 @@
  */
 
 import {decode as cborDecode, encode as cborEncode} from '@ipld/dag-cbor'
-import type {HMPrepareDocumentChangeInput, HMPublishBlobsInput, HMSigner} from './hm-types'
+import type {HMPrepareDocumentChangeInput, HMPublishBlobsInput} from './hm-types'
 import {CID} from 'multiformats'
 import * as Block from 'multiformats/block'
 import {sha256} from 'multiformats/hashes/sha2'
 import {createVersionRef} from './ref'
-import {cborCodec, normalizeBytes} from './signing'
+import {cborCodec, normalizeBytes, signerPublicKey} from './signing'
+import type {AnySigner} from './signer'
 
 export type DocumentOperation =
   | {type: 'SetAttributes'; attrs: Array<{key: string[]; value: string | number | boolean | null}>}
@@ -70,7 +71,7 @@ export function createChangeOps(input: CreateChangeOpsInput): {unsignedBytes: Ui
  */
 export async function createChange(
   unsignedBytes: Uint8Array,
-  signer: HMSigner,
+  signer: AnySigner,
 ): Promise<{bytes: Uint8Array; cid: CID; genesis: CID | null; ts: number | undefined}> {
   const change = cborDecode(unsignedBytes) as Record<string, unknown>
 
@@ -78,7 +79,7 @@ export async function createChange(
   const genesis = change.genesis instanceof CID ? change.genesis : null
   const ts = timestampToNumber(change.ts)
 
-  change.signer = new Uint8Array(await signer.getPublicKey())
+  change.signer = new Uint8Array(await signerPublicKey(signer))
   change.sig = new Uint8Array(64)
 
   change.sig = await signer.sign(cborEncode(change))
@@ -91,7 +92,7 @@ export async function createChange(
 /** @deprecated Use createChange instead */
 export const signPreparedChange = async (
   unsignedBytes: Uint8Array,
-  signer: HMSigner,
+  signer: AnySigner,
 ): Promise<{signedBytes: Uint8Array; cid: CID; genesis: CID | null}> => {
   const result = await createChange(unsignedBytes, signer)
   return {signedBytes: result.bytes, cid: result.cid, genesis: result.genesis}
@@ -101,8 +102,8 @@ export const signPreparedChange = async (
  * Create a signed genesis Change blob (empty, ts=0).
  * This deterministic sentinel is only intended for home documents.
  */
-export async function createGenesisChange(signer: HMSigner): Promise<{bytes: Uint8Array; cid: CID}> {
-  const pubKey = await signer.getPublicKey()
+export async function createGenesisChange(signer: AnySigner): Promise<{bytes: Uint8Array; cid: CID}> {
+  const pubKey = await signerPublicKey(signer)
   const unsigned: Record<string, unknown> = {
     type: 'Change',
     signer: new Uint8Array(pubKey),
@@ -123,7 +124,7 @@ export type CreateDocumentChangeFromOpsInput = CreateChangeOpsInput
  */
 export async function createDocumentChangeFromOps(
   input: CreateChangeOpsInput,
-  signer: HMSigner,
+  signer: AnySigner,
 ): Promise<{bytes: Uint8Array; cid: CID; ts: bigint}> {
   const {unsignedBytes, ts} = createChangeOps(input)
   const {bytes, cid} = await createChange(unsignedBytes, signer)
@@ -147,7 +148,7 @@ export type CreateDocumentChangeInput = {
  */
 export async function createDocumentChange(
   input: CreateDocumentChangeInput,
-  signer: HMSigner,
+  signer: AnySigner,
 ): Promise<{bytes: Uint8Array; cid: CID}> {
   const ops = protoChangesToOps(input.changes)
   const {unsignedBytes} = createChangeOps({ops, genesisCid: input.genesisCid, deps: input.deps, depth: input.depth})
@@ -215,7 +216,7 @@ export type SignDocumentChangeInput = {
  */
 export async function signDocumentChange(
   input: SignDocumentChangeInput,
-  signer: HMSigner,
+  signer: AnySigner,
 ): Promise<{changeCid: CID; publishInput: HMPublishBlobsInput}> {
   const {
     bytes: signedBytes,

--- a/frontend/packages/client/src/client.ts
+++ b/frontend/packages/client/src/client.ts
@@ -1,15 +1,9 @@
 import {z} from 'zod'
-import {
-  type HMPrepareDocumentChangeInput,
-  type HMRequest,
-  type HMSigner,
-  HMActionSchema,
-  HMRequestSchema,
-  packHmId,
-} from './hm-types'
+import {type HMPrepareDocumentChangeInput, type HMRequest, HMActionSchema, HMRequestSchema, packHmId} from './hm-types'
 import {encode as cborEncode} from '@ipld/dag-cbor'
 import {deserialize} from 'superjson'
 import {SeedClientError, SeedNetworkError, SeedValidationError} from './errors'
+import type {AnySigner} from './signer'
 import {createDocumentChange, createGenesisChange, signDocumentChange} from './change'
 import {createVersionRef} from './ref'
 
@@ -148,7 +142,7 @@ export type SeedClient = {
   ): Promise<Extract<HMRequest, {key: K}>['output']>
   publish(input: PublishBlobsRequest['input']): Promise<PublishBlobsRequest['output']>
   publishBlobs(input: PublishBlobsRequest['input']): Promise<PublishBlobsRequest['output']>
-  publishDocument(input: PublishDocumentInput, signer: HMSigner): Promise<void>
+  publishDocument(input: PublishDocumentInput, signer: AnySigner): Promise<void>
   baseUrl: string
 }
 
@@ -260,7 +254,7 @@ export function createSeedClient(baseUrl: string, options?: SeedClientOptions): 
     return request<PublishBlobsRequest>('PublishBlobs', input)
   }
 
-  async function publishDocument(input: PublishDocumentInput, signer: HMSigner): Promise<void> {
+  async function publishDocument(input: PublishDocumentInput, signer: AnySigner): Promise<void> {
     // Brand-new home documents need their deterministic genesis change created and
     // signed client-side — the server's PrepareChange cannot bootstrap it (it has no
     // signing key, and requires the genesis to already exist).

--- a/frontend/packages/client/src/comment.ts
+++ b/frontend/packages/client/src/comment.ts
@@ -7,11 +7,11 @@ import type {
   HMPublishBlobsInput,
   HMPublishableAnnotation,
   HMPublishableBlock,
-  HMSigner,
   UnpackedHypermediaId,
 } from './hm-types'
 import {hmIdPathToEntityQueryPath, packHmId} from './hm-types'
-import {signObject, toPublishInput} from './signing'
+import {signObject, signerPublicKey, toPublishInput} from './signing'
+import type {AnySigner} from './signer'
 import {validateExclusiveAnnotations} from './unicode'
 
 // ─── Block trimming ─────────────────────────────────────────────────────────
@@ -341,7 +341,7 @@ function createUnsignedComment({
   return unsignedComment
 }
 
-async function createSignedComment(comment: UnsignedComment, signer: HMSigner): Promise<SignedComment> {
+async function createSignedComment(comment: UnsignedComment, signer: AnySigner): Promise<SignedComment> {
   const commentForSigning = {
     ...comment,
     version: comment.version.split('.').map((v) => CID.parse(v)),
@@ -364,12 +364,12 @@ async function createCommentBlob({
   content: HMBlockNode[]
   docId: UnpackedHypermediaId
   docVersion: string
-  signer: HMSigner
+  signer: AnySigner
   replyCommentVersion?: string | null
   rootReplyCommentVersion?: string | null
   visibility?: 'Private' | ''
 }): Promise<Uint8Array> {
-  const signerKey = await signer.getPublicKey()
+  const signerKey = await signerPublicKey(signer)
   cleanContentOfUndefined(content)
   const unsignedComment = createUnsignedComment({
     content,
@@ -451,7 +451,7 @@ async function resolveCommentContentAndBlobs(input: CreateCommentInput): Promise
   }
 }
 
-export async function createComment(input: CreateCommentInput, signer: HMSigner): Promise<HMPublishBlobsInput> {
+export async function createComment(input: CreateCommentInput, signer: AnySigner): Promise<HMPublishBlobsInput> {
   const {content, blobs} = await resolveCommentContentAndBlobs(input)
   const comment = await createCommentBlob({
     content,
@@ -473,7 +473,7 @@ export type DeleteCommentInput = {
   visibility?: 'Private' | ''
 }
 
-export async function deleteComment(input: DeleteCommentInput, signer: HMSigner): Promise<HMPublishBlobsInput> {
+export async function deleteComment(input: DeleteCommentInput, signer: AnySigner): Promise<HMPublishBlobsInput> {
   // Extract TSID from comment ID (format: "authority/tsid")
   const parts = input.commentId.split('/')
   const tsid = parts[1]
@@ -481,7 +481,7 @@ export async function deleteComment(input: DeleteCommentInput, signer: HMSigner)
     throw new Error(`Invalid comment ID format: ${input.commentId}`)
   }
 
-  const signerKey = await signer.getPublicKey()
+  const signerKey = await signerPublicKey(signer)
 
   // Create the tombstone comment object for signing
   // Empty body signals deletion, zeroed thread/reply refs, same TSID as original
@@ -520,7 +520,7 @@ export type UpdateCommentInput = {
 }
 
 /** Creates a signed update blob for an existing comment. */
-export async function updateComment(input: UpdateCommentInput, signer: HMSigner): Promise<HMPublishBlobsInput> {
+export async function updateComment(input: UpdateCommentInput, signer: AnySigner): Promise<HMPublishBlobsInput> {
   // Extract TSID from comment ID (format: "authority/tsid")
   const parts = input.commentId.split('/')
   const tsid = parts[1]
@@ -528,7 +528,7 @@ export async function updateComment(input: UpdateCommentInput, signer: HMSigner)
     throw new Error(`Invalid comment ID format: ${input.commentId}`)
   }
 
-  const signerKey = await signer.getPublicKey()
+  const signerKey = await signerPublicKey(signer)
   cleanContentOfUndefined(input.content)
   const trimmedContent = trimTrailingEmptyBlocks(input.content)
 

--- a/frontend/packages/client/src/contact.ts
+++ b/frontend/packages/client/src/contact.ts
@@ -1,7 +1,8 @@
 import {decode as cborDecode, encode as cborEncode} from '@ipld/dag-cbor'
 import {base58btc} from 'multiformats/bases/base58'
-import type {HMPublishBlobsInput, HMSigner} from './hm-types'
-import {signObject, toPublishInput} from './signing'
+import type {HMPublishBlobsInput} from './hm-types'
+import {signObject, signerPublicKey, toPublishInput} from './signing'
+import type {AnySigner} from './signer'
 
 export type ContactSubscribe = {
   site?: boolean
@@ -94,8 +95,8 @@ async function computeTSID(timestampMs: bigint, blobData: Uint8Array): Promise<s
  * Create a new contact blob and compute its record ID.
  * Returns the publish input plus a `recordId` in "authority/tsid" format.
  */
-export async function createContact(input: CreateContactInput, signer: HMSigner): Promise<CreateContactResult> {
-  const signerKey = await signer.getPublicKey()
+export async function createContact(input: CreateContactInput, signer: AnySigner): Promise<CreateContactResult> {
+  const signerKey = await signerPublicKey(signer)
   const ts = BigInt(Date.now())
   const signerUid = base58btc.encode(new Uint8Array(signerKey))
   const authority = input.accountUid || signerUid
@@ -130,8 +131,8 @@ export async function createContact(input: CreateContactInput, signer: HMSigner)
 /**
  * Update an existing contact blob. Reuses the original TSID.
  */
-export async function updateContact(input: UpdateContactInput, signer: HMSigner): Promise<HMPublishBlobsInput> {
-  const signerKey = await signer.getPublicKey()
+export async function updateContact(input: UpdateContactInput, signer: AnySigner): Promise<HMPublishBlobsInput> {
+  const signerKey = await signerPublicKey(signer)
   const tsid = extractTsid(input.contactId)
   const accountUid = input.accountUid || extractAuthority(input.contactId)
 
@@ -161,8 +162,8 @@ export async function updateContact(input: UpdateContactInput, signer: HMSigner)
  * Delete a contact by publishing a tombstone blob.
  * A tombstone has the same TSID but no subject and no name.
  */
-export async function deleteContact(input: DeleteContactInput, signer: HMSigner): Promise<HMPublishBlobsInput> {
-  const signerKey = await signer.getPublicKey()
+export async function deleteContact(input: DeleteContactInput, signer: AnySigner): Promise<HMPublishBlobsInput> {
+  const signerKey = await signerPublicKey(signer)
   const tsid = extractTsid(input.contactId)
   const accountUid = input.accountUid || extractAuthority(input.contactId)
 

--- a/frontend/packages/client/src/index.ts
+++ b/frontend/packages/client/src/index.ts
@@ -56,6 +56,8 @@ export {
   unpackHmId,
 } from './hm-types'
 export type {HMRequest, HMSigner, UnpackedHypermediaId} from './hm-types'
+export {toHMSigner, toPrincipalSigner} from './signer'
+export type {AnySigner, PrincipalSigner} from './signer'
 
 export {resolveHypermediaUrl, resolveId} from './hm-resolver'
 export type {DomainResolverFn, DomainIdChangedCallback, ResolveOptions, ResolvedUrl} from './hm-resolver'

--- a/frontend/packages/client/src/ref.ts
+++ b/frontend/packages/client/src/ref.ts
@@ -3,10 +3,11 @@
  */
 
 import {encode as cborEncode} from '@ipld/dag-cbor'
-import type {HMPublishBlobsInput, HMSigner} from './hm-types'
+import type {HMPublishBlobsInput} from './hm-types'
 import {CID} from 'multiformats'
 import {base58btc} from 'multiformats/bases/base58'
-import {signObject, toPublishInput} from './signing'
+import {signObject, signerPublicKey, toPublishInput} from './signing'
+import type {AnySigner} from './signer'
 
 export type CreateVersionRefInput = {
   /** Account UID (base58btc-encoded principal) */
@@ -130,8 +131,8 @@ function buildUnsignedRef({
  * Points to a specific document version (genesis + heads).
  * Used for fork/branch operations and normal document refs.
  */
-export async function createVersionRef(input: CreateVersionRefInput, signer: HMSigner): Promise<HMPublishBlobsInput> {
-  const signerKey = await signer.getPublicKey()
+export async function createVersionRef(input: CreateVersionRefInput, signer: AnySigner): Promise<HMPublishBlobsInput> {
+  const signerKey = await signerPublicKey(signer)
 
   const unsigned = buildUnsignedRef({
     signerKey,
@@ -158,9 +159,9 @@ export async function createVersionRef(input: CreateVersionRefInput, signer: HMS
  */
 export async function createTombstoneRef(
   input: CreateTombstoneRefInput,
-  signer: HMSigner,
+  signer: AnySigner,
 ): Promise<HMPublishBlobsInput> {
-  const signerKey = await signer.getPublicKey()
+  const signerKey = await signerPublicKey(signer)
 
   const unsigned = buildUnsignedRef({
     signerKey,
@@ -184,8 +185,11 @@ export async function createTombstoneRef(
  * Redirects this document path to a different account/path.
  * Optionally republishes the target content at this location.
  */
-export async function createRedirectRef(input: CreateRedirectRefInput, signer: HMSigner): Promise<HMPublishBlobsInput> {
-  const signerKey = await signer.getPublicKey()
+export async function createRedirectRef(
+  input: CreateRedirectRefInput,
+  signer: AnySigner,
+): Promise<HMPublishBlobsInput> {
+  const signerKey = await signerPublicKey(signer)
 
   const unsigned = buildUnsignedRef({
     signerKey,

--- a/frontend/packages/client/src/signer.test.ts
+++ b/frontend/packages/client/src/signer.test.ts
@@ -1,0 +1,119 @@
+import {encode as dagEncode} from '@ipld/dag-cbor'
+import {base58btc} from 'multiformats/bases/base58'
+import {describe, expect, test} from 'vitest'
+import * as blobs from './blobs'
+import {createCapability} from './capability'
+import * as cbor from './cbor'
+import type {HMSigner} from './hm-types'
+import {toHMSigner, toPrincipalSigner} from './signer'
+
+const seed = new Uint8Array(32).fill(7)
+const delegateSeed = new Uint8Array(32).fill(9)
+
+function principalSigner() {
+  return blobs.nobleKeyPairFromSeed(seed)
+}
+
+function hmSigner(): HMSigner {
+  const kp = blobs.nobleKeyPairFromSeed(seed)
+  return {
+    getPublicKey: async () => kp.principal,
+    sign: (data) => kp.sign(data),
+  }
+}
+
+describe('signer normalization', () => {
+  test('toHMSigner and toPrincipalSigner agree on the principal', async () => {
+    const fromPrincipal = await toPrincipalSigner(principalSigner())
+    const fromHM = await toPrincipalSigner(hmSigner())
+    expect(blobs.principalEqual(fromPrincipal.principal, fromHM.principal)).toBe(true)
+
+    expect(await toHMSigner(principalSigner()).getPublicKey()).toEqual(await hmSigner().getPublicKey())
+  })
+
+  test('normalization round-trips without changing signatures', async () => {
+    const data = new TextEncoder().encode('payload')
+    const direct = await principalSigner().sign(data)
+    const viaHM = await toHMSigner(principalSigner()).sign(data)
+    const viaPrincipal = await (await toPrincipalSigner(hmSigner())).sign(data)
+
+    expect(viaHM).toEqual(direct)
+    expect(viaPrincipal).toEqual(direct)
+  })
+
+  test('passing through an already-normalized signer is a no-op', async () => {
+    const original = principalSigner()
+    expect(await toPrincipalSigner(original)).toBe(original)
+    const hm = hmSigner()
+    expect(toHMSigner(hm)).toBe(hm)
+  })
+})
+
+describe('blob builders accept either signer shape', () => {
+  test('createCapability produces identical bytes from both shapes', async () => {
+    const delegate = blobs.nobleKeyPairFromSeed(delegateSeed).principal
+    const ts = 1_700_000_000_000
+
+    const fromPrincipal = await blobs.createCapability(principalSigner(), delegate, 'AGENT', ts, {label: 'x'})
+    const fromHM = await blobs.createCapability(hmSigner(), delegate, 'AGENT', ts, {label: 'x'})
+
+    expect(fromHM.data).toEqual(fromPrincipal.data)
+    expect(fromHM.cid.toString()).toBe(fromPrincipal.cid.toString())
+    expect(blobs.verify(fromHM.decoded)).toBe(true)
+  })
+
+  test('createProfile produces identical bytes from both shapes', async () => {
+    const ts = 1_700_000_000_000
+    const fromPrincipal = await blobs.createProfile(principalSigner(), {name: 'Test'}, ts)
+    const fromHM = await blobs.createProfile(hmSigner(), {name: 'Test'}, ts)
+
+    expect(fromHM.data).toEqual(fromPrincipal.data)
+    expect(blobs.verify(fromHM.decoded)).toBe(true)
+  })
+})
+
+describe('capability.createCapability delegates without changing the wire format', () => {
+  test('matches a hand-rolled blob of the pre-dedupe shape', async () => {
+    const kp = blobs.nobleKeyPairFromSeed(seed)
+    const delegate = blobs.nobleKeyPairFromSeed(delegateSeed).principal
+    const delegateUid = blobs.principalToString(delegate)
+
+    const result = await createCapability({delegateUid, role: 'AGENT', label: 'x', path: '/p'}, kp)
+    const actual = result.blobs[0]!.data
+
+    // Reconstruct exactly what the old implementation emitted: bigint ts, raw
+    // dag-cbor, keys omitted rather than nulled.
+    const decoded = cbor.decode<Record<string, unknown>>(actual)
+    const unsigned: Record<string, unknown> = {
+      type: 'Capability',
+      signer: kp.principal,
+      sig: new Uint8Array(64),
+      ts: BigInt(decoded.ts as number),
+      delegate: new Uint8Array(base58btc.decode(delegateUid)),
+      role: 'AGENT',
+      path: '/p',
+      label: 'x',
+    }
+    unsigned.sig = await kp.sign(dagEncode(unsigned))
+    const expected = dagEncode(unsigned)
+
+    expect(new Uint8Array(actual)).toEqual(new Uint8Array(expected))
+  })
+
+  test('omits absent path and label rather than encoding null', async () => {
+    const kp = blobs.nobleKeyPairFromSeed(seed)
+    const delegateUid = blobs.principalToString(blobs.nobleKeyPairFromSeed(delegateSeed).principal)
+
+    const result = await createCapability({delegateUid, role: 'WRITER'}, kp)
+    const decoded = cbor.decode<Record<string, unknown>>(result.blobs[0]!.data)
+
+    expect('path' in decoded).toBe(false)
+    expect('label' in decoded).toBe(false)
+  })
+
+  test('accepts an HMSigner too', async () => {
+    const delegateUid = blobs.principalToString(blobs.nobleKeyPairFromSeed(delegateSeed).principal)
+    const result = await createCapability({delegateUid, role: 'AGENT'}, hmSigner())
+    expect(blobs.verify(cbor.decode(result.blobs[0]!.data))).toBe(true)
+  })
+})

--- a/frontend/packages/client/src/signer.ts
+++ b/frontend/packages/client/src/signer.ts
@@ -1,0 +1,66 @@
+/**
+ * The signer abstraction shared across this package.
+ *
+ * Two signer shapes grew up independently here:
+ *
+ *   - {@link HMSigner} (`getPublicKey()`) — used by the blob builders
+ *     (`createComment`, `createContact`, `createChange`, …) and by `SeedClient`.
+ *   - {@link PrincipalSigner} (`principal`) — used by the blob primitives in
+ *     `./blobs` and by the auth/vault code, where the principal is already
+ *     known synchronously.
+ *
+ * Neither is wrong, and both produce identical bytes. Rather than break one set
+ * of callers, every public entry point now accepts {@link AnySigner} and
+ * normalizes with the helpers below, so callers never have to care which shape
+ * a given function was originally written against.
+ *
+ * This module intentionally has no runtime imports, so importing it never pulls
+ * crypto or schema code into a bundle.
+ */
+
+import type {HMSigner} from './hm-types'
+
+export type {HMSigner}
+
+/**
+ * A signer that exposes its principal synchronously.
+ *
+ * Structurally identical to the `Signer` interface in `./blobs`; declared
+ * separately here so this module stays dependency-free.
+ */
+export type PrincipalSigner = {
+  readonly principal: Uint8Array
+  sign(data: Uint8Array): Promise<Uint8Array>
+}
+
+/** Either accepted signer shape. */
+export type AnySigner = HMSigner | PrincipalSigner
+
+function hasPrincipal(signer: AnySigner): signer is PrincipalSigner {
+  return 'principal' in signer
+}
+
+/** Normalize to the `getPublicKey()` shape. Cheap — no key material is touched. */
+export function toHMSigner(signer: AnySigner): HMSigner {
+  if (!hasPrincipal(signer)) return signer
+  const {principal} = signer
+  return {
+    getPublicKey: async () => principal,
+    sign: (data) => signer.sign(data),
+  }
+}
+
+/**
+ * Normalize to the synchronous-principal shape.
+ *
+ * Async because an {@link HMSigner} only reveals its public key through a
+ * promise; the result caches it so callers can read `.principal` directly.
+ */
+export async function toPrincipalSigner(signer: AnySigner): Promise<PrincipalSigner> {
+  if (hasPrincipal(signer)) return signer
+  const principal = await signer.getPublicKey()
+  return {
+    principal,
+    sign: (data) => signer.sign(data),
+  }
+}

--- a/frontend/packages/client/src/signing.ts
+++ b/frontend/packages/client/src/signing.ts
@@ -4,7 +4,8 @@
  */
 
 import {encode as cborEncode} from '@ipld/dag-cbor'
-import type {HMPublishBlobsInput, HMSigner} from './hm-types'
+import type {HMPublishBlobsInput} from './hm-types'
+import {type AnySigner, toHMSigner} from './signer'
 
 export const cborCodec = {
   code: 0x71 as const,
@@ -18,8 +19,18 @@ export function normalizeBytes(data: Uint8Array): Uint8Array<ArrayBuffer> {
   return normalized
 }
 
-export async function signObject(signer: HMSigner, data: unknown): Promise<Uint8Array> {
+export async function signObject(signer: AnySigner, data: unknown): Promise<Uint8Array> {
   return await signer.sign(cborEncode(data))
+}
+
+/**
+ * Read a signer's principal, accepting either signer shape.
+ *
+ * Lets the blob builders take an `AnySigner` without each one having to
+ * normalize first.
+ */
+export async function signerPublicKey(signer: AnySigner): Promise<Uint8Array> {
+  return toHMSigner(signer).getPublicKey()
 }
 
 export function toPublishInput(

--- a/frontend/packages/client/src/vault.ts
+++ b/frontend/packages/client/src/vault.ts
@@ -14,9 +14,9 @@
 import * as dagCBOR from '@ipld/dag-cbor'
 import {ed25519} from '@noble/curves/ed25519.js'
 import * as cborg from 'cborg'
-import {base58btc} from 'multiformats/bases/base58'
 import {CID} from 'multiformats/cid'
 import './base64'
+import {principalFromEd25519, principalToString as blobsPrincipalToString} from './blobs'
 import {decrypt} from './encryption'
 
 /** Current vault schema version. Bump on every incompatible schema change. */
@@ -38,24 +38,24 @@ const delegationExtraKey = Symbol('vault-delegation-extra')
 const capabilityExtraKey = Symbol('vault-capability-extra')
 const accountNamePattern = /^[A-Za-z0-9_-]+$/
 
-// Ed25519 multicodec prefix (varint-encoded 0xed = [0xed, 0x01]).
-const ED25519_MULTICODEC_PREFIX = new Uint8Array([0xed, 0x01])
-
 /** A principal: multicodec prefix + raw Ed25519 public key. */
 export type Principal = Uint8Array
 
-/** Build a Principal from a raw 32-byte Ed25519 public key. */
-export function principalFromPublicKey(publicKey: Uint8Array): Principal {
-  const principal = new Uint8Array(ED25519_MULTICODEC_PREFIX.length + publicKey.length)
-  principal.set(ED25519_MULTICODEC_PREFIX, 0)
-  principal.set(publicKey, ED25519_MULTICODEC_PREFIX.length)
-  return principal
-}
+/**
+ * Build a Principal from a raw 32-byte Ed25519 public key.
+ *
+ * @deprecated Use `principalFromEd25519` from `./blobs`, the single
+ * implementation. Kept as an alias so existing vault callers keep working.
+ */
+export const principalFromPublicKey: (publicKey: Uint8Array) => Principal = principalFromEd25519
 
-/** Encode a Principal to its base58btc multibase string (starts with 'z'). */
-export function principalToString(principal: Principal): string {
-  return base58btc.encode(principal)
-}
+/**
+ * Encode a Principal to its base58btc multibase string (starts with 'z').
+ *
+ * @deprecated Use `principalToString` from `./blobs`, the single
+ * implementation. Re-exported here so existing vault callers keep working.
+ */
+export const principalToString: (principal: Principal) => string = blobsPrincipalToString
 
 /** Derive the account ID (base58btc principal string) from a 32-byte Ed25519 seed. */
 export function accountIdFromSeed(seed: Uint8Array): string {


### PR DESCRIPTION
Follow-up to #963, taking items 1 and 3 from the API-surface cleanup. Item 2 (splitting `shared/utils/entity-id-url.ts`) needs more planning and is not here.

## 1. Two signer types on one public API

Two signer abstractions grew up independently in this package, and both ended up public — so which one you needed depended on which function you happened to call:

| Shape | Used by |
|---|---|
| `HMSigner` — `{getPublicKey()}` | `createComment`, `createContact`, `createChange`, `SeedClient` |
| `blobs.Signer` — `{principal}` | the `./blobs` primitives, `hmauth`, `auth` |

They are semantically identical and produce identical bytes, so nothing was broken. But every integrator hit the mismatch in the first ten minutes and had to hand-write an adapter — a vault `NobleKeyPair` could not be passed to `createComment`, and an `HMSigner` could not be passed to `blobs.createProfile`.

Adds a dependency-free `./signer` module (`AnySigner`, `toHMSigner`, `toPrincipalSigner`) and widens every public entry point to accept either shape, normalizing internally. **Purely additive** — neither existing shape changes, so all current callers keep working.

It has no runtime imports, so importing it never pulls crypto or schema code into a bundle.

Both directions now work against the packed tarball:

```js
const vaultKey = blobs.nobleKeyPairFromSeed(seed)     // {principal} shape
await createCapability({delegateUid, role: 'AGENT'}, vaultKey)   // ✅ was a type error
await createContact({subjectUid, name: 'Alice'}, vaultKey)       // ✅ was a type error
await blobs.createProfile(toHMSigner(vaultKey), {name: 'Bob'}, ts) // ✅ reverse direction
```

## 3. Duplicate implementations

- **`createCapability` existed twice.** `capability.ts` hand-rolled the same blob that `blobs.ts` already built, differing only cosmetically (`BigInt` vs `number` `ts`, raw `dag-cbor` vs the shared encoder). I verified those produce **byte-identical** DAG-CBOR before collapsing them, and `capability.ts` now wraps the primitive. A test pins the output against a reconstruction of the old implementation so the wire format cannot drift.
- **`vault.principalFromPublicKey` / `principalToString`** were a second copy of the `blobs` helpers. Now deprecated aliases pointing at the single implementation.

## Latent bug found while comparing them

`blobs.createCapability` spread `opts` straight onto the blob, so an explicitly-`undefined` `path`, `label`, or `audience` was encoded as CBOR **null** rather than omitted — while `capability.ts` omitted them. That divergence is exactly what a single implementation prevents. Now only keys that were actually set are carried over, with a regression test.

## Verification

- New `signer.test.ts` — 8 tests: normalization round-trips, no-op passthrough, byte-identical output from both shapes, wire-format pin against the old implementation, and the null-vs-omitted regression
- `client`: 239 pass (up from 231). The same 2 failures are pre-existing on `main` (`client.test.ts` Search enum, `vault-local.test.ts` well-known path) and untouched here
- Typecheck clean: client, shared, web, **cli**, vault, agents
- `vault`: 212 pass / 0 fail
- Packed with `pnpm pack`, installed clean: 87 exports, `signer` subpath resolves, cross-stack interop verified end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)