### PR TITLE
feat(web): .md and .json exports for resource URLs

### DIFF
--- a/frontend/apps/web/app/entry.server.tsx
+++ b/frontend/apps/web/app/entry.server.tsx
@@ -30,6 +30,8 @@ import {createResourceMetadata, metadataToHeaders} from './hypermedia-metadata'
 import {getComment, resolveResource} from './loaders'
 import {logDebug} from './logger'
 import {ParsedRequest, parseRequest} from './request'
+import {extractCommentId, getHmIdOfRequest, parseResourceExportPath} from './resource-export-path'
+import {EXPOSED_HYPERMEDIA_HEADERS, handleResourceExportRequest} from './resource-export.server'
 import {getOrCreateServerSignerAccountUid} from './server-signing'
 import {applyConfigSubscriptions, getConfig} from './site-config.server'
 
@@ -111,52 +113,11 @@ initializeServer()
     console.error('Error initializing server', e)
   })
 
-const COMMENT_VIEW_TERMS = [':comments', ':comment', ':discussions']
-
-function extractCommentId(pathParts: string[]): string | null {
-  if (pathParts.length >= 3) {
-    const thirdToLast = pathParts[pathParts.length - 3]!
-    if (COMMENT_VIEW_TERMS.includes(thirdToLast)) {
-      return `${pathParts[pathParts.length - 2]}/${pathParts[pathParts.length - 1]}`
-    }
-  }
-  if (pathParts.length >= 2) {
-    const secondToLast = pathParts[pathParts.length - 2]!
-    if (COMMENT_VIEW_TERMS.includes(secondToLast)) {
-      return pathParts[pathParts.length - 1]!
-    }
-  }
-  return null
-}
-
-function stripInspectPrefix(pathParts: string[]): string[] {
-  if (pathParts[0] === 'hm' && pathParts[1] === 'inspect') {
-    return ['hm', ...pathParts.slice(2)]
-  }
-  if (pathParts[0] === 'inspect') {
-    return pathParts.slice(1)
-  }
-  return pathParts
-}
-
-function getHmIdOfRequest({pathParts, url}: ParsedRequest, originAccountId: string | undefined) {
-  const effectivePathParts = stripInspectPrefix(pathParts)
-  const version = url.searchParams.get('v')
-  const latest = url.searchParams.get('l') === '' || !version
-  if (effectivePathParts.length === 0) {
-    if (!originAccountId) return null
-    return hmId(originAccountId, {path: [], version, latest})
-  }
-  if (effectivePathParts[0] === 'hm') {
-    return hmId(effectivePathParts[1], {path: effectivePathParts.slice(2), version, latest})
-  }
-  if (!originAccountId) return null
-  return hmId(originAccountId, {path: effectivePathParts, version, latest})
-}
-
 async function handleOptionsRequest(request: Request) {
   const parsedRequest = parseRequest(request)
-  const {hostname, pathParts} = parsedRequest
+  const {hostname} = parsedRequest
+  // Preflights for .md/.json export URLs should resolve the same resource as their GET.
+  const pathParts = parseResourceExportPath(parsedRequest.pathParts)?.pathParts ?? parsedRequest.pathParts
   const serviceConfig = await getConfig(hostname)
   const originAccountId = serviceConfig?.registeredAccountUid
 
@@ -164,8 +125,7 @@ async function handleOptionsRequest(request: Request) {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, HEAD',
     'Access-Control-Allow-Headers': 'Content-Type',
-    'Access-Control-Expose-Headers':
-      'X-Hypermedia-Id, X-Hypermedia-Version, X-Hypermedia-Title, X-Hypermedia-Target, X-Hypermedia-Authors, X-Hypermedia-Type',
+    'Access-Control-Expose-Headers': EXPOSED_HYPERMEDIA_HEADERS,
   }
 
   try {
@@ -206,7 +166,7 @@ async function handleOptionsRequest(request: Request) {
     }
 
     // Document URL
-    const resourceId = getHmIdOfRequest(parsedRequest, originAccountId)
+    const resourceId = getHmIdOfRequest({...parsedRequest, pathParts}, originAccountId)
     if (resourceId) {
       const resource = await resolveResource(resourceId)
       if (resource.type === 'document') {
@@ -279,6 +239,14 @@ async function handleRequestWithAuth(
   }
   if (url.pathname.startsWith('/.well-known/')) {
     return new Response('Not Found', {status: 404})
+  }
+  if (request.method === 'GET' || request.method === 'HEAD') {
+    // Serve raw markdown/JSON for URLs with a .md/.json export extension, so
+    // agents and bots can consume content without parsing HTML.
+    const exportPath = parseResourceExportPath(pathParts)
+    if (exportPath) {
+      return await handleResourceExportRequest(parsedRequest, exportPath)
+    }
   }
   if (parsedRequest.pathParts.length > 1 && parsedRequest.pathParts.find((part) => part === '') == '') {
     // This block handles redirecting from trailing slash requests

--- a/frontend/apps/web/app/resource-export-path.test.ts
+++ b/frontend/apps/web/app/resource-export-path.test.ts
@@ -1,0 +1,114 @@
+import {describe, expect, it} from 'vitest'
+import {extractExportView, parseResourceExportPath} from './resource-export-path'
+
+describe('parseResourceExportPath', () => {
+  it('detects .md on the last segment', () => {
+    expect(parseResourceExportPath(['guides', 'publishing.md'])).toEqual({
+      format: 'markdown',
+      pathParts: ['guides', 'publishing'],
+    })
+  })
+
+  it('detects .json on the last segment', () => {
+    expect(parseResourceExportPath(['guides', 'publishing.json'])).toEqual({
+      format: 'json',
+      pathParts: ['guides', 'publishing'],
+    })
+  })
+
+  it('detects the extension on the document segment before a view term', () => {
+    expect(parseResourceExportPath(['guides', 'publishing.md', ':attributes'])).toEqual({
+      format: 'markdown',
+      pathParts: ['guides', 'publishing', ':attributes'],
+    })
+    expect(parseResourceExportPath(['guides', 'publishing.json', ':activity', 'citations'])).toEqual({
+      format: 'json',
+      pathParts: ['guides', 'publishing', ':activity', 'citations'],
+    })
+  })
+
+  it('detects the extension on a comment id after a view term', () => {
+    expect(parseResourceExportPath(['docs', ':comments', 'z6MkUid', 'abc123.md'])).toEqual({
+      format: 'markdown',
+      pathParts: ['docs', ':comments', 'z6MkUid', 'abc123'],
+    })
+  })
+
+  it('supports cross-account hm paths', () => {
+    expect(parseResourceExportPath(['hm', 'z6MkUid', 'some-doc.md'])).toEqual({
+      format: 'markdown',
+      pathParts: ['hm', 'z6MkUid', 'some-doc'],
+    })
+  })
+
+  it('supports the home document', () => {
+    expect(parseResourceExportPath(['.md'])).toEqual({format: 'markdown', pathParts: []})
+    expect(parseResourceExportPath(['.json', ':activity'])).toEqual({format: 'json', pathParts: [':activity']})
+  })
+
+  it('returns null when there is no export extension', () => {
+    expect(parseResourceExportPath(['guides', 'publishing'])).toBeNull()
+    expect(parseResourceExportPath([])).toBeNull()
+  })
+
+  it('ignores extensions on intermediate non-view segments', () => {
+    expect(parseResourceExportPath(['guides.md', 'publishing'])).toBeNull()
+  })
+
+  it('never intercepts reserved hm app routes', () => {
+    expect(parseResourceExportPath(['hm', 'api', 'file', 'notes.md'])).toBeNull()
+    expect(parseResourceExportPath(['hm', 'agents', 'session', 'plan.md'])).toBeNull()
+  })
+})
+
+describe('extractExportView', () => {
+  it('returns the document view for plain paths', () => {
+    expect(extractExportView(['guides', 'publishing'])).toEqual({
+      docPathParts: ['guides', 'publishing'],
+      view: {key: 'document'},
+    })
+  })
+
+  it('extracts the attributes view as metadata', () => {
+    expect(extractExportView(['guides', 'publishing', ':attributes'])).toEqual({
+      docPathParts: ['guides', 'publishing'],
+      view: {key: 'metadata'},
+    })
+  })
+
+  it('extracts the comments view', () => {
+    expect(extractExportView(['docs', ':comments'])).toEqual({
+      docPathParts: ['docs'],
+      view: {key: 'comments'},
+    })
+  })
+
+  it('extracts a UID/TSID comment id', () => {
+    expect(extractExportView(['docs', ':comments', 'z6MkUid', 'abc123'])).toEqual({
+      docPathParts: ['docs'],
+      view: {key: 'comments', commentId: 'z6MkUid/abc123'},
+    })
+  })
+
+  it('extracts the activity view with a filter', () => {
+    expect(extractExportView(['docs', ':activity', 'citations'])).toEqual({
+      docPathParts: ['docs'],
+      view: {key: 'activity', filterSlug: 'citations'},
+    })
+    expect(extractExportView(['docs', ':activity'])).toEqual({
+      docPathParts: ['docs'],
+      view: {key: 'activity'},
+    })
+  })
+
+  it('extracts simple view terms', () => {
+    expect(extractExportView(['docs', ':directory'])).toEqual({
+      docPathParts: ['docs'],
+      view: {key: 'directory'},
+    })
+    expect(extractExportView([':all-documents'])).toEqual({
+      docPathParts: [],
+      view: {key: 'all-documents'},
+    })
+  })
+})

--- a/frontend/apps/web/app/resource-export-path.ts
+++ b/frontend/apps/web/app/resource-export-path.ts
@@ -1,0 +1,160 @@
+/**
+ * URL path parsing for hypermedia requests, including the `.md` / `.json`
+ * export syntax. The export extension attaches to the document path segment,
+ * and view-term suffixes come after it:
+ *
+ *   /guides/publishing.md
+ *   /guides/publishing.md/:attributes
+ *   /guides/publishing.json/:activity/citations
+ *   /guides/publishing.md/:comments/z6Mk.../abc123
+ *
+ * These helpers are pure (no server imports) so they can be unit tested.
+ */
+import {hmId, VIEW_TERMS, viewTermToRouteKey, ViewRouteKey} from '@shm/shared'
+
+export const COMMENT_VIEW_TERMS = [':comments', ':comment', ':discussions']
+
+export function extractCommentId(pathParts: string[]): string | null {
+  if (pathParts.length >= 3) {
+    const thirdToLast = pathParts[pathParts.length - 3]!
+    if (COMMENT_VIEW_TERMS.includes(thirdToLast)) {
+      return `${pathParts[pathParts.length - 2]}/${pathParts[pathParts.length - 1]}`
+    }
+  }
+  if (pathParts.length >= 2) {
+    const secondToLast = pathParts[pathParts.length - 2]!
+    if (COMMENT_VIEW_TERMS.includes(secondToLast)) {
+      return pathParts[pathParts.length - 1]!
+    }
+  }
+  return null
+}
+
+export function stripInspectPrefix(pathParts: string[]): string[] {
+  if (pathParts[0] === 'hm' && pathParts[1] === 'inspect') {
+    return ['hm', ...pathParts.slice(2)]
+  }
+  if (pathParts[0] === 'inspect') {
+    return pathParts.slice(1)
+  }
+  return pathParts
+}
+
+export function getHmIdOfRequest(
+  {pathParts, url}: {pathParts: string[]; url: URL},
+  originAccountId: string | undefined,
+) {
+  const effectivePathParts = stripInspectPrefix(pathParts)
+  const version = url.searchParams.get('v')
+  const latest = url.searchParams.get('l') === '' || !version
+  if (effectivePathParts.length === 0) {
+    if (!originAccountId) return null
+    return hmId(originAccountId, {path: [], version, latest})
+  }
+  if (effectivePathParts[0] === 'hm') {
+    return hmId(effectivePathParts[1]!, {path: effectivePathParts.slice(2), version, latest})
+  }
+  if (!originAccountId) return null
+  return hmId(originAccountId, {path: effectivePathParts, version, latest})
+}
+
+export type ResourceExportFormat = 'markdown' | 'json'
+
+export type ResourceExportPath = {
+  format: ResourceExportFormat
+  /** The request path parts with the export extension stripped (view terms intact). */
+  pathParts: string[]
+}
+
+const FORMAT_EXTENSIONS: [string, ResourceExportFormat][] = [
+  ['.md', 'markdown'],
+  ['.json', 'json'],
+]
+
+/** App routes under /hm/ that must never be intercepted by export handling. */
+const RESERVED_HM_SUBROUTES = new Set([
+  'api',
+  'agents',
+  'auth',
+  'connect',
+  'create-site',
+  'download',
+  'embed',
+  'notifications',
+  'register',
+])
+
+/**
+ * Detect a `.md` / `.json` export extension in a URL path.
+ *
+ * The extension is recognized on the last path segment, or on an earlier
+ * segment when everything after it is a `:view-term` suffix (so both
+ * `publishing.md` and `publishing.md/:attributes` work, as well as
+ * `publishing/:comments/z6Mk.../abc.md`).
+ *
+ * Returns null when the path carries no export extension, or when it belongs
+ * to a reserved app route (e.g. /hm/api/... file downloads).
+ */
+export function parseResourceExportPath(pathParts: string[]): ResourceExportPath | null {
+  if (pathParts[0] === 'hm' && pathParts[1] && RESERVED_HM_SUBROUTES.has(pathParts[1])) {
+    return null
+  }
+  for (let i = 0; i < pathParts.length; i++) {
+    const part = pathParts[i]!
+    const isLast = i === pathParts.length - 1
+    if (!isLast && !pathParts[i + 1]!.startsWith(':')) continue
+    for (const [extension, format] of FORMAT_EXTENSIONS) {
+      if (!part.endsWith(extension)) continue
+      const stripped = part.slice(0, -extension.length)
+      return {
+        format,
+        pathParts: [...pathParts.slice(0, i), ...(stripped ? [stripped] : []), ...pathParts.slice(i + 1)],
+      }
+    }
+  }
+  return null
+}
+
+export type ResourceExportView =
+  | {key: 'document'}
+  | {key: 'comments'; commentId?: string}
+  | {key: 'activity'; filterSlug?: string}
+  | {key: Exclude<ViewRouteKey, 'comments' | 'activity'>}
+
+/**
+ * Split an export path into the document path and the requested view,
+ * mirroring the web page routing in routes/$.tsx.
+ */
+export function extractExportView(pathParts: string[]): {
+  docPathParts: string[]
+  view: ResourceExportView
+} {
+  if (pathParts.length >= 3 && COMMENT_VIEW_TERMS.includes(pathParts[pathParts.length - 3]!)) {
+    return {
+      docPathParts: pathParts.slice(0, -3),
+      view: {
+        key: 'comments',
+        commentId: `${pathParts[pathParts.length - 2]}/${pathParts[pathParts.length - 1]}`,
+      },
+    }
+  }
+  if (pathParts.length >= 2 && COMMENT_VIEW_TERMS.includes(pathParts[pathParts.length - 2]!)) {
+    return {
+      docPathParts: pathParts.slice(0, -2),
+      view: {key: 'comments', commentId: pathParts[pathParts.length - 1]!},
+    }
+  }
+  if (pathParts.length >= 2 && pathParts[pathParts.length - 2] === ':activity') {
+    return {
+      docPathParts: pathParts.slice(0, -2),
+      view: {key: 'activity', filterSlug: pathParts[pathParts.length - 1]!},
+    }
+  }
+  const lastPart = pathParts[pathParts.length - 1]
+  const viewTerm = VIEW_TERMS.find((term) => term === lastPart)
+  const viewKey = viewTerm ? viewTermToRouteKey(viewTerm) : null
+  if (viewKey) {
+    return {docPathParts: pathParts.slice(0, -1), view: {key: viewKey} as ResourceExportView}
+  }
+  return {docPathParts: pathParts, view: {key: 'document'}}
+}

--- a/frontend/apps/web/app/resource-export.server.ts
+++ b/frontend/apps/web/app/resource-export.server.ts
@@ -40,12 +40,7 @@ import {HMNotFoundError} from '@shm/shared/models/entity'
 import {createResourceMetadata, metadataToHeaders} from './hypermedia-metadata'
 import {getComment, resolveResource} from './loaders'
 import type {ParsedRequest} from './request'
-import {
-  extractExportView,
-  getHmIdOfRequest,
-  ResourceExportFormat,
-  ResourceExportPath,
-} from './resource-export-path'
+import {extractExportView, getHmIdOfRequest, ResourceExportFormat, ResourceExportPath} from './resource-export-path'
 import {serverUniversalClient} from './server-universal-client'
 import {getConfig} from './site-config.server'
 

--- a/frontend/apps/web/app/resource-export.server.ts
+++ b/frontend/apps/web/app/resource-export.server.ts
@@ -1,0 +1,339 @@
+/**
+ * Raw markdown / JSON export for web URLs, for agents, bots, and CLI tools.
+ *
+ * Any resource URL requested with a `.md` or `.json` extension on the document
+ * path segment is served as raw data instead of the React app:
+ *
+ *   GET /guides/publishing.md                    → document as markdown
+ *   GET /guides/publishing.json                  → document as JSON
+ *   GET /guides/publishing.md/:attributes        → document metadata (frontmatter only)
+ *   GET /guides/publishing.md/:comments          → all comments on the document
+ *   GET /guides/publishing.md/:comments/UID/TSID → one comment
+ *   GET /guides/publishing.json/:activity        → activity feed for the document
+ *   GET /guides/publishing.json/:activity/citations → citation events only
+ *   GET /guides/publishing.json/:collaborators   → collaborators
+ *   GET /guides/publishing.json/:directory       → child documents
+ *   GET /hm/UID/some-path.md                     → cross-account access
+ *
+ * Markdown rendering uses the shared resolved-markdown workflow from
+ * @seed-hypermedia/client (the same one used by the CLI and Agents service):
+ * YAML frontmatter with the document metadata, resolved mention names, inline
+ * embed content, and executed query blocks.
+ */
+import {
+  commentToResolvedMarkdown,
+  documentToResolvedMarkdown,
+  emitFrontmatter,
+  type ResolvedMarkdownOptions,
+} from '@seed-hypermedia/client'
+import type {HMComment, HMDocument, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {
+  activitySlugToFilter,
+  commentIdToHmId,
+  getCommentTargetId,
+  getDocumentTitle,
+  hmId,
+  hmIdPathToEntityQueryPath,
+  normalizeDate,
+} from '@shm/shared'
+import {HMNotFoundError} from '@shm/shared/models/entity'
+import {createResourceMetadata, metadataToHeaders} from './hypermedia-metadata'
+import {getComment, resolveResource} from './loaders'
+import type {ParsedRequest} from './request'
+import {
+  extractExportView,
+  getHmIdOfRequest,
+  ResourceExportFormat,
+  ResourceExportPath,
+} from './resource-export-path'
+import {serverUniversalClient} from './server-universal-client'
+import {getConfig} from './site-config.server'
+
+export {parseResourceExportPath} from './resource-export-path'
+
+export const EXPOSED_HYPERMEDIA_HEADERS =
+  'X-Hypermedia-Id, X-Hypermedia-Version, X-Hypermedia-Title, X-Hypermedia-Target, X-Hypermedia-Authors, X-Hypermedia-Type'
+
+// UniversalClient['request'] and SeedClient['request'] share the same HMRequest
+// signature, but the compiler sees two module instances of hm-types through the
+// @shm/shared and @seed-hypermedia/client resolution paths, so a cast bridges them.
+const RESOLVE_OPTIONS: ResolvedMarkdownOptions = {
+  client: {
+    request: serverUniversalClient.request as unknown as ResolvedMarkdownOptions['client']['request'],
+  },
+}
+
+function exportResponse(
+  format: ResourceExportFormat,
+  body: string,
+  opts?: {status?: number; headers?: Record<string, string>},
+): Response {
+  return new Response(body.endsWith('\n') ? body : body + '\n', {
+    status: opts?.status || 200,
+    headers: {
+      'Content-Type': format === 'json' ? 'application/json; charset=utf-8' : 'text/markdown; charset=utf-8',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Expose-Headers': EXPOSED_HYPERMEDIA_HEADERS,
+      'Cache-Control': 'public, max-age=60',
+      ...opts?.headers,
+    },
+  })
+}
+
+/** Plain JSON (not superjson-wrapped like the hm/api routes), so any HTTP client can consume it. */
+function exportJSON(value: unknown, opts?: {status?: number; headers?: Record<string, string>}): Response {
+  const body = JSON.stringify(value, (_k, v) => (typeof v === 'bigint' ? v.toString() : v), 2)
+  return exportResponse('json', body + '\n', opts)
+}
+
+function exportError(format: ResourceExportFormat, status: number, message: string): Response {
+  const headers = {'Cache-Control': 'no-store'}
+  if (format === 'json') {
+    return exportResponse('json', JSON.stringify({error: message}, null, 2) + '\n', {status, headers})
+  }
+  return exportResponse('markdown', message + '\n', {status, headers})
+}
+
+function formatTime(time: unknown): string {
+  const date = normalizeDate(time as Parameters<typeof normalizeDate>[0])
+  return date ? date.toISOString() : ''
+}
+
+export async function handleResourceExportRequest(
+  parsedRequest: ParsedRequest,
+  exportPath: ResourceExportPath,
+): Promise<Response> {
+  const {format} = exportPath
+  try {
+    const serviceConfig = await getConfig(parsedRequest.hostname)
+    const originAccountId = serviceConfig?.registeredAccountUid
+    const {docPathParts, view} = extractExportView(exportPath.pathParts)
+
+    if (view.key === 'comments' && view.commentId) {
+      const comment = await getComment(view.commentId)
+      if (!comment) return exportError(format, 404, 'Comment not found')
+      return await commentExportResponse(format, commentIdToHmId(view.commentId), comment)
+    }
+
+    const resourceId = getHmIdOfRequest({...parsedRequest, pathParts: docPathParts}, originAccountId)
+    if (!resourceId) {
+      return exportError(format, 404, 'Could not resolve this URL to a hypermedia resource')
+    }
+
+    switch (view.key) {
+      case 'document':
+        return await documentExportResponse(format, resourceId)
+      case 'metadata':
+        return await metadataExportResponse(format, resourceId)
+      case 'comments':
+        return await commentsExportResponse(format, resourceId)
+      case 'activity':
+        return await activityExportResponse(format, parsedRequest, resourceId, view.filterSlug)
+      case 'feed':
+        return await activityExportResponse(format, parsedRequest, null, undefined)
+      case 'collaborators':
+        return await collaboratorsExportResponse(format, resourceId)
+      case 'directory':
+        return await directoryExportResponse(format, resourceId, 'Children')
+      case 'all-documents':
+        return await directoryExportResponse(format, resourceId, 'AllDescendants')
+      default:
+        return exportError(format, 404, `The ${view.key} view does not support ${format} export`)
+    }
+  } catch (e) {
+    if (e instanceof HMNotFoundError) {
+      return exportError(format, 404, 'Not found')
+    }
+    console.error('Error handling resource export request:', e)
+    const message = e instanceof Error ? e.message : String(e)
+    return exportError(format, 500, `Failed to load resource: ${message}`)
+  }
+}
+
+async function documentExportResponse(format: ResourceExportFormat, resourceId: UnpackedHypermediaId) {
+  const resource = await resolveResource(resourceId)
+  if (resource.type === 'comment') {
+    return await commentExportResponse(format, resourceId, resource.comment)
+  }
+  if (resource.type !== 'document') {
+    return exportError(format, 404, `Resource type ${resource.type} cannot be exported`)
+  }
+  const headers = metadataToHeaders(createResourceMetadata({id: resourceId, document: resource.document}))
+  if (format === 'json') return exportJSON(resource, {headers})
+  const markdown = await documentToResolvedMarkdown(resource.document, RESOLVE_OPTIONS)
+  return exportResponse(format, markdown, {headers})
+}
+
+async function metadataExportResponse(format: ResourceExportFormat, resourceId: UnpackedHypermediaId) {
+  const resource = await resolveResource(resourceId)
+  if (resource.type !== 'document') {
+    return exportError(format, 404, `Resource type ${resource.type} has no attributes view`)
+  }
+  const document = resource.document
+  const headers = metadataToHeaders(createResourceMetadata({id: resourceId, document}))
+  if (format === 'json') {
+    return exportJSON(
+      {id: resourceId.id, version: document.version, authors: document.authors, metadata: document.metadata},
+      {headers},
+    )
+  }
+  return exportResponse(format, emitFrontmatter(document.metadata || {}), {headers})
+}
+
+async function commentExportResponse(
+  format: ResourceExportFormat,
+  commentId: UnpackedHypermediaId,
+  comment: HMComment,
+) {
+  const targetId = getCommentTargetId(comment)
+  let targetDocument: HMDocument | undefined
+  if (targetId) {
+    try {
+      const target = await resolveResource(targetId)
+      if (target.type === 'document') targetDocument = target.document
+    } catch (e) {}
+  }
+  let commentAuthorTitle: string | undefined
+  if (comment.author) {
+    try {
+      const author = await resolveResource(hmId(comment.author))
+      if (author.type === 'document' && author.document.metadata.name) {
+        commentAuthorTitle = author.document.metadata.name
+      }
+    } catch (e) {}
+  }
+  const metadata = createResourceMetadata({id: commentId, document: targetDocument, comment, commentAuthorTitle})
+  const headers = metadataToHeaders(metadata)
+  if (format === 'json') return exportJSON({type: 'comment', id: commentId, comment}, {headers})
+  const frontmatterLines = [
+    '---',
+    `title: ${JSON.stringify(metadata.title)}`,
+    `author: ${JSON.stringify(`hm://${comment.author}`)}`,
+    ...(metadata.target ? [`target: ${JSON.stringify(metadata.target)}`] : []),
+    `createTime: ${JSON.stringify(formatTime(comment.createTime))}`,
+    '---',
+    '',
+  ]
+  const markdown = await commentToResolvedMarkdown(comment, RESOLVE_OPTIONS)
+  return exportResponse(format, frontmatterLines.join('\n') + markdown, {headers})
+}
+
+async function commentsExportResponse(format: ResourceExportFormat, resourceId: UnpackedHypermediaId) {
+  const result = await serverUniversalClient.request('ListComments', {targetId: resourceId})
+  if (format === 'json') return exportJSON(result)
+  let title = resourceId.id
+  try {
+    const resource = await resolveResource(resourceId)
+    if (resource.type === 'document') title = getDocumentTitle(resource.document)
+  } catch (e) {}
+  const sections = [`# Comments on ${title}`]
+  for (const comment of result.comments) {
+    const authorName = result.authors[comment.author]?.metadata?.name || comment.author
+    const time = formatTime(comment.createTime)
+    const commentMarkdown = await commentToResolvedMarkdown(comment, RESOLVE_OPTIONS)
+    sections.push(`## ${authorName} — ${time} <!-- comment:${comment.id} -->\n\n${commentMarkdown}`)
+  }
+  return exportResponse(format, sections.join('\n\n') + '\n')
+}
+
+const ACTIVITY_FILTER_SLUGS = ['comments', 'versions', 'citations']
+const ACTIVITY_DEFAULT_PAGE_SIZE = 30
+
+async function activityExportResponse(
+  format: ResourceExportFormat,
+  parsedRequest: ParsedRequest,
+  resourceId: UnpackedHypermediaId | null,
+  filterSlug: string | undefined,
+) {
+  const filterEventType = filterSlug ? activitySlugToFilter(filterSlug) : undefined
+  if (filterSlug && !filterEventType) {
+    return exportError(
+      format,
+      404,
+      `Unknown activity filter "${filterSlug}" (expected one of: ${ACTIVITY_FILTER_SLUGS.join(', ')})`,
+    )
+  }
+  const pageSizeParam = Number(parsedRequest.url.searchParams.get('pageSize'))
+  const result = await serverUniversalClient.request('ListEvents', {
+    filterResource: resourceId ? resourceId.id : undefined,
+    filterEventType,
+    pageSize: Number.isFinite(pageSizeParam) && pageSizeParam > 0 ? pageSizeParam : ACTIVITY_DEFAULT_PAGE_SIZE,
+    pageToken: parsedRequest.url.searchParams.get('pageToken') || undefined,
+  })
+  if (format === 'json') return exportJSON(result)
+  const heading = filterSlug ? `# Activity (${filterSlug})` : resourceId ? '# Activity' : '# Feed'
+  const lines = [heading, '']
+  for (const event of result.events) {
+    lines.push(`- ${eventToMarkdown(event)}`)
+  }
+  if (result.nextPageToken) {
+    lines.push('', `<!-- nextPageToken: ${result.nextPageToken} -->`)
+  }
+  return exportResponse(format, lines.join('\n') + '\n')
+}
+
+/** Render one loaded activity event (see @shm/shared activity-service) as a markdown line. */
+function eventToMarkdown(event: Record<string, unknown>): string {
+  const author = event.author as {id?: UnpackedHypermediaId; metadata?: {name?: string}} | undefined
+  const authorName = author?.metadata?.name || author?.id?.uid || 'Unknown'
+  const time = formatTime(event.time)
+  const type = event.type as string
+  switch (type) {
+    case 'comment': {
+      const commentId = event.commentId as UnpackedHypermediaId | undefined
+      const target = event.target as {metadata?: {name?: string}} | undefined
+      const targetName = target?.metadata?.name
+      return `${time} — Comment by ${authorName}${targetName ? ` on ${targetName}` : ''}${
+        commentId ? ` (${commentId.id})` : ''
+      }`
+    }
+    case 'doc-update': {
+      const docId = event.docId as UnpackedHypermediaId | undefined
+      const docName = (event.document as {metadata?: {name?: string}} | undefined)?.metadata?.name
+      return `${time} — ${authorName} updated ${docName || docId?.id || 'a document'}${docId ? ` (${docId.id})` : ''}`
+    }
+    case 'capability':
+      return `${time} — ${authorName} granted a collaborator role`
+    case 'contact':
+      return `${time} — ${authorName} updated a contact`
+    case 'citation':
+      return `${time} — ${authorName} cited this document`
+    default:
+      return `${time} — ${type} event by ${authorName}`
+  }
+}
+
+async function collaboratorsExportResponse(format: ResourceExportFormat, resourceId: UnpackedHypermediaId) {
+  const result = await serverUniversalClient.request('ListDocumentCollaborators', {targetId: resourceId})
+  if (format === 'json') return exportJSON(result)
+  const lines = ['# Collaborators', '']
+  const seen = new Set<string>()
+  const addLine = (uid: string, role: string) => {
+    if (seen.has(uid)) return
+    seen.add(uid)
+    const name = result.accounts[uid]?.metadata?.name || uid
+    lines.push(`- ${name} (${role}) — hm://${uid}`)
+  }
+  if (result.publisherUid) addLine(result.publisherUid, 'owner')
+  for (const member of [...result.members, ...result.grantedMembers]) {
+    addLine(member.account.uid, member.role)
+  }
+  return exportResponse(format, lines.join('\n') + '\n')
+}
+
+async function directoryExportResponse(
+  format: ResourceExportFormat,
+  resourceId: UnpackedHypermediaId,
+  mode: 'Children' | 'AllDescendants',
+) {
+  const result = await serverUniversalClient.request('Query', {
+    includes: [{space: resourceId.uid, path: hmIdPathToEntityQueryPath(resourceId.path), mode}],
+  })
+  if (format === 'json') return exportJSON(result)
+  const lines = [mode === 'Children' ? '# Directory' : '# All Documents', '']
+  for (const doc of result?.results || []) {
+    const name = doc.metadata?.name || doc.id.path?.join('/') || doc.id.uid
+    lines.push(`- [${name}](${doc.id.id})`)
+  }
+  return exportResponse(format, lines.join('\n') + '\n')
+}


### PR DESCRIPTION
Supersedes #181 (rebuilt on current main — that branch was ~1,300 commits behind and used a bespoke markdown converter).

## Summary

Any web URL requested with a `.md` or `.json` extension on the document path segment returns raw markdown or JSON instead of the React app, so agents, bots, and CLI tools can consume Seed Hypermedia content without parsing HTML.

Markdown rendering now uses the **shared resolved-markdown workflow** from `@seed-hypermedia/client` (`documentToResolvedMarkdown` / `commentToResolvedMarkdown`) — the same code path as the CLI and Agents service — instead of the PR-specific converter. That workflow already covers everything requested in the #181 review:

- YAML frontmatter with the document metadata is **always** included (no `?frontmatter` param)
- Mention names are resolved (`@Eric Vicenti` instead of a bare link)
- Block embeds inline the target content, selected by `blockRef`/block range
- Query blocks execute and render as link lists
- Block IDs are preserved as round-trippable HTML comments

## Usage

```bash
# Document as markdown (frontmatter + resolved content)
curl https://hyper.media/guides/publishing.md

# Document as plain JSON (HMResource)
curl https://hyper.media/guides/publishing.json

# The old ?frontmatter is replaced by the :attributes view (metadata only)
curl https://hyper.media/guides/publishing.md/:attributes

# View routes work in both formats
curl https://hyper.media/guides/publishing.md/:comments
curl https://hyper.media/guides/publishing.md/:comments/z6Mk.../abc123
curl https://hyper.media/guides/publishing.json/:activity/citations?pageSize=10
curl https://hyper.media/guides/publishing.json/:collaborators
curl https://hyper.media/guides/publishing.json/:directory
curl https://hyper.media/guides/publishing.json/:all-documents

# Cross-account + version pinning still work
curl https://hyper.media/hm/z6Mk.../some-doc.md?v=bafy...
```

Activity accepts the same filter slugs as the web UI (`comments`, `versions`, `citations`) plus `pageSize`/`pageToken` params. All responses carry `X-Hypermedia-Id/-Version/-Title/-Type/-Authors` headers, `Access-Control-Allow-Origin: *`, and `Cache-Control: public, max-age=60`. OPTIONS preflights on export URLs resolve the same resource as their GET.

## Implementation

- `resource-export-path.ts` — pure path parsing (extension detection, view-term extraction, hm-id resolution helpers moved out of `entry.server.tsx`), unit tested
- `resource-export.server.ts` — the export handler; markdown resolution runs through `serverUniversalClient`, which shares the SSR request cache
- `entry.server.tsx` — intercepts GET/HEAD export URLs before Remix routing; reserved `/hm/api`, `/hm/agents` etc. routes are never intercepted (so file downloads named `*.md` keep working)

Views without an obvious data mapping (`:explore`, `:settings`, profile tabs) return a clear 404 for now.

## Testing

- 15 new unit tests for path parsing; full web suite passes (180 tests), `tsc` clean
- Smoke-tested against a live local daemon: document/subpath/version-pinned markdown, JSON resource, `:attributes`, `:comments` (list + single, with resolved mentions), `:activity` (+ `citations` filter and paging), `:collaborators`, `:directory`, OPTIONS preflight, and confirmed HTML pages and `/hm/api/*` routes are unaffected

Credit to @ion-kitty for the original implementation and direction in #181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)