### PR TITLE
Agent page options menu with "Move to another server"

### DIFF
--- a/frontend/packages/ui/src/__tests__/move-agent.test.ts
+++ b/frontend/packages/ui/src/__tests__/move-agent.test.ts
@@ -1,0 +1,293 @@
+import {describe, expect, it} from 'vitest'
+
+import {moveAgentToServer, MoveAgentSourceDeleteError, type MoveAgentSend} from '../agents/move-agent'
+
+const SOURCE = 'https://source.example.com'
+const TARGET = 'https://target.example.com'
+const ACCOUNT = 'z6MkAccount'
+const AGENT_ID = 'agent-1'
+const NEW_AGENT_ID = 'agent-2'
+
+const baseDefinition = {
+  name: 'Mover',
+  systemPrompt: 'Be helpful.',
+  modelProvider: 'openai-main',
+  model: 'gpt-5-mini',
+  reasoningLevel: 'high' as const,
+  tools: ['seed_search'],
+  signingKey: 'secret-key-1',
+  signingKeys: ['secret-key-1'],
+  metadata: {createdFrom: 'test'},
+}
+
+type SentAction = {serverUrl: string; action: any}
+
+/**
+ * Fake transport backed by canned source-server state. Records every action so assertions can
+ * check exactly what was sent where, in order.
+ */
+function makeFakeSend(options?: {failAction?: string; failServerUrl?: string}): {
+  send: MoveAgentSend
+  calls: SentAction[]
+} {
+  const calls: SentAction[] = []
+  const send: MoveAgentSend = async ({serverUrl, action}) => {
+    calls.push({serverUrl, action})
+    if (options?.failAction === action._ && (!options.failServerUrl || options.failServerUrl === serverUrl)) {
+      throw new Error(`boom: ${action._}`)
+    }
+    switch (action._) {
+      case 'GetAgent':
+        return {
+          _: 'GetAgentResponse',
+          agent: {
+            id: AGENT_ID,
+            account: ACCOUNT,
+            definition: baseDefinition,
+            stateDir: '/tmp/x',
+            status: 'idle',
+            createdAt: 1,
+            updatedAt: 1,
+            accessRole: 'owner',
+          },
+          sessions: [],
+        } as any
+      case 'ListAgentMemory':
+        return {
+          _: 'ListAgentMemoryResponse',
+          agentId: AGENT_ID,
+          entries: [
+            {path: 'notes', type: 'dir', size: 0, updatedAt: 1},
+            {path: 'notes/todo.md', type: 'file', size: 5, updatedAt: 1},
+            {path: 'pic.bin', type: 'file', size: 3, updatedAt: 1},
+          ],
+          totalBytes: 8,
+        } as any
+      case 'ReadAgentMemoryFile':
+        if (action.path === 'notes/todo.md') {
+          return {
+            _: 'ReadAgentMemoryFileResponse',
+            agentId: AGENT_ID,
+            file: {path: action.path, size: 5, updatedAt: 1, encoding: 'utf8', content: 'hello'},
+          } as any
+        }
+        return {
+          _: 'ReadAgentMemoryFileResponse',
+          agentId: AGENT_ID,
+          file: {path: action.path, size: 3, updatedAt: 1, encoding: 'binary', data: new Uint8Array([1, 2, 3])},
+        } as any
+      case 'ListAgentTools':
+        return {
+          _: 'ListAgentToolsResponse',
+          agentId: AGENT_ID,
+          tools: [
+            {
+              name: 'seed_search',
+              kind: 'builtin',
+              summary: 'Search',
+              description: 'Search Seed',
+              input: {},
+              cid: 'cid-builtin',
+              enabled: true,
+              granted: true,
+              createdAt: 1,
+              updatedAt: 1,
+            },
+            {
+              name: 'my_lambda',
+              kind: 'lambda',
+              summary: 'Adds',
+              description: 'Adds numbers',
+              input: {type: 'object'},
+              output: {type: 'object'},
+              source: 'export default async () => ({})',
+              runtime: 'typescript',
+              cid: 'cid-lambda',
+              enabled: true,
+              granted: true,
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          ],
+        } as any
+      case 'ListAgentTriggers':
+        return {
+          _: 'ListAgentTriggersResponse',
+          triggers: [
+            {
+              id: 'trigger-1',
+              account: ACCOUNT,
+              agentId: AGENT_ID,
+              name: 'Hourly check',
+              enabled: true,
+              source: {type: 'schedule', schedule: {kind: 'interval', every: 1, unit: 'hours'}},
+              prompt: 'Check things.',
+              continuation: {kind: 'newThread'},
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          ],
+        } as any
+      case 'CreateAgent':
+        return {_: 'CreateAgentResponse', agentId: NEW_AGENT_ID} as any
+      case 'WriteAgentMemoryFile':
+        return {
+          _: 'WriteAgentMemoryFileResponse',
+          agentId: action.agentId,
+          entry: {path: action.path, type: 'file', size: 1, updatedAt: 2},
+        } as any
+      case 'SaveAgentTool':
+        return {_: 'SaveAgentToolResponse', agentId: action.agentId, tool: {}} as any
+      case 'CreateAgentTrigger':
+        return {_: 'CreateAgentTriggerResponse', trigger: {}} as any
+      case 'DeleteAgent':
+        return {_: 'DeleteAgentResponse', agentId: action.agentId} as any
+      default:
+        throw new Error(`Unexpected action: ${action._}`)
+    }
+  }
+  return {send, calls}
+}
+
+describe('moveAgentToServer', () => {
+  it('copies definition, memory, authored tools, and triggers, then deletes the original', async () => {
+    const {send, calls} = makeFakeSend()
+    const progress: string[] = []
+    const result = await moveAgentToServer({
+      accountUid: ACCOUNT,
+      agentId: AGENT_ID,
+      sourceServerUrl: SOURCE,
+      targetServerUrl: TARGET,
+      targetModelProvider: 'openai-main',
+      targetProviderType: 'openai',
+      onProgress: (update) => progress.push(update.label),
+      send,
+    })
+
+    expect(result).toEqual({newAgentId: NEW_AGENT_ID, copiedMemoryFiles: 2, copiedTools: 1, copiedTriggers: 1})
+
+    const create = calls.find((call) => call.action._ === 'CreateAgent')!
+    expect(create.serverUrl).toBe(TARGET)
+    // Signing keys are server-side secrets — they must not travel with the definition.
+    expect(create.action.definition.signingKey).toBeUndefined()
+    expect(create.action.definition.signingKeys).toBeUndefined()
+    expect(create.action.definition.name).toBe('Mover')
+    expect(create.action.definition.tools).toEqual(['seed_search'])
+    expect(create.action.definition.reasoningLevel).toBe('high')
+
+    const writes = calls.filter((call) => call.action._ === 'WriteAgentMemoryFile')
+    expect(writes.map((call) => call.action.path)).toEqual(['notes/todo.md', 'pic.bin'])
+    expect(writes.every((call) => call.serverUrl === TARGET && call.action.agentId === NEW_AGENT_ID)).toBe(true)
+    expect(writes[0]!.action.content).toBe('hello')
+    expect(writes[1]!.action.content).toEqual(new Uint8Array([1, 2, 3]))
+
+    const savedTools = calls.filter((call) => call.action._ === 'SaveAgentTool')
+    expect(savedTools).toHaveLength(1)
+    expect(savedTools[0]!.action.tool.name).toBe('my_lambda')
+    expect(savedTools[0]!.action.tool.source).toBe('export default async () => ({})')
+
+    const createdTriggers = calls.filter((call) => call.action._ === 'CreateAgentTrigger')
+    expect(createdTriggers).toHaveLength(1)
+    expect(createdTriggers[0]!.action.agentId).toBe(NEW_AGENT_ID)
+    expect(createdTriggers[0]!.action.trigger).toMatchObject({
+      name: 'Hourly check',
+      enabled: true,
+      prompt: 'Check things.',
+      continuation: {kind: 'newThread'},
+    })
+
+    // The original is deleted only from the source, and only at the very end.
+    const deletes = calls.filter((call) => call.action._ === 'DeleteAgent')
+    expect(deletes).toHaveLength(1)
+    expect(deletes[0]!.serverUrl).toBe(SOURCE)
+    expect(deletes[0]!.action.agentId).toBe(AGENT_ID)
+    expect(calls[calls.length - 1]!.action._).toBe('DeleteAgent')
+
+    expect(progress[0]).toBe('Reading the agent')
+    expect(progress[progress.length - 1]).toBe('Deleting the original agent')
+  })
+
+  it('remaps the model provider and drops a reasoning level the target provider cannot honor', async () => {
+    const {send, calls} = makeFakeSend()
+    await moveAgentToServer({
+      accountUid: ACCOUNT,
+      agentId: AGENT_ID,
+      sourceServerUrl: SOURCE,
+      targetServerUrl: TARGET,
+      targetModelProvider: 'groq-main',
+      targetProviderType: 'groq',
+      send,
+    })
+    const create = calls.find((call) => call.action._ === 'CreateAgent')!
+    expect(create.action.definition.modelProvider).toBe('groq-main')
+    expect(create.action.definition.reasoningLevel).toBeUndefined()
+  })
+
+  it('rolls back the target copy and keeps the source when copying fails', async () => {
+    const {send, calls} = makeFakeSend({failAction: 'WriteAgentMemoryFile'})
+    await expect(
+      moveAgentToServer({
+        accountUid: ACCOUNT,
+        agentId: AGENT_ID,
+        sourceServerUrl: SOURCE,
+        targetServerUrl: TARGET,
+        send,
+      }),
+    ).rejects.toThrow('boom: WriteAgentMemoryFile')
+
+    const deletes = calls.filter((call) => call.action._ === 'DeleteAgent')
+    expect(deletes).toHaveLength(1)
+    expect(deletes[0]!.serverUrl).toBe(TARGET)
+    expect(deletes[0]!.action.agentId).toBe(NEW_AGENT_ID)
+  })
+
+  it('reports a landed copy when only the source delete fails', async () => {
+    const {send} = makeFakeSend({failAction: 'DeleteAgent', failServerUrl: SOURCE})
+    const promise = moveAgentToServer({
+      accountUid: ACCOUNT,
+      agentId: AGENT_ID,
+      sourceServerUrl: SOURCE,
+      targetServerUrl: TARGET,
+      send,
+    })
+    await expect(promise).rejects.toBeInstanceOf(MoveAgentSourceDeleteError)
+    await promise.catch((error: MoveAgentSourceDeleteError) => {
+      expect(error.newAgentId).toBe(NEW_AGENT_ID)
+    })
+  })
+
+  it('refuses to move an agent onto the server it already lives on', async () => {
+    const {send, calls} = makeFakeSend()
+    await expect(
+      moveAgentToServer({
+        accountUid: ACCOUNT,
+        agentId: AGENT_ID,
+        sourceServerUrl: SOURCE,
+        targetServerUrl: `${SOURCE}/`,
+        send,
+      }),
+    ).rejects.toThrow('already lives on that server')
+    expect(calls).toHaveLength(0)
+  })
+
+  it('refuses to move an agent the account does not own', async () => {
+    const fake = makeFakeSend()
+    const send: MoveAgentSend = async (input) => {
+      if (input.action._ === 'GetAgent') {
+        const response = (await fake.send(input)) as any
+        return {...response, agent: {...response.agent, accessRole: 'writer'}}
+      }
+      return fake.send(input)
+    }
+    await expect(
+      moveAgentToServer({
+        accountUid: ACCOUNT,
+        agentId: AGENT_ID,
+        sourceServerUrl: SOURCE,
+        targetServerUrl: TARGET,
+        send,
+      }),
+    ).rejects.toThrow('Only the agent owner can move it')
+    expect(fake.calls.every((call) => call.action._ !== 'CreateAgent')).toBe(true)
+  })
+})

--- a/frontend/packages/ui/src/agents/detail.tsx
+++ b/frontend/packages/ui/src/agents/detail.tsx
@@ -68,7 +68,7 @@ import {SizableText} from '@shm/ui/text'
 import {Spinner} from '@shm/ui/spinner'
 import {toast} from '@shm/ui/toast'
 import {useAppDialog} from '@shm/ui/universal-dialog'
-import {ArrowRight, Info, KeyRound, Pencil, Plus, Trash2, X} from 'lucide-react'
+import {ArrowRight, ArrowRightLeft, Info, KeyRound, Pencil, Plus, Trash2, X} from 'lucide-react'
 import {HMIcon} from '@shm/ui/hm-icon'
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {getSeedTool} from '@seed-hypermedia/agents-protocol'
@@ -92,6 +92,7 @@ import {
   type AgentAccountRenameStatus,
 } from './dialogs'
 import {AgentHeader, AgentSubpageHeader, type AgentPageTab} from './header'
+import {MoveAgentDialog} from './move-agent-dialog'
 import {modelReasoningSupport, type ReasoningLevel} from '@seed-hypermedia/agents-protocol'
 import {ModelSelect} from './model-select'
 import {coerceReasoningLevel, ReasoningSelect} from './reasoning-select'
@@ -133,6 +134,7 @@ function AgentDetailPage({
   const updateAgent = useUpdateAgent(serverUrl, selectedAccountId)
   const updateSigningIdentity = useUpdateSigningIdentity(serverUrl, selectedAccountId)
   const deleteAgentDialog = useAppDialog(DeleteAgentDialog, {isAlert: true})
+  const moveAgentDialog = useAppDialog(MoveAgentDialog)
   const signingIdentities = useSigningIdentities(serverUrl, selectedAccountId, agentId)
   const createSigningIdentity = useCreateSigningIdentity(serverUrl, selectedAccountId)
   const createTriggerDialog = useAppDialog(CreateAgentTriggerDialog)
@@ -408,11 +410,50 @@ function AgentDetailPage({
                   canWrite ? () => createTriggerDialog.open({serverUrl, selectedAccountId, agentId}) : undefined
                 }
                 canCreateTrigger={!!selectedAccountId && canWrite}
+                menuItems={
+                  isOwner
+                    ? [
+                        {
+                          key: 'move-server',
+                          label: 'Move to another server…',
+                          icon: <ArrowRightLeft className="size-4" />,
+                          disabled: !selectedAccountId,
+                          onClick: () =>
+                            moveAgentDialog.open({
+                              sourceServerUrl: serverUrl,
+                              selectedAccountId,
+                              agentId,
+                              agentName: name,
+                              modelProvider: agent.data?.agent.definition.modelProvider ?? '',
+                              sessionsCount: topLevelSessions.length,
+                              onMoved: ({serverUrl: movedServerUrl, agentId: movedAgentId}) =>
+                                navigate({key: 'agent', agentId: movedAgentId, serverUrl: movedServerUrl}),
+                            }),
+                        },
+                        {
+                          key: 'delete-agent',
+                          label: 'Delete agent…',
+                          icon: <Trash2 className="size-4" />,
+                          variant: 'destructive' as const,
+                          disabled: !selectedAccountId,
+                          onClick: () =>
+                            deleteAgentDialog.open({
+                              serverUrl,
+                              selectedAccountId: selectedAccountId ?? null,
+                              agentId,
+                              agentName: name,
+                              onDeleted: () => navigate({key: 'agents'}),
+                            }),
+                        },
+                      ]
+                    : undefined
+                }
                 breadcrumbItems={breadcrumbItems}
               />
 
               {createTriggerDialog.content}
               {deleteAgentDialog.content}
+              {moveAgentDialog.content}
               {addProviderDialog.content}
               {editNameDialog.content}
 

--- a/frontend/packages/ui/src/agents/header.tsx
+++ b/frontend/packages/ui/src/agents/header.tsx
@@ -5,6 +5,7 @@ import type {NavRoute} from '@shm/shared/routes'
 import {useIsomorphicLayoutEffect} from '@shm/shared/utils/use-isomorphic-layout-effect'
 import {Button} from '@shm/ui/button'
 import {Badge} from '@shm/ui/components/badge'
+import {OptionsDropdown, type MenuItemType} from '@shm/ui/options-dropdown'
 import {PageTab} from '@shm/ui/page-tabs'
 import {ReasoningBadge} from './reasoning-select'
 import {SizableText} from '@shm/ui/text'
@@ -177,6 +178,7 @@ export function AgentHeader({
   creatingSession,
   onCreateTrigger,
   canCreateTrigger,
+  menuItems,
   breadcrumbItems,
 }: {
   agent?: AgentHeaderInfo
@@ -193,6 +195,8 @@ export function AgentHeader({
   creatingSession?: boolean
   onCreateTrigger?: () => void
   canCreateTrigger?: boolean
+  /** Rows for the top-right options menu; the menu renders only when at least one row is present. */
+  menuItems?: (MenuItemType | null)[]
   breadcrumbItems?: AgentBreadcrumbItem[]
 }) {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -312,6 +316,9 @@ export function AgentHeader({
               <Button className="max-sm:min-h-10" onClick={onCreateTrigger} disabled={!canCreateTrigger}>
                 <GitBranch className="mr-2 size-4" /> New trigger
               </Button>
+            ) : null}
+            {menuItems?.some((item) => item != null) ? (
+              <OptionsDropdown menuItems={menuItems} align="end" ariaLabel="Agent options" />
             ) : null}
           </div>
         </div>

--- a/frontend/packages/ui/src/agents/models.ts
+++ b/frontend/packages/ui/src/agents/models.ts
@@ -30,6 +30,7 @@ import {
   type SigningIdentityIcon,
 } from './client'
 import {isOptimisticUserEcho} from './agent-session-rows'
+import {moveAgentToServer, type MoveAgentOptions} from './move-agent'
 import {getAgentsPlatform} from './platform'
 import {getToolReferencedUrls} from '@seed-hypermedia/agents-protocol'
 import * as cbor from '@shm/shared/cbor'
@@ -1003,6 +1004,25 @@ export function useDeleteAgent(serverUrl: string | undefined, accountUid: string
       return sendAgentAction({serverUrl, accountUid, action: {_: 'DeleteAgent', agentId}})
     },
     onSuccess() {
+      invalidateQueries(['agents'])
+    },
+  })
+}
+
+/**
+ * Moves one agent to another configured agent server: copies its portable state (definition,
+ * memory, authored tools, triggers) to the target, then deletes the original. See
+ * {@link moveAgentToServer} for what moves and what each server keeps.
+ */
+export function useMoveAgent(accountUid: string | null | undefined) {
+  return useMutation({
+    mutationFn: async (input: Omit<MoveAgentOptions, 'accountUid' | 'send'>) => {
+      if (!accountUid) throw new Error('Select an account first')
+      return moveAgentToServer({...input, accountUid})
+    },
+    onSettled() {
+      // The copy may exist even when the mutation errored (e.g. the source delete failed), so
+      // refresh agent state on both servers regardless of outcome.
       invalidateQueries(['agents'])
     },
   })

--- a/frontend/packages/ui/src/agents/move-agent-dialog.tsx
+++ b/frontend/packages/ui/src/agents/move-agent-dialog.tsx
@@ -1,0 +1,211 @@
+import {
+  describeAgentServer,
+  prefetchAgentDetail,
+  useAgentServerHealth,
+  useAgentServerUrls,
+  useLocalAgentServerUrl,
+  useModelProviders,
+  useMoveAgent,
+} from './models'
+import {MoveAgentSourceDeleteError} from './move-agent'
+import {Button} from '@shm/ui/button'
+import {DialogDescription, DialogTitle} from '@shm/ui/components/dialog'
+import {SelectDropdown} from '@shm/ui/select-dropdown'
+import {Spinner} from '@shm/ui/spinner'
+import {SizableText} from '@shm/ui/text'
+import {toast} from '@shm/ui/toast'
+import {useAppDialog} from '@shm/ui/universal-dialog'
+import {ArrowRightLeft, Plus} from 'lucide-react'
+import {useEffect, useState} from 'react'
+import {AddModelProviderDialog} from './dialogs'
+import {ProviderSelect} from './provider-select'
+
+/**
+ * Moves an agent to another configured agent server. The dialog picks the destination, preflights
+ * what the destination can honor (reachability, a model provider for the agent), spells out what
+ * moves and what stays, and then runs the copy-then-delete orchestration with live progress.
+ */
+export function MoveAgentDialog({
+  input,
+  onClose,
+}: {
+  input: {
+    sourceServerUrl: string
+    selectedAccountId: string | null | undefined
+    agentId: string
+    agentName: string
+    /** Provider name the agent currently references, used to preflight the destination. */
+    modelProvider: string
+    /** Top-level session count, so the warning about deleted history is concrete. */
+    sessionsCount: number
+    onMoved: (moved: {serverUrl: string; agentId: string}) => void
+  }
+  onClose: () => void
+}) {
+  const serverUrls = useAgentServerUrls()
+  const localServerUrl = useLocalAgentServerUrl()
+  const targetUrls = (serverUrls.data || []).filter((url) => url !== input.sourceServerUrl)
+  const [targetServerUrl, setTargetServerUrl] = useState('')
+  const targetHealth = useAgentServerHealth(targetServerUrl || undefined)
+  const targetProviders = useModelProviders(targetServerUrl || undefined, input.selectedAccountId)
+  const [providerOverride, setProviderOverride] = useState('')
+  const addProviderDialog = useAppDialog(AddModelProviderDialog)
+  const moveAgent = useMoveAgent(input.selectedAccountId)
+  const [progress, setProgress] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!targetServerUrl && targetUrls.length) setTargetServerUrl(targetUrls[0]!)
+  }, [targetServerUrl, targetUrls])
+
+  // A provider choice belongs to one server; a stale override must not follow a server switch.
+  useEffect(() => {
+    setProviderOverride('')
+  }, [targetServerUrl])
+
+  const providerMatches = targetProviders.data?.some((provider) => provider.name === input.modelProvider) ?? false
+  const effectiveProvider = providerMatches ? input.modelProvider : providerOverride
+  const targetProviderType = targetProviders.data?.find((provider) => provider.name === effectiveProvider)?.type
+  const targetUnreachable = !!targetServerUrl && targetHealth.isError
+  const moving = moveAgent.isLoading
+
+  async function handleMove() {
+    if (!targetServerUrl) {
+      toast.error('Choose a destination server')
+      return
+    }
+    if (!effectiveProvider) {
+      toast.error('Choose a model provider on the destination server')
+      return
+    }
+    try {
+      const result = await moveAgent.mutateAsync({
+        agentId: input.agentId,
+        sourceServerUrl: input.sourceServerUrl,
+        targetServerUrl,
+        targetModelProvider: effectiveProvider,
+        targetProviderType,
+        onProgress: (update) => setProgress(update.label),
+      })
+      await prefetchAgentDetail(targetServerUrl, input.selectedAccountId, result.newAgentId).catch(() => {})
+      toast.success('Agent moved')
+      onClose()
+      input.onMoved({serverUrl: targetServerUrl, agentId: result.newAgentId})
+    } catch (error) {
+      if (error instanceof MoveAgentSourceDeleteError) {
+        // The copy landed; only the source cleanup failed. Follow the agent to its new home and
+        // tell the user the original is still on the old server.
+        toast.error(error.message)
+        onClose()
+        input.onMoved({serverUrl: targetServerUrl, agentId: error.newAgentId})
+        return
+      }
+      setProgress(null)
+      toast.error(error instanceof Error ? error.message : 'Could not move agent')
+    }
+  }
+
+  if (serverUrls.data && !targetUrls.length) {
+    return (
+      <div className="flex min-w-[420px] flex-col gap-4">
+        <DialogTitle>Move “{input.agentName}”</DialogTitle>
+        <DialogDescription>
+          This is the only agent server configured. Add another server from the Agents page, then move the agent there.
+        </DialogDescription>
+        <div className="flex justify-end">
+          <Button variant="ghost" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-w-[460px] flex-col gap-5">
+      <div className="flex flex-col gap-3">
+        <DialogTitle>Move “{input.agentName}” to another server</DialogTitle>
+        <DialogDescription>
+          The agent’s settings, system prompt, memory files, authored tools, and triggers move with it. Sessions and run
+          history cannot move and are deleted with the original
+          {input.sessionsCount ? ` (${input.sessionsCount} session${input.sessionsCount === 1 ? '' : 's'})` : ''}. Its
+          publishing accounts and collaborators stay on the current server.
+        </DialogDescription>
+      </div>
+
+      <label className="flex flex-col gap-1">
+        <SizableText size="sm" weight="bold">
+          Destination server
+        </SizableText>
+        <SelectDropdown
+          options={targetUrls.map((url) => ({value: url, label: describeAgentServer(url, localServerUrl.data)}))}
+          value={targetServerUrl}
+          onValue={setTargetServerUrl}
+          placeholder="Select a server"
+          disabled={moving}
+        />
+        {targetUnreachable ? (
+          <SizableText size="xs" className="text-destructive">
+            Can’t reach this server right now.
+          </SizableText>
+        ) : null}
+      </label>
+
+      {targetServerUrl && !targetUnreachable && targetProviders.data && !providerMatches ? (
+        <div className="flex flex-col gap-1">
+          <SizableText size="sm" weight="bold">
+            Model provider
+          </SizableText>
+          <SizableText size="xs" color="muted">
+            The destination server has no provider named “{input.modelProvider}”. Choose one for the agent to use there.
+          </SizableText>
+          {targetProviders.data.length ? (
+            <ProviderSelect
+              providers={targetProviders.data}
+              value={providerOverride}
+              onChange={setProviderOverride}
+              onAddProvider={() =>
+                addProviderDialog.open({serverUrl: targetServerUrl, selectedAccountId: input.selectedAccountId})
+              }
+              disabled={moving}
+            />
+          ) : (
+            <Button
+              variant="outline"
+              className="w-fit"
+              disabled={moving}
+              onClick={() =>
+                addProviderDialog.open({serverUrl: targetServerUrl, selectedAccountId: input.selectedAccountId})
+              }
+            >
+              <Plus className="size-4" />
+              Add a provider on this server
+            </Button>
+          )}
+        </div>
+      ) : null}
+
+      {moving && progress ? (
+        <div className="flex items-center gap-2">
+          <Spinner />
+          <SizableText size="sm" color="muted">
+            {progress}…
+          </SizableText>
+        </div>
+      ) : null}
+
+      <div className="flex justify-end gap-2">
+        <Button variant="ghost" onClick={onClose} disabled={moving}>
+          Cancel
+        </Button>
+        <Button
+          onClick={() => void handleMove()}
+          disabled={moving || !targetServerUrl || targetUnreachable || !effectiveProvider}
+        >
+          <ArrowRightLeft className="size-4" />
+          Move agent
+        </Button>
+      </div>
+      {addProviderDialog.content}
+    </div>
+  )
+}

--- a/frontend/packages/ui/src/agents/move-agent.ts
+++ b/frontend/packages/ui/src/agents/move-agent.ts
@@ -1,0 +1,208 @@
+import {
+  normalizeAgentServerUrl,
+  sendAgentAction,
+  type AgentDefinition,
+  type AgentToolInput,
+  type AgentTriggerInput,
+} from './client'
+import {modelReasoningSupport} from '@seed-hypermedia/agents-protocol'
+
+/**
+ * Client-orchestrated move of one agent between agent servers.
+ *
+ * Agent servers never talk to each other, but every signed action works against any server the
+ * account can reach — so the desktop app itself is the mover: it reads the agent's portable state
+ * from the source server, recreates it on the target server, and only after every copy succeeded
+ * deletes the original. A failure while copying rolls back the partial copy on the target and
+ * leaves the source agent untouched.
+ *
+ * What moves: the definition (name, prompt, model settings, tool grants, metadata), memory files,
+ * authored lambda tools, and triggers. What cannot move: sessions and run history (there is no
+ * import API for durable events), signing identities (private keys never leave their server), and
+ * account-level state each server keeps for itself (model provider keys, collaborators).
+ */
+
+export type MoveAgentProgress = {
+  /** Human-readable step, e.g. "Copying memory files (3/12)". */
+  label: string
+}
+
+/** Transport used for every signed action; injectable so tests can drive the orchestration. */
+export type MoveAgentSend = typeof sendAgentAction
+
+export type MoveAgentOptions = {
+  accountUid: string
+  agentId: string
+  sourceServerUrl: string
+  targetServerUrl: string
+  /**
+   * Provider name the moved agent should reference on the target server. Defaults to the source
+   * definition's provider name, which the target rejects if no provider of that name exists there.
+   */
+  targetModelProvider?: string
+  /**
+   * The target provider's type. When set, a reasoning level the target provider/model pair cannot
+   * honor is dropped instead of failing `CreateAgent` validation.
+   */
+  targetProviderType?: string
+  onProgress?: (progress: MoveAgentProgress) => void
+  send?: MoveAgentSend
+}
+
+export type MoveAgentResult = {
+  newAgentId: string
+  copiedMemoryFiles: number
+  copiedTools: number
+  copiedTriggers: number
+}
+
+/**
+ * The copy fully succeeded but the original could not be deleted: the agent now exists on both
+ * servers. Callers should still treat the move as landed (navigate to `newAgentId`) and tell the
+ * user the original remains on the source server.
+ */
+export class MoveAgentSourceDeleteError extends Error {
+  newAgentId: string
+
+  constructor(newAgentId: string, cause: unknown) {
+    const detail = cause instanceof Error ? cause.message : String(cause)
+    super(`Agent copied, but the original could not be deleted from the source server: ${detail}`)
+    this.name = 'MoveAgentSourceDeleteError'
+    this.newAgentId = newAgentId
+  }
+}
+
+export async function moveAgentToServer(options: MoveAgentOptions): Promise<MoveAgentResult> {
+  const send = options.send ?? sendAgentAction
+  const {accountUid, agentId} = options
+  const sourceServerUrl = normalizeAgentServerUrl(options.sourceServerUrl)
+  const targetServerUrl = normalizeAgentServerUrl(options.targetServerUrl)
+  if (sourceServerUrl === targetServerUrl) {
+    throw new Error('The agent already lives on that server')
+  }
+  const report = (label: string) => options.onProgress?.({label})
+
+  report('Reading the agent')
+  const agentRes = await send({serverUrl: sourceServerUrl, accountUid, action: {_: 'GetAgent', agentId}})
+  if (agentRes._ !== 'GetAgentResponse') throw new Error('Unexpected agent response')
+  if (agentRes.agent.accessRole && agentRes.agent.accessRole !== 'owner') {
+    throw new Error('Only the agent owner can move it')
+  }
+  const definition = agentRes.agent.definition
+
+  const memoryRes = await send({serverUrl: sourceServerUrl, accountUid, action: {_: 'ListAgentMemory', agentId}})
+  if (memoryRes._ !== 'ListAgentMemoryResponse') throw new Error('Unexpected memory list response')
+  const memoryFiles = memoryRes.entries.filter((entry) => entry.type === 'file')
+
+  const toolsRes = await send({serverUrl: sourceServerUrl, accountUid, action: {_: 'ListAgentTools', agentId}})
+  if (toolsRes._ !== 'ListAgentToolsResponse') throw new Error('Unexpected tool list response')
+  const authoredTools = toolsRes.tools.filter((tool) => tool.kind === 'lambda')
+
+  const triggersRes = await send({serverUrl: sourceServerUrl, accountUid, action: {_: 'ListAgentTriggers', agentId}})
+  if (triggersRes._ !== 'ListAgentTriggersResponse') throw new Error('Unexpected trigger list response')
+  const triggers = triggersRes.triggers
+
+  // Signing keys name secrets on the source server; they would fail validation on the target and
+  // the private keys behind them cannot move, so the copy starts without a publishing account.
+  const {signingKey: _signingKey, signingKeys: _signingKeys, ...portable} = definition
+  const targetDefinition: AgentDefinition = {...portable}
+  if (options.targetModelProvider) targetDefinition.modelProvider = options.targetModelProvider
+  if (targetDefinition.reasoningLevel && options.targetProviderType) {
+    const support = modelReasoningSupport(options.targetProviderType, targetDefinition.model)
+    if (!support || !support.levels.includes(targetDefinition.reasoningLevel)) {
+      delete targetDefinition.reasoningLevel
+    }
+  }
+
+  report('Creating the agent on the new server')
+  const createRes = await send({
+    serverUrl: targetServerUrl,
+    accountUid,
+    action: {_: 'CreateAgent', definition: targetDefinition, clientRequestId: crypto.randomUUID()},
+  })
+  if (createRes._ !== 'CreateAgentResponse') throw new Error('Unexpected create response')
+  const newAgentId = createRes.agentId
+
+  try {
+    for (let index = 0; index < memoryFiles.length; index++) {
+      const entry = memoryFiles[index]!
+      report(`Copying memory files (${index + 1}/${memoryFiles.length})`)
+      const fileRes = await send({
+        serverUrl: sourceServerUrl,
+        accountUid,
+        action: {_: 'ReadAgentMemoryFile', agentId, path: entry.path},
+      })
+      if (fileRes._ !== 'ReadAgentMemoryFileResponse') throw new Error('Unexpected memory read response')
+      const content = fileRes.file.encoding === 'utf8' ? fileRes.file.content ?? '' : fileRes.file.data
+      if (content === undefined) throw new Error(`Memory file has no content: ${entry.path}`)
+      await send({
+        serverUrl: targetServerUrl,
+        accountUid,
+        action: {_: 'WriteAgentMemoryFile', agentId: newAgentId, path: entry.path, content},
+      })
+    }
+
+    for (let index = 0; index < authoredTools.length; index++) {
+      const tool = authoredTools[index]!
+      report(`Copying authored tools (${index + 1}/${authoredTools.length})`)
+      if (!tool.source || !tool.runtime) throw new Error(`Authored tool is missing its source: ${tool.name}`)
+      const toolInput: AgentToolInput = {
+        name: tool.name,
+        ...(tool.summary ? {summary: tool.summary} : {}),
+        description: tool.description,
+        input: tool.input,
+        ...(tool.output ? {output: tool.output} : {}),
+        source: tool.source,
+        runtime: tool.runtime,
+      }
+      await send({
+        serverUrl: targetServerUrl,
+        accountUid,
+        action: {_: 'SaveAgentTool', agentId: newAgentId, tool: toolInput},
+      })
+    }
+
+    // Triggers copy last so none can fire on a half-copied agent.
+    for (let index = 0; index < triggers.length; index++) {
+      const trigger = triggers[index]!
+      report(`Copying triggers (${index + 1}/${triggers.length})`)
+      const triggerInput: AgentTriggerInput = {
+        name: trigger.name,
+        enabled: trigger.enabled,
+        source: trigger.source,
+        prompt: trigger.prompt,
+        ...(trigger.continuation ? {continuation: trigger.continuation} : {}),
+      }
+      await send({
+        serverUrl: targetServerUrl,
+        accountUid,
+        action: {
+          _: 'CreateAgentTrigger',
+          agentId: newAgentId,
+          trigger: triggerInput,
+          clientRequestId: crypto.randomUUID(),
+        },
+      })
+    }
+  } catch (error) {
+    report('Move failed — removing the partial copy')
+    await send({serverUrl: targetServerUrl, accountUid, action: {_: 'DeleteAgent', agentId: newAgentId}}).catch(
+      () => {},
+    )
+    throw error
+  }
+
+  report('Deleting the original agent')
+  try {
+    await send({serverUrl: sourceServerUrl, accountUid, action: {_: 'DeleteAgent', agentId}})
+  } catch (error) {
+    throw new MoveAgentSourceDeleteError(newAgentId, error)
+  }
+
+  return {
+    newAgentId,
+    copiedMemoryFiles: memoryFiles.length,
+    copiedTools: authoredTools.length,
+    copiedTriggers: triggers.length,
+  }
+}


### PR DESCRIPTION
## What

The agent detail page gets a top-right **options dropdown** (owner-only) with:

- **Move to another server…** — fully implemented, moves the agent to any other configured agent server
- **Delete agent…** — the existing delete flow, now also reachable from the header

Since the agents UI just moved to `@shm/ui` (#958), this lands in the shared package, so the same menu works on desktop and at `/hm/agents` on web.

## How moving works

Agent servers never talk to each other, but every signed action works against any server the account can reach — so the client is the mover (`packages/ui/src/agents/move-agent.ts`):

1. Read portable state from the source: definition, memory files, authored lambda tools, triggers.
2. Recreate on the target: `CreateAgent`, then `WriteAgentMemoryFile` / `SaveAgentTool` / `CreateAgentTrigger` (triggers last, so none fires on a half-copied agent).
3. Only after every copy succeeded, `DeleteAgent` on the source.

Failure handling:
- A failure mid-copy deletes the partial target copy and leaves the source untouched.
- If only the final source delete fails, a dedicated `MoveAgentSourceDeleteError` carries the new agent id — the UI still lands on the moved agent and tells the user the original remains.

Server-validation realities the move respects:
- **Signing keys are stripped** — the private keys behind them never leave their server, and the target rejects unknown secret names. The dialog says publishing accounts stay behind.
- **Provider remap** — the target validates `definition.modelProvider` exists there; the dialog preflights the destination's providers and offers a picker (or the add-provider flow) when the name is missing.
- **Reasoning coercion** — a reasoning level the target provider type can't honor is dropped so `CreateAgent` validation passes.

The dialog spells out what moves (settings, prompt, memory, authored tools, triggers) and what can't (sessions/run history — deleted with the original, with the concrete session count shown; publishing accounts; collaborators), checks destination reachability, and shows live per-step progress.

## Tests

6 new unit tests for the orchestration (`packages/ui/src/__tests__/move-agent.test.ts`) via an injected transport: exact action sequence and delete-last ordering, signing-key stripping, binary + utf8 memory round-trip, builtin-tool exclusion, provider remap + reasoning drop, mid-copy rollback, source-delete failure, same-server and non-owner refusal.

ui 320/320 (6 new), desktop 687/687, web 165/165, ui+desktop+web `tsc` clean, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)