### PR TITLE
Agents: public chat toggle for publicly readable agents

### DIFF
--- a/agents/docs/readme.md
+++ b/agents/docs/readme.md
@@ -33,7 +33,8 @@ Completed and usable locally:
 - encrypted secrets and redacted provider/secret responses;
 - model-provider CRUD, provider listing, and provider-backed model listing for model dropdowns;
 - agent CRUD and session CRUD, including inline session-title editing;
-- pending agent invitations plus accepted reader/writer collaborators, with agent-wide read/write enforcement;
+- pending agent invitations plus accepted reader/writer collaborators, with agent-wide read/write enforcement, plus
+  owner-set public read and public chat flags (any signed account can view, or view and message, the agent by id);
 - durable session event replay;
 - schedule triggers for interval, weekly, and one-time proactive sessions;
 - Pi SDK-backed chat execution;

--- a/agents/docs/security.md
+++ b/agents/docs/security.md
@@ -49,6 +49,11 @@ Seed account, first as a pending invitation and then as an accepted `reader` or 
   runs;
 - writers can additionally mutate agent-scoped state and interact with sessions;
 - only the owner can invite/revoke members or delete the agent;
+- two owner-set agent flags open the agent beyond membership: `public_read` makes every signed account a reader by agent
+  id, and `public_chat` (only settable while `public_read` is on; cleared with it) promotes those public readers to
+  `chatter` — they may create, message, attach to, and stop sessions, but every writer-level action (agent, memory,
+  tool, and trigger edits; session rename/delete; `InvokeSessionTool`; run cancel/signal) is still refused. Public chat
+  is the intended way to expose an agent to the world; `writer` is for people trusted to reshape it;
 - provider, secret, OAuth, and signing-identity mutations remain scoped to the collaborator's own account. Optional
   `agentId` on provider/identity list actions exposes only the owner's redacted records needed to render/edit that
   shared agent.

