### PR TITLE
Agents: carry the signer delegation in every envelope instead of registering it

### DIFF
--- a/agents/protocol/src/index.ts
+++ b/agents/protocol/src/index.ts
@@ -129,6 +129,20 @@ export type SignedActionEnvelope = {
   signer: Uint8Array
   sig: Uint8Array
   account: Uint8Array
+  /**
+   * CID of the published Capability blob by which `account` delegated to `signer` (role AGENT or
+   * WRITER). Required whenever `signer` is not `account` — this is how a web device key acts as
+   * the vault account it was delegated from, so every surface sees the same agents. The server
+   * resolves the blob (from {@link capabilityBlob}, its own cache, or its HM node), verifies the
+   * delegation end to end, and remembers it by CID; the reference rides inside the signed payload,
+   * so it cannot be swapped in transit.
+   */
+  capability?: string
+  /**
+   * Optional raw canonical DAG-CBOR bytes of the {@link capability} blob, for servers that cannot
+   * (or need not) fetch it from the network. Must hash to {@link capability}.
+   */
+  capabilityBlob?: Uint8Array
   action: AgentAction
 }
 
@@ -209,10 +223,13 @@ export type ListAgents = {
 }
 
 /**
+ * @deprecated Delegations now ride inside every envelope as {@link SignedActionEnvelope.capability};
+ * nothing needs to be registered ahead of time. Still accepted so clients from before that change
+ * keep working; remove after one release.
+ *
  * Registers the envelope's signer as a delegated signer for another account, proven by a signed
  * Capability blob (the account key delegating role AGENT to this signer). After registration the
- * signer may send envelopes whose `account` is the delegating account — this is how a web device
- * key acts as the vault account it was delegated from, so both surfaces see the same agents.
+ * signer may send envelopes whose `account` is the delegating account.
  */
 export type RegisterSigner = {
   _: 'RegisterSigner'

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -587,6 +587,7 @@ export class Service {
   readonly #onEvent?: (event: ServiceEvent) => void
   readonly #hmServerUrl: string
   readonly #ipfsServerUrl: string
+  readonly #fetchCapability: auth.CapabilityFetcher
   readonly #web: WebToolsConfig
   readonly #codeExec: CodeExecutor
   readonly #runningSessions = new Map<string, RunningSession>()
@@ -632,6 +633,8 @@ export class Service {
       hmServerUrl?: string
       /** Endpoint serving `/ipfs/*`; defaults to hmServerUrl for hosted all-in-one servers. */
       ipfsServerUrl?: string
+      /** Resolves a delegation Capability blob by CID; defaults to the IPFS endpoint above. */
+      fetchCapability?: auth.CapabilityFetcher
       web?: WebToolsConfig
       exec?: CodeExecConfig
       codeExecutor?: CodeExecutor
@@ -648,6 +651,7 @@ export class Service {
     this.#providerOAuth = options.providerOAuth ?? new ProviderOAuthManager()
     this.#hmServerUrl = options.hmServerUrl || 'https://hyper.media'
     this.#ipfsServerUrl = options.ipfsServerUrl || this.#hmServerUrl
+    this.#fetchCapability = options.fetchCapability ?? ((cid) => fetchBlobFromGateway(this.#ipfsServerUrl, cid))
     this.#web = options.web ?? {}
     this.#codeExec = options.codeExecutor ?? createCodeExecutor(options.exec ?? defaultCodeExecConfig())
     this.#subscriptionAuthEnabled = options.subscriptionAuth ?? false
@@ -734,15 +738,19 @@ export class Service {
     return await this.#codeExec.availability()
   }
 
-  /** Verifies and dispatches a signed action envelope. */
-  async message(envelope: api.SignedActionEnvelope): Promise<api.AgentResponse> {
-    let verified: auth.VerifiedEnvelope
+  /** Verifies an envelope's signature and delegation, mapping every failure to 401. */
+  async #verifyEnvelope(envelope: api.SignedActionEnvelope): Promise<auth.VerifiedEnvelope> {
     try {
-      verified = auth.verifyEnvelope(this.#db, envelope)
+      return await auth.verifyEnvelope(this.#db, envelope, {fetchCapability: this.#fetchCapability})
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Invalid signed envelope'
       throw new APIError(401, message)
     }
+  }
+
+  /** Verifies and dispatches a signed action envelope. */
+  async message(envelope: api.SignedActionEnvelope): Promise<api.AgentResponse> {
+    const verified = await this.#verifyEnvelope(envelope)
 
     const accountId = this.#actionAccountId(verified.accountId, envelope.action)
 
@@ -1116,6 +1124,7 @@ export class Service {
     return {ownerAccountId: row.owner_account_id, role, viaPublic}
   }
 
+  /** @deprecated Delegations ride in every envelope now; kept one release for older web clients. */
   #registerSigner(envelopeSigner: Uint8Array, capabilityBytes: Uint8Array): api.RegisterSignerResponse {
     let registered: {accountId: string; signerId: string}
     try {
@@ -6299,13 +6308,7 @@ export class Service {
     /** Snapshot + durable journal replay for `runs/<rootRunId>` subscriptions. */
     runsReplay?: {runs: api.RunInfo[]; entries: api.RunJournalEntryInfo[]}
   }> {
-    let verified: auth.VerifiedEnvelope
-    try {
-      verified = auth.verifyEnvelope(this.#db, envelope)
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Invalid signed envelope'
-      throw new APIError(401, message)
-    }
+    const verified = await this.#verifyEnvelope(envelope)
     if (envelope.action._ !== 'Subscribe') throw new APIError(400, 'Expected Subscribe action')
     const key = envelope.action.key
     if (key === `account/${verified.accountId}`) return {accountId: verified.accountId, key}
@@ -6988,6 +6991,14 @@ async function publishSigningIdentityProfile(
 ): Promise<void> {
   const profile = await blobs.createProfile(keyPair, {name, avatar}, Date.now())
   await createSeedClient(hmServerUrl).publish({blobs: [{cid: profile.cid.toString(), data: profile.data}]})
+}
+
+/** Reads a published blob's raw bytes from the IPFS gateway; null when the gateway does not have it. */
+async function fetchBlobFromGateway(ipfsServerUrl: string, cid: string): Promise<Uint8Array | null> {
+  const res = await fetch(`${ipfsServerUrl.replace(/\/$/, '')}/ipfs/${encodeURIComponent(cid)}`)
+  if (res.status === 404) return null
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  return new Uint8Array(await res.arrayBuffer())
 }
 
 /** Extracts a bare CID from a bare CID, an ipfs://<cid> URI, or a gateway URL containing /ipfs/<cid>. */
@@ -11732,13 +11743,22 @@ function normalizeBoundedString(value: unknown, label: string, maxBytes: number)
 /** Creates a signed envelope for tests and future local clients. */
 export async function createSignedEnvelope(
   signer: blobs.Signer,
-  input: {account?: blobs.Principal; action: api.UnsignedAgentAction; ts?: number},
+  input: {
+    account?: blobs.Principal
+    /** CID of the Capability by which `account` delegated to the signer (see the envelope type). */
+    capability?: string
+    capabilityBlob?: Uint8Array
+    action: api.UnsignedAgentAction
+    ts?: number
+  },
 ): Promise<api.SignedActionEnvelope> {
   const envelope: api.SignedActionEnvelope = {
     type: 'AgentsAction',
     signer: signer.principal,
     sig: new Uint8Array(blobs.ED25519_SIGNATURE_SIZE),
     account: input.account ?? signer.principal,
+    ...(input.capability !== undefined ? {capability: input.capability} : {}),
+    ...(input.capabilityBlob !== undefined ? {capabilityBlob: input.capabilityBlob} : {}),
     action: {...input.action, ts: input.ts ?? Date.now()} as api.AgentAction,
   }
   return (await blobs.sign(signer, envelope as unknown as blobs.Blob)) as unknown as api.SignedActionEnvelope

--- a/agents/src/auth.test.ts
+++ b/agents/src/auth.test.ts
@@ -12,7 +12,7 @@ describe('auth', () => {
     try {
       const account = blobs.generateNobleKeyPair()
       const envelope = await apisvc.createSignedEnvelope(account, {action: {_: 'ListAgents'}})
-      const verified = auth.verifyEnvelope(db, envelope)
+      const verified = await auth.verifyEnvelope(db, envelope)
       expect(verified.accountId).toBe(blobs.principalToString(account.principal))
       expect(verified.signerId).toBe(verified.accountId)
     } finally {
@@ -33,7 +33,7 @@ describe('auth', () => {
         account: account.principal,
         action: {_: 'ListAgents'},
       })
-      expect(auth.verifyEnvelope(db, envelope).signerId).toBe(delegateId)
+      expect((await auth.verifyEnvelope(db, envelope)).signerId).toBe(delegateId)
     } finally {
       db.close()
     }
@@ -48,7 +48,7 @@ describe('auth', () => {
         account: account.principal,
         action: {_: 'ListAgents'},
       })
-      expect(() => auth.verifyEnvelope(db, envelope)).toThrow('Signer is not authorized')
+      await expect(auth.verifyEnvelope(db, envelope)).rejects.toThrow('Signer is not authorized')
 
       const signedByAccount = await apisvc.createSignedEnvelope(account, {action: {_: 'ListAgents'}})
       signedByAccount.action = {
@@ -56,7 +56,7 @@ describe('auth', () => {
         definition: {name: 'bad', systemPrompt: 'tampered', modelProvider: 'openai', model: 'gpt'},
         ts: Date.now(),
       }
-      expect(() => auth.verifyEnvelope(db, signedByAccount)).toThrow('Invalid signature')
+      await expect(auth.verifyEnvelope(db, signedByAccount)).rejects.toThrow('Invalid signature')
     } finally {
       db.close()
     }
@@ -68,124 +68,334 @@ describe('auth', () => {
       const account = blobs.generateNobleKeyPair()
       const envelope = await apisvc.createSignedEnvelope(account, {action: {_: 'ListAgents'}})
 
-      expect(() => auth.verifyEnvelope(db, {...envelope, type: 'Wrong'} as never)).toThrow('Invalid envelope type')
-      expect(() => auth.verifyEnvelope(db, {...envelope, signer: new Uint8Array([1, 2])})).toThrow('Invalid signer')
-      expect(() =>
+      await expect(auth.verifyEnvelope(db, {...envelope, type: 'Wrong'} as never)).rejects.toThrow(
+        'Invalid envelope type',
+      )
+      await expect(auth.verifyEnvelope(db, {...envelope, signer: new Uint8Array([1, 2])})).rejects.toThrow(
+        'Invalid signer',
+      )
+      await expect(
         auth.verifyEnvelope(db, {
           ...envelope,
           account: new Uint8Array([0xed, 0x02, ...account.publicKey]),
         }),
-      ).toThrow('Invalid account')
-      expect(() => auth.verifyEnvelope(db, {...envelope, sig: new Uint8Array(12)})).toThrow('Invalid signature bytes')
-      expect(() => auth.verifyEnvelope(db, {...envelope, action: {} as never})).toThrow('Invalid action')
+      ).rejects.toThrow('Invalid account')
+      await expect(auth.verifyEnvelope(db, {...envelope, sig: new Uint8Array(12)})).rejects.toThrow(
+        'Invalid signature bytes',
+      )
+      await expect(auth.verifyEnvelope(db, {...envelope, action: {} as never})).rejects.toThrow('Invalid action')
     } finally {
       db.close()
     }
   })
 
-  test('registers a delegated signer from a capability, then delegated envelopes verify', async () => {
-    const db = createInitializedMemoryDatabase()
-    try {
-      const account = blobs.generateNobleKeyPair()
-      const device = blobs.generateNobleKeyPair()
-      const capability = await blobs.createCapability(account, device.principal, 'AGENT', Date.now(), {
-        label: 'Session key for web',
-      })
+  describe('delegation carried in the envelope', () => {
+    test('verifies a delegated envelope from inline capability bytes and remembers the delegation', async () => {
+      const db = createInitializedMemoryDatabase()
+      try {
+        const {account, device, capability} = await makeDelegation()
+        const envelope = await apisvc.createSignedEnvelope(device, {
+          account: account.principal,
+          capability: capability.cid.toString(),
+          capabilityBlob: capability.data,
+          action: {_: 'ListAgents'},
+        })
 
-      const registered = auth.registerDelegatedSigner(db, capability.data, device.principal)
-      expect(registered.accountId).toBe(blobs.principalToString(account.principal))
-      expect(registered.signerId).toBe(blobs.principalToString(device.principal))
+        const verified = await auth.verifyEnvelope(db, envelope)
+        expect(verified.accountId).toBe(blobs.principalToString(account.principal))
+        expect(verified.signerId).toBe(blobs.principalToString(device.principal))
 
-      // The whole point: an envelope signed by the device key acting as the account now verifies.
-      const envelope = await apisvc.createSignedEnvelope(device, {
-        account: account.principal,
-        action: {_: 'ListAgents'},
-      })
-      expect(auth.verifyEnvelope(db, envelope).accountId).toBe(registered.accountId)
-    } finally {
-      db.close()
-    }
+        // Remembered by CID, so the next envelope needs neither the bytes nor the network.
+        const row = db
+          .query<{capability_cid: string}, [string, string]>(
+            `SELECT capability_cid FROM account_authorizations WHERE account_id = ? AND signer = ?`,
+          )
+          .get(verified.accountId, verified.signerId)
+        expect(row?.capability_cid).toBe(capability.cid.toString())
+        const bare = await apisvc.createSignedEnvelope(device, {
+          account: account.principal,
+          capability: capability.cid.toString(),
+          action: {_: 'ListAgents'},
+        })
+        expect((await auth.verifyEnvelope(db, bare)).accountId).toBe(verified.accountId)
+      } finally {
+        db.close()
+      }
+    })
+
+    test('fetches the capability from the HM network when the envelope carries only the CID', async () => {
+      const db = createInitializedMemoryDatabase()
+      try {
+        const {account, device, capability} = await makeDelegation()
+        const envelope = await apisvc.createSignedEnvelope(device, {
+          account: account.principal,
+          capability: capability.cid.toString(),
+          action: {_: 'ListAgents'},
+        })
+
+        const requested: string[] = []
+        const fetchCapability = async (cid: string) => {
+          requested.push(cid)
+          return cid === capability.cid.toString() ? capability.data : null
+        }
+        const verified = await auth.verifyEnvelope(db, envelope, {fetchCapability})
+        expect(verified.accountId).toBe(blobs.principalToString(account.principal))
+        expect(requested).toEqual([capability.cid.toString()])
+
+        // The second envelope is served from the remembered delegation: no fetch.
+        const again = await apisvc.createSignedEnvelope(device, {
+          account: account.principal,
+          capability: capability.cid.toString(),
+          action: {_: 'ListAgents'},
+        })
+        await auth.verifyEnvelope(db, again, {fetchCapability})
+        expect(requested).toHaveLength(1)
+      } finally {
+        db.close()
+      }
+    })
+
+    test('reports a capability the network does not have, or that this server cannot fetch', async () => {
+      const db = createInitializedMemoryDatabase()
+      try {
+        const {account, device, capability} = await makeDelegation()
+        const envelope = await apisvc.createSignedEnvelope(device, {
+          account: account.principal,
+          capability: capability.cid.toString(),
+          action: {_: 'ListAgents'},
+        })
+        await expect(auth.verifyEnvelope(db, envelope, {fetchCapability: async () => null})).rejects.toThrow(
+          'is not available on the HM network',
+        )
+        await expect(
+          auth.verifyEnvelope(db, envelope, {
+            fetchCapability: async () => {
+              throw new Error('gateway down')
+            },
+          }),
+        ).rejects.toThrow('Failed to fetch capability')
+        await expect(auth.verifyEnvelope(db, envelope)).rejects.toThrow('not available to this server')
+        expect(
+          auth.isAuthorizedSigner(
+            db,
+            blobs.principalToString(account.principal),
+            blobs.principalToString(device.principal),
+          ),
+        ).toBe(false)
+      } finally {
+        db.close()
+      }
+    })
+
+    test('rejects inline bytes that are not the blob the envelope names', async () => {
+      const db = createInitializedMemoryDatabase()
+      try {
+        const {account, device, capability} = await makeDelegation()
+        const other = await blobs.createCapability(account, device.principal, 'AGENT', Date.now() - 1)
+        expect(other.cid.toString()).not.toBe(capability.cid.toString())
+
+        const envelope = await apisvc.createSignedEnvelope(device, {
+          account: account.principal,
+          capability: capability.cid.toString(),
+          capabilityBlob: other.data,
+          action: {_: 'ListAgents'},
+        })
+        await expect(auth.verifyEnvelope(db, envelope)).rejects.toThrow('do not match the envelope capability CID')
+      } finally {
+        db.close()
+      }
+    })
+
+    test('rejects a capability issued by an account other than the one the envelope acts as', async () => {
+      const db = createInitializedMemoryDatabase()
+      try {
+        const {device, capability} = await makeDelegation()
+        const victim = blobs.generateNobleKeyPair()
+        const envelope = await apisvc.createSignedEnvelope(device, {
+          account: victim.principal,
+          capability: capability.cid.toString(),
+          capabilityBlob: capability.data,
+          action: {_: 'ListAgents'},
+        })
+        await expect(auth.verifyEnvelope(db, envelope)).rejects.toThrow('not issued by the envelope account')
+        expect(
+          auth.isAuthorizedSigner(
+            db,
+            blobs.principalToString(victim.principal),
+            blobs.principalToString(device.principal),
+          ),
+        ).toBe(false)
+      } finally {
+        db.close()
+      }
+    })
+
+    test('rejects a published capability replayed by a key it does not delegate to', async () => {
+      const db = createInitializedMemoryDatabase()
+      try {
+        const {account, capability} = await makeDelegation()
+        const attacker = blobs.generateNobleKeyPair()
+        const envelope = await apisvc.createSignedEnvelope(attacker, {
+          account: account.principal,
+          capability: capability.cid.toString(),
+          capabilityBlob: capability.data,
+          action: {_: 'ListAgents'},
+        })
+        await expect(auth.verifyEnvelope(db, envelope)).rejects.toThrow(
+          'Capability delegate does not match envelope signer',
+        )
+      } finally {
+        db.close()
+      }
+    })
+
+    test('the capability reference is covered by the envelope signature', async () => {
+      const db = createInitializedMemoryDatabase()
+      try {
+        const {account, device, capability} = await makeDelegation()
+        const envelope = await apisvc.createSignedEnvelope(device, {
+          account: account.principal,
+          action: {_: 'ListAgents'},
+        })
+        const spliced = {...envelope, capability: capability.cid.toString(), capabilityBlob: capability.data}
+        await expect(auth.verifyEnvelope(db, spliced)).rejects.toThrow('Invalid signature')
+      } finally {
+        db.close()
+      }
+    })
+
+    test('rejects a malformed capability CID', async () => {
+      const db = createInitializedMemoryDatabase()
+      try {
+        const {account, device, capability} = await makeDelegation()
+        const envelope = await apisvc.createSignedEnvelope(device, {
+          account: account.principal,
+          capability: '../not-a-cid',
+          capabilityBlob: capability.data,
+          action: {_: 'ListAgents'},
+        })
+        await expect(auth.verifyEnvelope(db, envelope)).rejects.toThrow('Invalid capability CID')
+      } finally {
+        db.close()
+      }
+    })
   })
 
-  test('accepts a WRITER capability, which is a broader grant than AGENT', async () => {
-    const db = createInitializedMemoryDatabase()
-    try {
-      const account = blobs.generateNobleKeyPair()
-      const device = blobs.generateNobleKeyPair()
-      const capability = await blobs.createCapability(account, device.principal, 'WRITER', Date.now())
-      const registered = auth.registerDelegatedSigner(db, capability.data, device.principal)
-      expect(auth.isAuthorizedSigner(db, registered.accountId, registered.signerId)).toBe(true)
-    } finally {
-      db.close()
-    }
-  })
+  describe('legacy RegisterSigner', () => {
+    test('registers a delegated signer from a capability, then delegated envelopes verify', async () => {
+      const db = createInitializedMemoryDatabase()
+      try {
+        const account = blobs.generateNobleKeyPair()
+        const device = blobs.generateNobleKeyPair()
+        const capability = await blobs.createCapability(account, device.principal, 'AGENT', Date.now(), {
+          label: 'Session key for web',
+        })
 
-  test('rejects a capability replayed by a key it does not delegate to', async () => {
-    const db = createInitializedMemoryDatabase()
-    try {
-      const account = blobs.generateNobleKeyPair()
-      const device = blobs.generateNobleKeyPair()
-      const attacker = blobs.generateNobleKeyPair()
-      const capability = await blobs.createCapability(account, device.principal, 'AGENT', Date.now())
-      expect(() => auth.registerDelegatedSigner(db, capability.data, attacker.principal)).toThrow(
-        'Capability delegate does not match envelope signer',
-      )
-      expect(
-        auth.isAuthorizedSigner(
-          db,
-          blobs.principalToString(account.principal),
-          blobs.principalToString(device.principal),
-        ),
-      ).toBe(false)
-    } finally {
-      db.close()
-    }
-  })
+        const registered = auth.registerDelegatedSigner(db, capability.data, device.principal)
+        expect(registered.accountId).toBe(blobs.principalToString(account.principal))
+        expect(registered.signerId).toBe(blobs.principalToString(device.principal))
 
-  test('rejects tampered capability bytes and non-capability blobs', async () => {
-    const db = createInitializedMemoryDatabase()
-    try {
-      const account = blobs.generateNobleKeyPair()
-      const device = blobs.generateNobleKeyPair()
-      const capability = await blobs.createCapability(account, device.principal, 'AGENT', Date.now())
+        // The whole point: an envelope signed by the device key acting as the account now verifies.
+        const envelope = await apisvc.createSignedEnvelope(device, {
+          account: account.principal,
+          action: {_: 'ListAgents'},
+        })
+        expect((await auth.verifyEnvelope(db, envelope)).accountId).toBe(registered.accountId)
+      } finally {
+        db.close()
+      }
+    })
 
-      // Flip a byte inside the delegate field so the signature no longer covers the content.
-      const flippedDelegate = device.principal.map((b, i) => (i === 5 ? b ^ 1 : b)) as blobs.Principal
-      const tampered = {...cbor.decode<blobs.Capability>(capability.data), delegate: flippedDelegate}
-      expect(() => auth.registerDelegatedSigner(db, cbor.encode(tampered), flippedDelegate)).toThrow(
-        'Invalid capability signature',
-      )
+    test('accepts a WRITER capability, which is a broader grant than AGENT', async () => {
+      const db = createInitializedMemoryDatabase()
+      try {
+        const account = blobs.generateNobleKeyPair()
+        const device = blobs.generateNobleKeyPair()
+        const capability = await blobs.createCapability(account, device.principal, 'WRITER', Date.now())
+        const registered = auth.registerDelegatedSigner(db, capability.data, device.principal)
+        expect(auth.isAuthorizedSigner(db, registered.accountId, registered.signerId)).toBe(true)
+      } finally {
+        db.close()
+      }
+    })
 
-      expect(() => auth.registerDelegatedSigner(db, cbor.encode({type: 'Profile'}), device.principal)).toThrow(
-        'Blob is not a Capability',
-      )
-      expect(() => auth.registerDelegatedSigner(db, new Uint8Array(), device.principal)).toThrow(
-        'Invalid capability bytes',
-      )
-    } finally {
-      db.close()
-    }
-  })
+    test('rejects a capability replayed by a key it does not delegate to', async () => {
+      const db = createInitializedMemoryDatabase()
+      try {
+        const account = blobs.generateNobleKeyPair()
+        const device = blobs.generateNobleKeyPair()
+        const attacker = blobs.generateNobleKeyPair()
+        const capability = await blobs.createCapability(account, device.principal, 'AGENT', Date.now())
+        expect(() => auth.registerDelegatedSigner(db, capability.data, attacker.principal)).toThrow(
+          'Capability delegate does not match envelope signer',
+        )
+        expect(
+          auth.isAuthorizedSigner(
+            db,
+            blobs.principalToString(account.principal),
+            blobs.principalToString(device.principal),
+          ),
+        ).toBe(false)
+      } finally {
+        db.close()
+      }
+    })
 
-  test('rejects a role that does not permit agent actions and self-delegation', async () => {
-    const db = createInitializedMemoryDatabase()
-    try {
-      const account = blobs.generateNobleKeyPair()
-      const device = blobs.generateNobleKeyPair()
-      const badRole = await blobs.createCapability(account, device.principal, 'READER' as blobs.Role, Date.now())
-      expect(() => auth.registerDelegatedSigner(db, badRole.data, device.principal)).toThrow(
-        'Capability role does not permit agent actions',
-      )
+    test('rejects tampered capability bytes and non-capability blobs', async () => {
+      const db = createInitializedMemoryDatabase()
+      try {
+        const account = blobs.generateNobleKeyPair()
+        const device = blobs.generateNobleKeyPair()
+        const capability = await blobs.createCapability(account, device.principal, 'AGENT', Date.now())
 
-      const selfCapability = await blobs.createCapability(account, account.principal, 'AGENT', Date.now())
-      expect(() => auth.registerDelegatedSigner(db, selfCapability.data, account.principal)).toThrow(
-        'Capability delegates to its own issuer',
-      )
-    } finally {
-      db.close()
-    }
+        // Flip a byte inside the delegate field so the signature no longer covers the content.
+        const flippedDelegate = device.principal.map((b, i) => (i === 5 ? b ^ 1 : b)) as blobs.Principal
+        const tampered = {...cbor.decode<blobs.Capability>(capability.data), delegate: flippedDelegate}
+        expect(() => auth.registerDelegatedSigner(db, cbor.encode(tampered), flippedDelegate)).toThrow(
+          'Invalid capability signature',
+        )
+
+        expect(() => auth.registerDelegatedSigner(db, cbor.encode({type: 'Profile'}), device.principal)).toThrow(
+          'Blob is not a Capability',
+        )
+        expect(() => auth.registerDelegatedSigner(db, new Uint8Array(), device.principal)).toThrow(
+          'Invalid capability bytes',
+        )
+      } finally {
+        db.close()
+      }
+    })
+
+    test('rejects a role that does not permit agent actions and self-delegation', async () => {
+      const db = createInitializedMemoryDatabase()
+      try {
+        const account = blobs.generateNobleKeyPair()
+        const device = blobs.generateNobleKeyPair()
+        const badRole = await blobs.createCapability(account, device.principal, 'READER' as blobs.Role, Date.now())
+        expect(() => auth.registerDelegatedSigner(db, badRole.data, device.principal)).toThrow(
+          'Capability role does not permit agent actions',
+        )
+
+        const selfCapability = await blobs.createCapability(account, account.principal, 'AGENT', Date.now())
+        expect(() => auth.registerDelegatedSigner(db, selfCapability.data, account.principal)).toThrow(
+          'Capability delegates to its own issuer',
+        )
+      } finally {
+        db.close()
+      }
+    })
   })
 })
+
+/** An account that delegated AGENT to a device key, as the vault does for a web session. */
+async function makeDelegation() {
+  const account = blobs.generateNobleKeyPair()
+  const device = blobs.generateNobleKeyPair()
+  const capability = await blobs.createCapability(account, device.principal, 'AGENT', Date.now(), {
+    label: 'Session key for web',
+  })
+  return {account, device, capability}
+}
 
 function createInitializedMemoryDatabase(): Database {
   const db = new Database(':memory:', {create: true, strict: true})

--- a/agents/src/auth.ts
+++ b/agents/src/auth.ts
@@ -5,6 +5,9 @@ import * as cbor from '@/cbor'
 
 const MAX_ACTION_CLOCK_SKEW_MS = 30_000
 
+/** Capability blobs are a few hundred bytes; anything near this is not one. */
+const MAX_CAPABILITY_BYTES = 64 * 1024
+
 /** Authorization role values understood by the Agents service. */
 export type Role = 'OWNER' | 'AGENT'
 
@@ -15,8 +18,24 @@ export type VerifiedEnvelope = {
   signerId: string
 }
 
-/** Verifies envelope signature and authorizes the signer for the account. */
-export function verifyEnvelope(db: Database, envelope: api.SignedActionEnvelope): VerifiedEnvelope {
+/** Fetches the raw bytes of a published blob by CID, or null when the network does not have it. */
+export type CapabilityFetcher = (cid: string) => Promise<Uint8Array | null>
+
+/**
+ * Verifies envelope signature and authorizes the signer for the account.
+ *
+ * A signer that is not the account must prove a delegation. The envelope names the account's
+ * Capability blob by CID; the bytes come from the envelope itself, from a delegation this server
+ * already verified, or from the HM network via `fetchCapability`. Whichever source, the blob's own
+ * signature shows the account granted the delegation and the envelope signature (already verified)
+ * shows the caller holds the delegated key — a published capability replayed by anyone else fails
+ * the delegate check.
+ */
+export async function verifyEnvelope(
+  db: Database,
+  envelope: api.SignedActionEnvelope,
+  options: {fetchCapability?: CapabilityFetcher} = {},
+): Promise<VerifiedEnvelope> {
   validateEnvelopeShape(envelope)
   validateActionTimestamp(envelope.action.ts)
   if (!verifySignature(envelope)) {
@@ -26,11 +45,61 @@ export function verifyEnvelope(db: Database, envelope: api.SignedActionEnvelope)
   const accountId = blobs.principalToString(envelope.account)
   const signerId = blobs.principalToString(envelope.signer)
 
-  if (!blobs.principalEqual(envelope.signer, envelope.account) && !isAuthorizedSigner(db, accountId, signerId)) {
+  if (blobs.principalEqual(envelope.signer, envelope.account)) {
+    return {envelope, accountId, signerId}
+  }
+  if (isAuthorizedSigner(db, accountId, signerId)) {
+    return {envelope, accountId, signerId}
+  }
+  if (envelope.capability === undefined) {
     throw new Error('Signer is not authorized for account')
   }
 
+  const capabilityBytes = await resolveCapabilityBytes(envelope, options.fetchCapability)
+  const capability = verifyCapabilityDelegation(capabilityBytes, {
+    delegate: envelope.signer,
+    expectedCid: envelope.capability,
+  })
+  if (!blobs.principalEqual(capability.signer, envelope.account)) {
+    throw new Error('Capability was not issued by the envelope account')
+  }
+  setLocalAuthorization(db, {
+    accountId,
+    signerId,
+    role: 'AGENT',
+    capability: Buffer.from(capabilityBytes).toString('base64'),
+    capabilityCid: envelope.capability,
+  })
   return {envelope, accountId, signerId}
+}
+
+async function resolveCapabilityBytes(
+  envelope: api.SignedActionEnvelope,
+  fetchCapability: CapabilityFetcher | undefined,
+): Promise<Uint8Array> {
+  const cid = envelope.capability
+  if (typeof cid !== 'string' || !/^[a-z0-9]{10,}$/.test(cid)) {
+    throw new Error('Invalid capability CID')
+  }
+  if (envelope.capabilityBlob !== undefined) {
+    if (!(envelope.capabilityBlob instanceof Uint8Array) || !envelope.capabilityBlob.length) {
+      throw new Error('Invalid capability bytes')
+    }
+    return envelope.capabilityBlob
+  }
+  if (!fetchCapability) {
+    throw new Error('Capability blob is not available to this server')
+  }
+  let fetched: Uint8Array | null
+  try {
+    fetched = await fetchCapability(cid)
+  } catch (error) {
+    throw new Error(`Failed to fetch capability ${cid}: ${error instanceof Error ? error.message : String(error)}`)
+  }
+  if (!fetched || !fetched.length) {
+    throw new Error(`Capability ${cid} is not available on the HM network`)
+  }
+  return fetched
 }
 
 /** Returns whether a non-account signer has an AGENT authorization for the account. */
@@ -44,20 +113,20 @@ export function isAuthorizedSigner(db: Database, accountId: string, signerId: st
 }
 
 /**
- * Registers a delegated signer for an account from a signed Capability blob.
+ * Decodes and verifies a Capability blob that delegates agent actions to `delegate`.
  *
- * The proof is end to end: the blob's own signature shows the account key granted the delegation,
- * and requiring `delegate == envelopeSigner` shows the caller holds the delegated key (the
- * envelope's signature already verified). A third party replaying a published capability cannot
- * register because it cannot sign the envelope as the delegate.
+ * Checks the blob shape, its signature, that it names `delegate`, that its role permits agent
+ * actions, that it is not self-issued, and (when given) that its bytes hash to `expectedCid`.
  */
-export function registerDelegatedSigner(
-  db: Database,
+export function verifyCapabilityDelegation(
   capabilityBytes: Uint8Array,
-  envelopeSigner: blobs.Principal,
-): {accountId: string; signerId: string} {
+  input: {delegate: blobs.Principal; expectedCid?: string},
+): blobs.Capability {
   if (!(capabilityBytes instanceof Uint8Array) || !capabilityBytes.length) {
     throw new Error('Invalid capability bytes')
+  }
+  if (capabilityBytes.length > MAX_CAPABILITY_BYTES) {
+    throw new Error('Capability blob is too large')
   }
   let capability: blobs.Capability
   try {
@@ -70,26 +139,49 @@ export function registerDelegatedSigner(
   }
   validatePrincipal('capability signer', capability.signer)
   validatePrincipal('capability delegate', capability.delegate)
+  if (input.expectedCid !== undefined) {
+    // The CID is what the envelope signed over; the bytes must be that blob, not merely a valid one.
+    const reencoded = blobs.encode(capability as unknown as blobs.Blob)
+    if (reencoded.cid.toString() !== input.expectedCid) {
+      throw new Error('Capability bytes do not match the envelope capability CID')
+    }
+  }
   if (!blobs.verify(capability as unknown as blobs.Blob)) {
     throw new Error('Invalid capability signature')
   }
-  if (!blobs.principalEqual(capability.delegate, envelopeSigner)) {
+  if (!blobs.principalEqual(capability.delegate, input.delegate)) {
     throw new Error('Capability delegate does not match envelope signer')
   }
   // WRITER is a broader grant than AGENT, so both prove the account trusts this key to act for it.
   if (capability.role !== 'AGENT' && capability.role !== 'WRITER') {
     throw new Error('Capability role does not permit agent actions')
   }
-  const accountId = blobs.principalToString(capability.signer)
-  const signerId = blobs.principalToString(capability.delegate)
-  if (accountId === signerId) {
+  if (blobs.principalEqual(capability.signer, capability.delegate)) {
     throw new Error('Capability delegates to its own issuer')
   }
+  return capability
+}
+
+/**
+ * Registers a delegated signer for an account from a signed Capability blob.
+ *
+ * @deprecated Envelopes now carry their delegation (see {@link verifyEnvelope}); this backs the
+ * legacy `RegisterSigner` action for clients from before that change.
+ */
+export function registerDelegatedSigner(
+  db: Database,
+  capabilityBytes: Uint8Array,
+  envelopeSigner: blobs.Principal,
+): {accountId: string; signerId: string} {
+  const capability = verifyCapabilityDelegation(capabilityBytes, {delegate: envelopeSigner})
+  const accountId = blobs.principalToString(capability.signer)
+  const signerId = blobs.principalToString(capability.delegate)
   setLocalAuthorization(db, {
     accountId,
     signerId,
     role: 'AGENT',
     capability: Buffer.from(capabilityBytes).toString('base64'),
+    capabilityCid: blobs.encode(capability as unknown as blobs.Blob).cid.toString(),
   })
   return {accountId, signerId}
 }
@@ -97,7 +189,7 @@ export function registerDelegatedSigner(
 /** Inserts or updates a local account authorization. Useful for tests and future admin actions. */
 export function setLocalAuthorization(
   db: Database,
-  input: {accountId: string; signerId: string; role: Role; capability?: string; now?: number},
+  input: {accountId: string; signerId: string; role: Role; capability?: string; capabilityCid?: string; now?: number},
 ): void {
   const now = input.now ?? Date.now()
   db.run(
@@ -106,10 +198,13 @@ export function setLocalAuthorization(
     [input.accountId, now, now],
   )
   db.run(
-    `INSERT INTO account_authorizations (account_id, signer, role, capability, created_at)
-     VALUES (?, ?, ?, ?, ?)
-     ON CONFLICT(account_id, signer) DO UPDATE SET role = excluded.role, capability = excluded.capability`,
-    [input.accountId, input.signerId, input.role, input.capability ?? null, now],
+    `INSERT INTO account_authorizations (account_id, signer, role, capability, capability_cid, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(account_id, signer) DO UPDATE SET
+       role = excluded.role,
+       capability = excluded.capability,
+       capability_cid = excluded.capability_cid`,
+    [input.accountId, input.signerId, input.role, input.capability ?? null, input.capabilityCid ?? null, now],
   )
 }
 

--- a/agents/src/sqlite-schema.sql
+++ b/agents/src/sqlite-schema.sql
@@ -10,6 +10,7 @@ CREATE TABLE account_authorizations (
     role TEXT NOT NULL,
     capability TEXT,
     created_at INTEGER NOT NULL,
+    capability_cid TEXT,
     PRIMARY KEY (account_id, signer),
     FOREIGN KEY (account_id) REFERENCES accounts (id)
 ) WITHOUT ROWID;

--- a/agents/src/sqlite.ts
+++ b/agents/src/sqlite.ts
@@ -13,6 +13,10 @@ export const BASELINE_SCHEMA_MIGRATION_VERSION = 0
 /** Prepend-only database migrations. */
 export const migrations: string[] = [
   // ======= IMPORTANT: Add new migrations below this line. =======
+  // Delegations are proven per envelope by the CID of the account's Capability blob; a verified
+  // one is remembered here so later envelopes skip the blob fetch. Rows from the old RegisterSigner
+  // flow have no CID and stay valid.
+  `ALTER TABLE account_authorizations ADD COLUMN capability_cid TEXT;`,
   // Optionally-public agents: when set, any signed account can read the agent by id (the same view
   // an invited reader gets). Owners toggle it from the collaborators panel via SetAgentPublicRead.
   `ALTER TABLE agents ADD COLUMN public_read INTEGER NOT NULL DEFAULT 0;`,

--- a/frontend/apps/web/app/__tests__/web-agents-platform.test.ts
+++ b/frontend/apps/web/app/__tests__/web-agents-platform.test.ts
@@ -16,7 +16,6 @@ const mocks = vi.hoisted(() => ({
   keyPairFromStore: null as CryptoKeyPair | null,
   localKeyPair: null as {id: string; delegatedAccountUid?: string} | null,
   appContext: {origin: undefined as string | undefined},
-  sendAgentAction: vi.fn(),
 }))
 
 vi.mock('@shm/shared', () => ({
@@ -38,10 +37,6 @@ vi.mock('@/auth', () => ({
 
 vi.mock('@/local-db', () => ({
   getStoredLocalKeys: async () => (mocks.storedKeyPair ? {keyPair: mocks.storedKeyPair, ...mocks.storedExtras} : null),
-}))
-
-vi.mock('@shm/ui/agents/client', () => ({
-  sendAgentAction: (input: unknown) => mocks.sendAgentAction(input),
 }))
 
 // The rich editor drags in the whole ProseMirror stack; the adapter only passes it through.
@@ -78,7 +73,6 @@ beforeEach(() => {
   mocks.keyPairFromStore = null
   mocks.localKeyPair = null
   mocks.appContext.origin = undefined
-  mocks.sendAgentAction.mockReset()
 })
 
 afterEach(() => {
@@ -220,31 +214,48 @@ describe('web agents platform', () => {
     await expect(platform.getSigner('z6MkSomeoneElse')).rejects.toThrow(/local web identity/)
   })
 
-  it('registers the delegation with a self-signed envelope carrying the stored capability', async () => {
-    const {devicePrincipal, keyPair} = await makeDeviceIdentity()
+  it('hands the shared client the stored delegation, bytes included, for the delegated account', async () => {
+    const {keyPair} = await makeDeviceIdentity()
     const capability = new Uint8Array([1, 2, 3, 4])
     mocks.storedKeyPair = keyPair
-    mocks.storedExtras = {delegatedAccountUid: 'z6MkVaultAccount', capabilityBlob: capability}
+    mocks.storedExtras = {delegatedAccountUid: 'z6MkVaultAccount', capabilityCid: 'bafycap', capabilityBlob: capability}
     const platform = await loadPlatform()
 
-    await platform.registerSigner!('https://agents.example.com')
-
-    expect(mocks.sendAgentAction).toHaveBeenCalledWith({
-      serverUrl: 'https://agents.example.com',
-      // The registration proves itself: the envelope is signed by the device key AS the device
-      // key, and the capability inside is the account's own signature over the delegation.
-      accountUid: devicePrincipal,
-      action: {_: 'RegisterSigner', capability},
+    await expect(platform.getDelegation!('z6MkVaultAccount')).resolves.toEqual({
+      capabilityCid: 'bafycap',
+      capabilityBlob: capability,
     })
   })
 
-  it('refuses to register when there is no delegation to prove', async () => {
+  it('hands out the CID alone for sessions delegated before the blob was stored, without fetching', async () => {
+    // The agent server resolves the published blob from its own HM node; a fetch from the browser
+    // through this site's file proxy would fail for any visitor whose auth cookie the daemon rejects.
     const {keyPair} = await makeDeviceIdentity()
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
     mocks.storedKeyPair = keyPair
+    mocks.storedExtras = {delegatedAccountUid: 'z6MkVaultAccount', capabilityCid: 'bafycap'}
     const platform = await loadPlatform()
 
-    await expect(platform.registerSigner!('https://agents.example.com')).rejects.toThrow(/No account delegation/)
-    expect(mocks.sendAgentAction).not.toHaveBeenCalled()
+    await expect(platform.getDelegation!('z6MkVaultAccount')).resolves.toEqual({
+      capabilityCid: 'bafycap',
+      capabilityBlob: undefined,
+    })
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('holds no delegation for other accounts, or when the identity was never delegated', async () => {
+    const {keyPair, devicePrincipal} = await makeDeviceIdentity()
+    mocks.storedKeyPair = keyPair
+    mocks.storedExtras = {delegatedAccountUid: 'z6MkVaultAccount', capabilityCid: 'bafycap'}
+    const platform = await loadPlatform()
+
+    await expect(platform.getDelegation!('z6MkSomeoneElse')).resolves.toBeNull()
+    // The device key is its own account: no delegation needed or held.
+    await expect(platform.getDelegation!(devicePrincipal)).resolves.toBeNull()
+
+    mocks.storedExtras = {}
+    await expect(platform.getDelegation!('z6MkVaultAccount')).resolves.toBeNull()
   })
 })
 

--- a/frontend/apps/web/app/web-agents-platform.ts
+++ b/frontend/apps/web/app/web-agents-platform.ts
@@ -6,8 +6,7 @@ import * as blobs from '@shm/shared/blobs'
 import {SEED_AGENT_SERVER_URL} from '@shm/shared/constants'
 import type {NavRoute} from '@shm/shared/routes'
 import type {NavMode} from '@shm/shared/utils/navigation'
-import {sendAgentAction} from '@shm/ui/agents/client'
-import {setAgentsPlatform} from '@shm/ui/agents/platform'
+import {setAgentsPlatform, type AgentsSignerDelegation} from '@shm/ui/agents/platform'
 import React, {useCallback} from 'react'
 
 /**
@@ -15,9 +14,9 @@ import React, {useCallback} from 'react'
  *
  * Signing uses the local web identity (non-extractable WebCrypto Ed25519 device key in IndexedDB).
  * When the vault delegated an account to this device key, the device signs envelopes *as that
- * account* — so web and desktop see the same agents — and {@link registerWebSigner} proves the
- * delegation to each agent server with the vault-issued Capability blob. Without a delegation the
- * device key is its own account, as before.
+ * account* — so web and desktop see the same agents — and {@link getWebAgentsDelegation} names the
+ * vault-issued Capability in every envelope so any agent server can verify the delegation itself.
+ * Without a delegation the device key is its own account, as before.
  */
 async function getWebAgentsSigner(accountUid: string): Promise<blobs.Signer> {
   const stored = await getStoredLocalKeys()
@@ -33,32 +32,19 @@ async function getWebAgentsSigner(accountUid: string): Promise<blobs.Signer> {
 }
 
 /**
- * Proves this device key's delegation to an agent server (see the platform seam's registerSigner).
+ * The vault-issued delegation this device key holds for `accountUid` (see the platform seam's
+ * getDelegation).
  *
- * Sends a self-signed RegisterSigner action carrying the vault-issued Capability blob. The bytes
- * are stored at sign-in; sessions delegated before that was stored fall back to fetching the
- * published blob by CID through this site's own IPFS proxy.
+ * The CID has been stored at sign-in since web auth shipped; the blob bytes only since agents
+ * came to web, so older sessions hand out the CID alone and the agent server fetches the published
+ * blob from its own HM node. Nothing here touches the network.
  */
-async function registerWebSigner(serverUrl: string): Promise<void> {
+async function getWebAgentsDelegation(accountUid: string): Promise<AgentsSignerDelegation | null> {
   const stored = await getStoredLocalKeys()
-  if (!stored?.delegatedAccountUid) {
-    throw new Error('No account delegation is available for this web identity')
+  if (!stored?.delegatedAccountUid || stored.delegatedAccountUid !== accountUid || !stored.capabilityCid) {
+    return null
   }
-  let capability = stored.capabilityBlob ?? null
-  if (!capability && stored.capabilityCid) {
-    const res = await fetch(`/hm/api/file/${stored.capabilityCid}`)
-    if (res.ok) capability = new Uint8Array(await res.arrayBuffer())
-  }
-  if (!capability) {
-    throw new Error('The delegation capability for this web identity is not available')
-  }
-  const rawPublicKey = new Uint8Array(await crypto.subtle.exportKey('raw', stored.keyPair.publicKey))
-  const devicePrincipal = blobs.principalToString(blobs.principalFromEd25519(rawPublicKey))
-  await sendAgentAction({
-    serverUrl,
-    accountUid: devicePrincipal,
-    action: {_: 'RegisterSigner', capability},
-  })
+  return {capabilityCid: stored.capabilityCid, capabilityBlob: stored.capabilityBlob}
 }
 
 const SETTING_STORAGE_PREFIX = 'seed.agents.setting.'
@@ -130,6 +116,7 @@ export function registerWebAgentsPlatform() {
   setAgentsPlatform({
     defaultServerUrl: () => SEED_AGENT_SERVER_URL ?? null,
     getSigner: getWebAgentsSigner,
+    getDelegation: getWebAgentsDelegation,
     getSetting: async (key: string) => {
       if (typeof window === 'undefined') return null
       const raw = window.localStorage.getItem(settingStorageKey(key))
@@ -148,7 +135,6 @@ export function registerWebAgentsPlatform() {
       }
       window.localStorage.setItem(settingStorageKey(key), JSON.stringify(value))
     },
-    registerSigner: registerWebSigner,
     // The vault-delegated account when one exists — the same identity desktop signs as, so both
     // surfaces see the same agents — else the device key is its own account.
     useAccountUid: () => {

--- a/frontend/packages/ui/src/agents/client.ts
+++ b/frontend/packages/ui/src/agents/client.ts
@@ -163,14 +163,27 @@ export function getAgentWebSocketUrl(serverUrl: string): string {
 }
 
 export async function signAgentAction(input: {accountUid: string; action: AgentAction}) {
-  const signer = await getAgentsPlatform().getSigner(input.accountUid)
+  const platform = getAgentsPlatform()
+  const signer = await platform.getSigner(input.accountUid)
   // The account is who the action is for; the signer is who holds the key. They differ on web,
-  // where a delegated device key acts as the vault account (see the platform's registerSigner).
+  // where a delegated device key acts as the vault account: the envelope then names the account's
+  // Capability so the server can verify the delegation itself (see the platform's getDelegation).
+  const delegated = blobs.principalToString(signer.principal) !== input.accountUid
+  const delegation = delegated ? await platform.getDelegation?.(input.accountUid) : null
+  if (delegated && !delegation) {
+    throw new Error('The local key holds no delegation for this account')
+  }
   return blobs.sign(signer, {
     type: 'AgentsAction',
     signer: signer.principal,
     sig: new Uint8Array(blobs.ED25519_SIGNATURE_SIZE),
     account: blobs.principalFromString(input.accountUid),
+    ...(delegation
+      ? {
+          capability: delegation.capabilityCid,
+          ...(delegation.capabilityBlob ? {capabilityBlob: delegation.capabilityBlob} : {}),
+        }
+      : {}),
     action: {...omitUndefined(input.action), ts: Date.now()},
   } as unknown as blobs.Blob)
 }
@@ -190,28 +203,6 @@ function omitUndefined<T>(value: T): T {
 }
 
 export async function sendAgentAction(input: {
-  serverUrl: string
-  accountUid: string
-  action: AgentAction
-}): Promise<AgentsResponse> {
-  try {
-    return await sendSignedAgentAction(input)
-  } catch (error) {
-    // A delegated signer the server has not seen yet is rejected with this exact message. When the
-    // platform can prove the delegation (web holds the vault-issued Capability blob), register it
-    // once and retry, so the same account sees the same agents on every surface.
-    const registerSigner = getAgentsPlatform().registerSigner
-    if (!registerSigner || !isUnauthorizedSignerError(error) || input.action._ === 'RegisterSigner') throw error
-    await registerSigner(input.serverUrl)
-    return await sendSignedAgentAction(input)
-  }
-}
-
-function isUnauthorizedSignerError(error: unknown): boolean {
-  return error instanceof Error && error.message.includes('Signer is not authorized')
-}
-
-async function sendSignedAgentAction(input: {
   serverUrl: string
   accountUid: string
   action: AgentAction

--- a/frontend/packages/ui/src/agents/platform.ts
+++ b/frontend/packages/ui/src/agents/platform.ts
@@ -100,18 +100,27 @@ export type AgentsOAuthRedirectCatcher = {
  * safe to store on a singleton because the platform is registered once at app startup, before any
  * agents UI renders, and never swapped afterwards.
  */
+/** A published Capability by which an account delegated agent actions to the platform's signing key. */
+export type AgentsSignerDelegation = {
+  /** CID of the Capability blob (the account's signature over the delegation). */
+  capabilityCid: string
+  /** The blob's raw bytes when the platform holds them, so servers need not fetch them. */
+  capabilityBlob?: Uint8Array
+}
+
 export type AgentsPlatform = {
   /** Built-in default agent server URL for this runtime, or null when there is none. */
   defaultServerUrl: () => string | null
   /** Returns a signer whose principal is the given account, used to sign agent actions. */
   getSigner: (accountUid: string) => Promise<blobs.Signer>
   /**
-   * Proves a delegated signer to an agent server so it accepts envelopes whose account differs
-   * from the signing key (web: the vault account delegated to the local device key). Called once
-   * per server when it rejects the signer as unauthorized; omitted on platforms whose signing key
-   * is the account itself (desktop's daemon signing).
+   * The delegation by which {@link getSigner}'s key acts for `accountUid` when it is not that
+   * account's own key (web: the vault account delegated to the local device key). It rides inside
+   * every signed envelope so any agent server can verify it without prior registration. Omitted
+   * on platforms whose signing key is the account itself (desktop's daemon signing); returning
+   * null means the key holds no delegation for that account.
    */
-  registerSigner?: (serverUrl: string) => Promise<void>
+  getDelegation?: (accountUid: string) => Promise<AgentsSignerDelegation | null>
   /** Reads one persisted agents setting (JSON-compatible value) by key. */
   getSetting: (key: string) => Promise<unknown>
   /** Persists one agents setting (JSON-compatible value) by key. */


### PR DESCRIPTION
## Why

Web agents (shipped in 2026.8.8 via #958) sign with a device key acting *as* the vault account. The server learned about that delegation through a one-time `RegisterSigner` action: first rejection as unauthorized → client pushes the Capability blob → retry. That is per-server state with no revocation path, and it only works if the browser holds the blob bytes.

On production it fails for every session delegated before Aug 20 (no stored blob): the fallback fetch through `/hm/api/file/<cid>` returns 500 whenever the daemon rejects the visitor's auth cookie (the loader forwards it as `Bearer`, and the daemon 401s any invalid token even for public blobs). Result: **"The delegation capability for this web identity is not available"**, and only 3 web signers ever registered on `agentic.seed.hyper.media`.

## What

Reference the capability the way the rest of Seed already does — by CID — and let the server resolve it.

- **Protocol**: `SignedActionEnvelope` gains `capability?: string` (CID of the account's Capability blob) and optional inline `capabilityBlob?: Uint8Array`. Both sit inside the signed payload. `RegisterSigner` is marked deprecated but still accepted for one release.
- **Server** (`agents/src/auth.ts`): `verifyEnvelope` is async. For `signer ≠ account` it resolves the blob from the envelope, from an already-verified delegation, or from its HM node via `${ipfsServerUrl}/ipfs/<cid>` (verified working against hyper.media), then checks blob signature, `delegate == signer`, `issuer == account`, role (AGENT/WRITER), not self-issued, and that the bytes hash to the named CID. Verified delegations are cached in `account_authorizations` (new `capability_cid` column, migration + baseline schema). The fetcher is injectable for tests.
- **Client** (`@shm/ui/agents`): `signAgentAction` attaches the delegation from a new platform hook `getDelegation(accountUid)`; the reject-and-retry dance and `registerSigner` seam are gone.
- **Web**: hands out `{capabilityCid, capabilityBlob?}` straight from IndexedDB — no network call from the browser. Desktop needs nothing (its signer is the account).

## Compatibility / rollout

- Old web client (2026.8.8) + new server: still works via `RegisterSigner`.
- New web client + old server: delegated envelopes are rejected ("Signer is not authorized"). **Deploy the agents server before the web release** (agents-stable auto-deploys on image push).
- Existing `account_authorizations` rows stay valid.

## Tests

- `agents`: `bun test src/auth.test.ts src/api-service.test.ts src/main.test.ts` — 125 pass. New coverage: inline bytes, CID-only with fetch (and no re-fetch once cached), unavailable/failed fetch, wrong-blob-for-CID, capability issued by a different account, replay by a non-delegate key, capability reference covered by the envelope signature, malformed CID; legacy RegisterSigner suite kept.
- `web`: `vitest app/__tests__/web-agents-platform.test.ts` — 17 pass.
- Typecheck: ui, web, desktop clean. (`agents` typecheck has one pre-existing error at `api-service.test.ts:5203` on `main`, unrelated.)

## Not in this PR

- `/hm/api/file` (and likely `/hm/api/image`) should retry without `Authorization` when the daemon rejects the cookie — public blobs should never depend on cookie validity. Separate fix.
- `agents/docs/roadmap.md` §2 / `future-projects.md` still describe delegated signers as future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3qMAzkS2n5WXESGxVy1Wi
