### PR TITLE
feat(agents): spaces publish agents to their readers

### DIFF
--- a/agents/docs/environments.md
+++ b/agents/docs/environments.md
@@ -214,12 +214,15 @@ Clients (desktop, web, the web gateway) can talk to any number of agents servers
 server. The list a client uses is the union of three sources, in this order (order matters: the assistant panel's
 default agent context is the first agent of the first server):
 
-1. **The app's own local server** — desktop only (`getLocalServerUrl` on the platform seam).
-2. **The server advertised by the site on screen** — the `agentServerUrl` field in the site's home-document metadata
-   (`HMDocumentMetadataSchema`, set from the home document's options panel as "Agents Server"). While any document of
-   that site is open, its server joins the list (ahead of the user's own servers, labeled "This site" in the panel's
-   agent picker) and leaves it again when the user navigates elsewhere; it is never written into the user's configured
-   list. This is what lets the gateway, which shows many sites, use a different agents backend per site.
+1. **The app's own local server** — desktop only (`getLocalServerUrl` on the platform seam). A client connects to it; a
+   space never advertises it, since it is reachable only from the computer running it.
+2. **The server advertised by the space on screen** — the `agentServerUrl` field in the space's home-document metadata
+   (`HMDocumentMetadataSchema`, set on the Agents tab of desktop's Space Settings). While any document of that space is
+   open, its server joins the list (ahead of the user's own servers, labeled "This site" in the panel's agent picker)
+   and leaves it again when the user navigates elsewhere; it is never written into the user's configured list. This is
+   what lets the gateway, which shows many sites, use a different agents backend per site. Where the app is itself
+   served by a space — the web app and the gateway — that space also applies on pages that name no document, so
+   `/hm/agents` is still "in" the space hosting it.
 3. **The user's configured servers** — persisted per client (`agent-server-urls` setting: electron-store on desktop,
    `localStorage` under `seed.agents.setting.` on web). On first run this list is seeded with the deployment default:
    `SEED_AGENT_SERVER_URL` for the web server (read on the server, injected into `window.ENV` for the client, e.g.
@@ -229,3 +232,24 @@ default agent context is the first agent of the first server):
 
 The agents server itself needs no per-client configuration for this: it answers signed requests from any origin
 (`Access-Control-Allow-Origin: *`) and identifies callers by their signed account, not by where the page was served.
+
+### Which agents a reader of a space sees
+
+Naming a server is only half of reaching a reader. `ListAgents` returns agents the caller owns or accepted an invitation
+to and nothing else, so a visitor asking a space's server for a list gets an empty one. A space therefore names its
+agents too, in `spaceAgents` on the home document: `{[agentId]: order}`, written from the same Space Settings tab —
+where both the server and the agent are picked from dropdowns (the servers this app talks to, then that server's public
+agents) rather than typed. Given an id, the server resolves the owning account itself and answers `GetAgent` for any
+signed account once the agent is public-read — so clients fetch each published agent by id and put them at the head of
+the assistant panel's picker, where the first one becomes the default context. Because the default is the first
+published agent, someone arriving at a space can open the panel and start chatting without configuring anything,
+provided the agent has public chat enabled (`SetAgentPublicChat`, offered per agent on that same settings tab).
+
+Public read is a precondition rather than something publishing arranges: only an already-public agent can be published,
+because opening an agent to the world is a decision made on the agent (`SetAgentPublicRead`), not a side effect of
+listing it on a space. The order carries exactly one meaning — the first published agent is the default — so the
+settings tab offers a "make default" button rather than a way to arrange the list.
+
+Only ids and order live in the document. An agent's name, icon, and status are read from the agent itself, so renaming
+one never strands a stale copy in a signed document. Document metadata attributes have no array encoding, which is why
+the ordered list is a map to positions rather than a list.

--- a/frontend/apps/desktop/src/__tests__/agents-list-local-server.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/agents-list-local-server.test.tsx
@@ -32,6 +32,7 @@ vi.mock('@shm/ui/agents/models', () => ({
   useLocalAgentServerUrl: () => ({data: mockState.localServerUrl}),
   useAgentServerHealths: () => mockState.healths,
   useAgentLists: () => mockState.serverUrls.map(() => ({data: [], isFetching: false, isError: false})),
+  useSpaceAgents: () => ({agents: [], isLoading: false}),
   useAgentInviteLists: () =>
     mockState.serverUrls.map((_, index) => ({
       data: index === 0 ? mockState.invites : [],

--- a/frontend/apps/desktop/src/__tests__/assistant-panel-context.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/assistant-panel-context.test.tsx
@@ -36,6 +36,7 @@ vi.mock('@shm/ui/agents/models', () => ({
   useAgentDetail: () => ({data: undefined, isLoading: false}),
   useRun: () => ({data: undefined}),
   useAgentLists: () => mockState.agentLists,
+  useSpaceAgents: () => ({agents: [], isLoading: false}),
   useAgentServerUrls: () => ({data: mockState.serverUrls, isSuccess: true, isLoading: false}),
   useAgentSession: () => ({data: undefined}),
   useAgentWebSocketSubscription: () => ({text: ''}),

--- a/frontend/apps/desktop/src/__tests__/assistant-selection.test.ts
+++ b/frontend/apps/desktop/src/__tests__/assistant-selection.test.ts
@@ -1,7 +1,11 @@
 import {describe, expect, it} from 'vitest'
 import type {AgentInfo} from '@shm/ui/agents/client'
 import type {AgentSessionListEntry} from '@shm/ui/agents/models'
-import {resolveAssistantSelection, type AssistantAgentOption} from '@shm/ui/agents/assistant-selection'
+import {
+  orderAssistantAgents,
+  resolveAssistantSelection,
+  type AssistantAgentOption,
+} from '@shm/ui/agents/assistant-selection'
 
 /**
  * Selection rules for the agent-scoped assistant sidebar.
@@ -105,5 +109,40 @@ describe('resolveAssistantSelection', () => {
     const remaining = sessions.filter((entry) => entry.session.id !== 's-a2')
     const result = resolveAssistantSelection({...base, sessions: remaining, storedSession: null})
     expect(result.session).toEqual({serverUrl: LOCAL, sessionId: 's-a1'})
+  })
+})
+
+/**
+ * A space publishes agents for its readers. Since the default context is the first option, that
+ * ordering is what lets someone who just arrived open the panel and find something to talk to.
+ */
+describe('orderAssistantAgents', () => {
+  const SPACE = 'https://agents.space.example'
+  const docsBot = agent(SPACE, 'docs', 'Docs Helper')
+  const supportBot = agent(SPACE, 'support', 'Support')
+
+  it("puts the space's agents ahead of the user's own, so the default lands on the space", () => {
+    const ordered = orderAssistantAgents([docsBot, supportBot], agents)
+    expect(ordered.map((option) => option.agent.id)).toEqual(['docs', 'support', 'assistant', 'researcher'])
+    expect(resolveAssistantSelection({...base, agents: ordered}).agent?.agent.id).toBe('docs')
+  })
+
+  it('leaves the local server leading when no space publishes anything', () => {
+    expect(orderAssistantAgents([], agents)).toEqual(agents)
+  })
+
+  it('lists an agent that is both published and owned once, in the leading position', () => {
+    const ordered = orderAssistantAgents([agent(REMOTE, 'researcher', 'Researcher')], agents)
+    expect(ordered.map((option) => option.agent.id)).toEqual(['researcher', 'assistant'])
+  })
+
+  it("keeps an explicitly chosen agent over the space's default", () => {
+    const ordered = orderAssistantAgents([docsBot], agents)
+    const result = resolveAssistantSelection({
+      ...base,
+      agents: ordered,
+      chosenAgent: {serverUrl: LOCAL, agentId: 'assistant'},
+    })
+    expect(result.agent?.agent.id).toBe('assistant')
   })
 })

--- a/frontend/apps/desktop/src/__tests__/space-agents-settings.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/space-agents-settings.test.tsx
@@ -1,0 +1,354 @@
+import React from 'react'
+import {createRoot, type Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+;(globalThis as typeof globalThis & {React?: typeof React}).React = React
+
+/**
+ * Space Settings → Agents.
+ *
+ * The owner picks a server from the ones this app already talks to and an agent from that server's
+ * public agents — neither is typed, and publishing never changes an agent's access. The published
+ * order carries one meaning, the default, so the list offers a promote button rather than reordering.
+ * The server and the published list are saved together into the space's home document.
+ */
+
+const mockState = vi.hoisted(() => ({
+  metadata: {} as Record<string, unknown>,
+  servers: [] as string[],
+  localServerUrl: null as string | null,
+  agents: [] as any[],
+  isSiteOwner: true,
+}))
+const mocks = vi.hoisted(() => ({
+  updateHome: vi.fn(async () => {}),
+  setPublicRead: vi.fn(async () => {}),
+  setPublicChat: vi.fn(async () => {}),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+  navigate: vi.fn(),
+}))
+
+vi.mock('@/models/site', () => ({
+  useUpdateHomeDocument: () => ({mutateAsync: mocks.updateHome, isPending: false}),
+}))
+vi.mock('@shm/shared/models/capabilities', () => ({
+  useIsSiteOwner: () => ({isSiteOwner: mockState.isSiteOwner, isLoading: false}),
+}))
+vi.mock('@shm/shared/models/entity', () => ({
+  useResource: () => ({
+    isInitialLoading: false,
+    data: {type: 'document', document: {metadata: mockState.metadata}},
+  }),
+}))
+vi.mock('@shm/ui/agents/account', () => ({useSelectedAccountId: () => 'owner-uid'}))
+vi.mock('@shm/ui/agents/client', () => ({
+  normalizeAgentServerUrl: (value: string) => new URL(value).origin,
+}))
+vi.mock('@shm/ui/agents/models', () => ({
+  describeAgentServer: (serverUrl: string, localServerUrl: string | null) =>
+    localServerUrl === serverUrl ? 'Local Agents' : new URL(serverUrl).host,
+  isLocalAgentServer: (serverUrl: string, localServerUrl?: string | null) =>
+    !!localServerUrl && serverUrl === localServerUrl,
+  useAgentList: () => ({data: mockState.agents, isInitialLoading: false, isError: false, error: null}),
+  useAgentServerUrls: () => ({data: mockState.servers}),
+  useLocalAgentServerUrl: () => ({data: mockState.localServerUrl}),
+  useSetAgentPublicRead: () => ({mutateAsync: mocks.setPublicRead, isLoading: false}),
+  useSetAgentPublicChat: () => ({mutateAsync: mocks.setPublicChat, isLoading: false}),
+}))
+vi.mock('@shm/ui/agents/platform', () => ({getAgentsPlatform: () => ({})}))
+vi.mock('@shm/ui/toast', () => ({toast: {error: mocks.toastError, success: mocks.toastSuccess}}))
+vi.mock('@/utils/useNavigate', () => ({useNavigate: () => mocks.navigate}))
+vi.mock('@/trpc', () => ({client: {}}))
+vi.mock('@sentry/electron/renderer', () => ({}))
+
+import {hmId} from '@shm/shared/utils/entity-id-url'
+import {TooltipProvider} from '@shm/ui/tooltip'
+import {SpaceAgentsSettings} from '@/components/site-settings-agents'
+
+const agent = (id: string, name: string, extra: Record<string, unknown> = {}) => ({
+  id,
+  definition: {name},
+  status: 'idle',
+  accessRole: 'owner',
+  publicRead: true,
+  publicChat: false,
+  ...extra,
+})
+
+let container: HTMLDivElement
+let root: Root
+
+function render() {
+  act(() => {
+    root.render(
+      <TooltipProvider>
+        <SpaceAgentsSettings siteId={hmId('space-uid')} />
+      </TooltipProvider>,
+    )
+  })
+}
+
+/**
+ * Flushes the promises a click handler kicked off.
+ *
+ * Note that {@link chooseFromSelect} and {@link click} run their own `act()`, so they must be
+ * called outside one: a nested `act` defers the flush and the assertions would read stale DOM.
+ */
+async function settle() {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+function click(element: Element | null | undefined) {
+  expect(element).toBeTruthy()
+  act(() => {
+    element!.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+  })
+}
+
+/** Every published row's text, top to bottom. */
+function publishedRows(): string[] {
+  return Array.from(container.querySelectorAll('[data-testid="published-agent"]')).map((row) => row.textContent ?? '')
+}
+
+function buttonByText(text: string): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll('button')).find((button) => button.textContent?.includes(text))
+}
+
+/** The option labels a Radix Select offers, found by its trigger text. */
+function selectOptions(triggerText: string): string[] {
+  const trigger = Array.from(container.querySelectorAll('[data-slot="select-trigger"]')).find(
+    (element) => element.textContent?.includes(triggerText),
+  )
+  expect(trigger, `no select trigger showing "${triggerText}"`).toBeTruthy()
+  act(() => {
+    trigger!.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+  })
+  return Array.from(document.querySelectorAll('[data-slot="select-item"]')).map((item) => item.textContent ?? '')
+}
+
+/** Opens a Radix Select by its trigger text and picks the option labeled `option`. */
+function chooseFromSelect(triggerText: string, option: string) {
+  const trigger = Array.from(container.querySelectorAll('[data-slot="select-trigger"]')).find(
+    (element) => element.textContent?.includes(triggerText),
+  )
+  expect(trigger, `no select trigger showing "${triggerText}"`).toBeTruthy()
+  act(() => {
+    // Radix opens on click when it has not seen a mouse pointerdown, which jsdom never sends.
+    trigger!.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+  })
+  const item = Array.from(document.querySelectorAll('[data-slot="select-item"]')).find(
+    (element) => element.textContent === option,
+  )
+  expect(item, `no option labeled "${option}"`).toBeTruthy()
+  act(() => {
+    item!.dispatchEvent(new PointerEvent('pointermove', {bubbles: true}))
+    item!.dispatchEvent(new PointerEvent('pointerup', {bubbles: true, button: 0}))
+  })
+}
+
+beforeEach(() => {
+  ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+  ;(globalThis as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  // jsdom implements none of these; Radix's Select trigger calls them on open.
+  HTMLElement.prototype.hasPointerCapture = () => false
+  HTMLElement.prototype.setPointerCapture = () => {}
+  HTMLElement.prototype.releasePointerCapture = () => {}
+  HTMLElement.prototype.scrollIntoView = () => {}
+  if (!(globalThis as any).PointerEvent) {
+    ;(globalThis as any).PointerEvent = class extends MouseEvent {
+      readonly pointerId = 1
+      readonly pointerType = 'mouse'
+      readonly isPrimary = true
+    }
+  }
+  mockState.metadata = {}
+  mockState.servers = []
+  mockState.localServerUrl = null
+  mockState.agents = []
+  mockState.isSiteOwner = true
+  mocks.updateHome.mockClear()
+  mocks.setPublicRead.mockClear()
+  mocks.setPublicChat.mockClear()
+  mocks.toastError.mockClear()
+  mocks.toastSuccess.mockClear()
+  mocks.navigate.mockClear()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+describe('SpaceAgentsSettings', () => {
+  it('renders published agents in order, naming them from the server rather than the document', () => {
+    // Agent ids are uuids, which is why they are never rendered: they name nothing a person knows.
+    const docsId = '2b9d0c5a-1f4e-4d55-9b1c-7c1e2f3a4b5c'
+    mockState.metadata = {agentServerUrl: 'https://agents.example', spaceAgents: {[docsId]: 0, support: 1}}
+    mockState.agents = [agent('support', 'Support'), agent(docsId, 'Docs Helper')]
+    render()
+    // The document stores ids and order only; a rename on the server shows up here immediately.
+    expect(publishedRows()[0]).toContain('Docs Helper')
+    expect(publishedRows()[1]).toContain('Support')
+    expect(container.textContent).not.toContain(docsId)
+  })
+
+  it('tags the first published agent as the default and offers to promote the rest', () => {
+    mockState.metadata = {agentServerUrl: 'https://agents.example', spaceAgents: {docs: 0, support: 1}}
+    mockState.agents = [agent('docs', 'Docs Helper'), agent('support', 'Support')]
+    render()
+    expect(publishedRows()[0]).toContain('Default')
+    expect(publishedRows()[1]).not.toContain('Default')
+    // Only the non-default rows can be promoted.
+    expect(container.querySelectorAll('[data-testid="published-agent"]')[0]!.textContent).not.toContain('Make default')
+    expect(publishedRows()[1]).toContain('Make default')
+  })
+
+  it('opens the agent page when a published row is clicked', () => {
+    mockState.metadata = {agentServerUrl: 'https://agents.example', spaceAgents: {docs: 0}}
+    mockState.agents = [agent('docs', 'Docs Helper')]
+    render()
+    click(container.querySelector('[data-testid="published-agent"]'))
+    expect(mocks.navigate).toHaveBeenCalledWith({
+      key: 'agent',
+      agentId: 'docs',
+      serverUrl: 'https://agents.example',
+    })
+  })
+
+  it('does not navigate when a row control is used', () => {
+    mockState.metadata = {agentServerUrl: 'https://agents.example', spaceAgents: {docs: 0, support: 1}}
+    mockState.agents = [agent('docs', 'Docs Helper'), agent('support', 'Support')]
+    render()
+    click(buttonByText('Make default'))
+    expect(mocks.navigate).not.toHaveBeenCalled()
+    expect(publishedRows()[0]).toContain('Support')
+  })
+
+  it('warns when a published agent is private, because no reader can see it', () => {
+    mockState.metadata = {agentServerUrl: 'https://agents.example', spaceAgents: {docs: 0}}
+    mockState.agents = [agent('docs', 'Docs Helper', {publicRead: false})]
+    render()
+    expect(container.textContent).toContain('Private — readers of this space cannot see it')
+  })
+
+  it('promotes and removes, then saves the server and the published order together', async () => {
+    mockState.metadata = {agentServerUrl: 'https://agents.example', spaceAgents: {docs: 0, support: 1, extra: 2}}
+    mockState.agents = [agent('docs', 'Docs Helper'), agent('support', 'Support'), agent('extra', 'Extra')]
+    render()
+
+    // Nothing to save until something is edited.
+    expect(buttonByText('Save')?.disabled).toBe(true)
+
+    // "Make default" on the second row; the first row has no such button.
+    click(container.querySelectorAll('[data-testid="published-agent"]')[1]!.querySelector('button'))
+    expect(publishedRows()[0]).toContain('Support')
+
+    click(container.querySelectorAll('[aria-label="Remove from this space"]')[2])
+    expect(publishedRows()).toHaveLength(2)
+
+    click(buttonByText('Save'))
+    await settle()
+    expect(mocks.updateHome).toHaveBeenCalledWith({
+      metadata: expect.objectContaining({
+        agentServerUrl: 'https://agents.example',
+        // Renumbered densely; the dropped agent is absent, which the change diff turns into a removal.
+        spaceAgents: {support: 0, docs: 1},
+      }),
+    })
+  })
+
+  it('offers only public agents, and says how many are held back', () => {
+    // A private agent is not publishable and publishing never makes one public: opening an agent to
+    // the world is a decision made on the agent, not a side effect of listing it on a space.
+    mockState.metadata = {agentServerUrl: 'https://agents.example'}
+    mockState.agents = [agent('secret', 'Secret', {publicRead: false})]
+    render()
+    expect(container.textContent).toContain('No public agents to add')
+    expect(container.textContent).toContain('One agent on this server is private')
+
+    mockState.agents = [agent('secret', 'Secret', {publicRead: false}), agent('open', 'Open')]
+    render()
+    expect(container.textContent).toContain('Add an agent…')
+  })
+
+  it('offers nothing more once every public agent is published', () => {
+    mockState.metadata = {agentServerUrl: 'https://agents.example', spaceAgents: {mine: 0}}
+    mockState.agents = [agent('mine', 'Mine')]
+    render()
+    expect(container.textContent).toContain('No public agents to add')
+  })
+
+  it("publishes without touching the agent's access", async () => {
+    mockState.metadata = {agentServerUrl: 'https://agents.example'}
+    mockState.agents = [agent('docs', 'Docs Helper')]
+    render()
+
+    chooseFromSelect('Add an agent…', 'Docs Helper')
+    await settle()
+    expect(mocks.setPublicRead).not.toHaveBeenCalled()
+    expect(mocks.setPublicChat).not.toHaveBeenCalled()
+    expect(publishedRows()[0]).toContain('Docs Helper')
+  })
+
+  it('empties the published list when the server changes, and restores it on switching back', () => {
+    // Published ids name agents on one particular server and mean nothing on another.
+    mockState.metadata = {agentServerUrl: 'https://agents.example', spaceAgents: {docs: 0}}
+    mockState.servers = ['https://agents.example', 'https://other.example']
+    mockState.agents = [agent('docs', 'Docs Helper')]
+    render()
+    expect(publishedRows()).toHaveLength(1)
+
+    chooseFromSelect('agents.example', 'other.example')
+    expect(publishedRows()).toHaveLength(0)
+
+    chooseFromSelect('other.example', 'agents.example')
+    expect(publishedRows()).toHaveLength(1)
+  })
+
+  it('leaves the local server out of the options, since no visitor can reach this computer', () => {
+    mockState.localServerUrl = 'http://localhost:3050'
+    mockState.servers = ['http://localhost:3050', 'https://agents.example']
+    mockState.metadata = {}
+    render()
+    expect(selectOptions('No agents server')).toEqual(['No agents server', 'agents.example'])
+  })
+
+  it('still explains a space that already advertises this computer', () => {
+    // Not selectable, but a space that somehow holds that value has to be told why it is broken.
+    mockState.localServerUrl = 'http://localhost:3050'
+    mockState.metadata = {agentServerUrl: 'http://localhost:3050'}
+    render()
+    expect(container.textContent).toContain('Local Agents runs only on this computer')
+  })
+
+  it('hides the published list until a server is chosen', () => {
+    // The ids name agents on one particular server; without one they are addresses to nowhere.
+    mockState.metadata = {}
+    mockState.servers = ['https://agents.example']
+    mockState.agents = [agent('docs', 'Docs Helper')]
+    render()
+    expect(container.textContent).not.toContain('Published agents')
+
+    chooseFromSelect('No agents server', 'agents.example')
+    expect(container.textContent).toContain('Published agents')
+    expect(container.textContent).toContain('Add an agent…')
+  })
+
+  it('leaves everything to the space owner', () => {
+    mockState.isSiteOwner = false
+    mockState.metadata = {agentServerUrl: 'https://agents.example', spaceAgents: {docs: 0}}
+    render()
+    expect(container.textContent).toContain('Only the space owner can edit these settings')
+    expect(buttonByText('Save')).toBeUndefined()
+  })
+})

--- a/frontend/apps/desktop/src/components/site-settings-agents.tsx
+++ b/frontend/apps/desktop/src/components/site-settings-agents.tsx
@@ -1,0 +1,463 @@
+import {useUpdateHomeDocument} from '@/models/site'
+import {useNavigate} from '@/utils/useNavigate'
+import type {HMMetadata, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {useIsSiteOwner} from '@shm/shared/models/capabilities'
+import {useResource} from '@shm/shared/models/entity'
+import {useSelectedAccountId} from '@shm/ui/agents/account'
+import {normalizeAgentServerUrl, type AgentInfo} from '@shm/ui/agents/client'
+import {
+  describeAgentServer,
+  isLocalAgentServer,
+  useAgentList,
+  useAgentServerUrls,
+  useLocalAgentServerUrl,
+  useSetAgentPublicChat,
+  useSetAgentPublicRead,
+} from '@shm/ui/agents/models'
+import {getAgentsPlatform} from '@shm/ui/agents/platform'
+import {
+  canPublishAgent,
+  makeSpaceAgentDefault,
+  parseSpaceAgentIds,
+  spaceAgentsMetadata,
+} from '@shm/ui/agents/space-agents'
+import {Button} from '@shm/ui/button'
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@shm/ui/select-dropdown'
+import {Spinner} from '@shm/ui/spinner'
+import {SizableText} from '@shm/ui/text'
+import {toast} from '@shm/ui/toast'
+import {Tooltip} from '@shm/ui/tooltip'
+import {cn} from '@shm/ui/utils'
+import {Bot, Plus, Settings, X} from 'lucide-react'
+import {useState} from 'react'
+
+/**
+ * Space Settings → Agents.
+ *
+ * Two things a space says about agents, both stored in its home document so every reader of the
+ * space — including gateway visitors who have never heard of this space's server — picks them up
+ * from the same signed document that names the space: which server hosts them (`agentServerUrl`),
+ * and which of that server's agents the space publishes (`spaceAgents`, see @shm/ui/agents/space-agents).
+ *
+ * Both are chosen from what the app already knows about rather than typed: the server from the list
+ * this app talks to, the agent from that server's public agents. Only public agents are offered —
+ * opening an agent to the world is a decision made on the agent, not a side effect of listing it
+ * here. The published order carries exactly one meaning, the default (the agent a new visitor opens
+ * on), so that is all the list offers: a button to promote an agent, not a way to arrange them.
+ */
+export function SpaceAgentsSettings({siteId}: {siteId: UnpackedHypermediaId}) {
+  const resource = useResource(siteId)
+  const document = resource.data?.type === 'document' ? resource.data.document : undefined
+  const {isSiteOwner, isLoading: isOwnerLoading} = useIsSiteOwner(siteId.uid)
+  const updateHome = useUpdateHomeDocument(siteId.uid)
+  // Agent-server calls are signed by the person configuring the space, not by the space account:
+  // a space can be administered through an agent capability by someone who holds no key for it,
+  // and the agents they can publish are the ones their own account administers.
+  const accountUid = useSelectedAccountId()
+  const knownServers = useAgentServerUrls()
+  const localServerUrl = useLocalAgentServerUrl()
+  const openServerSettings = (getAgentsPlatform().useOpenServerSettings ?? (() => null))()
+  const navigate = useNavigate()
+
+  const [serverDraft, setServerDraft] = useState<string | null>(null)
+  const [idsDraft, setIdsDraft] = useState<string[] | null>(null)
+  // Remounts the add-an-agent dropdown after each pick, so it returns to its prompt. It is an
+  // action, not a value: a Select left holding the agent it just published would read as a setting.
+  const [addKey, setAddKey] = useState(0)
+
+  const metadata = document?.metadata
+  const publishedServer = safeServerUrl(typeof metadata?.agentServerUrl === 'string' ? metadata.agentServerUrl : '')
+  const publishedIds = parseSpaceAgentIds(metadata?.spaceAgents)
+  const serverValue = serverDraft ?? publishedServer ?? ''
+  const idsValue = idsDraft ?? publishedIds
+
+  // A dropdown choice is committed the moment it is made, so the agent list can follow the draft
+  // rather than waiting for a save.
+  const agentList = useAgentList(serverValue || undefined, accountUid)
+  const serverAgents = agentList.data ?? []
+  const setPublicRead = useSetAgentPublicRead(serverValue || undefined, accountUid)
+  const setPublicChat = useSetAgentPublicChat(serverValue || undefined, accountUid)
+
+  if (resource.isInitialLoading || isOwnerLoading) {
+    return (
+      <div className="flex justify-center py-10">
+        <Spinner />
+      </div>
+    )
+  }
+  if (!document || !metadata) {
+    return <SizableText color="muted">This account doesn't have a space yet.</SizableText>
+  }
+  if (!isSiteOwner) {
+    return (
+      <>
+        <SizableText size="2xl" weight="bold">
+          Agents
+        </SizableText>
+        <SizableText color="muted">Only the space owner can edit these settings.</SizableText>
+      </>
+    )
+  }
+
+  const isDirty = serverValue !== (publishedServer ?? '') || !sameOrder(idsValue, publishedIds)
+  const canSave = isDirty && !updateHome.isPending
+  const isLocal = !!serverValue && isLocalAgentServer(serverValue, localServerUrl.data)
+
+  // The desktop's own local server is deliberately absent: it is reachable only from this computer,
+  // so advertising it to a space's readers publishes an address none of them can resolve.
+  //
+  // Whatever the space already advertises stays selectable even if this app has not configured it,
+  // so opening the page on another machine can never silently drop the space's server.
+  const serverOptions = Array.from(
+    new Set([
+      ...(publishedServer ? [publishedServer] : []),
+      ...(knownServers.data ?? []).filter((serverUrl) => !isLocalAgentServer(serverUrl, localServerUrl.data)),
+    ]),
+  )
+
+  const publishedRows = idsValue.map((agentId) => ({
+    agentId,
+    agent: serverAgents.find((agent) => agent.id === agentId),
+  }))
+  const unpublished = serverAgents.filter((agent) => !idsValue.includes(agent.id))
+  const addableAgents = unpublished.filter(canPublishAgent)
+  const privateCount = unpublished.length - addableAgents.length
+
+  function chooseServer(next: string) {
+    const serverUrl = next === NO_SERVER ? '' : next
+    setServerDraft(serverUrl)
+    // Published ids name agents on one particular server and mean nothing on another, so switching
+    // servers empties the list — and switching back before saving restores what was published.
+    setIdsDraft(serverUrl === (publishedServer ?? '') ? null : [])
+  }
+
+  async function handleSave() {
+    try {
+      const nextMetadata: HMMetadata = {
+        ...metadata,
+        agentServerUrl: serverValue || undefined,
+        spaceAgents: spaceAgentsMetadata(idsValue),
+      }
+      await updateHome.mutateAsync({metadata: nextMetadata})
+      toast.success('Space agents updated')
+      setServerDraft(null)
+      setIdsDraft(null)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to update space agents')
+    }
+  }
+
+  async function setAccess(agent: AgentInfo, access: AgentAccess) {
+    try {
+      if (access === 'private') {
+        // Turning public read off clears public chat on the server, so this one call is enough.
+        await setPublicRead.mutateAsync({agentId: agent.id, publicRead: false})
+      } else {
+        if (!agent.publicRead) await setPublicRead.mutateAsync({agentId: agent.id, publicRead: true})
+        await setPublicChat.mutateAsync({agentId: agent.id, publicChat: access === 'chat'})
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to change who can reach this agent')
+    }
+  }
+
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <SizableText size="2xl" weight="bold">
+          Agents
+        </SizableText>
+        <Button variant="default" disabled={!canSave} onClick={handleSave}>
+          {updateHome.isPending ? 'Saving…' : 'Save'}
+        </Button>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <SizableText weight="medium">Agents server</SizableText>
+        <div className="flex items-center gap-2">
+          <Select value={serverValue || NO_SERVER} onValueChange={chooseServer}>
+            <SelectTrigger className="h-9 max-w-md">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NO_SERVER}>No agents server</SelectItem>
+              {serverOptions.map((serverUrl) => (
+                <SelectItem key={serverUrl} value={serverUrl}>
+                  {describeAgentServer(serverUrl, localServerUrl.data)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {openServerSettings ? (
+            <Tooltip content="Add or remove agent servers">
+              <Button variant="outline" size="sm" onClick={openServerSettings}>
+                <Settings className="size-4" />
+                Manage servers
+              </Button>
+            </Tooltip>
+          ) : null}
+        </div>
+        <SizableText size="xs" color="muted">
+          Everyone reading this space connects to this server, alongside their own, to reach the agents you publish.
+        </SizableText>
+        {isLocal ? (
+          // Not offered by the dropdown, but a space that already advertises it needs to be told why
+          // that is broken rather than left to wonder where its readers' agents went.
+          <SizableText size="xs" className="text-destructive">
+            Local Agents runs only on this computer, so visitors to your space cannot reach it. Choose a server they
+            can.
+          </SizableText>
+        ) : null}
+      </div>
+
+      {/* Nothing to publish to until a server is chosen: the ids in this list name agents on one
+          particular server, so without one the list would be a set of addresses to nowhere. */}
+      {serverValue ? (
+        <div className="flex flex-col gap-2">
+          <SizableText weight="medium">Published agents</SizableText>
+          <SizableText size="xs" color="muted">
+            These appear in the agents panel for everyone visiting this space. The default is the one a new visitor
+            opens on.
+          </SizableText>
+
+          {/* One card: the published agents and the control that adds to them are the same list, and
+              reading them as two stacked sections made adding look like a separate setting. */}
+          <div className="border-border divide-border divide-y overflow-hidden rounded-lg border">
+            {publishedRows.map(({agentId, agent}, index) => (
+              <PublishedAgentRow
+                key={agentId}
+                agent={agent}
+                isDefault={index === 0}
+                onOpen={agent ? () => navigate({key: 'agent', agentId, serverUrl: serverValue}) : undefined}
+                onMakeDefault={index === 0 ? undefined : () => setIdsDraft(makeSpaceAgentDefault(idsValue, agentId))}
+                onRemove={() => setIdsDraft(idsValue.filter((id) => id !== agentId))}
+                onAccessChange={agent ? (access) => setAccess(agent, access) : undefined}
+                accessDisabled={setPublicRead.isLoading || setPublicChat.isLoading}
+              />
+            ))}
+            {!publishedRows.length ? (
+              <div className="px-3 py-4">
+                <SizableText size="xs" color="muted">
+                  No agents published yet — visitors to this space find nothing to chat with.
+                </SizableText>
+              </div>
+            ) : null}
+            <div className="bg-muted/30 flex items-center gap-2 px-3 py-2">
+              <Plus className="text-muted-foreground size-4 flex-none" />
+              <AddAgentControl
+                key={addKey}
+                agents={addableAgents}
+                agentList={agentList}
+                onAdd={(agent) => {
+                  setAddKey((key) => key + 1)
+                  setIdsDraft([...idsValue, agent.id])
+                }}
+              />
+            </div>
+          </div>
+
+          {privateCount ? (
+            <SizableText size="xs" color="muted">
+              {privateCount === 1 ? 'One agent on this server is' : `${privateCount} agents on this server are`} private
+              and cannot be published. Give an agent public access from its own page first.
+            </SizableText>
+          ) : null}
+        </div>
+      ) : null}
+    </>
+  )
+}
+
+/** Sentinel for the "no agents server" choice: a Select item cannot carry an empty value. */
+const NO_SERVER = 'none'
+
+function PublishedAgentRow({
+  agent,
+  isDefault,
+  onOpen,
+  onMakeDefault,
+  onRemove,
+  onAccessChange,
+  accessDisabled,
+}: {
+  /** Absent when the published id names no agent this account can see on the selected server. */
+  agent: AgentInfo | undefined
+  isDefault: boolean
+  onOpen?: () => void
+  onMakeDefault?: () => void
+  onRemove: () => void
+  onAccessChange?: (access: AgentAccess) => void
+  accessDisabled: boolean
+}) {
+  return (
+    <div
+      data-testid="published-agent"
+      role={onOpen ? 'button' : undefined}
+      tabIndex={onOpen ? 0 : undefined}
+      onClick={onOpen}
+      onKeyDown={(event) => {
+        if (onOpen && (event.key === 'Enter' || event.key === ' ')) {
+          event.preventDefault()
+          onOpen()
+        }
+      }}
+      className={cn('flex items-center gap-3 px-3 py-2.5', onOpen && 'hover:bg-muted/50 cursor-pointer')}
+    >
+      <div className="bg-primary/10 text-primary flex size-9 flex-none items-center justify-center rounded-lg">
+        <Bot className="size-4" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <SizableText weight="bold" className="truncate">
+            {agent ? agent.definition.name : 'Unavailable agent'}
+          </SizableText>
+          {isDefault ? (
+            <span className="bg-primary/10 text-primary rounded-full px-2 py-0.5 text-[10px] font-bold uppercase">
+              Default
+            </span>
+          ) : null}
+        </div>
+        {!agent ? (
+          <SizableText size="xs" color="muted" className="block">
+            Not on this server, or not visible to you
+          </SizableText>
+        ) : !agent.publicRead ? (
+          <SizableText size="xs" className="text-destructive block">
+            Private — readers of this space cannot see it
+          </SizableText>
+        ) : null}
+      </div>
+      {/* The row opens the agent; its controls act on the space, so they must not also navigate. */}
+      <div className="flex items-center gap-2" onClick={(event) => event.stopPropagation()}>
+        {onMakeDefault ? (
+          <Tooltip content="Open the agents panel on this agent for new visitors">
+            <Button variant="outline" size="sm" onClick={onMakeDefault}>
+              Make default
+            </Button>
+          </Tooltip>
+        ) : null}
+        {agent && onAccessChange ? (
+          <AccessSelect agent={agent} disabled={accessDisabled} onChange={onAccessChange} />
+        ) : null}
+        <Tooltip content="Remove from this space">
+          <Button variant="ghost" size="sm" aria-label="Remove from this space" onClick={onRemove}>
+            <X className="size-4" />
+          </Button>
+        </Tooltip>
+      </div>
+    </div>
+  )
+}
+
+/** The dropdown that publishes one more agent, plus the states in which there is nothing to offer. */
+function AddAgentControl({
+  agents,
+  agentList,
+  onAdd,
+}: {
+  agents: AgentInfo[]
+  agentList: {isInitialLoading: boolean; isError: boolean; error: unknown}
+  onAdd: (agent: AgentInfo) => void
+}) {
+  if (agentList.isInitialLoading) return <Spinner />
+  if (agentList.isError) {
+    return (
+      <SizableText size="xs" className="text-destructive">
+        {agentList.error instanceof Error ? agentList.error.message : 'Could not reach the agents server'}
+      </SizableText>
+    )
+  }
+  return (
+    <Select
+      onValueChange={(agentId) => {
+        const agent = agents.find((candidate) => candidate.id === agentId)
+        if (agent) onAdd(agent)
+      }}
+    >
+      <SelectTrigger className="h-8 max-w-xs border-none bg-transparent shadow-none" size="sm">
+        <SelectValue placeholder={agents.length ? 'Add an agent…' : 'No public agents to add'} />
+      </SelectTrigger>
+      <SelectContent>
+        {agents.map((agent) => (
+          <SelectItem key={agent.id} value={agent.id}>
+            {agent.definition.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+/** Who, besides the agent's own collaborators, may reach it. */
+type AgentAccess = 'private' | 'read' | 'chat'
+
+const ACCESS_OPTIONS: {value: AgentAccess; label: string; hint: string}[] = [
+  {value: 'private', label: 'Private', hint: 'Only collaborators. Readers of this space see nothing.'},
+  {value: 'read', label: 'Anyone can view', hint: 'Visitors see the agent but cannot start a chat.'},
+  {value: 'chat', label: 'Anyone can chat', hint: 'Visitors can open the panel and start chatting.'},
+]
+
+/** An absent role comes from the owner's own listing, so it counts as ownership. */
+function isAgentOwner(agent: AgentInfo): boolean {
+  return agent.accessRole === undefined || agent.accessRole === 'owner'
+}
+
+function agentAccess(agent: AgentInfo): AgentAccess {
+  if (!agent.publicRead) return 'private'
+  return agent.publicChat ? 'chat' : 'read'
+}
+
+/**
+ * Who can reach one agent, as a single choice rather than two switches: public chat requires public
+ * read, and offering them separately invites the state where chat is asked for and silently refused.
+ */
+function AccessSelect({
+  agent,
+  disabled,
+  onChange,
+}: {
+  agent: AgentInfo
+  disabled: boolean
+  onChange: (access: AgentAccess) => void
+}) {
+  const access = agentAccess(agent)
+  if (!isAgentOwner(agent)) {
+    return (
+      <SizableText size="xs" color="muted">
+        {ACCESS_OPTIONS.find((option) => option.value === access)?.label}
+      </SizableText>
+    )
+  }
+  return (
+    <Tooltip content={ACCESS_OPTIONS.find((option) => option.value === access)?.hint ?? ''}>
+      <div>
+        <Select value={access} onValueChange={(value) => onChange(value as AgentAccess)} disabled={disabled}>
+          <SelectTrigger className="h-8 w-40" size="sm">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {ACCESS_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </Tooltip>
+  )
+}
+
+/** The server URL to use, or null when the setting is empty or not an http(s) address. */
+function safeServerUrl(value: string): string | null {
+  if (!value.trim()) return null
+  try {
+    return normalizeAgentServerUrl(value)
+  } catch {
+    return null
+  }
+}
+
+function sameOrder(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index])
+}

--- a/frontend/apps/desktop/src/pages/site-settings.tsx
+++ b/frontend/apps/desktop/src/pages/site-settings.tsx
@@ -1,3 +1,4 @@
+import {SpaceAgentsSettings} from '@/components/site-settings-agents'
 import {MembersSettings} from '@/components/site-settings-members'
 import {NavigationSettings} from '@/components/site-settings-navigation'
 import {useUpdateHomeDocument} from '@/models/site'
@@ -17,11 +18,11 @@ import {Spinner} from '@shm/ui/spinner'
 import {SizableText} from '@shm/ui/text'
 import {toast} from '@shm/ui/toast'
 import {cn} from '@shm/ui/utils'
-import {Image as ImageIcon, Navigation as NavigationIcon, Plus, Users} from 'lucide-react'
+import {Bot, Image as ImageIcon, Navigation as NavigationIcon, Plus, Users} from 'lucide-react'
 import {type ReactNode, useState} from 'react'
 
 // Tabs of the site settings page
-type SiteSettingsSection = 'identity' | 'navigation' | 'members'
+type SiteSettingsSection = 'identity' | 'navigation' | 'members' | 'agents'
 
 type SiteSettingsTabConfig = {
   key: SiteSettingsSection
@@ -33,12 +34,14 @@ const SITE_SETTINGS_TAB_CONFIG: SiteSettingsTabConfig[] = [
   {key: 'identity', icon: ImageIcon, label: 'Identity'},
   {key: 'navigation', icon: NavigationIcon, label: 'Navigation'},
   {key: 'members', icon: Users, label: 'Members'},
+  {key: 'agents', icon: Bot, label: 'Agents'},
 ]
 
 /** Map a URL subpath to its tab. */
 function sectionForTab(tab: SiteSettingsTab | undefined): SiteSettingsSection {
   if (tab === 'navigation') return 'navigation'
   if (tab === 'members' || tab === 'writers' || tab === 'email-subscribers') return 'members'
+  if (tab === 'agents') return 'agents'
   return 'identity'
 }
 
@@ -74,6 +77,7 @@ export default function SiteSettings() {
                 {activeSection === 'identity' && <IdentityTab siteId={route.id} />}
                 {activeSection === 'navigation' && <NavigationSettings siteId={route.id} />}
                 {activeSection === 'members' && <MembersSettings siteId={route.id} activeTab={route.tab} />}
+                {activeSection === 'agents' && <SpaceAgentsSettings siteId={route.id} />}
               </div>
             </ScrollArea>
           </div>

--- a/frontend/packages/client/src/hm-types.ts
+++ b/frontend/packages/client/src/hm-types.ts
@@ -564,6 +564,21 @@ export const HMDocumentMetadataSchema = z
      * agents for its audience — on the gateway, each site brings its own agents backend.
      */
     agentServerUrl: z.string().optional(),
+    /**
+     * Agents this space publishes to its readers: `{[agentId]: order}`, where each id names an agent
+     * on {@link agentServerUrl} and the number is its position in the picker.
+     *
+     * This is what makes a space's agents reachable by someone who just arrived: an agent server
+     * only ever lists agents you own or collaborate on, so a reader cannot discover them by asking.
+     * Named here, the client fetches each one by id, which the server serves to any signed account
+     * once the agent is public-read.
+     *
+     * Only ids and order live here — an agent's name and icon are read from the agent itself, so
+     * renaming one never strands a stale copy in a signed document. Values are typed loosely
+     * because removal leaves a null attribute behind rather than dropping the key; `parseSpaceAgentIds`
+     * in @shm/ui/agents/space-agents is the reader for this field.
+     */
+    spaceAgents: z.record(z.unknown()).optional(),
     layout: z.union([z.literal('Seed/Experimental/Newspaper'), z.literal('')]).optional(),
     displayPublishTime: z.string().optional(),
     displayAuthor: z.string().optional(),
@@ -612,6 +627,7 @@ export const DOCUMENT_ATTRIBUTE_DESCRIPTIONS: Readonly<Record<string, string>> =
   cover: 'Wide cover image shown in headers and cards.',
   siteUrl: 'Published website URL for a space.',
   agentServerUrl: 'Agents server readers of this space connect to.',
+  spaceAgents: 'Agents this space publishes to its readers, by id and order.',
   layout: 'Legacy space header layout setting.',
   displayPublishTime: 'Publication date shown to readers.',
   displayAuthor: 'Author byline shown to readers.',

--- a/frontend/packages/shared/src/routes.ts
+++ b/frontend/packages/shared/src/routes.ts
@@ -291,7 +291,14 @@ export const accountSettingsRouteSchema = z.object({
 /** Navigation route for the desktop Account Settings page. */
 export type AccountSettingsRoute = z.infer<typeof accountSettingsRouteSchema>
 
-export const siteSettingsTabSchema = z.enum(['identity', 'navigation', 'members', 'writers', 'email-subscribers'])
+export const siteSettingsTabSchema = z.enum([
+  'identity',
+  'navigation',
+  'members',
+  'writers',
+  'email-subscribers',
+  'agents',
+])
 export type SiteSettingsTab = z.infer<typeof siteSettingsTabSchema>
 
 export const siteSettingsRouteSchema = z.object({

--- a/frontend/packages/ui/src/__tests__/options-panel.test.tsx
+++ b/frontend/packages/ui/src/__tests__/options-panel.test.tsx
@@ -49,35 +49,10 @@ function renderOptionsPanel(isHomeDoc: boolean) {
 }
 
 describe('OptionsPanel document metadata fields', () => {
-  it('offers the agents server field on the home document only, saving a trimmed URL on blur', () => {
-    const onMetadata = vi.fn()
-    act(() => {
-      root.render(
-        <TooltipProvider>
-          <OptionsPanel draftId="draft" metadata={{name: 'Site'}} isHomeDoc onMetadata={onMetadata} />
-        </TooltipProvider>,
-      )
-    })
-    const input = container.querySelector('#agent-server-url') as HTMLInputElement
-    expect(input).not.toBeNull()
-    act(() => {
-      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!
-      setter.call(input, '  https://agentic.example.com  ')
-      input.dispatchEvent(new Event('input', {bubbles: true}))
-    })
-    act(() => {
-      // React's onBlur listens to the bubbling focusout event.
-      input.dispatchEvent(new FocusEvent('focusout', {bubbles: true}))
-    })
-    expect(onMetadata).toHaveBeenCalledWith({agentServerUrl: 'https://agentic.example.com'})
-
-    act(() => {
-      root.render(
-        <TooltipProvider>
-          <OptionsPanel draftId="draft" metadata={{name: 'Doc'}} isHomeDoc={false} onMetadata={onMetadata} />
-        </TooltipProvider>,
-      )
-    })
+  // The agents server a space advertises is a space-wide setting, not a document one: it lives on
+  // the Agents tab of Space Settings, so it is deliberately absent here.
+  it('does not offer the agents server field', () => {
+    renderOptionsPanel(true)
     expect(container.querySelector('#agent-server-url')).toBeNull()
   })
 

--- a/frontend/packages/ui/src/__tests__/space-agents-hook.test.tsx
+++ b/frontend/packages/ui/src/__tests__/space-agents-hook.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import {createRoot, type Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+/**
+ * The agents a space publishes to its readers.
+ *
+ * A reader owns none of a space's agents and collaborates on none, so asking the server to list
+ * them returns nothing. Each published agent is fetched by the id the space named instead — which
+ * the server answers for any signed account once the agent is public-read.
+ */
+
+const mockState = vi.hoisted(() => ({
+  route: null as null | Record<string, unknown>,
+  originHomeId: undefined as undefined | {uid: string},
+  homeMetadata: {} as Record<string, unknown>,
+  requests: [] as {serverUrl: string; accountUid: string; agentId: string}[],
+  missingAgentIds: new Set<string>(),
+}))
+
+vi.mock('../agents/platform', () => ({
+  getAgentsPlatform: () => ({
+    defaultServerUrl: () => null,
+    getSetting: async () => null,
+    setSetting: vi.fn(),
+    getLocalServerUrl: async () => null,
+  }),
+  setAgentsPlatform: vi.fn(),
+}))
+vi.mock('../agents/client', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  sendAgentAction: async ({
+    serverUrl,
+    accountUid,
+    action,
+  }: {
+    serverUrl: string
+    accountUid: string
+    action: {_: string; agentId: string}
+  }) => {
+    mockState.requests.push({serverUrl, accountUid, agentId: action.agentId})
+    if (mockState.missingAgentIds.has(action.agentId)) throw new Error('Agent not found')
+    return {
+      _: 'GetAgentResponse',
+      agent: {id: action.agentId, definition: {name: `Agent ${action.agentId}`}},
+      sessions: [],
+    }
+  },
+}))
+vi.mock('@shm/shared/utils/navigation', () => ({useNavRouteOrNull: () => mockState.route}))
+vi.mock('@shm/shared/models/entity', () => ({
+  useResource: (id: {uid: string} | undefined) =>
+    id ? {data: {type: 'document', document: {metadata: mockState.homeMetadata}}} : {data: undefined},
+}))
+
+import {UniversalAppContext} from '@shm/shared/routing'
+import {useSpaceAgents} from '../agents/models'
+
+let container: HTMLDivElement
+let root: Root
+let latest: ReturnType<typeof useSpaceAgents> | null = null
+
+function Probe({accountUid}: {accountUid: string | null}) {
+  latest = useSpaceAgents(accountUid)
+  return null
+}
+
+async function render(accountUid: string | null = 'reader-uid') {
+  const client = new QueryClient({defaultOptions: {queries: {retry: false}}})
+  await act(async () => {
+    root.render(
+      <QueryClientProvider client={client}>
+        <UniversalAppContext.Provider value={{originHomeId: mockState.originHomeId, openUrl: () => {}} as any}>
+          <Probe accountUid={accountUid} />
+        </UniversalAppContext.Provider>
+      </QueryClientProvider>,
+    )
+  })
+  // Let the GetAgent queries resolve.
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+}
+
+beforeEach(() => {
+  ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+  mockState.route = null
+  mockState.originHomeId = undefined
+  mockState.homeMetadata = {}
+  mockState.requests = []
+  mockState.missingAgentIds = new Set()
+  latest = null
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+describe('useSpaceAgents', () => {
+  it('fetches each published agent by id from the space server, in published order', async () => {
+    mockState.route = {key: 'document', id: {uid: 'space-uid', path: ['about']}}
+    mockState.homeMetadata = {
+      agentServerUrl: 'https://agents.space.example/',
+      spaceAgents: {second: 1, first: 0},
+    }
+    await render()
+    expect(mockState.requests.map((request) => request.agentId).sort()).toEqual(['first', 'second'])
+    expect(mockState.requests[0]!.serverUrl).toBe('https://agents.space.example')
+    expect(latest!.agents.map((option) => option.agent.id)).toEqual(['first', 'second'])
+    expect(latest!.agents[0]!.serverUrl).toBe('https://agents.space.example')
+  })
+
+  it('drops an agent that no longer loads instead of failing the list', async () => {
+    // A space naming an agent that was since deleted or made private should offer one fewer agent,
+    // not an error where a chat belongs.
+    mockState.route = {key: 'document', id: {uid: 'space-uid', path: []}}
+    mockState.homeMetadata = {
+      agentServerUrl: 'https://agents.space.example',
+      spaceAgents: {gone: 0, here: 1},
+    }
+    mockState.missingAgentIds = new Set(['gone'])
+    await render()
+    expect(latest!.agents.map((option) => option.agent.id)).toEqual(['here'])
+  })
+
+  it('uses the space hosting the app when the route names no document', async () => {
+    // The web app's own /hm/agents pages are served by a space but carry no document route.
+    mockState.route = {key: 'agents'}
+    mockState.originHomeId = {uid: 'origin-uid'}
+    mockState.homeMetadata = {agentServerUrl: 'https://agents.space.example', spaceAgents: {only: 0}}
+    await render()
+    expect(latest!.agents.map((option) => option.agent.id)).toEqual(['only'])
+  })
+
+  it('fetches nothing without a space server, a published list, or an account to sign with', async () => {
+    mockState.route = {key: 'document', id: {uid: 'space-uid', path: []}}
+    mockState.homeMetadata = {spaceAgents: {orphan: 0}}
+    await render()
+    expect(latest!.agents).toEqual([])
+
+    mockState.homeMetadata = {agentServerUrl: 'https://agents.space.example'}
+    await render()
+    expect(latest!.agents).toEqual([])
+
+    mockState.homeMetadata = {agentServerUrl: 'https://agents.space.example', spaceAgents: {only: 0}}
+    await render(null)
+    expect(latest!.agents).toEqual([])
+    expect(mockState.requests).toEqual([])
+  })
+})

--- a/frontend/packages/ui/src/__tests__/space-agents.test.ts
+++ b/frontend/packages/ui/src/__tests__/space-agents.test.ts
@@ -1,0 +1,62 @@
+import {describe, expect, it} from 'vitest'
+import {canPublishAgent, makeSpaceAgentDefault, parseSpaceAgentIds, spaceAgentsMetadata} from '../agents/space-agents'
+
+/**
+ * A space publishes its agents as `{[agentId]: order}` on the home document, because document
+ * metadata attributes have no array encoding. These are the rules for reading that back and for
+ * writing it out again.
+ */
+describe('space agents metadata', () => {
+  it('reads published ids in their published order', () => {
+    expect(parseSpaceAgentIds({b: 1, a: 0, c: 2})).toEqual(['a', 'b', 'c'])
+  })
+
+  it('skips the tombstones left by removing an agent', () => {
+    // Removal writes a null attribute rather than dropping the key, so the document keeps a hole.
+    expect(parseSpaceAgentIds({a: 0, b: null, c: 1})).toEqual(['a', 'c'])
+  })
+
+  it('breaks ties on the id so the order is total, and tolerates gaps', () => {
+    expect(parseSpaceAgentIds({b: 5, a: 5, c: 90})).toEqual(['a', 'b', 'c'])
+  })
+
+  it('reads nothing from a missing, non-object, or array value', () => {
+    expect(parseSpaceAgentIds(undefined)).toEqual([])
+    expect(parseSpaceAgentIds('agent-1')).toEqual([])
+    expect(parseSpaceAgentIds(['agent-1'])).toEqual([])
+  })
+
+  it('renumbers positions densely from zero when writing', () => {
+    expect(spaceAgentsMetadata(['a', 'b', 'c'])).toEqual({a: 0, b: 1, c: 2})
+    // An emptied list writes an empty object; the change diff turns that into a removal.
+    expect(spaceAgentsMetadata([])).toEqual({})
+  })
+
+  it('round-trips an edited order', () => {
+    const ids = parseSpaceAgentIds({a: 0, b: 1, c: 2})
+    expect(parseSpaceAgentIds(spaceAgentsMetadata(makeSpaceAgentDefault(ids, 'c')))).toEqual(['c', 'a', 'b'])
+  })
+})
+
+/** The default agent is the first one, since the assistant panel opens on the first option. */
+describe('makeSpaceAgentDefault', () => {
+  it('moves the chosen agent to the front, keeping the rest in order', () => {
+    expect(makeSpaceAgentDefault(['a', 'b', 'c'], 'c')).toEqual(['c', 'a', 'b'])
+  })
+
+  it('changes nothing when the agent already leads, or is not published at all', () => {
+    const ids = ['a', 'b']
+    expect(makeSpaceAgentDefault(ids, 'a')).toBe(ids)
+    expect(makeSpaceAgentDefault(ids, 'missing')).toBe(ids)
+  })
+})
+
+describe('canPublishAgent', () => {
+  it('only allows an agent that is already public, whoever owns it', () => {
+    // Opening an agent to the world is a decision made on the agent, never a side effect of
+    // listing it on a space.
+    expect(canPublishAgent({publicRead: true})).toBe(true)
+    expect(canPublishAgent({publicRead: false})).toBe(false)
+    expect(canPublishAgent({})).toBe(false)
+  })
+})

--- a/frontend/packages/ui/src/agents/assistant-panel.tsx
+++ b/frontend/packages/ui/src/agents/assistant-panel.tsx
@@ -10,6 +10,7 @@ import {
   useSessionRuns,
   useAgentWebSocketSubscription,
   useAllAgentSessions,
+  useSpaceAgents,
   useCreateAgentSessionOnServer,
   useDeleteAgentSession,
   useLocalAgentServerUrl,
@@ -28,7 +29,12 @@ import {
   frozenRunIds,
   retryableErrorRowKey,
 } from './agent-session-rows'
-import {resolveAssistantSelection, type AssistantAgentKey, type AssistantAgentOption} from './assistant-selection'
+import {
+  orderAssistantAgents,
+  resolveAssistantSelection,
+  type AssistantAgentKey,
+  type AssistantAgentOption,
+} from './assistant-selection'
 import {CreateAgentDialog} from './dialogs'
 import {useSelectedAccountId} from './account'
 import {useNavigate} from './navigation'
@@ -103,12 +109,17 @@ export function AssistantPanel({
   const sessions = useAllAgentSessions(serverUrls.data, accountUid)
   const navigate = useNavigate()
 
+  const spaceAgents = useSpaceAgents(accountUid)
+
   const agents: AssistantAgentOption[] = useMemo(
     () =>
-      (serverUrls.data || []).flatMap((serverUrl, index) =>
-        (agentQueries[index]?.data || []).map((agent) => ({serverUrl, agent})),
+      orderAssistantAgents(
+        spaceAgents.agents,
+        (serverUrls.data || []).flatMap((serverUrl, index) =>
+          (agentQueries[index]?.data || []).map((agent) => ({serverUrl, agent})),
+        ),
       ),
-    [serverUrls.data, agentQueries],
+    [serverUrls.data, agentQueries, spaceAgents.agents],
   )
 
   const [stored, setStoredRaw] = useState<AssistantSessionRef | null>(() => decodeAssistantSessionRef(initialSessionId))

--- a/frontend/packages/ui/src/agents/assistant-selection.ts
+++ b/frontend/packages/ui/src/agents/assistant-selection.ts
@@ -41,6 +41,32 @@ export type AssistantSelection = {
   session: AssistantSessionRef | null
 }
 
+/**
+ * Orders the agents offered in the context dropdown.
+ *
+ * The space in view leads, because the default context is the first option (see
+ * {@link resolveAssistantSelection}): a reader who opens the panel on a space should land in the
+ * agent that space put first, without picking one. The user's own agents follow in server order,
+ * with the app's local server first, so a desktop user away from any space still opens on the
+ * built-in Assistant. An agent reachable both ways appears once, in the leading position.
+ *
+ * This only sets the default. An agent the user explicitly chose outranks it.
+ */
+export function orderAssistantAgents(
+  spaceAgents: AssistantAgentOption[],
+  ownAgents: AssistantAgentOption[],
+): AssistantAgentOption[] {
+  const options: AssistantAgentOption[] = []
+  const seen = new Set<string>()
+  for (const option of [...spaceAgents, ...ownAgents]) {
+    const key = `${option.serverUrl}:${option.agent.id}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    options.push(option)
+  }
+  return options
+}
+
 function findAgent(agents: AssistantAgentOption[], key: {serverUrl: string; agentId: string}) {
   return agents.find((option) => option.serverUrl === key.serverUrl && option.agent.id === key.agentId) ?? null
 }

--- a/frontend/packages/ui/src/agents/list.tsx
+++ b/frontend/packages/ui/src/agents/list.tsx
@@ -10,6 +10,7 @@ import {
   useAgentServerUrls,
   useAgentWebSocketSubscription,
   useLocalAgentServerUrl,
+  useSpaceAgents,
 } from './models'
 import {useSelectedAccountId} from './account'
 import {useNavigate} from './navigation'
@@ -67,6 +68,17 @@ function AgentsListContent({selectedAccountId}: {selectedAccountId: string}) {
         (inviteQueries[index]?.data || []).map((invite) => ({...invite, serverUrl})),
       ),
     [inviteQueries, serverUrls],
+  )
+  const spaceAgents = useSpaceAgents(selectedAccountId)
+  // Only the ones the user does not already have. A space owner's own agents belong under "All
+  // Agents" below, where they can be opened and edited; what this section is for is the visitor
+  // case, where every list comes back empty and the space's published agents are the only way in.
+  const publishedAgents = useMemo(
+    () =>
+      spaceAgents.agents.filter(
+        (option) => !agents.some((agent) => agent.serverUrl === option.serverUrl && agent.id === option.agent.id),
+      ),
+    [agents, spaceAgents.agents],
   )
   const isLoadingAgents = agentQueries.some((query) => query.isFetching && !query.data)
   const agentError = agentQueries.find((query) => query.isError)?.error
@@ -179,6 +191,24 @@ function AgentsListContent({selectedAccountId}: {selectedAccountId: string}) {
                   key={`${invite.serverUrl}:${invite.agentId}`}
                   invite={invite}
                   selectedAccountId={selectedAccountId}
+                />
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        {publishedAgents.length ? (
+          <section className="flex flex-col gap-3">
+            <SizableText weight="bold">Agents in this space</SizableText>
+            <div className="flex flex-col gap-2">
+              {publishedAgents.map(({serverUrl, agent}) => (
+                <AgentListRow
+                  key={`${serverUrl}:${agent.id}`}
+                  agentId={agent.id}
+                  name={agent.definition.name}
+                  status={agent.status}
+                  serverUrl={serverUrl}
+                  accessRole={agent.accessRole}
                 />
               ))}
             </div>

--- a/frontend/packages/ui/src/agents/models.ts
+++ b/frontend/packages/ui/src/agents/models.ts
@@ -35,17 +35,20 @@ import {
 import {isOptimisticUserEcho} from './agent-session-rows'
 import {moveAgentToServer, type MoveAgentOptions} from './move-agent'
 import {getAgentsPlatform} from './platform'
+import {parseSpaceAgentIds} from './space-agents'
 import {getToolReferencedUrls} from '@seed-hypermedia/agents-protocol'
 import * as cbor from '@shm/shared/cbor'
 import {getQueryClient, invalidateQueries} from '@shm/shared/models/query-client'
+import type {HMMetadata} from '@seed-hypermedia/client/hm-types'
 import {useResource} from '@shm/shared/models/entity'
+import {UniversalAppContext} from '@shm/shared/routing'
 import type {NavRoute} from '@shm/shared/routes'
 import {hmId} from '@shm/shared/utils/entity-id-url'
 import {useNavRouteOrNull} from '@shm/shared/utils/navigation'
 import {queryKeys} from '@shm/shared'
 import {unpackHmId} from '@shm/shared/utils/entity-id-url'
 import {useMutation, useQueries, useQuery} from '@tanstack/react-query'
-import {useEffect, useMemo, useRef, useState} from 'react'
+import {useContext, useEffect, useMemo, useRef, useState} from 'react'
 
 const AGENT_SERVER_URL_KEY = 'agent-server-url'
 const AGENT_SERVER_URLS_KEY = 'agent-server-urls'
@@ -274,20 +277,87 @@ export function useAgentServerUrls() {
 }
 
 /**
+ * Home document metadata of the space in view, if any.
+ *
+ * The space is the account of the current route's document (a draft's edit target counts). Where
+ * the app is itself served by a space — the web app and the gateway — that space is the fallback
+ * for routes that name no document, so the /hm/agents pages are still "in" the space hosting them.
+ * The desktop app sets no origin, so there it is the route or nothing. Code rendered outside a
+ * navigation provider (settings windows) reads no space at all rather than throwing.
+ */
+function useSiteHomeMetadata(): HMMetadata | undefined {
+  const route = useNavRouteOrNull()
+  const originHomeId = useContext(UniversalAppContext).originHomeId
+  const siteUid = (route ? siteUidOfRoute(route) : undefined) ?? originHomeId?.uid
+  const home = useResource(siteUid ? hmId(siteUid) : undefined)
+  return home.data?.type === 'document' ? home.data.document?.metadata : undefined
+}
+
+/**
  * The agents server advertised by the site whose document is on screen, if any.
  *
  * Read from the site home document's `agentServerUrl` metadata — the same signed document that
  * names the site — so it is discoverable wherever the site's content is, with no server config.
- * The site is the account of the current route's document (a draft's edit target counts); routes
- * without a document, and code rendered outside a navigation provider, advertise nothing. It is
- * never persisted into the user's configured list: it applies while viewing that site.
+ * It is never persisted into the user's configured list: it applies while viewing that site.
  */
 export function useSiteAdvertisedAgentServerUrl(): string | null {
-  const route = useNavRouteOrNull()
-  const siteUid = route ? siteUidOfRoute(route) : undefined
-  const home = useResource(siteUid ? hmId(siteUid) : undefined)
-  const raw = home.data?.type === 'document' ? home.data.document?.metadata?.agentServerUrl : undefined
+  const raw = useSiteHomeMetadata()?.agentServerUrl
   return useMemo(() => (typeof raw === 'string' && raw ? tryNormalizeAgentServerUrl(raw) : null), [raw])
+}
+
+/** One agent a space publishes, paired with the server it lives on. */
+export type SpaceAgentOption = {serverUrl: string; agent: AgentInfo}
+
+/**
+ * The agents the space in view publishes to its readers, in the order it published them.
+ *
+ * A reader cannot list a space's agents — `ListAgents` only ever returns agents the caller owns or
+ * collaborates on — so each one is fetched by the id the space named in its home document. The
+ * server resolves the owning account from the id itself and answers for any signed account once the
+ * agent is public-read, which is what lets somebody who just joined a space open the assistant and
+ * find something to talk to.
+ *
+ * Agents that fail to load are dropped rather than surfaced: a space naming an agent that was since
+ * deleted, made private, or moved should quietly offer one fewer agent, not an error where a chat
+ * belongs. The queries share their cache key with {@link useAgentDetail}, so opening one of these
+ * agents in the full view renders from what the panel already loaded.
+ */
+export function useSpaceAgents(accountUid: string | null | undefined): {
+  agents: SpaceAgentOption[]
+  isLoading: boolean
+} {
+  const metadata = useSiteHomeMetadata()
+  const rawServerUrl = metadata?.agentServerUrl
+  const serverUrl = useMemo(
+    () => (typeof rawServerUrl === 'string' && rawServerUrl ? tryNormalizeAgentServerUrl(rawServerUrl) : null),
+    [rawServerUrl],
+  )
+  const agentIds = useMemo(() => parseSpaceAgentIds(metadata?.spaceAgents), [metadata?.spaceAgents])
+  const queries = useQueries({
+    queries: (serverUrl && accountUid ? agentIds : []).map((agentId) => ({
+      queryKey: ['agents', 'detail', serverUrl, accountUid, agentId],
+      queryFn: async () => {
+        const res = await sendAgentAction({
+          serverUrl: serverUrl!,
+          accountUid: accountUid!,
+          action: {_: 'GetAgent', agentId},
+        })
+        if (res._ !== 'GetAgentResponse') throw new Error('Unexpected GetAgent response')
+        return res
+      },
+      refetchInterval: AGENT_BACKGROUND_REFETCH_INTERVAL_MS,
+      refetchIntervalInBackground: true,
+      retry: false,
+      useErrorBoundary: false,
+    })),
+  })
+  const agents = serverUrl
+    ? queries
+        .map((query) => query.data?.agent)
+        .filter((agent): agent is AgentInfo => !!agent)
+        .map((agent) => ({serverUrl, agent}))
+    : []
+  return {agents, isLoading: queries.some((query) => query.isLoading)}
 }
 
 /** Account uid of the site a route is looking at, when the route is about a document. */
@@ -708,14 +778,20 @@ export function useAgentServerHealths(serverUrls: string[] | undefined) {
  * The assistant entry points key off this rather than off server availability: the desktop always
  * runs a local server, so "a server exists" is always true and says nothing about whether there is
  * anything to chat with. A server with no agents cannot start a session.
+ *
+ * The space in view counts too. A visitor owns no agents and collaborates on none, so every list
+ * comes back empty for them — without this they would be told there is nothing to chat with while
+ * standing in a space that publishes agents.
  */
 export function useHasAnyAgent(serverUrls: string[] | undefined, accountUid: string | null | undefined) {
   const agentLists = useAgentLists(serverUrls, accountUid)
-  const hasAgents = agentLists.some((query) => (query.data?.length || 0) > 0)
+  const spaceAgents = useSpaceAgents(accountUid)
+  const hasAgents = spaceAgents.agents.length > 0 || agentLists.some((query) => (query.data?.length || 0) > 0)
   // "No agents" is only meaningful once every server has answered. Treating the in-flight state as
   // empty would hide the assistant on each launch and discard the restored sidebar state.
   const isSettled =
     serverUrls !== undefined &&
+    !spaceAgents.isLoading &&
     (agentLists.length === 0 || agentLists.every((query) => query.isSuccess || query.isError))
   return {hasAgents, isSettled}
 }

--- a/frontend/packages/ui/src/agents/space-agents.ts
+++ b/frontend/packages/ui/src/agents/space-agents.ts
@@ -1,0 +1,72 @@
+/**
+ * The agents a space publishes to its readers.
+ *
+ * An agent server only ever lists agents the caller owns or collaborates on, so a reader who has
+ * just arrived at a space cannot discover its agents by asking. The space names them instead, in
+ * its home document's `spaceAgents` metadata, and clients fetch each one by id from the space's
+ * `agentServerUrl` — which the server answers for any signed account once the agent is public-read.
+ *
+ * Stored as `{[agentId]: order}` rather than an ordered list because document metadata attributes
+ * have no array encoding (see `getDocAttributeChanges`): values are strings, ints, bools, and
+ * nested objects only. Nothing but the id and the position is stored — an agent's name, icon, and
+ * status are read from the agent, so renaming one never strands a stale copy in a signed document.
+ *
+ * These helpers are deliberately free of React and fetching so the encoding is directly testable.
+ */
+
+/**
+ * Reads the published agent ids, first to last.
+ *
+ * Tolerates everything a hand-edited or partially-removed document can hold: removing an agent
+ * writes a null attribute rather than dropping the key, so tombstones must be skipped, and orders
+ * may collide or leave gaps. The id breaks ties, keeping the sort total and stable.
+ */
+export function parseSpaceAgentIds(spaceAgents: unknown): string[] {
+  if (!spaceAgents || typeof spaceAgents !== 'object' || Array.isArray(spaceAgents)) return []
+  const entries: [string, number][] = []
+  for (const [agentId, order] of Object.entries(spaceAgents as Record<string, unknown>)) {
+    if (!agentId) continue
+    const position = typeof order === 'number' ? order : typeof order === 'bigint' ? Number(order) : null
+    if (position === null || !Number.isFinite(position)) continue
+    entries.push([agentId, position])
+  }
+  entries.sort((a, b) => a[1] - b[1] || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
+  return entries.map(([agentId]) => agentId)
+}
+
+/**
+ * Encodes an ordered id list back into the metadata value.
+ *
+ * Positions are always renumbered from zero, so the stored orders stay a dense sequence no matter
+ * how the list was edited. Ids dropped from the list are simply absent: `getDocAttributeChanges`
+ * diffs the result against the published value and emits the removals itself.
+ */
+export function spaceAgentsMetadata(agentIds: string[]): Record<string, number> {
+  const value: Record<string, number> = {}
+  for (const agentId of agentIds) {
+    if (!agentId || agentId in value) continue
+    value[agentId] = Object.keys(value).length
+  }
+  return value
+}
+
+/**
+ * Makes one published agent the space's default, which is simply the first of them: the assistant
+ * panel opens on the first option, so position is the whole of what "default" means here.
+ */
+export function makeSpaceAgentDefault(agentIds: string[], agentId: string): string[] {
+  if (!agentIds.includes(agentId) || agentIds[0] === agentId) return agentIds
+  return [agentId, ...agentIds.filter((id) => id !== agentId)]
+}
+
+/**
+ * Whether a space may publish this agent.
+ *
+ * A published agent has to be readable by the people it is published to, so only an agent that is
+ * already public can be published. Publishing deliberately does not grant that itself: opening an
+ * agent to the world is its owner's decision to make on the agent, not a side effect of listing it
+ * on a space.
+ */
+export function canPublishAgent(agent: {publicRead?: boolean}): boolean {
+  return agent.publicRead === true
+}

--- a/frontend/packages/ui/src/options-panel.tsx
+++ b/frontend/packages/ui/src/options-panel.tsx
@@ -36,7 +36,6 @@ export function OptionsPanel({
             <OriginalPublishDate metadata={metadata} onMetadata={onMetadata} />
             <ContentWidth metadata={metadata} onMetadata={onMetadata} />
             <ActivityVisibility metadata={metadata} onMetadata={onMetadata} />
-            <AgentServerInput metadata={metadata} onMetadata={onMetadata} />
           </>
         ) : (
           <>
@@ -242,36 +241,6 @@ function OriginalPublishDate({
           onMetadata({displayPublishTime: ''})
         }}
       />
-    </div>
-  )
-}
-
-/**
- * The agents server this site advertises to its readers. Stored on the home document, so anyone
- * viewing the site — including gateway visitors — connects to it alongside their own servers.
- */
-function AgentServerInput({
-  metadata,
-  onMetadata,
-}: {
-  metadata: HMMetadata
-  onMetadata: (values: Partial<HMMetadata>) => void
-}) {
-  const [value, setValue] = useState(metadata.agentServerUrl || '')
-  return (
-    <div className="flex flex-col gap-1">
-      <Label htmlFor="agent-server-url">Agents Server</Label>
-      <Input
-        id="agent-server-url"
-        type="url"
-        placeholder="https://agentic.example.com"
-        value={value}
-        onChange={(event) => setValue(event.target.value)}
-        onBlur={() => onMetadata({agentServerUrl: value.trim() || undefined})}
-      />
-      <span className="text-muted-foreground text-xs">
-        Readers of this space will see agents hosted on this server in their agents panel.
-      </span>
     </div>
   )
 }


### PR DESCRIPTION
An agent server only ever lists agents the caller owns or collaborates on, so a reader arriving at a space could not discover its agents by asking: every list came back empty, and the `agentServerUrl` a space already advertises (#990) reached nothing they could use. A space now names its agents too.

## Storage

`spaceAgents` on the home document: `{[agentId]: order}`. Given an id, the server resolves the owning account itself and answers `GetAgent` for any signed account once the agent is public-read — so a visitor who owns nothing still gets a list.

Only ids and order live in the document. A name here would be a copy that goes stale the moment the agent is renamed. It is a map to positions rather than a list because document metadata attributes have no array encoding (`getDocAttributeChanges` handles strings, ints, bools, and nested objects only).

## Readers

- `useSpaceAgents` fetches each published agent by id from the space's server, sharing `useAgentDetail`'s cache key so opening one in the full view is already loaded. Agents that fail to load are dropped rather than surfaced: a space naming a since-deleted agent should offer one fewer agent, not an error where a chat belongs.
- `orderAssistantAgents` puts them ahead of the user's own, deduped. The panel's default context is its first option, so opening the sidebar on a space lands in that space's agent without picking one. An explicit choice still outranks it.
- `useHasAnyAgent` counts them — otherwise a visitor is told there is nothing to chat with while standing in a space that publishes agents.
- `/hm/agents` gains an "Agents in this space" section, showing only agents the user does not already own so no row appears twice.
- The site-metadata lookup falls back to the app's own `originHomeId`, which is what makes web's `/hm/agents` pages "in" the space serving them. Desktop sets no origin, so there it is the route or nothing.

## Owners

A new **Agents** tab in Space Settings. It also takes over the agents-server field from the home document's options panel, so that setting lives in one place.

Both the server and the agent are picked from dropdowns rather than typed:

- **Server** — the servers this app talks to, plus whatever the space already advertises (so opening the page on another machine cannot silently drop it). The desktop's own local server is excluded: advertising `localhost` publishes an address no reader can resolve. A space that somehow holds that value still gets told why it is broken.
- **Agent** — that server's public agents. Publishing never changes an agent's access; opening an agent to the world is a decision made on the agent, not a side effect of listing it on a space. Private agents are held back with a line saying how many, so their absence does not read as a bug.

The published order carries exactly one meaning — the first agent is the default a new visitor opens on — so rows offer a "make default" button rather than reordering, and the first row wears a `Default` tag. Rows open the agent page on click; the row's own controls stop propagation so they do not also navigate. Agent ids are uuids and are never rendered. The add control sits inside the published-agents card as a footer row, and the whole section stays hidden until a server is chosen.

Per-row access (Private / Anyone can view / Anyone can chat) is one control rather than two switches, since public chat requires public read and offering them separately invites asking for chat and being silently refused. That applies immediately — it is server state, not document state — while the published list saves with the page.

## What this does not do

Web still gates the agents entry point on having a local key, so "join a space and immediately chat" costs an account-creation dialog before the composer appears. Everything behind that wall now works for a visitor; removing it is a separate change.

## Testing

`pnpm typecheck` clean across ui / desktop / web / shared. Suites pass: desktop 714, ui 340, web 205, shared 1028.

New coverage: the metadata encoding and its rules (`space-agents.test.ts`), `useSpaceAgents` fetch/order/failure/origin-fallback (`space-agents-hook.test.tsx`), picker ordering and precedence (`assistant-selection.test.ts`), and the settings tab end to end including the default tag, row navigation, local-server exclusion, and the server-gating (`space-agents-settings.test.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZYw3xXjs8mfd7rb3M97Sj
