### PR TITLE
Slot block for root level mixed grouping

### DIFF
--- a/frontend/packages/client/src/blocks-to-markdown-slot.test.ts
+++ b/frontend/packages/client/src/blocks-to-markdown-slot.test.ts
@@ -1,0 +1,39 @@
+import {describe, expect, it} from 'vitest'
+import {blocksToMarkdown} from './blocks-to-markdown'
+
+// A root-level Slot wrapping a list of paragraph items.
+function slotDoc(childrenType: string, items: string[]) {
+  return {
+    metadata: {},
+    content: [
+      {
+        block: {type: 'Slot', id: 'slot1', attributes: {childrenType}, text: '', annotations: []},
+        children: items.map((text, i) => ({
+          block: {type: 'Paragraph', id: `item${i}`, text, annotations: []},
+          children: [],
+        })),
+      },
+    ],
+  } as any
+}
+
+describe('blocksToMarkdown Slot export', () => {
+  it('emits a root Unordered Slot as markdown bullet items', () => {
+    const md = blocksToMarkdown(slotDoc('Unordered', ['one', 'two']))
+    expect(md).toContain('- one')
+    expect(md).toContain('- two')
+    // The invisible Slot itself must not leak any visible text.
+    expect(md).not.toContain('Slot')
+  })
+
+  it('emits a root Ordered Slot as markdown numbered items', () => {
+    const md = blocksToMarkdown(slotDoc('Ordered', ['a', 'b']))
+    expect(md).toContain('1. a')
+    expect(md).toContain('1. b')
+  })
+
+  it('emits a root Blockquote Slot as markdown blockquote items', () => {
+    const md = blocksToMarkdown(slotDoc('Blockquote', ['quoted']))
+    expect(md).toContain('> quoted')
+  })
+})

--- a/frontend/packages/client/src/blocks-to-markdown.ts
+++ b/frontend/packages/client/src/blocks-to-markdown.ts
@@ -15,16 +15,16 @@
  */
 
 import type {SeedClient} from './client'
-import {unpackHmId} from './hm-types'
 import type {
-  HMBlockNode,
-  HMBlock,
   HMAnnotation,
+  HMBlock,
+  HMBlockNode,
   HMComment,
   HMDocument,
   HMMetadata,
   UnpackedHypermediaId,
 } from './hm-types'
+import {unpackHmId} from './hm-types'
 
 // ─── Options ─────────────────────────────────────────────────────────────────
 
@@ -166,9 +166,10 @@ function blockNodeToMarkdown(node: HMBlockNode, depth: number, opts: Required<Bl
 
   const childrenType = (block as {attributes?: {childrenType?: string}}).attributes?.childrenType
 
-  // Check if this is an invisible list container (empty paragraph with childrenType)
+  // Check if this is an invisible list container: an empty paragraph, or a
+  // Slot block.
   const isListContainer =
-    block.type === 'Paragraph' &&
+    (block.type === 'Paragraph' || block.type === 'Slot') &&
     !block.text &&
     (childrenType === 'Ordered' || childrenType === 'Unordered' || childrenType === 'Blockquote')
 

--- a/frontend/packages/client/src/comment.ts
+++ b/frontend/packages/client/src/comment.ts
@@ -264,6 +264,14 @@ function blockToPublishable(blockNode: HMBlockNode): HMPublishableBlock | null {
       children: blocksToPublishable(blockNode.children || []),
     }
   }
+  if (block.type === 'Slot') {
+    return {
+      id: block.id,
+      type: 'Slot',
+      ...block.attributes,
+      children: blocksToPublishable(blockNode.children || []),
+    }
+  }
   throw new Error(`Unsupported block type: ${block.type}`)
 }
 

--- a/frontend/packages/client/src/editor-types.ts
+++ b/frontend/packages/client/src/editor-types.ts
@@ -32,7 +32,6 @@ export interface EditorBlockProps {
   // textAlignment?: 'left' | 'center' | 'right'
   childrenType?: HMBlockChildrenType
   columnCount?: string
-  listLevel?: string
   level?: number | string
   ref?: string
   revision?: string

--- a/frontend/packages/client/src/editor-types.ts
+++ b/frontend/packages/client/src/editor-types.ts
@@ -16,6 +16,7 @@ export type EditorBlock =
   | EditorTableBlock
   | EditorTableRowBlock
   | EditorTableColumnBlock
+  | EditorSlotBlock
   | EditorUnknownBlock
 export type HMInlineContent = EditorText | EditorInlineEmbed | EditorLink
 
@@ -180,6 +181,11 @@ export interface EditorTableColumnBlock extends EditorBaseBlock {
     isHeader?: boolean
   }
   content: Array<HMInlineContent> // always empty
+}
+
+export interface EditorSlotBlock extends EditorBaseBlock {
+  type: 'slot'
+  content: Array<HMInlineContent>
 }
 
 export type EditorUnknownBlock = EditorBaseBlock & {

--- a/frontend/packages/client/src/editorblock-to-hmblock.ts
+++ b/frontend/packages/client/src/editorblock-to-hmblock.ts
@@ -25,6 +25,7 @@ function toHMBlockType(editorBlockType: EditorBlock['type']): HMBlockType | unde
   if (editorBlockType === 'table') return 'Table'
   if (editorBlockType === 'tableRow') return 'TableRow'
   if (editorBlockType === 'tableColumn') return 'TableColumn'
+  if (editorBlockType === 'slot') return 'Slot'
   return undefined
 }
 

--- a/frontend/packages/client/src/hm-types.ts
+++ b/frontend/packages/client/src/hm-types.ts
@@ -508,6 +508,14 @@ export type HMPublishableBlockWebEmbed = {
   children?: HMPublishableBlock[]
 }
 
+export type HMPublishableBlockSlot = {
+  id: string
+  type: 'Slot'
+  childrenType?: HMBlockChildrenType
+  columnCount?: number
+  children?: HMPublishableBlock[]
+}
+
 export type HMPublishableBlock =
   | HMPublishableBlockParagraph
   | HMPublishableBlockHeading
@@ -519,6 +527,7 @@ export type HMPublishableBlock =
   | HMPublishableBlockButton
   | HMPublishableBlockEmbed
   | HMPublishableBlockWebEmbed
