### PR TITLE
feat(web): hide the agents entry on a space with no agents server

### DIFF
--- a/agents/docs/environments.md
+++ b/agents/docs/environments.md
@@ -245,6 +245,9 @@ the assistant panel's picker, where the first one becomes the default context. B
 published agent, someone arriving at a space can open the panel and start chatting without configuring anything,
 provided the agent has public chat enabled (`SetAgentPublicChat`, offered per agent on that same settings tab).
 
+A space that names no agents server offers no agents at all: the web account menu leaves out the agents entry while
+browsing it, since opening the panel there would only show an empty picker.
+
 Public read is a precondition rather than something publishing arranges: only an already-public agent can be published,
 because opening an agent to the world is a decision made on the agent (`SetAgentPublicRead`), not a side effect of
 listing it on a space. The order carries exactly one meaning — the first published agent is the default — so the

--- a/frontend/apps/web/app/__tests__/web-header-agents-entry.test.tsx
+++ b/frontend/apps/web/app/__tests__/web-header-agents-entry.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import React from 'react'
+import {createRoot, type Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+;(globalThis as typeof globalThis & {React?: typeof React}).React = React
+
+/**
+ * The account menu's way into the agents panel.
+ *
+ * A space names the agents server its readers connect to, in its home document. A space that names
+ * none has nothing for a reader to talk to, so browsing it must not offer the entry point at all —
+ * opening the panel there would only show an empty picker.
+ */
+
+const mockState = vi.hoisted(() => ({
+  homeMetadata: {} as Record<string, unknown>,
+}))
+
+// Partial mocks throughout: only the data this component reads is faked, so the rest of each
+// module keeps working and the test does not have to model the whole app.
+vi.mock('@shm/shared/models/entity', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useAccount: () => ({data: {id: {uid: 'reader-uid'}, metadata: {name: 'Reader'}}}),
+  useResource: () => ({data: {type: 'document', document: {metadata: mockState.homeMetadata}}}),
+}))
+vi.mock('@shm/shared', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useJoinSite: () => ({isJoined: true, joinSite: vi.fn()}),
+}))
+// The account menu renders at mobile width, where it is an inline sheet rather than a portal.
+vi.mock('@shm/ui/use-media', () => ({useMedia: () => ({xs: true})}))
+vi.mock('../auth', () => ({
+  useLocalKeyPair: () => ({id: 'reader-uid', notifyServerUrl: null}),
+  useCreateAccount: () => ({content: null, createAccount: vi.fn()}),
+  LogoutDialog: () => null,
+}))
+vi.mock('../web-create-space-dialog', () => ({
+  useCreateSpaceDialog: () => ({open: vi.fn(), content: null}),
+  useHasExistingSpace: () => ({data: true}),
+}))
+vi.mock('@shm/ui/universal-dialog', () => ({useAppDialog: () => ({open: vi.fn(), content: null})}))
+vi.mock('@shm/shared/utils/navigation', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useNavigate: () => vi.fn(),
+  useNavRoute: () => ({key: 'document', id: {uid: 'space-uid', path: []}}),
+}))
+
+import {WebHeaderActions} from '../web-utils'
+
+let container: HTMLDivElement
+let root: Root
+
+/**
+ * Mounts the header, opens the account menu, and returns its text.
+ *
+ * At mobile width the menu is a sheet, which portals to the body to escape the header's transform —
+ * so it is found on the document rather than in the container the header was rendered into.
+ */
+function openMenu(): string {
+  act(() => {
+    root.render(<WebHeaderActions siteUid="space-uid" />)
+  })
+  const avatarButton = container.querySelector('button')
+  expect(avatarButton, 'no account button rendered').toBeTruthy()
+  act(() => {
+    avatarButton!.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+  })
+  const sheet = document.querySelector('[data-slot="mobile-panel-sheet"]')
+  expect(sheet, 'the account menu did not render').toBeTruthy()
+  return sheet!.textContent ?? ''
+}
+
+beforeEach(() => {
+  ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+  ;(globalThis as any).requestAnimationFrame = (callback: FrameRequestCallback) =>
+    setTimeout(() => callback(0), 0) as unknown as number
+  ;(globalThis as any).cancelAnimationFrame = (handle: number) => clearTimeout(handle)
+  // The sheet restores scroll position on unmount; jsdom implements neither of these.
+  window.scrollTo = () => {}
+  mockState.homeMetadata = {}
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+describe('agents entry in the web account menu', () => {
+  it('offers agents on a space that names an agents server', () => {
+    mockState.homeMetadata = {name: 'A Space', agentServerUrl: 'https://agents.example'}
+    expect(openMenu()).toContain('Agents')
+  })
+
+  it('offers nothing on a space that names none', () => {
+    mockState.homeMetadata = {name: 'A Space'}
+    const menu = openMenu()
+    expect(menu).not.toContain('Agents')
+    // The rest of the menu is untouched, so the space is still perfectly usable.
+    expect(menu).toContain('My Profile')
+  })
+
+  it('treats an empty server setting as none', () => {
+    mockState.homeMetadata = {agentServerUrl: ''}
+    expect(openMenu()).not.toContain('Agents')
+  })
+})

--- a/frontend/apps/web/app/web-utils.tsx
+++ b/frontend/apps/web/app/web-utils.tsx
@@ -9,7 +9,7 @@ import {
 } from '@shm/shared'
 import {DEFAULT_GATEWAY_URL} from '@shm/shared/constants'
 import {useIsSiteOwner} from '@shm/shared/models/capabilities'
-import {useAccount} from '@shm/shared/models/entity'
+import {useAccount, useResource} from '@shm/shared/models/entity'
 import {isNotificationEventRead} from '@shm/shared/models/notification-read-logic'
 import {hmIdToURL} from '@shm/shared/utils/entity-id-url'
 import {useNavigate, useNavRoute} from '@shm/shared/utils/navigation'
@@ -266,6 +266,20 @@ function PlaceholderAvatar({onClick}: {onClick: () => void}) {
 /**
  * Site-header join button or avatar with notifications bell
  */
+/**
+ * The agents server this space names for its readers, if any.
+ *
+ * Read straight from the home document rather than through `useSiteAdvertisedAgentServerUrl`: that
+ * lives in the agents models, and importing them here would pull the whole agents chunk — editor
+ * included — into the initial bundle, which the assistant panel and the /hm/agents pages go out of
+ * their way to avoid. `useResource` is already here via `useAccount`, so this costs nothing.
+ */
+function useSiteAgentServerUrl(siteUid: string): string | null {
+  const home = useResource(hmId(siteUid))
+  const raw = home.data?.type === 'document' ? home.data.document?.metadata?.agentServerUrl : undefined
+  return typeof raw === 'string' && raw ? raw : null
+}
+
 export function WebHeaderActions({siteUid}: {siteUid: string}) {
   const keyPair = useLocalKeyPair()
   const accountId = keyPair?.delegatedAccountUid ?? keyPair?.id
@@ -299,6 +313,10 @@ export function WebHeaderActions({siteUid}: {siteUid: string}) {
   const isMobile = media.xs
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const assistantPanel = useAssistantPanel()
+  // A space that names no agents server has nothing for its readers to talk to, so the entry point
+  // is not offered while browsing it. It stays absent until the home document has loaded, so the
+  // item appears late rather than appearing and then vanishing.
+  const hasSiteAgents = !!useSiteAgentServerUrl(siteUid)
 
   // Show the join button if not joined the site
   if (!keyPair) {
@@ -363,17 +381,21 @@ export function WebHeaderActions({siteUid}: {siteUid: string}) {
         <UserCog className="size-5" />
         <span className="text-sm">Manage account</span>
       </button>
-      <div className="bg-border mx-4 h-px" />
-      <button
-        className="hover:bg-accent flex w-full items-center gap-3 px-4 py-3 text-left"
-        onClick={() => {
-          setMobileMenuOpen(false)
-          assistantPanel.toggle()
-        }}
-      >
-        <Bot className="size-5" />
-        <span className="text-sm">{assistantPanel.isOpen ? 'Close Agents' : 'Agents'}</span>
-      </button>
+      {hasSiteAgents ? (
+        <>
+          <div className="bg-border mx-4 h-px" />
+          <button
+            className="hover:bg-accent flex w-full items-center gap-3 px-4 py-3 text-left"
+            onClick={() => {
+              setMobileMenuOpen(false)
+              assistantPanel.toggle()
+            }}
+          >
+            <Bot className="size-5" />
+            <span className="text-sm">{assistantPanel.isOpen ? 'Close Agents' : 'Agents'}</span>
+          </button>
+        </>
+      ) : null}
       <div className="bg-border mx-4 h-px" />
       {canCreateSpace ? (
         <button
@@ -472,11 +494,15 @@ export function WebHeaderActions({siteUid}: {siteUid: string}) {
                 <UserCog className="size-4" />
                 Manage account
               </DropdownMenuItem>
-              <DropdownMenuSeparator className="bg-black/10 dark:bg-white/10" />
-              <DropdownMenuItem onClick={assistantPanel.toggle}>
-                <Bot className="size-4" />
-                {assistantPanel.isOpen ? 'Close Agents' : 'Agents'}
-              </DropdownMenuItem>
+              {hasSiteAgents ? (
+                <>
+                  <DropdownMenuSeparator className="bg-black/10 dark:bg-white/10" />
+                  <DropdownMenuItem onClick={assistantPanel.toggle}>
+                    <Bot className="size-4" />
+                    {assistantPanel.isOpen ? 'Close Agents' : 'Agents'}
+                  </DropdownMenuItem>
+                </>
+              ) : null}
               <DropdownMenuSeparator className="bg-black/10 dark:bg-white/10" />
               {canCreateSpace ? (
                 <DropdownMenuItem


### PR DESCRIPTION
Follow-up to #992.

A space names the agents server its readers connect to, in its home document. A space that names none has nothing for a reader to talk to, so the web account menu no longer offers the way in while browsing it — both the desktop dropdown item and the mobile sheet entry. Opening the panel there would only show an empty picker.

The check reads `agentServerUrl` straight from the home document rather than going through `useSiteAdvertisedAgentServerUrl`. That hook lives in the agents models, and importing them into the site header would pull the whole agents chunk — editor included — into the initial bundle, which the assistant panel and the `/hm/agents` pages go out of their way to avoid. `useResource` is already in this bundle via `useAccount`, so the check costs nothing.

It stays absent until the home document has loaded, so the item appears late rather than appearing and then vanishing.

`/hm/agents` itself is untouched and still reachable by URL; this is about not advertising an empty room.

## Testing

`pnpm typecheck` clean; web suite 208 passing. New `web-header-agents-entry.test.tsx` mounts the header at mobile width (where the menu is a sheet rather than a Radix portal) and covers all three cases: a server set, none set, and an empty string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZYw3xXjs8mfd7rb3M97Sj
