### PR TITLE
Agents: sites advertise their agents server (per-site backends on the gateway)

### DIFF
--- a/agents/docs/environments.md
+++ b/agents/docs/environments.md
@@ -207,3 +207,25 @@ What an operator must decide, in rough order of importance:
   not assume obscurity; if that matters, gate reachability at the network layer.
 - **Updates.** `docker pull` on your schedule, or run Watchtower as production does. `/api/version` tells you what a
   running server was built from.
+
+## Which agents server a client connects to
+
+Clients (desktop, web, the web gateway) can talk to any number of agents servers at once; the agents UI groups agents by
+server. The list a client uses is the union of three sources, in this order (order matters: the assistant panel's
+default agent context is the first agent of the first server):
+
+1. **The app's own local server** — desktop only (`getLocalServerUrl` on the platform seam).
+2. **The server advertised by the site on screen** — the `agentServerUrl` field in the site's home-document metadata
+   (`HMDocumentMetadataSchema`, set from the home document's options panel as "Agents Server"). While any document of
+   that site is open, its server joins the list (ahead of the user's own servers, labeled "This site" in the panel's
+   agent picker) and leaves it again when the user navigates elsewhere; it is never written into the user's configured
+   list. This is what lets the gateway, which shows many sites, use a different agents backend per site.
+3. **The user's configured servers** — persisted per client (`agent-server-urls` setting: electron-store on desktop,
+   `localStorage` under `seed.agents.setting.` on web). On first run this list is seeded with the deployment default:
+   `SEED_AGENT_SERVER_URL` for the web server (read on the server, injected into `window.ENV` for the client, e.g.
+   `https://agentic.seed.hyper.media` in production and `https://dev.agentic.seed.hyper.media` on dev deployments);
+   desktop's default lives in `frontend/apps/desktop/src/agents-defaults.ts`. Once the user has edited the list — even
+   to empty — the default is no longer re-added.
+
+The agents server itself needs no per-client configuration for this: it answers signed requests from any origin
+(`Access-Control-Allow-Origin: *`) and identifies callers by their signed account, not by where the page was served.

