### PR TITLE
Routable comment versions: ?v on comment permalinks pins the comment version

### DIFF
--- a/frontend/apps/desktop/src/components/search-input.tsx
+++ b/frontend/apps/desktop/src/components/search-input.tsx
@@ -475,7 +475,13 @@ function applyViewTermToRoute(
   }
   if (!routeKey) return route
   if (routeKey === 'comments' && commentId) {
-    return {key: 'comments', id: route.id, openComment: commentId}
+    // On comment permalinks, ?v pins the comment version, not the document version
+    return {
+      key: 'comments',
+      id: {...route.id, version: null, latest: true},
+      openComment: commentId,
+      openCommentVersion: route.id.version || undefined,
+    }
   }
   if (isSiteProfileTab(routeKey)) {
     return {key: 'site-profile', id: route.id, accountUid: accountUid || undefined, tab: routeKey}

--- a/frontend/apps/desktop/src/omnibar-url.ts
+++ b/frontend/apps/desktop/src/omnibar-url.ts
@@ -190,7 +190,13 @@ function applyResolvedViewTerm(
   if (!routeKey) return route
 
   if (routeKey === 'comments' && commentId) {
-    return {key: 'comments', id: route.id, openComment: commentId}
+    // On comment permalinks, ?v pins the comment version, not the document version
+    return {
+      key: 'comments',
+      id: {...route.id, version: null, latest: true},
+      openComment: commentId,
+      openCommentVersion: route.id.version || undefined,
+    }
   }
 
   if (isSiteProfileTab(routeKey)) {

--- a/frontend/apps/web/app/__tests__/comment-permalink-route.test.ts
+++ b/frontend/apps/web/app/__tests__/comment-permalink-route.test.ts
@@ -1,0 +1,161 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getConfig: vi.fn(),
+  loadSiteResource: vi.fn(),
+}))
+
+vi.mock('@/client-lazy', () => ({
+  WebCommenting: () => null,
+}))
+
+vi.mock('@/instrumentation.server', () => ({
+  createInstrumentationContext: () => ({enabled: false}),
+  instrument: (_ctx: unknown, _name: string, fn: () => unknown) => fn(),
+  printInstrumentationSummary: vi.fn(),
+  setRequestInstrumentationContext: vi.fn(),
+}))
+
+vi.mock('@/hypermedia-metadata', () => ({
+  createResourceMetadata: vi.fn(),
+  metadataToPageMeta: () => [],
+}))
+
+vi.mock('@/loaders', () => ({
+  GRPCError: class GRPCError extends Error {},
+  loadSiteHeaderData: vi.fn(),
+  loadSiteResource: mocks.loadSiteResource,
+  loadWebDraftPlaceholderResource: vi.fn(),
+}))
+
+vi.mock('@/site-settings-emails-content', () => ({
+  SiteSettingsEmailsScreen: () => null,
+}))
+
+vi.mock('@/meta', () => ({
+  defaultPageMeta: () => () => [],
+}))
+
+vi.mock('@/not-registered', () => ({
+  NoSitePage: () => null,
+  NotRegisteredPage: () => null,
+}))
+
+vi.mock('@/providers', () => ({
+  WebSiteProvider: ({children}: {children: unknown}) => children,
+}))
+
+vi.mock('@/site-config.server', () => ({
+  getConfig: mocks.getConfig,
+}))
+
+vi.mock('@/wrapping', () => ({
+  unwrap: <T>(value: T) => value,
+}))
+
+vi.mock('@/daemon-auth.server', () => ({
+  getDaemonAuthToken: async () => null,
+  withDaemonAuthToken: (_token: unknown, fn: () => unknown) => fn(),
+}))
+
+vi.mock('@/web-feed-page', () => ({
+  WebFeedPage: () => null,
+}))
+
+vi.mock('@/web-resource-page', () => ({
+  WebInspectorPage: () => null,
+  WebResourcePage: () => null,
+}))
+
+vi.mock('@/wrapping.server', () => ({
+  wrapJSON: (data: unknown, init?: unknown) => ({data, init}),
+}))
+
+vi.mock('@shm/shared/utils/navigation', () => ({
+  useNavigationState: () => null,
+}))
+
+vi.mock('@shm/ui/inspect-ipfs-page', () => ({
+  InspectIpfsPage: () => null,
+}))
+
+vi.mock('@shm/shared/translation', () => ({
+  useTx: () => (key: string, fallback?: string) => fallback || key,
+}))
+
+vi.mock('@shm/ui/spinner', () => ({
+  Spinner: () => null,
+}))
+
+vi.mock('@shm/ui/text', () => ({
+  SizableText: ({children}: {children: unknown}) => children,
+}))
+
+import {loader} from '../routes/$'
+
+describe('comment permalink route loading', () => {
+  beforeEach(() => {
+    mocks.getConfig.mockReset()
+    mocks.loadSiteResource.mockReset()
+    mocks.getConfig.mockResolvedValue({registeredAccountUid: 'site-account'})
+    mocks.loadSiteResource.mockResolvedValue({ok: true})
+  })
+
+  it('treats ?v on a comment permalink as the comment version, not the document version', async () => {
+    await loader({
+      params: {'*': 'hm/doc-account/docs/:comments/comment-author/comment-tsid'},
+      request: new Request(
+        'https://seed.example/hm/doc-account/docs/:comments/comment-author/comment-tsid?v=comment-version-cid',
+      ),
+    })
+
+    expect(mocks.loadSiteResource).toHaveBeenCalledTimes(1)
+    const [, documentId, extraData] = mocks.loadSiteResource.mock.calls[0]!
+
+    expect(documentId).toMatchObject({
+      uid: 'doc-account',
+      path: ['docs'],
+      version: null,
+      latest: true,
+    })
+    expect(extraData).toMatchObject({
+      viewTerm: 'comments',
+      openComment: 'comment-author/comment-tsid',
+      commentVersion: 'comment-version-cid',
+    })
+  })
+
+  it('keeps ?v on the document when the URL is not a comment permalink', async () => {
+    await loader({
+      params: {'*': 'hm/doc-account/docs'},
+      request: new Request('https://seed.example/hm/doc-account/docs?v=doc-version-cid'),
+    })
+
+    expect(mocks.loadSiteResource).toHaveBeenCalledTimes(1)
+    const [, documentId, extraData] = mocks.loadSiteResource.mock.calls[0]!
+
+    expect(documentId).toMatchObject({
+      uid: 'doc-account',
+      path: ['docs'],
+      version: 'doc-version-cid',
+      latest: false,
+    })
+    expect(extraData).toMatchObject({commentVersion: null})
+  })
+
+  it('loads a comment permalink without ?v with no comment version', async () => {
+    await loader({
+      params: {'*': 'hm/doc-account/docs/:comments/comment-author/comment-tsid'},
+      request: new Request('https://seed.example/hm/doc-account/docs/:comments/comment-author/comment-tsid'),
+    })
+
+    expect(mocks.loadSiteResource).toHaveBeenCalledTimes(1)
+    const [, documentId, extraData] = mocks.loadSiteResource.mock.calls[0]!
+
+    expect(documentId).toMatchObject({version: null, latest: true})
+    expect(extraData).toMatchObject({
+      openComment: 'comment-author/comment-tsid',
+      commentVersion: null,
+    })
+  })
+})