--- a/agents/docs/signed-api.md
+++ b/agents/docs/signed-api.md
@@ -72,6 +72,7 @@ Current `AgentAction` union (`UnsignedAgentAction` in `agents/protocol/src/index
 - `InviteAgentCollaborator`
 - `RemoveAgentCollaborator`
 - `SetAgentPublicRead`
+- `SetAgentPublicChat`
 - `AcceptAgentInvite`
 - `DeclineAgentInvite`
 - `CreateAgent`
@@ -159,15 +160,15 @@ Response:
 ```
 
 Lists agents owned by the verified account plus agents on which it is an accepted reader or writer, ordered by update
-time descending. Each `AgentInfo.accessRole` is `owner`, `reader`, or `writer`; pending invitations are deliberately not
-returned here.
+time descending. Each `AgentInfo.accessRole` is `owner`, `reader`, or `writer` (an agent read through public access
+reports `reader`, or `chatter` when public chat is on); pending invitations are deliberately not returned here.
 
 ### Agent invitations and collaborators
 
 - `ListAgentInvites {}` returns pending `AgentInviteInfo` rows for the signed account. An invite discloses only the
   agent id/name, owner account, role, and timestamps; agent contents remain unavailable until acceptance.
-- `ListAgentCollaborators {agentId}` returns the owner and accepted members plus the agent's `publicRead` flag. The
-  owner also sees pending invitations.
+- `ListAgentCollaborators {agentId}` returns the owner and accepted members plus the agent's `publicRead` and
+  `publicChat` flags. The owner also sees pending invitations.
 - `InviteAgentCollaborator {agentId, accountId, role}` creates an invitation (`reader` or `writer`) or updates an
   existing member's role. Owner-only.
 - `RemoveAgentCollaborator {agentId, accountId}` revokes an accepted member or cancels a pending invitation. Owner-only.
@@ -176,12 +177,20 @@ returned here.
 - `SetAgentPublicRead {agentId, publicRead}` turns public read access on or off. Owner-only. While on, every signed
   account that knows the agent id is treated as a `reader` (the same view an invited reader gets, including live
   subscriptions); the agent is still never returned from `ListAgents` or account-wide `ListSessions` for accounts that
-  are not owner or collaborator. `AgentInfo.publicRead` reports the flag.
+  are not owner or collaborator. `AgentInfo.publicRead` reports the flag. Turning it off also clears `publicChat`.
+- `SetAgentPublicChat {agentId, publicChat}` turns public chat on or off. Owner-only, and enabling requires `publicRead`
+  to already be on (400 otherwise). While on, every signed account that reads the agent publicly is a `chatter`: it may
+  `CreateSession`, `MessageSession`, `UploadSessionAttachment` (and the chunked-upload actions targeting a session),
+  `StopSession`, and `RetrySession` on any of the agent's sessions. It still cannot do anything writer-level —
+  `UpdateAgent`, memory/tool/trigger writes, `UpdateSession`, `DeleteSession`, `InvokeSessionTool`, `CancelRun`,
+  `SignalRun`. `AgentInfo.publicChat` reports the flag. This is deliberately narrower than inviting a `writer`: public
+  chat lets the world talk to the agent, not reshape it.
 
-Readers can inspect all agent-scoped state. Writers can additionally create/update/delete agent-scoped resources and
-interact with sessions. Managing collaborators and deleting the agent remain owner-only. Account-scoped provider and
-secret mutations are never inherited from an agent collaboration; agent settings may list the owner's redacted
-providers/signing identities through optional `agentId` fields.
+Readers can inspect all agent-scoped state. Chatters (public chat only; not an invitable role) can additionally create,
+message, and stop sessions. Writers can additionally create/update/delete agent-scoped resources, rename/delete
+sessions, control runs, and run session tools. Managing collaborators and deleting the agent remain owner-only.
+Account-scoped provider and secret mutations are never inherited from an agent collaboration; agent settings may list
+the owner's redacted providers/signing identities through optional `agentId` fields.
 
 ### `CreateAgent`
 

--- a/agents/protocol/src/index.ts
+++ b/agents/protocol/src/index.ts
@@ -160,6 +160,7 @@ export type UnsignedAgentAction =
   | InviteAgentCollaborator
   | RemoveAgentCollaborator
   | SetAgentPublicRead
+  | SetAgentPublicChat
   | AcceptAgentInvite
   | DeclineAgentInvite
   | CreateAgent
@@ -269,6 +270,19 @@ export type SetAgentPublicRead = {
   _: 'SetAgentPublicRead'
   agentId: string
   publicRead: boolean
+}
+
+/**
+ * Turns public chat on or off for one owned agent that already has public read access. When on,
+ * any signed account that can read the agent publicly is a `chatter`: it can create sessions,
+ * message them, attach files, and stop/retry turns, but cannot change the agent, its memory, tools,
+ * or triggers, rename or delete sessions, or run session tools. Enabling requires `publicRead`;
+ * turning public read off clears this flag.
+ */
+export type SetAgentPublicChat = {
+  _: 'SetAgentPublicChat'
+  agentId: string
+  publicChat: boolean
 }
 
 /** Revokes an accepted collaborator or cancels a pending invitation. */
@@ -914,7 +928,11 @@ export type ModelProviderConfig = {
 export type AgentCollaboratorRole = 'reader' | 'writer'
 
 /** The signed account's relationship to an agent. */
-export type AgentAccessRole = 'owner' | AgentCollaboratorRole
+/**
+ * What the requesting account may do with an agent. `owner`/`writer`/`reader` are memberships;
+ * `chatter` is a public reader on an agent with public chat enabled (see `SetAgentPublicChat`).
+ */
+export type AgentAccessRole = 'owner' | AgentCollaboratorRole | 'chatter'
 
 /** One owner, accepted collaborator, or pending invitation on an agent. */
 export type AgentCollaboratorInfo = {
@@ -948,6 +966,8 @@ export type AgentInfo = {
   accessRole?: AgentAccessRole
   /** True when any signed account can read this agent by id (see `SetAgentPublicRead`). */
   publicRead?: boolean
+  /** True when any signed account can also create and message sessions (see `SetAgentPublicChat`). */
+  publicChat?: boolean
 }
 
 /** Public metadata returned for an agent trigger. */
@@ -1393,6 +1413,8 @@ export type ListAgentCollaboratorsResponse = {
   _: 'ListAgentCollaboratorsResponse'
   /** Whether the agent is readable by every signed account (see `SetAgentPublicRead`). */
   publicRead: boolean
+  /** Whether every signed account may also chat with the agent (see `SetAgentPublicChat`). */
+  publicChat: boolean
   agentId: string
   collaborators: AgentCollaboratorInfo[]
 }
@@ -1406,6 +1428,12 @@ export type InviteAgentCollaboratorResponse = {
 /** Successful response for `SetAgentPublicRead`. */
 export type SetAgentPublicReadResponse = {
   _: 'SetAgentPublicReadResponse'
+  agent: AgentInfo
+}
+
+/** Successful response for `SetAgentPublicChat`. */
+export type SetAgentPublicChatResponse = {
+  _: 'SetAgentPublicChatResponse'
   agent: AgentInfo
 }
 
@@ -1837,6 +1865,7 @@ export type AgentResponse =
   | InviteAgentCollaboratorResponse
   | RemoveAgentCollaboratorResponse
   | SetAgentPublicReadResponse
+  | SetAgentPublicChatResponse
   | AcceptAgentInviteResponse
   | DeclineAgentInviteResponse
   | ListModelProvidersResponse

--- a/agents/src/api-service.test.ts
+++ b/agents/src/api-service.test.ts
@@ -353,7 +353,7 @@ describe('api service', () => {
       ).rejects.toThrow('Write access is required')
       await expect(
         svc.message(await apisvc.createSignedEnvelope(stranger, {action: {_: 'CreateSession', agentId}})),
-      ).rejects.toThrow('Write access is required')
+      ).rejects.toThrow('Chat access is required')
       await expect(
         svc.message(await apisvc.createSignedEnvelope(stranger, {action: {_: 'DeleteAgent', agentId}})),
       ).rejects.toThrow('Only the agent owner can do this')
@@ -395,6 +395,180 @@ describe('api service', () => {
         ),
       ).rejects.toThrow('Agent not found')
     } finally {
+      db.close()
+      cleanup()
+    }
+  })
+
+  test('public chat lets any signed account create and message sessions without editing the agent', async () => {
+    const {db, dataDir, cleanup} = createTestState()
+    const originalFetch = globalThis.fetch
+    const svc = new apisvc.Service(db, dataDir)
+    try {
+      const owner = blobs.generateNobleKeyPair()
+      const ownerAccountId = blobs.principalToString(owner.principal)
+      const stranger = blobs.generateNobleKeyPair()
+      const strangerAccountId = blobs.principalToString(stranger.principal)
+      await svc.message(
+        await apisvc.createSignedEnvelope(owner, {
+          action: {_: 'SetSecret', name: 'openai-key', value: new TextEncoder().encode('sk-test')},
+        }),
+      )
+      await svc.message(
+        await apisvc.createSignedEnvelope(owner, {
+          action: {
+            _: 'SetModelProvider',
+            name: 'openai',
+            provider: {type: 'openai', secretRefs: {apiKey: 'openai-key'}},
+          },
+        }),
+      )
+      const created = await svc.message(
+        await apisvc.createSignedEnvelope(owner, {
+          action: {
+            _: 'CreateAgent',
+            definition: {name: 'Chatty Agent', systemPrompt: 'Be open.', modelProvider: 'openai', model: 'gpt'},
+          },
+        }),
+      )
+      if (created._ !== 'CreateAgentResponse') throw new Error('unexpected response')
+      const agentId = created.agentId
+
+      // Chat rides on top of public read: it cannot be enabled on a private agent.
+      await expect(
+        svc.message(
+          await apisvc.createSignedEnvelope(owner, {action: {_: 'SetAgentPublicChat', agentId, publicChat: true}}),
+        ),
+      ).rejects.toThrow('Enable public access before enabling public chat')
+      await svc.message(
+        await apisvc.createSignedEnvelope(owner, {action: {_: 'SetAgentPublicRead', agentId, publicRead: true}}),
+      )
+
+      // A public reader cannot chat yet, and cannot flip the flag either.
+      await expect(
+        svc.message(await apisvc.createSignedEnvelope(stranger, {action: {_: 'CreateSession', agentId}})),
+      ).rejects.toThrow('Chat access is required')
+      await expect(
+        svc.message(
+          await apisvc.createSignedEnvelope(stranger, {action: {_: 'SetAgentPublicChat', agentId, publicChat: true}}),
+        ),
+      ).rejects.toThrow('Only the agent owner can do this')
+
+      const enabled = await svc.message(
+        await apisvc.createSignedEnvelope(owner, {action: {_: 'SetAgentPublicChat', agentId, publicChat: true}}),
+      )
+      expect(enabled).toMatchObject({
+        _: 'SetAgentPublicChatResponse',
+        agent: {id: agentId, publicRead: true, publicChat: true, accessRole: 'owner'},
+      })
+      const collaborators = await svc.message(
+        await apisvc.createSignedEnvelope(stranger, {action: {_: 'ListAgentCollaborators', agentId}}),
+      )
+      expect(collaborators).toMatchObject({
+        _: 'ListAgentCollaboratorsResponse',
+        publicRead: true,
+        publicChat: true,
+        collaborators: [{accountId: ownerAccountId, role: 'owner'}],
+      })
+
+      // The stranger is now a chatter: it can open a session and talk to the agent...
+      const read = await svc.message(await apisvc.createSignedEnvelope(stranger, {action: {_: 'GetAgent', agentId}}))
+      expect(read).toMatchObject({
+        _: 'GetAgentResponse',
+        agent: {id: agentId, accessRole: 'chatter', publicRead: true, publicChat: true},
+      })
+      const session = await svc.message(
+        await apisvc.createSignedEnvelope(stranger, {action: {_: 'CreateSession', agentId}}),
+      )
+      if (session._ !== 'CreateSessionResponse') throw new Error('unexpected response')
+      const requestBodies: string[] = []
+      globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+        const href = String(url)
+        if (href.includes('/api/Account')) {
+          const accountId = href.includes(ownerAccountId) ? ownerAccountId : strangerAccountId
+          return Response.json(
+            serialize({
+              type: 'account',
+              id: unpackHmId(`hm://${accountId}`),
+              metadata: {name: accountId === ownerAccountId ? 'Olivia Owner' : 'Sam Stranger'},
+            }),
+          )
+        }
+        requestBodies.push(String(init?.body))
+        return openAIStreamResponse([
+          {id: 'chat-1', choices: [{delta: {content: 'Hello stranger'}}]},
+          {id: 'chat-1', choices: [{delta: {}, finish_reason: 'stop'}], usage: openAIUsage()},
+        ])
+      }) as unknown as typeof fetch
+      const turn = await svc.message(
+        await apisvc.createSignedEnvelope(stranger, {
+          action: {
+            _: 'MessageSession',
+            sessionId: session.sessionId,
+            content: [{type: 'text', text: 'Hi from the public'}],
+          },
+        }),
+      )
+      expect(turn).toMatchObject({_: 'MessageSessionResponse'})
+      await svc.awaitQueueIdle()
+      expect(requestBodies).toHaveLength(1)
+      expect(requestBodies[0]).toContain('Hi from the public')
+      await expect(
+        svc.message(
+          await apisvc.createSignedEnvelope(stranger, {action: {_: 'StopSession', sessionId: session.sessionId}}),
+        ),
+      ).resolves.toMatchObject({_: 'StopSessionResponse'})
+
+      // ...but nothing that edits the agent or its sessions beyond talking.
+      await expect(
+        svc.message(
+          await apisvc.createSignedEnvelope(stranger, {
+            action: {_: 'WriteAgentMemoryFile', agentId, path: 'x.txt', content: 'no'},
+          }),
+        ),
+      ).rejects.toThrow('Write access is required')
+      await expect(
+        svc.message(
+          await apisvc.createSignedEnvelope(stranger, {
+            action: {_: 'UpdateSession', sessionId: session.sessionId, title: 'Renamed'},
+          }),
+        ),
+      ).rejects.toThrow('Write access is required')
+      await expect(
+        svc.message(
+          await apisvc.createSignedEnvelope(stranger, {
+            action: {
+              _: 'InvokeSessionTool',
+              sessionId: session.sessionId,
+              verb: 'read',
+              input: {address: '~/memory/x.txt'},
+            },
+          }),
+        ),
+      ).rejects.toThrow('Write access is required')
+      await expect(
+        svc.message(
+          await apisvc.createSignedEnvelope(stranger, {action: {_: 'DeleteSession', sessionId: session.sessionId}}),
+        ),
+      ).rejects.toThrow('Write access is required')
+
+      // Closing public read closes chat with it; re-opening read does not silently re-open chat.
+      await svc.message(
+        await apisvc.createSignedEnvelope(owner, {action: {_: 'SetAgentPublicRead', agentId, publicRead: false}}),
+      )
+      await expect(
+        svc.message(await apisvc.createSignedEnvelope(stranger, {action: {_: 'GetAgent', agentId}})),
+      ).rejects.toThrow('Agent not found')
+      const reopened = await svc.message(
+        await apisvc.createSignedEnvelope(owner, {action: {_: 'SetAgentPublicRead', agentId, publicRead: true}}),
+      )
+      expect(reopened).toMatchObject({agent: {publicRead: true, publicChat: false}})
+      await expect(
+        svc.message(await apisvc.createSignedEnvelope(stranger, {action: {_: 'CreateSession', agentId}})),
+      ).rejects.toThrow('Chat access is required')
+    } finally {
+      globalThis.fetch = originalFetch
+      svc.stopRunQueue()
       db.close()
       cleanup()
     }

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -774,6 +774,8 @@ export class Service {
         return this.#removeAgentCollaborator(verified.accountId, envelope.action.agentId, envelope.action.accountId)
       case 'SetAgentPublicRead':
         return this.#setAgentPublicRead(verified.accountId, envelope.action.agentId, envelope.action.publicRead)
+      case 'SetAgentPublicChat':
+        return this.#setAgentPublicChat(verified.accountId, envelope.action.agentId, envelope.action.publicChat)
       case 'AcceptAgentInvite':
         return this.#acceptAgentInvite(verified.accountId, envelope.action.agentId)
       case 'DeclineAgentInvite':
@@ -969,52 +971,58 @@ export class Service {
     }
   }
 
-  /** Resolves an agent-scoped action to the owning account and enforces read/write access once. */
+  /**
+   * Resolves an agent-scoped action to the owning account and enforces access once. Three levels:
+   * `reader` (inspect), `chat` (create/message/stop sessions — what public chat grants), and
+   * `writer` (everything else that mutates agent-scoped state, including session tools, renames,
+   * deletes, and run control).
+   */
   #actionAccountId(actorAccountId: string, action: api.UnsignedAgentAction): string {
-    const fromAgent = (agentId: string, write = false) =>
-      this.#requireAgentAccess(actorAccountId, agentId, write ? 'writer' : 'reader').ownerAccountId
-    const fromSession = (sessionId: string, write = false) => {
+    const fromAgent = (agentId: string, level: AgentAccessLevel = 'reader') =>
+      this.#requireAgentAccess(actorAccountId, agentId, level).ownerAccountId
+    const fromSession = (sessionId: string, level: AgentAccessLevel = 'reader') => {
       const row = this.#db
         .query<{agent_id: string}, [string]>(`SELECT agent_id FROM sessions WHERE id = ?`)
         .get(sessionId)
       if (!row) throw new APIError(404, 'Session not found')
       try {
-        return fromAgent(row.agent_id, write)
+        return fromAgent(row.agent_id, level)
       } catch (error) {
         if (error instanceof APIError && error.status === 404) throw new APIError(404, 'Session not found')
         throw error
       }
     }
-    const fromTrigger = (triggerId: string, write = false) => {
+    const fromTrigger = (triggerId: string, level: AgentAccessLevel = 'reader') => {
       const row = this.#db
         .query<{agent_id: string}, [string]>(`SELECT agent_id FROM agent_triggers WHERE id = ?`)
         .get(triggerId)
       if (!row) throw new APIError(404, 'Agent trigger not found')
       try {
-        return fromAgent(row.agent_id, write)
+        return fromAgent(row.agent_id, level)
       } catch (error) {
         if (error instanceof APIError && error.status === 404) throw new APIError(404, 'Agent trigger not found')
         throw error
       }
     }
-    const fromRun = (runId: string, write = false) => {
+    const fromRun = (runId: string, level: AgentAccessLevel = 'reader') => {
       const row = this.#db
         .query<{agent_id: string | null}, [string]>(`SELECT agent_id FROM runs WHERE id = ?`)
         .get(runId)
       if (!row?.agent_id) throw new APIError(404, 'Run not found')
       try {
-        return fromAgent(row.agent_id, write)
+        return fromAgent(row.agent_id, level)
       } catch (error) {
         if (error instanceof APIError && error.status === 404) throw new APIError(404, 'Run not found')
         throw error
       }
     }
-    const fromUpload = (uploadId: string, write = false) => {
+    // Memory uploads change agent state (writer); session attachments are part of chatting.
+    const fromUpload = (uploadId: string) => {
       const upload = this.#uploads.get(uploadId)
       if (!upload) throw new APIError(404, 'Upload not found')
       return upload.target.kind === 'memory'
-        ? fromAgent(upload.target.agentId, write)
-        : fromSession(upload.target.sessionId, write)
+        ? fromAgent(upload.target.agentId, 'writer')
+        : fromSession(upload.target.sessionId, 'chat')
     }
 
     switch (action._) {
@@ -1036,15 +1044,16 @@ export class Service {
       case 'DownloadAgentMemoryFile':
       case 'UploadAgentMemoryFileToIpfs':
       case 'CreateAgentTrigger':
+        return fromAgent(action.agentId, 'writer')
       case 'CreateSession':
-        return fromAgent(action.agentId, true)
+        return fromAgent(action.agentId, 'chat')
       case 'DeleteAgent':
         return this.#requireAgentAccess(actorAccountId, action.agentId, 'owner').ownerAccountId
       case 'GetAgentTrigger':
         return fromTrigger(action.triggerId)
       case 'UpdateAgentTrigger':
       case 'DeleteAgentTrigger':
-        return fromTrigger(action.triggerId, true)
+        return fromTrigger(action.triggerId, 'writer')
       case 'ListSessions':
         if (action.agentId) return fromAgent(action.agentId)
         if (action.parentSessionId) return fromSession(action.parentSessionId)
@@ -1054,20 +1063,21 @@ export class Service {
         return fromSession(action.sessionId)
       case 'UpdateSession':
       case 'DeleteSession':
-      case 'MessageSession':
       case 'InvokeSessionTool':
+        return fromSession(action.sessionId, 'writer')
+      case 'MessageSession':
       case 'UploadSessionAttachment':
       case 'StopSession':
       case 'RetrySession':
-        return fromSession(action.sessionId, true)
+        return fromSession(action.sessionId, 'chat')
       case 'BeginFileUpload':
         return action.target.kind === 'memory'
-          ? fromAgent(action.target.agentId, true)
-          : fromSession(action.target.sessionId, true)
+          ? fromAgent(action.target.agentId, 'writer')
+          : fromSession(action.target.sessionId, 'chat')
       case 'AppendFileUploadChunk':
       case 'CommitFileUpload':
       case 'AbortFileUpload':
-        return fromUpload(action.uploadId, true)
+        return fromUpload(action.uploadId)
       case 'GetRun':
       case 'GetRunJournal':
         return fromRun(action.runId)
@@ -1078,7 +1088,7 @@ export class Service {
         return actorAccountId
       case 'CancelRun':
       case 'SignalRun':
-        return fromRun(action.runId, true)
+        return fromRun(action.runId, 'writer')
       default:
         return actorAccountId
     }
@@ -1086,21 +1096,27 @@ export class Service {
 
   /**
    * Resolves the actor's role on an agent. Owners and accepted collaborators get their membership
-   * role; when the agent has public read enabled, every other signed account is a `reader` and
-   * `viaPublic` is set so callers can tell membership from public access. Agents the actor cannot
-   * access look identical to missing ones (404).
+   * role; when the agent has public read enabled, every other signed account is a `reader` (or a
+   * `chatter` when public chat is on too) and `viaPublic` is set so callers can tell membership
+   * from public access. Agents the actor cannot access look identical to missing ones (404).
    */
   #requireAgentAccess(
     actorAccountId: string,
     agentId: string,
-    required: 'reader' | 'writer' | 'owner',
+    required: AgentAccessLevel | 'owner',
   ): {ownerAccountId: string; role: api.AgentAccessRole; viaPublic: boolean} {
     const row = this.#db
       .query<
-        {owner_account_id: string; public_read: number; role: string | null; status: string | null},
+        {
+          owner_account_id: string
+          public_read: number
+          public_chat: number
+          role: string | null
+          status: string | null
+        },
         [string, string]
       >(
-        `SELECT a.account_id AS owner_account_id, a.public_read, c.role, c.status
+        `SELECT a.account_id AS owner_account_id, a.public_read, a.public_chat, c.role, c.status
          FROM agents a
          LEFT JOIN agent_collaborators c ON c.agent_id = a.id AND c.account_id = ?
          WHERE a.id = ?`,
@@ -1114,13 +1130,16 @@ export class Service {
     } else if (row.status === 'accepted' && (row.role === 'reader' || row.role === 'writer')) {
       role = row.role
     } else if (row.public_read === 1) {
-      role = 'reader'
+      role = row.public_chat === 1 ? 'chatter' : 'reader'
       viaPublic = true
     } else {
       throw new APIError(404, 'Agent not found')
     }
     if (required === 'owner' && role !== 'owner') throw new APIError(403, 'Only the agent owner can do this')
-    if (required === 'writer' && role === 'reader') throw new APIError(403, 'Write access is required')
+    if (required === 'writer' && (role === 'reader' || role === 'chatter')) {
+      throw new APIError(403, 'Write access is required')
+    }
+    if (required === 'chat' && role === 'reader') throw new APIError(403, 'Chat access is required')
     return {ownerAccountId: row.owner_account_id, role, viaPublic}
   }
 
@@ -1138,7 +1157,7 @@ export class Service {
   #listAgents(accountId: string): api.ListAgentsResponse {
     const rows = this.#db
       .query<AgentRow, [string, string, string]>(
-        `SELECT a.id, a.account_id, a.definition_cbor, a.state_dir, a.status, a.public_read, a.created_at, a.updated_at,
+        `SELECT a.id, a.account_id, a.definition_cbor, a.state_dir, a.status, a.public_read, a.public_chat, a.created_at, a.updated_at,
                 CASE WHEN a.account_id = ? THEN 'owner' ELSE c.role END AS access_role
          FROM agents a
          LEFT JOIN agent_collaborators c ON c.agent_id = a.id AND c.account_id = ? AND c.status = 'accepted'
@@ -1189,8 +1208,8 @@ export class Service {
   #listAgentCollaborators(accountId: string, agentId: string): api.ListAgentCollaboratorsResponse {
     const access = this.#requireAgentAccess(accountId, agentId, 'reader')
     const owner = this.#db
-      .query<{created_at: number; updated_at: number; public_read: number}, [string]>(
-        `SELECT created_at, updated_at, public_read FROM agents WHERE id = ?`,
+      .query<{created_at: number; updated_at: number; public_read: number; public_chat: number}, [string]>(
+        `SELECT created_at, updated_at, public_read, public_chat FROM agents WHERE id = ?`,
       )
       .get(agentId)
     if (!owner) throw new APIError(404, 'Agent not found')
@@ -1213,6 +1232,7 @@ export class Service {
       _: 'ListAgentCollaboratorsResponse',
       agentId,
       publicRead: owner.public_read === 1,
+      publicChat: owner.public_chat === 1,
       collaborators: [
         {
           accountId: access.ownerAccountId,
@@ -1237,16 +1257,40 @@ export class Service {
   #setAgentPublicRead(accountId: string, agentId: string, publicRead: unknown): api.SetAgentPublicReadResponse {
     if (typeof publicRead !== 'boolean') throw new APIError(400, 'publicRead must be a boolean')
     this.#requireAgentAccess(accountId, agentId, 'owner')
-    this.#db.run(`UPDATE agents SET public_read = ?, updated_at = ? WHERE id = ?`, [
-      publicRead ? 1 : 0,
+    // Public chat only exists on top of public read, so closing the agent closes chat with it.
+    this.#db.run(
+      publicRead
+        ? `UPDATE agents SET public_read = 1, updated_at = ? WHERE id = ?`
+        : `UPDATE agents SET public_read = 0, public_chat = 0, updated_at = ? WHERE id = ?`,
+      [Date.now(), agentId],
+    )
+    return {_: 'SetAgentPublicReadResponse', agent: this.#emitPublicAccessChange(accountId, agentId)}
+  }
+
+  #setAgentPublicChat(accountId: string, agentId: string, publicChat: unknown): api.SetAgentPublicChatResponse {
+    if (typeof publicChat !== 'boolean') throw new APIError(400, 'publicChat must be a boolean')
+    this.#requireAgentAccess(accountId, agentId, 'owner')
+    if (publicChat) {
+      const row = this.#db
+        .query<{public_read: number}, [string]>(`SELECT public_read FROM agents WHERE id = ?`)
+        .get(agentId)
+      if (row?.public_read !== 1) throw new APIError(400, 'Enable public access before enabling public chat')
+    }
+    this.#db.run(`UPDATE agents SET public_chat = ?, updated_at = ? WHERE id = ?`, [
+      publicChat ? 1 : 0,
       Date.now(),
       agentId,
     ])
+    return {_: 'SetAgentPublicChatResponse', agent: this.#emitPublicAccessChange(accountId, agentId)}
+  }
+
+  /** Re-reads an agent after a public-access flag changed and notifies the owner and members. */
+  #emitPublicAccessChange(accountId: string, agentId: string): api.AgentInfo {
     const agent = this.#getAgentInfo(accountId, agentId)
     if (!agent) throw new APIError(404, 'Agent not found')
     this.#emit({type: 'agent-change', accountId, agent})
     this.#emit({type: 'account-change', accountId, reason: 'agent-collaborators-changed', agentId})
-    return {_: 'SetAgentPublicReadResponse', agent}
+    return agent
   }
 
   #inviteAgentCollaborator(
@@ -2062,7 +2106,7 @@ export class Service {
   #getAgent(accountId: string, agentId: string, viewerAccountId = accountId): api.GetAgentResponse {
     const agent = this.#db
       .query<AgentRow, [string, string]>(
-        `SELECT id, account_id, definition_cbor, state_dir, status, public_read, created_at, updated_at
+        `SELECT id, account_id, definition_cbor, state_dir, status, public_read, public_chat, created_at, updated_at
          FROM agents WHERE account_id = ? AND id = ?`,
       )
       .get(accountId, agentId)
@@ -3250,7 +3294,7 @@ export class Service {
     }
     const agent = this.#db
       .query<AgentRow, [string, string]>(
-        `SELECT id, account_id, definition_cbor, state_dir, status, public_read, created_at, updated_at
+        `SELECT id, account_id, definition_cbor, state_dir, status, public_read, public_chat, created_at, updated_at
          FROM agents WHERE account_id = ? AND id = ?`,
       )
       .get(accountId, session.agentId)
@@ -3426,7 +3470,7 @@ export class Service {
 
     const agent = this.#db
       .query<AgentRow, [string, string]>(
-        `SELECT id, account_id, definition_cbor, state_dir, status, public_read, created_at, updated_at
+        `SELECT id, account_id, definition_cbor, state_dir, status, public_read, public_chat, created_at, updated_at
          FROM agents WHERE account_id = ? AND id = ?`,
       )
       .get(accountId, session.agent_id)
@@ -3559,7 +3603,7 @@ export class Service {
     const sessionId = run.sessionId
     const agent = this.#db
       .query<AgentRow, [string, string]>(
-        `SELECT id, account_id, definition_cbor, state_dir, status, public_read, created_at, updated_at
+        `SELECT id, account_id, definition_cbor, state_dir, status, public_read, public_chat, created_at, updated_at
          FROM agents WHERE account_id = ? AND id = ?`,
       )
       .get(run.accountId, run.agentId)
@@ -3872,7 +3916,7 @@ export class Service {
     if (!session) return
     const agent = this.#db
       .query<AgentRow, [string, string]>(
-        `SELECT id, account_id, definition_cbor, state_dir, status, public_read, created_at, updated_at
+        `SELECT id, account_id, definition_cbor, state_dir, status, public_read, public_chat, created_at, updated_at
          FROM agents WHERE account_id = ? AND id = ?`,
       )
       .get(accountId, session.agent_id)
@@ -4813,7 +4857,7 @@ export class Service {
     }
     const agent = this.#db
       .query<AgentRow, [string, string]>(
-        `SELECT id, account_id, definition_cbor, state_dir, status, public_read, created_at, updated_at
+        `SELECT id, account_id, definition_cbor, state_dir, status, public_read, public_chat, created_at, updated_at
          FROM agents WHERE account_id = ? AND id = ?`,
       )
       .get(run.accountId, run.agentId)
@@ -6233,7 +6277,7 @@ export class Service {
 
     const agent = this.#db
       .query<AgentRow, [string, string]>(
-        `SELECT id, account_id, definition_cbor, state_dir, status, public_read, created_at, updated_at
+        `SELECT id, account_id, definition_cbor, state_dir, status, public_read, public_chat, created_at, updated_at
          FROM agents WHERE account_id = ? AND id = ?`,
       )
       .get(accountId, session.agent_id)
@@ -6355,7 +6399,7 @@ export class Service {
   #getAgentInfo(accountId: string, agentId: string): api.AgentInfo | null {
     const agent = this.#db
       .query<AgentRow, [string, string]>(
-        `SELECT id, account_id, definition_cbor, state_dir, status, public_read, created_at, updated_at
+        `SELECT id, account_id, definition_cbor, state_dir, status, public_read, public_chat, created_at, updated_at
          FROM agents WHERE account_id = ? AND id = ?`,
       )
       .get(accountId, agentId)
@@ -6918,6 +6962,9 @@ export class Service {
   }
 }
 
+/** How much an action needs from an agent: inspect it, chat with it, or change it. */
+type AgentAccessLevel = 'reader' | 'chat' | 'writer'
+
 type AgentRow = {
   id: string
   account_id: string
@@ -6925,6 +6972,7 @@ type AgentRow = {
   state_dir: string
   status: api.AgentInfo['status']
   public_read?: number
+  public_chat?: number
   created_at: number
   updated_at: number
   access_role?: api.AgentAccessRole
@@ -7237,6 +7285,7 @@ function agentRowToInfo(row: AgentRow, accessRole: api.AgentAccessRole = 'owner'
     updatedAt: row.updated_at,
     accessRole,
     publicRead: row.public_read === 1,
+    publicChat: row.public_chat === 1,
   }
 }
 

--- a/agents/src/main.ts
+++ b/agents/src/main.ts
@@ -126,10 +126,12 @@ function sendIfSubscribed(
 ): void {
   if (ws.data.accountId !== sourceAccountId) {
     // Not this socket's account: only the owner's events for a publicly-read key pass through, and
-    // an agent snapshot is downgraded so a public reader never sees the owner's access role.
+    // an agent snapshot is downgraded so a public reader never sees the owner's access role — it
+    // gets the role public access grants, which the snapshot's own flags determine.
     if (ws.data.publicSubscriptions.get(key) !== sourceAccountId) return
     if (event._ === 'change' && event.key.startsWith('agents/')) {
-      const value = {...(event.value as api.AgentInfo), accessRole: 'reader'} satisfies api.AgentInfo
+      const agent = event.value as api.AgentInfo
+      const value = {...agent, accessRole: agent.publicChat ? 'chatter' : 'reader'} satisfies api.AgentInfo
       sendWS(ws, {...event, value} as api.AgentWSEvent)
       return
     }

--- a/agents/src/sqlite-schema.sql
+++ b/agents/src/sqlite-schema.sql
@@ -45,6 +45,7 @@ CREATE TABLE agents (
     status TEXT NOT NULL,
     -- 1 when any signed account may read the agent (definition, memory, tools, sessions) by id.
     public_read INTEGER NOT NULL DEFAULT 0,
+    public_chat INTEGER NOT NULL DEFAULT 0,
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL
 ) WITHOUT ROWID;

--- a/agents/src/sqlite.test.ts
+++ b/agents/src/sqlite.test.ts
@@ -61,7 +61,9 @@ describe('sqlite', () => {
             '',
           )
           .replace(/CREATE INDEX sessions_by_parent ON sessions \(parent_session_id, created_at\);\n\n/u, '')
+          .replace(/    capability_cid TEXT,\n/u, '')
           .replace(/    public_read INTEGER NOT NULL DEFAULT 0,\n/u, '')
+          .replace(/    public_chat INTEGER NOT NULL DEFAULT 0,\n/u, '')
           .replace(
             /CREATE TABLE agent_collaborators[\s\S]*?CREATE TABLE agent_triggers/u,
             'CREATE TABLE agent_triggers',
@@ -93,6 +95,7 @@ describe('sqlite', () => {
       expect(tableExists(db, 'tool_documents')).toBe(true)
       expect(columnExists(db, 'agent_triggers', 'cooldown_ms')).toBe(true)
       expect(columnExists(db, 'agents', 'public_read')).toBe(true)
+      expect(columnExists(db, 'agents', 'public_chat')).toBe(true)
       expect(columnExists(db, 'sessions', 'title_source')).toBe(true)
       expect(columnExists(db, 'sessions', 'model_override_cbor')).toBe(true)
       expect(columnExists(db, 'sessions', 'parent_session_id')).toBe(true)

--- a/agents/src/sqlite.ts
+++ b/agents/src/sqlite.ts
@@ -13,6 +13,10 @@ export const BASELINE_SCHEMA_MIGRATION_VERSION = 0
 /** Prepend-only database migrations. */
 export const migrations: string[] = [
   // ======= IMPORTANT: Add new migrations below this line. =======
+  // Public chat: while an agent is publicly readable, this additionally lets every signed account
+  // create sessions and message them (the `chatter` access role). Never set without public_read;
+  // SetAgentPublicRead(false) clears it.
+  `ALTER TABLE agents ADD COLUMN public_chat INTEGER NOT NULL DEFAULT 0;`,
   // Delegations are proven per envelope by the CID of the account's Capability blob; a verified
   // one is remembered here so later envelopes skip the blob fetch. Rows from the old RegisterSigner
   // flow have no CID and stay valid.

--- a/frontend/apps/desktop/src/components/assistant-panel.tsx
+++ b/frontend/apps/desktop/src/components/assistant-panel.tsx
@@ -62,6 +62,7 @@ import {
   Trash2,
 } from 'lucide-react'
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {agentAccessCanChat, agentAccessCanWrite} from '@shm/ui/agents/access'
 import {AgentRunStatusBar, useRunStartedAt} from '@shm/ui/agents/agent-run-status'
 import {AgentErrorRow, AssistantMessageParts, ChatMessageBubble} from '@shm/ui/agents/message-rendering'
 import {useChatAutoScroll} from '@shm/ui/agents/chat-autoscroll'
@@ -314,7 +315,8 @@ export function AssistantPanel({
           agentId={activeAgent.agent.id}
           agentName={activeAgent.agent.definition.name}
           accountUid={accountUid}
-          readOnly={activeAgent.agent.accessRole === 'reader'}
+          readOnly={!agentAccessCanChat(activeAgent.agent.accessRole)}
+          canInvokeTools={agentAccessCanWrite(activeAgent.agent.accessRole)}
           composerRef={composerRef}
           onSessionCreated={selectSession}
         />
@@ -552,12 +554,15 @@ function AssistantDraftChat({
   composerRef,
   onSessionCreated,
   readOnly,
+  canInvokeTools,
 }: {
   serverUrl: string
   agentId: string
   agentName: string
   accountUid: string | null | undefined
   readOnly: boolean
+  /** False for chat-only access: the tool palette needs write access to the agent. */
+  canInvokeTools: boolean
   composerRef: React.MutableRefObject<CommentEditorSubmitHandle | null>
   onSessionCreated: (ref: AssistantSessionRef) => void
 }) {
@@ -621,6 +626,7 @@ function AssistantDraftChat({
         disabledMessage={readOnly ? 'You have read-only access to this agent.' : undefined}
         serverUrl={serverUrl}
         accountId={accountUid ?? null}
+        canInvokeTools={canInvokeTools}
         composerHandleRef={composerRef}
         onSend={(message) => void handleSend(message)}
         onStop={() => {}}
@@ -654,7 +660,10 @@ function AssistantSessionChat({
 
   const autoScroll = useChatAutoScroll()
 
-  const readOnly = agentDetail.data?.agent.accessRole === 'reader'
+  // Chatters (public chat) may send; only owners/writers may control runs, switch the model, or
+  // run session tools.
+  const readOnly = !agentAccessCanChat(agentDetail.data?.agent.accessRole)
+  const canWrite = !!agentDetail.data && agentAccessCanWrite(agentDetail.data.agent.accessRole)
   const status = session.data?.session.status
   const isStreaming = status === 'streaming'
   const isBusy = messageSession.isPending || isStreaming
@@ -815,7 +824,7 @@ function AssistantSessionChat({
         sessionId={sessionId}
         sessionPlan={session.data?.session.plan}
         frozenRunIds={frozenRuns}
-        readOnly={readOnly}
+        readOnly={!canWrite}
         onOpenSession={(childSessionId, childAgentId) =>
           navigate({key: 'agent-session', agentId: childAgentId, sessionId: childSessionId, serverUrl})
         }
@@ -841,6 +850,7 @@ function AssistantSessionChat({
         agentTools={agentDetail.data?.agent.definition.tools}
         agentToolsLoading={agentDetail.isLoading}
         focusOnMount={false}
+        canInvokeTools={canWrite}
         composerHandleRef={composerRef}
         onSend={handleSend}
         onStop={() => void handleStop()}
@@ -855,7 +865,7 @@ function AssistantSessionChat({
             serverUrl={serverUrl}
             sessionId={sessionId}
             modelOverride={session.data.session.modelOverride}
-            canWrite={!readOnly && !!agentDetail.data}
+            canWrite={canWrite}
           />
         </div>
       ) : null}

--- a/frontend/packages/ui/src/agents/access.ts
+++ b/frontend/packages/ui/src/agents/access.ts
@@ -1,0 +1,15 @@
+import type {AgentAccessRole} from '@seed-hypermedia/agents-protocol'
+
+/**
+ * What an access role lets the UI offer. `chatter` (a public reader on an agent with public chat on)
+ * can create and message sessions but cannot change the agent, rename or delete sessions, control
+ * runs, or invoke session tools. An absent role comes from the owner's own listing.
+ */
+export function agentAccessCanWrite(role: AgentAccessRole | undefined): boolean {
+  return role === undefined || role === 'owner' || role === 'writer'
+}
+
+/** Whether the role may create sessions and send messages (everything but a plain reader). */
+export function agentAccessCanChat(role: AgentAccessRole | undefined): boolean {
+  return role !== 'reader'
+}

--- a/frontend/packages/ui/src/agents/agent-row.tsx
+++ b/frontend/packages/ui/src/agents/agent-row.tsx
@@ -29,7 +29,7 @@ export function AgentListRow({
   name: string
   status: string
   serverUrl: string
-  accessRole?: 'owner' | 'reader' | 'writer'
+  accessRole?: 'owner' | 'reader' | 'writer' | 'chatter'
 }) {
   const navigate = useNavigate()
   const statusIndicator = getAgentStatusIndicator(status)

--- a/frontend/packages/ui/src/agents/detail.tsx
+++ b/frontend/packages/ui/src/agents/detail.tsx
@@ -39,6 +39,7 @@ import {
   useModelProviders,
   useProviderModels,
   useRemoveAgentCollaborator,
+  useSetAgentPublicChat,
   useSetAgentPublicRead,
   useSaveAgentTool,
   useSigningIdentities,
@@ -77,7 +78,19 @@ import {SizableText} from '@shm/ui/text'
 import {Spinner} from '@shm/ui/spinner'
 import {toast} from '@shm/ui/toast'
 import {useAppDialog} from '@shm/ui/universal-dialog'
-import {ArrowRight, ArrowRightLeft, ExternalLink, Globe, Info, KeyRound, Pencil, Plus, Trash2, X} from 'lucide-react'
+import {
+  ArrowRight,
+  ArrowRightLeft,
+  ExternalLink,
+  Globe,
+  Info,
+  KeyRound,
+  MessageSquare,
+  Pencil,
+  Plus,
+  Trash2,
+  X,
+} from 'lucide-react'
 import {HMIcon} from '@shm/ui/hm-icon'
 import React, {useEffect, useMemo, useRef, useState} from 'react'
 import {getSeedTool} from '@seed-hypermedia/agents-protocol'
@@ -108,6 +121,7 @@ import {coerceReasoningLevel, ReasoningSlider} from './reasoning-select'
 import {pickDefaultProviderModel} from './model-utils'
 import {AgentPromptEditor, promptBlocksForRequest, promptBlocksToMarkdown} from './prompt-editor'
 import {AgentsNoAccountPage} from './no-account'
+import {agentAccessCanChat, agentAccessCanWrite} from './access'
 import {AgentRichMessageComposer} from './rich-message-composer'
 import {type AgentsRichEditorSubmitHandle} from './platform'
 
@@ -157,7 +171,9 @@ function AgentDetailPage({
   const addProviderDialog = useAppDialog(AddModelProviderDialog)
   useAgentWebSocketSubscription(serverUrl, selectedAccountId, `agents/${agentId}`)
   const accessRole = agent.data?.agent.accessRole ?? 'owner'
-  const canWrite = accessRole === 'owner' || accessRole === 'writer'
+  const canWrite = agentAccessCanWrite(accessRole)
+  // Chatters (public chat) can start sessions here but cannot edit the agent or run session tools.
+  const canChat = agentAccessCanChat(accessRole)
   const isOwner = accessRole === 'owner'
   const [name, setName] = useState('')
   const [modelProvider, setModelProvider] = useState('')
@@ -481,7 +497,7 @@ function AgentDetailPage({
                 triggersCount={triggers.data?.length}
                 // The session is only created when the first message is sent, so "New session"
                 // just puts the cursor in the composer that will do it.
-                onCreateSession={canWrite ? () => startComposerRef.current?.focus({moveCursorToEnd: true}) : undefined}
+                onCreateSession={canChat ? () => startComposerRef.current?.focus({moveCursorToEnd: true}) : undefined}
                 creatingSession={createSession.isLoading}
                 onCreateTrigger={
                   canWrite ? () => createTriggerDialog.open({serverUrl, selectedAccountId, agentId}) : undefined
@@ -567,7 +583,7 @@ function AgentDetailPage({
                       />
                     ))}
                   </div>
-                  {canWrite ? (
+                  {canChat ? (
                     // No sessionId: this is a draft composer — the first send creates the session
                     // and delivers the message in one motion (see handleStartSession).
                     <AgentRichMessageComposer
@@ -580,6 +596,7 @@ function AgentDetailPage({
                       agentTools={agent.data.agent.definition.tools}
                       agentToolsLoading={agent.isLoading}
                       focusOnMount={false}
+                      canInvokeTools={canWrite}
                       composerHandleRef={startComposerRef}
                       onToolStartSession={startDraftSession}
                       onToolSessionStarted={(sessionId) =>
@@ -691,6 +708,7 @@ function AgentDetailPage({
                   ownerAccountId={agent.data.agent.account}
                   collaborators={collaborators.data?.collaborators || []}
                   publicRead={collaborators.data?.publicRead ?? agent.data.agent.publicRead ?? false}
+                  publicChat={collaborators.data?.publicChat ?? agent.data.agent.publicChat ?? false}
                   loading={collaborators.isLoading}
                   isOwner={isOwner}
                 />
@@ -834,6 +852,7 @@ function AgentCollaboratorsTab({
   ownerAccountId,
   collaborators,
   publicRead,
+  publicChat,
   loading,
   isOwner,
 }: {
@@ -843,12 +862,14 @@ function AgentCollaboratorsTab({
   ownerAccountId: string
   collaborators: AgentCollaboratorInfo[]
   publicRead: boolean
+  publicChat: boolean
   loading: boolean
   isOwner: boolean
 }) {
   const invite = useInviteAgentCollaborator(serverUrl, accountUid)
   const remove = useRemoveAgentCollaborator(serverUrl, accountUid)
   const setPublicRead = useSetAgentPublicRead(serverUrl, accountUid)
+  const setPublicChat = useSetAgentPublicChat(serverUrl, accountUid)
   const [selected, setSelected] = useState<SearchResult[]>([])
   const [role, setRole] = useState<AgentCollaboratorRole>('writer')
   const excludedAccountIds = [ownerAccountId, ...collaborators.map((member) => member.accountId)]
@@ -905,37 +926,77 @@ function AgentCollaboratorsTab({
         </div>
       ) : null}
 
-      <div className="border-border flex items-center gap-3 rounded-md border p-3">
-        <Globe className="text-muted-foreground size-5 shrink-0" />
-        <div className="flex flex-1 flex-col gap-0.5 overflow-hidden">
-          <SizableText size="sm" weight="medium">
-            Public access
-          </SizableText>
-          <SizableText size="xs" color="muted">
-            {publicRead
-              ? 'This agent is public: anyone with a link can view its settings, memory, tools, and sessions.'
-              : 'This agent is private: only the owner and collaborators can view it.'}
-          </SizableText>
+      <div className="border-border flex flex-col gap-3 rounded-md border p-3">
+        <div className="flex items-center gap-3">
+          <Globe className="text-muted-foreground size-5 shrink-0" />
+          <div className="flex flex-1 flex-col gap-0.5 overflow-hidden">
+            <SizableText size="sm" weight="medium">
+              Public access
+            </SizableText>
+            <SizableText size="xs" color="muted">
+              {publicRead
+                ? 'This agent is public: anyone with a link can view its settings, memory, tools, and sessions.'
+                : 'This agent is private: only the owner and collaborators can view it.'}
+            </SizableText>
+          </div>
+          {isOwner ? (
+            <Switch
+              aria-label="Public access"
+              checked={publicRead}
+              disabled={setPublicRead.isLoading}
+              onCheckedChange={(checked) =>
+                setPublicRead.mutate(
+                  {agentId, publicRead: checked},
+                  {
+                    onError: (error) =>
+                      toast.error(error instanceof Error ? error.message : 'Could not change public access'),
+                  },
+                )
+              }
+            />
+          ) : publicRead ? (
+            <SizableText size="xs" color="muted" className="shrink-0">
+              Public
+            </SizableText>
+          ) : null}
         </div>
-        {isOwner ? (
-          <Switch
-            aria-label="Public access"
-            checked={publicRead}
-            disabled={setPublicRead.isLoading}
-            onCheckedChange={(checked) =>
-              setPublicRead.mutate(
-                {agentId, publicRead: checked},
-                {
-                  onError: (error) =>
-                    toast.error(error instanceof Error ? error.message : 'Could not change public access'),
-                },
-              )
-            }
-          />
-        ) : publicRead ? (
-          <SizableText size="xs" color="muted" className="shrink-0">
-            Public
-          </SizableText>
+        {/* Public chat only exists on top of public read: the server clears it when read is turned
+            off, and the row is hidden with it. Chat is narrower than collaborator "write" access —
+            it covers creating and messaging sessions, nothing that edits the agent. */}
+        {publicRead ? (
+          <div className="border-border flex items-center gap-3 border-t pt-3">
+            <MessageSquare className="text-muted-foreground size-5 shrink-0" />
+            <div className="flex flex-1 flex-col gap-0.5 overflow-hidden">
+              <SizableText size="sm" weight="medium">
+                Public chat
+              </SizableText>
+              <SizableText size="xs" color="muted">
+                {publicChat
+                  ? 'Anyone signed in can start sessions and send messages. Only collaborators can change settings, memory, tools, or triggers.'
+                  : 'Only the owner and collaborators can start sessions or send messages.'}
+              </SizableText>
+            </div>
+            {isOwner ? (
+              <Switch
+                aria-label="Public chat"
+                checked={publicChat}
+                disabled={setPublicChat.isLoading}
+                onCheckedChange={(checked) =>
+                  setPublicChat.mutate(
+                    {agentId, publicChat: checked},
+                    {
+                      onError: (error) =>
+                        toast.error(error instanceof Error ? error.message : 'Could not change public chat'),
+                    },
+                  )
+                }
+              />
+            ) : publicChat ? (
+              <SizableText size="xs" color="muted" className="shrink-0">
+                Open
+              </SizableText>
+            ) : null}
+          </div>
         ) : null}
       </div>
 

--- a/frontend/packages/ui/src/agents/models.ts
+++ b/frontend/packages/ui/src/agents/models.ts
@@ -1134,7 +1134,7 @@ export function useCreateAgent(serverUrl: string | undefined, accountUid: string
   })
 }
 
-/** Lists everyone with access to one agent, including pending invitations, plus its public-read flag. */
+/** Lists everyone with access to one agent, including pending invitations, plus its public-access flags. */
 export function useAgentCollaborators(
   serverUrl: string | undefined,
   accountUid: string | null | undefined,
@@ -1142,11 +1142,19 @@ export function useAgentCollaborators(
 ) {
   return useQuery({
     queryKey: ['agents', 'collaborators', serverUrl, accountUid, agentId],
-    queryFn: async (): Promise<{collaborators: AgentCollaboratorInfo[]; publicRead: boolean}> => {
-      if (!serverUrl || !accountUid || !agentId) return {collaborators: [], publicRead: false}
+    queryFn: async (): Promise<{
+      collaborators: AgentCollaboratorInfo[]
+      publicRead: boolean
+      publicChat: boolean
+    }> => {
+      if (!serverUrl || !accountUid || !agentId) return {collaborators: [], publicRead: false, publicChat: false}
       const res = await sendAgentAction({serverUrl, accountUid, action: {_: 'ListAgentCollaborators', agentId}})
       if (res._ !== 'ListAgentCollaboratorsResponse') throw new Error('Unexpected collaborator list response')
-      return {collaborators: res.collaborators, publicRead: res.publicRead === true}
+      return {
+        collaborators: res.collaborators,
+        publicRead: res.publicRead === true,
+        publicChat: res.publicChat === true,
+      }
     },
     enabled: !!serverUrl && !!accountUid && !!agentId,
     refetchInterval: AGENT_BACKGROUND_REFETCH_INTERVAL_MS,
@@ -1187,6 +1195,19 @@ export function useSetAgentPublicRead(serverUrl: string | undefined, accountUid:
     mutationFn: async ({agentId, publicRead}: {agentId: string; publicRead: boolean}) => {
       if (!serverUrl || !accountUid) throw new Error('Select an account and agent server first')
       return sendAgentAction({serverUrl, accountUid, action: {_: 'SetAgentPublicRead', agentId, publicRead}})
+    },
+    onSuccess() {
+      invalidateQueries(['agents'])
+    },
+  })
+}
+
+/** Owner-only: lets every signed account chat with a public agent (create and message sessions). */
+export function useSetAgentPublicChat(serverUrl: string | undefined, accountUid: string | null | undefined) {
+  return useMutation({
+    mutationFn: async ({agentId, publicChat}: {agentId: string; publicChat: boolean}) => {
+      if (!serverUrl || !accountUid) throw new Error('Select an account and agent server first')
+      return sendAgentAction({serverUrl, accountUid, action: {_: 'SetAgentPublicChat', agentId, publicChat}})
     },
     onSuccess() {
       invalidateQueries(['agents'])

--- a/frontend/packages/ui/src/agents/rich-message-composer.tsx
+++ b/frontend/packages/ui/src/agents/rich-message-composer.tsx
@@ -36,6 +36,7 @@ export function AgentRichMessageComposer({
   agentTools,
   agentToolsLoading,
   focusOnMount = true,
+  canInvokeTools = true,
   composerHandleRef,
   onToolStartSession,
   onToolSessionStarted,
@@ -58,6 +59,8 @@ export function AgentRichMessageComposer({
   agentToolsLoading?: boolean
   /** Focus the editor when the composer mounts. On by default, like the full session page. */
   focusOnMount?: boolean
+  /** Whether the user tool palette is offered. Off for chat-only access, which cannot run session tools. */
+  canInvokeTools?: boolean
   /** External handle for imperative focus/submit (e.g. the sidebar's new-chat flows). */
   composerHandleRef?: React.MutableRefObject<AgentsRichEditorSubmitHandle | null>
   /** Draft composer only: lets a tool run create the session, the same way the first send would. */
@@ -172,16 +175,18 @@ export function AgentRichMessageComposer({
           />
         </div>
         <div className="flex shrink-0 gap-1 pb-1">
-          <UserToolPalette
-            serverUrl={serverUrl}
-            accountId={accountId}
-            sessionId={sessionId}
-            agentTools={agentTools}
-            agentToolsLoading={agentToolsLoading}
-            disabled={isBusy}
-            onStartSession={sessionId ? undefined : onToolStartSession}
-            onSessionStarted={onToolSessionStarted}
-          />
+          {canInvokeTools ? (
+            <UserToolPalette
+              serverUrl={serverUrl}
+              accountId={accountId}
+              sessionId={sessionId}
+              agentTools={agentTools}
+              agentToolsLoading={agentToolsLoading}
+              disabled={isBusy}
+              onStartSession={sessionId ? undefined : onToolStartSession}
+              onSessionStarted={onToolSessionStarted}
+            />
+          ) : null}
           {draftMarkdown.trim() ? (
             <Button
               size="sm"

--- a/frontend/packages/ui/src/agents/session.tsx
+++ b/frontend/packages/ui/src/agents/session.tsx
@@ -1,3 +1,4 @@
+import {agentAccessCanChat, agentAccessCanWrite} from './access'
 import {type AgentRunActivity, type AgentSessionTriggerContext} from './client'
 import {AgentRunStatusBar, useRunStartedAt} from './agent-run-status'
 import {SessionSummaryBanner} from './session-children'
@@ -221,13 +222,16 @@ function AgentSessionPage({
   )
   // Which runs the scroll already owns, so the pinned slot does not tell the same story twice.
   const frozenRuns = useMemo(() => frozenRunIds(chatRows), [chatRows])
-  const canWrite = !!agent.data && agent.data.agent.accessRole !== 'reader'
+  // Chatters (public chat) may send and retry; only owners/writers may rename, delete, control
+  // runs, or run session tools.
+  const canChat = !!agent.data && agentAccessCanChat(agent.data.agent.accessRole)
+  const canWrite = !!agent.data && agentAccessCanWrite(agent.data.agent.accessRole)
   const isAgentStreaming = session.data?.session.status === 'streaming'
   const isAgentBusy = messageSession.isPending || isAgentStreaming
   const retrySession = useRetrySession(serverUrl, selectedAccountId)
   // Deliberately not gated on the mutation being in flight: the button stays put and shows its
   // pending state until the retried run actually starts streaming, which is what removes the row.
-  const retryableRowKey = canWrite ? retryableErrorRowKey(chatRows, !!isAgentBusy) : undefined
+  const retryableRowKey = canChat ? retryableErrorRowKey(chatRows, !!isAgentBusy) : undefined
   const runStartedAt = useRunStartedAt(isAgentBusy)
   // Sub-session affordances: the parent is loaded only for its title/route, and the child's own run
   // to tell "still being driven by the parent" from "finished, yours to continue". That run is a
@@ -547,7 +551,7 @@ function AgentSessionPage({
               isBusy={isAgentBusy}
               isStreaming={isAgentStreaming}
               disabledMessage={
-                !canWrite
+                !canChat
                   ? 'You have read-only access to this agent.'
                   : isDrivenByParent
                     ? SUB_SESSION_DRIVEN_MESSAGE
@@ -559,6 +563,7 @@ function AgentSessionPage({
               sessionId={sessionId}
               agentTools={agent.data?.agent.definition.tools}
               agentToolsLoading={agent.isLoading}
+              canInvokeTools={canWrite}
               onSend={(message) => void handleSendMessage(message)}
               onStop={() => void handleStopSession()}
             />


### PR DESCRIPTION
## Summary

Adds a **Public chat** switch inside the "Public access" box on the agent collaboration page, shown only while public read is on. When enabled, any correctly-signing account becomes a `chatter` on the agent: it can **create sessions, send messages, attach files, and stop/retry turns** — but nothing writer-level (agent/memory/tool/trigger edits, session rename/delete, `InvokeSessionTool`, run cancel/signal). This is deliberately narrower than inviting a `writer`.

### Server (`agents/`)
- `agents.public_chat` column + migration; `SetAgentPublicChat {agentId, publicChat}` action/response; `AgentInfo.publicChat`; `ListAgentCollaborators` returns `publicChat`.
- `AgentAccessRole` gains `chatter`; `#actionAccountId` now enforces three levels — `reader` / `chat` / `writer`.
- Enabling chat without public read → 400. Turning public read off clears chat; re-enabling read does not silently re-open chat.
- WebSocket agent snapshots for public subscribers downgrade to `chatter` or `reader` from the agent's own flags.

### UI
- The switch row (same layout as "Public access") in `detail.tsx`.
- Chatters get the composer on the session page, the desktop assistant panel, and the sessions-tab start-a-chat box + "New session" button; the user tool palette, rename, delete, model switch, and run controls stay owner/writer-only (`agentAccessCanChat` / `agentAccessCanWrite` helpers, `canInvokeTools` on `AgentRichMessageComposer`).

### Docs & tests
- `signed-api.md`, `security.md`, `readme.md` document the role and the exact action boundary.
- New api-service test covering the lifecycle (gating, chatter messaging, refused writer actions, read-off clears chat).
- Fixes the sqlite baseline-migration test that #982 broke (`capability_cid` wasn't stripped from the baseline schema).

## Test plan
- [x] `bun test src/api-service.test.ts src/sqlite.test.ts` + main/attachments/memory/tools/auth/runs suites pass
- [x] `pnpm typecheck` in `frontend/packages/ui` and `frontend/apps/desktop`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3qMAzkS2n5WXESGxVy1Wi
