### PR TITLE
fix(web): preserve view term, open comment, and panel across moved-document redirects

### DIFF
--- a/frontend/apps/web/app/loaders.ts
+++ b/frontend/apps/web/app/loaders.ts
@@ -13,7 +13,6 @@ import {
 } from '@seed-hypermedia/client/hm-types'
 import {
   commentIdToHmId,
-  createWebHMUrl,
   extractQueryBlocks,
   extractRefs,
   getBreadcrumbDocumentIds,
@@ -22,6 +21,7 @@ import {
   hmIdPathToEntityQueryPath,
   hypermediaUrlToHref,
   packHmId,
+  RedirectErrorDetails,
 } from '@shm/shared'
 import {DAEMON_FILE_URL, SITE_BASE_URL, WEB_SIGNING_ENABLED} from '@shm/shared/constants'
 import {prepareHMDocument} from '@shm/shared/document-utils'
@@ -47,6 +47,7 @@ import {instrument, InstrumentationContext} from './instrumentation.server'
 import {getOptimizedImageUrl} from './providers'
 import {createPrefetchContext, dehydratePrefetchContext, PrefetchContext} from './queries.server'
 import {ParsedRequest} from './request'
+import {createResourceRedirectUrl, RedirectRouteContext} from './resource-redirect'
 import {serverUniversalClient} from './server-universal-client'
 import {getConfig} from './site-config.server'
 import {createResourceMetadata, metadataToHeaders} from './hypermedia-metadata'
@@ -525,21 +526,15 @@ export async function loadResource(
 
   const resource = await instrument(ctx || noopCtx, `fetchResource(${packHmId(id)})`, () => fetchResource(id))
   if (resource.type === 'redirect') {
-    const destRedirectUrl = createWebHMUrl(resource.redirectTarget.uid, {
-      path: resource.redirectTarget.path,
-      version: resource.redirectTarget.version,
-      latest: resource.redirectTarget.latest,
-      blockRef: resource.redirectTarget.blockRef,
-      blockRange: resource.redirectTarget.blockRange,
-      originHomeId: options?.originHomeId,
-      hostname: null,
-    })
-    console.log('[web-loader] redirecting resource route', {
-      from: id,
-      to: resource.redirectTarget,
-      destRedirectUrl,
-    })
-    throw redirect(destRedirectUrl)
+    // The destination URL is built in loadSiteResource, which has the route
+    // context (view term, open comment, panel) that must survive the redirect.
+    throw new HMRedirectError(
+      new RedirectErrorDetails({
+        targetAccount: resource.redirectTarget.uid,
+        targetPath: hmIdPathToEntityQueryPath(resource.redirectTarget.path),
+        republish: resource.republish,
+      }),
+    )
   }
   if (resource.type === 'not-found') {
     throw new HMNotFoundError()
@@ -824,19 +819,20 @@ export async function loadSiteResource<T extends Record<string, unknown> = Recor
         {status: 404, headers: {'Cache-Control': 'no-store'}},
       )
     }
-    console.error('Error Loading Site Document', id, e)
     if (e instanceof HMRedirectError) {
-      const destRedirectUrl = createWebHMUrl(e.target.uid, {
-        path: e.target.path,
-        version: e.target.version,
-        latest: e.target.latest,
-        blockRef: e.target.blockRef,
-        blockRange: e.target.blockRange,
+      const destRedirectUrl = createResourceRedirectUrl(
+        e.target,
+        (extraData || {}) as RedirectRouteContext,
         originHomeId,
-        hostname: null,
+      )
+      console.log('[web-loader] redirecting resource route', {
+        from: id,
+        to: e.target,
+        destRedirectUrl,
       })
       return redirect(destRedirectUrl)
     }
+    console.error('Error Loading Site Document', id, e)
 
     let daemonError: GRPCError | undefined = undefined
     if (e instanceof ConnectError) {

--- a/frontend/apps/web/app/resource-redirect.test.ts
+++ b/frontend/apps/web/app/resource-redirect.test.ts
@@ -1,0 +1,46 @@
+import {hmId} from '@shm/shared'
+import {describe, expect, it} from 'vitest'
+import {createResourceRedirectUrl} from './resource-redirect'
+
+const SITE_UID = 'z6MkvSiteAccountUid'
+const originHomeId = hmId(SITE_UID)
+const target = hmId(SITE_UID, {path: ['notes', 'high-network-usage-in-activity-monitor']})
+
+describe('createResourceRedirectUrl', () => {
+  it('redirects a plain document URL to the new path', () => {
+    expect(createResourceRedirectUrl(target, {}, originHomeId)).toBe('/notes/high-network-usage-in-activity-monitor')
+  })
+
+  it('preserves an open comment deep link (/:comments/UID/TSID)', () => {
+    const openComment = 'z6MkwRWdU6HY11Qzi9SQZrwSx3rxFw94ipYyiN7Dtbrcg2yU/z6GeWHYXTLa49x'
+    expect(createResourceRedirectUrl(target, {viewTerm: 'comments', openComment}, originHomeId)).toBe(
+      `/notes/high-network-usage-in-activity-monitor/:comments/${openComment}`,
+    )
+  })
+
+  it('preserves plain view terms', () => {
+    expect(createResourceRedirectUrl(target, {viewTerm: 'directory'}, originHomeId)).toBe(
+      '/notes/high-network-usage-in-activity-monitor/:directory',
+    )
+  })
+
+  it('preserves an activity filter slug', () => {
+    expect(
+      createResourceRedirectUrl(target, {viewTerm: 'activity', panelParam: 'activity/versions'}, originHomeId),
+    ).toBe('/notes/high-network-usage-in-activity-monitor/:activity/versions')
+  })
+
+  it('preserves a panel query param on a document route', () => {
+    const url = createResourceRedirectUrl(target, {panelParam: 'comments'}, originHomeId)
+    const parsed = new URL(url, 'http://example.com')
+    expect(parsed.pathname).toBe('/notes/high-network-usage-in-activity-monitor')
+    expect(parsed.searchParams.get('panel')).toBe('comments')
+  })
+
+  it('uses the /hm/UID prefix when the target is not the origin home account', () => {
+    const otherTarget = hmId('z6MkvOtherAccountUid', {path: ['docs']})
+    expect(createResourceRedirectUrl(otherTarget, {viewTerm: 'comments', openComment: 'a/b'}, originHomeId)).toBe(
+      '/hm/z6MkvOtherAccountUid/docs/:comments/a/b',
+    )
+  })
+})

--- a/frontend/apps/web/app/resource-redirect.ts
+++ b/frontend/apps/web/app/resource-redirect.ts
@@ -1,0 +1,32 @@
+import {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {createDocumentNavRoute, createWebHMUrl, routeToUrl, ViewRouteKey} from '@shm/shared'
+
+export type RedirectRouteContext = {
+  viewTerm?: ViewRouteKey | null
+  panelParam?: string | null
+  openComment?: string | null
+  accountUid?: string | null
+}
+
+/**
+ * Builds the destination URL for a moved/redirected resource. The request's
+ * route context (view term, open comment, panel) is rebuilt on the redirect
+ * target so deep links survive document moves.
+ */
+export function createResourceRedirectUrl(
+  target: UnpackedHypermediaId,
+  routeContext: RedirectRouteContext,
+  originHomeId?: UnpackedHypermediaId,
+): string {
+  const route = createDocumentNavRoute(
+    target,
+    routeContext.viewTerm,
+    routeContext.panelParam,
+    routeContext.openComment,
+    routeContext.accountUid,
+  )
+  return (
+    routeToUrl(route, {hostname: null, originHomeId}) ??
+    createWebHMUrl(target.uid, {path: target.path, originHomeId, hostname: null})
+  )
+}


### PR DESCRIPTION
## Problem

Visiting an old URL of a moved document with a deep-link suffix drops the suffix on redirect. Repro on prod:

```
GET /discussions/high-network-usage-in-activity-monitor/:comments/z6MkwRWdU6HY11Qzi9SQZrwSx3rxFw94ipYyiN7Dtbrcg2yU/z6GeWHYXTLa49x
302 → /notes/high-network-usage-in-activity-monitor        (comment link lost)
```

Expected: `302 → /notes/high-network-usage-in-activity-monitor/:comments/z6MkwRWdU6HY.../z6GeWHYXTLa49x`

## Cause

When the daemon reports a moved document, the web loader built the redirect URL from only the target uid/path (`createWebHMUrl`) — in two separate places in `loaders.ts` — while the `:comments/...` view-term suffix and `?panel` param had already been stripped into route context back in `$.tsx` and never reached the redirect construction.

## Fix

Mirror the client-side redirect handling (which preserves the route shape via `replaceRouteDocumentId`):

- `loadResource` now throws a typed `HMRedirectError` instead of building a URL, joining its siblings (`HMNotFoundError`, etc.).
- `loadSiteResource`'s existing `HMRedirectError` handler becomes the single redirect builder. It already receives the route context (`viewTerm`, `openComment`, `panelParam`, `accountUid`) via `extraData`, and rebuilds the same nav route on the new document id using the canonical `createDocumentNavRoute` + `routeToUrl` serializers from `@shm/shared` — so `:comments/UID/TSID`, `:activity/<filter>`, `:directory`, profile tabs, and `?panel=` all round-trip. No new URL-building logic.
- The construction lives in a small pure module, `app/resource-redirect.ts`, unit-testable without `loaders.ts`'s server-only import graph.

## Testing

- New regression test `app/resource-redirect.test.ts` covering the exact repro plus plain view terms, activity filter slugs, panel params, and the `/hm/UID` gateway prefix.
- Full web suite green (32 files, 186 passed / 1 skipped); web + shared + agents typechecks and whole-repo `format:check` pass.

Pre-existing quirk left unchanged: redirects for `/inspect/...` URLs still lose the inspect prefix (`createDocumentNavRoute` has no inspect route) — same behavior as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)