--- a/frontend/apps/web/app/loaders.ts
+++ b/frontend/apps/web/app/loaders.ts
@@ -35,6 +35,7 @@ import {
 } from '@shm/shared/models/entity'
 import {
   queryAccount,
+  queryCommentVersions,
   queryDirectory,
   queryDocumentCollaborators,
   queryQueryBlock,
@@ -717,6 +718,7 @@ export async function loadSiteResource<T extends Record<string, unknown> = Recor
     viewTerm?: string | null
     accountUid?: string | null
     openComment?: string | null
+    commentVersion?: string | null
   },
 ): Promise<WrappedResponse<SiteDocumentPayload & Omit<T, 'instrumentationCtx'>>> {
   const {hostname, origin} = parsedRequest
@@ -761,9 +763,12 @@ export async function loadSiteResource<T extends Record<string, unknown> = Recor
     let comment = resourceContent.comment
     let commentAuthorTitle: string | undefined
     const openCommentId = extraData?.openComment || undefined
+    const openCommentVersion = extraData?.commentVersion || undefined
     if (!comment && openCommentId) {
       try {
-        comment = (await getComment(openCommentId)) ?? undefined
+        // ?v on comment permalinks is the comment version CID. The comments
+        // API accepts either the stable comment id or a version CID.
+        comment = (await getComment(openCommentVersion || openCommentId)) ?? undefined
         if (comment?.author) {
           try {
             const authorResource = await resolveResource(hmId(comment.author))
@@ -779,6 +784,22 @@ export async function loadSiteResource<T extends Record<string, unknown> = Recor
     // doesn't enter the "discovering" state (web has no discovery service).
     const accountUid = extraData?.accountUid || undefined
     let mergedDehydratedState = resourceContent.dehydratedState
+    // When a comment permalink pins an old comment version, prefetch the edit
+    // history so the client renders that version without a flash of the
+    // current content.
+    if (openCommentId && openCommentVersion) {
+      try {
+        const versionsPrefetchCtx = createPrefetchContext()
+        await versionsPrefetchCtx.queryClient.prefetchQuery(queryCommentVersions(serverUniversalClient, openCommentId))
+        const versionsDehydrated = dehydratePrefetchContext(versionsPrefetchCtx)
+        mergedDehydratedState = mergedDehydratedState
+          ? {
+              mutations: [...mergedDehydratedState.mutations, ...versionsDehydrated.mutations],
+              queries: [...mergedDehydratedState.queries, ...versionsDehydrated.queries],
+            }
+          : versionsDehydrated
+      } catch (e) {}
+    }
     if (accountUid) {
       const profilePrefetchCtx = createPrefetchContext()
       const client = serverUniversalClient

--- a/frontend/apps/web/app/routes/$.tsx
+++ b/frontend/apps/web/app/routes/$.tsx
@@ -61,6 +61,7 @@ type ExtendedSitePayload = SiteDocumentPayload & {
   exploreSort?: 'relevance' | 'recently_updated' | 'newest' | 'oldest' | 'title' | null
   panelParam?: string | null // Supports extended format like "comments/BLOCKID" or "comments/COMMENT_ID"
   openComment?: string | null
+  commentVersion?: string | null
   accountUid?: string | null
   inspectTab?: InspectTab | null
 }
@@ -360,6 +361,10 @@ async function loadRoute({params, request}: {params: Params; request: Request}) 
   // Merge activity filter slug from path into panelParam for createDocumentNavRoute
   let effectivePanelParam = panelParam
   let openComment: string | null = null
+  // On comment permalink routes, ?v refers to the comment version CID, not
+  // the target document version. Keep it off the document lookup or the
+  // target document resolves as not found.
+  let isCommentPermalink = false
   let accountUid: string | null = null
 
   // Determine document type based on URL pattern
@@ -385,12 +390,13 @@ async function loadRoute({params, request}: {params: Params; request: Request}) 
     }
     if (extracted.commentId) {
       openComment = extracted.commentId
+      isCommentPermalink = true
     }
     accountUid = extracted.accountUid || null
     documentId = hmId(docUid, {
       path: extracted.path,
-      version,
-      latest,
+      version: isCommentPermalink ? null : version,
+      latest: isCommentPermalink ? true : latest,
     })
   } else {
     // Site document (regular path) or inspector document (/inspect/path...)
@@ -404,12 +410,13 @@ async function loadRoute({params, request}: {params: Params; request: Request}) 
     }
     if (extracted.commentId) {
       openComment = extracted.commentId
+      isCommentPermalink = true
     }
     accountUid = extracted.accountUid || null
     documentId = hmId(registeredAccountUid, {
       path: extracted.path,
-      version,
-      latest,
+      version: isCommentPermalink ? null : version,
+      latest: isCommentPermalink ? true : latest,
     })
   }
 
@@ -420,6 +427,7 @@ async function loadRoute({params, request}: {params: Params; request: Request}) 
     exploreSort,
     panelParam: effectivePanelParam,
     openComment,
+    commentVersion: isCommentPermalink ? version : null,
     accountUid,
     isInspect,
     inspectTab: isInspect ? getInspectTab(inspectTab) : null,
@@ -499,6 +507,7 @@ export default function UnifiedDocumentPage() {
     siteData.panelParam,
     siteData.openComment,
     siteData.accountUid,
+    siteData.commentVersion,
   )
   const initialRouteWithExploreParams =
     initialRoute.key === 'explore'

--- a/frontend/apps/web/app/routes/revalidation.ts
+++ b/frontend/apps/web/app/routes/revalidation.ts
@@ -12,6 +12,13 @@ export function shouldRevalidateDocumentRoute({
     return true
   }
 
+  // On comment permalinks (/:comments/UID/TSID), ?v pins the comment version.
+  // The client renders old comment versions from the edit-history query, so a
+  // version switch doesn't need fresh loader data.
+  if (/\/:(comments?|discussions)\//.test(decodeURIComponent(currentUrl.pathname))) {
+    return false
+  }
+
   const currentV = currentUrl.searchParams.get('v')
   const nextV = nextUrl.searchParams.get('v')
   const currentL = currentUrl.searchParams.get('l')

--- a/frontend/apps/web/app/routes/route-revalidation.test.ts
+++ b/frontend/apps/web/app/routes/route-revalidation.test.ts
@@ -28,6 +28,23 @@ describe('document route revalidation', () => {
     ).toBe(false)
   })
 
+  it('does not revalidate when only the comment version changes on a comment permalink', () => {
+    expect(
+      shouldRevalidateDocumentRoute({
+        currentUrl: url('/doc/:comments/author/tsid'),
+        nextUrl: url('/doc/:comments/author/tsid?v=comment-version-cid'),
+        defaultShouldRevalidate: true,
+      }),
+    ).toBe(false)
+    expect(
+      shouldRevalidateDocumentRoute({
+        currentUrl: url('/doc/:comments/author/tsid?v=comment-version-cid'),
+        nextUrl: url('/doc/:comments/author/tsid'),
+        defaultShouldRevalidate: true,
+      }),
+    ).toBe(false)
+  })
+
   it('revalidates when moving from an activity URL to a versioned document URL', () => {
     expect(
       shouldRevalidateDocumentRoute({

--- a/frontend/packages/shared/src/__tests__/routes.test.ts
+++ b/frontend/packages/shared/src/__tests__/routes.test.ts
@@ -949,3 +949,97 @@ describe('explore routes', () => {
     })
   })
 })
+
+describe('comment permalink version (?v pins the comment version)', () => {
+  test('commentsRouteSchema accepts openCommentVersion', () => {
+    const parsed = commentsRouteSchema.parse({
+      key: 'comments',
+      id: testDocId,
+      openComment: 'z6Mk/z6FC',
+      openCommentVersion: 'bafyCommentVersion',
+    })
+    expect(parsed.openCommentVersion).toBe('bafyCommentVersion')
+  })
+
+  test('createDocumentNavRoute puts openCommentVersion on the comments route', () => {
+    const route = createDocumentNavRoute(testDocId, 'comments', null, 'z6Mk/z6FC', null, 'bafyCommentVersion')
+    expect(route).toMatchObject({
+      key: 'comments',
+      openComment: 'z6Mk/z6FC',
+      openCommentVersion: 'bafyCommentVersion',
+    })
+  })
+
+  test('routeToHref serializes openCommentVersion as ?v', () => {
+    const href = routeToHref(
+      {key: 'comments', id: hmId('uid1'), openComment: 'z6Mk/z6FC', openCommentVersion: 'bafyCommentVersion'},
+      {originHomeId: hmId('uid1')},
+    )
+    expect(href).toBe('/:comments/z6Mk/z6FC?v=bafyCommentVersion')
+  })
+
+  test('routeToHref omits ?v when no openCommentVersion', () => {
+    const href = routeToHref(
+      {key: 'comments', id: hmId('uid1'), openComment: 'z6Mk/z6FC'},
+      {originHomeId: hmId('uid1')},
+    )
+    expect(href).toBe('/:comments/z6Mk/z6FC')
+  })
+
+  test('routeToUrl uses the comment version for ?v, not the document version', () => {
+    const url = routeToUrl(
+      {
+        key: 'comments',
+        id: hmId('uid1', {version: 'bafyDocVersion', latest: false}),
+        openComment: 'z6Mk/z6FC',
+        openCommentVersion: 'bafyCommentVersion',
+      },
+      {hostname: null, originHomeId: hmId('uid1')},
+    )
+    expect(url).toBe('/:comments/z6Mk/z6FC?v=bafyCommentVersion')
+  })
+
+  test('routeToUrl drops the document version on comment permalinks without a comment version', () => {
+    const url = routeToUrl(
+      {key: 'comments', id: hmId('uid1', {version: 'bafyDocVersion', latest: false}), openComment: 'z6Mk/z6FC'},
+      {hostname: null, originHomeId: hmId('uid1')},
+    )
+    expect(url).toBe('/:comments/z6Mk/z6FC')
+  })
+
+  test('hypermediaUrlToRoute treats ?v on a comment permalink as the comment version', () => {
+    const route = hypermediaUrlToRoute('https://example.com/hm/uid1/docs/:comments/z6Mk/z6FC?v=bafyCommentVersion')
+    expect(route).toMatchObject({
+      key: 'comments',
+      id: {uid: 'uid1', path: ['docs'], version: null, latest: true},
+      openComment: 'z6Mk/z6FC',
+      openCommentVersion: 'bafyCommentVersion',
+    })
+  })
+
+  test('hypermediaUrlToRoute keeps ?v on the document for non-permalink URLs', () => {
+    const route = hypermediaUrlToRoute('https://example.com/hm/uid1/docs/:comments?v=bafyDocVersion')
+    expect(route).toMatchObject({
+      key: 'comments',
+      id: {uid: 'uid1', path: ['docs'], version: 'bafyDocVersion'},
+    })
+    expect((route as any).openCommentVersion).toBeUndefined()
+  })
+
+  test('comment permalink with version round-trips through routeToHref and hypermediaUrlToRoute', () => {
+    const route: NavRoute = {
+      key: 'comments',
+      id: hmId('uid1', {path: ['docs'], version: null, latest: true}),
+      openComment: 'z6Mk/z6FC',
+      openCommentVersion: 'bafyCommentVersion',
+    }
+    const href = routeToHref(route, {originHomeId: hmId('home')})
+    expect(href).toBe('/hm/uid1/docs/:comments/z6Mk/z6FC?v=bafyCommentVersion')
+    const parsed = hypermediaUrlToRoute(`https://example.com${href}`)
+    expect(parsed).toMatchObject({
+      key: 'comments',
+      openComment: 'z6Mk/z6FC',
+      openCommentVersion: 'bafyCommentVersion',
+    })
+  })
+})

--- a/frontend/packages/shared/src/optimistic-comment.ts
+++ b/frontend/packages/shared/src/optimistic-comment.ts
@@ -188,6 +188,7 @@ export function navigateToComment(
     navigate({
       ...route,
       openComment: recordId,
+      openCommentVersion: undefined,
       targetBlockId: undefined,
       isReplying: undefined,
       replyCommentVersion: undefined,

--- a/frontend/packages/shared/src/routes.ts
+++ b/frontend/packages/shared/src/routes.ts
@@ -187,6 +187,8 @@ export const commentsRouteSchema = z.object({
   id: unpackedHmIdSchema,
   width: z.number().optional(),
   openComment: z.string().optional(),
+  /** Version CID of the opened comment to view (an old version from its edit history). */
+  openCommentVersion: z.string().optional(),
   targetBlockId: z.string().optional(),
   blockId: z.string().optional(),
   blockRange: BlockRangeSchema.nullable().optional(),
@@ -610,6 +612,7 @@ export function createDocumentNavRoute(
   panelParam?: string | null,
   openComment?: string | null,
   accountUid?: string | null,
+  openCommentVersion?: string | null,
 ): NavRoute {
   // Create properly typed panel route if panelParam provided.
   // Cast needed: each route schema has a narrow panel union (excluding itself),
@@ -644,7 +647,7 @@ export function createDocumentNavRoute(
       }
       // /:comments/UID/TSID → comments main with openComment
       if (openComment) {
-        return {key: 'comments', id: docId, openComment, panel}
+        return {key: 'comments', id: docId, openComment, openCommentVersion: openCommentVersion || undefined, panel}
       }
       // Preserve non-comments panel (e.g. activity, collaborators)
       return {key: 'comments', id: docId, panel}

--- a/frontend/packages/shared/src/routing.tsx
+++ b/frontend/packages/shared/src/routing.tsx
@@ -339,6 +339,10 @@ export function routeToHref(
       viewTerm += `/${route.openComment}`
     }
     let href = basePath ? `${basePath}/${viewTerm}` : `/${viewTerm}`
+    // On comment permalinks, ?v pins the comment version (not the document version)
+    if (route.key === 'comments' && route.openComment && route.openCommentVersion) {
+      href += `?v=${route.openCommentVersion}`
+    }
     // Append panel query param if present
     const panelParam = getRoutePanelParam(route)
     if (panelParam) {

--- a/frontend/packages/shared/src/utils/comment-navigation.ts
+++ b/frontend/packages/shared/src/utils/comment-navigation.ts
@@ -46,7 +46,13 @@ export function useCommentNavigation({
           },
         } as any)
       } else if (route.key === 'comments') {
-        replaceRoute({...route, openComment: replyComment.id, isReplying: true, ...replyVersionData} as any)
+        replaceRoute({
+          ...route,
+          openComment: replyComment.id,
+          openCommentVersion: undefined,
+          isReplying: true,
+          ...replyVersionData,
+        } as any)
       } else {
         replaceRoute({
           ...route,
@@ -84,6 +90,7 @@ export function useCommentNavigation({
         replaceRoute({
           ...route,
           openComment: replyComment.id,
+          openCommentVersion: undefined,
           isReplying: undefined,
           replyCommentVersion: undefined,
           rootReplyCommentVersion: undefined,

--- a/frontend/packages/shared/src/utils/entity-id-url.ts
+++ b/frontend/packages/shared/src/utils/entity-id-url.ts
@@ -622,13 +622,17 @@ export function routeToUrl(
         viewTermPath = `:activity/${filterSlug}`
       }
     }
-    // For comments with openComment, put commentId in view term path
+    // For comments with openComment, put commentId in view term path.
+    // On comment permalinks, ?v pins the comment version (not the document version).
+    let commentPermalinkVersion: {version: string | null; latest: null} | undefined
     if (route.key === 'comments' && route.openComment) {
       viewTermPath = `:comments/${route.openComment}`
+      commentPermalinkVersion = {version: route.openCommentVersion || null, latest: null}
     }
     const effectivePanelParam = route.key === 'all-documents' ? null : panelParam
     return createWebHMUrl(route.id.uid, {
       ...route.id,
+      ...commentPermalinkVersion,
       hostname: opts?.hostname,
       originHomeId: opts?.originHomeId,
       viewTerm: viewTermPath,
@@ -712,15 +716,20 @@ export function routeToHmUrl(route: NavRoute): string | null {
       const filterSlug = activityFilterToSlug(route.filterEventType)
       if (filterSlug) viewTermPath = `:activity/${filterSlug}`
     }
+    // On comment permalinks, ?v pins the comment version (not the document version).
+    let versionQuery: {version?: string | null; latest?: boolean | null} = {
+      version: route.id.version,
+      latest: route.id.latest,
+    }
     if (route.key === 'comments' && route.openComment) {
       viewTermPath = `:comments/${route.openComment}`
+      versionQuery = {version: route.openCommentVersion || null}
     }
 
     let url = packBaseId(route.id.uid, route.id.path)
     url += `/${viewTermPath}`
     url += getHMQueryString({
-      version: route.id.version,
-      latest: route.id.latest,
+      ...versionQuery,
       panel: panelParam,
     })
     if (route.id.blockRef) {

--- a/frontend/packages/shared/src/utils/url-to-route.ts
+++ b/frontend/packages/shared/src/utils/url-to-route.ts
@@ -44,8 +44,16 @@ export function hypermediaUrlToRoute(url: string): NavRoute | null {
     settingsTab,
   } = extractViewTermFromUrl(url)
   const routeKey = viewTermToRouteKey(viewTerm)
-  const id = unpackHmId(cleanUrl)
+  let id = unpackHmId(cleanUrl)
   if (!id) return null
+
+  // On comment permalink URLs (/:comments/UID/TSID?v=CID), ?v is the comment
+  // version, not the target document version — keep it off the document id.
+  let commentVersion: string | null = null
+  if (commentId && id.version) {
+    commentVersion = id.version
+    id = {...id, version: null, latest: true}
+  }
 
   const query = parseCustomURL(cleanUrl)?.query
   if (routeKey === 'explore') {
@@ -72,7 +80,7 @@ export function hypermediaUrlToRoute(url: string): NavRoute | null {
   }
 
   if (routeKey || panelParam || commentId || accountUid) {
-    const route = createDocumentNavRoute(id, routeKey, effectivePanelParam, commentId, accountUid)
+    const route = createDocumentNavRoute(id, routeKey, effectivePanelParam, commentId, accountUid, commentVersion)
     if (route.key === 'activity' && activityFilter) {
       return {
         ...route,

--- a/frontend/packages/ui/src/comments.tsx
+++ b/frontend/packages/ui/src/comments.tsx
@@ -626,6 +626,33 @@ export const Comment = memo(function Comment({
     }
   }, [defaultExpandReplies])
   const navigate = useNavigate('replace')
+
+  // When this comment is the focused permalink comment (/:comments/UID/TSID),
+  // the viewed version lives on the route (?v=) so it survives copy/paste and
+  // reload. Other comments keep the version preview as local state.
+  const isRouteControlledVersion = currentRoute.key === 'comments' && currentRoute.openComment === comment.id
+  const routeCommentVersion =
+    currentRoute.key === 'comments' && currentRoute.openComment === comment.id
+      ? currentRoute.openCommentVersion
+      : undefined
+  const routeVersionToView =
+    routeCommentVersion && routeCommentVersion !== comment.version ? routeCommentVersion : undefined
+  const commentVersions = useCommentVersions(routeVersionToView ? comment.id : null)
+  const routeViewingVersion = routeVersionToView
+    ? commentVersions.data?.versions?.find((version) => version.version === routeVersionToView) ?? null
+    : null
+  const activeViewingVersion = isRouteControlledVersion ? routeViewingVersion : viewingVersion
+  const selectViewingVersion = (version: HMComment | null) => {
+    if (currentRoute.key === 'comments' && currentRoute.openComment === comment.id) {
+      navigate({
+        ...currentRoute,
+        openCommentVersion: (version && version.version !== comment.version && version.version) || undefined,
+      })
+    } else {
+      setViewingVersion(version)
+    }
+  }
+
   const options: MenuItemType[] = []
   if (isAuthor) {
     options.push({
@@ -655,7 +682,7 @@ export const Comment = memo(function Comment({
                 onSuccess: () => {
                   if (!isFocusedComment) return
                   if (currentRoute.key === 'comments' && currentRoute.openComment) {
-                    navigate({...currentRoute, openComment: undefined})
+                    navigate({...currentRoute, openComment: undefined, openCommentVersion: undefined})
                   } else if ('panel' in currentRoute && routePanel?.key === 'comments' && routePanel.openComment) {
                     navigate({...currentRoute, panel: {...routePanel, openComment: undefined}} as NavRoute)
                   }
@@ -724,7 +751,7 @@ export const Comment = memo(function Comment({
                 ) : null}
                 <CommentDate comment={comment} />
                 {JSON.stringify(comment.createTime) !== JSON.stringify(comment.updateTime) ? (
-                  <EditedIndicator commentId={comment.id} onSelectVersion={setViewingVersion} />
+                  <EditedIndicator commentId={comment.id} onSelectVersion={selectViewingVersion} />
                 ) : null}
               </InlineDescriptor>
             )}
@@ -783,8 +810,8 @@ export const Comment = memo(function Comment({
               }}
               isSaving={updateCommentMutation.isPending}
             />
-          ) : viewingVersion ? (
-            <VersionPreview version={viewingVersion} onDismiss={() => setViewingVersion(null)} />
+          ) : activeViewingVersion ? (
+            <VersionPreview version={activeViewingVersion} onDismiss={() => selectViewingVersion(null)} />
           ) : (
             <CommentContent comment={comment} selection={selection} />
           )}
@@ -1016,8 +1043,8 @@ function EditedIndicator({
   )
 }
 
-/** Popover list of comment versions. Clicking a past version triggers onSelect. */
-function CommentVersionList({commentId, onSelect}: {commentId: string; onSelect: (version: HMComment) => void}) {
+/** Popover list of comment versions. Clicking a version triggers onSelect (null for the current version). */
+function CommentVersionList({commentId, onSelect}: {commentId: string; onSelect: (version: HMComment | null) => void}) {
   const {data, isLoading, error} = useCommentVersions(commentId)
 
   if (isLoading) {
@@ -1053,9 +1080,10 @@ function CommentVersionList({commentId, onSelect}: {commentId: string; onSelect:
           const isCurrent = index === 0
           if (isCurrent) {
             return (
-              <div
+              <button
                 key={version.version || index}
-                className="border-border flex w-full items-center justify-between border-b px-3 py-2 last:border-b-0"
+                className="hover:bg-accent border-border flex w-full items-center justify-between border-b px-3 py-2 text-left last:border-b-0"
+                onClick={() => onSelect(null)}
               >
                 <div className="flex items-center gap-2">
                   <SizableText size="xs">Version {versionNumber}</SizableText>
@@ -1066,7 +1094,7 @@ function CommentVersionList({commentId, onSelect}: {commentId: string; onSelect:
                 <SizableText size="xs" color="muted">
                   {version.updateTime ? formattedDateShort(version.updateTime) : ''}
                 </SizableText>
-              </div>
+              </button>
             )
           }
           return (


### PR DESCRIPTION
## Summary

Fixes #572. Supersedes #573 (thanks @ion-lion for the diagnosis and the original loader fix this builds on — that branch is 590+ commits behind main and only covered the web loader, so this re-applies its intent on current main and completes the flow end to end).

On `/:comments/<author>/<tsid>` permalinks, `?v=` is the **comment** version CID, not the target document version. Previously:

- web passed it as the document version, so the target document resolved as not found (#572)
- desktop's URL resolvers (`hypermediaUrlToRoute`, omnibar, search input) had the same misparse
- viewing an old comment version was purely local React state — no URL could express it

## What this does

**Route model** — `commentsRouteSchema` gains `openCommentVersion`; `createDocumentNavRoute` threads it through.

**URL round-trip** — `routeToHref`, `routeToUrl`, and `routeToHmUrl` serialize `?v=<commentVersion>` on comment permalinks (and stop leaking the document version there); `hypermediaUrlToRoute` and the desktop omnibar/search-input resolvers parse it back, keeping the document id at latest.

**Viewing versions** — when a comment is the route's focused permalink comment, the "(edited)" version dropdown navigates (replace) with `openCommentVersion` instead of local state: picking an old version updates `?v=` in the URL, and a copy-pasted URL restores that version on both web and desktop (rendered via the edit-history query in the existing version-preview banner). The current-version row in the dropdown is now clickable to return to the latest version. Non-focused comments (replies, panels) keep the local-state preview. Navigation that changes/clears `openComment` (reply nav, delete, optimistic comments) clears the stale version.

**Web loading** — the loader keeps `?v` off the document lookup on comment permalinks, loads the comment via `getComment(commentVersion || openCommentId)` for SSR metadata (the comments API accepts either the stable id or a version CID), prefetches the edit history so pasted URLs render the old version without flashing the current content, and skips loader revalidation for comment-version-only URL changes.

## Verification

- New regression tests: `apps/web/app/__tests__/comment-permalink-route.test.ts` (loader treats `?v` as comment version on permalinks, keeps it as document version elsewhere), 9 round-trip tests in `packages/shared/src/__tests__/routes.test.ts`, and revalidation cases in `route-revalidation.test.ts`
- Full suites pass: `@shm/shared` (1027), `@shm/ui` (320), `@shm/web` (187)
- Typechecks clean on shared, ui, web, and desktop

## Manual test

1. Open an edited comment's permalink on web, click "(edited)", pick an old version → URL gains `?v=<cid>`, yellow version banner shows that version
2. Copy that URL into a fresh tab → old version renders (no flash of current content)
3. Paste the same URL into the desktop launcher/omnibar → same result
4. Pick "current" in the dropdown or dismiss the banner → `?v=` is removed
5. The original #572 repro URL now loads its target document

🤖 Generated with [Claude Code](https://claude.com/claude-code)