### PR TITLE
Match the grpcrecovery test to the message the interceptor logs

### DIFF
--- a/backend/util/grpcrecovery/grpcrecovery_test.go
+++ b/backend/util/grpcrecovery/grpcrecovery_test.go
@@ -92,7 +92,7 @@ func TestUnaryServerKeepsServingAfterPanic(t *testing.T) {
 	require.NoError(t, cc.Invoke(ctx, okMethod, &emptypb.Empty{}, &emptypb.Empty{}),
 		"the server must keep serving after recovering a panic")
 
-	entries := logs.FilterMessage("RecoveredPanicInGRPCHandler").All()
+	entries := logs.FilterMessage("GRPCHandlerPanic").All()
 	require.Len(t, entries, 1, "the recovered panic must be logged exactly once")
 
 	fields := entries[0].ContextMap()
@@ -129,5 +129,5 @@ func TestStreamServerInterceptorRecovers(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, codes.Internal, status.Code(err))
 	require.NotContains(t, err.Error(), panicValue)
-	require.Len(t, logs.FilterMessage("RecoveredPanicInGRPCHandler").All(), 1)
+	require.Len(t, logs.FilterMessage("GRPCHandlerPanic").All(), 1)
 }


### PR DESCRIPTION
`test-go` has been red on main since `18e169357` (#970).

The interceptor logs `GRPCHandlerPanic`:

```go
log.Error("GRPCHandlerPanic",
    zap.String("method", method),
    ...
```

but both assertions in the test filter for `RecoveredPanicInGRPCHandler`:

```go
entries := logs.FilterMessage("RecoveredPanicInGRPCHandler").All()
require.Len(t, entries, 1, "the recovered panic must be logged exactly once")
```

The filter matches nothing, `logs` comes back empty, and both `require.Len(..., 1)` calls fail with `"[]" should have 1 item(s), but has 0`.

Fixed on the test side rather than the implementation: `GRPCHandlerPanic` is the name that actually ships, it matches the convention used by its neighbours (`IndexedHookFailed`, `SQLiteLeakedTxRepairFailed`, `BtrfsDisableCOWFailed`), and `grep` finds no reference to either string outside this package.

## Verification

On a clean checkout of `main` with this change: `go test ./backend/util/grpcrecovery/...` → `ok`, and `go build ./...` clean. Reproduced the failure first both locally and in the CI log on main, so it is not flaky or platform-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpayUJJV7RDovKerpaWftB