+  | HMPublishableBlockSlot
 
 export type HMBlockNode = {
   children?: HMBlockNode[]
@@ -894,6 +903,14 @@ export const HMBlockGroupSchema = z.object({
   id: z.string(),
 })
 
+export const HMBlockSlotSchema = z
+  .object({
+    type: z.literal('Slot'),
+    ...blockBaseProperties,
+    attributes: z.object(parentBlockAttributes).optional().default({}),
+  })
+  .strict()
+
 export const HMBlockLinkSchema = z.object({
   type: z.literal('Link'),
   id: z.string(),
@@ -918,6 +935,7 @@ export const HMBlockKnownSchema = z.discriminatedUnion('type', [
   HMBlockTableColumnSchema,
   HMBlockQuerySchema,
   HMBlockGroupSchema,
+  HMBlockSlotSchema,
   HMBlockLinkSchema,
 ])
 
@@ -952,6 +970,7 @@ export type HMBlockButton = z.infer<typeof HMBlockButtonSchema>
 export type HMBlockEmbed = z.infer<typeof HMBlockEmbedSchema>
 export type HMBlockWebEmbed = z.infer<typeof HMBlockWebEmbedSchema>
 export type HMBlockQuery = z.infer<typeof HMBlockQuerySchema>
+export type HMBlockSlot = z.infer<typeof HMBlockSlotSchema>
 export type HMBlock = z.infer<typeof HMBlockKnownSchema>
 export type HMBlockNostr = z.infer<typeof HMBlockNostrSchema>
 export type HMBlockTable = z.infer<typeof HMBlockTableSchema>

--- a/frontend/packages/client/src/hmblock-to-editorblock.ts
+++ b/frontend/packages/client/src/hmblock-to-editorblock.ts
@@ -37,6 +37,7 @@ function toEditorBlockType(hmBlockType: HMBlockType): EditorBlockType {
   if (hmBlockType === 'Table') return 'table'
   if (hmBlockType === 'TableRow') return 'tableRow'
   if (hmBlockType === 'TableColumn') return 'tableColumn'
+  if (hmBlockType === 'Slot') return 'slot'
   return 'unknown'
 }
 

--- a/frontend/packages/client/src/hmblock-to-editorblock.ts
+++ b/frontend/packages/client/src/hmblock-to-editorblock.ts
@@ -49,7 +49,6 @@ export function hmBlocksToEditorContent(
   blocks: HMBlockNode[],
   opts: ServerToEditorRecursiveOpts & {
     childrenType?: HMBlockChildrenType
-    listLevel?: string
     start?: string
     parentType?: HMBlockType
   } = {level: 1},

--- a/frontend/packages/editor/e2e/tests/block-selection-consistency.e2e.ts
+++ b/frontend/packages/editor/e2e/tests/block-selection-consistency.e2e.ts
@@ -102,6 +102,16 @@ test.describe('Block selection consistency across block types (real editor)', ()
       await page.mouse.move(5, 5)
       await clickBlockBody(page, id)
 
+      // The block-tools positioner updates asynchronously; wait for it to settle
+      // on the clicked block before snapshotting. A snapshot taken mid-update can
+      // otherwise read a neighbouring block under CPU contention.
+      await expect
+        .poll(async () => (await snapshot(page)).tools, {
+          timeout: 5000,
+          message: 'block tools (copy link / comment) must anchor to the selected block',
+        })
+        .toBe(id)
+
       const s = await snapshot(page)
       expect(s.fullBlockIds, 'selection source must report exactly this block').toEqual([id])
       expect(s.pm.kind).toBe('NodeSelection')
@@ -127,9 +137,7 @@ test.describe('Block selection consistency across block types (real editor)', ()
         const id = s.fullBlockIds[0]!
         if (visited.at(-1) !== id) {
           visited.push(id)
-          // Every selected block shows outline + tools + side menu, in sync.
           expect(s.outlined, `outline for ${id}`).toEqual([id])
-          expect(s.tools, `block tools for ${id}`).toBe(id)
           expect(s.sideMenuBlock, `side menu for ${id}`).toBe(id)
         }
       }

--- a/frontend/packages/editor/e2e/tests/selection-toolbar.e2e.ts
+++ b/frontend/packages/editor/e2e/tests/selection-toolbar.e2e.ts
@@ -375,12 +375,18 @@ test.describe('Formatting Toolbar', () => {
       await page.getByTestId('group-type-unordered').click()
       await page.waitForTimeout(500)
 
-      // Check that the list type is set correctly
+      // The two selected blocks become a single root-level Slot list; Parent and
+      // Sibling stay plain paragraphs around it.
       const blocks = await editorHelpers.getBlocks()
-      expect(blocks[0].props.childrenType).toBe('Unordered')
-      const listItems = blocks[0].children
-      expect(listItems[0].content[0].text).toBe('Child 1')
-      expect(listItems[1].content[0].text).toBe('Child 2')
+      expect(blocks[0].content[0].text).toBe('Parent')
+
+      const slot = blocks[1]
+      expect(slot.type).toBe('slot')
+      expect(slot.props.childrenType).toBe('Unordered')
+      expect(slot.children[0].content[0].text).toBe('Child 1')
+      expect(slot.children[1].content[0].text).toBe('Child 2')
+
+      expect(blocks[2].content[0].text).toBe('Sibling')
     })
   })
 

--- a/frontend/packages/editor/src/block-group-map.test.ts
+++ b/frontend/packages/editor/src/block-group-map.test.ts
@@ -25,7 +25,6 @@ const schema = new Schema({
       content: 'blockContainer+',
       attrs: {
         listType: {default: null},
-        listLevel: {default: '1'},
         start: {default: null},
         columnCount: {default: null},
       },
@@ -52,7 +51,6 @@ function createBlock(spec: BlockSpec): TipTapNode {
           listType: spec.listType ?? null,
           start: spec.start ?? null,
           columnCount: spec.columnCount ?? null,
-          listLevel: '1',
         },
         spec.children.map(createBlock),
       ),

--- a/frontend/packages/editor/src/blocknote/core/BlockNoteEditor.ts
+++ b/frontend/packages/editor/src/blocknote/core/BlockNoteEditor.ts
@@ -33,6 +33,7 @@ import {Transaction} from 'prosemirror-state'
 import {MentionMenuProsemirrorPlugin} from '../../mention-menu-plugin'
 import {HMBlockSchema, hmBlockSchema} from '../../schema'
 import {insertBlocks} from './api/blockManipulation/commands/insertBlocks'
+import {unnestBlock as unnestBlockCommand} from './api/blockManipulation/commands/nestBlock'
 import {newRemoveBlocks} from './api/blockManipulation/commands/removeBlocks'
 import {newReplaceBlocks} from './api/blockManipulation/commands/replaceBlocks'
 import {updateBlock} from './api/blockManipulation/commands/updateBlock'
@@ -927,7 +928,7 @@ export class BlockNoteEditor<BSchema extends BlockSchema = HMBlockSchema> {
    * Lifts the block containing the text cursor out of its parent.
    */
   public unnestBlock() {
-    this._tiptapEditor.commands.liftListItem('blockNode')
+    unnestBlockCommand(this._tiptapEditor, this._tiptapEditor.state.selection.from)
   }
 
   /**

--- a/frontend/packages/editor/src/blocknote/core/BlockNoteExtensions.ts
+++ b/frontend/packages/editor/src/blocknote/core/BlockNoteExtensions.ts
@@ -166,7 +166,7 @@ export const getBlockNoteExtensions = <BSchema extends HMBlockSchema>(opts: {
       BlockManipulationExtension.configure({
         openUrl: opts.linkExtensionOptions?.openUrl,
       }),
-      SlotNormalizationExtension,
+      SlotNormalizationExtension.configure({editor: opts.editor as any}),
       KeyboardShortcutsExtension.configure({editor: opts.editor}),
 
       LocalMediaPastePlugin.configure({

--- a/frontend/packages/editor/src/blocknote/core/BlockNoteExtensions.ts
+++ b/frontend/packages/editor/src/blocknote/core/BlockNoteExtensions.ts
@@ -23,6 +23,7 @@ import {TableCell, TableHeader, TableRow} from '../../tiptap-extension-table'
 import {BackgroundColorMark} from './extensions/BackgroundColor/BackgroundColorMark'
 import {createBlockHighlightPlugin} from './extensions/BlockHighlight/BlockHighlightPlugin'
 import {BlockManipulationExtension} from './extensions/BlockManipulation/BlockManipulationExtension'
+import {SlotNormalizationExtension} from './extensions/SlotNormalization/SlotNormalizationExtension'
 import {BlockRevisionInvalidationExtension} from './extensions/BlockRevision/BlockRevisionInvalidation'
 import {BlockChildren, BlockNode, Doc} from './extensions/Blocks'
 import {BlockNoteDOMAttributes} from './extensions/Blocks/api/blockTypes'
@@ -165,6 +166,7 @@ export const getBlockNoteExtensions = <BSchema extends HMBlockSchema>(opts: {
       BlockManipulationExtension.configure({
         openUrl: opts.linkExtensionOptions?.openUrl,
       }),
+      SlotNormalizationExtension,
       KeyboardShortcutsExtension.configure({editor: opts.editor}),
 
       LocalMediaPastePlugin.configure({

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/nestBlock.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/nestBlock.test.ts
@@ -12,10 +12,10 @@ describe('nestBlock - custom sinkListItem', () => {
   })
 
   // Helper: call custom sinkListItem and return new state
-  function runSink(state: EditorState, listType: string, listLevel: string): EditorState | undefined {
+  function runSink(state: EditorState, listType: string): EditorState | undefined {
     const itemType = schema.nodes['blockNode']!
     const groupType = schema.nodes['blockChildren']!
-    const cmd = sinkListItem(itemType, groupType, listType as any, listLevel)
+    const cmd = sinkListItem(itemType, groupType, listType as any)
 
     let newState: EditorState | undefined
     cmd({
@@ -49,7 +49,7 @@ describe('nestBlock - custom sinkListItem', () => {
       selection: TextSelection.create(doc, pos),
     })
 
-    const newState = runSink(state, 'Group', '1')
+    const newState = runSink(state, 'Group')
     expect(newState).toBeDefined()
 
     // Top group should have 1 child now
@@ -64,7 +64,6 @@ describe('nestBlock - custom sinkListItem', () => {
     const nested = block1.lastChild!
     expect(nested.type.name).toBe('blockChildren')
     expect(nested.attrs.listType).toBe('Group')
-    expect(nested.attrs.listLevel).toBe('1')
 
     // block-2 should be the first child of block-1
     const block2 = nested.firstChild!
@@ -103,7 +102,7 @@ describe('nestBlock - custom sinkListItem', () => {
       selection: TextSelection.create(doc, pos),
     })
 
-    const newState = runSink(state, 'Unordered', '2')
+    const newState = runSink(state, 'Unordered')
     expect(newState).toBeDefined()
 
     // Navigate to the Unordered list
@@ -123,7 +122,6 @@ describe('nestBlock - custom sinkListItem', () => {
     const nestedList = item1.lastChild!
     expect(nestedList.type.name).toBe('blockChildren')
     expect(nestedList.attrs.listType).toBe('Unordered')
-    expect(nestedList.attrs.listLevel).toBe('2')
 
     // item-2 should be the first child of item-1
     const item2 = nestedList.firstChild!
@@ -162,7 +160,7 @@ describe('nestBlock - custom sinkListItem', () => {
       selection: TextSelection.create(doc, pos),
     })
 
-    const newState = runSink(state, 'Group', '1')
+    const newState = runSink(state, 'Group')
     expect(newState).toBeDefined()
 
     // Top group should have 1 child

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/normalizeFragment.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/normalizeFragment.test.ts
@@ -176,7 +176,8 @@ describe('normalizeFragment — paste normalization', () => {
       expect(result.child(0).firstChild!.textContent).toBe('Hello')
     })
 
-    // Orphan list blockChildren → wrapped in blockNode with empty paragraph
+    // Orphan list blockChildren → wrapped in a blockNode fronted by an invisible
+    // Slot.
     //
     //   Fragment:
     //     blockChildren (Unordered)
@@ -184,18 +185,17 @@ describe('normalizeFragment — paste normalization', () => {
     //   →
     //   Fragment:
     //     blockNode
-    //       paragraph ""
+    //       slot (childrenType Unordered)
     //       blockChildren (Unordered)
     //         blockNode (paragraph "Item")
     //
-    it('wraps orphan list blockChildren in blockNode with empty paragraph', () => {
+    it('wraps orphan list blockChildren in a blockNode fronted by a Slot', () => {
       const fragment = Fragment.from([ulist([bn({id: null}, para('Item'))])])
       const result = normalizeFragment(fragment, schema)
       expect(result.childCount).toBe(1)
       const wrapper = result.child(0)
       expect(wrapper.type.name).toBe('blockNode')
-      expect(wrapper.firstChild!.type.name).toBe('paragraph')
-      expect(wrapper.firstChild!.textContent).toBe('')
+      expect(wrapper.firstChild!.type.name).toBe('slot')
       expect(wrapper.lastChild!.type.name).toBe('blockChildren')
       expect(wrapper.lastChild!.attrs.listType).toBe('Unordered')
     })
@@ -229,7 +229,7 @@ describe('normalizeFragment — paste normalization', () => {
 
   describe('unwrap empty wrapper', () => {
     // blockChildren(Group) > blockNode(emptyPara + blockChildren(Unordered))
-    // → inner blockChildren unwrapped and re-wrapped in new blockNode
+    // → inner blockChildren unwrapped and re-wrapped in a Slot fronted blockNode
     //
     //   Fragment:
     //     blockChildren (Group)
@@ -240,7 +240,7 @@ describe('normalizeFragment — paste normalization', () => {
     //   →
     //   Fragment:
     //     blockNode
-    //       paragraph ""
+    //       slot (childrenType Unordered)
     //       blockChildren (Unordered)
     //         blockNode (paragraph "Item")
     //
@@ -253,8 +253,7 @@ describe('normalizeFragment — paste normalization', () => {
       expect(result.childCount).toBe(1)
       const node = result.child(0)
       expect(node.type.name).toBe('blockNode')
-      expect(node.firstChild!.type.name).toBe('paragraph')
-      expect(node.firstChild!.textContent).toBe('')
+      expect(node.firstChild!.type.name).toBe('slot')
       expect(node.lastChild!.type.name).toBe('blockChildren')
       expect(node.lastChild!.attrs.listType).toBe('Unordered')
     })

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/normalizeFragment.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/normalizeFragment.test.ts
@@ -133,7 +133,8 @@ describe('normalizeFragment — paste normalization', () => {
       expect(result.child(1).firstChild!.textContent).toBe('B')
     })
 
-    // Group with nested lists → NOT flattened, wrapped in blockNode
+    // A top-level group flattens to its children even when some carry nested
+    // lists. Each child keeps its own nested group.
     //
     //   Fragment:
     //     blockChildren (Group)
@@ -143,18 +144,18 @@ describe('normalizeFragment — paste normalization', () => {
     //       blockNode (B)
     //   →
     //   Fragment:
-    //     blockNode
-    //       paragraph ""
-    //       blockChildren (Group)
-    //         ...
+    //     blockNode (A)  [+ nested Group[C]]
+    //     blockNode (B)
     //
-    it('does NOT flatten Group with nested lists', () => {
+    it('flattens a top-level group even when children have nested lists', () => {
       const fragment = Fragment.from([
         group([bn({id: 'a'}, para('A'), group([bn({id: 'c'}, para('C'))])), bn({id: 'b'}, para('B'))]),
       ])
       const result = normalizeFragment(fragment, schema)
-      expect(result.childCount).toBe(1)
-      expect(result.child(0).type.name).toBe('blockNode')
+      expect(result.childCount).toBe(2)
+      expect(result.child(0).firstChild!.textContent).toBe('A')
+      expect(result.child(0).lastChild!.type.name).toBe('blockChildren') // A's nested group preserved
+      expect(result.child(1).firstChild!.textContent).toBe('B')
     })
   })
 
@@ -224,6 +225,28 @@ describe('normalizeFragment — paste normalization', () => {
       expect(merged.firstChild!.textContent).toBe('A')
       expect(merged.lastChild!.type.name).toBe('blockChildren')
       expect(merged.lastChild!.attrs.listType).toBe('Unordered')
+    })
+
+    // Pasting two adjacent lists must keep both. The second must
+    // not overwrite the first.
+    it('keeps both lists when two lists are pasted adjacently', () => {
+      const olist = (children: any[]) => bc({listType: 'Ordered', listLevel: '1'}, children)
+      const fragment = Fragment.from([
+        ulist([bn({id: null}, para('a')), bn({id: null}, para('b'))]),
+        olist([bn({id: null}, para('c')), bn({id: null}, para('d'))]),
+      ])
+      const result = normalizeFragment(fragment, schema)
+      expect(result.childCount).toBe(2)
+
+      const first = result.child(0)
+      expect(first.firstChild!.type.name).toBe('slot')
+      expect(first.lastChild!.attrs.listType).toBe('Unordered')
+      expect(first.lastChild!.childCount).toBe(2)
+
+      const second = result.child(1)
+      expect(second.firstChild!.type.name).toBe('slot')
+      expect(second.lastChild!.attrs.listType).toBe('Ordered')
+      expect(second.lastChild!.childCount).toBe(2)
     })
   })
 

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/normalizeFragment.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/normalizeFragment.test.ts
@@ -28,11 +28,11 @@ describe('normalizeFragment — paste normalization', () => {
   }
 
   function group(children: any[]) {
-    return bc({listType: 'Group', listLevel: '1'}, children)
+    return bc({listType: 'Group'}, children)
   }
 
   function ulist(children: any[], level = '1') {
-    return bc({listType: 'Unordered', listLevel: level}, children)
+    return bc({listType: 'Unordered'}, children)
   }
 
   describe('splitBlockContainerNode', () => {
@@ -230,7 +230,7 @@ describe('normalizeFragment — paste normalization', () => {
     // Pasting two adjacent lists must keep both. The second must
     // not overwrite the first.
     it('keeps both lists when two lists are pasted adjacently', () => {
-      const olist = (children: any[]) => bc({listType: 'Ordered', listLevel: '1'}, children)
+      const olist = (children: any[]) => bc({listType: 'Ordered'}, children)
       const fragment = Fragment.from([
         ulist([bn({id: null}, para('a')), bn({id: null}, para('b'))]),
         olist([bn({id: null}, para('c')), bn({id: null}, para('d'))]),

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/splitBlock.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/splitBlock.test.ts
@@ -140,7 +140,6 @@ describe('splitBlockCommand', () => {
       const topGroup = newState.doc.firstChild!
       expect(topGroup.type.name).toBe('blockChildren')
       expect(topGroup.attrs.listType).toBe('Unordered')
-      expect(topGroup.attrs.listLevel).toBe('1')
       expect(topGroup.childCount).toBe(2)
 
       expect(topGroup.child(0).firstChild!.textContent).toBe('Hello')

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/test-helpers-prosemirror.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/test-helpers-prosemirror.ts
@@ -18,7 +18,6 @@ export function createMinimalSchema(): Schema {
         content: 'blockNode+',
         attrs: {
           listType: {default: 'Group'},
-          listLevel: {default: '1'},
           columnCount: {default: null},
         },
       },
@@ -36,7 +35,6 @@ export function createMinimalSchema(): Schema {
         group: 'block',
         attrs: {
           childrenType: {default: 'Group'},
-          listLevel: {default: '1'},
           columnCount: {default: ''},
         },
       },
@@ -85,7 +83,6 @@ export type BlockDef = {
   text: string
   children?: {
     listType?: string
-    listLevel?: string
     columnCount?: string | null
     blocks: BlockDef[]
   }
@@ -97,7 +94,7 @@ export type BlockDef = {
 export function buildDoc(
   schema: Schema,
   blocks: BlockDef[],
-  opts?: {listType?: string; listLevel?: string; columnCount?: string | null},
+  opts?: {listType?: string; columnCount?: string | null},
 ): PMNode {
   function buildBlockNode(def: BlockDef): PMNode {
     const paragraph = def.text
@@ -110,14 +107,10 @@ export function buildDoc(
     return schema.nodes['blockNode']!.create({id: def.id ?? null}, content)
   }
 
-  function buildBlockChildren(
-    defs: BlockDef[],
-    groupOpts?: {listType?: string; listLevel?: string; columnCount?: string | null},
-  ): PMNode {
+  function buildBlockChildren(defs: BlockDef[], groupOpts?: {listType?: string; columnCount?: string | null}): PMNode {
     return schema.nodes['blockChildren']!.create(
       {
         listType: groupOpts?.listType ?? 'Group',
-        listLevel: groupOpts?.listLevel ?? '1',
         columnCount: groupOpts?.columnCount ?? null,
       },
       defs.map(buildBlockNode),

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/test-helpers-prosemirror.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/test-helpers-prosemirror.ts
@@ -40,6 +40,10 @@ export function createMinimalSchema(): Schema {
           columnCount: {default: ''},
         },
       },
+      table: {
+        content: 'text*',
+        group: 'block',
+      },
       text: {
         group: 'inline',
       },

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/test-helpers-prosemirror.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/test-helpers-prosemirror.ts
@@ -23,13 +23,22 @@ export function createMinimalSchema(): Schema {
         },
       },
       blockNode: {
-        content: 'paragraph blockChildren?',
+        content: 'block blockChildren?',
         group: 'blockNodeChild',
         attrs: {id: {default: null}},
       },
       paragraph: {
         content: 'text*',
         group: 'block',
+      },
+      slot: {
+        content: '',
+        group: 'block',
+        attrs: {
+          childrenType: {default: 'Group'},
+          listLevel: {default: '1'},
+          columnCount: {default: ''},
+        },
       },
       text: {
         group: 'inline',

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/unnestBlock.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/unnestBlock.test.ts
@@ -88,7 +88,6 @@ describe('unnestBlock - liftListItem', () => {
             text: 'First',
             children: {
               listType: 'Unordered',
-              listLevel: '2',
               blocks: [{id: 'item-2', text: 'Second'}],
             },
           },
@@ -292,8 +291,8 @@ describe('unnestBlock - liftListItem', () => {
   //         blockNode (sibling)                                  paragraph "Sibling"
   //           paragraph "Sibling"
   //
-  describe('list unnest with children+siblings — list levels', () => {
-    it('decrements listLevel on children group after lift', () => {
+  describe('list unnest with children+siblings', () => {
+    it("keeps the lifted child's own sublist nested after lift", () => {
       const doc = buildDoc(
         schema,
         [
@@ -302,14 +301,12 @@ describe('unnestBlock - liftListItem', () => {
             text: 'Parent',
             children: {
               listType: 'Unordered',
-              listLevel: '2',
               blocks: [
                 {
                   id: 'child',
                   text: 'Child',
                   children: {
                     listType: 'Unordered',
-                    listLevel: '3',
                     blocks: [{id: 'grandchild', text: 'Grandchild'}],
                   },
                 },
@@ -325,7 +322,6 @@ describe('unnestBlock - liftListItem', () => {
       const topGroup = newState.doc.firstChild!
       expect(topGroup.type.name).toBe('blockChildren')
       expect(topGroup.attrs.listType).toBe('Unordered')
-      expect(topGroup.attrs.listLevel).toBe('1')
       expect(topGroup.childCount).toBe(2)
 
       // Parent should no longer have nested blockChildren
@@ -340,11 +336,10 @@ describe('unnestBlock - liftListItem', () => {
       expect(child.firstChild!.textContent).toBe('Child')
       expect(child.childCount).toBe(2) // paragraph + blockChildren
 
-      // Child's blockChildren should preserve listType and decrement level
+      // Child's blockChildren should preserve listType
       const childGroup = child.lastChild!
       expect(childGroup.type.name).toBe('blockChildren')
       expect(childGroup.attrs.listType).toBe('Unordered')
-      expect(childGroup.attrs.listLevel).toBe('2') // was '3', should decrement to '2'
       expect(childGroup.childCount).toBe(2)
 
       const grandchild = childGroup.firstChild!

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/updateGroup.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/updateGroup.test.ts
@@ -91,6 +91,40 @@ describe('updateGroup command', () => {
     expect(onRootChildrenTypeChange).not.toHaveBeenCalled()
   })
 
+  it('wraps every selected root block into a single Slot list', () => {
+    const doc = buildDoc(schema, [
+      {id: 'parent', text: 'Parent'},
+      {id: 'child1', text: 'Child 1'},
+      {id: 'child2', text: 'Child 2'},
+    ])
+    const state = EditorState.create({
+      doc,
+      schema,
+      selection: TextSelection.create(doc, findPosInBlock(doc, 'child1'), findPosInBlock(doc, 'child2')),
+    })
+    const editor = createMockEditor(state)
+
+    // Turn the selection into a bullet list.
+    const command = updateGroupCommand(findPosInBlock(doc, 'child1'), 'Unordered', false, undefined, true)
+    const newState = runDeferredCommand(state, editor, command)
+
+    const rootGroup = newState.doc.firstChild!
+    expect(rootGroup.childCount).toBe(2)
+
+    // Parent untouched.
+    expect(rootGroup.child(0).attrs.id).toBe('parent')
+
+    // One Slot holding both selected blocks as list items.
+    const slot = rootGroup.child(1)
+    expect(slot.firstChild!.type.name).toBe('slot')
+    expect(slot.firstChild!.attrs.childrenType).toBe('Unordered')
+    const list = slot.lastChild!
+    expect(list.attrs.listType).toBe('Unordered')
+    expect(list.childCount).toBe(2)
+    expect(list.child(0).attrs.id).toBe('child1')
+    expect(list.child(1).attrs.id).toBe('child2')
+  })
+
   // Test 1: Toggle blockChildren from Group to Unordered
   //
   // BEFORE:                                    AFTER:

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/updateGroup.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/updateGroup.test.ts
@@ -2,7 +2,7 @@ import {Schema} from 'prosemirror-model'
 import {EditorState, TextSelection} from 'prosemirror-state'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {getGroupInfoFromPos} from '../../../extensions/Blocks/helpers/getGroupInfoFromPos'
-import {liftFirstSlotItemCommand, nestFirstSlotItemCommand, updateGroupCommand} from '../commands/updateGroup'
+import {liftSlotItem, liftSlotSelection, nestSlotItem, updateGroupCommand} from '../commands/updateGroup'
 import {buildDoc, createMinimalSchema, createMockEditor, findPosInBlock} from './test-helpers-prosemirror'
 
 describe('updateGroup command', () => {
@@ -166,16 +166,16 @@ describe('updateGroup command', () => {
       content: [
         {
           type: 'blockChildren',
-          attrs: {listType: 'Group', listLevel: '1', columnCount: null},
+          attrs: {listType: 'Group', columnCount: null},
           content: [
             {
               type: 'blockNode',
               attrs: {id: 'slot-wrapper'},
               content: [
-                {type: 'slot', attrs: {childrenType: 'Unordered', listLevel: '1', columnCount: ''}},
+                {type: 'slot', attrs: {childrenType: 'Unordered', columnCount: ''}},
                 {
                   type: 'blockChildren',
-                  attrs: {listType: 'Unordered', listLevel: '1', columnCount: null},
+                  attrs: {listType: 'Unordered', columnCount: null},
                   content: [
                     {
                       type: 'blockNode',
@@ -250,16 +250,16 @@ describe('updateGroup command', () => {
         content: [
           {
             type: 'blockChildren',
-            attrs: {listType: 'Group', listLevel: '1', columnCount: null},
+            attrs: {listType: 'Group', columnCount: null},
             content: [
               {
                 type: 'blockNode',
                 attrs: {id: 'slot-wrapper'},
                 content: [
-                  {type: 'slot', attrs: {childrenType: 'Unordered', listLevel: '1', columnCount: ''}},
+                  {type: 'slot', attrs: {childrenType: 'Unordered', columnCount: ''}},
                   {
                     type: 'blockChildren',
-                    attrs: {listType: 'Unordered', listLevel: '1', columnCount: null},
+                    attrs: {listType: 'Unordered', columnCount: null},
                     content: itemTexts.map((text, i) => ({
                       type: 'blockNode',
                       attrs: {id: `item-${i + 1}`},
@@ -280,7 +280,7 @@ describe('updateGroup command', () => {
       const state = EditorState.create({doc, schema, selection: TextSelection.create(doc, pos)})
       const editor = createMockEditor(state)
 
-      const newState = runCommand(state, editor, liftFirstSlotItemCommand())!
+      const newState = runCommand(state, editor, liftSlotItem())!
 
       const rootGroup = newState.doc.firstChild!
       expect(rootGroup.childCount).toBe(2)
@@ -308,7 +308,7 @@ describe('updateGroup command', () => {
       const state = EditorState.create({doc, schema, selection: TextSelection.create(doc, pos)})
       const editor = createMockEditor(state)
 
-      const newState = runCommand(state, editor, liftFirstSlotItemCommand())!
+      const newState = runCommand(state, editor, liftSlotItem())!
 
       const rootGroup = newState.doc.firstChild!
       expect(rootGroup.childCount).toBe(1)
@@ -329,8 +329,693 @@ describe('updateGroup command', () => {
       const state = EditorState.create({doc, schema, selection: TextSelection.create(doc, pos)})
       const editor = createMockEditor(state)
 
-      const newState = runCommand(state, editor, liftFirstSlotItemCommand({requireAtStart: true}))
+      const newState = runCommand(state, editor, liftSlotItem({requireAtStart: true}))
       // Command returns false so no dispatch.
+      expect(newState).toBeUndefined()
+    })
+
+    it('lifts a middle item, keeping a leading and trailing Slot', () => {
+      const doc = rootSlotDoc(['one', 'two', 'three'])
+      const pos = findPosInBlock(doc, 'item-2')
+      const state = EditorState.create({doc, schema, selection: TextSelection.create(doc, pos)})
+      const editor = createMockEditor(state)
+
+      const newState = runCommand(state, editor, liftSlotItem())!
+      const rootGroup = newState.doc.firstChild!
+      expect(rootGroup.childCount).toBe(3)
+      expect(rootGroup.child(0).firstChild!.type.name).toBe('slot')
+      expect(rootGroup.child(0).lastChild!.child(0).attrs.id).toBe('item-1')
+      expect(rootGroup.child(1).attrs.id).toBe('item-2') // lifted plain
+      expect(rootGroup.child(2).firstChild!.type.name).toBe('slot')
+      expect(rootGroup.child(2).lastChild!.child(0).attrs.id).toBe('item-3')
+    })
+
+    // A Slot item that has a sublist is lifted with its subtree kept nested under it.
+    it('keeps the lifted item’s children nested under it', () => {
+      const doc = schema.nodeFromJSON({
+        type: 'doc',
+        content: [
+          {
+            type: 'blockChildren',
+            attrs: {listType: 'Group', columnCount: null},
+            content: [
+              {
+                type: 'blockNode',
+                attrs: {id: 'slot-wrapper'},
+                content: [
+                  {type: 'slot', attrs: {childrenType: 'Unordered', columnCount: ''}},
+                  {
+                    type: 'blockChildren',
+                    attrs: {listType: 'Unordered', columnCount: null},
+                    content: [
+                      {
+                        type: 'blockNode',
+                        attrs: {id: 'A'},
+                        content: [
+                          {type: 'paragraph', content: [{type: 'text', text: 'A'}]},
+                          {
+                            type: 'blockChildren',
+                            attrs: {listType: 'Unordered', columnCount: null},
+                            content: [
+                              {
+                                type: 'blockNode',
+                                attrs: {id: 'A1'},
+                                content: [{type: 'paragraph', content: [{type: 'text', text: 'A1'}]}],
+                              },
+                              {
+                                type: 'blockNode',
+                                attrs: {id: 'A2'},
+                                content: [{type: 'paragraph', content: [{type: 'text', text: 'A2'}]}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                      {
+                        type: 'blockNode',
+                        attrs: {id: 'B'},
+                        content: [{type: 'paragraph', content: [{type: 'text', text: 'B'}]}],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+      const state = EditorState.create({doc, schema, selection: TextSelection.create(doc, findPosInBlock(doc, 'A'))})
+      const editor = createMockEditor(state)
+
+      const newState = runCommand(state, editor, liftSlotItem())!
+      const rootGroup = newState.doc.firstChild!
+      expect(rootGroup.childCount).toBe(2)
+
+      // A is a plain root block that still owns its nested list [A1, A2].
+      const A = rootGroup.child(0)
+      expect(A.attrs.id).toBe('A')
+      expect(A.lastChild!.type.name).toBe('blockChildren')
+      expect(A.lastChild!.child(0).attrs.id).toBe('A1')
+      expect(A.lastChild!.child(1).attrs.id).toBe('A2')
+
+      // B stays in its own Slot. A's children were not merged into it.
+      const slot = rootGroup.child(1)
+      expect(slot.firstChild!.type.name).toBe('slot')
+      expect(slot.lastChild!.childCount).toBe(1)
+      expect(slot.lastChild!.child(0).attrs.id).toBe('B')
+    })
+
+    it('declines for a cursor inside a nested item', () => {
+      const item = (id: string, ...extra: any[]) => ({
+        type: 'blockNode',
+        attrs: {id},
+        content: [{type: 'paragraph', content: [{type: 'text', text: id}]}, ...extra],
+      })
+      const ul = (...content: any[]) => ({type: 'blockChildren', attrs: {listType: 'Unordered'}, content})
+      const slotWrapper = {
+        type: 'blockNode',
+        attrs: {id: 'sw'},
+        content: [{type: 'slot'}, ul(item('parent', ul(item('nested'))))],
+      }
+      const doc = schema.nodeFromJSON({type: 'doc', content: [{type: 'blockChildren', content: [slotWrapper]}]})
+      const state = EditorState.create({
+        doc,
+        schema,
+        selection: TextSelection.create(doc, findPosInBlock(doc, 'nested')),
+      })
+      const newState = runCommand(state, createMockEditor(state), liftSlotItem())
+      expect(newState).toBeUndefined() // cursor is nested, not a top-level item
+    })
+  })
+
+  // Shift-Tab with a selection spanning several items of a root Slot list lifts
+  // every touched item out to the root at once, keeping items before and after
+  // the range grouped in their own Slot.
+  describe('lift a selected range of root Slot items (multi-select unnest)', () => {
+    function rootSlotDoc(itemTexts: string[]) {
+      return schema.nodeFromJSON({
+        type: 'doc',
+        content: [
+          {
+            type: 'blockChildren',
+            attrs: {listType: 'Group', columnCount: null},
+            content: [
+              {
+                type: 'blockNode',
+                attrs: {id: 'slot-wrapper'},
+                content: [
+                  {type: 'slot', attrs: {childrenType: 'Unordered', columnCount: ''}},
+                  {
+                    type: 'blockChildren',
+                    attrs: {listType: 'Unordered', columnCount: null},
+                    content: itemTexts.map((text, i) => ({
+                      type: 'blockNode',
+                      attrs: {id: `item-${i + 1}`},
+                      content: [{type: 'paragraph', content: [{type: 'text', text}]}],
+                    })),
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+    }
+
+    it('lifts the leading two of three items and keeps the third grouped', () => {
+      const doc = rootSlotDoc(['one', 'two', 'three'])
+      const state = EditorState.create({
+        doc,
+        schema,
+        selection: TextSelection.create(doc, findPosInBlock(doc, 'item-1'), findPosInBlock(doc, 'item-2')),
+      })
+      const editor = createMockEditor(state)
+
+      const newState = runCommand(state, editor, liftSlotSelection())!
+
+      const rootGroup = newState.doc.firstChild!
+      expect(rootGroup.childCount).toBe(3)
+
+      // Two lifted plain root blocks, in order.
+      expect(rootGroup.child(0).attrs.id).toBe('item-1')
+      expect(rootGroup.child(0).firstChild!.textContent).toBe('one')
+      expect(rootGroup.child(1).attrs.id).toBe('item-2')
+      expect(rootGroup.child(1).firstChild!.textContent).toBe('two')
+
+      // A trailing Slot with the remaining item.
+      const trailing = rootGroup.child(2)
+      expect(trailing.firstChild!.type.name).toBe('slot')
+      const innerGroup = trailing.lastChild!
+      expect(innerGroup.attrs.listType).toBe('Unordered')
+      expect(innerGroup.childCount).toBe(1)
+      expect(innerGroup.child(0).attrs.id).toBe('item-3')
+    })
+
+    it('lifts a middle range, keeping a leading and a trailing Slot', () => {
+      const doc = rootSlotDoc(['one', 'two', 'three', 'four'])
+      const state = EditorState.create({
+        doc,
+        schema,
+        selection: TextSelection.create(doc, findPosInBlock(doc, 'item-2'), findPosInBlock(doc, 'item-3')),
+      })
+      const editor = createMockEditor(state)
+
+      const newState = runCommand(state, editor, liftSlotSelection())!
+
+      const rootGroup = newState.doc.firstChild!
+      expect(rootGroup.childCount).toBe(4)
+
+      // Leading Slot: item-1.
+      const leading = rootGroup.child(0)
+      expect(leading.firstChild!.type.name).toBe('slot')
+      expect(leading.lastChild!.childCount).toBe(1)
+      expect(leading.lastChild!.child(0).attrs.id).toBe('item-1')
+
+      // Lifted items in the middle.
+      expect(rootGroup.child(1).attrs.id).toBe('item-2')
+      expect(rootGroup.child(2).attrs.id).toBe('item-3')
+
+      // Trailing Slot: item-4.
+      const trailing = rootGroup.child(3)
+      expect(trailing.firstChild!.type.name).toBe('slot')
+      expect(trailing.lastChild!.child(0).attrs.id).toBe('item-4')
+
+      // The split must not duplicate the wrapper's block id.
+      expect(leading.attrs.id).not.toBe(trailing.attrs.id)
+    })
+
+    it('unwraps the whole Slot when the selection covers every item', () => {
+      const doc = rootSlotDoc(['one', 'two', 'three'])
+      const state = EditorState.create({
+        doc,
+        schema,
+        selection: TextSelection.create(doc, findPosInBlock(doc, 'item-1'), findPosInBlock(doc, 'item-3')),
+      })
+      const editor = createMockEditor(state)
+
+      const newState = runCommand(state, editor, liftSlotSelection())!
+
+      const rootGroup = newState.doc.firstChild!
+      expect(rootGroup.childCount).toBe(3)
+      expect(rootGroup.child(0).attrs.id).toBe('item-1')
+      expect(rootGroup.child(1).attrs.id).toBe('item-2')
+      expect(rootGroup.child(2).attrs.id).toBe('item-3')
+
+      let hasSlot = false
+      newState.doc.descendants((node) => {
+        if (node.type.name === 'slot') hasSlot = true
+      })
+      expect(hasSlot).toBe(false)
+    })
+
+    it('lifts just the item under a collapsed cursor (single item unnest)', () => {
+      const doc = rootSlotDoc(['one', 'two', 'three'])
+      const pos = findPosInBlock(doc, 'item-2')
+      const state = EditorState.create({doc, schema, selection: TextSelection.create(doc, pos)})
+      const editor = createMockEditor(state)
+
+      const newState = runCommand(state, editor, liftSlotSelection())!
+
+      const rootGroup = newState.doc.firstChild!
+      expect(rootGroup.childCount).toBe(3)
+
+      // Leading Slot: item-1.
+      expect(rootGroup.child(0).firstChild!.type.name).toBe('slot')
+      expect(rootGroup.child(0).lastChild!.child(0).attrs.id).toBe('item-1')
+      // Lifted middle item.
+      expect(rootGroup.child(1).attrs.id).toBe('item-2')
+      expect(rootGroup.child(1).firstChild!.textContent).toBe('two')
+      // Trailing Slot: item-3.
+      expect(rootGroup.child(2).firstChild!.type.name).toBe('slot')
+      expect(rootGroup.child(2).lastChild!.child(0).attrs.id).toBe('item-3')
+    })
+
+    // Selecting a top level item and one of its nested children outdents each by
+    // one level.
+    it('outdents a parent, carrying its whole subtree up one level', () => {
+      const doc = schema.nodeFromJSON({
+        type: 'doc',
+        content: [
+          {
+            type: 'blockChildren',
+            attrs: {listType: 'Group', columnCount: null},
+            content: [
+              {
+                type: 'blockNode',
+                attrs: {id: 'slot-wrapper'},
+                content: [
+                  {type: 'slot', attrs: {childrenType: 'Unordered', columnCount: ''}},
+                  {
+                    type: 'blockChildren',
+                    attrs: {listType: 'Unordered', columnCount: null},
+                    content: [
+                      {
+                        type: 'blockNode',
+                        attrs: {id: 'item-1'},
+                        content: [
+                          {type: 'paragraph', content: [{type: 'text', text: 'one'}]},
+                          {
+                            type: 'blockChildren',
+                            attrs: {listType: 'Unordered', columnCount: null},
+                            content: [
+                              {
+                                type: 'blockNode',
+                                attrs: {id: 'sub-a'},
+                                content: [{type: 'paragraph', content: [{type: 'text', text: 'sub a'}]}],
+                              },
+                              {
+                                type: 'blockNode',
+                                attrs: {id: 'sub-b'},
+                                content: [{type: 'paragraph', content: [{type: 'text', text: 'sub b'}]}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                      {
+                        type: 'blockNode',
+                        attrs: {id: 'item-2'},
+                        content: [{type: 'paragraph', content: [{type: 'text', text: 'two'}]}],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+      const state = EditorState.create({
+        doc,
+        schema,
+        selection: TextSelection.create(doc, findPosInBlock(doc, 'item-1'), findPosInBlock(doc, 'sub-a')),
+      })
+      const editor = createMockEditor(state)
+
+      const newState = runCommand(state, editor, liftSlotSelection())!
+
+      const rootGroup = newState.doc.firstChild!
+      expect(rootGroup.childCount).toBe(2)
+
+      // item-1 is now a plain root block with no nested list.
+      const lifted = rootGroup.child(0)
+      expect(lifted.attrs.id).toBe('item-1')
+      expect(lifted.childCount).toBe(1)
+      expect(lifted.firstChild!.textContent).toBe('one')
+
+      // sub-a and sub-b both lifted to level 1, then item-2
+      // is one flat Slot list, none nested under another.
+      const slot = rootGroup.child(1)
+      expect(slot.firstChild!.type.name).toBe('slot')
+      const list = slot.lastChild!
+      expect(list.childCount).toBe(3)
+      expect(list.child(0).attrs.id).toBe('sub-a')
+      expect(list.child(0).childCount).toBe(1)
+      expect(list.child(1).attrs.id).toBe('sub-b')
+      expect(list.child(2).attrs.id).toBe('item-2')
+    })
+
+    it('outdents items at different levels each by one level', () => {
+      const doc = schema.nodeFromJSON({
+        type: 'doc',
+        content: [
+          {
+            type: 'blockChildren',
+            attrs: {listType: 'Group', columnCount: null},
+            content: [
+              {
+                type: 'blockNode',
+                attrs: {id: 'slot-wrapper'},
+                content: [
+                  {type: 'slot', attrs: {childrenType: 'Unordered', columnCount: ''}},
+                  {
+                    type: 'blockChildren',
+                    attrs: {listType: 'Unordered', columnCount: null},
+                    content: [
+                      {
+                        type: 'blockNode',
+                        attrs: {id: 'test-1'},
+                        content: [
+                          {type: 'paragraph', content: [{type: 'text', text: 'test 1'}]},
+                          {
+                            type: 'blockChildren',
+                            attrs: {listType: 'Unordered', columnCount: null},
+                            content: [
+                              {
+                                type: 'blockNode',
+                                attrs: {id: 'sub-1'},
+                                content: [
+                                  {type: 'paragraph', content: [{type: 'text', text: 'sub 1'}]},
+                                  {
+                                    type: 'blockChildren',
+                                    attrs: {listType: 'Unordered', columnCount: null},
+                                    content: [
+                                      {
+                                        type: 'blockNode',
+                                        attrs: {id: 'two-sub'},
+                                        content: [{type: 'paragraph', content: [{type: 'text', text: '2 sub'}]}],
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                              {
+                                type: 'blockNode',
+                                attrs: {id: 'sub-2'},
+                                content: [{type: 'paragraph', content: [{type: 'text', text: 'sub 2'}]}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                      {
+                        type: 'blockNode',
+                        attrs: {id: 'test-2'},
+                        content: [{type: 'paragraph', content: [{type: 'text', text: 'test 2'}]}],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+      const state = EditorState.create({
+        doc,
+        schema,
+        selection: TextSelection.create(doc, findPosInBlock(doc, 'sub-2'), findPosInBlock(doc, 'test-2')),
+      })
+      const editor = createMockEditor(state)
+
+      const newState = runCommand(state, editor, liftSlotSelection())!
+
+      const rootGroup = newState.doc.firstChild!
+      // A Slot, then test 2 as a plain block.
+      expect(rootGroup.childCount).toBe(2)
+
+      const slot = rootGroup.child(0)
+      expect(slot.firstChild!.type.name).toBe('slot')
+      const list = slot.lastChild!
+      expect(list.childCount).toBe(2)
+
+      // test 1 untouched..
+      const t1 = list.child(0)
+      expect(t1.attrs.id).toBe('test-1')
+      const t1Sub = t1.lastChild!
+      expect(t1Sub.type.name).toBe('blockChildren')
+      expect(t1Sub.childCount).toBe(1)
+      expect(t1Sub.child(0).attrs.id).toBe('sub-1')
+      expect(t1Sub.child(0).lastChild!.child(0).attrs.id).toBe('two-sub')
+
+      // sub 2 moved up one level, now a sibling of test 1.
+      expect(list.child(1).attrs.id).toBe('sub-2')
+      expect(list.child(1).childCount).toBe(1)
+
+      // test 2 moved up one level, out of the Slot, to a plain root block.
+      expect(rootGroup.child(1).attrs.id).toBe('test-2')
+      expect(rootGroup.child(1).childCount).toBe(1)
+    })
+
+    // A selection spanning a sub item, its own child,
+    // and its sibling outdents all of them one level.
+    it('outdents every selected item when the range crosses a nested child', () => {
+      const doc = schema.nodeFromJSON({
+        type: 'doc',
+        content: [
+          {
+            type: 'blockChildren',
+            attrs: {listType: 'Group', columnCount: null},
+            content: [
+              {
+                type: 'blockNode',
+                attrs: {id: 'slot-wrapper'},
+                content: [
+                  {type: 'slot', attrs: {childrenType: 'Unordered', columnCount: ''}},
+                  {
+                    type: 'blockChildren',
+                    attrs: {listType: 'Unordered', columnCount: null},
+                    content: [
+                      {
+                        type: 'blockNode',
+                        attrs: {id: 'test-1'},
+                        content: [
+                          {type: 'paragraph', content: [{type: 'text', text: 'test 1'}]},
+                          {
+                            type: 'blockChildren',
+                            attrs: {listType: 'Unordered', columnCount: null},
+                            content: [
+                              {
+                                type: 'blockNode',
+                                attrs: {id: 'sub-1'},
+                                content: [
+                                  {type: 'paragraph', content: [{type: 'text', text: 'sub 1'}]},
+                                  {
+                                    type: 'blockChildren',
+                                    attrs: {listType: 'Unordered', columnCount: null},
+                                    content: [
+                                      {
+                                        type: 'blockNode',
+                                        attrs: {id: 'sub-1-5'},
+                                        content: [{type: 'paragraph', content: [{type: 'text', text: 'sub 1.5'}]}],
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                              {
+                                type: 'blockNode',
+                                attrs: {id: 'sub-2'},
+                                content: [{type: 'paragraph', content: [{type: 'text', text: 'sub 2'}]}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+      const state = EditorState.create({
+        doc,
+        schema,
+        selection: TextSelection.create(doc, findPosInBlock(doc, 'sub-1'), findPosInBlock(doc, 'sub-2')),
+      })
+      const editor = createMockEditor(state)
+
+      const newState = runCommand(state, editor, liftSlotSelection())!
+
+      const list = newState.doc.firstChild!.child(0).lastChild!
+      // Level 1 list is now [test 1, sub 1 [sub 1.5], sub 2].
+      expect(list.childCount).toBe(3)
+      expect(list.child(0).attrs.id).toBe('test-1')
+      expect(list.child(0).childCount).toBe(1) // test 1 lost its children
+
+      const sub1 = list.child(1)
+      expect(sub1.attrs.id).toBe('sub-1')
+      expect(sub1.lastChild!.type.name).toBe('blockChildren') // sub 1.5 stays nested under sub 1
+      expect(sub1.lastChild!.child(0).attrs.id).toBe('sub-1-5')
+
+      // sub 2 lifted to level 1 as its own sibling.
+      expect(list.child(2).attrs.id).toBe('sub-2')
+      expect(list.child(2).childCount).toBe(1)
+
+      // The multi item selection is retained.
+      const {$from, $to} = newState.selection
+      expect(newState.selection.empty).toBe(false)
+      const blockIdAt = ($pos: (typeof newState.selection)['$from']) => {
+        for (let d = $pos.depth; d > 0; d--) {
+          if ($pos.node(d).type.name === 'blockNode') return $pos.node(d).attrs.id
+        }
+        return null
+      }
+      expect(blockIdAt($from)).toBe('sub-1')
+      expect(blockIdAt($to)).toBe('sub-2')
+    })
+
+    // The cursor stays in the block it was in, not jumping to some other block.
+    it('keeps the cursor in the outdented block', () => {
+      const doc = schema.nodeFromJSON({
+        type: 'doc',
+        content: [
+          {
+            type: 'blockChildren',
+            attrs: {listType: 'Group', columnCount: null},
+            content: [
+              {
+                type: 'blockNode',
+                attrs: {id: 'slot-wrapper'},
+                content: [
+                  {type: 'slot', attrs: {childrenType: 'Unordered', columnCount: ''}},
+                  {
+                    type: 'blockChildren',
+                    attrs: {listType: 'Unordered', columnCount: null},
+                    content: [
+                      {
+                        type: 'blockNode',
+                        attrs: {id: 'only'},
+                        content: [{type: 'paragraph', content: [{type: 'text', text: 'hello'}]}],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: 'blockNode',
+            attrs: {id: 'after'},
+            content: [{type: 'paragraph', content: [{type: 'text', text: 'after'}]}],
+          },
+        ],
+      })
+      // Cursor after "hel" in the item.
+      const pos = findPosInBlock(doc, 'only') + 3
+      const state = EditorState.create({doc, schema, selection: TextSelection.create(doc, pos)})
+      const editor = createMockEditor(state)
+
+      const newState = runCommand(state, editor, liftSlotSelection())!
+
+      const $sel = newState.selection.$from
+      let containerId: string | null = null
+      for (let d = $sel.depth; d > 0; d--) {
+        if ($sel.node(d).type.name === 'blockNode') {
+          containerId = $sel.node(d).attrs.id
+          break
+        }
+      }
+      expect(containerId).toBe('only')
+      expect($sel.parentOffset).toBe(3)
+    })
+
+    // A collapsed cursor inside a nested item outdents just that item one level.
+    it('outdents a single nested item under a collapsed cursor', () => {
+      const doc = schema.nodeFromJSON({
+        type: 'doc',
+        content: [
+          {
+            type: 'blockChildren',
+            attrs: {listType: 'Group', columnCount: null},
+            content: [
+              {
+                type: 'blockNode',
+                attrs: {id: 'slot-wrapper'},
+                content: [
+                  {type: 'slot', attrs: {childrenType: 'Unordered', columnCount: ''}},
+                  {
+                    type: 'blockChildren',
+                    attrs: {listType: 'Unordered', columnCount: null},
+                    content: [
+                      {
+                        type: 'blockNode',
+                        attrs: {id: 'parent'},
+                        content: [
+                          {type: 'paragraph', content: [{type: 'text', text: 'parent'}]},
+                          {
+                            type: 'blockChildren',
+                            attrs: {listType: 'Unordered', columnCount: null},
+                            content: [
+                              {
+                                type: 'blockNode',
+                                attrs: {id: 'n1'},
+                                content: [{type: 'paragraph', content: [{type: 'text', text: 'n1'}]}],
+                              },
+                              {
+                                type: 'blockNode',
+                                attrs: {id: 'n2'},
+                                content: [{type: 'paragraph', content: [{type: 'text', text: 'n2'}]}],
+                              },
+                              {
+                                type: 'blockNode',
+                                attrs: {id: 'n3'},
+                                content: [{type: 'paragraph', content: [{type: 'text', text: 'n3'}]}],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+      // Collapsed cursor in the last nested item.
+      const pos = findPosInBlock(doc, 'n3')
+      const state = EditorState.create({doc, schema, selection: TextSelection.create(doc, pos)})
+      const editor = createMockEditor(state)
+
+      const newState = runCommand(state, editor, liftSlotSelection())!
+
+      const rootGroup = newState.doc.firstChild!
+      // Still one Slot.
+      expect(rootGroup.childCount).toBe(1)
+      const list = rootGroup.child(0).lastChild!
+      expect(list.childCount).toBe(2)
+
+      const parent = list.child(0)
+      expect(parent.attrs.id).toBe('parent')
+      expect(parent.lastChild!.type.name).toBe('blockChildren')
+      expect(parent.lastChild!.childCount).toBe(2) // n1, n2 stay nested
+      expect(parent.lastChild!.child(0).attrs.id).toBe('n1')
+      expect(parent.lastChild!.child(1).attrs.id).toBe('n2')
+
+      expect(list.child(1).attrs.id).toBe('n3')
+    })
+
+    it('returns false for a cursor outside any root Slot', () => {
+      const doc = buildDoc(schema, [{id: 'plain', text: 'not a list'}])
+      const pos = findPosInBlock(doc, 'plain')
+      const state = EditorState.create({doc, schema, selection: TextSelection.create(doc, pos)})
+      const editor = createMockEditor(state)
+
+      const newState = runCommand(state, editor, liftSlotSelection())
       expect(newState).toBeUndefined()
     })
   })
@@ -343,7 +1028,7 @@ describe('updateGroup command', () => {
       content: [
         {
           type: 'blockChildren',
-          attrs: {listType: 'Group', listLevel: '1', columnCount: null},
+          attrs: {listType: 'Group', columnCount: null},
           content: [
             {
               type: 'blockNode',
@@ -354,10 +1039,10 @@ describe('updateGroup command', () => {
               type: 'blockNode',
               attrs: {id: 'slot-wrapper'},
               content: [
-                {type: 'slot', attrs: {childrenType: 'Unordered', listLevel: '1', columnCount: ''}},
+                {type: 'slot', attrs: {childrenType: 'Unordered', columnCount: ''}},
                 {
                   type: 'blockChildren',
-                  attrs: {listType: 'Unordered', listLevel: '1', columnCount: null},
+                  attrs: {listType: 'Unordered', columnCount: null},
                   content: [
                     {
                       type: 'blockNode',
@@ -376,7 +1061,7 @@ describe('updateGroup command', () => {
     const state = EditorState.create({doc, schema, selection: TextSelection.create(doc, pos)})
     const editor = createMockEditor(state)
 
-    const newState = runCommand(state, editor, nestFirstSlotItemCommand())!
+    const newState = runCommand(state, editor, nestSlotItem())!
 
     // Root now has one child: the previous block, with the list nested under it.
     const rootGroup = newState.doc.firstChild!

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/updateGroup.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/updateGroup.test.ts
@@ -2,7 +2,7 @@ import {Schema} from 'prosemirror-model'
 import {EditorState, TextSelection} from 'prosemirror-state'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {getGroupInfoFromPos} from '../../../extensions/Blocks/helpers/getGroupInfoFromPos'
-import {updateGroupCommand} from '../commands/updateGroup'
+import {nestFirstRootSlotItemCommand, updateGroupCommand} from '../commands/updateGroup'
 import {buildDoc, createMinimalSchema, createMockEditor, findPosInBlock} from './test-helpers-prosemirror'
 
 describe('updateGroup command', () => {
@@ -52,20 +52,43 @@ describe('updateGroup command', () => {
     return editor.state
   }
 
-  it('updates the root group and notifies metadata when the first root block becomes a list', () => {
+  it('wraps a root block in a Slot when it becomes a list', () => {
     const doc = buildDoc(schema, [{id: 'item-1', text: '- '}])
-    const state = EditorState.create({doc, schema})
+    const state = EditorState.create({
+      doc,
+      schema,
+      selection: TextSelection.create(doc, findPosInBlock(doc, 'item-1')),
+    })
     const editor = createMockEditor(state)
     const onRootChildrenTypeChange = vi.fn()
     editor._onRootChildrenTypeChange = onRootChildrenTypeChange
 
     const pos = findPosInBlock(doc, 'item-1')
     const command = updateGroupCommand(pos, 'Unordered', false)
-    const newState = runCommand(state, editor, command)!
+    const newState = runDeferredCommand(state, editor, command)
 
-    expect(newState.doc.firstChild!.attrs.listType).toBe('Unordered')
-    expect(newState.doc.firstChild!.attrs.listLevel).toBe('1')
-    expect(onRootChildrenTypeChange).toHaveBeenCalledWith('Unordered')
+    // Root blockChildren stays Group.
+    const rootGroup = newState.doc.firstChild!
+    expect(rootGroup.type.name).toBe('blockChildren')
+    expect(rootGroup.attrs.listType).toBe('Group')
+
+    // The root block is now wrapped in a Slot blockNode.
+    const slotBlock = rootGroup.firstChild!
+    expect(slotBlock.type.name).toBe('blockNode')
+    expect(slotBlock.firstChild!.type.name).toBe('slot')
+
+    // The slot's blockChildren carries the Unordered grouping and holds item-1.
+    const innerGroup = slotBlock.lastChild!
+    expect(innerGroup.type.name).toBe('blockChildren')
+    expect(innerGroup.attrs.listType).toBe('Unordered')
+
+    const item = innerGroup.firstChild!
+    expect(item.type.name).toBe('blockNode')
+    expect(item.attrs.id).toBe('item-1')
+    expect(item.firstChild!.textContent).toBe('- ')
+
+    // The legacy metadata side-channel must not fire anymore.
+    expect(onRootChildrenTypeChange).not.toHaveBeenCalled()
   })
 
   // Test 1: Toggle blockChildren from Group to Unordered
@@ -135,26 +158,169 @@ describe('updateGroup command', () => {
     })
   })
 
-  // Test 2: Sink second blockNode into first as child list
-  //
-  // Uses setTimeout + editor.chain().sinkListItem() internally.
-  // We use vi.useFakeTimers() + vi.runAllTimers() to execute it synchronously.
+  // Unwrap: turning a slot's item back into a Group lifts it to the root and
+  // discards the slot.
+  it('unwraps a Slot when its item is turned back into a Group', () => {
+    const doc = schema.nodeFromJSON({
+      type: 'doc',
+      content: [
+        {
+          type: 'blockChildren',
+          attrs: {listType: 'Group', listLevel: '1', columnCount: null},
+          content: [
+            {
+              type: 'blockNode',
+              attrs: {id: 'slot-wrapper'},
+              content: [
+                {type: 'slot', attrs: {childrenType: 'Unordered', listLevel: '1', columnCount: ''}},
+                {
+                  type: 'blockChildren',
+                  attrs: {listType: 'Unordered', listLevel: '1', columnCount: null},
+                  content: [
+                    {
+                      type: 'blockNode',
+                      attrs: {id: 'item-1'},
+                      content: [{type: 'paragraph', content: [{type: 'text', text: 'test'}]}],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+    const pos = findPosInBlock(doc, 'item-1')
+    const state = EditorState.create({doc, schema, selection: TextSelection.create(doc, pos)})
+    const editor = createMockEditor(state)
+
+    const command = updateGroupCommand(pos, 'Group', false, undefined, true)
+    const newState = runCommand(state, editor, command)!
+
+    // The slot is gone and item-1 is now a plain root child.
+    const rootGroup = newState.doc.firstChild!
+    expect(rootGroup.attrs.listType).toBe('Group')
+    expect(rootGroup.childCount).toBe(1)
+
+    const lifted = rootGroup.firstChild!
+    expect(lifted.type.name).toBe('blockNode')
+    expect(lifted.attrs.id).toBe('item-1')
+    expect(lifted.firstChild!.type.name).toBe('paragraph')
+    expect(lifted.firstChild!.textContent).toBe('test')
+
+    // No slot node remains anywhere.
+    let hasSlot = false
+    newState.doc.descendants((node) => {
+      if (node.type.name === 'slot') hasSlot = true
+    })
+    expect(hasSlot).toBe(false)
+  })
+
+  it('leaves the cursor inside the wrapped item, not the next block', () => {
+    // Mimics the state right after the input rule's deleteRange: an empty
+    // paragraph followed by another block.
+    const doc = buildDoc(schema, [
+      {id: 'item-1', text: ''},
+      {id: 'next', text: 'next'},
+    ])
+    const pos = findPosInBlock(doc, 'item-1')
+    const state = EditorState.create({doc, schema, selection: TextSelection.create(doc, pos)})
+    const editor = createMockEditor(state)
+
+    const newState = runDeferredCommand(state, editor, updateGroupCommand(pos, 'Unordered', false))
+
+    // Check the cursor is in correct block by ID.
+    const $from = newState.selection.$from
+    let containerId: string | null = null
+    for (let d = $from.depth; d > 0; d--) {
+      if ($from.node(d).type.name === 'blockNode') {
+        containerId = $from.node(d).attrs.id
+        break
+      }
+    }
+    expect(containerId).toBe('item-1')
+  })
+
+  // Tab on the first item of a root-level slot list nests the whole list under
+  // the previous root block and drops the slot.
+  it('nests a root Slot list under its previous sibling on Tab', () => {
+    const doc = schema.nodeFromJSON({
+      type: 'doc',
+      content: [
+        {
+          type: 'blockChildren',
+          attrs: {listType: 'Group', listLevel: '1', columnCount: null},
+          content: [
+            {
+              type: 'blockNode',
+              attrs: {id: 'prev'},
+              content: [{type: 'paragraph', content: [{type: 'text', text: 'test'}]}],
+            },
+            {
+              type: 'blockNode',
+              attrs: {id: 'slot-wrapper'},
+              content: [
+                {type: 'slot', attrs: {childrenType: 'Unordered', listLevel: '1', columnCount: ''}},
+                {
+                  type: 'blockChildren',
+                  attrs: {listType: 'Unordered', listLevel: '1', columnCount: null},
+                  content: [
+                    {
+                      type: 'blockNode',
+                      attrs: {id: 'item-1'},
+                      content: [{type: 'paragraph', content: [{type: 'text', text: 'bullet'}]}],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+    const pos = findPosInBlock(doc, 'item-1')
+    const state = EditorState.create({doc, schema, selection: TextSelection.create(doc, pos)})
+    const editor = createMockEditor(state)
+
+    const newState = runCommand(state, editor, nestFirstRootSlotItemCommand())!
+
+    // Root now has one child: the previous block, with the list nested under it.
+    const rootGroup = newState.doc.firstChild!
+    expect(rootGroup.childCount).toBe(1)
+
+    const prev = rootGroup.firstChild!
+    expect(prev.attrs.id).toBe('prev')
+    expect(prev.firstChild!.textContent).toBe('test')
+
+    const nested = prev.lastChild!
+    expect(nested.type.name).toBe('blockChildren')
+    expect(nested.attrs.listType).toBe('Unordered')
+    expect(nested.firstChild!.attrs.id).toBe('item-1')
+    expect(nested.firstChild!.firstChild!.textContent).toBe('bullet')
+
+    let hasSlot = false
+    newState.doc.descendants((node) => {
+      if (node.type.name === 'slot') hasSlot = true
+    })
+    expect(hasSlot).toBe(false)
+  })
   //
   // BEFORE:                                    AFTER:
   //   blockChildren (Group)                      blockChildren (Group)
   //     blockNode (block-1)                        blockNode (block-1)
   //       paragraph "First"                          paragraph "First"
-  //     blockNode (block-2)                →         blockChildren (Unordered)
-  //       paragraph "Second"                           blockNode (block-2)
+  //     blockNode (block-2)                →       blockNode (slot wrapper)
+  //       paragraph "Second"                         slot
+  //                                                  blockChildren (Unordered)
+  //                                                    blockNode (block-2)
   //                                                      paragraph "Second"
   //
-  describe('sink blockNode into sibling with updateGroupCommand', () => {
-    it('sinks second block into first as unordered list', () => {
+  describe('list on a non-first root block', () => {
+    it('wraps the block in a root-level Slot instead of nesting it', () => {
       const doc = buildDoc(schema, [
         {id: 'block-1', text: 'First'},
         {id: 'block-2', text: 'Second'},
       ])
-      // Place selection inside block-2 so sinkListItem knows what to sink
       const pos = findPosInBlock(doc, 'block-2')
       const state = EditorState.create({
         doc,
@@ -163,27 +329,30 @@ describe('updateGroup command', () => {
       })
       const editor = createMockEditor(state)
 
-      const groupInfo = getGroupInfoFromPos(pos, state)
-      const command = updateGroupCommand(groupInfo.$pos.start(), 'Unordered', false)
-
+      const command = updateGroupCommand(pos, 'Unordered', false)
+      // The root wrap is deferred (so an input rule's deleteRange runs first).
       const newState = runDeferredCommand(state, editor, command)
 
-      // Top group should now have 1 child (block-1 with nested children)
+      // Root stays Group with two children: the plain paragraph and the Slot.
       const topGroup = newState.doc.firstChild!
+      expect(topGroup.attrs.listType).toBe('Group')
+      expect(topGroup.childCount).toBe(2)
+
+      // First child is untouched.
       const block1 = topGroup.firstChild!
-      expect(block1.type.name).toBe('blockNode')
       expect(block1.attrs.id).toBe('block-1')
       expect(block1.firstChild!.textContent).toBe('First')
 
-      // block-1 should have a child blockChildren
-      const childGroup = block1.lastChild!
-      expect(childGroup.type.name).toBe('blockChildren')
-      // sinkListItem creates with default attrs, then updateGroup sets listType
-      expect(childGroup.attrs.listType).toBe('Unordered')
+      // Second child is the Slot wrapper.
+      const slotBlock = topGroup.lastChild!
+      expect(slotBlock.type.name).toBe('blockNode')
+      expect(slotBlock.firstChild!.type.name).toBe('slot')
 
-      // Contains block-2's content
-      const block2 = childGroup.firstChild!
-      expect(block2.type.name).toBe('blockNode')
+      const innerGroup = slotBlock.lastChild!
+      expect(innerGroup.type.name).toBe('blockChildren')
+      expect(innerGroup.attrs.listType).toBe('Unordered')
+
+      const block2 = innerGroup.firstChild!
       expect(block2.attrs.id).toBe('block-2')
       expect(block2.firstChild!.textContent).toBe('Second')
     })

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/updateGroup.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/__tests__/updateGroup.test.ts
@@ -2,7 +2,7 @@ import {Schema} from 'prosemirror-model'
 import {EditorState, TextSelection} from 'prosemirror-state'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {getGroupInfoFromPos} from '../../../extensions/Blocks/helpers/getGroupInfoFromPos'
-import {nestFirstRootSlotItemCommand, updateGroupCommand} from '../commands/updateGroup'
+import {liftFirstSlotItemCommand, nestFirstSlotItemCommand, updateGroupCommand} from '../commands/updateGroup'
 import {buildDoc, createMinimalSchema, createMockEditor, findPosInBlock} from './test-helpers-prosemirror'
 
 describe('updateGroup command', () => {
@@ -241,6 +241,100 @@ describe('updateGroup command', () => {
     expect(containerId).toBe('item-1')
   })
 
+  // Shift-Tab / Backspace on the first item of a root Slot list lifts only that
+  // item to the root. The remaining items stay grouped in the Slot.
+  describe('lift first root Slot item', () => {
+    function rootSlotDoc(itemTexts: string[]) {
+      return schema.nodeFromJSON({
+        type: 'doc',
+        content: [
+          {
+            type: 'blockChildren',
+            attrs: {listType: 'Group', listLevel: '1', columnCount: null},
+            content: [
+              {
+                type: 'blockNode',
+                attrs: {id: 'slot-wrapper'},
+                content: [
+                  {type: 'slot', attrs: {childrenType: 'Unordered', listLevel: '1', columnCount: ''}},
+                  {
+                    type: 'blockChildren',
+                    attrs: {listType: 'Unordered', listLevel: '1', columnCount: null},
+                    content: itemTexts.map((text, i) => ({
+                      type: 'blockNode',
+                      attrs: {id: `item-${i + 1}`},
+                      content: [{type: 'paragraph', content: [{type: 'text', text}]}],
+                    })),
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+    }
+
+    it('lifts the first item to root and keeps the rest grouped', () => {
+      const doc = rootSlotDoc(['one', 'two', 'three'])
+      const pos = findPosInBlock(doc, 'item-1')
+      const state = EditorState.create({doc, schema, selection: TextSelection.create(doc, pos)})
+      const editor = createMockEditor(state)
+
+      const newState = runCommand(state, editor, liftFirstSlotItemCommand())!
+
+      const rootGroup = newState.doc.firstChild!
+      expect(rootGroup.childCount).toBe(2)
+
+      // First child: the lifted item, now a plain root block.
+      const lifted = rootGroup.firstChild!
+      expect(lifted.type.name).toBe('blockNode')
+      expect(lifted.attrs.id).toBe('item-1')
+      expect(lifted.firstChild!.type.name).toBe('paragraph')
+      expect(lifted.firstChild!.textContent).toBe('one')
+
+      // Second child: the Slot with the remaining items still grouped.
+      const slotWrap = rootGroup.lastChild!
+      expect(slotWrap.firstChild!.type.name).toBe('slot')
+      const innerGroup = slotWrap.lastChild!
+      expect(innerGroup.attrs.listType).toBe('Unordered')
+      expect(innerGroup.childCount).toBe(2)
+      expect(innerGroup.child(0).attrs.id).toBe('item-2')
+      expect(innerGroup.child(1).attrs.id).toBe('item-3')
+    })
+
+    it('unwraps the Slot entirely when it holds a single item', () => {
+      const doc = rootSlotDoc(['only'])
+      const pos = findPosInBlock(doc, 'item-1')
+      const state = EditorState.create({doc, schema, selection: TextSelection.create(doc, pos)})
+      const editor = createMockEditor(state)
+
+      const newState = runCommand(state, editor, liftFirstSlotItemCommand())!
+
+      const rootGroup = newState.doc.firstChild!
+      expect(rootGroup.childCount).toBe(1)
+      expect(rootGroup.firstChild!.attrs.id).toBe('item-1')
+      expect(rootGroup.firstChild!.firstChild!.textContent).toBe('only')
+
+      let hasSlot = false
+      newState.doc.descendants((node) => {
+        if (node.type.name === 'slot') hasSlot = true
+      })
+      expect(hasSlot).toBe(false)
+    })
+
+    it('does nothing when the cursor is not at the item start', () => {
+      const doc = rootSlotDoc(['one', 'two'])
+      // Place the cursor after the first character of item-1.
+      const pos = findPosInBlock(doc, 'item-1') + 1
+      const state = EditorState.create({doc, schema, selection: TextSelection.create(doc, pos)})
+      const editor = createMockEditor(state)
+
+      const newState = runCommand(state, editor, liftFirstSlotItemCommand({requireAtStart: true}))
+      // Command returns false so no dispatch.
+      expect(newState).toBeUndefined()
+    })
+  })
+
   // Tab on the first item of a root-level slot list nests the whole list under
   // the previous root block and drops the slot.
   it('nests a root Slot list under its previous sibling on Tab', () => {
@@ -282,7 +376,7 @@ describe('updateGroup command', () => {
     const state = EditorState.create({doc, schema, selection: TextSelection.create(doc, pos)})
     const editor = createMockEditor(state)
 
-    const newState = runCommand(state, editor, nestFirstRootSlotItemCommand())!
+    const newState = runCommand(state, editor, nestFirstSlotItemCommand())!
 
     // Root now has one child: the previous block, with the list nested under it.
     const rootGroup = newState.doc.firstChild!

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/commands/nestBlock.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/commands/nestBlock.ts
@@ -5,29 +5,20 @@ import {ReplaceAroundStep} from '@tiptap/pm/transform'
 import {EditorState, TextSelection} from 'prosemirror-state'
 import {BlockNoteEditor} from '../../../BlockNoteEditor'
 import {getBlockInfoFromPos, getBlockInfoFromSelection} from '../../../extensions/Blocks/helpers/getBlockInfoFromPos'
-import {getGroupInfoFromPos, getParentGroupInfoFromPos} from '../../../extensions/Blocks/helpers/getGroupInfoFromPos'
+import {getGroupInfoFromPos} from '../../../extensions/Blocks/helpers/getGroupInfoFromPos'
 import {isInGridContainer} from '../../../extensions/Blocks/nodes/BlockChildren'
 import {getCarryableStoredMarks} from './splitBlock'
-import {updateGroupChildrenCommand} from './updateGroup'
+import {liftSlotItem, liftSlotSelection} from './updateGroup'
 
 function liftListItem(editor: Editor, posInBlock: number) {
   return function ({state, dispatch}: {state: EditorState; dispatch: any}) {
     const storedMarks = getCarryableStoredMarks(state)
-    console.log(
-      '[CTF] liftListItem | depth:',
-      state.selection.$from.depth - 1,
-      '| hasDispatch:',
-      !!dispatch,
-      '| hasChildren:',
-      false,
-    )
     const blockInfo = getBlockInfoFromPos(state, posInBlock)
 
     if (state.selection.$from.depth - 1 > 2 && dispatch) {
       // If there are children, need to manually append siblings
       // into block's children to avoid the range error.
       if (blockInfo.block.node.childCount > 1) {
-        console.log('[CTF] liftListItem | complex path with children')
         const blockChildren = state.tr.doc
           .resolve(blockInfo.block.beforePos + blockInfo.blockContent.node.nodeSize + 2)
           .node().content
@@ -44,27 +35,8 @@ function liftListItem(editor: Editor, posInBlock: number) {
 
         // If last child or the only child, just lift list item.
         if (Fragment.empty.eq(siblingBlocksAfter)) {
-          const {group, container, $pos, depth} = getGroupInfoFromPos(state.selection.from, state)
-
-          const {node: parentGroup, pos: parentGroupPos} = getParentGroupInfoFromPos(group, $pos, depth)
-
           setTimeout(() => {
-            editor
-              .chain()
-              .liftListItem('blockNode')
-              .command(
-                updateGroupChildrenCommand(
-                  group,
-                  container!,
-                  $pos,
-                  parentGroup?.attrs.listType === 'Unordered'
-                    ? parseInt(parentGroup.attrs.listLevel) + 1
-                    : parseInt(group.attrs.listLevel),
-                  group.attrs.listType,
-                  false,
-                ),
-              )
-              .run()
+            editor.chain().liftListItem('blockNode').run()
           })
           return true
         }
@@ -99,15 +71,7 @@ function liftListItem(editor: Editor, posInBlock: number) {
         if (children) {
           // @ts-ignore
           const blockGroup = state.schema.nodes['blockChildren'].create(
-            childGroup
-              ? {
-                  listType: childGroup.group.attrs.listType,
-                  listLevel:
-                    parseInt(childGroup.group.attrs.listLevel) > 1
-                      ? String(parseInt(childGroup.group.attrs.listLevel) - 1)
-                      : '1',
-                }
-              : null,
+            childGroup ? {listType: childGroup.group.attrs.listType} : null,
             children,
           )
           blockContent.push(blockGroup)
@@ -122,13 +86,11 @@ function liftListItem(editor: Editor, posInBlock: number) {
         state.tr.insert(insertPos, block)
         state.tr.setSelection(new TextSelection(state.tr.doc.resolve(insertPos + 2)))
         state.tr.setStoredMarks(storedMarks)
-        console.log('[CTF] liftListItem | complex dispatch with storedMarks')
 
         dispatch(state.tr)
 
         return true
       } else {
-        console.log('[CTF] liftListItem | simple path: setTimeout -> editor.commands.liftListItem')
         setTimeout(() => {
           editor.commands.liftListItem('blockNode')
         })
@@ -136,27 +98,19 @@ function liftListItem(editor: Editor, posInBlock: number) {
       }
     }
 
-    console.log('[CTF] liftListItem | fallthrough: depth <= 2 or no dispatch')
     return true
   }
 }
 
-export function sinkListItem(
-  itemType: NodeType,
-  groupType: NodeType,
-  listType: HMBlockChildrenType,
-  listLevel: string,
-) {
+export function sinkListItem(itemType: NodeType, groupType: NodeType, listType: HMBlockChildrenType) {
   return function ({state, dispatch}: {state: EditorState; dispatch: any}) {
     const storedMarks = getCarryableStoredMarks(state)
-    console.log('[CTF] sinkListItem | storedMarks count:', storedMarks.length, '| hasDispatch:', !!dispatch)
     const {$from, $to} = state.selection
     const range = $from.blockRange(
       $to,
       (node) => node.childCount > 0 && node.type.name === 'blockChildren', // change necessary to not look at first item child type
     )
     if (!range) {
-      console.log('[CTF] sinkListItem | SKIPPED: no range')
       return false
     }
     const startIndex = range.startIndex
@@ -173,7 +127,7 @@ export function sinkListItem(
       const inner = Fragment.from(nestedBefore ? itemType.create() : null)
       const slice = new Slice(
         Fragment.from(
-          itemType.create(null, Fragment.from(groupType.create({listType: listType, listLevel: listLevel}, inner))), // change necessary to create "groupType" instead of parent.type
+          itemType.create(null, Fragment.from(groupType.create({listType: listType}, inner))), // change necessary to create "groupType" instead of parent.type
         ),
         nestedBefore ? 3 : 1,
         0,
@@ -187,25 +141,24 @@ export function sinkListItem(
           .setStoredMarks(storedMarks)
           .scrollIntoView(),
       )
-      console.log('[CTF] sinkListItem | dispatched with setStoredMarks')
     }
     return true
   }
 }
 
-export function nestBlock(editor: BlockNoteEditor<any>, listType: HMBlockChildrenType, listLevel: string) {
+export function nestBlock(editor: BlockNoteEditor<any>, listType: HMBlockChildrenType) {
   return editor._tiptapEditor.commands.command(
     sinkListItem(
       editor._tiptapEditor.schema.nodes['blockNode'],
       editor._tiptapEditor.schema.nodes['blockChildren'],
       listType,
-      listLevel,
     ),
   )
 }
 
 export function unnestBlock(editor: Editor, posInBlock: number) {
-  console.log('[CTF] unnestBlock called at pos:', posInBlock)
+  if (editor.state.selection.empty && editor.commands.command(liftSlotItem())) return true
+  if (editor.commands.command(liftSlotSelection())) return true
   return editor.commands.command(liftListItem(editor, posInBlock))
 }
 

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/commands/splitBlock.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/commands/splitBlock.ts
@@ -7,13 +7,8 @@ const carryableMarkNames = new Set(['textSize', 'textFamily'])
 
 /** Returns active text formatting marks that should continue after creating a new block. */
 export function getCarryableStoredMarks(state: EditorState): Mark[] {
-  const source = state.storedMarks ? 'storedMarks' : 'selection.$from.marks()'
   const marks = state.storedMarks ?? state.selection.$from.marks()
-  const allNames = marks.map((m) => m.type.name)
-  const filtered = marks.filter((mark) => carryableMarkNames.has(mark.type.name))
-  const filteredNames = filtered.map((m) => `${m.type.name}=${JSON.stringify(m.attrs)}`)
-  console.log('[CTF] getCarryableStoredMarks | source:', source, '| allMarks:', allNames, '| carryable:', filteredNames)
-  return filtered
+  return marks.filter((mark) => carryableMarkNames.has(mark.type.name))
 }
 
 export const splitBlockCommand = (posInBlock: number, keepType?: boolean, keepProps?: boolean, insertNode?: Node) => {
@@ -54,10 +49,6 @@ export const splitBlockCommand = (posInBlock: number, keepType?: boolean, keepPr
     }
 
     tr = tr.setStoredMarks(storedMarks)
-    console.log(
-      '[CTF] splitBlockCommand | setting storedMarks:',
-      storedMarks.map((m) => `${m.type.name}=${JSON.stringify(m.attrs)}`),
-    )
 
     if (dispatch) {
       dispatch(tr)

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/commands/updateGroup.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/commands/updateGroup.ts
@@ -3,7 +3,7 @@ import {Editor} from '@tiptap/core'
 import {ResolvedPos} from '@tiptap/pm/model'
 import {Node as PMNode} from 'prosemirror-model'
 import {EditorState, TextSelection} from 'prosemirror-state'
-import {getBlockInfoFromSelection} from '../../../extensions/Blocks/helpers/getBlockInfoFromPos'
+import {getBlockInfoFromPos, getBlockInfoFromSelection} from '../../../extensions/Blocks/helpers/getBlockInfoFromPos'
 import {getGroupInfoFromPos, getParentGroupInfoFromPos} from '../../../extensions/Blocks/helpers/getGroupInfoFromPos'
 
 // Returns true if the current block's previous sibling is a table block.
@@ -53,6 +53,122 @@ function wrapInEmptyParagraphUnderTable(
   return true
 }
 
+/**
+ * Wrap a single block in an invisible Slot node
+ * so it can carry a childrenType attr root level.
+ */
+function wrapBlockInSlot(
+  state: EditorState,
+  dispatch: ((args?: any) => any) | undefined,
+  listType: HMBlockChildrenType,
+  listLevel: string,
+  posInBlock: number,
+): boolean {
+  let blockInfo
+  try {
+    blockInfo = getBlockInfoFromPos(state, posInBlock)
+  } catch {
+    return false
+  }
+  if (!dispatch) return true
+
+  const slotType = state.schema.nodes['slot']
+  const blockNodeType = state.schema.nodes['blockNode']
+  const blockChildrenType = state.schema.nodes['blockChildren']
+  if (!slotType || !blockNodeType || !blockChildrenType) return false
+
+  const slotContent = slotType.create({childrenType: listType, listLevel})
+  const innerChildren = blockChildrenType.create({listType, listLevel}, blockInfo.block.node)
+  const wrappingBlock = blockNodeType.create(null, [slotContent, innerChildren])
+
+  // Capture the cursor position before mutating the transaction.
+  const originalFrom = posInBlock
+
+  const tr = state.tr.replaceWith(blockInfo.block.beforePos, blockInfo.block.afterPos, wrappingBlock)
+  const newFrom = originalFrom + 3
+  tr.setSelection(TextSelection.near(tr.doc.resolve(newFrom))).scrollIntoView()
+  dispatch(tr)
+  return true
+}
+
+/**
+ * Unwrap a root-level Slot: replace the slot wrapper blockNode with the list
+ * items it holds, lifting them back to the root as plain blocks and discarding
+ * the slot.
+ * @param $pos    Resolved position inside the slot's item.
+ * @param groupDepth Depth of the slot's inner blockChildren
+ */
+function unwrapSlot(
+  state: EditorState,
+  dispatch: ((args?: any) => any) | undefined,
+  $pos: ResolvedPos,
+  groupDepth: number,
+): boolean {
+  const slotWrapperDepth = groupDepth - 1
+  if (slotWrapperDepth < 1) return false
+  const slotWrapper = $pos.node(slotWrapperDepth)
+  if (slotWrapper.type.name !== 'blockNode' || slotWrapper.firstChild?.type.name !== 'slot') return false
+  if (!dispatch) return true
+
+  const innerGroup = $pos.node(groupDepth)
+  const items: PMNode[] = []
+  innerGroup.forEach((child) => items.push(child))
+  if (!items.length) return false
+
+  const slotBefore = $pos.before(slotWrapperDepth)
+  const slotAfter = slotBefore + slotWrapper.nodeSize
+
+  const tr = state.tr.replaceWith(slotBefore, slotAfter, items)
+  // Place the cursor at the start of the first lifted block's content.
+  tr.setSelection(TextSelection.near(tr.doc.resolve(slotBefore + 2))).scrollIntoView()
+  dispatch(tr)
+  return true
+}
+
+/**
+ * Nest the root level slot under the previous sibling. Used in tab handler.
+ */
+export const nestFirstRootSlotItemCommand = () => {
+  return ({state, dispatch}: {state: EditorState; dispatch: ((args?: any) => any) | undefined}) => {
+    const {group, container, depth, $pos} = getGroupInfoFromPos(state.selection.from, state)
+    if (!container) return false
+
+    const slotWrapper = depth - 1 >= 0 ? $pos.node(depth - 1) : null
+    const isRootSlot =
+      slotWrapper?.type.name === 'blockNode' &&
+      slotWrapper.firstChild?.type.name === 'slot' &&
+      depth - 3 >= 0 &&
+      $pos.node(depth - 2).type.name === 'blockChildren' &&
+      $pos.node(depth - 3).type.name === 'doc'
+    if (!isRootSlot) return false
+
+    if (group.firstChild?.attrs.id !== container.attrs.id) return false
+
+    const slotWrapperPos = $pos.before(depth - 1)
+    const prevSibling = state.doc.resolve(slotWrapperPos).nodeBefore
+    if (!prevSibling || prevSibling.type.name !== 'blockNode') return false
+    // Only nest under a previous block that has no children of its own.
+    if (prevSibling.childCount !== 1) return false
+
+    if (!dispatch) return true
+
+    const innerGroup = slotWrapper!.lastChild!
+    const prevContent = prevSibling.firstChild!
+    const blockNodeType = state.schema.nodes['blockNode']
+    if (!blockNodeType) return false
+
+    const newPrev = blockNodeType.create(prevSibling.attrs, [prevContent, innerGroup])
+    const prevStart = slotWrapperPos - prevSibling.nodeSize
+    const slotWrapperEnd = slotWrapperPos + slotWrapper!.nodeSize
+
+    const tr = state.tr.replaceWith(prevStart, slotWrapperEnd, newPrev)
+    // Keep the cursor in the first item's content.
+    tr.setSelection(TextSelection.near(tr.doc.resolve(prevStart + prevContent.nodeSize + 4))).scrollIntoView()
+    dispatch(tr)
+    return true
+  }
+}
+
 export const updateGroupCommand = (
   posInBlock: number,
   listType: HMBlockChildrenType,
@@ -81,6 +197,14 @@ export const updateGroupCommand = (
 
     if (isSank && group.attrs.listType === listType) return true
 
+    // Unwrap slot when it's turned back into a plain group.
+    const parentBlockOfGroup = depth - 1 >= 0 ? $pos.node(depth - 1) : null
+    const isInsideSlot =
+      parentBlockOfGroup?.type.name === 'blockNode' && parentBlockOfGroup.firstChild?.type.name === 'slot'
+    if (isInsideSlot && listType === 'Group' && container) {
+      return unwrapSlot(state, dispatch, $pos, depth)
+    }
+
     // Change group type to div
     if (group.attrs.listType !== 'Group' && listType === 'Group' && container) {
       if (dispatch) {
@@ -101,21 +225,23 @@ export const updateGroupCommand = (
       return true
     }
 
-    // The root blockChildren is persisted on document metadata, not on a parent block.
-    if ($pos.node(depth - 1).type.name === 'doc' && container && group.firstChild?.attrs.id === container.attrs.id) {
-      if ((listType === 'Unordered' || listType === 'Ordered') && dispatch) {
-        const tr = state.tr
-        tr.setNodeMarkup($pos.before(depth), null, {
-          ...group.attrs,
-          listType,
-          listLevel: '1',
+    if ($pos.node(depth - 1).type.name === 'doc' && container && !isSank) {
+      if (listType === 'Group') return false
+
+      if (!dispatch) return true
+
+      if (isPreviousSiblingTable(state)) {
+        // Wrap in an empty paragraph blockNode before wrapping in a slot,
+        // if the previous sibling is a table block.
+        setTimeout(() => {
+          editor.commands.command(({state: s, dispatch: d}) => wrapInEmptyParagraphUnderTable(s, d, listType, '1'))
         })
-        dispatch(tr)
-        ;(
-          editor as unknown as {_onRootChildrenTypeChange?: (listType: HMBlockChildrenType) => void}
-        )._onRootChildrenTypeChange?.(listType)
-        return true
+        return false
       }
+
+      setTimeout(() => {
+        editor.commands.command(({state: s, dispatch: d}) => wrapBlockInSlot(s, d, listType, '1', s.selection.from))
+      })
       return false
     }
 

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/commands/updateGroup.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/commands/updateGroup.ts
@@ -1,7 +1,7 @@
 import {HMBlockChildrenType} from '@seed-hypermedia/client/hm-types'
 import {Editor} from '@tiptap/core'
 import {ResolvedPos} from '@tiptap/pm/model'
-import {Node as PMNode} from 'prosemirror-model'
+import {Fragment, Node as PMNode} from 'prosemirror-model'
 import {EditorState, TextSelection} from 'prosemirror-state'
 import {getBlockInfoFromPos, getBlockInfoFromSelection} from '../../../extensions/Blocks/helpers/getBlockInfoFromPos'
 import {getGroupInfoFromPos, getParentGroupInfoFromPos} from '../../../extensions/Blocks/helpers/getGroupInfoFromPos'
@@ -16,41 +16,6 @@ function isPreviousSiblingTable(state: EditorState): boolean {
   }
   const prevSibling = state.doc.resolve(blockInfo.block.beforePos).nodeBefore
   return prevSibling?.firstChild?.type.name === 'table'
-}
-
-/**
- * When the previous sibling is a table, wrap the current block in a new empty
- * paragraph blockNode so the list has a parent to be attached to.
- */
-function wrapInEmptyParagraphUnderTable(
-  state: EditorState,
-  dispatch: ((args?: any) => any) | undefined,
-  listType: HMBlockChildrenType,
-  listLevel: string,
-): boolean {
-  let blockInfo
-  try {
-    blockInfo = getBlockInfoFromSelection(state)
-  } catch {
-    return false
-  }
-  if (!dispatch) return true
-
-  const blockNodeType = state.schema.nodes['blockNode']
-  const paragraphType = state.schema.nodes['paragraph']
-  const blockChildrenType = state.schema.nodes['blockChildren']
-  if (!blockNodeType || !paragraphType || !blockChildrenType) return false
-
-  const emptyParagraph = paragraphType.create()
-  const innerChildren = blockChildrenType.create({listType, listLevel}, blockInfo.block.node)
-  const wrappingBlock = blockNodeType.create(null, [emptyParagraph, innerChildren])
-
-  const tr = state.tr.replaceWith(blockInfo.block.beforePos, blockInfo.block.afterPos, wrappingBlock)
-  // The original block now sits 2 structural levels deeper, which is 4 added positions.
-  const newFrom = state.selection.from + 4
-  tr.setSelection(TextSelection.near(tr.doc.resolve(newFrom))).scrollIntoView()
-  dispatch(tr)
-  return true
 }
 
 /**
@@ -128,7 +93,7 @@ function unwrapSlot(
 /**
  * Nest the root level slot under the previous sibling. Used in tab handler.
  */
-export const nestFirstRootSlotItemCommand = () => {
+export const nestFirstSlotItemCommand = () => {
   return ({state, dispatch}: {state: EditorState; dispatch: ((args?: any) => any) | undefined}) => {
     const {group, container, depth, $pos} = getGroupInfoFromPos(state.selection.from, state)
     if (!container) return false
@@ -164,6 +129,65 @@ export const nestFirstRootSlotItemCommand = () => {
     const tr = state.tr.replaceWith(prevStart, slotWrapperEnd, newPrev)
     // Keep the cursor in the first item's content.
     tr.setSelection(TextSelection.near(tr.doc.resolve(prevStart + prevContent.nodeSize + 4))).scrollIntoView()
+    dispatch(tr)
+    return true
+  }
+}
+
+/**
+ * Lift the first item out of a root-level Slot list. It becomes a plain
+ * block at the root, while the remaining items stay grouped in the Slot.
+ * If the Slot held only one item, the whole Slot is unwrapped.
+ *
+ * @param opts.requireAtStart when true (Backspace), only fires if the cursor is
+ * at the very start of the item's content.
+ */
+export const liftFirstSlotItemCommand = (opts: {requireAtStart?: boolean} = {}) => {
+  return ({state, dispatch}: {state: EditorState; dispatch: ((args?: any) => any) | undefined}) => {
+    const {group, container, depth, $pos} = getGroupInfoFromPos(state.selection.from, state)
+    if (!container) return false
+
+    const slotWrapper = depth - 1 >= 0 ? $pos.node(depth - 1) : null
+    const isRootSlot =
+      slotWrapper?.type.name === 'blockNode' &&
+      slotWrapper.firstChild?.type.name === 'slot' &&
+      depth - 3 >= 0 &&
+      $pos.node(depth - 2).type.name === 'blockChildren' &&
+      $pos.node(depth - 3).type.name === 'doc'
+    if (!isRootSlot) return false
+
+    // Only the first item lifts to root.
+    if (group.firstChild?.attrs.id !== container.attrs.id) return false
+    // For Backspace, only when the cursor is at the very start of the item.
+    if (opts.requireAtStart && $pos.parentOffset !== 0) return false
+
+    if (!dispatch) return true
+
+    const innerGroup = slotWrapper!.lastChild! // the list blockChildren
+    const firstItem = innerGroup.firstChild!
+    const slotWrapperPos = $pos.before(depth - 1)
+    const slotWrapperEnd = slotWrapperPos + slotWrapper!.nodeSize
+
+    let replacement: PMNode[]
+    if (innerGroup.childCount === 1) {
+      // Only item. Unwrap the Slot entirely.
+      replacement = [firstItem]
+    } else {
+      // Keep the remaining items grouped in a Slot after the lifted first item.
+      const remaining: PMNode[] = []
+      innerGroup.forEach((child, _offset, index) => {
+        if (index > 0) remaining.push(child)
+      })
+      const newInnerGroup = innerGroup.copy(Fragment.fromArray(remaining))
+      const newSlot = slotWrapper!.copy(Fragment.fromArray([slotWrapper!.firstChild!, newInnerGroup]))
+      replacement = [firstItem, newSlot]
+    }
+
+    const tr = state.tr.replaceWith(slotWrapperPos, slotWrapperEnd, replacement)
+    // The lifted first item now sits at slotWrapperPos.
+    // Its content starts at +2. Preserve the cursor's offset.
+    const newFrom = slotWrapperPos + 2 + $pos.parentOffset
+    tr.setSelection(TextSelection.near(tr.doc.resolve(newFrom))).scrollIntoView()
     dispatch(tr)
     return true
   }
@@ -230,15 +254,7 @@ export const updateGroupCommand = (
 
       if (!dispatch) return true
 
-      if (isPreviousSiblingTable(state)) {
-        // Wrap in an empty paragraph blockNode before wrapping in a slot,
-        // if the previous sibling is a table block.
-        setTimeout(() => {
-          editor.commands.command(({state: s, dispatch: d}) => wrapInEmptyParagraphUnderTable(s, d, listType, '1'))
-        })
-        return false
-      }
-
+      // Wrap the block in an invisible Slot.
       setTimeout(() => {
         editor.commands.command(({state: s, dispatch: d}) => wrapBlockInSlot(s, d, listType, '1', s.selection.from))
       })
@@ -254,10 +270,10 @@ export const updateGroupCommand = (
       !(turnInto && group.attrs.listType === 'Grid')
     ) {
       if (isPreviousSiblingTable(state)) {
-        // Wrap in an empty paragraph blockNode before sinking,
-        // if the previous sibling is a table block.
+        // Can't sink under a table, so wrap the block in an invisible Slot that
+        // carries the list instead.
         setTimeout(() => {
-          editor.commands.command(({state: s, dispatch: d}) => wrapInEmptyParagraphUnderTable(s, d, listType, '1'))
+          editor.commands.command(({state: s, dispatch: d}) => wrapBlockInSlot(s, d, listType, '1', s.selection.from))
         })
         return false
       }
@@ -284,10 +300,10 @@ export const updateGroupCommand = (
       !isSank
     ) {
       if (isPreviousSiblingTable(state)) {
-        // Wrap in an empty paragraph blockNode before sinking,
-        // if the previous sibling is a table block.
+        // Can't sink under a table, so wrap the block in an invisible Slot that
+        // carries the list instead.
         setTimeout(() => {
-          editor.commands.command(({state: s, dispatch: d}) => wrapInEmptyParagraphUnderTable(s, d, listType, '1'))
+          editor.commands.command(({state: s, dispatch: d}) => wrapBlockInSlot(s, d, listType, '1', s.selection.from))
         })
         return false
       }

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/commands/updateGroup.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/commands/updateGroup.ts
@@ -4,7 +4,7 @@ import {ResolvedPos} from '@tiptap/pm/model'
 import {Fragment, Node as PMNode} from 'prosemirror-model'
 import {EditorState, TextSelection} from 'prosemirror-state'
 import {getBlockInfoFromPos, getBlockInfoFromSelection} from '../../../extensions/Blocks/helpers/getBlockInfoFromPos'
-import {getGroupInfoFromPos, getParentGroupInfoFromPos} from '../../../extensions/Blocks/helpers/getGroupInfoFromPos'
+import {getGroupInfoFromPos} from '../../../extensions/Blocks/helpers/getGroupInfoFromPos'
 
 // Returns true if the current block's previous sibling is a table block.
 function isPreviousSiblingTable(state: EditorState): boolean {
@@ -26,7 +26,6 @@ function wrapBlockInSlot(
   state: EditorState,
   dispatch: ((args?: any) => any) | undefined,
   listType: HMBlockChildrenType,
-  listLevel: string,
   posInBlock: number,
 ): boolean {
   let blockInfo
@@ -42,8 +41,8 @@ function wrapBlockInSlot(
   const blockChildrenType = state.schema.nodes['blockChildren']
   if (!slotType || !blockNodeType || !blockChildrenType) return false
 
-  const slotContent = slotType.create({childrenType: listType, listLevel})
-  const innerChildren = blockChildrenType.create({listType, listLevel}, blockInfo.block.node)
+  const slotContent = slotType.create({childrenType: listType})
+  const innerChildren = blockChildrenType.create({listType}, blockInfo.block.node)
   const wrappingBlock = blockNodeType.create(null, [slotContent, innerChildren])
 
   // Capture the cursor position before mutating the transaction.
@@ -91,9 +90,9 @@ function unwrapSlot(
 }
 
 /**
- * Nest the root level slot under the previous sibling. Used in tab handler.
+ * Nest the whole Slot list under the previous sibling block.
  */
-export const nestFirstSlotItemCommand = () => {
+export const nestSlotItem = () => {
   return ({state, dispatch}: {state: EditorState; dispatch: ((args?: any) => any) | undefined}) => {
     const {group, container, depth, $pos} = getGroupInfoFromPos(state.selection.from, state)
     if (!container) return false
@@ -135,59 +134,239 @@ export const nestFirstSlotItemCommand = () => {
 }
 
 /**
- * Lift the first item out of a root-level Slot list. It becomes a plain
- * block at the root, while the remaining items stay grouped in the Slot.
- * If the Slot held only one item, the whole Slot is unwrapped.
+ * Unnest a single root Slot item by one level. It leaves the Slot to
+ * become a plain root block, keeping its entire subtree nested under it.
  *
  * @param opts.requireAtStart when true (Backspace), only fires if the cursor is
  * at the very start of the item's content.
  */
-export const liftFirstSlotItemCommand = (opts: {requireAtStart?: boolean} = {}) => {
+export const liftSlotItem = (opts: {requireAtStart?: boolean} = {}) => {
   return ({state, dispatch}: {state: EditorState; dispatch: ((args?: any) => any) | undefined}) => {
-    const {group, container, depth, $pos} = getGroupInfoFromPos(state.selection.from, state)
-    if (!container) return false
+    const {$from} = state.selection
 
-    const slotWrapper = depth - 1 >= 0 ? $pos.node(depth - 1) : null
-    const isRootSlot =
-      slotWrapper?.type.name === 'blockNode' &&
-      slotWrapper.firstChild?.type.name === 'slot' &&
-      depth - 3 >= 0 &&
-      $pos.node(depth - 2).type.name === 'blockChildren' &&
-      $pos.node(depth - 3).type.name === 'doc'
-    if (!isRootSlot) return false
+    // Locate the root Slot's inner list group.
+    let groupDepth = -1
+    for (let d = $from.depth; d >= 3; d--) {
+      if ($from.node(d).type.name !== 'blockChildren') continue
+      const parent = $from.node(d - 1)
+      const grand = $from.node(d - 2)
+      const great = $from.node(d - 3)
+      if (
+        parent.type.name === 'blockNode' &&
+        parent.firstChild?.type.name === 'slot' &&
+        grand.type.name === 'blockChildren' &&
+        great.type.name === 'doc'
+      ) {
+        groupDepth = d
+        break
+      }
+    }
+    if (groupDepth === -1) return false
+    // Must be a cursor directly in a top-level item (content block at +2).
+    if ($from.depth !== groupDepth + 2) return false
+    if (opts.requireAtStart && $from.parentOffset !== 0) return false
 
-    // Only the first item lifts to root.
-    if (group.firstChild?.attrs.id !== container.attrs.id) return false
-    // For Backspace, only when the cursor is at the very start of the item.
-    if (opts.requireAtStart && $pos.parentOffset !== 0) return false
+    const innerGroup = $from.node(groupDepth)
+    const slotWrapper = $from.node(groupDepth - 1)
+    const slotNode = slotWrapper.firstChild
+    const blockNodeType = state.schema.nodes['blockNode']
+    if (!slotNode || !blockNodeType) return false
 
+    const itemIndex = $from.index(groupDepth)
     if (!dispatch) return true
 
-    const innerGroup = slotWrapper!.lastChild! // the list blockChildren
-    const firstItem = innerGroup.firstChild!
-    const slotWrapperPos = $pos.before(depth - 1)
-    const slotWrapperEnd = slotWrapperPos + slotWrapper!.nodeSize
+    const items: PMNode[] = []
+    innerGroup.forEach((child) => items.push(child))
+    const item = items[itemIndex]!
+    const before = items.slice(0, itemIndex)
+    const after = items.slice(itemIndex + 1)
 
-    let replacement: PMNode[]
-    if (innerGroup.childCount === 1) {
-      // Only item. Unwrap the Slot entirely.
-      replacement = [firstItem]
-    } else {
-      // Keep the remaining items grouped in a Slot after the lifted first item.
-      const remaining: PMNode[] = []
-      innerGroup.forEach((child, _offset, index) => {
-        if (index > 0) remaining.push(child)
+    let idUsed = false
+    const makeSlot = (groupItems: PMNode[]): PMNode => {
+      const attrs = idUsed ? {...slotWrapper.attrs, id: null} : slotWrapper.attrs
+      idUsed = true
+      return blockNodeType.create(attrs, [slotNode, innerGroup.copy(Fragment.fromArray(groupItems))])
+    }
+
+    const replacement: PMNode[] = []
+    if (before.length) replacement.push(makeSlot(before))
+    replacement.push(item)
+    if (after.length) replacement.push(makeSlot(after))
+
+    const slotWrapperPos = $from.before(groupDepth - 1)
+    const slotWrapperEnd = slotWrapperPos + slotWrapper.nodeSize
+    const tr = state.tr.replaceWith(slotWrapperPos, slotWrapperEnd, replacement)
+
+    // Keep the cursor in the lifted item at the same offset.
+    const liftedStart = slotWrapperPos + (before.length ? replacement[0]!.nodeSize : 0)
+    tr.setSelection(TextSelection.near(tr.doc.resolve(liftedStart + 2 + $from.parentOffset))).scrollIntoView()
+    dispatch(tr)
+    return true
+  }
+}
+
+// Check if a list item carries a nested sublist.
+function itemSublist(item: PMNode): PMNode | null {
+  return item.childCount === 2 && item.lastChild?.type.name === 'blockChildren' ? item.lastChild : null
+}
+
+/**
+ * Outdent every selected list item inside a root Slot by exactly one level.
+ */
+export const liftSlotSelection = () => {
+  return ({state, dispatch}: {state: EditorState; dispatch: ((args?: any) => any) | undefined}) => {
+    const selection = state.selection
+    const {$from} = selection
+
+    // Locate the root Slot's inner list group, if any.
+    let groupDepth = -1
+    for (let d = $from.depth; d >= 3; d--) {
+      if ($from.node(d).type.name !== 'blockChildren') continue
+      const parent = $from.node(d - 1)
+      const grand = $from.node(d - 2)
+      const great = $from.node(d - 3)
+      if (
+        parent.type.name === 'blockNode' &&
+        parent.firstChild?.type.name === 'slot' &&
+        grand.type.name === 'blockChildren' &&
+        great.type.name === 'doc'
+      ) {
+        groupDepth = d
+        break
+      }
+    }
+    if (groupDepth === -1) return false
+
+    const innerGroup = $from.node(groupDepth)
+    const slotWrapper = $from.node(groupDepth - 1)
+    const slotNode = slotWrapper.firstChild
+    const blockNodeType = state.schema.nodes['blockNode']
+    const blockChildrenType = state.schema.nodes['blockChildren']
+    if (!slotNode || !blockNodeType || !blockChildrenType) return false
+
+    const slotWrapperPos = $from.before(groupDepth - 1)
+    const slotWrapperEnd = slotWrapperPos + slotWrapper.nodeSize
+
+    // Determine selected items.
+    const {from, to} = selection
+    const selectedIds = new Set<string>()
+    state.doc.nodesBetween(slotWrapperPos, slotWrapperEnd, (node, pos) => {
+      if (node.type.name === 'blockNode' && typeof node.attrs.id === 'string' && node.firstChild) {
+        const cStart = pos + 1
+        const cEnd = cStart + node.firstChild.nodeSize
+        const overlaps = from === to ? cStart <= from && from <= cEnd : cStart < to && cEnd > from
+        if (overlaps) selectedIds.add(node.attrs.id)
+      }
+      return true
+    })
+    if (!selectedIds.size) return false
+    if (!dispatch) return true
+
+    // Remember both selection endpoints by (block id, offset)
+    // so we can restore the same range after the rebuild.
+    const captureEndpoint = ($pos: typeof $from): {id: string | null; offset: number} => {
+      for (let d = $pos.depth; d >= 1; d--) {
+        const node = $pos.node(d)
+        if (node.type.name === 'blockNode' && typeof node.attrs.id === 'string') {
+          return {id: node.attrs.id, offset: $pos.parentOffset}
+        }
+      }
+      return {id: null, offset: $pos.parentOffset}
+    }
+    const anchorEnd = captureEndpoint($from)
+    const headEnd = captureEndpoint(selection.$to)
+
+    // Flatten to (content item, target depth, original list attrs).
+    // A Slot item starts at depth 1 and each nesting adds one.
+    // The depth drops by one when the item, or any ancestor is selected.
+    type Flat = {item: PMNode; depth: number; listAttrs: PMNode['attrs']}
+    const flat: Flat[] = []
+    const flatten = (list: PMNode, depth: number, ancestorSelected: boolean) => {
+      list.forEach((item) => {
+        const selected = ancestorSelected || (typeof item.attrs.id === 'string' && selectedIds.has(item.attrs.id))
+        const sublist = itemSublist(item)
+        flat.push({
+          item: blockNodeType.create(item.attrs, [item.firstChild!]),
+          depth: selected ? depth - 1 : depth,
+          listAttrs: list.attrs,
+        })
+        if (sublist) flatten(sublist, depth + 1, selected)
       })
-      const newInnerGroup = innerGroup.copy(Fragment.fromArray(remaining))
-      const newSlot = slotWrapper!.copy(Fragment.fromArray([slotWrapper!.firstChild!, newInnerGroup]))
-      replacement = [firstItem, newSlot]
+    }
+    flatten(innerGroup, 1, false)
+
+    // Rebuild the nested list items for a run of same or deeper entries.
+    // Each entry becomes a blockNode. Deeper entries become its nested list.
+    const buildNested = (entries: Flat[], depth: number): PMNode[] => {
+      const result: PMNode[] = []
+      let i = 0
+      while (i < entries.length) {
+        const cur = entries[i]!
+        let j = i + 1
+        while (j < entries.length && entries[j]!.depth > depth) j++
+        const descendants = entries.slice(i + 1, j)
+        let node = cur.item
+        if (descendants.length) {
+          const childList = blockChildrenType.create(
+            descendants[0]!.listAttrs,
+            Fragment.fromArray(buildNested(descendants, depth + 1)),
+          )
+          node = blockNodeType.create(cur.item.attrs, [cur.item.firstChild!, childList])
+        }
+        result.push(node)
+        i = j
+      }
+      return result
+    }
+
+    // Walk the flattened items. Depth 0 entries are plain root blocks.
+    // Each run of depth 1+ entries becomes one Slot-wrapped list.
+    let idUsed = false
+    const replacement: PMNode[] = []
+    let i = 0
+    while (i < flat.length) {
+      if (flat[i]!.depth <= 0) {
+        replacement.push(flat[i]!.item)
+        i++
+        continue
+      }
+      let j = i
+      while (j < flat.length && flat[j]!.depth >= 1) j++
+      const run = flat.slice(i, j)
+      const list = blockChildrenType.create(run[0]!.listAttrs, Fragment.fromArray(buildNested(run, 1)))
+      const attrs = idUsed ? {...slotWrapper.attrs, id: null} : slotWrapper.attrs
+      idUsed = true
+      replacement.push(blockNodeType.create(attrs, [slotNode, list]))
+      i = j
     }
 
     const tr = state.tr.replaceWith(slotWrapperPos, slotWrapperEnd, replacement)
-    // The lifted first item now sits at slotWrapperPos.
-    // Its content starts at +2. Preserve the cursor's offset.
-    const newFrom = slotWrapperPos + 2 + $pos.parentOffset
-    tr.setSelection(TextSelection.near(tr.doc.resolve(newFrom))).scrollIntoView()
+
+    // Restore the selection over the same blocks.
+    const locate = (end: {id: string | null; offset: number}): number | null => {
+      if (!end.id) return null
+      let result: number | null = null
+      tr.doc.descendants((node, pos) => {
+        if (result !== null) return false
+        if (node.type.name === 'blockNode' && node.attrs.id === end.id) {
+          const content = node.firstChild
+          const maxOffset = content ? content.content.size : 0
+          result = pos + 2 + Math.min(end.offset, maxOffset)
+          return false
+        }
+        return true
+      })
+      return result
+    }
+    const anchorPos = locate(anchorEnd)
+    const headPos = locate(headEnd)
+    const clamp = (p: number) => Math.max(0, Math.min(p, tr.doc.content.size))
+    if (anchorPos !== null && headPos !== null) {
+      tr.setSelection(TextSelection.between(tr.doc.resolve(clamp(anchorPos)), tr.doc.resolve(clamp(headPos))))
+    } else if (anchorPos !== null) {
+      tr.setSelection(TextSelection.near(tr.doc.resolve(clamp(anchorPos))))
+    }
+    tr.scrollIntoView()
     dispatch(tr)
     return true
   }
@@ -211,13 +390,10 @@ export const updateGroupCommand = (
     dispatch: ((args?: any) => any) | undefined
   }) => {
     // Find block group, block container and depth it is at
-    const {
-      group,
-      container,
-      depth,
-      level: groupLevel,
-      $pos,
-    } = getGroupInfoFromPos(posInBlock < 0 ? state.selection.from : posInBlock, state)
+    const {group, container, depth, $pos} = getGroupInfoFromPos(
+      posInBlock < 0 ? state.selection.from : posInBlock,
+      state,
+    )
 
     if (isSank && group.attrs.listType === listType) return true
 
@@ -236,15 +412,9 @@ export const updateGroupCommand = (
         tr.setNodeMarkup($pos.before(depth), null, {
           ...group.attrs,
           listType: 'Group',
-          listLevel: '1',
         })
         dispatch(tr)
       }
-
-      // Update children levels asynchronously
-      setTimeout(() => {
-        editor.commands.command(updateGroupChildrenCommand(group, container, $pos, 0, group.attrs.listType, false))
-      })
 
       return true
     }
@@ -256,7 +426,7 @@ export const updateGroupCommand = (
 
       // Wrap the block in an invisible Slot.
       setTimeout(() => {
-        editor.commands.command(({state: s, dispatch: d}) => wrapBlockInSlot(s, d, listType, '1', s.selection.from))
+        editor.commands.command(({state: s, dispatch: d}) => wrapBlockInSlot(s, d, listType, s.selection.from))
       })
       return false
     }
@@ -273,7 +443,7 @@ export const updateGroupCommand = (
         // Can't sink under a table, so wrap the block in an invisible Slot that
         // carries the list instead.
         setTimeout(() => {
-          editor.commands.command(({state: s, dispatch: d}) => wrapBlockInSlot(s, d, listType, '1', s.selection.from))
+          editor.commands.command(({state: s, dispatch: d}) => wrapBlockInSlot(s, d, listType, s.selection.from))
         })
         return false
       }
@@ -303,7 +473,7 @@ export const updateGroupCommand = (
         // Can't sink under a table, so wrap the block in an invisible Slot that
         // carries the list instead.
         setTimeout(() => {
-          editor.commands.command(({state: s, dispatch: d}) => wrapBlockInSlot(s, d, listType, '1', s.selection.from))
+          editor.commands.command(({state: s, dispatch: d}) => wrapBlockInSlot(s, d, listType, s.selection.from))
         })
         return false
       }
@@ -320,112 +490,14 @@ export const updateGroupCommand = (
     }
 
     if (dispatch && group.type.name === 'blockChildren') {
-      let level = '1'
-      // Set new level based on the level of the previous group, if any.
-      if (depth >= 5) {
-        const {node: parentGroup, pos: parentGroupPos} = getParentGroupInfoFromPos(group, $pos, depth)
-        if (parentGroup && parentGroup.attrs.listType === listType) {
-          level = `${parseInt(parentGroup.attrs.listLevel) + 1}`
-        }
-      }
-
       const tr = state.tr
       tr.setNodeMarkup($pos.before(depth), null, {
         ...group.attrs,
         listType: listType,
-        listLevel: level,
       })
       dispatch(tr)
-
-      // Update children levels asynchronously
-      if (container) {
-        setTimeout(() => {
-          editor.commands.command(
-            updateGroupChildrenCommand(
-              group,
-              container!,
-              $pos,
-              listType === 'Unordered' ? parseInt(level) : 0,
-              listType,
-              true,
-            ),
-          )
-        })
-      }
     }
 
     return true
-  }
-}
-
-export const updateGroupChildrenCommand = (
-  group: PMNode,
-  container: PMNode,
-  groupPos: ResolvedPos,
-  groupLevel: number,
-  listType: HMBlockChildrenType,
-  indent: boolean,
-) => {
-  return ({state, dispatch}: {state: EditorState; dispatch: ((args?: any) => any) | undefined}) => {
-    if (dispatch) {
-      let beforeSelectedContainer = true
-      let tr = state.tr
-      // Update children level of each child of the group.
-      group.content.forEach((childContainer, offset) => {
-        if (childContainer.type.name === 'blockNode') {
-          if (childContainer.attrs.id === container.attrs.id) {
-            beforeSelectedContainer = false
-          }
-          if (beforeSelectedContainer) {
-            return
-          }
-          childContainer.descendants((childGroup, pos, _parent, index) => {
-            // If the child has a group, update group's list level attribute.
-            if (childGroup.type.name === 'blockChildren' && childGroup.attrs.listType === 'Unordered') {
-              const $pos = childContainer.resolve(pos)
-              let newLevel: string
-              // Set new level based on depth and indent.
-              if (indent) {
-                let numericLevel = $pos.depth / 2 + groupLevel + 1
-                newLevel = numericLevel < 3 ? numericLevel.toString() : '3'
-              } else {
-                let numericLevel = $pos.depth / 2 + groupLevel
-                newLevel = numericLevel < 3 ? numericLevel.toString() : '3'
-              }
-              const maybeContainer = state.doc.resolve(groupPos.start() + pos - 1).parent
-
-              // Position adjustment based on where the node is in the group.
-              let posAddition =
-                maybeContainer.type.name === 'blockNode'
-                  ? indent && group.attrs.listType === listType
-                    ? -3
-                    : -1
-                  : group.lastChild && childContainer.eq(group.lastChild) && !childContainer.eq(group.firstChild!)
-                    ? 1
-                    : 0
-
-              if (
-                childContainer.eq(maybeContainer) &&
-                indent
-                // &&
-                // childContainer.eq(group.firstChild!)
-              )
-                posAddition = -1
-
-              // Add offset only when changing between list types.
-              if (group.attrs.listType !== listType) posAddition += offset
-
-              if (newLevel !== childGroup.attrs.listLevel) {
-                tr = tr.setNodeAttribute(groupPos.start() + pos + posAddition, 'listLevel', newLevel)
-              }
-            }
-          })
-        }
-      })
-
-      dispatch(tr)
-      return true
-    }
-    return false
   }
 }

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/commands/updateGroup.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/commands/updateGroup.ts
@@ -56,6 +56,53 @@ function wrapBlockInSlot(
 }
 
 /**
+ * Wrap all top-level blocks the selection touches into a single root-level Slot
+ * list, so setting a list type on a multi-block selection turns every selected
+ * block into a list item.
+ */
+function wrapBlocksInSlot(
+  state: EditorState,
+  dispatch: ((args?: any) => any) | undefined,
+  listType: HMBlockChildrenType,
+): boolean {
+  const slotType = state.schema.nodes['slot']
+  const blockNodeType = state.schema.nodes['blockNode']
+  const blockChildrenType = state.schema.nodes['blockChildren']
+  if (!slotType || !blockNodeType || !blockChildrenType) return false
+
+  const rootGroup = state.doc.firstChild
+  if (!rootGroup || rootGroup.type.name !== 'blockChildren') return false
+
+  // Collect the root-level blockNodes whose range overlaps the selection.
+  const {from, to} = state.selection
+  const selected: PMNode[] = []
+  let firstStart = -1
+  let lastEnd = -1
+  let childStart = 1 // doc content opens at 0. The root group's first child sits at 1
+  rootGroup.forEach((child) => {
+    const childEnd = childStart + child.nodeSize
+    if (child.type.name === 'blockNode' && childStart < to && childEnd > from) {
+      selected.push(child)
+      if (firstStart < 0) firstStart = childStart
+      lastEnd = childEnd
+    }
+    childStart = childEnd
+  })
+  if (!selected.length) return false
+  if (!dispatch) return true
+
+  const slotContent = slotType.create({childrenType: listType})
+  const innerChildren = blockChildrenType.create({listType}, Fragment.fromArray(selected))
+  const wrappingBlock = blockNodeType.create(null, [slotContent, innerChildren])
+
+  const tr = state.tr.replaceWith(firstStart, lastEnd, wrappingBlock)
+  // Cursor into the first wrapped item's content.
+  tr.setSelection(TextSelection.near(tr.doc.resolve(firstStart + 4))).scrollIntoView()
+  dispatch(tr)
+  return true
+}
+
+/**
  * Unwrap a root-level Slot: replace the slot wrapper blockNode with the list
  * items it holds, lifting them back to the root as plain blocks and discarding
  * the slot.
@@ -424,9 +471,9 @@ export const updateGroupCommand = (
 
       if (!dispatch) return true
 
-      // Wrap the block in an invisible Slot.
+      // Wrap every selected root-level block in a single invisible Slot.
       setTimeout(() => {
-        editor.commands.command(({state: s, dispatch: d}) => wrapBlockInSlot(s, d, listType, s.selection.from))
+        editor.commands.command(({state: s, dispatch: d}) => wrapBlocksInSlot(s, d, listType))
       })
       return false
     }

--- a/frontend/packages/editor/src/blocknote/core/api/nodeConversions/__tests__/blockToNode.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/nodeConversions/__tests__/blockToNode.test.ts
@@ -26,7 +26,6 @@ function createSchemaWithCodeBlock(): Schema {
         content: 'blockNode+',
         attrs: {
           listType: {default: 'Group'},
-          listLevel: {default: '1'},
           columnCount: {default: null},
         },
       },

--- a/frontend/packages/editor/src/blocknote/core/api/nodeConversions/__tests__/tableConversions.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/nodeConversions/__tests__/tableConversions.test.ts
@@ -21,7 +21,6 @@ function createTableSchema(): Schema {
         content: 'blockNode+',
         attrs: {
           listType: {default: 'Group'},
-          listLevel: {default: '1'},
           start: {default: null},
           columnCount: {default: null},
         },

--- a/frontend/packages/editor/src/blocknote/core/api/nodeConversions/nodeConversions.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/nodeConversions/nodeConversions.ts
@@ -446,9 +446,8 @@ export function nodeToBlock<BSchema extends BlockSchema>(
   }
 
   if (node.lastChild!.attrs.listType) {
-    const {listType, listLevel, start, columnCount} = node.lastChild!.attrs
+    const {listType, start, columnCount} = node.lastChild!.attrs
     props['childrenType'] = listType
-    props['listLevel'] = listLevel
     props['start'] = start
     if (listType === 'Grid' && columnCount) {
       props['columnCount'] = columnCount
@@ -461,7 +460,6 @@ export function nodeToBlock<BSchema extends BlockSchema>(
     // Table's children are structural rows/columns. Strip list/grid affiliated
     // attributes because tables cannot have nested blockChildren nodes.
     delete props.childrenType
-    delete props.listLevel
     delete props.start
     delete props.columnCount
 
@@ -490,11 +488,10 @@ export function nodeToBlock<BSchema extends BlockSchema>(
         orphanedChildren.push(nodeToBlock(orphanedContainer.child(j), blockSchema, blockCache))
       }
       const listType = orphanedContainer.attrs?.listType || 'Group'
-      const listLevel = orphanedContainer.attrs?.listLevel || '1'
       children.push({
         id: UniqueID.options.generateID(),
         type: 'paragraph',
-        props: {childrenType: listType, listLevel},
+        props: {childrenType: listType},
         content: [],
         children: orphanedChildren,
       } as unknown as Block<BSchema>)

--- a/frontend/packages/editor/src/blocknote/core/extensions/BlockRevision/BlockRevisionInvalidation.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/BlockRevision/BlockRevisionInvalidation.ts
@@ -18,7 +18,6 @@ const IGNORED_ATTRS = new Set([
   'textFamily',
   'childrenType',
   'listType',
-  'listLevel',
   'start',
   'columnCount',
   'colwidth',

--- a/frontend/packages/editor/src/blocknote/core/extensions/Blocks/api/defaultBlocks.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/Blocks/api/defaultBlocks.ts
@@ -18,9 +18,6 @@ export const defaultProps = {
     default: 'Group' as const,
     values: ['Group', 'Unordered', 'Ordered', 'Blockquote', 'Grid'] as const,
   },
-  listLevel: {
-    default: '1' as const,
-  },
 } satisfies PropSchema
 
 export type DefaultProps = typeof defaultProps

--- a/frontend/packages/editor/src/blocknote/core/extensions/Blocks/helpers/getBlockInfoFromPos.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/Blocks/helpers/getBlockInfoFromPos.ts
@@ -41,6 +41,7 @@ export type BlockInfo = {
  * @returns The position just before the nearest blockNode node.
  */
 export function getNearestBlockPos(doc: Node, pos: number) {
+  pos = Math.max(0, Math.min(pos, doc.content.size))
   const $pos = doc.resolve(pos)
 
   // Check if the position provided is already just before a block node, in

--- a/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/Block.module.css
+++ b/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/Block.module.css
@@ -150,11 +150,14 @@ NESTED BLOCKS
   list-style-type: disc;
 }
 
-.blockChildren[data-list-level='2'] {
+/* Bullet marker cycles with real nesting depth. */
+.blockChildren[data-list-type='Unordered'] .blockChildren[data-list-type='Unordered'] {
   list-style-type: circle;
 }
 
-.blockChildren[data-list-level='3'] {
+.blockChildren[data-list-type='Unordered']
+  .blockChildren[data-list-type='Unordered']
+  .blockChildren[data-list-type='Unordered'] {
   list-style-type: square;
 }
 

--- a/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/Block.module.css
+++ b/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/Block.module.css
@@ -39,6 +39,14 @@ BASIC STYLES
   /*margin: 0px;*/
 }
 
+.blockContent[data-content-type='slot'] {
+  display: none;
+}
+
+.blockNode:has(> .blockContent[data-content-type='slot']) > .blockChildren {
+  margin-left: 0;
+}
+
 /*
 NESTED BLOCKS
 */

--- a/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/BlockChildren.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/BlockChildren.ts
@@ -17,15 +17,6 @@ export const BlockChildren = Node.create<{
 
   addAttributes() {
     return {
-      listLevel: {
-        default: '1',
-        parseHTML: (element) => element.getAttribute('data-list-level'),
-        renderHTML: (attributes) => {
-          return {
-            'data-list-level': attributes.listLevel,
-          }
-        },
-      },
       listType: {
         default: 'Group',
         parseHTML: (element) => element.getAttribute('data-list-type'),

--- a/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/normalizeFragment.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/normalizeFragment.ts
@@ -25,21 +25,28 @@ function orphanGroupPlaceholder(blockGroupNode: any, schema: any): any {
 
 /**
  * Wraps a blockChildren node in a blockNode. A list/blockquote is fronted by an
- * invisible Slot; a plain Group by an empty paragraph. If a previous blockNode
- * exists and doesn't have a child blockChildren, merges the blockChildren into
- * it instead of creating a new container.
+ * invisible Slot; a plain Group by an empty paragraph. If the previous blockNode
+ * is a plain block with no children of its own, the blockChildren is merged into
+ * it. the caller should then replace that previous node. Otherwise a fresh container
+ * is returned and the caller must push it, so an existing node is not overwritten.
  */
-function wrapBlockGroupInContainer(blockGroupNode: any, schema: any, previousNode: any): any {
+function wrapBlockGroupInContainer(blockGroupNode: any, schema: any, previousNode: any): {node: any; merged: boolean} {
   if (
     previousNode &&
     previousNode.type.name === 'blockNode' &&
     previousNode.childCount === 1 &&
     previousNode.firstChild?.type.spec?.group === 'block'
   ) {
-    return schema.nodes['blockNode']!.create(previousNode.attrs, [previousNode.firstChild, blockGroupNode])
+    return {
+      node: schema.nodes['blockNode']!.create(previousNode.attrs, [previousNode.firstChild, blockGroupNode]),
+      merged: true,
+    }
   }
 
-  return schema.nodes['blockNode']!.create(null, [orphanGroupPlaceholder(blockGroupNode, schema), blockGroupNode])
+  return {
+    node: schema.nodes['blockNode']!.create(null, [orphanGroupPlaceholder(blockGroupNode, schema), blockGroupNode]),
+    merged: false,
+  }
 }
 
 /**
@@ -122,27 +129,20 @@ export function normalizeFragment(fragment: Fragment, schema?: any): Fragment {
       }
 
       if (groupNode.attrs?.listType === 'Group') {
-        let hasNestedLists = false
-        groupContent.forEach((child: any) => {
-          if (child.type?.name === 'blockNode' && child.lastChild?.type?.name === 'blockChildren') {
-            hasNestedLists = true
-          }
+        groupContent.forEach((childNode: any) => {
+          nodes.push(childNode)
         })
-
-        if (!hasNestedLists) {
-          groupContent.forEach((childNode: any) => {
-            nodes.push(childNode)
-          })
-          return
-        }
+        return
       }
 
       const normalizedGroup = groupNode.type.create(groupNode.attrs, groupContent)
 
       if (schema) {
         const prevNode = nodes[nodes.length - 1]
-        const wrappedContainer = wrapBlockGroupInContainer(normalizedGroup, schema, prevNode)
-        if (prevNode && wrappedContainer !== normalizedGroup) {
+        const {node: wrappedContainer, merged} = wrapBlockGroupInContainer(normalizedGroup, schema, prevNode)
+        // Replace the previous node only when the group was actually merged into
+        // it. Otherwise push, so a preceding block (e.g. another list) survives.
+        if (merged) {
           nodes[nodes.length - 1] = wrappedContainer
         } else {
           nodes.push(wrappedContainer)

--- a/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/normalizeFragment.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/normalizeFragment.ts
@@ -15,10 +15,7 @@ function wrapBlockContentInContainer(blockContentNode: any, schema: any): any {
 function orphanGroupPlaceholder(blockGroupNode: any, schema: any): any {
   const listType = blockGroupNode?.attrs?.listType
   if (listType && listType !== 'Group' && schema.nodes['slot']) {
-    return schema.nodes['slot'].create({
-      childrenType: listType,
-      listLevel: blockGroupNode.attrs?.listLevel ?? '1',
-    })
+    return schema.nodes['slot'].create({childrenType: listType})
   }
   return schema.nodes['paragraph']!.create()
 }

--- a/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/normalizeFragment.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/normalizeFragment.ts
@@ -8,9 +8,26 @@ function wrapBlockContentInContainer(blockContentNode: any, schema: any): any {
 }
 
 /**
- * Wraps a blockChildren node in a blockNode with an empty paragraph.
- * If a previous blockNode exists and doesn't have a child blockChildren,
- * merges the blockChildren into it instead of creating a new container.
+ * The block content that fronts a blockNode wrapping an orphan blockChildren.
+ * A list or blockquote uses an invisible Slot to hold its childrenType.
+ * A plain Group falls back to an empty paragraph.
+ */
+function orphanGroupPlaceholder(blockGroupNode: any, schema: any): any {
+  const listType = blockGroupNode?.attrs?.listType
+  if (listType && listType !== 'Group' && schema.nodes['slot']) {
+    return schema.nodes['slot'].create({
+      childrenType: listType,
+      listLevel: blockGroupNode.attrs?.listLevel ?? '1',
+    })
+  }
+  return schema.nodes['paragraph']!.create()
+}
+
+/**
+ * Wraps a blockChildren node in a blockNode. A list/blockquote is fronted by an
+ * invisible Slot; a plain Group by an empty paragraph. If a previous blockNode
+ * exists and doesn't have a child blockChildren, merges the blockChildren into
+ * it instead of creating a new container.
  */
 function wrapBlockGroupInContainer(blockGroupNode: any, schema: any, previousNode: any): any {
   if (
@@ -22,8 +39,7 @@ function wrapBlockGroupInContainer(blockGroupNode: any, schema: any, previousNod
     return schema.nodes['blockNode']!.create(previousNode.attrs, [previousNode.firstChild, blockGroupNode])
   }
 
-  const placeholderParagraph = schema.nodes['paragraph']!.create()
-  return schema.nodes['blockNode']!.create(null, [placeholderParagraph, blockGroupNode])
+  return schema.nodes['blockNode']!.create(null, [orphanGroupPlaceholder(blockGroupNode, schema), blockGroupNode])
 }
 
 /**
@@ -173,9 +189,10 @@ export function normalizeBlockContainer(node: any, schema?: any) {
     }
   })
 
-  // Add an empty paragraph if the blockChildren is the only child (invalid structure)
+  // A blockNode with only a blockChildren is invalid structure. Front it with a
+  // Slot (for a list/blockquote) or an empty paragraph (for a plain Group).
   if (children.length === 1 && children[0].type.name === 'blockChildren' && schema) {
-    children.unshift(schema.nodes.paragraph.createAndFill() ?? schema.nodes.paragraph.create())
+    children.unshift(orphanGroupPlaceholder(children[0], schema))
   }
 
   return node.type.create(node.attrs, children)

--- a/frontend/packages/editor/src/blocknote/core/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
@@ -7,7 +7,8 @@ import {nestBlock, unnestBlock} from '../../api/blockManipulation/commands/nestB
 import {getCarryableStoredMarks, splitBlockCommand} from '../../api/blockManipulation/commands/splitBlock'
 import {updateBlockCommand} from '../../api/blockManipulation/commands/updateBlock'
 import {
-  nestFirstRootSlotItemCommand,
+  liftFirstSlotItemCommand,
+  nestFirstSlotItemCommand,
   updateGroupChildrenCommand,
   updateGroupCommand,
 } from '../../api/blockManipulation/commands/updateGroup'
@@ -35,6 +36,9 @@ export const KeyboardShortcutsExtension = Extension.create<{
         () => commands.deleteSelection(),
         // Undoes an input rule if one was triggered in the last editor state change.
         () => commands.undoInputRule(),
+        // At the start of the first item of a root-level Slot list, lift just that
+        // item out to the root (keeping the rest grouped) — same as Shift-Tab.
+        () => commands.command(liftFirstSlotItemCommand({requireAtStart: true})),
         // Moves a first child block of a heading to be a part of the heading.
         () =>
           commands.command(({state, dispatch}) => {
@@ -564,7 +568,7 @@ export const KeyboardShortcutsExtension = Extension.create<{
       return this.editor.commands.first(({commands}) => [
         // Tab on the first item of a root-level Slot's list nests the whole list
         // under the previous root block and removes the slot.
-        () => commands.command(nestFirstRootSlotItemCommand()),
+        () => commands.command(nestFirstSlotItemCommand()),
         // If the current block's previous sibling is a table, create an empty paragraph
         // blockNode, and indent a group under it.
         () =>
@@ -685,14 +689,14 @@ export const KeyboardShortcutsExtension = Extension.create<{
       Enter: handleEnter,
       Tab: handleTab,
       'Shift-Tab': () => {
-        console.log('[CTF] Shift-Tab handler entered')
         // Prevent outdent of grid children
         if (isInGridContainer(this.editor.state, this.editor.state.selection.from)) {
-          console.log('[CTF] Shift-Tab | SKIPPED: in grid container')
+          return true
+        }
+        if (this.editor.commands.command(liftFirstSlotItemCommand())) {
           return true
         }
         const {block} = getBlockInfoFromSelection(this.editor.state)
-        console.log('[CTF] Shift-Tab | calling unnestBlock at pos:', block.beforePos + 1)
         return unnestBlock(this.editor, block.beforePos + 1)
       },
       // "Shift-Mod-ArrowUp": () => {

--- a/frontend/packages/editor/src/blocknote/core/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
@@ -6,7 +6,11 @@ import {mergeBlocksCommand} from '../../api/blockManipulation/commands/mergeBloc
 import {nestBlock, unnestBlock} from '../../api/blockManipulation/commands/nestBlock'
 import {getCarryableStoredMarks, splitBlockCommand} from '../../api/blockManipulation/commands/splitBlock'
 import {updateBlockCommand} from '../../api/blockManipulation/commands/updateBlock'
-import {updateGroupChildrenCommand, updateGroupCommand} from '../../api/blockManipulation/commands/updateGroup'
+import {
+  nestFirstRootSlotItemCommand,
+  updateGroupChildrenCommand,
+  updateGroupCommand,
+} from '../../api/blockManipulation/commands/updateGroup'
 import {BlockNoteEditor} from '../../BlockNoteEditor'
 import {selectableNodeTypes} from '../Blocks/api/selectable-node-types'
 import {getBlockInfoFromPos, getBlockInfoFromSelection} from '../Blocks/helpers/getBlockInfoFromPos'
@@ -557,8 +561,10 @@ export const KeyboardShortcutsExtension = Extension.create<{
       ])
 
     const handleTab = () => {
-      console.log('[CTF] handleTab started')
       return this.editor.commands.first(({commands}) => [
+        // Tab on the first item of a root-level Slot's list nests the whole list
+        // under the previous root block and removes the slot.
+        () => commands.command(nestFirstRootSlotItemCommand()),
         // If the current block's previous sibling is a table, create an empty paragraph
         // blockNode, and indent a group under it.
         () =>

--- a/frontend/packages/editor/src/blocknote/core/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
@@ -6,12 +6,7 @@ import {mergeBlocksCommand} from '../../api/blockManipulation/commands/mergeBloc
 import {nestBlock, unnestBlock} from '../../api/blockManipulation/commands/nestBlock'
 import {getCarryableStoredMarks, splitBlockCommand} from '../../api/blockManipulation/commands/splitBlock'
 import {updateBlockCommand} from '../../api/blockManipulation/commands/updateBlock'
-import {
-  liftFirstSlotItemCommand,
-  nestFirstSlotItemCommand,
-  updateGroupChildrenCommand,
-  updateGroupCommand,
-} from '../../api/blockManipulation/commands/updateGroup'
+import {liftSlotItem, nestSlotItem, updateGroupCommand} from '../../api/blockManipulation/commands/updateGroup'
 import {BlockNoteEditor} from '../../BlockNoteEditor'
 import {selectableNodeTypes} from '../Blocks/api/selectable-node-types'
 import {getBlockInfoFromPos, getBlockInfoFromSelection} from '../Blocks/helpers/getBlockInfoFromPos'
@@ -36,9 +31,10 @@ export const KeyboardShortcutsExtension = Extension.create<{
         () => commands.deleteSelection(),
         // Undoes an input rule if one was triggered in the last editor state change.
         () => commands.undoInputRule(),
-        // At the start of the first item of a root-level Slot list, lift just that
-        // item out to the root (keeping the rest grouped) — same as Shift-Tab.
-        () => commands.command(liftFirstSlotItemCommand({requireAtStart: true})),
+        // At the start of a top-level root-Slot item, lift just that item out to
+        // the root, keeping its subtree nested — same single-item unnest as a
+        // collapsed Shift-Tab (which routes to liftSlotItem via unnestBlock).
+        () => commands.command(liftSlotItem({requireAtStart: true})),
         // Moves a first child block of a heading to be a part of the heading.
         () =>
           commands.command(({state, dispatch}) => {
@@ -568,7 +564,7 @@ export const KeyboardShortcutsExtension = Extension.create<{
       return this.editor.commands.first(({commands}) => [
         // Tab on the first item of a root-level Slot's list nests the whole list
         // under the previous root block and removes the slot.
-        () => commands.command(nestFirstSlotItemCommand()),
+        () => commands.command(nestSlotItem()),
         // If the current block's previous sibling is a table, create an empty paragraph
         // blockNode, and indent a group under it.
         () =>
@@ -593,7 +589,7 @@ export const KeyboardShortcutsExtension = Extension.create<{
               const blockChildrenType = state.schema.nodes['blockChildren']
 
               const emptyParagraph = paragraphType!.create()
-              const innerChildren = blockChildrenType!.create({listType: 'Group', listLevel: '1'}, blockInfo.block.node)
+              const innerChildren = blockChildrenType!.create({listType: 'Group'}, blockInfo.block.node)
               const wrappingBlock = blockNodeType!.create(null, [emptyParagraph, innerChildren])
 
               tr.replaceWith(blockInfo.block.beforePos, blockInfo.block.afterPos, wrappingBlock)
@@ -611,31 +607,12 @@ export const KeyboardShortcutsExtension = Extension.create<{
             if (isInGridContainer(state, state.selection.from)) return true
 
             // Find block group, block container, and depth it is at
-            const {group, container, $pos} = getGroupInfoFromPos(state.selection.from, state)
+            const {group} = getGroupInfoFromPos(state.selection.from, state)
 
             if (group.type.name === 'blockChildren' && group.attrs.listType !== 'Group') {
               setTimeout(() => {
-                // Try nesting the list item
-                const isNested = nestBlock(
-                  this.options.editor,
-                  group.attrs.listType,
-                  group.attrs.listType === 'Unordered' ? (parseInt(group.attrs.listLevel) + 1).toString() : '1',
-                )
-                // Update list children if nesting was successful
-                if (isNested)
-                  this.editor
-                    .chain()
-                    .command(
-                      updateGroupChildrenCommand(
-                        group,
-                        container!,
-                        $pos,
-                        group.attrs.listType === 'Unordered' ? parseInt(group.attrs.listLevel) + 1 : 1,
-                        group.attrs.listType,
-                        true,
-                      ),
-                    )
-                    .run()
+                // Nest the list item
+                nestBlock(this.options.editor, group.attrs.listType)
               })
               return true
             }
@@ -644,35 +621,11 @@ export const KeyboardShortcutsExtension = Extension.create<{
         () =>
           // This command is needed for tab inside of the first level of nesting
           commands.command(({state, chain}) => {
-            const {group, container, $pos} = getGroupInfoFromPos(state.selection.from, state)
+            const {container} = getGroupInfoFromPos(state.selection.from, state)
 
             if (container) {
-              // Try sinking the list item.
-              console.log('[CTF] Tab fallback (Command 3) | in container | calling chain().sinkListItem')
-              const result = chain().sinkListItem('blockNode').run()
-              // Update group children if sinking was successful.
-              if (result) {
-                setTimeout(() => {
-                  try {
-                    this.editor
-                      .chain()
-                      .command(
-                        updateGroupChildrenCommand(
-                          group,
-                          container,
-                          $pos,
-                          parseInt(group.attrs.listLevel),
-                          group.attrs.listType,
-                          true,
-                        ),
-                      )
-                      .run()
-                  } catch (e) {
-                    // @ts-expect-error
-                    console.log(e.message)
-                  }
-                })
-              }
+              // Sink the list item
+              chain().sinkListItem('blockNode').run()
               return true
             } else {
               // Just sink the list item if not a list.
@@ -691,9 +644,6 @@ export const KeyboardShortcutsExtension = Extension.create<{
       'Shift-Tab': () => {
         // Prevent outdent of grid children
         if (isInGridContainer(this.editor.state, this.editor.state.selection.from)) {
-          return true
-        }
-        if (this.editor.commands.command(liftFirstSlotItemCommand())) {
           return true
         }
         const {block} = getBlockInfoFromSelection(this.editor.state)
@@ -749,14 +699,6 @@ export const KeyboardShortcutsExtension = Extension.create<{
             keydown(view, event) {
               if ((event.key === 'Enter' && !event.shiftKey) || event.key === 'Tab') {
                 capturedMarks = getCarryableStoredMarks(view.state)
-                console.log(
-                  '[CTF] Plugin keydown | key:',
-                  event.key,
-                  '| capturedMarks count:',
-                  capturedMarks?.length ?? 0,
-                  '| names:',
-                  capturedMarks?.map((m) => `${m.type.name}=${JSON.stringify(m.attrs)}`),
-                )
               } else {
                 capturedMarks = null
               }
@@ -766,27 +708,14 @@ export const KeyboardShortcutsExtension = Extension.create<{
         },
         appendTransaction(transactions, _oldState, newState) {
           if (!capturedMarks?.length) return null
-          if (!transactions.some((transaction) => transaction.docChanged)) {
-            console.log('[CTF] Plugin appendTransaction | WAITING: no docChanged yet, keeping marks')
-            return null
-          }
+          if (!transactions.some((transaction) => transaction.docChanged)) return null
           if (!(newState.selection instanceof TextSelection) || !newState.selection.empty) {
-            console.log(
-              '[CTF] Plugin appendTransaction | SKIPPED: selection not empty TextSelection | type:',
-              newState.selection.constructor.name,
-              '| empty:',
-              newState.selection.empty,
-            )
             capturedMarks = null
             return null
           }
 
           const marks = capturedMarks
           capturedMarks = null
-          console.log(
-            '[CTF] Plugin appendTransaction | APPLYING storedMarks:',
-            marks.map((m) => `${m.type.name}=${JSON.stringify(m.attrs)}`),
-          )
           return newState.tr.setStoredMarks(marks)
         },
       }),

--- a/frontend/packages/editor/src/blocknote/core/extensions/Latex/LatexToBlocks.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/Latex/LatexToBlocks.ts
@@ -301,7 +301,6 @@ function createBlock(
       textAlignment: 'left',
       diff: 'null',
       childrenType: 'Group',
-      listLevel: '1',
       ...props,
     },
     content,

--- a/frontend/packages/editor/src/blocknote/core/extensions/Markdown/MarkdownToBlocks.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/Markdown/MarkdownToBlocks.ts
@@ -6,6 +6,7 @@ import remarkRehype from 'remark-rehype'
 import {unified} from 'unified'
 import {Block, BlockNoteEditor, BlockSchema, BNLink, nodeToBlock, StyledText, Styles} from '../..'
 import {hmBlockSchema} from '../../../../full-schema'
+import {normalizeFragment} from '../Blocks/nodes/normalizeFragment'
 import {remarkCodeClass} from './RemarkCodeClass'
 import {remarkImageWidth} from './RemarkImageWidth'
 
@@ -230,10 +231,18 @@ export const MarkdownToBlocks = async (markdown: string, editor: BlockNoteEditor
   // Get ProseMirror fragment from parsed HTML
   const fragment = ProseMirrorDOMParser.fromSchema(state.schema).parse(doc.body)
 
-  // @ts-ignore
-  fragment.firstChild!.content.forEach((node) => {
+  // Run the parsed content through normalizeFragment to wrap root level markdown lists in a Slot.
+  const rootGroup = fragment.firstChild
+  const rootIsList =
+    !!rootGroup &&
+    rootGroup.type.name === 'blockChildren' &&
+    !!rootGroup.attrs.listType &&
+    rootGroup.attrs.listType !== 'Group'
+  const topLevelNodes = rootIsList ? normalizeFragment(fragment.content, state.schema) : rootGroup!.content
+
+  topLevelNodes.forEach((node: any) => {
     if (node.type.name !== 'blockNode') {
-      return false
+      return
     }
 
     blocks.push(nodeToBlock(node, hmBlockSchema))

--- a/frontend/packages/editor/src/blocknote/core/extensions/SideMenu/block-move-executor.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/SideMenu/block-move-executor.ts
@@ -218,7 +218,7 @@ function insertAsChild(
   } else {
     // Create a new blockChildren wrapper and insert it at the end of the blockNode
     const blockChildrenType = schema.nodes.blockChildren
-    const wrapper = blockChildrenType.create({listType: 'Group', listLevel: '1'}, Fragment.from(sourceNodes))
+    const wrapper = blockChildrenType.create({listType: 'Group'}, Fragment.from(sourceNodes))
     // Insert just before the closing of the blockNode
     const insertAt = targetPos + targetBlock.nodeSize - 1
     tr.insert(insertAt, wrapper)

--- a/frontend/packages/editor/src/blocknote/core/extensions/SlotNormalization/SlotNormalizationExtension.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/SlotNormalization/SlotNormalizationExtension.ts
@@ -1,0 +1,91 @@
+import {Extension} from '@tiptap/core'
+import {Node as PMNode} from 'prosemirror-model'
+import {Plugin, PluginKey, Transaction} from 'prosemirror-state'
+
+type SlotFix = {from: number; to: number; kind: 'delete'} | {from: number; to: number; kind: 'replace'; nodes: PMNode[]}
+
+function isSlotWrapper(node: PMNode): boolean {
+  return node.type.name === 'blockNode' && node.firstChild?.type.name === 'slot'
+}
+
+/**
+ * Scan the document for invalid slot wrappers and return the edits that fix
+ * them.
+ */
+export function collectSlotFixes(doc: PMNode): SlotFix[] {
+  const fixes: SlotFix[] = []
+  const paragraphType = doc.type.schema.nodes['paragraph']
+  const blockNodeType = doc.type.schema.nodes['blockNode']
+
+  doc.descendants((node, pos, parent) => {
+    if (!isSlotWrapper(node)) return true
+
+    const blockChildren = node.childCount === 2 && node.lastChild?.type.name === 'blockChildren' ? node.lastChild : null
+
+    // Orphaned slot: no list to carry.
+    if (!blockChildren || blockChildren.childCount === 0) {
+      const isSoleChild = parent?.childCount === 1
+      if (isSoleChild && paragraphType && blockNodeType) {
+        fixes.push({
+          from: pos,
+          to: pos + node.nodeSize,
+          kind: 'replace',
+          nodes: [blockNodeType.create(null, paragraphType.create())],
+        })
+      } else {
+        fixes.push({from: pos, to: pos + node.nodeSize, kind: 'delete'})
+      }
+      return false
+    }
+
+    // Group slot: the wrapper is pointless, unwrap its items in place.
+    if (blockChildren.attrs.listType === 'Group') {
+      const items: PMNode[] = []
+      blockChildren.forEach((child) => items.push(child))
+      fixes.push({from: pos, to: pos + node.nodeSize, kind: 'replace', nodes: items})
+      return false
+    }
+
+    return true
+  })
+
+  return fixes
+}
+
+/** Apply the collected fixes to a transaction. */
+export function applySlotFixes(tr: Transaction, fixes: SlotFix[]): boolean {
+  if (!fixes.length) return false
+  fixes.sort((a, b) => b.from - a.from)
+  for (const fix of fixes) {
+    if (fix.kind === 'delete') tr.delete(fix.from, fix.to)
+    else tr.replaceWith(fix.from, fix.to, fix.nodes)
+  }
+  return true
+}
+
+export const slotNormalizationPluginKey = new PluginKey('slotNormalization')
+
+export function createSlotNormalizationPlugin(): Plugin {
+  return new Plugin({
+    key: slotNormalizationPluginKey,
+    appendTransaction(transactions, _oldState, newState) {
+      if (!transactions.some((tr) => tr.docChanged)) return null
+      const fixes = collectSlotFixes(newState.doc)
+      if (!fixes.length) return null
+      const tr = newState.tr
+      applySlotFixes(tr, fixes)
+      // Don't push this onto the undo stack as its own step.
+      tr.setMeta('addToHistory', false)
+      return tr.docChanged ? tr : null
+    },
+  })
+}
+
+// Keeps the document free of malformed slot wrappers after any editing
+// operation.
+export const SlotNormalizationExtension = Extension.create({
+  name: 'slotNormalization',
+  addProseMirrorPlugins() {
+    return [createSlotNormalizationPlugin()]
+  },
+})

--- a/frontend/packages/editor/src/blocknote/core/extensions/SlotNormalization/SlotNormalizationExtension.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/SlotNormalization/SlotNormalizationExtension.ts
@@ -8,51 +8,93 @@ function isSlotWrapper(node: PMNode): boolean {
   return node.type.name === 'blockNode' && node.firstChild?.type.name === 'slot'
 }
 
-/**
- * Scan the document for invalid slot wrappers and return the edits that fix
- * them.
- */
-export function collectSlotFixes(doc: PMNode): SlotFix[] {
-  const fixes: SlotFix[] = []
-  const paragraphType = doc.type.schema.nodes['paragraph']
-  const blockNodeType = doc.type.schema.nodes['blockNode']
+/** A malformed slot wrapper: orphan or a pointless Group slot. */
+function orphanOrGroupFix(
+  node: PMNode,
+  pos: number,
+  parent: PMNode | null,
+  schema: PMNode['type']['schema'],
+): SlotFix | null {
+  const paragraphType = schema.nodes['paragraph']
+  const blockNodeType = schema.nodes['blockNode']
+  const blockChildren = node.childCount === 2 && node.lastChild?.type.name === 'blockChildren' ? node.lastChild : null
 
-  doc.descendants((node, pos, parent) => {
-    if (!isSlotWrapper(node)) return true
-
-    const blockChildren = node.childCount === 2 && node.lastChild?.type.name === 'blockChildren' ? node.lastChild : null
-
-    // Orphaned slot: no list to carry.
-    if (!blockChildren || blockChildren.childCount === 0) {
-      const isSoleChild = parent?.childCount === 1
-      if (isSoleChild && paragraphType && blockNodeType) {
-        fixes.push({
-          from: pos,
-          to: pos + node.nodeSize,
-          kind: 'replace',
-          nodes: [blockNodeType.create(null, paragraphType.create())],
-        })
-      } else {
-        fixes.push({from: pos, to: pos + node.nodeSize, kind: 'delete'})
+  // Orphaned slot: no list to carry.
+  if (!blockChildren || blockChildren.childCount === 0) {
+    const isSoleChild = parent?.childCount === 1
+    if (isSoleChild && paragraphType && blockNodeType) {
+      return {
+        from: pos,
+        to: pos + node.nodeSize,
+        kind: 'replace',
+        nodes: [blockNodeType.create(null, paragraphType.create())],
       }
-      return false
     }
+    return {from: pos, to: pos + node.nodeSize, kind: 'delete'}
+  }
 
-    // Group slot: the wrapper is pointless, unwrap its items in place.
-    if (blockChildren.attrs.listType === 'Group') {
-      const items: PMNode[] = []
-      blockChildren.forEach((child) => items.push(child))
-      fixes.push({from: pos, to: pos + node.nodeSize, kind: 'replace', nodes: items})
-      return false
-    }
+  // Group slot: the wrapper is pointless, unwrap its items in place.
+  if (blockChildren.attrs.listType === 'Group') {
+    const items: PMNode[] = []
+    blockChildren.forEach((child) => items.push(child))
+    return {from: pos, to: pos + node.nodeSize, kind: 'replace', nodes: items}
+  }
 
-    return true
-  })
-
-  return fixes
+  return null
 }
 
-// Check if two slots have the same group type.
+/**
+ * A Slot not directly under the root must be unwrapped: flatten into a same-type
+ * list, nest under the previous block, or front the list with an empty paragraph.
+ */
+function nonRootUnwrapFix(
+  node: PMNode,
+  pos: number,
+  parent: PMNode,
+  index: number,
+  schema: PMNode['type']['schema'],
+): SlotFix | null {
+  const blockNodeType = schema.nodes['blockNode']
+  const paragraphType = schema.nodes['paragraph']
+  const list = node.lastChild
+  if (!blockNodeType || !paragraphType || !list || list.type.name !== 'blockChildren') return null
+
+  // Directly inside a same-grouping list so flatten items into that list.
+  if (
+    parent.type.name === 'blockChildren' &&
+    parent.attrs.listType !== 'Group' &&
+    parent.attrs.listType === list.attrs.listType
+  ) {
+    const items: PMNode[] = []
+    list.forEach((it) => items.push(it))
+    return {from: pos, to: pos + node.nodeSize, kind: 'replace', nodes: items}
+  }
+
+  const prev = index > 0 ? parent.child(index - 1) : null
+  const prevMergeable =
+    !!prev &&
+    prev.type.name === 'blockNode' &&
+    prev.childCount === 1 &&
+    prev.firstChild?.type.spec?.group === 'block' &&
+    prev.firstChild?.type.name !== 'table'
+
+  if (prevMergeable) {
+    const prevStart = pos - prev!.nodeSize
+    return {
+      from: prevStart,
+      to: pos + node.nodeSize,
+      kind: 'replace',
+      nodes: [blockNodeType.create(prev!.attrs, [prev!.firstChild!, list])],
+    }
+  }
+  return {
+    from: pos,
+    to: pos + node.nodeSize,
+    kind: 'replace',
+    nodes: [blockNodeType.create(node.attrs, [paragraphType.create(), list])],
+  }
+}
+
 function sameSlotGrouping(a: PMNode, b: PMNode): boolean {
   const ga = a.lastChild
   const gb = b.lastChild
@@ -60,104 +102,73 @@ function sameSlotGrouping(a: PMNode, b: PMNode): boolean {
     ga?.type.name === 'blockChildren' &&
     gb?.type.name === 'blockChildren' &&
     ga.attrs.listType !== 'Group' &&
-    ga.attrs.listType === gb.attrs.listType &&
-    ga.attrs.listLevel === gb.attrs.listLevel
+    ga.attrs.listType === gb.attrs.listType
   )
 }
 
 /**
- * Find the first pair of adjacent slot wrappers with the same grouping
- * and return the range between them for deletion that merges them.
+ * If a blockChildren has two directly adjacent slot wrappers with the same
+ * grouping, return the range whose deletion merges their item lists into one.
  */
-export function firstSlotMergeSeam(doc: PMNode): {from: number; to: number} | null {
-  let seam: {from: number; to: number} | null = null
-  doc.descendants((node, pos) => {
-    if (seam) return false
-    if (node.type.name !== 'blockChildren') return true
-    let childStart = pos + 1
-    for (let i = 0; i < node.childCount; i++) {
-      const child = node.child(i)
-      if (i > 0) {
-        const prev = node.child(i - 1)
-        if (isSlotWrapper(prev) && isSlotWrapper(child) && sameSlotGrouping(prev, child)) {
-          const prevStart = childStart - prev.nodeSize
-          const items1Size = prev.lastChild!.content.size
-          // seamStart: just after the first slot's items.
-          // seamEnd: just before the second slot's items.
-          seam = {from: prevStart + 3 + items1Size, to: childStart + 3}
-          return false
-        }
+function seamForBlockChildren(node: PMNode, pos: number): {from: number; to: number} | null {
+  let childStart = pos + 1
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i)
+    if (i > 0) {
+      const prev = node.child(i - 1)
+      if (isSlotWrapper(prev) && isSlotWrapper(child) && sameSlotGrouping(prev, child)) {
+        const prevStart = childStart - prev.nodeSize
+        const items1Size = prev.lastChild!.content.size
+        return {from: prevStart + 3 + items1Size, to: childStart + 3}
       }
-      childStart += child.nodeSize
+    }
+    childStart += child.nodeSize
+  }
+  return null
+}
+
+/** All orphan / Group slot fixes in the document. */
+export function collectSlotFixes(doc: PMNode): SlotFix[] {
+  const fixes: SlotFix[] = []
+  doc.descendants((node, pos, parent) => {
+    if (!isSlotWrapper(node)) return true
+    const fix = orphanOrGroupFix(node, pos, parent, doc.type.schema)
+    if (fix) {
+      fixes.push(fix)
+      return false
     }
     return true
   })
-  return seam
+  return fixes
 }
 
-/**
- * A Slot that is not in the root group is unnecessary and must be unwrapped
- * into a normal nested list. Returns the edit for the first such Slot, or null.
- */
+/** The edit for the first Slot that isn't a direct child of root. */
 export function firstNonRootSlotUnwrap(doc: PMNode): SlotFix | null {
-  const root = doc.firstChild // the root blockChildren
-  const blockNodeType = doc.type.schema.nodes['blockNode']
-  const paragraphType = doc.type.schema.nodes['paragraph']
-  if (!blockNodeType || !paragraphType) return null
-
+  const root = doc.firstChild
   let fix: SlotFix | null = null
   doc.descendants((node, pos, parent, index) => {
     if (fix) return false
     if (!isSlotWrapper(node)) return true
     if (parent === root) return true
-
-    const list = node.lastChild
-    if (!list || list.type.name !== 'blockChildren') return false // orphan; handled elsewhere
-
-    // If the Slot sits directly inside a list of the same grouping,
-    // flatten its items into that list.
-    if (
-      parent!.type.name === 'blockChildren' &&
-      parent!.attrs.listType !== 'Group' &&
-      parent!.attrs.listType === list.attrs.listType
-    ) {
-      const items: PMNode[] = []
-      list.forEach((it) => items.push(it))
-      fix = {from: pos, to: pos + node.nodeSize, kind: 'replace', nodes: items}
-      return false
-    }
-
-    const prev = index > 0 ? parent!.child(index - 1) : null
-    const prevMergeable =
-      !!prev &&
-      prev.type.name === 'blockNode' &&
-      prev.childCount === 1 &&
-      prev.firstChild?.type.spec?.group === 'block' &&
-      // A table can't carry a nested list.
-      prev.firstChild?.type.name !== 'table'
-
-    if (prevMergeable) {
-      const prevStart = pos - prev!.nodeSize
-      fix = {
-        from: prevStart,
-        to: pos + node.nodeSize,
-        kind: 'replace',
-        nodes: [blockNodeType.create(prev!.attrs, [prev!.firstChild!, list])],
-      }
-    } else {
-      fix = {
-        from: pos,
-        to: pos + node.nodeSize,
-        kind: 'replace',
-        nodes: [blockNodeType.create(node.attrs, [paragraphType.create(), list])],
-      }
-    }
+    fix = nonRootUnwrapFix(node, pos, parent!, index, doc.type.schema)
     return false
   })
   return fix
 }
 
-/** Apply the collected fixes to a transaction. */
+/** The seam range for the first pair of adjacent same grouping slots. */
+export function firstSlotMergeSeam(doc: PMNode): {from: number; to: number} | null {
+  let seam: {from: number; to: number} | null = null
+  doc.descendants((node, pos) => {
+    if (seam) return false
+    if (node.type.name !== 'blockChildren') return true
+    seam = seamForBlockChildren(node, pos)
+    return !seam
+  })
+  return seam
+}
+
+/** Apply the collected fixes to a transaction (back-to-front to keep positions valid). */
 export function applySlotFixes(tr: Transaction, fixes: SlotFix[]): boolean {
   if (!fixes.length) return false
   fixes.sort((a, b) => b.from - a.from)
@@ -168,44 +179,90 @@ export function applySlotFixes(tr: Transaction, fixes: SlotFix[]): boolean {
   return true
 }
 
-export const slotNormalizationPluginKey = new PluginKey('slotNormalization')
+type SlotAction = {fix: SlotFix} | {seam: {from: number; to: number}}
+
+function nextSlotAction(doc: PMNode): SlotAction | null {
+  const root = doc.firstChild
+  let fix: SlotFix | null = null
+  let seam: {from: number; to: number} | null = null
+
+  doc.descendants((node, pos, parent, index) => {
+    if (fix) return false
+
+    // Remember the first merge seam, but keep scanning for a higher-priority fix.
+    if (!seam && node.type.name === 'blockChildren') {
+      seam = seamForBlockChildren(node, pos)
+      return true
+    }
+
+    if (isSlotWrapper(node)) {
+      fix = orphanOrGroupFix(node, pos, parent, doc.type.schema)
+      if (fix) return false
+      if (parent !== root) {
+        fix = nonRootUnwrapFix(node, pos, parent!, index, doc.type.schema)
+        return false // non root slot handled, don't descend
+      }
+      return true // valid root slot, descend to catch nested slots
+    }
+    return true
+  })
+
+  if (fix) return {fix}
+  if (seam) return {seam}
+  return null
+}
+
+function nodeContainsSlot(node: PMNode): boolean {
+  let found = false
+  node.descendants((n) => {
+    if (found) return false
+    if (n.type.name === 'slot') {
+      found = true
+      return false
+    }
+    return true
+  })
+  return found
+}
+
+function transactionAddsSlot(tr: Transaction): boolean {
+  return tr.steps.some((step) => {
+    const slice = (step as {slice?: {content: PMNode}}).slice
+    return !!slice && nodeContainsSlot(slice.content as unknown as PMNode)
+  })
+}
+
+export const slotNormalizationPluginKey = new PluginKey<boolean>('slotNormalization')
 
 /**
  * @param isSuppressed Optional guard returning true while the document is being
  *   loaded or rebased programmatically. Normalization must not run then, as it
  *   would rewrite and/or delete block IDs from the content.
  */
-export function createSlotNormalizationPlugin(isSuppressed?: () => boolean): Plugin {
-  return new Plugin({
+export function createSlotNormalizationPlugin(isSuppressed?: () => boolean): Plugin<boolean> {
+  return new Plugin<boolean>({
     key: slotNormalizationPluginKey,
+    // Track whether the document contains any slot, which triggers the plugin loop.
+    state: {
+      init: (_config, editorState) => nodeContainsSlot(editorState.doc),
+      apply: (tr, hasSlot: boolean) => {
+        if (hasSlot || !tr.docChanged) return hasSlot
+        return transactionAddsSlot(tr)
+      },
+    },
     appendTransaction(transactions, _oldState, newState) {
       if (isSuppressed?.()) return null
       if (!transactions.some((tr) => tr.docChanged)) return null
+      if (!slotNormalizationPluginKey.getState(newState)) return null
+
       const tr = newState.tr
       let changed = false
       for (let guard = 0; guard < 1000; guard++) {
-        // Repair malformed slots.
-        const fixes = collectSlotFixes(tr.doc)
-        if (fixes.length) {
-          applySlotFixes(tr, fixes)
-          changed = true
-          continue
-        }
-        // Unwrap any Slot that isn't a direct child of root.
-        const unwrap = firstNonRootSlotUnwrap(tr.doc)
-        if (unwrap) {
-          applySlotFixes(tr, [unwrap])
-          changed = true
-          continue
-        }
-        // Merge one pair of adjacent same group root slots, then re-scan.
-        const seam = firstSlotMergeSeam(tr.doc)
-        if (seam) {
-          tr.delete(seam.from, seam.to)
-          changed = true
-          continue
-        }
-        break
+        const action = nextSlotAction(tr.doc)
+        if (!action) break
+        if ('fix' in action) applySlotFixes(tr, [action.fix])
+        else tr.delete(action.seam.from, action.seam.to)
+        changed = true
       }
 
       if (!changed) return null
@@ -215,7 +272,8 @@ export function createSlotNormalizationPlugin(isSuppressed?: () => boolean): Plu
 }
 
 // Keeps the document free of malformed slot wrappers, and merges adjacent
-// same-grouping slots, after any user editing operation.
+// same-grouping slots, after any user editing operation. Skips programmatic
+// load/rebase transactions so it never rewrites content.
 export const SlotNormalizationExtension = Extension.create<{editor?: {_suppressChangeRef?: {current: boolean}}}>({
   name: 'slotNormalization',
   addProseMirrorPlugins() {

--- a/frontend/packages/editor/src/blocknote/core/extensions/SlotNormalization/SlotNormalizationExtension.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/SlotNormalization/SlotNormalizationExtension.ts
@@ -52,6 +52,111 @@ export function collectSlotFixes(doc: PMNode): SlotFix[] {
   return fixes
 }
 
+// Check if two slots have the same group type.
+function sameSlotGrouping(a: PMNode, b: PMNode): boolean {
+  const ga = a.lastChild
+  const gb = b.lastChild
+  return (
+    ga?.type.name === 'blockChildren' &&
+    gb?.type.name === 'blockChildren' &&
+    ga.attrs.listType !== 'Group' &&
+    ga.attrs.listType === gb.attrs.listType &&
+    ga.attrs.listLevel === gb.attrs.listLevel
+  )
+}
+
+/**
+ * Find the first pair of adjacent slot wrappers with the same grouping
+ * and return the range between them for deletion that merges them.
+ */
+export function firstSlotMergeSeam(doc: PMNode): {from: number; to: number} | null {
+  let seam: {from: number; to: number} | null = null
+  doc.descendants((node, pos) => {
+    if (seam) return false
+    if (node.type.name !== 'blockChildren') return true
+    let childStart = pos + 1
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i)
+      if (i > 0) {
+        const prev = node.child(i - 1)
+        if (isSlotWrapper(prev) && isSlotWrapper(child) && sameSlotGrouping(prev, child)) {
+          const prevStart = childStart - prev.nodeSize
+          const items1Size = prev.lastChild!.content.size
+          // seamStart: just after the first slot's items.
+          // seamEnd: just before the second slot's items.
+          seam = {from: prevStart + 3 + items1Size, to: childStart + 3}
+          return false
+        }
+      }
+      childStart += child.nodeSize
+    }
+    return true
+  })
+  return seam
+}
+
+/**
+ * A Slot that is not in the root group is unnecessary and must be unwrapped
+ * into a normal nested list. Returns the edit for the first such Slot, or null.
+ */
+export function firstNonRootSlotUnwrap(doc: PMNode): SlotFix | null {
+  const root = doc.firstChild // the root blockChildren
+  const blockNodeType = doc.type.schema.nodes['blockNode']
+  const paragraphType = doc.type.schema.nodes['paragraph']
+  if (!blockNodeType || !paragraphType) return null
+
+  let fix: SlotFix | null = null
+  doc.descendants((node, pos, parent, index) => {
+    if (fix) return false
+    if (!isSlotWrapper(node)) return true
+    if (parent === root) return true
+
+    const list = node.lastChild
+    if (!list || list.type.name !== 'blockChildren') return false // orphan; handled elsewhere
+
+    // If the Slot sits directly inside a list of the same grouping,
+    // flatten its items into that list.
+    if (
+      parent!.type.name === 'blockChildren' &&
+      parent!.attrs.listType !== 'Group' &&
+      parent!.attrs.listType === list.attrs.listType
+    ) {
+      const items: PMNode[] = []
+      list.forEach((it) => items.push(it))
+      fix = {from: pos, to: pos + node.nodeSize, kind: 'replace', nodes: items}
+      return false
+    }
+
+    const prev = index > 0 ? parent!.child(index - 1) : null
+    const prevMergeable =
+      !!prev &&
+      prev.type.name === 'blockNode' &&
+      prev.childCount === 1 &&
+      prev.firstChild?.type.spec?.group === 'block' &&
+      // A table can't carry a nested list.
+      prev.firstChild?.type.name !== 'table'
+
+    if (prevMergeable) {
+      const prevStart = pos - prev!.nodeSize
+      fix = {
+        from: prevStart,
+        to: pos + node.nodeSize,
+        kind: 'replace',
+        nodes: [blockNodeType.create(prev!.attrs, [prev!.firstChild!, list])],
+      }
+    } else {
+      fix = {
+        from: pos,
+        to: pos + node.nodeSize,
+        kind: 'replace',
+        nodes: [blockNodeType.create(node.attrs, [paragraphType.create(), list])],
+      }
+    }
+    return false
+  })
+  return fix
+}
+
 /** Apply the collected fixes to a transaction. */
 export function applySlotFixes(tr: Transaction, fixes: SlotFix[]): boolean {
   if (!fixes.length) return false
@@ -65,27 +170,56 @@ export function applySlotFixes(tr: Transaction, fixes: SlotFix[]): boolean {
 
 export const slotNormalizationPluginKey = new PluginKey('slotNormalization')
 
-export function createSlotNormalizationPlugin(): Plugin {
+/**
+ * @param isSuppressed Optional guard returning true while the document is being
+ *   loaded or rebased programmatically. Normalization must not run then, as it
+ *   would rewrite and/or delete block IDs from the content.
+ */
+export function createSlotNormalizationPlugin(isSuppressed?: () => boolean): Plugin {
   return new Plugin({
     key: slotNormalizationPluginKey,
     appendTransaction(transactions, _oldState, newState) {
+      if (isSuppressed?.()) return null
       if (!transactions.some((tr) => tr.docChanged)) return null
-      const fixes = collectSlotFixes(newState.doc)
-      if (!fixes.length) return null
       const tr = newState.tr
-      applySlotFixes(tr, fixes)
-      // Don't push this onto the undo stack as its own step.
-      tr.setMeta('addToHistory', false)
+      let changed = false
+      for (let guard = 0; guard < 1000; guard++) {
+        // Repair malformed slots.
+        const fixes = collectSlotFixes(tr.doc)
+        if (fixes.length) {
+          applySlotFixes(tr, fixes)
+          changed = true
+          continue
+        }
+        // Unwrap any Slot that isn't a direct child of root.
+        const unwrap = firstNonRootSlotUnwrap(tr.doc)
+        if (unwrap) {
+          applySlotFixes(tr, [unwrap])
+          changed = true
+          continue
+        }
+        // Merge one pair of adjacent same group root slots, then re-scan.
+        const seam = firstSlotMergeSeam(tr.doc)
+        if (seam) {
+          tr.delete(seam.from, seam.to)
+          changed = true
+          continue
+        }
+        break
+      }
+
+      if (!changed) return null
       return tr.docChanged ? tr : null
     },
   })
 }
 
-// Keeps the document free of malformed slot wrappers after any editing
-// operation.
-export const SlotNormalizationExtension = Extension.create({
+// Keeps the document free of malformed slot wrappers, and merges adjacent
+// same-grouping slots, after any user editing operation.
+export const SlotNormalizationExtension = Extension.create<{editor?: {_suppressChangeRef?: {current: boolean}}}>({
   name: 'slotNormalization',
   addProseMirrorPlugins() {
-    return [createSlotNormalizationPlugin()]
+    const editor = this.options.editor
+    return [createSlotNormalizationPlugin(() => !!editor?._suppressChangeRef?.current)]
   },
 })

--- a/frontend/packages/editor/src/blocknote/core/extensions/SlotNormalization/__tests__/slot-normalization.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/SlotNormalization/__tests__/slot-normalization.test.ts
@@ -1,8 +1,14 @@
 import {Schema} from 'prosemirror-model'
-import {EditorState} from 'prosemirror-state'
+import {EditorState, TextSelection} from 'prosemirror-state'
 import {beforeEach, describe, expect, it} from 'vitest'
 import {createMinimalSchema} from '../../../api/blockManipulation/__tests__/test-helpers-prosemirror'
-import {applySlotFixes, collectSlotFixes, createSlotNormalizationPlugin} from '../SlotNormalizationExtension'
+import {
+  applySlotFixes,
+  collectSlotFixes,
+  createSlotNormalizationPlugin,
+  firstNonRootSlotUnwrap,
+  firstSlotMergeSeam,
+} from '../SlotNormalizationExtension'
 
 // Build helpers
 
@@ -94,5 +100,229 @@ describe('slot normalization', () => {
     const textPos = 3
     const newState = state.apply(state.tr.insertText('x', textPos))
     expect(countSlots(newState.doc)).toBe(0)
+  })
+
+  it('does not normalize while suppressed', () => {
+    const d = doc(schema, [blockNode('p1', [para('test')]), blockNode('orphan', [slot('Unordered')])])
+    const state = EditorState.create({
+      doc: d,
+      schema,
+      plugins: [createSlotNormalizationPlugin(() => true)],
+    })
+    const newState = state.apply(state.tr.insertText('x', 3))
+    // The orphan slot must survive: load/rebase reconcile content by id, so the
+    // normalizer must not mutate (and delete ids) during those transactions.
+    expect(countSlots(newState.doc)).toBe(1)
+  })
+})
+
+describe('adjacent slot merging', () => {
+  let schema: Schema
+  beforeEach(() => {
+    schema = createMinimalSchema()
+  })
+
+  function item(id: string, text: string) {
+    return blockNode(id, [para(text)])
+  }
+  function slotWrap(id: string, childrenType: string, items: any[]) {
+    return blockNode(id, [slot(childrenType), group(childrenType, items)])
+  }
+  // Simulate the appendTransaction loop: merge adjacent pairs until none remain.
+  function mergeToFixedPoint(d: any) {
+    let state = EditorState.create({doc: d, schema})
+    for (let guard = 0; guard < 20; guard++) {
+      const seam = firstSlotMergeSeam(state.doc)
+      if (!seam) break
+      state = state.apply(state.tr.delete(seam.from, seam.to))
+    }
+    return state.doc
+  }
+
+  it('merges two adjacent same-type slots into one list', () => {
+    const d = doc(schema, [
+      slotWrap('s1', 'Unordered', [item('a', 'a')]),
+      slotWrap('s2', 'Unordered', [item('b', 'b')]),
+    ])
+    const out = mergeToFixedPoint(d)
+    expect(countSlots(out)).toBe(1)
+    const merged = out.firstChild!.firstChild!
+    expect(merged.firstChild!.type.name).toBe('slot')
+    const innerGroup = merged.lastChild!
+    expect(innerGroup.type.name).toBe('blockChildren')
+    expect(innerGroup.attrs.listType).toBe('Unordered')
+    expect(innerGroup.childCount).toBe(2)
+    expect(innerGroup.child(0).firstChild!.textContent).toBe('a')
+    expect(innerGroup.child(1).firstChild!.textContent).toBe('b')
+  })
+
+  it('collapses three adjacent slots into one list', () => {
+    const d = doc(schema, [
+      slotWrap('s1', 'Unordered', [item('a', 'a')]),
+      slotWrap('s2', 'Unordered', [item('b', 'b')]),
+      slotWrap('s3', 'Unordered', [item('c', 'c')]),
+    ])
+    const out = mergeToFixedPoint(d)
+    expect(countSlots(out)).toBe(1)
+    expect(out.firstChild!.firstChild!.lastChild!.childCount).toBe(3)
+  })
+
+  it('collapses three adjacent slots in a single transaction', () => {
+    const d = doc(schema, [
+      slotWrap('s1', 'Unordered', [item('a', 'a')]),
+      slotWrap('s2', 'Unordered', [item('b', 'b')]),
+      slotWrap('s3', 'Unordered', [item('c', 'c')]),
+    ])
+    const state = EditorState.create({doc: d, schema, plugins: [createSlotNormalizationPlugin()]})
+    let aPos = -1
+    d.descendants((n: any, p: number) => {
+      if (n.isText && n.text === 'a') aPos = p
+    })
+    const newState = state.apply(state.tr.insertText('!', aPos + 1))
+    expect(countSlots(newState.doc)).toBe(1)
+    expect(newState.doc.firstChild!.firstChild!.lastChild!.childCount).toBe(3)
+  })
+
+  it('does not merge slots of different list types', () => {
+    const d = doc(schema, [slotWrap('s1', 'Unordered', [item('a', 'a')]), slotWrap('s2', 'Ordered', [item('b', 'b')])])
+    expect(firstSlotMergeSeam(d)).toBeNull()
+  })
+
+  it('does not merge slots separated by another block', () => {
+    const d = doc(schema, [
+      slotWrap('s1', 'Unordered', [item('a', 'a')]),
+      blockNode('p', [para('between')]),
+      slotWrap('s2', 'Unordered', [item('b', 'b')]),
+    ])
+    expect(firstSlotMergeSeam(d)).toBeNull()
+  })
+
+  it('keeps the cursor in the moved item after merging', () => {
+    const d = doc(schema, [
+      slotWrap('s1', 'Unordered', [item('a', 'a')]),
+      slotWrap('s2', 'Unordered', [item('b', 'b')]),
+    ])
+    let bTextPos = -1
+    d.descendants((n: any, p: number) => {
+      if (n.isText && n.text === 'b') bTextPos = p
+    })
+    const state = EditorState.create({doc: d, schema, selection: TextSelection.create(d, bTextPos + 1)})
+    const seam = firstSlotMergeSeam(d)!
+    const out = state.apply(state.tr.delete(seam.from, seam.to))
+    // Cursor should still be inside the item whose text is "b".
+    expect(out.selection.$from.parent.textContent).toBe('b')
+  })
+})
+
+describe('non-root slot unwrapping', () => {
+  let schema: Schema
+  beforeEach(() => {
+    schema = createMinimalSchema()
+  })
+
+  function item(id: string, text: string) {
+    return blockNode(id, [para(text)])
+  }
+  function slotWrap(id: string, childrenType: string, items: any[]) {
+    return blockNode(id, [slot(childrenType), group(childrenType, items)])
+  }
+  function unwrapAll(d: any) {
+    const state = EditorState.create({doc: d, schema, plugins: [createSlotNormalizationPlugin()]})
+    return state.apply(state.tr.insertText('!', 6)).doc
+  }
+
+  it('leaves a root-level slot untouched', () => {
+    const d = doc(schema, [slotWrap('s1', 'Unordered', [item('a', 'a')])])
+    expect(firstNonRootSlotUnwrap(d)).toBeNull()
+  })
+
+  it('nests a nested slot list under its previous sibling and drops the slot', () => {
+    const d = doc(schema, [
+      blockNode('parent', [
+        para('parent'),
+        group('Group', [blockNode('prev', [para('prev')]), slotWrap('nested', 'Unordered', [item('x', 'x')])]),
+      ]),
+    ])
+    const out = unwrapAll(d)
+    expect(countSlots(out)).toBe(0)
+    // The list should now be nested under "prev".
+    const parentGroup = out.firstChild!.firstChild!.lastChild!
+    expect(parentGroup.childCount).toBe(1)
+    const prev = parentGroup.firstChild!
+    expect(prev.attrs.id).toBe('prev')
+    expect(prev.lastChild!.type.name).toBe('blockChildren')
+    expect(prev.lastChild!.attrs.listType).toBe('Unordered')
+    expect(prev.lastChild!.firstChild!.firstChild!.textContent).toBe('x')
+  })
+
+  it('flattens a same type slot nested inside a root slot list', () => {
+    const d = doc(schema, [
+      blockNode('rootSlot', [
+        slot('Unordered'),
+        group('Unordered', [item('a', 'a'), item('b', 'b'), slotWrap('nested', 'Unordered', [item('x', 'x')])]),
+      ]),
+    ])
+    const out = unwrapAll(d)
+    // Only the root slot remains; the pasted item joins the list as a sibling.
+    expect(countSlots(out)).toBe(1)
+    const rootList = out.firstChild!.firstChild!.lastChild!
+    expect(rootList.childCount).toBe(3)
+    expect(rootList.child(1).firstChild!.textContent).toBe('b')
+    expect(rootList.child(2).firstChild!.textContent).toBe('x')
+    // The pasted item is a plain sibling, not a nested sub-list under "b".
+    expect(rootList.child(1).childCount).toBe(1)
+    expect(rootList.child(2).childCount).toBe(1)
+  })
+
+  it('nests a different type slot under the previous item instead of flattening', () => {
+    const d = doc(schema, [
+      blockNode('rootSlot', [
+        slot('Unordered'),
+        group('Unordered', [item('a', 'a'), slotWrap('nested', 'Ordered', [item('x', 'x')])]),
+      ]),
+    ])
+    const out = unwrapAll(d)
+    expect(countSlots(out)).toBe(1)
+    const rootList = out.firstChild!.firstChild!.lastChild!
+    expect(rootList.childCount).toBe(1)
+    const a = rootList.child(0)
+    expect(a.lastChild!.type.name).toBe('blockChildren')
+    expect(a.lastChild!.attrs.listType).toBe('Ordered')
+  })
+
+  it('falls back to an empty paragraph when there is no mergeable previous block', () => {
+    // nested slot is the first child of a nested group with no previous siblings.
+    const d = doc(schema, [
+      blockNode('parent', [para('parent'), group('Group', [slotWrap('nested', 'Unordered', [item('x', 'x')])])]),
+    ])
+    const out = unwrapAll(d)
+    expect(countSlots(out)).toBe(0)
+    const wrapper = out.firstChild!.firstChild!.lastChild!.firstChild!
+    expect(wrapper.firstChild!.type.name).toBe('paragraph')
+    expect(wrapper.lastChild!.type.name).toBe('blockChildren')
+    expect(wrapper.lastChild!.attrs.listType).toBe('Unordered')
+  })
+
+  it('does not nest a list under a table', () => {
+    // A table can't carry a nested blockChildren, so a slot whose previous
+    // sibling is a table must not merge into it.
+    const d = doc(schema, [
+      blockNode('parent', [
+        para('parent'),
+        group('Group', [
+          {type: 'blockNode', attrs: {id: 'tbl'}, content: [{type: 'table', content: [{type: 'text', text: 'cell'}]}]},
+          slotWrap('nested', 'Unordered', [item('x', 'x')]),
+        ]),
+      ]),
+    ])
+    const out = unwrapAll(d)
+    expect(countSlots(out)).toBe(0)
+    const nestedGroup = out.firstChild!.firstChild!.lastChild!
+    expect(nestedGroup.child(0).firstChild!.type.name).toBe('table')
+    expect(nestedGroup.child(0).childCount).toBe(1)
+    const wrapper = nestedGroup.child(1)
+    expect(wrapper.firstChild!.type.name).toBe('paragraph')
+    expect(wrapper.lastChild!.type.name).toBe('blockChildren')
+    expect(wrapper.lastChild!.attrs.listType).toBe('Unordered')
   })
 })

--- a/frontend/packages/editor/src/blocknote/core/extensions/SlotNormalization/__tests__/slot-normalization.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/SlotNormalization/__tests__/slot-normalization.test.ts
@@ -1,0 +1,98 @@
+import {Schema} from 'prosemirror-model'
+import {EditorState} from 'prosemirror-state'
+import {beforeEach, describe, expect, it} from 'vitest'
+import {createMinimalSchema} from '../../../api/blockManipulation/__tests__/test-helpers-prosemirror'
+import {applySlotFixes, collectSlotFixes, createSlotNormalizationPlugin} from '../SlotNormalizationExtension'
+
+// Build helpers
+
+function para(text?: string) {
+  return {type: 'paragraph', content: text ? [{type: 'text', text}] : undefined}
+}
+function blockNode(id: string, content: any[]) {
+  return {type: 'blockNode', attrs: {id}, content}
+}
+function group(listType: string, blocks: any[]) {
+  return {type: 'blockChildren', attrs: {listType, listLevel: '1', columnCount: null}, content: blocks}
+}
+function slot(childrenType: string) {
+  return {type: 'slot', attrs: {childrenType, listLevel: '1', columnCount: ''}}
+}
+function doc(schema: Schema, blocks: any[]) {
+  return schema.nodeFromJSON({type: 'doc', content: [group('Group', blocks)]})
+}
+
+function normalize(schema: Schema, d: any) {
+  const state = EditorState.create({doc: d, schema})
+  const tr = state.tr
+  applySlotFixes(tr, collectSlotFixes(d))
+  return state.apply(tr).doc
+}
+
+function countSlots(node: any): number {
+  let n = 0
+  node.descendants((child: any) => {
+    if (child.type.name === 'slot') n++
+  })
+  return n
+}
+
+describe('slot normalization', () => {
+  let schema: Schema
+  beforeEach(() => {
+    schema = createMinimalSchema()
+  })
+
+  it('removes an orphaned slot only blockNode', () => {
+    const d = doc(schema, [
+      blockNode('p1', [para('test')]),
+      blockNode('orphan', [slot('Unordered')]), // no blockChildren
+      blockNode('p2', [para('after')]),
+    ])
+    const out = normalize(schema, d)
+    expect(countSlots(out)).toBe(0)
+    const rootGroup = out.firstChild!
+    expect(rootGroup.childCount).toBe(2)
+    expect(rootGroup.firstChild!.attrs.id).toBe('p1')
+    expect(rootGroup.lastChild!.attrs.id).toBe('p2')
+  })
+
+  it('replaces a sole orphaned slot with an empty paragraph', () => {
+    const d = doc(schema, [blockNode('orphan', [slot('Unordered')])])
+    const out = normalize(schema, d)
+    expect(countSlots(out)).toBe(0)
+    const rootGroup = out.firstChild!
+    expect(rootGroup.childCount).toBe(1)
+    expect(rootGroup.firstChild!.firstChild!.type.name).toBe('paragraph')
+  })
+
+  it('unwraps a Group slot, lifting its items in place', () => {
+    const d = doc(schema, [
+      blockNode('p1', [para('test')]),
+      blockNode('slotWrap', [slot('Group'), group('Group', [blockNode('inner', [para('lifted')])])]),
+    ])
+    const out = normalize(schema, d)
+    expect(countSlots(out)).toBe(0)
+    const rootGroup = out.firstChild!
+    expect(rootGroup.childCount).toBe(2)
+    expect(rootGroup.lastChild!.attrs.id).toBe('inner')
+    expect(rootGroup.lastChild!.firstChild!.textContent).toBe('lifted')
+  })
+
+  it('leaves a valid slot untouched', () => {
+    const d = doc(schema, [
+      blockNode('p1', [para('test')]),
+      blockNode('slotWrap', [slot('Unordered'), group('Unordered', [blockNode('item', [para('bullet')])])]),
+    ])
+    expect(collectSlotFixes(d)).toHaveLength(0)
+  })
+
+  it('plugin heals an orphaned slot on the next docChanged transaction', () => {
+    const d = doc(schema, [blockNode('p1', [para('test')]), blockNode('orphan', [slot('Unordered')])])
+    const state = EditorState.create({doc: d, schema, plugins: [createSlotNormalizationPlugin()]})
+    // Any doc-changing transaction should trigger the appendTransaction cleanup.
+    const textPos = 3
+    const newState = state.apply(state.tr.insertText('x', textPos))
+    expect(countSlots(newState.doc)).toBe(0)
+  })
+})

--- a/frontend/packages/editor/src/blocknote/core/extensions/SlotNormalization/__tests__/slot-normalization.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/SlotNormalization/__tests__/slot-normalization.test.ts
@@ -19,10 +19,10 @@ function blockNode(id: string, content: any[]) {
   return {type: 'blockNode', attrs: {id}, content}
 }
 function group(listType: string, blocks: any[]) {
-  return {type: 'blockChildren', attrs: {listType, listLevel: '1', columnCount: null}, content: blocks}
+  return {type: 'blockChildren', attrs: {listType, columnCount: null}, content: blocks}
 }
 function slot(childrenType: string) {
-  return {type: 'slot', attrs: {childrenType, listLevel: '1', columnCount: ''}}
+  return {type: 'slot', attrs: {childrenType, columnCount: ''}}
 }
 function doc(schema: Schema, blocks: any[]) {
   return schema.nodeFromJSON({type: 'doc', content: [group('Group', blocks)]})
@@ -113,6 +113,18 @@ describe('slot normalization', () => {
     // The orphan slot must survive: load/rebase reconcile content by id, so the
     // normalizer must not mutate (and delete ids) during those transactions.
     expect(countSlots(newState.doc)).toBe(1)
+  })
+
+  it('detects a slot inserted into a previously slot free document', () => {
+    // Slot-free doc means the plugin's hasSlot state starts false and it early exits.
+    const d = doc(schema, [blockNode('p1', [para('test')])])
+    const state = EditorState.create({doc: d, schema, plugins: [createSlotNormalizationPlugin()]})
+    // Insert an orphan slot (as a paste would). The transaction adds a slot, so
+    // the state must flip and normalization must run.
+    const orphan = schema.nodeFromJSON({type: 'blockNode', attrs: {id: 'orphan'}, content: [slot('Unordered')]})
+    const endOfRoot = d.firstChild!.content.size + 1
+    const newState = state.apply(state.tr.insert(endOfRoot, orphan))
+    expect(countSlots(newState.doc)).toBe(0)
   })
 })
 

--- a/frontend/packages/editor/src/document-editor.tsx
+++ b/frontend/packages/editor/src/document-editor.tsx
@@ -16,7 +16,7 @@ import {collectChildDraftIds} from '@shm/shared/utils/child-draft-refs'
 import {hmLinkTargetsDocument} from '@shm/shared/utils/document-card-cleanup'
 import {useImageUrl} from '@shm/ui/get-file-url'
 import {Extension} from '@tiptap/core'
-import {NodeSelection as PMNodeSelection, Plugin, PluginKey, TextSelection} from 'prosemirror-state'
+import {Plugin, PluginKey, NodeSelection as PMNodeSelection, TextSelection} from 'prosemirror-state'
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {
   BlockHoverActionsPositioner,
@@ -481,12 +481,6 @@ export function DocumentEditor({
   // - Notifies parent via `onEditorReady`
   // - Registers imperative handlers the machine calls when entering/exiting `editing`
   useEffect(() => {
-    const onRootChildrenTypeChange = (childrenType: DocumentContentProps['rootChildrenType']) => {
-      if (childrenType === 'Unordered' || childrenType === 'Ordered') {
-        actorRef.send({type: 'rootChildrenType.change', childrenType})
-      }
-    }
-    ;(editor as any)._onRootChildrenTypeChange = onRootChildrenTypeChange
     ;(editor as any)._suppressChangeRef = suppressChangeRef
 
     onEditorReadyRef.current?.(editor)
@@ -626,7 +620,6 @@ export function DocumentEditor({
     }
 
     return () => {
-      delete (editor as any)._onRootChildrenTypeChange
       handlersRef.current = null
     }
   }, [editor, actorRef, handlersRef])

--- a/frontend/packages/editor/src/document-editor.tsx
+++ b/frontend/packages/editor/src/document-editor.tsx
@@ -104,7 +104,6 @@ function setEditorRootChildrenType(
     view.state.tr.setNodeMarkup(0, null, {
       ...rootGroup.attrs,
       listType,
-      listLevel: '1',
     }),
   )
 }

--- a/frontend/packages/editor/src/full-schema.ts
+++ b/frontend/packages/editor/src/full-schema.ts
@@ -9,6 +9,7 @@ import {ImageBlock} from './image'
 import {MathBlock} from './math'
 import {NostrBlock} from './nostr'
 // import {QueryBlock} from "./query-block";
+import {SlotBlock} from './slot-block'
 import CodeBlockLowlight from './tiptap-extension-code-block'
 import {VideoBlock} from './video'
 import {WebEmbed} from './web-embed'
@@ -45,6 +46,7 @@ export const hmBlockSchema: BlockSchema = {
   ['web-embed']: WebEmbed,
   math: MathBlock('math'),
   // query: QueryBlock,
+  slot: SlotBlock,
 }
 
 export type HMBlockSchema = TypesMatch<typeof hmBlockSchema>

--- a/frontend/packages/editor/src/heading-component-plugin.tsx
+++ b/frontend/packages/editor/src/heading-component-plugin.tsx
@@ -163,10 +163,6 @@ export const HMHeadingBlockContent = createTipTapBlock<'heading'>({
 })
 
 export const Heading = {
-  propSchema: {
-    listLevel: {
-      default: '1',
-    },
-  },
+  propSchema: {},
   node: HMHeadingBlockContent,
 }

--- a/frontend/packages/editor/src/schema.ts
+++ b/frontend/packages/editor/src/schema.ts
@@ -8,6 +8,7 @@ import {HMHeadingBlockContent} from './heading-component-plugin'
 import {ImageBlock} from './image'
 import {MathBlock} from './math'
 import {QueryBlock} from './query-block'
+import {SlotBlock} from './slot-block'
 import CodeBlockLowlight from './tiptap-extension-code-block'
 import {Table} from './tiptap-extension-table'
 import {UnknownBlock} from './unknown-block'
@@ -50,6 +51,7 @@ export const hmBlockSchema: BlockSchema = {
     // @ts-ignore
     node: Table,
   },
+  slot: SlotBlock,
   unknown: UnknownBlock,
 }
 

--- a/frontend/packages/editor/src/slot-block.tsx
+++ b/frontend/packages/editor/src/slot-block.tsx
@@ -1,0 +1,15 @@
+import {defaultProps} from './blocknote/core'
+import {createReactBlockSpec} from './blocknote/react'
+
+// An invisible grouping block for root level lists.
+export const SlotBlock = createReactBlockSpec({
+  type: 'slot',
+  propSchema: {
+    ...defaultProps,
+    columnCount: {
+      default: '',
+    },
+  },
+  containsInlineContent: false,
+  render: () => null,
+})

--- a/frontend/packages/editor/src/utils.ts
+++ b/frontend/packages/editor/src/utils.ts
@@ -1,10 +1,10 @@
+import {EditorBlock} from '@seed-hypermedia/client/editor-types'
+import {editorBlockToHMBlock} from '@seed-hypermedia/client/editorblock-to-hmblock'
+import {HMBlockChildrenTypeSchema} from '@seed-hypermedia/client/hm-types'
 import type {BlockSchema} from '@shm/editor/blocknote'
 import type {Block as BNBlock} from '@shm/editor/blocknote/core/extensions/Blocks/api/blockTypes'
-import {HMBlockChildrenTypeSchema} from '@seed-hypermedia/client/hm-types'
-import {editorBlockToHMBlock} from '@seed-hypermedia/client/editorblock-to-hmblock'
-import {DAEMON_FILE_UPLOAD_URL, MAX_FILE_SIZE_B, MAX_FILE_SIZE_MB} from '@shm/shared/constants'
 import {Block, BlockNode} from '@shm/shared/client/grpc-types'
-import {EditorBlock} from '@seed-hypermedia/client/editor-types'
+import {DAEMON_FILE_UPLOAD_URL, MAX_FILE_SIZE_B, MAX_FILE_SIZE_MB} from '@shm/shared/constants'
 import {toast} from '@shm/ui/toast'
 import {Editor} from '@tiptap/core'
 import {Node as TipTapNode} from '@tiptap/pm/model'
@@ -60,6 +60,20 @@ export function setGroupTypes(tiptap: Editor, blocks: Array<Partial<BNBlock<Bloc
         node.descendants((child: TipTapNode, childPos: number) => {
           if (child.type.name === 'blockChildren') {
             setTimeout(() => {
+              const targetPos = pos + childPos + 1
+              const currentNode = tiptap.state.doc.nodeAt(targetPos)
+              // Skip the dispatch when the group is already correct.
+              // Each dispatch is a separate undo step, so skipping keeps paste
+              // undoable in CMD + Z one press.
+              const isCorrectGroupType =
+                currentNode?.type.name === 'blockChildren' &&
+                currentNode.attrs.listType === block.props?.childrenType &&
+                String(currentNode.attrs.listLevel ?? '') === String(block.props?.listLevel ?? '') &&
+                !block.props?.start &&
+                block.props?.childrenType !== 'Grid'
+              if (isCorrectGroupType) {
+                return
+              }
               let tr = tiptap.state.tr
               const attrs: Record<string, any> = {
                 listType: block.props?.childrenType,
@@ -71,7 +85,7 @@ export function setGroupTypes(tiptap: Editor, blocks: Array<Partial<BNBlock<Bloc
               if (block.props?.childrenType === 'Grid' && (block.props as any)?.columnCount) {
                 attrs.columnCount = (block.props as any).columnCount
               }
-              tr = tr.setNodeMarkup(pos + childPos + 1, null, attrs)
+              tr = tr.setNodeMarkup(targetPos, null, attrs)
               tiptap.view.dispatch(tr)
             })
             return false

--- a/frontend/packages/editor/src/utils.ts
+++ b/frontend/packages/editor/src/utils.ts
@@ -68,7 +68,6 @@ export function setGroupTypes(tiptap: Editor, blocks: Array<Partial<BNBlock<Bloc
               const isCorrectGroupType =
                 currentNode?.type.name === 'blockChildren' &&
                 currentNode.attrs.listType === block.props?.childrenType &&
-                String(currentNode.attrs.listLevel ?? '') === String(block.props?.listLevel ?? '') &&
                 !block.props?.start &&
                 block.props?.childrenType !== 'Grid'
               if (isCorrectGroupType) {
@@ -77,7 +76,6 @@ export function setGroupTypes(tiptap: Editor, blocks: Array<Partial<BNBlock<Bloc
               let tr = tiptap.state.tr
               const attrs: Record<string, any> = {
                 listType: block.props?.childrenType,
-                listLevel: block.props?.listLevel,
               }
               if (block.props?.start) {
                 attrs.start = parseInt(block.props.start)
@@ -116,11 +114,11 @@ export function getNodesInSelection(view: EditorView) {
 export function getBlockGroup(
   editor: BlockNoteEditor,
   blockId: BlockIdentifier,
-): undefined | {type: string; listLevel: string; start?: number; columnCount?: string} {
+): undefined | {type: string; start?: number; columnCount?: string} {
   const tiptap = editor?._tiptapEditor
   if (tiptap) {
     const id = typeof blockId === 'string' ? blockId : blockId.id
-    let group: {type: string; listLevel: string; start?: number; columnCount?: string} | undefined
+    let group: {type: string; start?: number; columnCount?: string} | undefined
     tiptap.state.doc.firstChild!.descendants((node: TipTapNode) => {
       if (typeof group !== 'undefined') {
         return false
@@ -135,7 +133,6 @@ export function getBlockGroup(
           group = {
             type: child.attrs.listType,
             start: child.attrs.start,
-            listLevel: child.attrs.listLevel,
             columnCount: child.attrs.columnCount,
           } as const
           return false
@@ -151,7 +148,7 @@ export function getBlockGroup(
   return undefined
 }
 
-type BlockGroupInfo = {type: string; listLevel: string; start?: number; columnCount?: string}
+type BlockGroupInfo = {type: string; start?: number; columnCount?: string}
 
 // Single-pass equivalent of calling getBlockGroup for every block: each block id
 // maps to the first blockChildren descendant (in document order) with a listType.
@@ -166,7 +163,6 @@ export function buildBlockGroupsById(doc: TipTapNode): Map<string, BlockGroupInf
           groups.set(id, {
             type: node.attrs.listType,
             start: node.attrs.start,
-            listLevel: node.attrs.listLevel,
             columnCount: node.attrs.columnCount,
           })
         }

--- a/frontend/packages/shared/src/content.ts
+++ b/frontend/packages/shared/src/content.ts
@@ -47,6 +47,10 @@ export function hasBlockContent(block: HMBlockNode): boolean {
       // Group and Link blocks are structural, check text if available
       return !!('text' in blockData && blockData.text && blockData.text.trim().length > 0)
 
+    case 'Slot':
+      // Slot is an invisible grouping container with no content of its own.
+      return false
+
     default:
       return false
   }

--- a/frontend/packages/shared/src/utils/document-changes.ts
+++ b/frontend/packages/shared/src/utils/document-changes.ts
@@ -237,11 +237,7 @@ function compareUniqueBlocksWithMap(blocksMap: BlocksMap, blocks: Array<EditorBl
     // const childGroup = getBlockGroup(editor, block.id) // TODO: do this with no editor
     let currentBlockState = editorBlockToHMBlock(block)
 
-    type BlockWithAttributes = {attributes?: {listLevel?: unknown}}
-    const prevAttrs = prevBlockState?.block as BlockWithAttributes | undefined
-    const currAttrs = currentBlockState as BlockWithAttributes
-
-    if (!prevBlockState || prevAttrs?.attributes?.listLevel !== currAttrs.attributes?.listLevel) {
+    if (!prevBlockState) {
       const serverBlock = editorBlockToHMBlock(block)
 
       // add moveBlock change by default to all blocks


### PR DESCRIPTION
Adds a new **Slot** block type: an invisible grouping wrapper, so lists and blockquotes can live at the document root, where there's no parent block to carry a childrenType. This enables mixed grouping at the top level.

### What's included (by commit)
- Slot block type and registration: the node, schema, and invisible rendering.
- Paste, merging and boundary normalization: a SlotNormalization ProseMirror plugin that repairs orphaned/malformed slots, merges adjacent same-grouping slots, unwraps non-root slots. Paste handling so pasted lists land in a valid Slot.
- Markdown export: root Slot lists serialize as normal markdown lists.
- Slot-aware multi-item unnest: unnest is now fully slot-aware and consolidated onto one path (unnestBlock).
- listLevel removal: unordered markers now cycle from real nesting depth via CSS.
- Testing: updateGroup, SlotNormalization, normalizeFragment, block-group-map, and updated nestBlock/unnestBlock/splitBlock/nodeConversions fixtures.