### PR TITLE
Fix editing of republished (redirect) documents across agents, CLI, web, and desktop

### DIFF
--- a/agents/src/api-service.test.ts
+++ b/agents/src/api-service.test.ts
@@ -82,6 +82,87 @@ describe('api service', () => {
     }
   })
 
+  test("read tool follows a republished path but says so: content is the target's, and the notice tells a writer what each address means", async () => {
+    // Live incident (session b44d4d81): reading a republished path returned a bare
+    // {type: 'redirect'} blob with no content and no explanation, so the agent could not tell what
+    // it was looking at. Readers must follow the redirect to give the agent content, but never
+    // pretend the content lives at the requested address: writing there replaces the republish
+    // with an independent copy, while writing to the target edits the shared original.
+    const republishedAt = 'hm://z6MkAgent/guide'
+    const original = 'hm://z6MkOther/resources/guide'
+    const originalFetch = globalThis.fetch
+    const resourceRequests: string[] = []
+    globalThis.fetch = mock(async (url: string | URL) => {
+      const href = decodeURIComponent(String(url))
+      if (href.includes('/api/Resource')) {
+        const requestedId = new URL(href).searchParams.get('id') ?? ''
+        resourceRequests.push(requestedId)
+        if (requestedId.startsWith(republishedAt)) {
+          return Response.json(
+            serialize({
+              type: 'redirect',
+              id: unpackHmId(republishedAt),
+              redirectTarget: unpackHmId(original),
+              republish: true,
+            }),
+          )
+        }
+        return Response.json(
+          serialize({
+            type: 'document',
+            id: unpackHmId(original),
+            document: {
+              content: [{block: {id: 'b1', type: 'Paragraph', text: 'Canonical guide body'}, children: []}],
+              version: 'v3',
+              account: 'z6MkOther',
+              authors: ['z6MkOther'],
+              path: '/resources/guide',
+              createTime: '',
+              updateTime: '',
+              metadata: {name: 'Agent Guide'},
+              genesis: 'genesis',
+              visibility: 'PUBLIC',
+            },
+          }),
+        )
+      }
+      throw new Error(`Unexpected fetch: ${href}`)
+    }) as unknown as typeof fetch
+
+    try {
+      const result = await apisvc.readHypermedia({id: republishedAt})
+
+      // The redirect was followed: one request for the republished path, one for the original.
+      expect(resourceRequests).toEqual([republishedAt, original])
+
+      // The agent gets the original's content, attributed to the original's address...
+      expect(result.id).toBe(original)
+      expect(result.requestedId).toBe(republishedAt)
+      expect(result.title).toBe('Agent Guide')
+      expect(result.version).toBe('v3')
+      expect(result.markdown).toContain('Canonical guide body')
+
+      // ...and an explicit account of the redirect that was followed.
+      expect(result.redirect).toEqual({
+        from: republishedAt,
+        to: original,
+        republish: true,
+        hops: [{from: republishedAt, to: original, republish: true}],
+        notice:
+          `${republishedAt} republishes ${original}: the content shown is the latest version of ${original}. ` +
+          `To edit the shared original, write to ${original}. ` +
+          `Writing to ${republishedAt} replaces the republish with an independent copy that no longer follows ${original}.`,
+      })
+
+      // A plain document read carries no redirect field at all.
+      const direct = await apisvc.readHypermedia({id: original})
+      expect(direct.redirect).toBeUndefined()
+      expect(direct.id).toBe(original)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
   test('read tool lists child documents for :directory URLs', async () => {
     // `<doc>/:directory` is a view term like `:attributes`: it must trigger a Query listing of
     // the children (the desktop's directory tab), never a Resource fetch of a document at the

--- a/agents/src/api-service.test.ts
+++ b/agents/src/api-service.test.ts
@@ -5076,6 +5076,227 @@ describe('api service', () => {
     }
   })
 
+  test('moving a republished path moves the republish: the destination re-publishes the same original, not a frozen fork', async () => {
+    // A path that republishes B is a live mirror of B. Moving it must keep it a mirror: the
+    // destination republishes B (so it keeps tracking B's edits) and the source redirects to the
+    // destination. Forking instead — snapshotting B's current content at the destination — would
+    // silently sever the republish, so a later edit of B would never reach the moved path.
+    const {db, dataDir, cleanup} = createTestState()
+    const originalFetch = globalThis.fetch
+    try {
+      const account = blobs.generateNobleKeyPair()
+      const otherSpace = 'z6Mko5npVz4Bx9Rf4vkRUf2swvb568SDbhLwStaha3HzgrLS'
+      const targetGenesis = 'bafyreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku'
+      const targetHead = 'bafyreibnw7dfl23nougcud3jtdsc3v2ems3wymk3x4eiup2jo2qzzdhkbq'
+      let signerPublicKey = ''
+      let openAICallCount = 0
+      const publishedBodies: Uint8Array[] = []
+      globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+        const href = url instanceof Request ? url.url : String(url)
+        if (href.includes('/api/PublishBlobs')) {
+          publishedBodies.push(new Uint8Array(init?.body as ArrayBuffer))
+          return Response.json(serialize({cids: [`published-${publishedBodies.length}`]}))
+        }
+        if (href.includes('/api/ListCapabilities')) return Response.json(serialize({capabilities: []}))
+        if (href.includes('/api/Resource')) {
+          const requestedId = new URL(href).searchParams.get('id') ?? ''
+          // The source path `/guide` republishes the original at hm://otherSpace/resources/guide.
+          if (requestedId.startsWith(`hm://${signerPublicKey}/guide`)) {
+            return Response.json(
+              serialize({
+                type: 'redirect',
+                id: unpackHmId(requestedId),
+                redirectTarget: unpackHmId(`hm://${otherSpace}/resources/guide`),
+                republish: true,
+              }),
+            )
+          }
+          // The original document that both the source (today) and the destination (after the
+          // move) republish.
+          if (requestedId.startsWith(`hm://${otherSpace}/resources/guide`)) {
+            return Response.json(
+              serialize({
+                type: 'document',
+                id: unpackHmId(`hm://${otherSpace}/resources/guide`),
+                document: {
+                  content: [{block: {id: 'b1', type: 'Paragraph', text: 'Canonical guide body'}, children: []}],
+                  version: targetHead,
+                  account: otherSpace,
+                  authors: [otherSpace],
+                  path: '/resources/guide',
+                  createTime: '',
+                  updateTime: '',
+                  metadata: {name: 'Agent Guide'},
+                  genesis: targetGenesis,
+                  generationInfo: {genesis: targetGenesis, generation: 1000},
+                  visibility: 'PUBLIC',
+                },
+              }),
+            )
+          }
+          // The destination path is empty until the move creates the republish there.
+          return Response.json(serialize({type: 'not-found', id: unpackHmId(requestedId)}))
+        }
+        if (!href.includes('/chat/completions') && !href.includes('/responses')) {
+          throw new Error(`Unexpected fetch: ${href}`)
+        }
+        openAICallCount += 1
+        if (openAICallCount === 1) {
+          return openAIStreamResponse([
+            {
+              id: 'chat-1',
+              choices: [
+                {
+                  delta: {
+                    tool_calls: [
+                      {
+                        index: 0,
+                        id: 'call-1',
+                        type: 'function',
+                        function: {
+                          name: 'write',
+                          arguments: JSON.stringify({
+                            address: `hm://${signerPublicKey}/guide`,
+                            options: {
+                              action: 'move',
+                              toPath: '/resources/guide',
+                              signer: {publicKey: signerPublicKey},
+                            },
+                          }),
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            {id: 'chat-1', choices: [{delta: {}, finish_reason: 'tool_calls'}], usage: openAIUsage()},
+          ])
+        }
+        return openAIStreamResponse([
+          {id: `chat-${openAICallCount}`, choices: [{delta: {content: 'Moved.'}}]},
+          {id: `chat-${openAICallCount}`, choices: [{delta: {}, finish_reason: 'stop'}], usage: openAIUsage()},
+        ])
+      }) as unknown as typeof fetch
+
+      const svc = new apisvc.Service(db, dataDir, {hmServerUrl: 'https://hm.test'})
+      await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {_: 'SetSecret', name: 'openai-key', value: new TextEncoder().encode('sk-test')},
+        }),
+      )
+      await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {
+            _: 'SetModelProvider',
+            name: 'openai',
+            provider: {type: 'openai', secretRefs: {apiKey: 'openai-key'}},
+          },
+        }),
+      )
+      const identity = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {_: 'CreateSigningIdentity', label: 'Starlight', clientRequestId: 'starlight'},
+        }),
+      )
+      if (identity._ !== 'CreateSigningIdentityResponse') throw new Error('unexpected response')
+      signerPublicKey = identity.identity.accountId
+      const createdAgent = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {
+            _: 'CreateAgent',
+            definition: {
+              name: 'Starlight',
+              systemPrompt: 'Maintain docs.',
+              modelProvider: 'openai',
+              model: 'gpt-test',
+              tools: ['publish'],
+              signingKeys: [identity.identity.name],
+            },
+          },
+        }),
+      )
+      if (createdAgent._ !== 'CreateAgentResponse') throw new Error('unexpected response')
+      const createdSession = await svc.message(
+        await apisvc.createSignedEnvelope(account, {action: {_: 'CreateSession', agentId: createdAgent.agentId}}),
+      )
+      if (createdSession._ !== 'CreateSessionResponse') throw new Error('unexpected response')
+
+      const publishesBeforeMessage = publishedBodies.length
+      await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {
+            _: 'MessageSession',
+            sessionId: createdSession.sessionId,
+            content: [{type: 'text', text: 'Move the republished guide to /resources/guide'}],
+          },
+        }),
+      )
+
+      const loadedSession = await svc.message(
+        await apisvc.createSignedEnvelope(account, {action: {_: 'GetSession', sessionId: createdSession.sessionId}}),
+      )
+      if (loadedSession._ !== 'GetSessionResponse') throw new Error('unexpected response')
+      const moveResult = loadedSession.events
+        .map(
+          (event) =>
+            event.event as {
+              type?: string
+              name?: string
+              error?: string
+              output?: {
+                command?: string
+                destination?: string
+                republish?: {id?: string; target?: string}
+              }
+            },
+        )
+        .find((event) => event.type === 'tool_result' && event.name === 'write')
+      expect(moveResult?.error).toBeUndefined()
+      expect(moveResult?.output?.command).toBe('document.move')
+      // The move reports that the destination now republishes the ORIGINAL — not a copy.
+      expect(moveResult?.output?.destination).toBe(`hm://${signerPublicKey}/resources/guide`)
+      expect(moveResult?.output?.republish).toMatchObject({
+        id: `hm://${signerPublicKey}/resources/guide`,
+        target: `hm://${otherSpace}/resources/guide`,
+      })
+
+      // Two publishes, both plain redirect Refs. Crucially, NEITHER is a Change: no content was
+      // forked/snapshotted. A fork-based move would publish a Change here.
+      const messagePublishes = publishedBodies.slice(publishesBeforeMessage)
+      expect(messagePublishes).toHaveLength(2)
+      const refsByPath = new Map<string, Record<string, unknown>>()
+      for (const body of messagePublishes) {
+        const {blobs: published} = cbor.decode<{blobs: {data: Uint8Array}[]}>(body)
+        for (const blob of published) {
+          const decoded = cbor.decode<Record<string, unknown>>(new Uint8Array(blob.data))
+          expect(decoded.type).toBe('Ref') // never a 'Change'
+          refsByPath.set(String(decoded.path), decoded)
+        }
+      }
+
+      // At the destination: a republish redirect pointing at the original, with fresh generation.
+      const destRef = refsByPath.get('/resources/guide') as {
+        heads: unknown[]
+        generation: number
+        redirect?: {republish?: boolean}
+      }
+      expect(destRef).toBeDefined()
+      expect(destRef.heads).toHaveLength(0)
+      expect(destRef.redirect?.republish).toBe(true)
+      expect(destRef.generation).toBeGreaterThan(1000)
+
+      // At the source: a plain move redirect (NOT a republish) pointing at the destination.
+      const sourceRef = refsByPath.get('/guide') as {redirect?: {republish?: boolean}}
+      expect(sourceRef).toBeDefined()
+      expect(sourceRef.redirect?.republish).toBeUndefined()
+    } finally {
+      globalThis.fetch = originalFetch
+      db.close()
+      cleanup()
+    }
+  })
+
   test('a provider outage on a delegated child retries itself and succeeds without human action', async () => {
     // Live incident: a child's turn died on a Codex 503 and the parent was left parked. Retryable
     // failures on background runs must ride out the outage on the queue's backoff.

--- a/agents/src/api-service.test.ts
+++ b/agents/src/api-service.test.ts
@@ -4734,6 +4734,267 @@ describe('api service', () => {
     }
   })
 
+  test('write takes over a republished address: update rebases on the redirect target, delete tombstones it, and unauthorized writes fail loudly', async () => {
+    // Live incident (session b44d4d81): a path holding a republish redirect could not be updated
+    // ("Resource is redirect, not a document"), deleted ("Cannot delete redirect"), and an update
+    // signed without a capability on the target space "succeeded" without ever becoming latest.
+    // Editing a republished address must build the Change on the redirect target's DAG and publish
+    // a Version Ref at the address with a fresh generation, which supersedes the redirect.
+    const {db, dataDir, cleanup} = createTestState()
+    const originalFetch = globalThis.fetch
+    try {
+      const account = blobs.generateNobleKeyPair()
+      const otherSpace = 'z6Mko5npVz4Bx9Rf4vkRUf2swvb568SDbhLwStaha3HzgrLS'
+      const targetGenesis = 'bafyreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku'
+      const targetHead = 'bafyreibnw7dfl23nougcud3jtdsc3v2ems3wymk3x4eiup2jo2qzzdhkbq'
+      let openAICallCount = 0
+      let signerPublicKey = ''
+      const publishedBodies: Uint8Array[] = []
+      globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+        const href = url instanceof Request ? url.url : String(url)
+        if (href.includes('/api/PublishBlobs')) {
+          publishedBodies.push(new Uint8Array(init?.body as ArrayBuffer))
+          return Response.json(serialize({cids: [`published-${publishedBodies.length}`]}))
+        }
+        if (href.includes('/api/ListChanges')) {
+          return Response.json(
+            serialize({
+              changes: [
+                {id: targetGenesis, deps: [], author: otherSpace},
+                {id: targetHead, deps: [targetGenesis], author: otherSpace},
+              ],
+            }),
+          )
+        }
+        if (href.includes('/api/ListCapabilities')) {
+          return Response.json(serialize({capabilities: []}))
+        }
+        if (href.includes('/api/Resource')) {
+          const requestedId = new URL(href).searchParams.get('id') ?? ''
+          const targetDoc = {
+            type: 'document',
+            id: unpackHmId(`hm://${otherSpace}/resources/guide`),
+            document: {
+              content: [{block: {id: 'b1', type: 'Paragraph', text: 'Canonical guide body'}, children: []}],
+              version: targetHead,
+              account: otherSpace,
+              authors: [otherSpace],
+              path: '/resources/guide',
+              createTime: '',
+              updateTime: '',
+              metadata: {name: 'Agent Guide'},
+              genesis: targetGenesis,
+              generationInfo: {genesis: targetGenesis, generation: 1000},
+              visibility: 'PUBLIC',
+            },
+          }
+          if (requestedId.includes('/agent-guide') || requestedId.includes('/old-link')) {
+            return Response.json(
+              serialize({
+                type: 'redirect',
+                id: unpackHmId(requestedId),
+                redirectTarget: unpackHmId(`hm://${otherSpace}/resources/guide`),
+                republish: true,
+              }),
+            )
+          }
+          return Response.json(serialize(targetDoc))
+        }
+        if (!href.includes('/chat/completions') && !href.includes('/responses')) {
+          throw new Error(`Unexpected fetch: ${href}`)
+        }
+        openAICallCount += 1
+        if (openAICallCount === 1) {
+          return openAIStreamResponse([
+            {
+              id: 'chat-1',
+              choices: [
+                {
+                  delta: {
+                    tool_calls: [
+                      {
+                        index: 0,
+                        id: 'call-1',
+                        type: 'function',
+                        function: {
+                          name: 'write',
+                          arguments: JSON.stringify({
+                            address: `hm://${signerPublicKey}/agent-guide`,
+                            content: '# Agent Guide\n\nUpdated with PDF import lessons.',
+                            options: {action: 'update', signer: {publicKey: signerPublicKey}},
+                          }),
+                        },
+                      },
+                      {
+                        index: 1,
+                        id: 'call-2',
+                        type: 'function',
+                        function: {
+                          name: 'write',
+                          arguments: JSON.stringify({
+                            address: `hm://${signerPublicKey}/old-link`,
+                            options: {action: 'delete', signer: {publicKey: signerPublicKey}},
+                          }),
+                        },
+                      },
+                      {
+                        index: 2,
+                        id: 'call-3',
+                        type: 'function',
+                        function: {
+                          name: 'write',
+                          arguments: JSON.stringify({
+                            address: `hm://${otherSpace}/resources/guide`,
+                            content: '# Agent Guide\n\nUnauthorized revision.',
+                            options: {action: 'update', signer: {publicKey: signerPublicKey}},
+                          }),
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            {id: 'chat-1', choices: [{delta: {}, finish_reason: 'tool_calls'}], usage: openAIUsage()},
+          ])
+        }
+        return openAIStreamResponse([
+          {id: `chat-${openAICallCount}`, choices: [{delta: {content: 'Done.'}}]},
+          {id: `chat-${openAICallCount}`, choices: [{delta: {}, finish_reason: 'stop'}], usage: openAIUsage()},
+        ])
+      }) as unknown as typeof fetch
+
+      const svc = new apisvc.Service(db, dataDir, {hmServerUrl: 'https://hm.test'})
+      await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {_: 'SetSecret', name: 'openai-key', value: new TextEncoder().encode('sk-test')},
+        }),
+      )
+      await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {
+            _: 'SetModelProvider',
+            name: 'openai',
+            provider: {type: 'openai', secretRefs: {apiKey: 'openai-key'}},
+          },
+        }),
+      )
+      const identity = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {_: 'CreateSigningIdentity', label: 'Starlight', clientRequestId: 'starlight'},
+        }),
+      )
+      if (identity._ !== 'CreateSigningIdentityResponse') throw new Error('unexpected response')
+      if (!identity.identity.accountId) throw new Error('missing signing account id')
+      signerPublicKey = identity.identity.accountId
+      const createdAgent = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {
+            _: 'CreateAgent',
+            definition: {
+              name: 'Starlight',
+              systemPrompt: 'Maintain docs.',
+              modelProvider: 'openai',
+              model: 'gpt-test',
+              tools: ['publish'],
+              signingKeys: [identity.identity.name],
+            },
+          },
+        }),
+      )
+      if (createdAgent._ !== 'CreateAgentResponse') throw new Error('unexpected response')
+      const createdSession = await svc.message(
+        await apisvc.createSignedEnvelope(account, {action: {_: 'CreateSession', agentId: createdAgent.agentId}}),
+      )
+      if (createdSession._ !== 'CreateSessionResponse') throw new Error('unexpected response')
+
+      const publishesBeforeMessage = publishedBodies.length
+      const response = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {
+            _: 'MessageSession',
+            sessionId: createdSession.sessionId,
+            content: [{type: 'text', text: 'Update the republished guide'}],
+          },
+        }),
+      )
+      expect(response._).toBe('MessageSessionResponse')
+
+      const loadedSession = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {_: 'GetSession', sessionId: createdSession.sessionId},
+        }),
+      )
+      if (loadedSession._ !== 'GetSessionResponse') throw new Error('unexpected response')
+      const writeResults = loadedSession.events
+        .map(
+          (event) =>
+            event.event as {
+              type?: string
+              name?: string
+              error?: string
+              output?: {
+                command?: string
+                id?: string
+                version?: string
+                replacedRedirect?: {target?: string; republish?: boolean}
+              }
+            },
+        )
+        .filter((event) => event.type === 'tool_result' && event.name === 'write')
+      expect(writeResults).toHaveLength(3)
+
+      const takeover = writeResults.find((result) => result.output?.id === `hm://${signerPublicKey}/agent-guide`)
+      expect(takeover?.error).toBeUndefined()
+      expect(takeover?.output?.command).toBe('document.update')
+      expect(takeover?.output?.replacedRedirect).toEqual({
+        target: `hm://${otherSpace}/resources/guide`,
+        republish: true,
+      })
+
+      const deletion = writeResults.find((result) => result.output?.id === `hm://${signerPublicKey}/old-link`)
+      expect(deletion?.error).toBeUndefined()
+      expect(deletion?.output?.command).toBe('document.delete')
+
+      const unauthorized = writeResults.find(
+        (result) => !result.output?.id?.startsWith(`hm://${signerPublicKey}`) || result.error,
+      )
+      expect(unauthorized?.error).toContain('no write access')
+
+      // Two publishes: the takeover update and the tombstone. The unauthorized write never publishes.
+      const messagePublishes = publishedBodies.slice(publishesBeforeMessage)
+      expect(messagePublishes).toHaveLength(2)
+      const decodedRefs = messagePublishes.map((body) => {
+        const {blobs: published} = cbor.decode<{blobs: {data: Uint8Array}[]}>(body)
+        return published.map((blob) => cbor.decode<Record<string, unknown>>(new Uint8Array(blob.data)))
+      })
+      const updateBlobs = decodedRefs.find((blobsInBody) => blobsInBody.some((blob) => blob.type === 'Change'))
+      expect(updateBlobs).toBeDefined()
+      const change = updateBlobs!.find((blob) => blob.type === 'Change') as {deps: unknown[]; genesis: unknown}
+      // The takeover Change continues the redirect target's DAG.
+      expect(String(change.deps[0])).toBe(targetHead)
+      expect(String(change.genesis)).toBe(targetGenesis)
+      const updateRef = updateBlobs!.find((blob) => blob.type === 'Ref') as {
+        heads: unknown[]
+        generation: number
+        redirect?: unknown
+      }
+      expect(updateRef.heads).toHaveLength(1)
+      expect(updateRef.redirect).toBeUndefined()
+      // A fresh generation strictly above the redirect's is what supersedes it.
+      expect(updateRef.generation).toBeGreaterThan(1000)
+      const tombstoneBlobs = decodedRefs.find((blobsInBody) => blobsInBody.every((blob) => blob.type === 'Ref'))
+      expect(tombstoneBlobs).toBeDefined()
+      const tombstone = tombstoneBlobs![0] as {heads: unknown[]; generation: number}
+      expect(tombstone.heads).toHaveLength(0)
+      expect(tombstone.generation).toBeGreaterThan(1000)
+    } finally {
+      globalThis.fetch = originalFetch
+      db.close()
+      cleanup()
+    }
+  })
+
   test('a provider outage on a delegated child retries itself and succeeds without human action', async () => {
     // Live incident: a child's turn died on a Codex 503 and the parent was left parked. Retryable
     // failures on background runs must ride out the outage on the queue's backoff.

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -10401,11 +10401,27 @@ async function writeDocumentMove(
   const destination = await resolveMoveDestination(client, source, request.input)
   const {id: sourceId} = await resolveIdWithClient(source, {serverUrl: client.baseUrl})
   const {id: destId} = await resolveIdWithClient(destination, {serverUrl: client.baseUrl})
-  // Following redirects lets a republished path be moved: the destination receives the content
-  // the source path currently re-publishes, and the source is re-pointed at the destination.
   const sourceBase = await followToDocument(client, sourceId).catch((error) => {
     throw new APIError(400, error instanceof Error ? error.message : String(error))
   })
+  // A move acts on whatever kind of thing lives at the source, keeping it that kind of thing at
+  // the destination:
+  //   - a republish (A re-publishes B): the republish moves. The destination re-publishes B (so it
+  //     keeps tracking B's latest), and the source redirects to the destination — NOT a fork, which
+  //     would snapshot B and silently stop following it.
+  //   - a plain document: it forks to the destination (its history) and the source redirects there.
+  // A source that has itself already moved has nowhere to move to — it is a pointer, not content.
+  if (sourceBase.redirect && !sourceBase.redirect.republish) {
+    throw new APIError(
+      400,
+      `${packHmId(sourceId)} has already moved to ${packHmId(sourceBase.redirect.target)}; move ${packHmId(
+        sourceBase.redirect.target,
+      )} instead.`,
+    )
+  }
+  if (sourceBase.redirect?.republish) {
+    return writeRepublishMove(client, signer, request, {source, destination, sourceId, destId, sourceBase})
+  }
   const destinationAlreadyMatches = await destinationMatchesDocument(client, destId, sourceBase.document).catch(
     () => false,
   )
@@ -10430,6 +10446,64 @@ async function writeDocumentMove(
       destination: packHmId(destId),
       ref,
       warning: `Destination was created, but source redirect failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    })
+  }
+}
+
+/**
+ * Moves a republish: the destination re-publishes the same original the source did (so it keeps
+ * tracking the original's latest), then the source redirects to the destination. The alternative —
+ * forking — would freeze a snapshot of the original at the destination and silently break the
+ * republish link, which is never what "move this republish" means.
+ */
+async function writeRepublishMove(
+  client: ReturnType<typeof createSeedClient>,
+  signer: ResolvedAgentSigner,
+  request: ReturnType<typeof normalizeWriteToolRequest>,
+  ctx: {
+    source: string
+    destination: string
+    sourceId: NonNullable<ReturnType<typeof unpackHmId>>
+    destId: NonNullable<ReturnType<typeof unpackHmId>>
+    sourceBase: Awaited<ReturnType<typeof followToDocument>>
+  },
+): Promise<Record<string, unknown>> {
+  const {source, destination, destId, sourceBase} = ctx
+  const original = sourceBase.targetId
+  const capability = await requireWriteCapability(client, destId.uid, signer.publicKey)
+  if (request.dryRun)
+    return writeToolResult(request.command, signer, {
+      destination: packHmId(destId),
+      republish: {id: packHmId(destId), target: packHmId(original), dryRun: true},
+      dryRun: true,
+    })
+  // Fresh generation (the daemon's own CreateRef choice) so the redirect sits in its own generation
+  // row and any later publish at the destination supersedes it cleanly.
+  const republishInput = await createRedirectRef(
+    {
+      space: destId.uid,
+      path: hmIdPathToEntityQueryPath(destId.path),
+      genesis: sourceBase.document.genesis,
+      generation: Date.now(),
+      targetSpace: original.uid,
+      targetPath: hmIdPathToEntityQueryPath(original.path),
+      capability,
+      republish: true,
+    },
+    signer.signer,
+  )
+  const publishedRepublish = await client.publish(republishInput)
+  const republish = {id: packHmId(destId), target: packHmId(original), cids: publishedRepublish.cids}
+  try {
+    const redirect = await writeDocumentRedirect(client, signer, {...request, input: {id: source, to: destination}})
+    return writeToolResult(request.command, signer, {destination: packHmId(destId), republish, redirect})
+  } catch (error) {
+    return writeToolResult(request.command, signer, {
+      destination: packHmId(destId),
+      republish,
+      warning: `Destination now republishes ${packHmId(original)}, but the source redirect failed: ${
         error instanceof Error ? error.message : String(error)
       }`,
     })

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -74,8 +74,10 @@ import {
   parseMarkdown,
   fileToIpfsBlobs,
   resolveFileLinksInBlocks,
+  followToDocument,
   resolveCapability,
   resolveDocumentState,
+  resolveEditableDocument,
   resolveIdWithClient,
   updateComment,
   documentToResolvedMarkdown,
@@ -9304,21 +9306,24 @@ export async function executeWriteVerb(
           }),
         )
       case 'redirect':
+        // The command handler reads the target from `to` — mapping toUrl to `destination` (as this
+        // envelope once did) made every redirect fail with "Redirect target is required".
         return writeHypermedia(
           context,
           envelope('document.redirect', {
             source: address,
-            ...(typeof options.toUrl === 'string' ? {destination: options.toUrl} : {}),
+            ...(typeof options.toUrl === 'string' ? {to: options.toUrl} : {}),
           }),
         )
       case 'delete':
-        return writeHypermedia(context, envelope('document.delete', {account: hm.account, path: hm.path}))
+        // The command handler reads `id`, not account/path — the address is the document to delete.
+        return writeHypermedia(context, envelope('document.delete', {id: address}))
       case 'fork':
+        // The address is where the fork lands; the handler reads it from `destination`.
         return writeHypermedia(
           context,
           envelope('document.fork', {
-            account: hm.account,
-            path: hm.path,
+            destination: address,
             ...(typeof options.fromUrl === 'string' ? {source: options.fromUrl} : {}),
           }),
         )
@@ -10127,6 +10132,9 @@ async function writeDocumentCreate(
   await ensureParentDocumentExists(client, account, path)
   await assertHmContentLinks(client, parsed.blocks, {skipResolve: request.input.skipLinkCheck === true})
   const ops = metadataToWriteSetAttributes(metadata).concat(parsed.ops)
+  // Checked before the dry-run return so a dry run surfaces authorization failures instead of
+  // reporting a success that publish would silently lose.
+  const capability = await requireWriteCapability(client, account, signer.publicKey)
   if (request.dryRun)
     return writeToolResult(request.command, signer, {
       id: `hm://${account}${path}`,
@@ -10134,7 +10142,6 @@ async function writeDocumentCreate(
       blockCount: parsed.blocks.length,
       dryRun: true,
     })
-  const capability = await resolveCapability(client, account, signer.publicKey)
   const genesisBlock = await createGenesisChange(signer.signer)
   const {unsignedBytes, ts} = createChangeOps({ops, genesisCid: genesisBlock.cid, deps: [genesisBlock.cid], depth: 1})
   const changeBlock = await createChange(unsignedBytes, signer.signer)
@@ -10164,6 +10171,27 @@ async function writeDocumentCreate(
   })
 }
 
+/**
+ * Resolves the signer's capability on a space, refusing the write outright when the signer is
+ * neither the space owner nor a capability holder. Publishing without authorization "succeeds" at
+ * the blob layer but never advances the document's latest version — a silent no-op that reads as
+ * success (live incident: session b44d4d81's guide update) — so fail loudly before publishing.
+ */
+async function requireWriteCapability(
+  client: ReturnType<typeof createSeedClient>,
+  space: string,
+  signerPublicKey: string,
+): Promise<string | undefined> {
+  const capability = await resolveCapability(client, space, signerPublicKey)
+  if (space !== signerPublicKey && !capability) {
+    throw new APIError(
+      403,
+      `Signer ${signerPublicKey} has no write access to space ${space} — publishing would succeed but never become the document's latest version. Ask the space owner for a WRITER capability, or sign as the space owner.`,
+    )
+  }
+  return capability
+}
+
 async function writeDocumentUpdate(
   client: ReturnType<typeof createSeedClient>,
   signer: ResolvedAgentSigner,
@@ -10179,8 +10207,13 @@ async function writeDocumentUpdate(
   }
   const edit = normalizeBoundedString(editSource, 'Document edit target', 2048)
   const {id} = await resolveIdWithClient(edit, {serverUrl: client.baseUrl})
-  const resource = await client.request('Resource', id)
-  if (resource.type !== 'document') throw new APIError(400, `Resource is ${resource.type}, not a document`)
+  // A redirected address (including a republished one) is edited by building the Change on the
+  // redirect target's DAG and publishing a Version Ref at THIS address with a fresh generation,
+  // which supersedes the redirect: the path becomes a live document and stops following the target.
+  const base = await resolveEditableDocument(client, id).catch((error) => {
+    throw new APIError(400, error instanceof Error ? error.message : String(error))
+  })
+  const resource = {document: base.document}
   if (
     typeof request.input.expectedVersion === 'string' &&
     resource.document.version !== request.input.expectedVersion
@@ -10210,14 +10243,22 @@ async function writeDocumentUpdate(
   }
   const ops = metadataToWriteSetAttributes(metadata).concat(contentOps)
   if (ops.length === 0) throw new APIError(400, 'No document updates specified — provide content and/or metadata')
+  // The Ref lands at the requested address (id.uid's space), not the redirect target's, so
+  // authorization is checked against the address's space. Checked before the dry-run return so a
+  // dry run surfaces authorization failures instead of reporting a success that publish would
+  // silently lose.
+  const capability = await requireWriteCapability(client, id.uid, signer.publicKey)
+  const replacedRedirect = base.redirect
+    ? {target: packHmId(base.redirect.target), republish: base.redirect.republish}
+    : undefined
   if (request.dryRun)
     return writeToolResult(request.command, signer, {
       id: packHmId(id),
       ...(parsed ? {blockCount: parsed.blocks.length} : {metadataOnly: true}),
+      ...(replacedRedirect ? {replacedRedirect} : {}),
       dryRun: true,
     })
-  const state = await resolveDocumentState(client, edit)
-  const capability = await resolveCapability(client, resource.document.account, signer.publicKey)
+  const state = base.state
   const {unsignedBytes, ts} = createChangeOps({
     ops,
     genesisCid: CID.parse(state.genesis),
@@ -10227,8 +10268,8 @@ async function writeDocumentUpdate(
   const changeBlock = await createChange(unsignedBytes, signer.signer)
   const refInput = await createVersionRef(
     {
-      space: resource.document.account,
-      path: resource.document.path || '',
+      space: id.uid,
+      path: hmIdPathToEntityQueryPath(id.path),
       genesis: state.genesis,
       version: changeBlock.cid.toString(),
       generation: Number(ts),
@@ -10247,6 +10288,7 @@ async function writeDocumentUpdate(
     id: packHmId(id),
     version: changeBlock.cid.toString(),
     cids: published.cids,
+    ...(replacedRedirect ? {replacedRedirect} : {}),
   })
 }
 
@@ -10258,15 +10300,32 @@ async function writeDocumentDelete(
   const target = normalizeBoundedString(request.input.id ?? request.input.target, 'Document ID', 2048)
   const {id} = await resolveIdWithClient(target, {serverUrl: client.baseUrl})
   const resource = await client.request('Resource', id)
-  if (resource.type !== 'document') throw new APIError(400, `Cannot delete ${resource.type}`)
+  if (resource.type !== 'document' && resource.type !== 'redirect')
+    throw new APIError(400, `Cannot delete ${resource.type}`)
+  const capability = await requireWriteCapability(client, id.uid, signer.publicKey)
+  // A redirected path (including a republished one) has no document of its own to read genesis and
+  // generation from, so the tombstone borrows the redirect target's genesis and takes a fresh
+  // generation — the new maximum generation supersedes the redirect Ref, so the path reads as
+  // deleted instead of continuing to follow the target.
+  let genesis: string
+  let generation: number
+  if (resource.type === 'redirect') {
+    const base = await followToDocument(client, id).catch((error) => {
+      throw new APIError(400, error instanceof Error ? error.message : String(error))
+    })
+    genesis = base.document.genesis
+    generation = Date.now()
+  } else {
+    genesis = resource.document.genesis
+    generation = resource.document.generationInfo ? Number(resource.document.generationInfo.generation) : 0
+  }
   if (request.dryRun) return writeToolResult(request.command, signer, {id: packHmId(id), dryRun: true})
-  const capability = await resolveCapability(client, id.uid, signer.publicKey)
   const refInput = await createTombstoneRef(
     {
       space: id.uid,
       path: hmIdPathToEntityQueryPath(id.path),
-      genesis: resource.document.genesis,
-      generation: resource.document.generationInfo ? Number(resource.document.generationInfo.generation) : 0,
+      genesis,
+      generation,
       capability,
     },
     signer.signer,
@@ -10289,17 +10348,21 @@ async function writeDocumentRef(
     )
     const {id: sourceId} = await resolveIdWithClient(source, {serverUrl: client.baseUrl})
     const {id: destId} = await resolveIdWithClient(destination, {serverUrl: client.baseUrl})
-    const resource = await client.request('Resource', sourceId)
-    if (resource.type !== 'document') throw new APIError(400, 'Source is not a document')
-    if (!resource.document.generationInfo) throw new APIError(400, 'Source document has no generation info')
+    // Following redirects lets a republished path be forked: the fork points at the content the
+    // path is currently re-publishing.
+    const base = await followToDocument(client, sourceId).catch((error) => {
+      throw new APIError(400, error instanceof Error ? error.message : String(error))
+    })
+    const capability = await requireWriteCapability(client, destId.uid, signer.publicKey)
     if (request.dryRun) return writeToolResult(request.command, signer, {id: packHmId(destId), dryRun: true})
     const refInput = await createVersionRef(
       {
         space: destId.uid,
         path: hmIdPathToEntityQueryPath(destId.path),
-        genesis: resource.document.generationInfo.genesis,
-        version: resource.document.version,
-        generation: Number(resource.document.generationInfo.generation),
+        genesis: base.document.generationInfo?.genesis ?? base.document.genesis,
+        version: base.document.version,
+        generation: Date.now(),
+        capability,
       },
       signer.signer,
     )
@@ -10336,16 +10399,19 @@ async function writeDocumentMove(
   const destination = await resolveMoveDestination(client, source, request.input)
   const {id: sourceId} = await resolveIdWithClient(source, {serverUrl: client.baseUrl})
   const {id: destId} = await resolveIdWithClient(destination, {serverUrl: client.baseUrl})
-  const sourceResource = await client.request('Resource', sourceId)
-  if (sourceResource.type !== 'document') throw new APIError(400, 'Source is not a document')
-  const destinationAlreadyMatches = await destinationMatchesDocument(client, destId, sourceResource.document).catch(
+  // Following redirects lets a republished path be moved: the destination receives the content
+  // the source path currently re-publishes, and the source is re-pointed at the destination.
+  const sourceBase = await followToDocument(client, sourceId).catch((error) => {
+    throw new APIError(400, error instanceof Error ? error.message : String(error))
+  })
+  const destinationAlreadyMatches = await destinationMatchesDocument(client, destId, sourceBase.document).catch(
     () => false,
   )
   const ref = destinationAlreadyMatches
     ? writeToolResult('document.fork', signer, {
         id: packHmId(destId),
         status: 'already_exists',
-        version: sourceResource.document.version,
+        version: sourceBase.document.version,
       })
     : await writeDocumentRef(client, signer, {
         ...request,
@@ -10405,16 +10471,29 @@ async function writeDocumentRedirect(
   const {id: sourceId} = await resolveIdWithClient(source, {serverUrl: client.baseUrl})
   const {id: targetId} = await resolveIdWithClient(to, {serverUrl: client.baseUrl})
   const resource = await client.request('Resource', sourceId)
-  if (resource.type !== 'document') throw new APIError(400, 'Redirect source is not a document')
+  if (resource.type !== 'document' && resource.type !== 'redirect')
+    throw new APIError(400, `Redirect source is ${resource.type}, not a document`)
+  // Re-pointing an already-redirected source borrows the current target's genesis (the source has
+  // no document of its own). A fresh generation is minted either way — the same choice the daemon's
+  // CreateRef makes — so the redirect occupies its own generation row and any later publish at this
+  // path supersedes it cleanly.
+  const genesis =
+    resource.type === 'redirect'
+      ? await followToDocument(client, sourceId)
+          .then((base) => base.document.genesis)
+          .catch((error) => {
+            throw new APIError(400, error instanceof Error ? error.message : String(error))
+          })
+      : resource.document.genesis
+  const capability = await requireWriteCapability(client, sourceId.uid, signer.publicKey)
   if (request.dryRun)
     return writeToolResult(request.command, signer, {id: packHmId(sourceId), target: packHmId(targetId), dryRun: true})
-  const capability = await resolveCapability(client, sourceId.uid, signer.publicKey)
   const refInput = await createRedirectRef(
     {
       space: sourceId.uid,
       path: hmIdPathToEntityQueryPath(sourceId.path),
-      genesis: resource.document.genesis,
-      generation: resource.document.generationInfo ? Number(resource.document.generationInfo.generation) : 1,
+      genesis,
+      generation: Date.now(),
       targetSpace: targetId.uid,
       targetPath: hmIdPathToEntityQueryPath(targetId.path),
       capability,

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -74,6 +74,8 @@ import {
   parseMarkdown,
   fileToIpfsBlobs,
   resolveFileLinksInBlocks,
+  describeRedirect,
+  followRedirects,
   followToDocument,
   resolveCapability,
   resolveDocumentState,
@@ -11331,16 +11333,35 @@ export async function readHypermedia(input: unknown): Promise<Record<string, unk
   const stripped = stripAttributesViewTerm(id)
   id = stripped.id
   const attributesOnly = stripped.attributesOnly
-  const resource = await client.request('Resource', id)
+  // Redirects (a moved path, or a "republished" path that re-publishes another document as its
+  // own) are followed so the agent gets content — but never silently: `id` is the address the
+  // content was actually read from, and `redirect` spells out where the request went and what a
+  // write to either address would do. A write to the requested address does NOT edit the target.
+  const followed = await followRedirects(client, id)
+  const resource = followed.resource
   const outputFormat = format || 'markdown'
   const result: Record<string, unknown> = {
     type: 'hypermedia_document',
     requestedId,
-    id: packHmId(id),
+    id: packHmId(followed.targetId),
     server: serverUrl,
     format: outputFormat,
   }
   if (dev) result.dev = true
+  if (followed.redirects.length > 0) {
+    const first = followed.redirects[0]!
+    result.redirect = {
+      from: packHmId(id),
+      to: packHmId(followed.targetId),
+      republish: first.republish,
+      hops: followed.redirects.map((hop) => ({
+        from: packHmId(hop.from),
+        to: packHmId(hop.to),
+        republish: hop.republish,
+      })),
+      notice: describeRedirect(followed),
+    }
+  }
 
   if (resource.type === 'document') {
     result.title = resource.document.metadata?.name

--- a/frontend/apps/cli/src/commands/document.ts
+++ b/frontend/apps/cli/src/commands/document.ts
@@ -17,6 +17,8 @@ import {
   pdfToBlocks,
   fileToIpfsBlobs,
   slugify,
+  describeRedirect,
+  followRedirects,
   followToDocument,
   packHmId,
   resolveCapability,
@@ -44,7 +46,7 @@ import {
 } from '../utils/block-diff'
 import {resolveFileLinks} from '../utils/file-links'
 import {markdownBlockNodesToHMBlockNodes} from '@seed-hypermedia/client'
-import type {HMBlockNode, HMDocument, HMMetadata} from '@seed-hypermedia/client/hm-types'
+import type {HMBlockNode, HMDocument, HMMetadata, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 
 // ── Input helpers ────────────────────────────────────────────────────────────
 
@@ -209,6 +211,17 @@ export async function readInput(options: {file?: string; grobidUrl?: string; qui
   return {ops, metadata, fileBlobs: resolved.blobs, tree: resolvedTree}
 }
 
+/**
+ * Records a followed redirect in the markdown frontmatter so the fact survives piping to a file:
+ * `republishOf` (the address whose latest content this is) or `movedTo`. Both keys are ignored by
+ * the frontmatter parser on the way back in, so `get > file; update -f file` still round-trips.
+ */
+function withRedirectFrontmatter(md: string, republish: boolean, target: UnpackedHypermediaId): string {
+  const line = `${republish ? 'republishOf' : 'movedTo'}: ${JSON.stringify(packHmId(target))}`
+  if (md.startsWith('---\n')) return `---\n${line}\n${md.slice(4)}`
+  return `---\n${line}\n---\n${md}`
+}
+
 export function registerDocumentCommands(program: Command) {
   const doc = program
     .command('document')
@@ -284,7 +297,14 @@ export function registerDocumentCommands(program: Command) {
           return
         }
 
-        const result = await client.request('Resource', resolvedId)
+        // A redirected address (a moved path, or a "republished" path that re-publishes another
+        // document as its own) is followed so the reader gets content — but never silently: the
+        // output names the address the content really lives at, because a write to the requested
+        // address does something different (it replaces the redirect) from a write to the target.
+        const followed = await followRedirects(client, resolvedId)
+        const result = followed.resource
+        const redirectNotice = describeRedirect(followed)
+        if (redirectNotice && !globalOpts.quiet && !options.quiet) printInfo(redirectNotice)
 
         if (globalOpts.quiet || options.quiet) {
           if (result.type === 'document') {
@@ -296,7 +316,18 @@ export function registerDocumentCommands(program: Command) {
           }
         } else if (useStructuredOutput) {
           // --json or --yaml → structured output (optionally colorized with --pretty)
-          emit(formatOutput(result, format, pretty))
+          const structured = redirectNotice
+            ? {
+                ...result,
+                redirect: {
+                  from: packHmId(followed.id),
+                  to: packHmId(followed.targetId),
+                  republish: followed.redirects[0]!.republish,
+                  notice: redirectNotice,
+                },
+              }
+            : result
+          emit(formatOutput(structured, format, pretty))
         } else {
           // Default: markdown output (with frontmatter and block IDs)
           // When --pretty: render markdown with ANSI terminal styling
@@ -305,6 +336,7 @@ export function registerDocumentCommands(program: Command) {
               resolve: options.resolve,
               client: options.resolve ? client : undefined,
             })
+            if (redirectNotice) md = withRedirectFrontmatter(md, followed.redirects[0]!.republish, followed.targetId)
             if (pretty) md = renderMarkdown(md)
             emit(md)
           } else if (result.type === 'comment') {

--- a/frontend/apps/cli/src/commands/document.ts
+++ b/frontend/apps/cli/src/commands/document.ts
@@ -17,7 +17,10 @@ import {
   pdfToBlocks,
   fileToIpfsBlobs,
   slugify,
+  followToDocument,
+  packHmId,
   resolveCapability,
+  resolveEditableDocument,
   type DocumentOperation,
   type CollectedBlob,
 } from '@seed-hypermedia/client'
@@ -431,8 +434,13 @@ export function registerDocumentCommands(program: Command) {
                   `Document already exists at ${path}. Use "document update hm://${account}${path}" to modify it, or --force to overwrite with a new lineage.`,
                 )
               }
+              if (existing.type === 'redirect') {
+                throw new Error(
+                  `A redirect already exists at ${path}. Use "document update hm://${account}${path}" to replace it with edited content (continuing the target's history), or --force to overwrite with a new lineage.`,
+                )
+              }
             } catch (e) {
-              // Re-throw our own "already exists" error; swallow network/not-found errors
+              // Re-throw our own guard errors; swallow network/not-found errors
               if ((e as Error).message.includes('already exists')) throw e
             }
           }
@@ -541,13 +549,18 @@ export function registerDocumentCommands(program: Command) {
         let fileBlobs: CollectedBlob[] = []
         let metaBlobs: CollectedBlob[] = []
 
-        // Fetch the document — needed for diffing and state resolution
-        const resource = await client.request('Resource', resourceId)
-        if (resource.type !== 'document') {
-          printError(`Resource is ${resource.type}, not a document.`)
-          process.exit(1)
+        // Fetch the document — needed for diffing and state resolution. A redirected address
+        // (including a republished one) is followed to its target: the edit builds on the
+        // target's DAG and the new Version Ref at THIS address supersedes the redirect.
+        const base = await resolveEditableDocument(client, resourceId)
+        const existingDoc = base.document
+        if (base.redirect && !globalOpts.quiet) {
+          printInfo(
+            `This address currently ${base.redirect.republish ? 'republishes' : 'redirects to'} ${packHmId(
+              base.redirect.target,
+            )}; updating it replaces the redirect with an edited copy of that document.`,
+          )
         }
-        const existingDoc = resource.document
 
         // Collect content and metadata from file input
         let inputMeta: HMMetadata = {}
@@ -605,10 +618,11 @@ export function registerDocumentCommands(program: Command) {
           process.exit(1)
         }
 
-        const docAccount = existingDoc.account
-        const docPath = existingDoc.path || ''
+        // The Ref lands at the requested address, not the (possibly different) redirect target.
+        const docAccount = resourceId.uid
+        const docPath = resourceId.path?.length ? `/${resourceId.path.join('/')}` : existingDoc.path || ''
 
-        const state = await resolveDocumentState(client, id)
+        const state = base.state
         const genesisCid = CID.parse(state.genesis)
         const depCids = state.heads.map((h) => CID.parse(h))
         const newDepth = state.headDepth + 1
@@ -666,12 +680,24 @@ export function registerDocumentCommands(program: Command) {
         const signer = createSignerFromKey(key)
 
         const resource = await client.request('Resource', unpacked)
-        if (resource.type !== 'document') {
+        if (resource.type !== 'document' && resource.type !== 'redirect') {
           printError(`Cannot delete: resource is ${resource.type}, not a document.`)
           process.exit(1)
         }
-        const doc = resource.document
-        const generation = doc.generationInfo ? Number(doc.generationInfo.generation) : 0
+        // A redirected path (including a republished one) has no document of its own to read
+        // genesis and generation from, so the tombstone borrows the redirect target's genesis and
+        // takes a fresh generation — the new maximum generation supersedes the redirect Ref, so
+        // the path reads as deleted instead of continuing to follow the target.
+        let genesis: string
+        let generation: number
+        if (resource.type === 'redirect') {
+          const base = await followToDocument(client, unpacked)
+          genesis = base.document.genesis
+          generation = Date.now()
+        } else {
+          genesis = resource.document.genesis
+          generation = resource.document.generationInfo ? Number(resource.document.generationInfo.generation) : 0
+        }
         const docPath = hmIdPathToEntityQueryPath(unpacked.path)
         const capability = await resolveCapability(client, unpacked.uid, key.accountId, docPath)
 
@@ -679,7 +705,7 @@ export function registerDocumentCommands(program: Command) {
           {
             space: unpacked.uid,
             path: hmIdPathToEntityQueryPath(unpacked.path),
-            genesis: doc.genesis,
+            genesis,
             generation,
             capability,
           },
@@ -710,21 +736,18 @@ export function registerDocumentCommands(program: Command) {
         const key = await resolveSigningKey(_options.key, keyOptions(globalOpts))
         const signer = createSignerFromKey(key)
 
-        const resource = await client.request('Resource', sourceUnpacked)
-        if (resource.type !== 'document') {
-          printError(`Cannot fork: source is ${resource.type}, not a document.`)
-          process.exit(1)
-        }
-        const doc = resource.document
-        if (!doc.generationInfo) throw new Error('No generation info for source document')
+        // Follows redirects so a republished path can be forked: the fork points at the content
+        // the path currently re-publishes. A fresh generation lets the fork supersede any
+        // redirect Ref already sitting at the destination path.
+        const {document: doc} = await followToDocument(client, sourceUnpacked)
 
         const refInput = await createVersionRef(
           {
             space: dest.uid,
             path: hmIdPathToEntityQueryPath(dest.path),
-            genesis: doc.generationInfo.genesis,
+            genesis: doc.generationInfo?.genesis ?? doc.genesis,
             version: doc.version,
-            generation: Number(doc.generationInfo.generation),
+            generation: Date.now(),
           },
           signer,
         )
@@ -756,22 +779,20 @@ export function registerDocumentCommands(program: Command) {
         const key = await resolveSigningKey(_options.key, keyOptions(globalOpts))
         const signer = createSignerFromKey(key)
 
-        const resource = await client.request('Resource', source)
-        if (resource.type !== 'document') {
-          printError(`Cannot move: source is ${resource.type}, not a document.`)
-          process.exit(1)
-        }
-        const doc = resource.document
-        if (!doc.generationInfo) throw new Error('No generation info for source document')
+        // Follows redirects so an already-redirected source can be moved again: the destination
+        // receives the content the source currently presents, and the source is re-pointed.
+        const {document: doc} = await followToDocument(client, source)
+        const genesis = doc.generationInfo?.genesis ?? doc.genesis
 
-        // Create version ref at destination
+        // Create version ref at destination. Fresh generations let both refs supersede any
+        // redirect Refs already sitting at their paths.
         const versionRefInput = await createVersionRef(
           {
             space: dest.uid,
             path: hmIdPathToEntityQueryPath(dest.path),
-            genesis: doc.generationInfo.genesis,
+            genesis,
             version: doc.version,
-            generation: Number(doc.generationInfo.generation),
+            generation: Date.now(),
           },
           signer,
         )
@@ -782,8 +803,8 @@ export function registerDocumentCommands(program: Command) {
           {
             space: source.uid,
             path: hmIdPathToEntityQueryPath(source.path),
-            genesis: doc.generationInfo.genesis,
-            generation: Number(doc.generationInfo.generation),
+            genesis,
+            generation: Date.now(),
             targetSpace: dest.uid,
             targetPath: hmIdPathToEntityQueryPath(dest.path),
           },
@@ -820,19 +841,25 @@ export function registerDocumentCommands(program: Command) {
         const signer = createSignerFromKey(key)
 
         const resource = await client.request('Resource', source)
-        if (resource.type !== 'document') {
+        if (resource.type !== 'document' && resource.type !== 'redirect') {
           printError(`Cannot redirect: resource is ${resource.type}, not a document.`)
           process.exit(1)
         }
-        const doc = resource.document
-        const generation = doc.generationInfo ? Number(doc.generationInfo.generation) : 1
+        // Re-pointing an already-redirected source borrows the current target's genesis (the
+        // source has no document of its own). A fresh generation is minted either way — the same
+        // choice the daemon's CreateRef makes — so the redirect occupies its own generation row
+        // and any later publish at this path supersedes it cleanly.
+        const genesis =
+          resource.type === 'redirect'
+            ? (await followToDocument(client, source)).document.genesis
+            : resource.document.genesis
 
         const refInput = await createRedirectRef(
           {
             space: source.uid,
             path: hmIdPathToEntityQueryPath(source.path),
-            genesis: doc.genesis,
-            generation,
+            genesis,
+            generation: Date.now(),
             targetSpace: target.uid,
             targetPath: hmIdPathToEntityQueryPath(target.path),
             republish: !!_options.republish,

--- a/frontend/apps/cli/src/commands/document.ts
+++ b/frontend/apps/cli/src/commands/document.ts
@@ -811,26 +811,62 @@ export function registerDocumentCommands(program: Command) {
         const key = await resolveSigningKey(_options.key, keyOptions(globalOpts))
         const signer = createSignerFromKey(key)
 
-        // Follows redirects so an already-redirected source can be moved again: the destination
-        // receives the content the source currently presents, and the source is re-pointed.
-        const {document: doc} = await followToDocument(client, source)
-        const genesis = doc.generationInfo?.genesis ?? doc.genesis
+        // A move acts on whatever lives at the source and keeps it that kind of thing at the
+        // destination. Following redirects tells us which: a republish moves as a republish; a
+        // plain document moves as a fork of its history; a path that has itself already moved is a
+        // pointer with nothing to move.
+        const followed = await followToDocument(client, source)
+        const genesis = followed.document.generationInfo?.genesis ?? followed.document.genesis
 
-        // Create version ref at destination. Fresh generations let both refs supersede any
-        // redirect Refs already sitting at their paths.
-        const versionRefInput = await createVersionRef(
-          {
-            space: dest.uid,
-            path: hmIdPathToEntityQueryPath(dest.path),
-            genesis,
-            version: doc.version,
-            generation: Date.now(),
-          },
-          signer,
-        )
-        await client.publish(versionRefInput)
+        if (followed.redirect && !followed.redirect.republish) {
+          printError(
+            `${packHmId(source)} has already moved to ${packHmId(followed.redirect.target)}. ` +
+              `Move ${packHmId(followed.redirect.target)} instead.`,
+          )
+          process.exit(1)
+        }
 
-        // Create redirect ref at source
+        if (followed.redirect?.republish) {
+          // Moving a republish moves the republish: the destination re-publishes the same original
+          // (so it keeps tracking the original's edits), and the source redirects to the
+          // destination. Forking here would freeze a snapshot and sever the republish.
+          const original = followed.targetId
+          if (!globalOpts.quiet) {
+            printInfo(
+              `${packHmId(source)} republishes ${packHmId(original)}; ` +
+                `moving it makes ${packHmId(dest)} republish ${packHmId(original)}.`,
+            )
+          }
+          const destRepublishInput = await createRedirectRef(
+            {
+              space: dest.uid,
+              path: hmIdPathToEntityQueryPath(dest.path),
+              genesis,
+              generation: Date.now(),
+              targetSpace: original.uid,
+              targetPath: hmIdPathToEntityQueryPath(original.path),
+              republish: true,
+            },
+            signer,
+          )
+          await client.publish(destRepublishInput)
+        } else {
+          // A plain document forks its history to the destination. Fresh generations let both refs
+          // supersede any redirect Refs already sitting at their paths.
+          const versionRefInput = await createVersionRef(
+            {
+              space: dest.uid,
+              path: hmIdPathToEntityQueryPath(dest.path),
+              genesis,
+              version: followed.document.version,
+              generation: Date.now(),
+            },
+            signer,
+          )
+          await client.publish(versionRefInput)
+        }
+
+        // Redirect the source to the destination (a plain move redirect, not a republish).
         const redirectRefInput = await createRedirectRef(
           {
             space: source.uid,

--- a/frontend/apps/cli/src/test/cli-fixture.test.ts
+++ b/frontend/apps/cli/src/test/cli-fixture.test.ts
@@ -1832,6 +1832,140 @@ describe('CLI Full Integration Tests', () => {
     )
 
     test(
+      'moving a republished path moves the republish (destination keeps tracking the original)',
+      async () => {
+        // A path that republishes an original is a live mirror. Moving it must keep it a mirror:
+        // the destination republishes the SAME original (so later edits of the original still show
+        // through), rather than freezing a fork of the original's current content.
+        const runId = Date.now()
+        const original = `move-original-${runId}`
+        const originalHmId = `hm://${writeAccount.accountId}/${original}`
+        const republishedSlug = `move-republished-${runId}`
+        const republishedHmId = `hm://${writeAccount.accountId}/${republishedSlug}`
+        const destSlug = `move-destination-${runId}`
+        const destHmId = `hm://${writeAccount.accountId}/${destSlug}`
+
+        const tmpDirMove = mkdtempSync(join(tmpdir(), 'seed-test-'))
+        const mdOriginal = join(tmpDirMove, 'original.md')
+        writeFileSync(mdOriginal, 'Original guide, first edition.')
+        expect(
+          (
+            await runCli(
+              [
+                'document',
+                'create',
+                '--path',
+                original,
+                '--name',
+                'Original Guide',
+                '-f',
+                mdOriginal,
+                '--key',
+                TEST_KEY_NAME,
+              ],
+              {server: ctx.webServerUrl},
+            )
+          ).exitCode,
+        ).toBe(0)
+        await new Promise((r) => setTimeout(r, 2000))
+
+        // A path that republishes the original.
+        const mdRepub = join(tmpDirMove, 'repub.md')
+        writeFileSync(mdRepub, 'placeholder')
+        expect(
+          (
+            await runCli(
+              [
+                'document',
+                'create',
+                '--path',
+                republishedSlug,
+                '--name',
+                'Mirror',
+                '-f',
+                mdRepub,
+                '--key',
+                TEST_KEY_NAME,
+              ],
+              {server: ctx.webServerUrl},
+            )
+          ).exitCode,
+        ).toBe(0)
+        await new Promise((r) => setTimeout(r, 2000))
+        expect(
+          (
+            await runCli(
+              ['document', 'redirect', republishedHmId, '--to', originalHmId, '--republish', '--key', TEST_KEY_NAME],
+              {server: ctx.webServerUrl},
+            )
+          ).exitCode,
+        ).toBe(0)
+        await new Promise((r) => setTimeout(r, 2000))
+
+        // Move the republished path to a new location.
+        const moveResult = await runCli(['document', 'move', republishedHmId, destHmId, '--key', TEST_KEY_NAME], {
+          server: ctx.webServerUrl,
+        })
+        if (moveResult.exitCode !== 0) console.log('[test] republish move stderr:', moveResult.stderr)
+        expect(moveResult.exitCode).toBe(0)
+        expect(moveResult.stderr).toContain('republishes')
+        await new Promise((r) => setTimeout(r, 2000))
+
+        // The destination now shows the original's content, disclosed as a republish of the
+        // original (NOT a fork living in the destination's own space).
+        const getDest = await runCli(['document', 'get', destHmId], {server: ctx.webServerUrl})
+        expect(getDest.exitCode).toBe(0)
+        expect(getDest.stdout).toContain('Original guide, first edition.')
+        expect(getDest.stdout).toContain(`republishOf: "${originalHmId}"`)
+
+        // Editing the ORIGINAL after the move still shows through at the destination — proof the
+        // move preserved a live republish rather than snapshotting a fork.
+        const mdOriginal2 = join(tmpDirMove, 'original2.md')
+        writeFileSync(mdOriginal2, 'Original guide, first edition.\n\nSecond edition addendum.')
+        expect(
+          (
+            await runCli(
+              [
+                'document',
+                'update',
+                originalHmId,
+                '--name',
+                'Original Guide',
+                '-f',
+                mdOriginal2,
+                '--key',
+                TEST_KEY_NAME,
+              ],
+              {server: ctx.webServerUrl},
+            )
+          ).exitCode,
+        ).toBe(0)
+        await new Promise((r) => setTimeout(r, 2000))
+        const getDestAfter = await runCli(['document', 'get', destHmId], {server: ctx.webServerUrl})
+        expect(getDestAfter.stdout).toContain('Second edition addendum.')
+
+        // The moved source now redirects to the destination, and moving it again is refused: a
+        // moved pointer has nothing left to move.
+        const moveAgain = await runCli(
+          [
+            'document',
+            'move',
+            republishedHmId,
+            `hm://${writeAccount.accountId}/move-again-${runId}`,
+            '--key',
+            TEST_KEY_NAME,
+          ],
+          {server: ctx.webServerUrl},
+        )
+        expect(moveAgain.exitCode).toBe(1)
+        expect(moveAgain.stderr).toContain('already moved')
+
+        rmSync(tmpDirMove, {recursive: true, force: true})
+      },
+      TEST_TIMEOUT * 2,
+    )
+
+    test(
       'document delete with missing key shows error',
       async () => {
         const result = await runCli(

--- a/frontend/apps/cli/src/test/cli-fixture.test.ts
+++ b/frontend/apps/cli/src/test/cli-fixture.test.ts
@@ -1691,6 +1691,123 @@ describe('CLI Full Integration Tests', () => {
     )
 
     test(
+      'republished document can be edited (takes over the path) and deleted',
+      async () => {
+        // Live incident (agent session b44d4d81): a path holding a republish redirect could not
+        // be updated ("Resource is redirect, not a document") or deleted ("Cannot delete:
+        // resource is redirect"). Editing a republished path must build on the redirect target's
+        // change DAG and publish a Version Ref at the path with a fresh generation, which
+        // supersedes the redirect in the daemon's generation resolution.
+        const runId = Date.now()
+        const targetSlug = `republish-target-${runId}`
+        const targetHmId = `hm://${writeAccount.accountId}/${targetSlug}`
+        const editedSlug = `republish-edited-${runId}`
+        const editedHmId = `hm://${writeAccount.accountId}/${editedSlug}`
+        const deletedSlug = `republish-deleted-${runId}`
+        const deletedHmId = `hm://${writeAccount.accountId}/${deletedSlug}`
+
+        const tmpDirRepub = mkdtempSync(join(tmpdir(), 'seed-test-'))
+        const mdTarget = join(tmpDirRepub, 'target.md')
+        writeFileSync(mdTarget, 'Canonical guide content')
+
+        const targetResult = await runCli(
+          [
+            'document',
+            'create',
+            '--path',
+            targetSlug,
+            '--name',
+            'Canonical Guide',
+            '-f',
+            mdTarget,
+            '--key',
+            TEST_KEY_NAME,
+          ],
+          {server: ctx.webServerUrl},
+        )
+        expect(targetResult.exitCode).toBe(0)
+        await new Promise((r) => setTimeout(r, 2000))
+
+        // Two republished paths pointing at the target: one to edit, one to delete.
+        for (const [slug, hmId] of [
+          [editedSlug, editedHmId],
+          [deletedSlug, deletedHmId],
+        ] as const) {
+          const mdSource = join(tmpDirRepub, `${slug}.md`)
+          writeFileSync(mdSource, 'Original body before republish')
+          const createResult = await runCli(
+            [
+              'document',
+              'create',
+              '--path',
+              slug,
+              '--name',
+              'Republished Copy',
+              '-f',
+              mdSource,
+              '--key',
+              TEST_KEY_NAME,
+            ],
+            {server: ctx.webServerUrl},
+          )
+          expect(createResult.exitCode).toBe(0)
+          await new Promise((r) => setTimeout(r, 2000))
+          const redirectResult = await runCli(
+            ['document', 'redirect', hmId, '--to', targetHmId, '--republish', '--key', TEST_KEY_NAME],
+            {server: ctx.webServerUrl},
+          )
+          if (redirectResult.exitCode !== 0) {
+            console.log('[test] republish redirect stderr:', redirectResult.stderr)
+          }
+          expect(redirectResult.exitCode).toBe(0)
+        }
+        await new Promise((r) => setTimeout(r, 2000))
+
+        // Editing the republished path takes it over: the update follows the redirect to the
+        // target for its baseline and publishes a fresh-generation Version Ref at the path.
+        const mdEdited = join(tmpDirRepub, 'edited.md')
+        writeFileSync(mdEdited, 'Canonical guide content\n\nPlus locally added lessons.')
+        const updateResult = await runCli(
+          ['document', 'update', editedHmId, '--name', 'Guide With Lessons', '-f', mdEdited, '--key', TEST_KEY_NAME],
+          {server: ctx.webServerUrl},
+        )
+        if (updateResult.exitCode !== 0) {
+          console.log('[test] republish update stderr:', updateResult.stderr)
+          console.log('[test] republish update stdout:', updateResult.stdout)
+        }
+        expect(updateResult.exitCode).toBe(0)
+        expect(updateResult.stderr + updateResult.stdout).toContain('republishes')
+        await new Promise((r) => setTimeout(r, 2000))
+
+        // The path now serves the edited document (not the redirect, not the plain target).
+        const getEdited = await runCli(['document', 'get', editedHmId], {server: ctx.webServerUrl})
+        expect(getEdited.exitCode).toBe(0)
+        expect(getEdited.stdout).toContain('Plus locally added lessons.')
+
+        // And the target document itself is untouched.
+        const getTarget = await runCli(['document', 'get', targetHmId], {server: ctx.webServerUrl})
+        expect(getTarget.exitCode).toBe(0)
+        expect(getTarget.stdout).not.toContain('Plus locally added lessons.')
+
+        // Deleting a republished path publishes a fresh-generation tombstone that supersedes the
+        // redirect: afterwards the path must not serve the target's content anymore.
+        const deleteResult = await runCli(['document', 'delete', deletedHmId, '--key', TEST_KEY_NAME], {
+          server: ctx.webServerUrl,
+        })
+        if (deleteResult.exitCode !== 0) {
+          console.log('[test] republish delete stderr:', deleteResult.stderr)
+        }
+        expect(deleteResult.exitCode).toBe(0)
+        await new Promise((r) => setTimeout(r, 2000))
+        const getDeleted = await runCli(['document', 'get', deletedHmId], {server: ctx.webServerUrl})
+        expect(`${getDeleted.stdout}${getDeleted.stderr}`).not.toContain('Canonical guide content')
+
+        rmSync(tmpDirRepub, {recursive: true, force: true})
+      },
+      TEST_TIMEOUT * 2,
+    )
+
+    test(
       'document delete with missing key shows error',
       async () => {
         const result = await runCli(

--- a/frontend/apps/cli/src/test/cli-fixture.test.ts
+++ b/frontend/apps/cli/src/test/cli-fixture.test.ts
@@ -1763,6 +1763,30 @@ describe('CLI Full Integration Tests', () => {
         }
         await new Promise((r) => setTimeout(r, 2000))
 
+        // Reading a republished path shows the TARGET's content, but never silently: the
+        // frontmatter records which address the content really belongs to, and the notice tells a
+        // writer what a write to either address would do.
+        const getRepublished = await runCli(['document', 'get', editedHmId], {server: ctx.webServerUrl})
+        expect(getRepublished.exitCode).toBe(0)
+        expect(getRepublished.stdout).toContain('Canonical guide content')
+        expect(getRepublished.stdout).toContain(`republishOf: "${targetHmId}"`)
+        expect(getRepublished.stderr).toContain(`${editedHmId} republishes ${targetHmId}`)
+        expect(getRepublished.stderr).toContain(`To edit the shared original, write to ${targetHmId}`)
+
+        // Structured output carries the same facts as data.
+        const getRepublishedJson = await runCli(['document', 'get', editedHmId, '--json'], {server: ctx.webServerUrl})
+        expect(getRepublishedJson.exitCode).toBe(0)
+        const republishedJson = JSON.parse(getRepublishedJson.stdout)
+        expect(republishedJson.type).toBe('document')
+        expect(republishedJson.id.id).toBe(targetHmId)
+        expect(republishedJson.redirect).toMatchObject({from: editedHmId, to: targetHmId, republish: true})
+        expect(republishedJson.redirect.notice).toContain('republishes')
+
+        // Reading the original directly involves no redirect at all.
+        const getOriginal = await runCli(['document', 'get', targetHmId], {server: ctx.webServerUrl})
+        expect(getOriginal.stdout).not.toContain('republishOf')
+        expect(getOriginal.stderr).not.toContain('republishes')
+
         // Editing the republished path takes it over: the update follows the redirect to the
         // target for its baseline and publishes a fresh-generation Version Ref at the path.
         const mdEdited = join(tmpDirRepub, 'edited.md')

--- a/frontend/apps/desktop/src/models/__tests__/document-relocation.test.ts
+++ b/frontend/apps/desktop/src/models/__tests__/document-relocation.test.ts
@@ -28,26 +28,29 @@ describe('republish ref operation', () => {
     const sourceId = hmId('source-site', {path: ['specs', 'api']})
     const destinationId = hmId('target-site', {path: ['library', 'api-copy']})
 
-    expect(
-      createRepublishRefOperation({
-        sourceId,
-        destinationId,
-        sourceDocument: {
-          version: 'bafy-version',
-          generationInfo: {genesis: 'bafy-genesis', generation: 7},
-        } as any,
-        capabilityId: 'bafy-capability',
-      }),
-    ).toEqual({
+    const before = Date.now()
+    const operation = createRepublishRefOperation({
+      sourceId,
+      destinationId,
+      sourceDocument: {
+        version: 'bafy-version',
+        generationInfo: {genesis: 'bafy-genesis', generation: 7},
+      } as any,
+      capabilityId: 'bafy-capability',
+    })
+    expect(operation).toEqual({
       space: 'target-site',
       path: '/library/api-copy',
       genesis: 'bafy-genesis',
-      generation: 7,
+      generation: operation.generation,
       targetSpace: 'source-site',
       targetPath: '/specs/api',
       republish: true,
       capability: 'bafy-capability',
     })
+    // A fresh generation — not the source document's — so the redirect occupies its own
+    // generation row and any later publish at the destination supersedes it.
+    expect(operation.generation).toBeGreaterThanOrEqual(before)
   })
 })
 

--- a/frontend/apps/desktop/src/models/__tests__/document-relocation.test.ts
+++ b/frontend/apps/desktop/src/models/__tests__/document-relocation.test.ts
@@ -4,6 +4,7 @@ import {
   createRepublishRefOperation,
   getDocumentCardReconciliationInputsForMove,
   getDocumentCardReconciliationInputForRepublish,
+  getDocumentMoveRefOperations,
   getMovedChildPath,
   isChildDocumentPath,
 } from '../document-relocation'
@@ -51,6 +52,91 @@ describe('republish ref operation', () => {
     // A fresh generation — not the source document's — so the redirect occupies its own
     // generation row and any later publish at the destination supersedes it.
     expect(operation.generation).toBeGreaterThanOrEqual(before)
+  })
+})
+
+describe('getDocumentMoveRefOperations (what a move publishes)', () => {
+  const plainDoc = {version: 'doc-version', generationInfo: {genesis: 'doc-genesis', generation: 3}} as any
+
+  it('forks a plain document to the destination and redirects the source there', () => {
+    const before = Date.now()
+    const ops = getDocumentMoveRefOperations({
+      sourceId: hmId('site', {path: ['old']}),
+      targetId: hmId('site', {path: ['new']}),
+      doc: plainDoc,
+      sourceRedirect: null,
+      originalId: hmId('site', {path: ['old']}),
+      targetCapabilityId: 'cap',
+      sourceCapabilityId: 'cap',
+    })
+
+    // Destination gets the document's own history (a version ref), not a redirect.
+    expect(ops.destination).toEqual({
+      kind: 'version',
+      space: 'site',
+      path: '/new',
+      genesis: 'doc-genesis',
+      version: 'doc-version',
+      generation: ops.destination.generation,
+      capability: 'cap',
+    })
+    // Source redirects to the destination (a plain move redirect — no republish flag).
+    expect(ops.sourceRedirect).toEqual({
+      space: 'site',
+      path: '/old',
+      genesis: 'doc-genesis',
+      generation: ops.sourceRedirect.generation,
+      targetSpace: 'site',
+      targetPath: '/new',
+      capability: 'cap',
+    })
+    // Fresh generations so both refs supersede anything already at their paths.
+    expect(ops.destination.generation).toBeGreaterThanOrEqual(before)
+    expect(ops.sourceRedirect.generation).toBeGreaterThanOrEqual(before)
+  })
+
+  it('moves a republish as a republish: the destination re-publishes the ORIGINAL, not a fork', () => {
+    // The source at hm://site/mirror republishes hm://other/resources/guide; following it reaches
+    // that original document. Moving the mirror must keep it a mirror of the original.
+    const ops = getDocumentMoveRefOperations({
+      sourceId: hmId('site', {path: ['mirror']}),
+      targetId: hmId('site', {path: ['moved-mirror']}),
+      // `doc` is the followed ORIGINAL (its genesis/version), living at `originalId`.
+      doc: {version: 'guide-version', generationInfo: {genesis: 'guide-genesis', generation: 9}} as any,
+      sourceRedirect: {republish: true, target: hmId('other', {path: ['resources', 'guide']})},
+      originalId: hmId('other', {path: ['resources', 'guide']}),
+    })
+
+    // Destination is a republish redirect pointing at the original — NOT a version/fork.
+    expect(ops.destination.kind).toBe('republish')
+    expect(ops.destination).toMatchObject({
+      space: 'site',
+      path: '/moved-mirror',
+      genesis: 'guide-genesis',
+      targetSpace: 'other',
+      targetPath: '/resources/guide',
+      republish: true,
+    })
+    // Source redirects to the destination (a plain move redirect, no republish).
+    expect(ops.sourceRedirect).toMatchObject({
+      space: 'site',
+      path: '/mirror',
+      targetSpace: 'site',
+      targetPath: '/moved-mirror',
+    })
+    expect(ops.sourceRedirect).not.toHaveProperty('republish')
+  })
+
+  it('refuses to move a path that has itself already moved (a pointer, not content)', () => {
+    expect(() =>
+      getDocumentMoveRefOperations({
+        sourceId: hmId('site', {path: ['old']}),
+        targetId: hmId('site', {path: ['newer']}),
+        doc: plainDoc,
+        sourceRedirect: {republish: false, target: hmId('site', {path: ['new']})},
+        originalId: hmId('site', {path: ['new']}),
+      }),
+    ).toThrow('already moved')
   })
 })
 

--- a/frontend/apps/desktop/src/models/document-relocation.ts
+++ b/frontend/apps/desktop/src/models/document-relocation.ts
@@ -91,7 +91,11 @@ export function createRepublishRefOperation({
     space: destinationId.uid,
     path: hmIdPathToEntityQueryPath(destinationId.path),
     genesis: sourceDocument.generationInfo.genesis,
-    generation: Number(sourceDocument.generationInfo.generation),
+    // A fresh generation (the same choice the daemon's CreateRef makes) puts the redirect in its
+    // own generation row, so any later publish at the destination path supersedes it cleanly —
+    // reusing the source document's generation could land below an existing Ref at the
+    // destination and be silently shadowed.
+    generation: Date.now(),
     targetSpace: sourceId.uid,
     targetPath: hmIdPathToEntityQueryPath(sourceId.path),
     republish: true,

--- a/frontend/apps/desktop/src/models/document-relocation.ts
+++ b/frontend/apps/desktop/src/models/document-relocation.ts
@@ -1,4 +1,5 @@
-import type {CreateRedirectRefInput} from '@seed-hypermedia/client/ref'
+import {packHmId} from '@seed-hypermedia/client'
+import type {CreateRedirectRefInput, CreateVersionRefInput} from '@seed-hypermedia/client/ref'
 import type {HMDocument, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {hmId} from '@shm/shared/utils/entity-id-url'
 import {planDocumentCardMoveOperations} from '@shm/shared/utils/document-card-cleanup'
@@ -101,4 +102,87 @@ export function createRepublishRefOperation({
     republish: true,
     capability: capabilityId || undefined,
   }
+}
+
+/** The two ref operations a move publishes: one at the destination, one (the redirect) at the source. */
+export type DocumentMoveRefOperations = {
+  /**
+   * The ref to publish at the destination. A plain document forks its history (`version`); a
+   * republish moves as a republish (`republish`) so the destination keeps tracking the original.
+   */
+  destination: ({kind: 'version'} & CreateVersionRefInput) | ({kind: 'republish'} & CreateRedirectRefInput)
+  /** The move redirect to publish at the source, pointing at the destination. */
+  sourceRedirect: CreateRedirectRefInput
+}
+
+/**
+ * Decides the two refs a move publishes, from the followed source document.
+ *
+ * A move acts on whatever kind of thing lives at the source and keeps it that kind at the
+ * destination: a plain document forks its history there, while a republish moves as a republish so
+ * the destination keeps tracking the original's edits (forking it would freeze a snapshot and
+ * silently sever the link). A source that has itself already moved is a pointer, not content —
+ * there is nothing to move, so this throws. Fresh generations let both refs supersede any redirect
+ * Ref already sitting at their paths — required for the republish case, where the source currently
+ * holds the republish redirect the new move redirect must overtake.
+ */
+export function getDocumentMoveRefOperations({
+  sourceId,
+  targetId,
+  doc,
+  sourceRedirect,
+  originalId,
+  sourceCapabilityId,
+  targetCapabilityId,
+}: {
+  sourceId: UnpackedHypermediaId
+  targetId: UnpackedHypermediaId
+  doc: HMDocument
+  /** The redirect (if any) currently at the source, from following it to `doc`. */
+  sourceRedirect: {republish: boolean; target: UnpackedHypermediaId} | null
+  /** The address `doc` really lives at — the republish target when the source is a republish. */
+  originalId: UnpackedHypermediaId
+  sourceCapabilityId?: string
+  targetCapabilityId?: string
+}): DocumentMoveRefOperations {
+  if (!doc.generationInfo) throw new Error('No generation info for document')
+  if (sourceRedirect && !sourceRedirect.republish) {
+    throw new Error(
+      `${packHmId(sourceId)} has already moved to ${packHmId(sourceRedirect.target)}. ` +
+        `Move ${packHmId(sourceRedirect.target)} instead.`,
+    )
+  }
+  const genesis = doc.generationInfo.genesis
+  const generation = Date.now()
+  const destination: DocumentMoveRefOperations['destination'] = sourceRedirect?.republish
+    ? {
+        kind: 'republish',
+        space: targetId.uid,
+        path: hmIdPathToEntityQueryPath(targetId.path),
+        genesis,
+        generation,
+        targetSpace: originalId.uid,
+        targetPath: hmIdPathToEntityQueryPath(originalId.path),
+        republish: true,
+        capability: targetCapabilityId || undefined,
+      }
+    : {
+        kind: 'version',
+        space: targetId.uid,
+        path: hmIdPathToEntityQueryPath(targetId.path),
+        genesis,
+        version: doc.version,
+        generation,
+        capability: targetCapabilityId || undefined,
+      }
+  const sourceRedirectOp: CreateRedirectRefInput = {
+    space: sourceId.uid,
+    path: hmIdPathToEntityQueryPath(sourceId.path),
+    genesis,
+    generation,
+    targetSpace: targetId.uid,
+    targetPath: hmIdPathToEntityQueryPath(targetId.path),
+    capability: sourceCapabilityId || undefined,
+  }
+  return {destination, sourceRedirect: sourceRedirectOp}
 }

--- a/frontend/apps/desktop/src/models/documents.ts
+++ b/frontend/apps/desktop/src/models/documents.ts
@@ -5,7 +5,7 @@ import {useSelectedAccountId} from '@/selected-account'
 import {client} from '@/trpc'
 import {Timestamp, toPlainMessage} from '@bufbuild/protobuf'
 import {Code, ConnectError} from '@connectrpc/connect'
-import {createRedirectRef, createVersionRef} from '@seed-hypermedia/client'
+import {createRedirectRef, createVersionRef, followToDocument, type SeedClient} from '@seed-hypermedia/client'
 import {EditorBlock} from '@seed-hypermedia/client/editor-types'
 import {
   HMAnnotation,
@@ -286,6 +286,11 @@ export function usePublishResource(
           // Skipped for legacy first-publishes (no `editId` outer arg) because
           // there is no doc to fetch yet.
           let existingDocVersion: string | null = null
+          // True when the destination path currently holds a redirect Ref (a republished or moved
+          // document). Editing such a path is a takeover: the editor was seeded with the redirect
+          // target's content, so the publish builds on the target's DAG and mints a fresh
+          // generation, which supersedes the redirect Ref at this path.
+          let takesOverRedirect = false
           if (editId) {
             try {
               const latestDoc = await grpcClient.documents.getDocument({
@@ -296,8 +301,22 @@ export function usePublishResource(
                 existingDocVersion = latestDoc.version
               }
             } catch (err) {
-              // Doc doesn't exist yet (first publish) — leave existingDoc null.
-              console.log('[publish] getDocument(latest) failed — treating as first publish', err)
+              try {
+                const raw = await desktopUniversalClient.request('Resource', destinationId)
+                takesOverRedirect = raw.type === 'redirect'
+              } catch {
+                // Raw resource probe is best-effort; fall through to first-publish handling.
+              }
+              if (takesOverRedirect && editDocument?.version) {
+                existingDocVersion = editDocument.version
+                console.log('[publish] destination is a redirect — taking over the path', {
+                  destination: destinationId.id,
+                  baseVersion: existingDocVersion,
+                })
+              } else {
+                // Doc doesn't exist yet (first publish) — leave existingDoc null.
+                console.log('[publish] getDocument(latest) failed — treating as first publish', err)
+              }
             }
           }
 
@@ -397,7 +416,13 @@ export function usePublishResource(
             capability: capabilityId,
             visibility,
             genesis: baseVersion ? editDocument?.genesis : undefined,
-            generation: baseVersion ? editDocument?.generationInfo?.generation : undefined,
+            // Taking over a redirect needs a generation strictly above the redirect Ref's;
+            // leaving it undefined lets signDocumentChange mint one from the change timestamp.
+            generation: takesOverRedirect
+              ? undefined
+              : baseVersion
+                ? editDocument?.generationInfo?.generation
+                : undefined,
           }
           await desktopUniversalClient.publishDocument!(publishInput)
 
@@ -1085,18 +1110,18 @@ export function useForkDocument() {
       origin?: DocumentCardActionOrigin
     }) => {
       if (!universalClient.getSigner) throw new Error('Signing not available')
-      const resource = await universalClient.request('Resource', from)
-      if (resource.type !== 'document') throw new Error(`Cannot fork: resource is ${resource.type}`)
-      const doc = resource.document
-      if (!doc.generationInfo) throw new Error('No generation info for document')
+      // Follows redirects so a republished path can be forked: the fork points at the content
+      // the path currently re-publishes. The fresh generation lets the fork supersede any
+      // redirect Ref already sitting at the destination path.
+      const {document: doc} = await followToDocument(universalClient as unknown as SeedClient, from)
       const signer = universalClient.getSigner(signingAccountId)
       const refInput = await createVersionRef(
         {
           space: to.uid,
           path: hmIdPathToEntityQueryPath(to.path),
-          genesis: doc.generationInfo.genesis,
+          genesis: doc.generationInfo?.genesis ?? doc.genesis,
           version: doc.version,
-          generation: Number(doc.generationInfo.generation),
+          generation: Date.now(),
         },
         signer,
       )
@@ -1429,9 +1454,9 @@ export function useMoveDocument() {
           //   sourceId,
           //   targetId,
           // })
-          const resource = await universalClient.request('Resource', sourceId)
-          if (resource.type !== 'document') throw new Error(`Cannot move: resource is ${resource.type}`)
-          const doc = resource.document
+          // Follows redirects so an already-redirected source can be moved again: the
+          // destination receives the content the source currently presents.
+          const {document: doc} = await followToDocument(universalClient as unknown as SeedClient, sourceId)
           if (!doc.generationInfo) throw new Error('No generation info for document')
           // console.log(`[move-document] loaded source document`, {
           //   moveScope: moveScopeLabel(isSubdocumentMove),
@@ -1577,9 +1602,8 @@ export function useRepublishDocument() {
     }) => {
       if (!universalClient.getSigner) throw new Error('Signing not available')
       const signer = universalClient.getSigner(signingAccountId)
-      const resource = await universalClient.request('Resource', from)
-      if (resource.type !== 'document') throw new Error(`Cannot republish: resource is ${resource.type}`)
-      const doc = resource.document
+      // Follows redirects so an already-republished doc can be republished elsewhere too.
+      const {document: doc} = await followToDocument(universalClient as unknown as SeedClient, from)
       if (!doc.generationInfo) throw new Error('No generation info for document')
       const capabilityId = await resolveWriteCapabilityId(signingAccountId, to)
       const refOperation = createRepublishRefOperation({

--- a/frontend/apps/desktop/src/models/documents.ts
+++ b/frontend/apps/desktop/src/models/documents.ts
@@ -69,6 +69,7 @@ import {
   createRepublishRefOperation,
   getDocumentCardReconciliationInputForRepublish,
   getDocumentCardReconciliationInputsForMove,
+  getDocumentMoveRefOperations,
   getMovedChildPath,
   isChildDocumentPath,
 } from './document-relocation'
@@ -1202,6 +1203,8 @@ async function createDocumentMoveRefs({
   signer,
   sourceCapabilityId,
   targetCapabilityId,
+  sourceRedirect,
+  originalId,
 }: {
   sourceId: UnpackedHypermediaId
   targetId: UnpackedHypermediaId
@@ -1210,6 +1213,10 @@ async function createDocumentMoveRefs({
   signer: HMSigner
   sourceCapabilityId?: string
   targetCapabilityId?: string
+  /** The redirect (if any) currently at the source, from following it to `doc`. */
+  sourceRedirect: {republish: boolean; target: UnpackedHypermediaId} | null
+  /** The address `doc` really lives at — the republish target when the source is a republish. */
+  originalId: UnpackedHypermediaId
 }): Promise<MoveRefBundle> {
   // console.log(`[move-document] creating move refs`, {
   //   moveScope: moveScopeLabel(isSubdocumentMove),
@@ -1217,20 +1224,23 @@ async function createDocumentMoveRefs({
   //   targetId,
   //   doc,
   // })
-  if (!doc.generationInfo) throw new Error('No generation info for document')
-  const generation = Number(doc.generationInfo.generation)
-
-  const versionRefOperation = {
-    space: targetId.uid,
-    path: hmIdPathToEntityQueryPath(targetId.path),
-    genesis: doc.generationInfo.genesis,
-    version: doc.version,
-    generation,
-    capability: targetCapabilityId || undefined,
-  }
-  const versionRefInput = await createVersionRef(versionRefOperation, signer)
+  // The behavior — fork vs. move-a-republish, and the "already moved" guard — is a pure decision
+  // extracted to document-relocation.ts so it can be unit-tested without signing/publishing.
+  const {destination: versionRefOperation, sourceRedirect: redirectRefOperation} = getDocumentMoveRefOperations({
+    sourceId,
+    targetId,
+    doc,
+    sourceRedirect,
+    originalId,
+    sourceCapabilityId,
+    targetCapabilityId,
+  })
+  const versionRefInput =
+    versionRefOperation.kind === 'republish'
+      ? await createRedirectRef(versionRefOperation, signer)
+      : await createVersionRef(versionRefOperation, signer)
   logMoveRefBlob({
-    kind: 'version',
+    kind: versionRefOperation.kind === 'republish' ? 'redirect' : 'version',
     sourceId,
     targetId,
     isSubdocumentMove,
@@ -1238,15 +1248,6 @@ async function createDocumentMoveRefs({
     publishInput: versionRefInput,
   })
 
-  const redirectRefOperation = {
-    space: sourceId.uid,
-    path: hmIdPathToEntityQueryPath(sourceId.path),
-    genesis: doc.generationInfo.genesis,
-    generation,
-    targetSpace: targetId.uid,
-    targetPath: hmIdPathToEntityQueryPath(targetId.path),
-    capability: sourceCapabilityId || undefined,
-  }
   const redirectRefInput = await createRedirectRef(redirectRefOperation, signer)
   logMoveRefBlob({
     kind: 'redirect',
@@ -1454,9 +1455,14 @@ export function useMoveDocument() {
           //   sourceId,
           //   targetId,
           // })
-          // Follows redirects so an already-redirected source can be moved again: the
-          // destination receives the content the source currently presents.
-          const {document: doc} = await followToDocument(universalClient as unknown as SeedClient, sourceId)
+          // Follows redirects so a redirected source can be moved: the destination receives the
+          // content the source currently presents. `redirect` tells us the source's kind (a
+          // republish moves as a republish) and `targetId` is where that content really lives.
+          const {
+            document: doc,
+            redirect,
+            targetId: originalId,
+          } = await followToDocument(universalClient as unknown as SeedClient, sourceId)
           if (!doc.generationInfo) throw new Error('No generation info for document')
           // console.log(`[move-document] loaded source document`, {
           //   moveScope: moveScopeLabel(isSubdocumentMove),
@@ -1465,13 +1471,13 @@ export function useMoveDocument() {
           //   version: doc.version,
           //   generationInfo: doc.generationInfo,
           // })
-          return {from: sourceId, to: targetId, isSubdocumentMove, doc}
+          return {from: sourceId, to: targetId, isSubdocumentMove, doc, redirect, originalId}
         }),
       )
 
       // console.log(`[move-document] creating ref bundles`, {count: moveResources.length})
       const moveRefBundles = []
-      for (const {from: sourceId, to: targetId, isSubdocumentMove, doc} of moveResources) {
+      for (const {from: sourceId, to: targetId, isSubdocumentMove, doc, redirect, originalId} of moveResources) {
         const moveRefs = await createDocumentMoveRefs({
           sourceId,
           targetId,
@@ -1480,6 +1486,8 @@ export function useMoveDocument() {
           signer,
           sourceCapabilityId,
           targetCapabilityId,
+          sourceRedirect: redirect,
+          originalId,
         })
         moveRefBundles.push(moveRefs)
       }

--- a/frontend/apps/desktop/src/models/entities.ts
+++ b/frontend/apps/desktop/src/models/entities.ts
@@ -1,7 +1,7 @@
 import {grpcClient} from '@/grpc-client'
 import {client} from '@/trpc'
 import {toPlainMessage} from '@bufbuild/protobuf'
-import {createTombstoneRef} from '@seed-hypermedia/client'
+import {createTombstoneRef, followToDocument, type SeedClient} from '@seed-hypermedia/client'
 import {DiscoveryState, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {createQueryResolver} from '@shm/shared/models/directory'
 import {invalidateQueries} from '@shm/shared/models/query-client'
@@ -70,14 +70,28 @@ export function useDeleteEntities(opts: UseMutationOptions<void, unknown, Delete
         ids.map(async (id) => {
           await deleteRecent.mutateAsync(id.id)
           const resource = await universalClient.request('Resource', id)
-          if (resource.type !== 'document') throw new Error(`Cannot delete: resource is ${resource.type}`)
-          const doc = resource.document
-          const generation = doc.generationInfo ? Number(doc.generationInfo.generation) : 0
+          if (resource.type !== 'document' && resource.type !== 'redirect')
+            throw new Error(`Cannot delete: resource is ${resource.type}`)
+          // A redirected path (including a republished one) has no document of its own to read
+          // genesis and generation from: the tombstone borrows the redirect target's genesis and
+          // takes a fresh generation, which supersedes the redirect Ref so the path reads as
+          // deleted instead of continuing to follow the target.
+          let genesis: string
+          let generation: number
+          if (resource.type === 'redirect') {
+            const followed = await followToDocument(universalClient as unknown as SeedClient, id)
+            genesis = followed.document.genesis
+            generation = Date.now()
+          } else {
+            const doc = resource.document
+            genesis = doc.genesis
+            generation = doc.generationInfo ? Number(doc.generationInfo.generation) : 0
+          }
           const refInput = await createTombstoneRef(
             {
               space: id.uid || '',
               path: hmIdPathToEntityQueryPath(id.path),
-              genesis: doc.genesis,
+              genesis,
               generation,
               capability: capabilityId,
             },

--- a/frontend/apps/web/app/document-edit/web-document-actors.ts
+++ b/frontend/apps/web/app/document-edit/web-document-actors.ts
@@ -10,7 +10,13 @@
  * closing over the host's editor accessor + universal client + signer factory.
  */
 
-import {createGenesisChange, createVersionRef, signDocumentChange} from '@seed-hypermedia/client'
+import {
+  createGenesisChange,
+  createVersionRef,
+  followToDocument,
+  signDocumentChange,
+  type SeedClient,
+} from '@seed-hypermedia/client'
 import type {EditorBlock} from '@seed-hypermedia/client/editor-types'
 import {editorBlocksToHMBlockNodes} from '@seed-hypermedia/client/editorblock-to-hmblock'
 import type {
@@ -240,7 +246,15 @@ export async function publishWebDocument(input: PublishInput, deps: CreateWebDoc
       : hmBlocksToEditorContent(draft.content ?? [], {childrenType: 'Group'})
 
   const resource = await deps.client.request('Resource', deps.docId)
-  const editDocument = resource.type === 'document' ? resource.document : null
+  // A path holding a redirect Ref (a republished or moved document) is edited by taking it over:
+  // the baseline is the redirect target's document — the same content the editor was seeded with —
+  // and the fresh generation minted below supersedes the redirect Ref at this path.
+  const editDocument =
+    resource.type === 'document'
+      ? resource.document
+      : resource.type === 'redirect'
+        ? (await followToDocument(deps.client as unknown as SeedClient, deps.docId)).document
+        : null
   const isPrivate = draft.visibility === 'PRIVATE' || editDocument?.visibility === 'PRIVATE'
   const currentPath = deps.docId.path ?? []
   const isPlaceholderPath = isWebDraftPlaceholderPath(currentPath, draft.draftId)

--- a/frontend/apps/web/app/loaders.ts
+++ b/frontend/apps/web/app/loaders.ts
@@ -525,6 +525,29 @@ export async function loadResource(
   } as InstrumentationContext
 
   const resource = await instrument(ctx || noopCtx, `fetchResource(${packHmId(id)})`, () => fetchResource(id))
+  if (resource.type === 'redirect' && resource.republish) {
+    // A republish redirect renders the target's latest content at THIS route — matching the
+    // client-side queryResource behavior — instead of bouncing the browser to the target URL.
+    const followed = await instrument(ctx || noopCtx, `followRepublish(${packHmId(resource.redirectTarget)})`, () =>
+      resolveResource(resource.redirectTarget),
+    )
+    if (followed.type === 'document') {
+      const latestDocument = await instrument(ctx || noopCtx, `getLatestDocument(${packHmId(followed.id)})`, () =>
+        getLatestDocument(followed.id),
+      )
+      return await loadResourcePayload(
+        id,
+        parsedRequest,
+        {
+          document: followed.document,
+          latestDocument,
+        },
+        ctx,
+        options,
+      )
+    }
+    // The chain does not end at a live document — fall through to the plain-redirect handling.
+  }
   if (resource.type === 'redirect') {
     const destRedirectUrl = createWebHMUrl(resource.redirectTarget.uid, {
       path: resource.redirectTarget.path,

--- a/frontend/apps/web/app/web-delete-document-dialog.tsx
+++ b/frontend/apps/web/app/web-delete-document-dialog.tsx
@@ -1,4 +1,4 @@
-import {createTombstoneRef} from '@seed-hypermedia/client'
+import {createTombstoneRef, followToDocument, type SeedClient} from '@seed-hypermedia/client'
 import type {HMDocumentInfo, HMSigner, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {hmId, useUniversalClient} from '@shm/shared'
 import {getDocumentTitle, getMetadataName} from '@shm/shared/content'
@@ -111,14 +111,28 @@ export async function deleteWebDocuments(
     input.ids.map(async (id) => {
       await client.deleteRecent?.(id.id)
       const resource = await client.request('Resource', id)
-      if (resource.type !== 'document') throw new Error(`Cannot delete: resource is ${resource.type}`)
-      const doc = resource.document
-      const generation = doc.generationInfo ? Number(doc.generationInfo.generation) : 0
+      if (resource.type !== 'document' && resource.type !== 'redirect')
+        throw new Error(`Cannot delete: resource is ${resource.type}`)
+      // A redirected path (including a republished one) has no document of its own to read
+      // genesis and generation from: the tombstone borrows the redirect target's genesis and
+      // takes a fresh generation, which supersedes the redirect Ref so the path reads as
+      // deleted instead of continuing to follow the target.
+      let genesis: string
+      let generation: number
+      if (resource.type === 'redirect') {
+        const followed = await followToDocument(client as unknown as SeedClient, id)
+        genesis = followed.document.genesis
+        generation = Date.now()
+      } else {
+        const doc = resource.document
+        genesis = doc.genesis
+        generation = doc.generationInfo ? Number(doc.generationInfo.generation) : 0
+      }
       const refInput = await createTombstoneRef(
         {
           space: id.uid,
           path: hmIdPathToEntityQueryPath(id.path),
-          genesis: doc.genesis,
+          genesis,
           generation,
           capability: input.capabilityId,
         },

--- a/frontend/apps/web/app/web-move-document-dialog.test.tsx
+++ b/frontend/apps/web/app/web-move-document-dialog.test.tsx
@@ -169,7 +169,8 @@ describe('moveWebDocuments', () => {
         path: '/old-parent/renamed',
         genesis: 'genesis-cid',
         version: 'doc-version',
-        generation: 5,
+        // Fresh generation so the ref supersedes anything already at the destination path.
+        generation: expect.any(Number),
         capability: 'cap-cid',
       },
       expect.anything(),
@@ -179,7 +180,7 @@ describe('moveWebDocuments', () => {
         space: 'site',
         path: '/old-parent/doc',
         genesis: 'genesis-cid',
-        generation: 5,
+        generation: expect.any(Number),
         targetSpace: 'site',
         targetPath: '/old-parent/renamed',
         capability: 'cap-cid',
@@ -258,7 +259,9 @@ describe('republishWebDocument', () => {
         space: 'site',
         path: '/parent/copy',
         genesis: 'genesis-cid',
-        generation: 8,
+        // Fresh generation — not the source document's — so any later publish at the
+        // destination supersedes the republish redirect.
+        generation: expect.any(Number),
         targetSpace: 'source',
         targetPath: '/doc',
         republish: true,

--- a/frontend/apps/web/app/web-move-document-dialog.test.tsx
+++ b/frontend/apps/web/app/web-move-document-dialog.test.tsx
@@ -229,6 +229,91 @@ describe('moveWebDocuments', () => {
     expect(publish).toHaveBeenCalledTimes(2)
     expect(enqueueCleanupMock).toHaveBeenCalled()
   })
+
+  it('moves a republished path as a republish: the destination re-publishes the original, not a fork', async () => {
+    // A path that republishes an original is a live mirror. Moving it must keep it a mirror — the
+    // destination republishes the SAME original — rather than freezing a fork of its content.
+    const from = makeId('site', ['mirror'])
+    const to = makeId('site', ['moved-mirror'])
+    const original = makeId('other', ['resources', 'guide'])
+    const publish = vi.fn(async () => ({}))
+    const getSigner = vi.fn(() => ({
+      getPublicKey: async () => new Uint8Array([1]),
+      sign: async () => new Uint8Array([2]),
+    }))
+    // The source republishes the original; following it reaches the original document.
+    const request = vi.fn(async (_key: string, id: UnpackedHypermediaId) => {
+      if (id.uid === 'site' && (id.path || []).join('/') === 'mirror') {
+        return {type: 'redirect', id, redirectTarget: original, republish: true}
+      }
+      return {
+        type: 'document',
+        document: {version: 'guide-version', generationInfo: {genesis: 'guide-genesis', generation: 9n}},
+      }
+    })
+    createVersionRefMock.mockClear()
+    createRedirectRefMock.mockClear()
+
+    await moveWebDocuments({request, publish, getSigner} as any, {
+      from,
+      to,
+      signingAccountId: 'site',
+      capabilityId: 'cap-cid',
+    })
+
+    // No fork: the destination gets a republish redirect pointing at the ORIGINAL.
+    expect(createVersionRefMock).not.toHaveBeenCalled()
+    expect(createRedirectRefMock).toHaveBeenCalledWith(
+      {
+        space: 'site',
+        path: '/moved-mirror',
+        genesis: 'guide-genesis',
+        generation: expect.any(Number),
+        targetSpace: 'other',
+        targetPath: '/resources/guide',
+        republish: true,
+        capability: 'cap-cid',
+      },
+      expect.anything(),
+    )
+    // And the source redirects to the destination — a plain move redirect, no republish flag.
+    expect(createRedirectRefMock).toHaveBeenCalledWith(
+      {
+        space: 'site',
+        path: '/mirror',
+        genesis: 'guide-genesis',
+        generation: expect.any(Number),
+        targetSpace: 'site',
+        targetPath: '/moved-mirror',
+        capability: 'cap-cid',
+      },
+      expect.anything(),
+    )
+    expect(publish).toHaveBeenCalledTimes(2)
+  })
+
+  it('refuses to move a path that has itself already moved', async () => {
+    const from = makeId('site', ['old'])
+    const to = makeId('site', ['newer'])
+    const movedTarget = makeId('site', ['new'])
+    const publish = vi.fn(async () => ({}))
+    const getSigner = vi.fn(() => ({
+      getPublicKey: async () => new Uint8Array([1]),
+      sign: async () => new Uint8Array([2]),
+    }))
+    // A move redirect (republish: false) — the source is a pointer, not content.
+    const request = vi.fn(async (_key: string, id: UnpackedHypermediaId) => {
+      if (id.uid === 'site' && (id.path || []).join('/') === 'old') {
+        return {type: 'redirect', id, redirectTarget: movedTarget, republish: false}
+      }
+      return {type: 'document', document: {version: 'v', generationInfo: {genesis: 'g', generation: 1n}}}
+    })
+
+    await expect(
+      moveWebDocuments({request, publish, getSigner} as any, {from, to, signingAccountId: 'site'}),
+    ).rejects.toThrow('already moved')
+    expect(publish).not.toHaveBeenCalled()
+  })
 })
 
 describe('republishWebDocument', () => {

--- a/frontend/apps/web/app/web-move-document-dialog.tsx
+++ b/frontend/apps/web/app/web-move-document-dialog.tsx
@@ -1,4 +1,4 @@
-import {createRedirectRef, createVersionRef, followToDocument, type SeedClient} from '@seed-hypermedia/client'
+import {createRedirectRef, createVersionRef, followToDocument, packHmId, type SeedClient} from '@seed-hypermedia/client'
 import type {HMDocumentInfo, HMSigner, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {hmId, useUniversalClient} from '@shm/shared'
 import {useResource, useResources} from '@shm/shared/models/entity'
@@ -159,26 +159,49 @@ export async function moveWebDocuments(
   const moves = [{from: input.from, to: input.to}, ...childMoves]
 
   for (const move of moves) {
-    // Follows redirects so an already-redirected source can be moved again: the destination
-    // receives the content the source currently presents. Fresh generations let both refs
-    // supersede any redirect Refs already sitting at their paths.
-    const {document: doc} = await followToDocument(client as unknown as SeedClient, move.from)
+    // Follows redirects so a redirected source can be moved. The destination keeps the source's
+    // KIND: a republish moves as a republish (so it keeps tracking the original's edits), a plain
+    // document forks its history. A source that has itself already moved is a pointer with nothing
+    // to move. Fresh generations let both refs supersede any redirect Ref sitting at their paths.
+    const {document: doc, redirect, targetId} = await followToDocument(client as unknown as SeedClient, move.from)
     if (!doc.generationInfo) throw new Error('No generation info for document')
+    if (redirect && !redirect.republish) {
+      throw new Error(`${packHmId(move.from)} has already moved to ${packHmId(redirect.target)}. Move that instead.`)
+    }
     const generation = Date.now()
     const genesis = doc.generationInfo.genesis
-    await client.publish(
-      await createVersionRef(
-        {
-          space: move.to.uid,
-          path: hmIdPathToEntityQueryPath(move.to.path),
-          genesis,
-          version: doc.version,
-          generation,
-          capability: input.capabilityId,
-        },
-        signer,
-      ),
-    )
+    if (redirect?.republish) {
+      // Moving a republish: the destination re-publishes the same original, not a frozen fork.
+      await client.publish(
+        await createRedirectRef(
+          {
+            space: move.to.uid,
+            path: hmIdPathToEntityQueryPath(move.to.path),
+            genesis,
+            generation,
+            targetSpace: targetId.uid,
+            targetPath: hmIdPathToEntityQueryPath(targetId.path),
+            republish: true,
+            capability: input.capabilityId,
+          },
+          signer,
+        ),
+      )
+    } else {
+      await client.publish(
+        await createVersionRef(
+          {
+            space: move.to.uid,
+            path: hmIdPathToEntityQueryPath(move.to.path),
+            genesis,
+            version: doc.version,
+            generation,
+            capability: input.capabilityId,
+          },
+          signer,
+        ),
+      )
+    }
     await client.publish(
       await createRedirectRef(
         {

--- a/frontend/apps/web/app/web-move-document-dialog.tsx
+++ b/frontend/apps/web/app/web-move-document-dialog.tsx
@@ -1,4 +1,4 @@
-import {createRedirectRef, createVersionRef} from '@seed-hypermedia/client'
+import {createRedirectRef, createVersionRef, followToDocument, type SeedClient} from '@seed-hypermedia/client'
 import type {HMDocumentInfo, HMSigner, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {hmId, useUniversalClient} from '@shm/shared'
 import {useResource, useResources} from '@shm/shared/models/entity'
@@ -159,11 +159,12 @@ export async function moveWebDocuments(
   const moves = [{from: input.from, to: input.to}, ...childMoves]
 
   for (const move of moves) {
-    const resource = await client.request('Resource', move.from)
-    if (resource.type !== 'document') throw new Error(`Cannot move: resource is ${resource.type}`)
-    const doc = resource.document
+    // Follows redirects so an already-redirected source can be moved again: the destination
+    // receives the content the source currently presents. Fresh generations let both refs
+    // supersede any redirect Refs already sitting at their paths.
+    const {document: doc} = await followToDocument(client as unknown as SeedClient, move.from)
     if (!doc.generationInfo) throw new Error('No generation info for document')
-    const generation = Number(doc.generationInfo.generation)
+    const generation = Date.now()
     const genesis = doc.generationInfo.genesis
     await client.publish(
       await createVersionRef(
@@ -215,9 +216,10 @@ export async function republishWebDocument(
 ): Promise<{from: UnpackedHypermediaId; to: UnpackedHypermediaId}> {
   if (!client.getSigner) throw new Error('Signing not available')
   const signer = client.getSigner(input.signingAccountId) as HMSigner
-  const resource = await client.request('Resource', input.from)
-  if (resource.type !== 'document') throw new Error(`Cannot republish: resource is ${resource.type}`)
-  const doc = resource.document
+  // Follows redirects so an already-republished doc can be republished elsewhere too. A fresh
+  // generation (the same choice the daemon's CreateRef makes) puts the redirect in its own
+  // generation row, so any later publish at the destination path supersedes it cleanly.
+  const {document: doc} = await followToDocument(client as unknown as SeedClient, input.from)
   if (!doc.generationInfo) throw new Error('No generation info for document')
   await client.publish(
     await createRedirectRef(
@@ -225,7 +227,7 @@ export async function republishWebDocument(
         space: input.to.uid,
         path: hmIdPathToEntityQueryPath(input.to.path),
         genesis: doc.generationInfo.genesis,
-        generation: Number(doc.generationInfo.generation),
+        generation: Date.now(),
         targetSpace: input.from.uid,
         targetPath: hmIdPathToEntityQueryPath(input.from.path),
         republish: true,

--- a/frontend/packages/client/src/document-state.test.ts
+++ b/frontend/packages/client/src/document-state.test.ts
@@ -1,0 +1,125 @@
+import {describe, expect, it} from 'vitest'
+import type {SeedClient} from './client'
+import {resolveEditableDocument} from './document-state'
+import {packHmId, unpackHmId, type UnpackedHypermediaId} from './hm-types'
+
+const SPACE_A = 'z6MkwRA1sPTdRk6nvDBs2eZiXAxYtvxRusN3faHibKPULdrL'
+const SPACE_B = 'z6MkuoiSMnMKtqifsnso587kJcaSrpLQBB2QvZzc7neh1CVy'
+
+function id(url: string): UnpackedHypermediaId {
+  const unpacked = unpackHmId(url)
+  if (!unpacked) throw new Error(`bad test id: ${url}`)
+  return unpacked
+}
+
+/** Builds a stub SeedClient serving canned Resource/ListChanges responses keyed by packed id. */
+function stubClient(handlers: {resources: Record<string, unknown>; changes?: Record<string, unknown>}): SeedClient {
+  return {
+    request: async (key: string, input: unknown) => {
+      if (key === 'Resource') {
+        const packed = packHmId(input as UnpackedHypermediaId)
+        const found = handlers.resources[packed]
+        if (!found) throw new Error(`no stub resource for ${packed}`)
+        return found
+      }
+      if (key === 'ListChanges') {
+        const packed = packHmId((input as {targetId: UnpackedHypermediaId}).targetId)
+        const found = handlers.changes?.[packed]
+        if (!found) throw new Error(`no stub changes for ${packed}`)
+        return found
+      }
+      throw new Error(`unexpected request: ${key}`)
+    },
+  } as unknown as SeedClient
+}
+
+const GENESIS = 'bafyreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku'
+const HEAD = 'bafyreibnw7dfl23nougcud3jtdsc3v2ems3wymk3x4eiup2jo2qzzdhkbq'
+
+function documentResource(atId: UnpackedHypermediaId) {
+  return {
+    type: 'document',
+    id: atId,
+    document: {version: HEAD, genesis: GENESIS, account: atId.uid, path: `/${(atId.path ?? []).join('/')}`},
+  }
+}
+
+const CHANGES = {
+  changes: [
+    {id: GENESIS, deps: []},
+    {id: HEAD, deps: [GENESIS]},
+  ],
+}
+
+describe('resolveEditableDocument', () => {
+  it('returns the document and DAG state for a plain document address', async () => {
+    const docId = id(`hm://${SPACE_A}/notes`)
+    const client = stubClient({
+      resources: {[packHmId(docId)]: documentResource(docId)},
+      changes: {[packHmId(docId)]: CHANGES},
+    })
+    const base = await resolveEditableDocument(client, docId)
+    expect(base.redirect).toBeNull()
+    expect(base.targetId).toEqual(docId)
+    expect(base.state).toEqual({genesis: GENESIS, heads: [HEAD], headDepth: 1, version: HEAD})
+  })
+
+  it('follows a republish redirect to the target and reports the redirect', async () => {
+    const sourceId = id(`hm://${SPACE_A}/guide`)
+    const targetId = id(`hm://${SPACE_B}/resources/guide`)
+    const client = stubClient({
+      resources: {
+        [packHmId(sourceId)]: {type: 'redirect', id: sourceId, redirectTarget: targetId, republish: true},
+        [packHmId(targetId)]: documentResource(targetId),
+      },
+      changes: {[packHmId(targetId)]: CHANGES},
+    })
+    const base = await resolveEditableDocument(client, sourceId)
+    expect(base.id).toEqual(sourceId)
+    expect(base.targetId).toEqual(targetId)
+    expect(base.redirect).toEqual({republish: true, target: targetId})
+    expect(base.state.genesis).toBe(GENESIS)
+    expect(base.state.heads).toEqual([HEAD])
+  })
+
+  it('reports the FIRST redirect when following a chain', async () => {
+    const a = id(`hm://${SPACE_A}/a`)
+    const b = id(`hm://${SPACE_A}/b`)
+    const c = id(`hm://${SPACE_B}/c`)
+    const client = stubClient({
+      resources: {
+        [packHmId(a)]: {type: 'redirect', id: a, redirectTarget: b, republish: true},
+        [packHmId(b)]: {type: 'redirect', id: b, redirectTarget: c, republish: false},
+        [packHmId(c)]: documentResource(c),
+      },
+      changes: {[packHmId(c)]: CHANGES},
+    })
+    const base = await resolveEditableDocument(client, a)
+    expect(base.targetId).toEqual(c)
+    expect(base.redirect).toEqual({republish: true, target: b})
+  })
+
+  it('throws on a redirect cycle', async () => {
+    const a = id(`hm://${SPACE_A}/a`)
+    const b = id(`hm://${SPACE_A}/b`)
+    const client = stubClient({
+      resources: {
+        [packHmId(a)]: {type: 'redirect', id: a, redirectTarget: b, republish: true},
+        [packHmId(b)]: {type: 'redirect', id: b, redirectTarget: a, republish: true},
+      },
+    })
+    await expect(resolveEditableDocument(client, a)).rejects.toThrow(/Redirect cycle/)
+  })
+
+  it('throws with the redirect context when the target is not editable', async () => {
+    const sourceId = id(`hm://${SPACE_A}/gone`)
+    const targetId = id(`hm://${SPACE_B}/dead`)
+    const client = stubClient({
+      resources: {
+        [packHmId(sourceId)]: {type: 'redirect', id: sourceId, redirectTarget: targetId, republish: true},
+        [packHmId(targetId)]: {type: 'tombstone', id: targetId},
+      },
+    })
+    await expect(resolveEditableDocument(client, sourceId)).rejects.toThrow(/is tombstone.*followed redirect/)
+  })
+})

--- a/frontend/packages/client/src/document-state.test.ts
+++ b/frontend/packages/client/src/document-state.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest'
 import type {SeedClient} from './client'
-import {resolveEditableDocument} from './document-state'
+import {describeRedirect, followRedirects, resolveEditableDocument} from './document-state'
 import {packHmId, unpackHmId, type UnpackedHypermediaId} from './hm-types'
 
 const SPACE_A = 'z6MkwRA1sPTdRk6nvDBs2eZiXAxYtvxRusN3faHibKPULdrL'
@@ -121,5 +121,109 @@ describe('resolveEditableDocument', () => {
       },
     })
     await expect(resolveEditableDocument(client, sourceId)).rejects.toThrow(/is tombstone.*followed redirect/)
+  })
+})
+
+describe('followRedirects (what a reader sees at a redirected address)', () => {
+  it('reading a plain document follows nothing and reports no redirects', async () => {
+    const docId = id(`hm://${SPACE_A}/notes`)
+    const client = stubClient({resources: {[packHmId(docId)]: documentResource(docId)}})
+    const followed = await followRedirects(client, docId)
+    expect(followed.targetId).toEqual(docId)
+    expect(followed.resource.type).toBe('document')
+    expect(followed.redirects).toEqual([])
+    expect(describeRedirect(followed)).toBeNull()
+  })
+
+  it('reading a republished path returns the TARGET content and says so', async () => {
+    const republishedAt = id(`hm://${SPACE_A}/guide`)
+    const original = id(`hm://${SPACE_B}/resources/guide`)
+    const client = stubClient({
+      resources: {
+        [packHmId(republishedAt)]: {type: 'redirect', id: republishedAt, redirectTarget: original, republish: true},
+        [packHmId(original)]: documentResource(original),
+      },
+    })
+    const followed = await followRedirects(client, republishedAt)
+
+    // The content is the original's, read from the original's address.
+    expect(followed.id).toEqual(republishedAt)
+    expect(followed.targetId).toEqual(original)
+    expect(followed.resource).toEqual(documentResource(original))
+    expect(followed.redirects).toEqual([{from: republishedAt, to: original, republish: true}])
+
+    // And the explanation tells a writer what each address means.
+    expect(describeRedirect(followed)).toBe(
+      `hm://${SPACE_A}/guide republishes hm://${SPACE_B}/resources/guide: ` +
+        `the content shown is the latest version of hm://${SPACE_B}/resources/guide. ` +
+        `To edit the shared original, write to hm://${SPACE_B}/resources/guide. ` +
+        `Writing to hm://${SPACE_A}/guide replaces the republish with an independent copy ` +
+        `that no longer follows hm://${SPACE_B}/resources/guide.`,
+    )
+  })
+
+  it('reading a moved path explains the move instead of a republish', async () => {
+    const oldPath = id(`hm://${SPACE_A}/old`)
+    const newPath = id(`hm://${SPACE_A}/new`)
+    const client = stubClient({
+      resources: {
+        [packHmId(oldPath)]: {type: 'redirect', id: oldPath, redirectTarget: newPath, republish: false},
+        [packHmId(newPath)]: documentResource(newPath),
+      },
+    })
+    const followed = await followRedirects(client, oldPath)
+    expect(followed.redirects).toEqual([{from: oldPath, to: newPath, republish: false}])
+    expect(describeRedirect(followed)).toBe(
+      `hm://${SPACE_A}/old has moved to hm://${SPACE_A}/new: ` +
+        `the content shown is the latest version of hm://${SPACE_A}/new. ` +
+        `Write to hm://${SPACE_A}/new. Writing to hm://${SPACE_A}/old would revive it as an ` +
+        `independent copy that no longer follows hm://${SPACE_A}/new.`,
+    )
+  })
+
+  it('reports every hop of a redirect chain, in order', async () => {
+    const a = id(`hm://${SPACE_A}/a`)
+    const b = id(`hm://${SPACE_A}/b`)
+    const c = id(`hm://${SPACE_B}/c`)
+    const client = stubClient({
+      resources: {
+        [packHmId(a)]: {type: 'redirect', id: a, redirectTarget: b, republish: true},
+        [packHmId(b)]: {type: 'redirect', id: b, redirectTarget: c, republish: false},
+        [packHmId(c)]: documentResource(c),
+      },
+    })
+    const followed = await followRedirects(client, a)
+    expect(followed.targetId).toEqual(c)
+    expect(followed.redirects).toEqual([
+      {from: a, to: b, republish: true},
+      {from: b, to: c, republish: false},
+    ])
+    expect(describeRedirect(followed)).toContain(`hm://${SPACE_A}/a republishes hm://${SPACE_B}/c (via 2 redirects)`)
+  })
+
+  it('a redirect that lands on a deleted or missing resource still reports the redirect', async () => {
+    const a = id(`hm://${SPACE_A}/a`)
+    const gone = id(`hm://${SPACE_B}/gone`)
+    const client = stubClient({
+      resources: {
+        [packHmId(a)]: {type: 'redirect', id: a, redirectTarget: gone, republish: true},
+        [packHmId(gone)]: {type: 'not-found', id: gone},
+      },
+    })
+    const followed = await followRedirects(client, a)
+    expect(followed.resource.type).toBe('not-found')
+    expect(followed.redirects).toHaveLength(1)
+  })
+
+  it('throws on a redirect cycle', async () => {
+    const a = id(`hm://${SPACE_A}/a`)
+    const b = id(`hm://${SPACE_A}/b`)
+    const client = stubClient({
+      resources: {
+        [packHmId(a)]: {type: 'redirect', id: a, redirectTarget: b, republish: true},
+        [packHmId(b)]: {type: 'redirect', id: b, redirectTarget: a, republish: true},
+      },
+    })
+    await expect(followRedirects(client, a)).rejects.toThrow('Redirect cycle detected')
   })
 })

--- a/frontend/packages/client/src/document-state.ts
+++ b/frontend/packages/client/src/document-state.ts
@@ -7,8 +7,8 @@
  */
 
 import type {SeedClient} from './client'
-import type {HMListChangesOutput} from './hm-types'
-import {unpackHmId} from './hm-types'
+import type {HMDocument, HMListChangesOutput, UnpackedHypermediaId} from './hm-types'
+import {packHmId, unpackHmId} from './hm-types'
 
 /** The resolved state of a document's change DAG. */
 export type DocumentState = {
@@ -86,6 +86,65 @@ export async function resolveDocumentState(client: SeedClient, targetId: string)
     headDepth: maxHeadDepth,
     version,
   }
+}
+
+/** Maximum redirect hops {@link resolveEditableDocument} follows before giving up. */
+const MAX_REDIRECT_HOPS = 5
+
+/** The baseline needed to edit (or take over) a document address. */
+export type EditableDocumentBase = {
+  /** The address being edited — where a new Ref should be published. */
+  id: UnpackedHypermediaId
+  /** Where the content baseline lives after following redirects (same as `id` for a plain document). */
+  targetId: UnpackedHypermediaId
+  /** The current document at the target — the content baseline for edits. */
+  document: HMDocument
+  /** Change-DAG state of the target (genesis/heads/depth) for building the next Change. */
+  state: DocumentState
+  /**
+   * Non-null when `id` currently holds a redirect Ref. Publishing a Version Ref at `id` with the
+   * target's genesis and a fresh (current-timestamp) generation replaces the redirect: the path
+   * becomes a live document continuing the target's change history, and stops following the target.
+   */
+  redirect: {republish: boolean; target: UnpackedHypermediaId} | null
+}
+
+/**
+ * Resolves an address to the state needed to edit the document there, following redirects.
+ *
+ * A path that holds a redirect Ref (including a "republish" redirect, which re-publishes the
+ * target's latest content at this path) has no change DAG of its own — `ListChanges` returns
+ * nothing for it. The editable content lives at the redirect target, so edits at the source
+ * address must build a Change on the target's DAG and publish a Version Ref at the source path
+ * with a fresh generation, which supersedes the redirect Ref.
+ */
+export async function resolveEditableDocument(
+  client: SeedClient,
+  id: UnpackedHypermediaId,
+): Promise<EditableDocumentBase> {
+  const seen = new Set<string>([packHmId(id)])
+  let current = id
+  let firstRedirect: EditableDocumentBase['redirect'] = null
+  for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
+    const resource = await client.request('Resource', current)
+    if (resource.type === 'document') {
+      const state = await resolveDocumentState(client, packHmId(current))
+      return {id, targetId: current, document: resource.document, state, redirect: firstRedirect}
+    }
+    if (resource.type === 'redirect') {
+      firstRedirect ??= {republish: resource.republish === true, target: resource.redirectTarget}
+      const next = packHmId(resource.redirectTarget)
+      if (seen.has(next)) throw new Error(`Redirect cycle detected at ${next}`)
+      seen.add(next)
+      current = resource.redirectTarget
+      continue
+    }
+    throw new Error(
+      `Cannot edit ${packHmId(current)}: resource is ${resource.type}` +
+        (firstRedirect ? ` (followed redirect from ${packHmId(id)})` : ''),
+    )
+  }
+  throw new Error(`Too many redirects while resolving ${packHmId(id)} (limit ${MAX_REDIRECT_HOPS})`)
 }
 
 /**

--- a/frontend/packages/client/src/document-state.ts
+++ b/frontend/packages/client/src/document-state.ts
@@ -7,7 +7,7 @@
  */
 
 import type {SeedClient} from './client'
-import type {HMDocument, HMListChangesOutput, UnpackedHypermediaId} from './hm-types'
+import type {HMDocument, HMListChangesOutput, HMResource, UnpackedHypermediaId} from './hm-types'
 import {packHmId, unpackHmId} from './hm-types'
 
 /** The resolved state of a document's change DAG. */
@@ -113,6 +113,80 @@ export type EditableDocumentBase = FollowedDocument & {
   state: DocumentState
 }
 
+/** One redirect Ref that was followed while resolving an address. */
+export type RedirectHop = {
+  /** The address holding the redirect Ref. */
+  from: UnpackedHypermediaId
+  /** Where it points. */
+  to: UnpackedHypermediaId
+  /**
+   * `true` for a "republish" redirect (the path re-publishes the target's latest content as its
+   * own), `false` for a move redirect (the path has moved away).
+   */
+  republish: boolean
+}
+
+/** A resource read through any redirect Refs on the way, plus the trail of redirects followed. */
+export type FollowedResource = {
+  /** The address that was asked for. */
+  id: UnpackedHypermediaId
+  /** The address the resource was actually read from (equals `id` when nothing was followed). */
+  targetId: UnpackedHypermediaId
+  /** The resource at `targetId` — never a redirect. */
+  resource: Exclude<HMResource, {type: 'redirect'}>
+  /** Every redirect followed, in order. Empty when `id` holds no redirect. */
+  redirects: RedirectHop[]
+}
+
+/**
+ * Reads the resource at an address, following redirect Refs (bounded, cycle-safe) and reporting
+ * every hop that was taken.
+ *
+ * Readers that follow redirects must never present the result as if it lived at the requested
+ * address: the content belongs to `targetId`, and a write to `id` behaves differently from a write
+ * to `targetId` (see {@link describeRedirect}). Callers surface `redirects` to the user or agent.
+ */
+export async function followRedirects(client: SeedClient, id: UnpackedHypermediaId): Promise<FollowedResource> {
+  const seen = new Set<string>([packHmId(id)])
+  const redirects: RedirectHop[] = []
+  let current = id
+  for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
+    const resource = await client.request('Resource', current)
+    if (resource.type !== 'redirect') {
+      return {id, targetId: current, resource, redirects}
+    }
+    redirects.push({from: current, to: resource.redirectTarget, republish: resource.republish === true})
+    const next = packHmId(resource.redirectTarget)
+    if (seen.has(next)) throw new Error(`Redirect cycle detected at ${next}`)
+    seen.add(next)
+    current = resource.redirectTarget
+  }
+  throw new Error(`Too many redirects while resolving ${packHmId(id)} (limit ${MAX_REDIRECT_HOPS})`)
+}
+
+/**
+ * One plain sentence explaining a followed redirect and what a write to either address does —
+ * shared by the CLI and the agents read tool so every surface tells the same story.
+ */
+export function describeRedirect(followed: Pick<FollowedResource, 'id' | 'targetId' | 'redirects'>): string | null {
+  const first = followed.redirects[0]
+  if (!first) return null
+  const from = packHmId(followed.id)
+  const to = packHmId(followed.targetId)
+  const via = followed.redirects.length > 1 ? ` (via ${followed.redirects.length} redirects)` : ''
+  if (first.republish) {
+    return (
+      `${from} republishes ${to}${via}: the content shown is the latest version of ${to}. ` +
+      `To edit the shared original, write to ${to}. ` +
+      `Writing to ${from} replaces the republish with an independent copy that no longer follows ${to}.`
+    )
+  }
+  return (
+    `${from} has moved to ${to}${via}: the content shown is the latest version of ${to}. ` +
+    `Write to ${to}. Writing to ${from} would revive it as an independent copy that no longer follows ${to}.`
+  )
+}
+
 /**
  * Resolves an address to the document it currently presents, following redirect Refs.
  *
@@ -122,28 +196,20 @@ export type EditableDocumentBase = FollowedDocument & {
  * target's document, so this follows the chain (bounded, cycle-safe) to that document.
  */
 export async function followToDocument(client: SeedClient, id: UnpackedHypermediaId): Promise<FollowedDocument> {
-  const seen = new Set<string>([packHmId(id)])
-  let current = id
-  let firstRedirect: FollowedDocument['redirect'] = null
-  for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
-    const resource = await client.request('Resource', current)
-    if (resource.type === 'document') {
-      return {id, targetId: current, document: resource.document, redirect: firstRedirect}
-    }
-    if (resource.type === 'redirect') {
-      firstRedirect ??= {republish: resource.republish === true, target: resource.redirectTarget}
-      const next = packHmId(resource.redirectTarget)
-      if (seen.has(next)) throw new Error(`Redirect cycle detected at ${next}`)
-      seen.add(next)
-      current = resource.redirectTarget
-      continue
-    }
+  const followed = await followRedirects(client, id)
+  const first = followed.redirects[0]
+  if (followed.resource.type !== 'document') {
     throw new Error(
-      `Cannot edit ${packHmId(current)}: resource is ${resource.type}` +
-        (firstRedirect ? ` (followed redirect from ${packHmId(id)})` : ''),
+      `Cannot edit ${packHmId(followed.targetId)}: resource is ${followed.resource.type}` +
+        (first ? ` (followed redirect from ${packHmId(id)})` : ''),
     )
   }
-  throw new Error(`Too many redirects while resolving ${packHmId(id)} (limit ${MAX_REDIRECT_HOPS})`)
+  return {
+    id,
+    targetId: followed.targetId,
+    document: followed.resource.document,
+    redirect: first ? {republish: first.republish, target: first.to} : null,
+  }
 }
 
 /**

--- a/frontend/packages/client/src/document-state.ts
+++ b/frontend/packages/client/src/document-state.ts
@@ -91,16 +91,14 @@ export async function resolveDocumentState(client: SeedClient, targetId: string)
 /** Maximum redirect hops {@link resolveEditableDocument} follows before giving up. */
 const MAX_REDIRECT_HOPS = 5
 
-/** The baseline needed to edit (or take over) a document address. */
-export type EditableDocumentBase = {
-  /** The address being edited — where a new Ref should be published. */
+/** A document address resolved through redirects to the document it currently presents. */
+export type FollowedDocument = {
+  /** The address that was resolved — where a new Ref should be published to affect this path. */
   id: UnpackedHypermediaId
-  /** Where the content baseline lives after following redirects (same as `id` for a plain document). */
+  /** Where the document actually lives after following redirects (same as `id` for a plain document). */
   targetId: UnpackedHypermediaId
-  /** The current document at the target — the content baseline for edits. */
+  /** The current document at the target — the content baseline for edits, forks, and moves. */
   document: HMDocument
-  /** Change-DAG state of the target (genesis/heads/depth) for building the next Change. */
-  state: DocumentState
   /**
    * Non-null when `id` currently holds a redirect Ref. Publishing a Version Ref at `id` with the
    * target's genesis and a fresh (current-timestamp) generation replaces the redirect: the path
@@ -109,27 +107,28 @@ export type EditableDocumentBase = {
   redirect: {republish: boolean; target: UnpackedHypermediaId} | null
 }
 
+/** The full baseline needed to build a new Change at an address: {@link FollowedDocument} plus DAG state. */
+export type EditableDocumentBase = FollowedDocument & {
+  /** Change-DAG state of the target (genesis/heads/depth) for building the next Change. */
+  state: DocumentState
+}
+
 /**
- * Resolves an address to the state needed to edit the document there, following redirects.
+ * Resolves an address to the document it currently presents, following redirect Refs.
  *
  * A path that holds a redirect Ref (including a "republish" redirect, which re-publishes the
- * target's latest content at this path) has no change DAG of its own — `ListChanges` returns
- * nothing for it. The editable content lives at the redirect target, so edits at the source
- * address must build a Change on the target's DAG and publish a Version Ref at the source path
- * with a fresh generation, which supersedes the redirect Ref.
+ * target's latest content at this path) has no document of its own: the `Resource` API reports
+ * `type: 'redirect'`. Operations on such a path (edit, fork, move, delete) act on the redirect
+ * target's document, so this follows the chain (bounded, cycle-safe) to that document.
  */
-export async function resolveEditableDocument(
-  client: SeedClient,
-  id: UnpackedHypermediaId,
-): Promise<EditableDocumentBase> {
+export async function followToDocument(client: SeedClient, id: UnpackedHypermediaId): Promise<FollowedDocument> {
   const seen = new Set<string>([packHmId(id)])
   let current = id
-  let firstRedirect: EditableDocumentBase['redirect'] = null
+  let firstRedirect: FollowedDocument['redirect'] = null
   for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
     const resource = await client.request('Resource', current)
     if (resource.type === 'document') {
-      const state = await resolveDocumentState(client, packHmId(current))
-      return {id, targetId: current, document: resource.document, state, redirect: firstRedirect}
+      return {id, targetId: current, document: resource.document, redirect: firstRedirect}
     }
     if (resource.type === 'redirect') {
       firstRedirect ??= {republish: resource.republish === true, target: resource.redirectTarget}
@@ -145,6 +144,22 @@ export async function resolveEditableDocument(
     )
   }
   throw new Error(`Too many redirects while resolving ${packHmId(id)} (limit ${MAX_REDIRECT_HOPS})`)
+}
+
+/**
+ * Resolves an address to the state needed to edit the document there, following redirects.
+ *
+ * Edits at a redirected address must build the Change on the redirect target's DAG (the source
+ * path has no changes of its own — `ListChanges` returns nothing for it) and publish a Version
+ * Ref at the source path with a fresh generation, which supersedes the redirect Ref.
+ */
+export async function resolveEditableDocument(
+  client: SeedClient,
+  id: UnpackedHypermediaId,
+): Promise<EditableDocumentBase> {
+  const followed = await followToDocument(client, id)
+  const state = await resolveDocumentState(client, packHmId(followed.targetId))
+  return {...followed, state}
 }
 
 /**

--- a/frontend/packages/client/src/index.ts
+++ b/frontend/packages/client/src/index.ts
@@ -106,8 +106,8 @@ export {
   shouldAutoLinkParent,
 } from './auto-link'
 export type {AutoLinkChildToParentOptions} from './auto-link'
-export {resolveDocumentState, resolveEditableDocument} from './document-state'
-export type {DocumentState, EditableDocumentBase} from './document-state'
+export {followToDocument, resolveDocumentState, resolveEditableDocument} from './document-state'
+export type {DocumentState, EditableDocumentBase, FollowedDocument} from './document-state'
 
 export {editorBlockToHMBlock, editorBlocksToHMBlockNodes} from './editorblock-to-hmblock'
 export {hmBlocksToEditorContent, hmBlockToEditorBlock, annotationContains} from './hmblock-to-editorblock'

--- a/frontend/packages/client/src/index.ts
+++ b/frontend/packages/client/src/index.ts
@@ -106,8 +106,8 @@ export {
   shouldAutoLinkParent,
 } from './auto-link'
 export type {AutoLinkChildToParentOptions} from './auto-link'
-export {resolveDocumentState} from './document-state'
-export type {DocumentState} from './document-state'
+export {resolveDocumentState, resolveEditableDocument} from './document-state'
+export type {DocumentState, EditableDocumentBase} from './document-state'
 
 export {editorBlockToHMBlock, editorBlocksToHMBlockNodes} from './editorblock-to-hmblock'
 export {hmBlocksToEditorContent, hmBlockToEditorBlock, annotationContains} from './hmblock-to-editorblock'

--- a/frontend/packages/client/src/index.ts
+++ b/frontend/packages/client/src/index.ts
@@ -106,8 +106,20 @@ export {
   shouldAutoLinkParent,
 } from './auto-link'
 export type {AutoLinkChildToParentOptions} from './auto-link'
-export {followToDocument, resolveDocumentState, resolveEditableDocument} from './document-state'
-export type {DocumentState, EditableDocumentBase, FollowedDocument} from './document-state'
+export {
+  describeRedirect,
+  followRedirects,
+  followToDocument,
+  resolveDocumentState,
+  resolveEditableDocument,
+} from './document-state'
+export type {
+  DocumentState,
+  EditableDocumentBase,
+  FollowedDocument,
+  FollowedResource,
+  RedirectHop,
+} from './document-state'
 
 export {editorBlockToHMBlock, editorBlocksToHMBlockNodes} from './editorblock-to-hmblock'
 export {hmBlocksToEditorContent, hmBlockToEditorBlock, annotationContains} from './hmblock-to-editorblock'


### PR DESCRIPTION
## Postmortem

Agent session `b44d4d81` (\"Update Import Process Guide\") hit a wall trying to edit a republished document: every write against the path failed — `Resource is redirect, not a document`, `Cannot delete redirect`, `Redirect target is required` — and an earlier cross-space update *reported success* while never becoming the document's latest version.

Investigation across all surfaces found:

- **Every surface guarded writes with `resource.type === 'document'`**, and a republished path resolves as `type: 'redirect'`, so update/delete/redirect/move/fork all dead-ended (agents write tool, CLI, web/desktop delete dialogs). Desktop's *editor* wasn't guarded but its publish degraded to a first publish that clobbered the redirect with an orphan lineage; web SSR 302'd republished paths away entirely.
- **The backend needs no changes.** A path holding a redirect Ref is not poisoned: publishing a Version Ref with a strictly higher generation clears the `$db.redirect` attribute (`blob_ref.go` generation reconciliation). All clients publish via `StoreBlobs`, so the fix is purely in client-side ref minting. Fresh-generation tombstones also make republished paths deletable, sidestepping the known redirect-before-tombstone resolution order.
- **Three write-verb envelope mismatches** in the agents service made `delete`/`redirect`/`fork` actions structurally unusable on any hm:// address (fields the handlers never read).
- **Unauthorized cross-space writes published silently**: `resolveCapability` returns `undefined` for a signer with no WRITER/AGENT capability and the publish proceeded — blobs stored, latest never advanced, success reported.

## The takeover model

Editing a path that holds a redirect Ref (republish or move) now works the same everywhere:

1. Follow the redirect chain (bounded, cycle-safe) to the target document — the content the path currently presents.
2. Build the new Change on the **target's DAG** (target genesis + heads), preserving history.
3. Publish a Version Ref at the **written address** with a **fresh generation**, which supersedes the redirect. The path becomes a live document and stops following the target.

Deletes tombstone through the redirect the same way; redirect/move/republish refs now always mint fresh `Date.now()` generations (matching the daemon's own `CreateRef`), so they occupy their own generation row and are cleanly superseded later.

## Changes

- **`@seed-hypermedia/client`**: new `followToDocument` / `resolveEditableDocument` helpers (redirect-following edit baseline), used by all surfaces.
- **Agents write tool**: document.update/delete/fork/move/redirect follow redirects; the three envelope mismatches fixed; unauthorized cross-space writes now fail loudly (403) before publishing, including on dry runs.
- **CLI**: `document update/delete/redirect/move/fork` follow redirects; `create` refuses a republished path without `--force` and points at `update`.
- **Desktop**: publish takes over redirected paths instead of clobbering; delete/move/fork/republish follow redirects.
- **Web**: publish actor follows redirects for its baseline; delete/move/republish follow redirects; SSR renders republished paths in place (target content at the source route) instead of 302ing, matching client-side navigation.

## Tests

- Client: unit tests for the redirect-following helper (plain doc, republish, chains, cycles, dead targets).
- Agents: full-service test mirroring the incident — takeover update rebases on the target DAG with fresh generation, delete tombstones a republished path, unauthorized write errors without publishing.
- CLI: end-to-end fixture test against a **real daemon** proving a republished path can be edited (target untouched) and deleted — both previously impossible.
- Desktop/web: relocation and dialog tests updated for fresh-generation refs.

`pnpm typecheck` green across the workspace; agents suite 335 pass; CLI fixture suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3qMAzkS2n5WXESGxVy1Wi

## Update: reads disclose followed redirects (commit 7a9519b2d)

Writing to a republished address deliberately acts on **that address** (replacing the redirect with an independent copy), while writing to the target edits the shared original. For that rule to be safe, readers must never hide which address content came from. Now:

- **`@seed-hypermedia/client`**: `followRedirects(client, id)` → `{id, targetId, resource, redirects[]}`; `describeRedirect(followed)` → the one sentence every surface prints, e.g. *"hm://A republishes hm://B: the content shown is the latest version of hm://B. To edit the shared original, write to hm://B. Writing to hm://A replaces the republish with an independent copy that no longer follows hm://B."*
- **Agents read tool**: `id` is the address the content was actually read from; `requestedId` is what was asked for; `redirect: {from, to, republish, hops, notice}` is present exactly when a redirect was followed.
- **CLI `document get`**: notice on stderr; markdown frontmatter gains `republishOf: "hm://B"` (or `movedTo:`), which the frontmatter parser ignores on re-import so `get > f.md; update -f f.md` still round-trips; `--json`/`--yaml` carry a `redirect` object.

Tests: `document-state.test.ts` (`followRedirects` block reads as a spec), `api-service.test.ts` ("read tool follows a republished path but says so…"), CLI fixture test extended with the disclosure assertions against a real daemon.

## Update: moving a republished path moves the republish (commit 2d57504e3)

This closes the last inconsistency with "an operation acts on whatever lives at the named address." Moving a republished path used to fork the original's current content at the destination — freezing a snapshot and silently severing the republish. Now a move keeps the source's kind:

- **republish source** → the destination re-publishes the **same original** (keeps tracking its edits); the source redirects to the destination. No fork.
- **plain document** → forks its history, as before.
- **already-moved source** (a pointer, not content) → refused: *"hm://A has already moved to hm://B. Move hm://B instead."*

Both refs mint fresh generations so they supersede any redirect Ref already at their paths (required so the source's own republish redirect is overtaken by the new move redirect).

Same decision on every surface — agents `writeRepublishMove`, CLI `document move`, `moveWebDocuments`, and desktop (extracted to a pure, unit-tested `getDocumentMoveRefOperations`). Tests: agents decodes the two published Refs (both redirects, neither a Change); desktop/web unit tests cover fork / republish-move / already-moved; the CLI fixture test proves it end-to-end against a real daemon — **editing the original after the move still shows through at the destination**, the definitive proof of a live republish rather than a frozen fork.