--- a/frontend/apps/desktop/src/__tests__/agent-server-advertised.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/agent-server-advertised.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react'
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import {createRoot, type Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+/**
+ * A site can advertise an agents server in its home document. While one of its documents is on
+ * screen, that server joins the list the agents UI connects to — after the app's local server,
+ * ahead of the user's own configured servers — without ever being written into the configured
+ * list. Outside a document (or a navigation provider) nothing is advertised.
+ */
+
+const mockState = vi.hoisted(() => ({
+  route: null as null | Record<string, unknown>,
+  homeMetadata: {} as Record<string, unknown>,
+  resourceRequests: [] as string[],
+  configured: ['https://mine.example'] as string[],
+}))
+
+vi.mock('@shm/ui/agents/platform', () => ({
+  getAgentsPlatform: () => ({
+    defaultServerUrl: () => null,
+    getSetting: async (key: string) => (key === 'agent-server-urls' ? mockState.configured : null),
+    setSetting: vi.fn(),
+    getLocalServerUrl: async () => 'http://localhost:4200',
+  }),
+  setAgentsPlatform: vi.fn(),
+}))
+vi.mock('@shm/shared/utils/navigation', () => ({useNavRouteOrNull: () => mockState.route}))
+vi.mock('@shm/shared/models/entity', () => ({
+  useResource: (id: {uid: string} | undefined) => {
+    if (id) mockState.resourceRequests.push(id.uid)
+    return id ? {data: {type: 'document', document: {metadata: mockState.homeMetadata}}} : {data: undefined}
+  },
+}))
+vi.mock('@/trpc', () => ({client: {}}))
+vi.mock('@/grpc-client', () => ({grpcClient: {}}))
+
+import {useAgentServerUrls} from '@shm/ui/agents/models'
+
+let container: HTMLDivElement
+let root: Root
+let latest: ReturnType<typeof useAgentServerUrls> | null = null
+
+function Probe() {
+  latest = useAgentServerUrls()
+  return null
+}
+
+async function render() {
+  const client = new QueryClient({defaultOptions: {queries: {retry: false}}})
+  await act(async () => {
+    root.render(
+      <QueryClientProvider client={client}>
+        <Probe />
+      </QueryClientProvider>,
+    )
+  })
+  // Let the settings and local-server queries resolve.
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+}
+
+beforeEach(() => {
+  ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+  mockState.route = null
+  mockState.homeMetadata = {}
+  mockState.resourceRequests = []
+  latest = null
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+describe('site-advertised agent server', () => {
+  it('adds the server of the site on screen after the local server and ahead of configured ones', async () => {
+    mockState.route = {key: 'document', id: {uid: 'site-uid', path: ['about']}}
+    mockState.homeMetadata = {name: 'A Site', agentServerUrl: 'https://agents.site.example/'}
+    await render()
+    expect(mockState.resourceRequests).toContain('site-uid')
+    expect(latest!.advertisedServerUrl).toBe('https://agents.site.example')
+    expect(latest!.data).toEqual(['http://localhost:4200', 'https://agents.site.example', 'https://mine.example'])
+  })
+
+  it('advertises nothing without a document route or when the home document has no server', async () => {
+    mockState.route = {key: 'agents'}
+    await render()
+    expect(latest!.advertisedServerUrl).toBeNull()
+    expect(latest!.data).toEqual(['http://localhost:4200', 'https://mine.example'])
+
+    mockState.route = {key: 'document', id: {uid: 'site-uid', path: []}}
+    mockState.homeMetadata = {name: 'A Site'}
+    await render()
+    expect(latest!.advertisedServerUrl).toBeNull()
+  })
+
+  it('ignores an advertised value that is not an http(s) URL and dedupes one the user already configured', async () => {
+    mockState.route = {key: 'document', id: {uid: 'site-uid', path: []}}
+    mockState.homeMetadata = {agentServerUrl: 'not a url'}
+    await render()
+    expect(latest!.advertisedServerUrl).toBeNull()
+
+    mockState.homeMetadata = {agentServerUrl: 'https://mine.example'}
+    await render()
+    expect(latest!.data).toEqual(['http://localhost:4200', 'https://mine.example'])
+  })
+
+  it("uses a draft's edit target as the site", async () => {
+    mockState.route = {key: 'draft', id: 'draft-1', editUid: 'site-uid'}
+    mockState.homeMetadata = {agentServerUrl: 'https://agents.site.example'}
+    await render()
+    expect(latest!.advertisedServerUrl).toBe('https://agents.site.example')
+  })
+})

--- a/frontend/packages/client/src/hm-types.ts
+++ b/frontend/packages/client/src/hm-types.ts
@@ -558,6 +558,12 @@ export const HMDocumentMetadataSchema = z
     thumbnail: z.string().optional(), // DEPRECATED
     cover: z.string().optional(),
     siteUrl: z.string().optional(),
+    /**
+     * Agents server a space advertises for its readers (an http(s) origin). Clients viewing the
+     * space's documents connect to it alongside their own configured servers, so a site can host
+     * agents for its audience — on the gateway, each site brings its own agents backend.
+     */
+    agentServerUrl: z.string().optional(),
     layout: z.union([z.literal('Seed/Experimental/Newspaper'), z.literal('')]).optional(),
     displayPublishTime: z.string().optional(),
     displayAuthor: z.string().optional(),
@@ -605,6 +611,7 @@ export const DOCUMENT_ATTRIBUTE_DESCRIPTIONS: Readonly<Record<string, string>> =
   thumbnail: 'Deprecated image field kept for older documents.',
   cover: 'Wide cover image shown in headers and cards.',
   siteUrl: 'Published website URL for a space.',
+  agentServerUrl: 'Agents server readers of this space connect to.',
   layout: 'Legacy site header layout setting.',
   displayPublishTime: 'Publication date shown to readers.',
   displayAuthor: 'Author byline shown to readers.',

--- a/frontend/packages/shared/src/utils/navigation.tsx
+++ b/frontend/packages/shared/src/utils/navigation.tsx
@@ -177,6 +177,24 @@ export function useNavRoute() {
   return navRoute
 }
 
+const NO_NAV_STATE: StateStream<NavState> = {
+  get: () => ({routes: [], routeIndex: 0, lastAction: 'push'}),
+  subscribe: () => () => {},
+}
+
+/**
+ * The current route, or null when rendered outside a navigation provider (a settings window, a
+ * page shell without routing). For code that adapts to the route when there is one but must not
+ * require it.
+ */
+export function useNavRouteOrNull(): NavRoute | null {
+  const nav = useContext(NavContext)
+  const navRoute = useStreamSelector<NavState, NavRoute | null>(nav?.state ?? NO_NAV_STATE, (state) => {
+    return state.routes[state.routeIndex] ?? null
+  })
+  return nav ? navRoute : null
+}
+
 export function useRouteDocId(): UnpackedHypermediaId | null {
   const route = useNavRoute()
   if (route.key === 'document' || route.key === 'inspect') {

--- a/frontend/packages/ui/src/__tests__/options-panel.test.tsx
+++ b/frontend/packages/ui/src/__tests__/options-panel.test.tsx
@@ -49,6 +49,38 @@ function renderOptionsPanel(isHomeDoc: boolean) {
 }
 
 describe('OptionsPanel document metadata fields', () => {
+  it('offers the agents server field on the home document only, saving a trimmed URL on blur', () => {
+    const onMetadata = vi.fn()
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <OptionsPanel draftId="draft" metadata={{name: 'Site'}} isHomeDoc onMetadata={onMetadata} />
+        </TooltipProvider>,
+      )
+    })
+    const input = container.querySelector('#agent-server-url') as HTMLInputElement
+    expect(input).not.toBeNull()
+    act(() => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!
+      setter.call(input, '  https://agentic.example.com  ')
+      input.dispatchEvent(new Event('input', {bubbles: true}))
+    })
+    act(() => {
+      // React's onBlur listens to the bubbling focusout event.
+      input.dispatchEvent(new FocusEvent('focusout', {bubbles: true}))
+    })
+    expect(onMetadata).toHaveBeenCalledWith({agentServerUrl: 'https://agentic.example.com'})
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <OptionsPanel draftId="draft" metadata={{name: 'Doc'}} isHomeDoc={false} onMetadata={onMetadata} />
+        </TooltipProvider>,
+      )
+    })
+    expect(container.querySelector('#agent-server-url')).toBeNull()
+  })
+
   it('keeps home document title and icon controls but removes summary and cover controls', () => {
     renderOptionsPanel(true)
 

--- a/frontend/packages/ui/src/agents/assistant-panel.tsx
+++ b/frontend/packages/ui/src/agents/assistant-panel.tsx
@@ -205,6 +205,7 @@ export function AssistantPanel({
           agents={agents}
           activeAgent={activeAgent}
           localServerUrl={localServerUrl.data ?? null}
+          advertisedServerUrl={serverUrls.advertisedServerUrl}
           onSelect={(key) => setChosenAgent(key)}
           onCreateAgent={() =>
             createAgentDialog.open({
@@ -359,6 +360,7 @@ function AssistantAgentPicker({
   agents,
   activeAgent,
   localServerUrl,
+  advertisedServerUrl,
   onSelect,
   onCreateAgent,
   onOpenAgentsPage,
@@ -366,6 +368,8 @@ function AssistantAgentPicker({
   agents: AssistantAgentOption[]
   activeAgent: AssistantAgentOption | null
   localServerUrl: string | null
+  /** Server the site on screen advertises; its group is labeled so the user knows why it is here. */
+  advertisedServerUrl?: string | null
   onSelect: (key: AssistantAgentKey) => void
   onCreateAgent: () => void
   onOpenAgentsPage: () => void
@@ -406,6 +410,11 @@ function AssistantAgentPicker({
                 <span className="text-muted-foreground text-[10px] font-medium tracking-wide uppercase">
                   {describeAgentServer(group.serverUrl, localServerUrl)}
                 </span>
+                {advertisedServerUrl && group.serverUrl === advertisedServerUrl ? (
+                  <span className="bg-muted text-muted-foreground rounded-full px-1.5 text-[10px] font-medium">
+                    This site
+                  </span>
+                ) : null}
               </div>
               {group.options.map((option) => {
                 const isActive = option.serverUrl === activeAgent?.serverUrl && option.agent.id === activeAgent.agent.id

--- a/frontend/packages/ui/src/agents/models.ts
+++ b/frontend/packages/ui/src/agents/models.ts
@@ -38,6 +38,10 @@ import {getAgentsPlatform} from './platform'
 import {getToolReferencedUrls} from '@seed-hypermedia/agents-protocol'
 import * as cbor from '@shm/shared/cbor'
 import {getQueryClient, invalidateQueries} from '@shm/shared/models/query-client'
+import {useResource} from '@shm/shared/models/entity'
+import type {NavRoute} from '@shm/shared/routes'
+import {hmId} from '@shm/shared/utils/entity-id-url'
+import {useNavRouteOrNull} from '@shm/shared/utils/navigation'
 import {queryKeys} from '@shm/shared'
 import {unpackHmId} from '@shm/shared/utils/entity-id-url'
 import {useMutation, useQueries, useQuery} from '@tanstack/react-query'
@@ -251,16 +255,48 @@ export function useConfiguredAgentServerUrls() {
 export function useAgentServerUrls() {
   const localServerUrl = useLocalAgentServerUrl()
   const configured = useConfiguredAgentServerUrls()
+  const advertisedServerUrl = useSiteAdvertisedAgentServerUrl()
 
+  // Order is meaning: the assistant panel's default agent context is the first agent of the first
+  // server. The app's own local server keeps that spot; a server the site in view advertises comes
+  // next, ahead of the user's configured list, so on a site (or the gateway, which shows many) the
+  // panel opens on that site's agents.
   const data = useMemo(() => {
     if (!configured.data) return undefined
     const urls = new Set<string>()
     if (localServerUrl.data) urls.add(localServerUrl.data)
+    if (advertisedServerUrl) urls.add(advertisedServerUrl)
     for (const url of configured.data) urls.add(url)
     return Array.from(urls)
-  }, [configured.data, localServerUrl.data])
+  }, [advertisedServerUrl, configured.data, localServerUrl.data])
 
-  return {...configured, data}
+  return {...configured, data, advertisedServerUrl}
+}
+
+/**
+ * The agents server advertised by the site whose document is on screen, if any.
+ *
+ * Read from the site home document's `agentServerUrl` metadata — the same signed document that
+ * names the site — so it is discoverable wherever the site's content is, with no server config.
+ * The site is the account of the current route's document (a draft's edit target counts); routes
+ * without a document, and code rendered outside a navigation provider, advertise nothing. It is
+ * never persisted into the user's configured list: it applies while viewing that site.
+ */
+export function useSiteAdvertisedAgentServerUrl(): string | null {
+  const route = useNavRouteOrNull()
+  const siteUid = route ? siteUidOfRoute(route) : undefined
+  const home = useResource(siteUid ? hmId(siteUid) : undefined)
+  const raw = home.data?.type === 'document' ? home.data.document?.metadata?.agentServerUrl : undefined
+  return useMemo(() => (typeof raw === 'string' && raw ? tryNormalizeAgentServerUrl(raw) : null), [raw])
+}
+
+/** Account uid of the site a route is looking at, when the route is about a document. */
+export function siteUidOfRoute(route: NavRoute): string | undefined {
+  if (route.key === 'draft') return route.editUid ?? undefined
+  if ('id' in route && route.id && typeof route.id === 'object' && 'uid' in route.id) {
+    return (route.id as {uid?: string}).uid || undefined
+  }
+  return undefined
 }
 
 /** Persists the configured agent server URL list. */

--- a/frontend/packages/ui/src/options-panel.tsx
+++ b/frontend/packages/ui/src/options-panel.tsx
@@ -36,6 +36,7 @@ export function OptionsPanel({
             <OriginalPublishDate metadata={metadata} onMetadata={onMetadata} />
             <ContentWidth metadata={metadata} onMetadata={onMetadata} />
             <ActivityVisibility metadata={metadata} onMetadata={onMetadata} />
+            <AgentServerInput metadata={metadata} onMetadata={onMetadata} />
           </>
         ) : (
           <>
@@ -241,6 +242,36 @@ function OriginalPublishDate({
           onMetadata({displayPublishTime: ''})
         }}
       />
+    </div>
+  )
+}
+
+/**
+ * The agents server this site advertises to its readers. Stored on the home document, so anyone
+ * viewing the site — including gateway visitors — connects to it alongside their own servers.
+ */
+function AgentServerInput({
+  metadata,
+  onMetadata,
+}: {
+  metadata: HMMetadata
+  onMetadata: (values: Partial<HMMetadata>) => void
+}) {
+  const [value, setValue] = useState(metadata.agentServerUrl || '')
+  return (
+    <div className="flex flex-col gap-1">
+      <Label htmlFor="agent-server-url">Agents Server</Label>
+      <Input
+        id="agent-server-url"
+        type="url"
+        placeholder="https://agentic.example.com"
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        onBlur={() => onMetadata({agentServerUrl: value.trim() || undefined})}
+      />
+      <span className="text-muted-foreground text-xs">
+        Readers of this site will see agents hosted on this server in their agents panel.
+      </span>
     </div>
   )
 }


### PR DESCRIPTION
Stacked on #987 (base branch `web-assistant-panel`); retarget to `main` once that merges.

## Summary

A space can advertise an agents server for its readers via `agentServerUrl` in its home-document metadata. While any document of that site is on screen, clients (desktop, web, gateway) connect to that server alongside their own — so on the gateway each site brings its own agents backend.

- **Schema:** `HMDocumentMetadataSchema.agentServerUrl` (beside `siteUrl`) + attribute description.
- **Editing:** "Agents Server" URL field in the home document's options panel (home docs only; trimmed on blur).
- **Source:** `useSiteAdvertisedAgentServerUrl()` — site = account of the current route's document (a draft's edit target counts) → home doc via `useResource` → normalized URL. Works on desktop and on web through the site-context bridge from #987.
- **Merge:** `useAgentServerUrls()` now returns local → advertised → configured (order = the panel's default agent context), plus `advertisedServerUrl`; the panel's agent picker labels that group "This site". Never written into the user's configured list.
- `useNavRouteOrNull()` in `@shm/shared` so the hook is safe outside a navigation provider (desktop settings window).
- `environments.md` documents the three sources and the deployment default `SEED_AGENT_SERVER_URL`.

No agents-server changes needed: it already answers signed requests from any origin.

## Test plan
- [x] root `pnpm typecheck` (all packages)
- [x] new desktop test `agent-server-advertised.test.tsx` (ordering, none without a document, invalid URL ignored, dedupe with configured, draft edit target); ui `options-panel` test for the field
- [x] desktop suite 696/696, ui 327/327, web suite (one SSR integration test flaked under concurrent load; passes alone)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3qMAzkS2n5WXESGxVy1Wi
