### PR TITLE
Fix the two agents test failures that are red on main

### DIFF
--- a/agents/src/api-service.test.ts
+++ b/agents/src/api-service.test.ts
@@ -639,7 +639,7 @@ describe('api service', () => {
       ).rejects.toThrow('Write access is required')
       await expect(
         svc.message(await apisvc.createSignedEnvelope(collaborator, {action: {_: 'CreateSession', agentId}})),
-      ).rejects.toThrow('Write access is required')
+      ).rejects.toThrow('Chat access is required')
 
       const promoted = await svc.message(
         await apisvc.createSignedEnvelope(owner, {
@@ -5374,6 +5374,7 @@ describe('api service', () => {
         }),
       )
       if (identity._ !== 'CreateSigningIdentityResponse') throw new Error('unexpected response')
+      if (!identity.identity.accountId) throw new Error('missing signing account id')
       signerPublicKey = identity.identity.accountId
       const createdAgent = await svc.message(
         await apisvc.createSignedEnvelope(account, {


### PR DESCRIPTION
`agents-tests (test)` and `agents-tests (check)` run from `dev-docker-images.yml` on **push to main**, not on pull requests. Both have been failing for a while as a result — the last few main pushes (`cb4006464`, `1fec8a89e`, `14e9f4b67`, `9d2f6ed71`) are all red on one or both.

Two one-line fixes, both in `agents/src/api-service.test.ts`.

**`agents-tests (test)`** — `invites read and write collaborators and enforces their roles` expects `CreateSession` to reject a reader with `"Write access is required"`, but #986 moved `CreateSession` to `fromAgent(action.agentId, 'chat')`, so it now throws `"Chat access is required"`. The behaviour is unchanged — a plain reader still can't open a session — only the message differs. Three sibling expectations in the same file were updated in #986; this one was missed.

**`agents-tests (check)`** — the `CreateSigningIdentity` call site at the end of the file assigns `identity.identity.accountId` (`string | undefined`) to a `string`. The other five call sites all guard with `if (!identity.identity.accountId) throw new Error('missing signing account id')` first; this one only narrows the response type. Added the same guard.

Not flaky — the assertion failure reproduces 5/5 locally and appears identically in the CI logs on main.

## Verification

On a clean checkout of `main` with these two changes:

- `bun tsgo --noEmit` → exit 0
- `bun test` → **346 pass, 0 fail** (27 files)
- `prettier --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpayUJJV7RDovKerpaWftB
