### PR TITLE
feat(documents): add table-first document collections

### DIFF
--- a/frontend/apps/desktop/src/components/create-doc-button.tsx
+++ b/frontend/apps/desktop/src/components/create-doc-button.tsx
@@ -1,6 +1,7 @@
 import {roleCanWrite, useSelectedAccountCapability} from '@/models/access-control'
 import {useMyAccountIds} from '@/models/daemon'
 import {useCreateDraft} from '@/models/documents'
+import {buildDocumentCollectionDraftSeed} from '@/utils/publish-utils'
 import {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {Button} from '@shm/ui/button'
 import {
@@ -12,7 +13,8 @@ import {
 } from '@shm/ui/components/dropdown-menu'
 import {Add} from '@shm/ui/icons'
 import {MenuItemType} from '@shm/ui/options-dropdown'
-import {FilePlus2, Import, Lock} from 'lucide-react'
+import {FilePlus2, Import, LibraryBig, Lock} from 'lucide-react'
+import {nanoid} from 'nanoid'
 import {ReactNode, useCallback, useMemo} from 'react'
 import {useImportDialog, useImporting} from './import-doc-button'
 
@@ -66,6 +68,15 @@ export function useCreateDocumentMenuItem({
           },
         },
         {
+          key: 'new-document-collection',
+          label: 'New Document Collection',
+          icon: <LibraryBig className="size-4" />,
+          onClick: () => {
+            const seed = buildDocumentCollectionDraftSeed(nanoid(10))
+            void createDraft({initialMetadata: seed.metadata, initialContent: seed.content})
+          },
+        },
+        {
           key: 'new-private-document',
           label: 'New Private Document',
           icon: <Lock className="size-4" />,
@@ -109,9 +120,9 @@ function CreateDocumentButtonContent({locationId}: {locationId: UnpackedHypermed
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-56">
-          {menuItem.children?.map((item, index) => (
+          {menuItem.children?.map((item) => (
             <div key={item.key}>
-              {index === 2 ? <DropdownMenuSeparator /> : null}
+              {item.key === 'import' ? <DropdownMenuSeparator /> : null}
               <DropdownMenuItem onClick={(event) => item.onClick?.(event as any)}>
                 {item.icon}
                 {item.label}

--- a/frontend/apps/desktop/src/editor/query-block.tsx
+++ b/frontend/apps/desktop/src/editor/query-block.tsx
@@ -281,7 +281,6 @@ function QuerySettings({
   onValuesChange: ({id, props}: {id: UnpackedHypermediaId | null; props: EditorQueryBlock['props']}) => void
   editor: BlockNoteEditor<HMBlockSchema>
 }) {
-  // @ts-expect-error
   const popoverState = usePopoverState(block.props.defaultOpen === 'true')
   const [limit, setLimit] = useState(!!block.props.queryLimit)
 

--- a/frontend/apps/desktop/src/models/documents.ts
+++ b/frontend/apps/desktop/src/models/documents.ts
@@ -1068,23 +1068,33 @@ export function useCreateDraft(
   const navigate = useNavigate('push')
   const selectedAccountId = useSelectedAccountId()
 
-  return async ({visibility}: {visibility?: HMResourceVisibility} = {}) => {
+  return async ({
+    visibility,
+    initialMetadata,
+    initialContent,
+  }: {
+    visibility?: HMResourceVisibility
+    initialMetadata?: HMDraft['metadata']
+    initialContent?: EditorBlock[]
+  } = {}) => {
+    const hasInitialData = initialMetadata !== undefined || initialContent !== undefined
     const plan = computeNewDraftParams(
       visibility,
       draftParams,
       selectedAccountId ?? undefined,
       () => nanoid(10),
       () => nanoid(21),
+      hasInitialData,
     )
     if (!plan) return
-    if (visibility === 'PRIVATE') {
-      rememberDraftReturnParentId(plan.draftId, hmId(plan.routeId.uid))
+    if (plan.shouldWrite) {
+      if (visibility === 'PRIVATE') rememberDraftReturnParentId(plan.draftId, hmId(plan.routeId.uid))
       await client.drafts.write.mutate({
         ...plan.writeParams,
         signingAccount: selectedAccountId ?? undefined,
-        metadata: {},
-        content: [],
-        deps: [],
+        metadata: initialMetadata ?? {},
+        content: initialContent ?? [],
+        deps: plan.writeParams.deps ?? [],
       })
       invalidateQueries([queryKeys.DRAFTS_LIST_ACCOUNT, plan.routeId.uid])
       invalidateQueries([queryKeys.DRAFTS_LIST])

--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -478,7 +478,9 @@ export default function DesktopResourcePage() {
         // :metadata view), preserve the draft's existing content or the
         // published document's blocks — writing [] would publish the body as a
         // full delete.
-        const content = editor ? editor.topLevelBlocks : existingDraft?.content ?? lastPublishedContentRef.current ?? []
+        const content =
+          input.contentOverride ??
+          (editor ? editor.topLevelBlocks : existingDraft?.content ?? lastPublishedContentRef.current ?? [])
         const cursorPosition = editor?._tiptapEditor?.view?.state?.selection?.$anchor?.pos ?? undefined
         const contentSummary = summarizeEditorBlocksForCleanup(content)
         cleanupInfo(`${CLEANUP_LOG_PREFIX} renderer writeDraft actor reading editor content`, {

--- a/frontend/apps/desktop/src/utils/__tests__/publish-utils.test.ts
+++ b/frontend/apps/desktop/src/utils/__tests__/publish-utils.test.ts
@@ -21,7 +21,7 @@ describe('buildDocumentCollectionDraftSeed', () => {
         id: 'query-block-id',
         type: 'query',
         props: {
-          style: 'Card',
+          style: 'Table',
           columnCount: '3',
           queryLimit: '',
           queryIncludes: '[{"space":"","path":"","mode":"Children"}]',

--- a/frontend/apps/desktop/src/utils/__tests__/publish-utils.test.ts
+++ b/frontend/apps/desktop/src/utils/__tests__/publish-utils.test.ts
@@ -5,10 +5,35 @@ import {
   computeInlineDraftPublishPath,
   computeNewDraftParams,
   computePublishPath,
+  buildDocumentCollectionDraftSeed,
   resolvePublishPath,
   shouldAutoLinkParent,
   validatePublishPath,
 } from '../publish-utils'
+
+describe('buildDocumentCollectionDraftSeed', () => {
+  it('creates Collection metadata and exactly one empty-target query block', () => {
+    const seed = buildDocumentCollectionDraftSeed('query-block-id')
+
+    expect(seed.metadata).toEqual({type: 'Collection'})
+    expect(seed.content).toEqual([
+      {
+        id: 'query-block-id',
+        type: 'query',
+        props: {
+          style: 'Card',
+          columnCount: '3',
+          queryLimit: '',
+          queryIncludes: '[{"space":"","path":"","mode":"Children"}]',
+          querySort: '[{"term":"UpdateTime","reverse":false}]',
+          defaultOpen: 'true',
+        },
+        content: [],
+        children: [],
+      },
+    ])
+  })
+})
 
 function createDocument(content: HMBlockNode[]): HMDocument {
   return {
@@ -424,6 +449,20 @@ describe('computeNewDraftParams', () => {
     })
     expect(result?.routeId.uid).toBe('location-uid')
     expect(result?.routeId.path).toEqual(['docs', 'sub', '-draft-id-10'])
+    expect(result?.shouldWrite).toBe(false)
+  })
+
+  it('writes a seeded public draft immediately', () => {
+    const result = computeNewDraftParams(
+      'PUBLIC',
+      {locationUid: 'location-uid'},
+      'selected-account-uid',
+      mockGenerateId,
+      mockGeneratePath,
+      true,
+    )
+
+    expect(result?.shouldWrite).toBe(true)
   })
 
   it('editing existing doc uses editUid/editPath and preserves deps', () => {

--- a/frontend/apps/desktop/src/utils/publish-utils.ts
+++ b/frontend/apps/desktop/src/utils/publish-utils.ts
@@ -1,9 +1,33 @@
-import {HMDocument, HMResourceVisibility, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {EditorBlock} from '@seed-hypermedia/client/editor-types'
+import {HMDocument, HMMetadata, HMResourceVisibility, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {hmId, hmIdPathToEntityQueryPath} from '@shm/shared'
 import {documentContainsLinkToChild, documentHasSelfQuery} from '@seed-hypermedia/client'
 import {pathNameify} from '@shm/shared/utils/path'
 import {computeInlineDraftPublishPath} from '@shm/shared/utils/publish-paths'
 export {computeInlineDraftPublishPath}
+
+/** Builds the metadata and initial query block for a document collection draft. */
+export function buildDocumentCollectionDraftSeed(blockId: string): {metadata: HMMetadata; content: EditorBlock[]} {
+  return {
+    metadata: {type: 'Collection'},
+    content: [
+      {
+        id: blockId,
+        type: 'query',
+        props: {
+          style: 'Card',
+          columnCount: '3',
+          queryLimit: '',
+          queryIncludes: JSON.stringify([{space: '', path: '', mode: 'Children'}]),
+          querySort: JSON.stringify([{term: 'UpdateTime', reverse: false}]),
+          defaultOpen: 'true',
+        },
+        content: [],
+        children: [],
+      },
+    ],
+  }
+}
 
 /**
  * Compute the publish path for a document.
@@ -115,6 +139,7 @@ export function computeNewDraftParams(
   selectedAccountId: string | undefined,
   generateId: () => string,
   generatePath: () => string,
+  hasInitialData = false,
 ): {
   draftId: string
   writeParams: {
@@ -127,6 +152,7 @@ export function computeNewDraftParams(
     visibility: HMResourceVisibility
   }
   routeId: UnpackedHypermediaId
+  shouldWrite: boolean
 } | null {
   const draftId = generateId()
 
@@ -145,6 +171,7 @@ export function computeNewDraftParams(
         visibility: 'PRIVATE',
       },
       routeId: hmId(locationUid, {path: [privatePath]}),
+      shouldWrite: true,
     }
   }
 
@@ -160,6 +187,7 @@ export function computeNewDraftParams(
         visibility: visibility ?? 'PUBLIC',
       },
       routeId: hmId(draftParams.editUid, {path: editPath}),
+      shouldWrite: hasInitialData,
     }
   }
 
@@ -176,6 +204,7 @@ export function computeNewDraftParams(
         visibility: visibility ?? 'PUBLIC',
       },
       routeId: hmId(draftParams.locationUid, {path: routePath}),
+      shouldWrite: hasInitialData,
     }
   }
 

--- a/frontend/apps/desktop/src/utils/publish-utils.ts
+++ b/frontend/apps/desktop/src/utils/publish-utils.ts
@@ -15,7 +15,7 @@ export function buildDocumentCollectionDraftSeed(blockId: string): {metadata: HM
         id: blockId,
         type: 'query',
         props: {
-          style: 'Card',
+          style: 'Table',
           columnCount: '3',
           queryLimit: '',
           queryIncludes: JSON.stringify([{space: '', path: '', mode: 'Children'}]),

--- a/frontend/apps/web/app/document-edit/web-document-actors.ts
+++ b/frontend/apps/web/app/document-edit/web-document-actors.ts
@@ -131,11 +131,9 @@ function makeWriteDraftActor(deps: CreateWebDocumentMachineDeps) {
     const cursorPosition = editor?.getCursorPosition?.() ?? null
     const draftId = input.draftId ?? nanoid(10)
     const existingDraft = input.draftId ? await getWebDocDraft(input.draftId) : null
-    const content = resolveWriteDraftContent(
-      editor?.getTopLevelBlocks() ?? null,
-      existingDraft?.content,
-      input.baseBlocks,
-    )
+    const content = input.contentOverride
+      ? editorBlocksToHMBlockNodes(input.contentOverride)
+      : resolveWriteDraftContent(editor?.getTopLevelBlocks() ?? null, existingDraft?.content, input.baseBlocks)
     const currentPath = deps.docId.path ?? []
     const routeDraftId = getWebDraftPlaceholderId(currentPath)
     const isReservedRouteDraft = !!routeDraftId && routeDraftId === draftId && !existingDraft

--- a/frontend/packages/client/src/editor-types.ts
+++ b/frontend/packages/client/src/editor-types.ts
@@ -151,6 +151,7 @@ export type EditorQueryBlock = EditorBaseBlock & {
     queryIncludes?: string
     querySort?: string
     banner?: 'true' | 'false'
+    defaultOpen?: 'true' | 'false'
     tableConfig?: string
   }
   content: Array<HMInlineContent>

--- a/frontend/packages/editor/src/query-block.tsx
+++ b/frontend/packages/editor/src/query-block.tsx
@@ -259,7 +259,6 @@ function QuerySettings({
   editor: BlockNoteEditor<HMBlockSchema>
   beginEditIfNeeded: () => void
 }) {
-  // @ts-expect-error
   const popoverState = usePopoverState(block.props.defaultOpen === 'true')
   const [limit, setLimit] = useState(!!block.props.queryLimit)
   // Portal the popover to document.body so it escapes the .blockNode's

--- a/frontend/packages/shared/src/models/__tests__/document-machine.test.ts
+++ b/frontend/packages/shared/src/models/__tests__/document-machine.test.ts
@@ -1,8 +1,11 @@
-import {describe, expect, it} from 'vitest'
+import {describe, expect, it, vi} from 'vitest'
 import {createActor, fromPromise} from 'xstate'
 import {
+  createDefaultCollectionQueryBlock,
   documentMachine,
   DocumentMachineInput,
+  isDocumentCollection,
+  normalizeCollectionEditorBlocks,
   PushDocumentInput,
   retargetQueryBlockIncludesForPublish,
   WriteDraftOutput,
@@ -40,6 +43,74 @@ const mockDocument = {
   genesis: 'bafygenesis',
   visibility: 'PUBLIC',
 } as unknown as HMDocument
+
+describe('document collection helpers', () => {
+  it('recognizes only the canonical Collection type', () => {
+    expect(isDocumentCollection({type: 'Collection'})).toBe(true)
+    expect(isDocumentCollection({type: 'collection'})).toBe(false)
+    expect(isDocumentCollection({})).toBe(false)
+  })
+
+  it('adds a default table query when one is missing', () => {
+    const result = normalizeCollectionEditorBlocks([], 'query-id')
+
+    expect(result).toEqual([createDefaultCollectionQueryBlock('query-id')])
+  })
+
+  it('normalizes only the first root query to Table', () => {
+    const blocks: EditorBlock[] = [
+      {
+        ...createDefaultCollectionQueryBlock('first'),
+        props: {...createDefaultCollectionQueryBlock('first').props, style: 'Card'},
+      } as EditorBlock,
+      {
+        ...createDefaultCollectionQueryBlock('second'),
+        props: {...createDefaultCollectionQueryBlock('second').props, style: 'List'},
+      } as EditorBlock,
+    ]
+
+    const result = normalizeCollectionEditorBlocks(blocks, 'unused')
+
+    expect((result[0] as any).props.style).toBe('Table')
+    expect((result[1] as any).props.style).toBe('List')
+  })
+
+  it('repairs an editable collection into a local Table draft and enters editing', async () => {
+    let repairInput: any
+    const machine = documentMachine.provide({
+      actors: {
+        writeDraft: fromPromise<WriteDraftOutput, any>(async ({input}) => {
+          repairInput = input
+          return {id: 'collection-draft', content: input.contentOverride}
+        }),
+      },
+    })
+    const actor = createActor(machine, {input: {documentId: mockDocumentId, canEdit: true}}).start()
+    const collection = {...mockDocument, metadata: {name: 'Collection', type: 'Collection'}} as HMDocument
+
+    loadDocument(actor as ReturnType<typeof createTestActor>, collection)
+    await vi.waitFor(() => expect(actor.getSnapshot().matches('editing')).toBe(true))
+
+    expect(repairInput.contentOverride).toHaveLength(1)
+    expect(repairInput.contentOverride[0].type).toBe('query')
+    expect(repairInput.contentOverride[0].props.style).toBe('Table')
+    expect(actor.getSnapshot().context.draftId).toBe('collection-draft')
+  })
+
+  it('does not create a repair draft for a reader', async () => {
+    const writeDraft = vi.fn(async () => ({id: 'unexpected-draft'}))
+    const machine = documentMachine.provide({
+      actors: {writeDraft: fromPromise<WriteDraftOutput, any>(writeDraft)},
+    })
+    const actor = createActor(machine, {input: {documentId: mockDocumentId, canEdit: false}}).start()
+    const collection = {...mockDocument, metadata: {type: 'Collection'}} as HMDocument
+
+    loadDocument(actor as ReturnType<typeof createTestActor>, collection)
+    await vi.waitFor(() => expect(actor.getSnapshot().matches('loaded')).toBe(true))
+
+    expect(writeDraft).not.toHaveBeenCalled()
+  })
+})
 
 /** Create an actor with test-friendly provided actors. */
 function createTestActor(inputOverrides: Partial<DocumentMachineInput> = {}) {

--- a/frontend/packages/shared/src/models/__tests__/document-machine.test.ts
+++ b/frontend/packages/shared/src/models/__tests__/document-machine.test.ts
@@ -110,6 +110,21 @@ describe('document collection helpers', () => {
 
     expect(writeDraft).not.toHaveBeenCalled()
   })
+
+  it('converts a collection back to a normal document in a local draft', async () => {
+    const actor = createTestActor().start()
+    const collection = {
+      ...mockDocument,
+      metadata: {type: 'Collection'},
+      content: [],
+    } as HMDocument
+
+    loadDocument(actor, collection)
+    await vi.waitFor(() => expect(actor.getSnapshot().matches('editing')).toBe(true))
+    actor.send({type: 'collection.convertToDocument'})
+
+    expect(actor.getSnapshot().context.metadata.type).toBeNull()
+  })
 })
 
 /** Create an actor with test-friendly provided actors. */

--- a/frontend/packages/shared/src/models/document-machine.ts
+++ b/frontend/packages/shared/src/models/document-machine.ts
@@ -314,6 +314,7 @@ export type DocumentMachineEvent =
   | {type: 'change.navigation'; navigation: HMNavigationItem[]}
   | {type: 'reset.content'}
   | {type: 'collection.query.change'; props: Partial<EditorQueryBlock['props']>}
+  | {type: 'collection.convertToDocument'}
   | {
       type: 'publish.start'
       /**
@@ -491,6 +492,9 @@ export const documentMachine = setup({
     }),
     markCollectionRepairAttempted: assign({
       collectionRepairAttempted: true,
+    }),
+    convertCollectionToDocument: assign({
+      metadata: ({context}) => ({...context.metadata, type: null}) as HMMetadata,
     }),
     setNavigation: assign({
       navigation: ({event}) => {
@@ -1265,6 +1269,16 @@ export const documentMachine = setup({
           guard: 'canTransitionToEditing',
           actions: ['setDepsFromPublished', 'snapshotBaseBlocks', 'updateCollectionQuery'],
         },
+        'collection.convertToDocument': {
+          target: 'editing',
+          guard: 'canTransitionToEditing',
+          actions: [
+            'setDepsFromPublished',
+            'snapshotBaseBlocks',
+            'convertCollectionToDocument',
+            raise({type: 'change'}),
+          ],
+        },
         'draft.existing': [
           {
             target: 'editing',
@@ -1305,6 +1319,9 @@ export const documentMachine = setup({
         {type: 'setEditorReadOnly'},
       ],
       on: {
+        'collection.convertToDocument': {
+          actions: ['convertCollectionToDocument', raise({type: 'change'})],
+        },
         // Already editing: only move the cursor when the event explicitly asks
         // for a position (e.g. the click-below-content affordance sends 'end').
         // A bare edit.start re-entry must not clobber the user's current

--- a/frontend/packages/shared/src/models/document-machine.ts
+++ b/frontend/packages/shared/src/models/document-machine.ts
@@ -1,4 +1,4 @@
-import {EditorBlock} from '@seed-hypermedia/client/editor-types'
+import {EditorBlock, EditorQueryBlock} from '@seed-hypermedia/client/editor-types'
 import {
   entityQueryPathToHmIdPath,
   HMBlockChildrenType,
@@ -10,8 +10,9 @@ import {
   UnpackedHypermediaId,
 } from '@seed-hypermedia/client/hm-types'
 import {hmBlocksToEditorContent} from '@seed-hypermedia/client/hmblock-to-editorblock'
-import {collectChildDraftIds} from '../utils/child-draft-refs'
+import {nanoid} from 'nanoid'
 import {assign, emit, fromPromise, raise, setup, spawnChild, StateFrom} from 'xstate'
+import {collectChildDraftIds} from '../utils/child-draft-refs'
 
 const DOCUMENT_EMBED_CLEANUP_LOG_PREFIX = '[Document embed cleanup]'
 
@@ -29,6 +30,41 @@ function documentEmbedCleanupError(...args: unknown[]) {
 
 function getTopLevelBlockCount(blocks: unknown[] | null | undefined) {
   return Array.isArray(blocks) ? blocks.length : 0
+}
+
+/** Whether metadata identifies the canonical document collection type. */
+export function isDocumentCollection(metadata: HMMetadata | null | undefined): boolean {
+  return metadata?.type == 'Collection'
+}
+
+/** Creates the standard query block required by a document collection. */
+export function createDefaultCollectionQueryBlock(blockId: string): EditorBlock {
+  return {
+    id: blockId,
+    type: 'query',
+    props: {
+      style: 'Table',
+      columnCount: '3',
+      queryLimit: '',
+      queryIncludes: JSON.stringify([{space: '', path: '', mode: 'Children'}]),
+      querySort: JSON.stringify([{term: 'UpdateTime', reverse: false}]),
+      defaultOpen: 'true',
+      tableConfig: '',
+    },
+    content: [],
+    children: [],
+  }
+}
+
+/** Ensures the first root query block exists and uses the collection Table view. */
+export function normalizeCollectionEditorBlocks(blocks: EditorBlock[], blockId: string): EditorBlock[] {
+  const queryIndex = blocks.findIndex((block) => block.type === 'query')
+  if (queryIndex === -1) return [...blocks, createDefaultCollectionQueryBlock(blockId)]
+  const query = blocks[queryIndex]
+  if (!query || query.type !== 'query' || query.props.style === 'Table') return blocks
+  const result = [...blocks]
+  result[queryIndex] = {...query, props: {...query.props, style: 'Table'}}
+  return result
 }
 
 type QueryInclude = {
@@ -224,6 +260,35 @@ export type DocumentMachineContext = {
   transientResourceError: TransientResourceError
   /** True after this old-version visit has already warned about blocked edit attempts. */
   oldVersionEditNoticeShown: boolean
+  /** Prevents a failed automatic collection repair from retrying in a tight loop. */
+  collectionRepairAttempted: boolean
+}
+
+function contentToEditorBlocks(content: HMBlockNode[] | EditorBlock[] | null | undefined): EditorBlock[] {
+  if (!content?.length) return []
+  const first = content[0]
+  return first && 'block' in first
+    ? hmBlocksToEditorContent(content as HMBlockNode[], {childrenType: 'Group'})
+    : (content as EditorBlock[])
+}
+
+/** Returns the machine's authoritative editor content for collection rendering and repair. */
+export function getCollectionEditorBlocks(context: DocumentMachineContext): EditorBlock[] {
+  const useDraft = shouldAllowDraftOverlay(context.isLatestVersion, context.routeVersion) && context.draftContent
+  return contentToEditorBlocks(useDraft || context.document?.content)
+}
+
+/** Returns the effective metadata derived from the published document and draft overlay. */
+export function getEffectiveDocumentMetadata(context: DocumentMachineContext): HMMetadata {
+  return {...(context.document?.metadata ?? {}), ...context.metadata}
+}
+
+/** Whether an editable collection needs a missing query repaired or its first root query normalized to Table. */
+export function collectionNeedsRepair(context: DocumentMachineContext): boolean {
+  if (!context.canEdit || !isDocumentCollection(getEffectiveDocumentMetadata(context))) return false
+  if (!shouldAllowDraftOverlay(context.isLatestVersion, context.routeVersion)) return false
+  const query = getCollectionEditorBlocks(context).find((block) => block.type === 'query')
+  return !query || query.props.style !== 'Table'
 }
 
 /**
@@ -248,6 +313,7 @@ export type DocumentMachineEvent =
   | {type: 'rootChildrenType.change'; childrenType: HMBlockChildrenType}
   | {type: 'change.navigation'; navigation: HMNavigationItem[]}
   | {type: 'reset.content'}
+  | {type: 'collection.query.change'; props: Partial<EditorQueryBlock['props']>}
   | {
       type: 'publish.start'
       /**
@@ -314,6 +380,8 @@ export type WriteDraftInput = {
   mineTouchedIds: string[]
   /** Three-way merge base captured at edit-start (or updated by `rebase.apply`). */
   baseBlocks: HMBlockNode[] | null
+  /** Explicit editor content for machine-owned repairs when no editor is mounted. */
+  contentOverride?: EditorBlock[]
 }
 
 /** Output returned by draft writers after the saved draft hits local storage. */
@@ -384,6 +452,7 @@ export const documentMachine = setup({
         }
         return null
       },
+      collectionRepairAttempted: false,
     }),
     setTransientResourceError: assign({
       transientResourceError: ({context, event}) => {
@@ -407,6 +476,21 @@ export const documentMachine = setup({
         }
         return context.metadata
       },
+    }),
+    updateCollectionQuery: assign({
+      draftContent: ({context, event}) => {
+        if (event.type !== 'collection.query.change') return context.draftContent
+        const blocks = normalizeCollectionEditorBlocks(getCollectionEditorBlocks(context), nanoid(10))
+        const queryIndex = blocks.findIndex((block) => block.type === 'query')
+        const query = blocks[queryIndex]
+        if (!query || query.type !== 'query') return context.draftContent
+        const next = [...blocks]
+        next[queryIndex] = {...query, props: {...query.props, ...event.props}}
+        return next as unknown as HMBlockNode[]
+      },
+    }),
+    markCollectionRepairAttempted: assign({
+      collectionRepairAttempted: true,
     }),
     setNavigation: assign({
       navigation: ({event}) => {
@@ -719,6 +803,7 @@ export const documentMachine = setup({
         if (event.type === 'draft.resolved' && event.content) return collectChildDraftIds(event.content)
         return context.referencedChildDraftIds
       },
+      collectionRepairAttempted: false,
     }),
     setExistingDraft: assign({
       draftId: ({event}) => {
@@ -969,6 +1054,7 @@ export const documentMachine = setup({
     hasExistingDraft: ({context}) => context.shouldAutoEdit,
     hasRemoteUpdate: ({context}) => context.pendingRemoteDocument !== null,
     bothSourcesReady: ({context}) => context.documentReady && context.draftReady,
+    collectionNeedsRepair: ({context}) => !context.collectionRepairAttempted && collectionNeedsRepair(context),
     capabilityLost: ({event}) => event.type === 'capability.changed' && !event.canEdit,
     hasPendingPublish: ({context}) => context.pendingPublish,
     hasPendingExitEditingAfterSave: ({context}) => context.pendingExitEditingAfterSave,
@@ -1058,6 +1144,7 @@ export const documentMachine = setup({
     error: null,
     transientResourceError: null,
     oldVersionEditNoticeShown: false,
+    collectionRepairAttempted: false,
   }),
   initial: 'loading',
   states: {
@@ -1088,14 +1175,52 @@ export const documentMachine = setup({
           actions: ['setRouteVersionState'],
         },
       },
-      always: {
-        target: 'loaded',
-        guard: 'bothSourcesReady',
-      },
+      always: [
+        {
+          target: 'repairingCollection',
+          guard: ({context}) =>
+            context.documentReady &&
+            context.draftReady &&
+            !context.collectionRepairAttempted &&
+            collectionNeedsRepair(context),
+        },
+        {target: 'loaded', guard: 'bothSourcesReady'},
+      ],
       after: {
         loadingTimeout: {
           target: 'error',
         },
+      },
+    },
+
+    repairingCollection: {
+      entry: ['markCollectionRepairAttempted', 'setDepsFromPublished', 'snapshotBaseBlocks'],
+      invoke: {
+        src: 'writeDraft',
+        input: ({context}) => ({
+          draftId: context.draftId,
+          metadata: getEffectiveDocumentMetadata(context),
+          deps: context.deps,
+          navigation: context.navigation,
+          locationUid: context.locationUid,
+          locationPath: context.locationPath,
+          editUid: context.editUid,
+          editPath: context.editPath,
+          signingAccountId: context.signingAccountId,
+          mineTouchedIds: context.mineTouchedIds,
+          baseBlocks: context.baseBlocks ?? context.document?.content ?? null,
+          contentOverride: normalizeCollectionEditorBlocks(getCollectionEditorBlocks(context), nanoid(10)),
+        }),
+        onDone: {
+          target: 'editing',
+          actions: [
+            'setDraftCreated',
+            {type: 'setDraftIdFromResult', params: ({event}: {event: any}) => event.output},
+            {type: 'setDraftSavedSnapshotFromResult', params: ({event}: {event: any}) => event.output},
+            'clearShouldAutoEdit',
+          ],
+        },
+        onError: {target: 'loaded'},
       },
     },
 
@@ -1135,6 +1260,11 @@ export const documentMachine = setup({
         'version.changed': {
           actions: ['setRouteVersionState'],
         },
+        'collection.query.change': {
+          target: 'editing',
+          guard: 'canTransitionToEditing',
+          actions: ['setDepsFromPublished', 'snapshotBaseBlocks', 'updateCollectionQuery'],
+        },
         'draft.existing': [
           {
             target: 'editing',
@@ -1146,15 +1276,18 @@ export const documentMachine = setup({
           },
         ],
       },
-      always: {
-        target: 'editing',
-        guard: ({context}) =>
-          context.shouldAutoEdit &&
-          context.canEdit &&
-          shouldAllowDraftOverlay(context.isLatestVersion, context.routeVersion) &&
-          (context.isLatestVersion || !!context.draftId),
-        actions: ['clearShouldAutoEdit', 'setDepsFromPublished', 'snapshotBaseBlocks'],
-      },
+      always: [
+        {target: 'repairingCollection', guard: 'collectionNeedsRepair'},
+        {
+          target: 'editing',
+          guard: ({context}) =>
+            context.shouldAutoEdit &&
+            context.canEdit &&
+            shouldAllowDraftOverlay(context.isLatestVersion, context.routeVersion) &&
+            (context.isLatestVersion || !!context.draftId),
+          actions: ['clearShouldAutoEdit', 'setDepsFromPublished', 'snapshotBaseBlocks'],
+        },
+      ],
     },
 
     editing: {
@@ -1240,6 +1373,10 @@ export const documentMachine = setup({
           states: {
             idle: {
               on: {
+                'collection.query.change': {
+                  target: 'changed',
+                  actions: ['updateCollectionQuery'],
+                },
                 change: {
                   target: 'changed',
                   actions: ['setMetadata'],
@@ -1282,6 +1419,11 @@ export const documentMachine = setup({
             },
             changed: {
               on: {
+                'collection.query.change': {
+                  target: 'changed',
+                  actions: ['updateCollectionQuery'],
+                  reenter: true,
+                },
                 change: {
                   target: 'changed',
                   actions: ['setMetadata'],
@@ -1346,6 +1488,9 @@ export const documentMachine = setup({
             creating: {
               entry: ['logSaveStarted', 'resetChangeWhileSaving', raise({type: '_save.started'})],
               on: {
+                'collection.query.change': {
+                  actions: ['setHasChangedWhileSaving', 'updateCollectionQuery'],
+                },
                 change: {
                   actions: ['setHasChangedWhileSaving', 'setMetadata'],
                 },
@@ -1390,6 +1535,9 @@ export const documentMachine = setup({
                   // the existing content instead of persisting an empty draft
                   // body that blanks the Content tab and wipes content on publish.
                   baseBlocks: context.baseBlocks ?? context.document?.content ?? null,
+                  contentOverride: isDocumentCollection(getEffectiveDocumentMetadata(context))
+                    ? getCollectionEditorBlocks(context)
+                    : undefined,
                 }),
                 onDone: [
                   {
@@ -1465,6 +1613,9 @@ export const documentMachine = setup({
             saving: {
               entry: ['logSaveStarted', 'resetChangeWhileSaving', raise({type: '_save.started'})],
               on: {
+                'collection.query.change': {
+                  actions: ['setHasChangedWhileSaving', 'updateCollectionQuery'],
+                },
                 change: {
                   actions: ['setHasChangedWhileSaving', 'setMetadata'],
                 },
@@ -1510,6 +1661,9 @@ export const documentMachine = setup({
                   // the existing content instead of persisting an empty draft
                   // body that blanks the Content tab and wipes content on publish.
                   baseBlocks: context.baseBlocks ?? context.document?.content ?? null,
+                  contentOverride: isDocumentCollection(getEffectiveDocumentMetadata(context))
+                    ? getCollectionEditorBlocks(context)
+                    : undefined,
                 }),
                 onDone: [
                   {

--- a/frontend/packages/shared/src/models/use-document-machine.ts
+++ b/frontend/packages/shared/src/models/use-document-machine.ts
@@ -8,6 +8,10 @@ import {ActorRefFrom, SnapshotFrom} from 'xstate'
 import {applyRebasePlan, classifyRebase} from '../utils/document-changes'
 import {
   documentMachine,
+  getCollectionEditorBlocks,
+  getEffectiveDocumentMetadata,
+  isDocumentCollection,
+  normalizeCollectionEditorBlocks,
   DocumentMachineContext,
   DocumentMachineEvent,
   DocumentMachineInput,
@@ -619,6 +623,20 @@ export function selectError(snapshot: DocumentMachineSnapshot): unknown {
 /** The full machine context. */
 export function selectContext(snapshot: DocumentMachineSnapshot): DocumentMachineContext {
   return snapshot.context
+}
+
+/** Whether the effective document metadata identifies a document collection. */
+export function selectIsDocumentCollection(snapshot: DocumentMachineSnapshot): boolean {
+  return isDocumentCollection(getEffectiveDocumentMetadata(snapshot.context))
+}
+
+/** The first root query block used by the document collection view. */
+export function selectCollectionQueryBlock(snapshot: DocumentMachineSnapshot): EditorBlock | null {
+  return (
+    normalizeCollectionEditorBlocks(getCollectionEditorBlocks(snapshot.context), 'collection-query-preview').find(
+      (block) => block.type === 'query',
+    ) ?? null
+  )
 }
 
 /** Whether draft content is allowed to overlay the published document for the current route. */

--- a/frontend/packages/ui/src/__tests__/document-header-breadcrumbs.test.tsx
+++ b/frontend/packages/ui/src/__tests__/document-header-breadcrumbs.test.tsx
@@ -247,4 +247,19 @@ describe('DocumentHeader Breadcrumbs', () => {
     expect(container.textContent).not.toContain('Private')
     expect(container.textContent).not.toContain('Merged')
   })
+
+  it('removes the byline divider and bottom padding for collection headers', () => {
+    renderWithProvider(
+      <DocumentHeader
+        docId={hmId('site', {path: ['collection']})}
+        docMetadata={{name: 'Collection'} as any}
+        authors={[]}
+        updateTime={null}
+        flushByline
+      />,
+    )
+
+    expect(container.querySelector('.border-b')).toBeNull()
+    expect(container.querySelector('.pb-2')).toBeNull()
+  })
 })

--- a/frontend/packages/ui/src/__tests__/document-metadata-affordances.test.tsx
+++ b/frontend/packages/ui/src/__tests__/document-metadata-affordances.test.tsx
@@ -271,6 +271,17 @@ describe('EditableDocumentMetadataFields', () => {
     expect(affordanceRow.parentElement?.className).toContain('relative')
     expect(affordanceRow.className).toContain('absolute')
     expect(affordanceRow.className).toContain('bottom-full')
+    expect(affordanceRow.className).toContain('pb-1')
+    expect(affordanceRow.className).not.toContain('mb-1')
+  })
+
+  it('keeps affordances inside the header surface when a cover is present', async () => {
+    await renderFields({metadata: {cover: 'ipfs://cover'}, fileUpload: vi.fn()})
+
+    const affordanceRow = container.querySelector('[data-document-metadata-affordances]')!
+    expect(affordanceRow.parentElement?.className).toContain('pt-8')
+    expect(affordanceRow.className).toContain('top-0')
+    expect(affordanceRow.className).not.toContain('bottom-full')
   })
 
   it('keeps editor affordances mobile-visible and desktop-hidden until hover', async () => {

--- a/frontend/packages/ui/src/__tests__/query-block-content.test.tsx
+++ b/frontend/packages/ui/src/__tests__/query-block-content.test.tsx
@@ -90,6 +90,16 @@ describe('QueryBlockContent loading state', () => {
 })
 
 describe('QueryBlockContent table view', () => {
+  it('stretches columns across the available table width while preserving horizontal overflow', () => {
+    act(() => {
+      root.render(<QueryBlockContent items={makeItems(1)} style="Table" accountsMetadata={{}} />)
+    })
+
+    const table = container.querySelector('table')
+    expect(table?.style.width).toBe('100%')
+    expect(table?.style.minWidth).toMatch(/px$/)
+  })
+
   it('renders discovered custom attributes in the default column order', () => {
     const items = makeItems(1)
     items[0].metadata.status = 'Ready'

--- a/frontend/packages/ui/src/__tests__/resource-page-common.test.ts
+++ b/frontend/packages/ui/src/__tests__/resource-page-common.test.ts
@@ -18,7 +18,31 @@ import {
   getDocumentSyncIsPlaceholderData,
   getOldVersionEditBlockedToastOptions,
   getCitationsTargetId,
+  getCollectionMenuPanelRoute,
 } from '../resource-page-common'
+
+describe('getCollectionMenuPanelRoute', () => {
+  const docId = hmId('alice', {path: ['projects']})
+
+  it.each(['metadata', 'directory', 'collaborators', 'activity', 'comments'] as const)(
+    'maps the %s menu item to the matching right panel',
+    (key) => {
+      expect(getCollectionMenuPanelRoute(key, docId)).toMatchObject({key, id: docId})
+    },
+  )
+
+  it('maps versions to the versions activity panel', () => {
+    expect(getCollectionMenuPanelRoute('versions', docId)).toMatchObject({
+      key: 'activity',
+      id: docId,
+      filterEventType: ['Ref'],
+    })
+  })
+
+  it('leaves menu actions without panel support unchanged', () => {
+    expect(getCollectionMenuPanelRoute('export', docId)).toBeNull()
+  })
+})
 
 describe('getDocumentResourceRouteKey', () => {
   it('changes when only the document version changes', () => {

--- a/frontend/packages/ui/src/__tests__/site-file-browser.test.tsx
+++ b/frontend/packages/ui/src/__tests__/site-file-browser.test.tsx
@@ -17,6 +17,12 @@ function makeDoc(path: string[], name: string, visibility: 'PUBLIC' | 'PRIVATE' 
   return {id: hmId('site', {path}), path, metadata: {name}, visibility} as HMDocumentInfo
 }
 
+function makeCollection(path: string[], name: string, visibility: 'PUBLIC' | 'PRIVATE' = 'PUBLIC') {
+  const doc = makeDoc(path, name, visibility)
+  doc.metadata = {...doc.metadata, type: 'Collection'}
+  return doc
+}
+
 beforeEach(() => {
   container = document.createElement('div')
   document.body.appendChild(container)
@@ -30,6 +36,21 @@ afterEach(() => {
 })
 
 describe('SiteFileBrowser', () => {
+  it('marks collections with a grid icon instead of a private icon', () => {
+    useDirectoryMock.mockReturnValue({
+      data: [makeCollection(['collections'], 'Collections'), makeCollection(['private'], 'Private', 'PRIVATE')],
+      isLoading: false,
+      isError: false,
+    })
+
+    act(() => {
+      root.render(<SiteFileBrowser siteId={hmId('site')} activeDocumentId={null} onNavigate={vi.fn()} />)
+    })
+
+    expect(container.querySelectorAll('[aria-label="Document collection"]')).toHaveLength(2)
+    expect(container.querySelector('[aria-label="Private document"]')).toBeNull()
+  })
+
   it('reveals the active document and marks private rows', () => {
     useDirectoryMock.mockReturnValue({
       data: [makeDoc(['guides'], 'Guides'), makeDoc(['guides', 'private'], 'Private guide', 'PRIVATE')],

--- a/frontend/packages/ui/src/document-header.tsx
+++ b/frontend/packages/ui/src/document-header.tsx
@@ -52,6 +52,7 @@ export function DocumentHeader({
   children,
   onRemoveIcon,
   mobileBylineAction,
+  flushByline = false,
 }: {
   docId: UnpackedHypermediaId | null
   docMetadata: HMMetadata | null
@@ -65,6 +66,8 @@ export function DocumentHeader({
   children?: React.ReactNode
   onRemoveIcon?: () => void
   mobileBylineAction?: React.ReactNode
+  /** Removes the divider and bottom padding beneath the author/date row. */
+  flushByline?: boolean
 }) {
   const hasCover = useMemo(() => !!docMetadata?.cover, [docMetadata])
   const hasIcon = useMemo(() => !!docMetadata?.icon, [docMetadata])
@@ -132,7 +135,7 @@ export function DocumentHeader({
             ) : null}
           </>
         )}
-        <div className="border-border flex flex-col gap-2 border-b pb-2 md:pb-4">
+        <div className={cn('flex flex-col gap-2', !flushByline && 'border-border border-b pb-2 md:pb-4')}>
           {siteUrl ? <SiteURLButton siteUrl={siteUrl} /> : null}
           <div className="flex flex-1 items-center justify-between gap-3">
             <div className="hidden flex-1 flex-wrap items-center gap-3 md:flex">

--- a/frontend/packages/ui/src/document-metadata-affordances.tsx
+++ b/frontend/packages/ui/src/document-metadata-affordances.tsx
@@ -343,7 +343,7 @@ export function EditableDocumentMetadataFields({
 
   return (
     <div
-      className={cn('relative flex flex-col gap-2', className)}
+      className={cn('relative flex flex-col gap-2', metadata?.cover && 'pt-8', className)}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
@@ -351,7 +351,7 @@ export function EditableDocumentMetadataFields({
         metadata={metadata}
         visible={showAffordances}
         fileUpload={fileUpload}
-        className="absolute bottom-full left-0 z-10 mb-1 -ml-2 max-md:hidden"
+        className={cn('absolute left-0 z-10 -ml-2 pb-1 max-md:hidden', metadata?.cover ? 'top-0' : 'bottom-full')}
         onBeforeMetadataChange={onBeginEdit}
         onMetadata={onMetadata}
         onRequestSummary={requestSummary}

--- a/frontend/packages/ui/src/query-block-table.tsx
+++ b/frontend/packages/ui/src/query-block-table.tsx
@@ -362,7 +362,7 @@ export function QueryBlockTable({
         </div>
       ) : (
         <div className="border-border max-w-full touch-pan-x overflow-x-auto overscroll-x-contain rounded-md border">
-          <Table className="table-fixed" style={{width: table.getCenterTotalSize()}}>
+          <Table className="table-fixed" style={{width: '100%', minWidth: table.getCenterTotalSize()}}>
             <TableHeader>
               {table.getHeaderGroups().map((group) => (
                 <TableRow key={group.id}>

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -105,7 +105,7 @@ import {isPendingSpaceUid} from '@shm/shared/utils/pending-space'
 import {getReservedLazyDraftBreadcrumbName} from '@shm/shared/utils/reserved-draft-ids'
 import {useIsomorphicLayoutEffect} from '@shm/shared/utils/use-isomorphic-layout-effect'
 import {useQuery} from '@tanstack/react-query'
-import {FilePen, Info, Quote, Search} from 'lucide-react'
+import {FilePen, FileText, Info, Quote, Search} from 'lucide-react'
 import {lazy, ReactNode, Suspense, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {createPortal} from 'react-dom'
 import {AccountPage} from './account-page'
@@ -125,7 +125,11 @@ import {
 import {DocumentMetadataView} from './document-metadata-view'
 import {DocumentTools} from './document-tools'
 import {DocumentTopBar} from './document-top-bar'
-import {DocumentVersionsPanel, isDocumentVersionsPanelRoute} from './document-versions-panel'
+import {
+  createDocumentVersionsPanelRoute,
+  DocumentVersionsPanel,
+  isDocumentVersionsPanelRoute,
+} from './document-versions-panel'
 import {ExplorePage} from './explore-page'
 import {Feed, type DraftVersionEntry} from './feed'
 import {FeedFilters} from './feed-filters'
@@ -351,6 +355,18 @@ function CitationFragmentPopover({
 function extractPanelRoute(route: NavRoute): DocumentPanelRoute {
   const {panel, width, ...params} = route as any
   return params as DocumentPanelRoute
+}
+
+/** Returns the right-panel destination for a collection-aware document menu item. */
+export function getCollectionMenuPanelRoute(key: string, docId: UnpackedHypermediaId): DocumentPanelRoute | null {
+  if (key === 'versions') return createDocumentVersionsPanelRoute(docId)
+  if (key === 'options') return {key: 'options'}
+  if (key === 'metadata') return {key: 'metadata', id: docId}
+  if (key === 'directory') return {key: 'directory', id: docId}
+  if (key === 'collaborators') return {key: 'collaborators', id: docId}
+  if (key === 'activity') return {key: 'activity', id: docId}
+  if (key === 'comments') return {key: 'comments', id: docId}
+  return null
 }
 
 /** Returns a stable key for the exact document resource being viewed, including version state. */
@@ -1743,6 +1759,18 @@ function DocumentBody({
   const isDocumentCollection = useDocumentSelector(selectIsDocumentCollection)
   const collectionQueryBlock = useDocumentSelector(selectCollectionQueryBlock)
   const send = useDocumentSend()
+  const previousIsDocumentCollection = useRef(isDocumentCollection)
+  useEffect(() => {
+    if (!previousIsDocumentCollection.current && isDocumentCollection) {
+      toast.success('Converted to Document Collection', {
+        action: {
+          label: 'Undo',
+          onClick: () => send({type: 'collection.convertToDocument'}),
+        },
+      })
+    }
+    previousIsDocumentCollection.current = isDocumentCollection
+  }, [isDocumentCollection, send])
   const {beginEditIfNeeded} = useEditorGate()
   // Draft metadata (partial) overrides published metadata, same as the options panel.
   const metadata = useMemo(
@@ -2397,12 +2425,41 @@ function DocumentBody({
     }
   }, [docId, navigate, route.key])
 
+  const convertToDocumentMenuItem = useMemo<MenuItemType | null>(() => {
+    if (!isDocumentCollection || !canEditCurrentRoute) return null
+    return {
+      key: 'convert-to-document',
+      label: 'Convert to normal document',
+      icon: <FileText className="size-4" />,
+      onClick: () => {
+        send({type: 'collection.convertToDocument'})
+        toast.success('Converted to normal document')
+      },
+    }
+  }, [canEditCurrentRoute, isDocumentCollection, send])
+
   const allMenuItems = useMemo(() => {
     let unorderedItems: MenuItemType[] = [...(optionsMenuItems ?? extraMenuItems ?? [])]
     unorderedItems.push(citationFragmentToggleMenuItem)
     if (inspectMenuItem) unorderedItems.push(inspectMenuItem)
     if (documentOptionsMenuItem) unorderedItems.push(documentOptionsMenuItem)
     if (metadataMenuItem) unorderedItems.push(metadataMenuItem)
+    if (convertToDocumentMenuItem) unorderedItems.push(convertToDocumentMenuItem)
+    if (isDocumentCollection) {
+      unorderedItems = unorderedItems.map((item) => {
+        const panel = getCollectionMenuPanelRoute(item.key, docId)
+        if (!panel) return item
+        return {
+          ...item,
+          onClick: () =>
+            navigate({
+              key: 'document',
+              id: {...docId, blockRef: null, blockRange: null},
+              panel,
+            }),
+        }
+      })
+    }
     // Drop share/copy-link entries while the doc is an unpublished draft —
     // its URL won't resolve for anyone else, so any "share" action is a footgun.
     if (isUnpublishedDraft) {
@@ -2415,6 +2472,7 @@ function DocumentBody({
       'versions',
       'options',
       'metadata',
+      'convert-to-document',
       'copy-link',
       'link-site',
       'link',
@@ -2450,7 +2508,11 @@ function DocumentBody({
     inspectMenuItem,
     documentOptionsMenuItem,
     metadataMenuItem,
+    convertToDocumentMenuItem,
     isUnpublishedDraft,
+    isDocumentCollection,
+    docId,
+    navigate,
   ])
 
   const hasOptions = allMenuItems.length > 0
@@ -2512,17 +2574,15 @@ function DocumentBody({
             !showSidebars && 'justify-center',
             isDocumentCollection && '!block w-full',
           )}
+          style={isDocumentCollection ? {...wrapperProps.style, maxWidth: undefined} : wrapperProps.style}
         >
           {showSidebars && !isDocumentCollection && (
             <div {...sidebarProps} className={cn(sidebarProps.className, '!h-auto')} />
           )}
           <div
             {...mainContentProps}
-            className={cn(
-              mainContentProps.className,
-              'flex flex-col',
-              isDocumentCollection && '!w-full !max-w-none px-5',
-            )}
+            className={cn(mainContentProps.className, 'flex flex-col', isDocumentCollection && '!w-full !max-w-none')}
+            style={isDocumentCollection ? {...mainContentProps.style, maxWidth: undefined} : mainContentProps.style}
           >
             {isHomeDoc &&
               activeView !== 'all-documents' &&
@@ -2542,6 +2602,7 @@ function DocumentBody({
                   visibility={headerVisibility}
                   version={document.version}
                   fileUpload={fileUpload}
+                  flushByline={isDocumentCollection}
                 />
               ) : (
                 <DocumentHeader
@@ -2551,6 +2612,7 @@ function DocumentBody({
                   updateTime={document.updateTime}
                   visibility={headerVisibility}
                   version={document.version}
+                  flushByline={isDocumentCollection}
                 />
               ))}
           </div>
@@ -2581,6 +2643,7 @@ function DocumentBody({
                 visibility={headerVisibility}
                 version={document.version}
                 fileUpload={fileUpload}
+                flushByline={isDocumentCollection}
               />
             ) : (
               <DocumentHeader
@@ -2590,6 +2653,7 @@ function DocumentBody({
                 updateTime={document.updateTime}
                 visibility={headerVisibility}
                 version={document.version}
+                flushByline={isDocumentCollection}
               />
             ))}
         </div>
@@ -2845,6 +2909,7 @@ function EditableDocumentHeader({
   visibility,
   version,
   fileUpload,
+  flushByline,
 }: {
   docId: UnpackedHypermediaId
   docMetadata: HMDocument['metadata']
@@ -2853,6 +2918,7 @@ function EditableDocumentHeader({
   visibility?: string
   version?: HMDocument['version'] | null
   fileUpload?: (file: File) => Promise<string>
+  flushByline?: boolean
 }) {
   const ctx = useDocumentSelector(selectContext)
   const isEditing = useDocumentSelector(selectIsEditing)
@@ -2873,6 +2939,7 @@ function EditableDocumentHeader({
       updateTime={updateTime}
       visibility={visibility as any}
       version={version}
+      flushByline={flushByline}
       mobileBylineAction={
         <DocumentMetadataAffordanceButtons
           metadata={metadata}

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -5,10 +5,13 @@ import {
   HMComment,
   HMDocument,
   HMExistingDraft,
+  HMBlockQuery,
+  HMQueryTableConfig,
   HMRawCitation,
   HMResource,
   UnpackedHypermediaId,
 } from '@seed-hypermedia/client/hm-types'
+import type {EditorBlock} from '@seed-hypermedia/client/editor-types'
 import {
   createInspectNavRoute,
   DocumentPanelRoute,
@@ -56,13 +59,16 @@ import {
 } from '@shm/shared/models/entity'
 import {useExploreResults} from '@shm/shared/models/explore'
 import {useInteractionSummary} from '@shm/shared/models/interaction-summary'
+import {queryQueryBlock} from '@shm/shared/models/queries'
 import {
   documentMachine,
   DocumentMachineProvider,
   selectCanEditCurrentRoute,
   selectContext,
+  selectCollectionQueryBlock,
   selectDraftOverlayAllowed,
   selectIsEditing,
+  selectIsDocumentCollection,
   selectIsUnpublishedDraft,
   selectPublishedVersion,
   selectRenderableBlocks,
@@ -83,7 +89,7 @@ import {
 } from '@shm/shared/models/use-document-machine'
 import {useEditorGate} from '@shm/shared/models/use-editor-gate'
 import {getRoutePanel} from '@shm/shared/routes'
-import {useOpenUrl} from '@shm/shared/routing'
+import {useOpenUrl, useUniversalClient} from '@shm/shared/routing'
 import {getBreadcrumbDocumentIds, isDraftPathSegment} from '@shm/shared/utils/breadcrumbs'
 import {
   activityFilterToSlug,
@@ -139,6 +145,7 @@ import {PrivateBadge} from './private-badge'
 import {SiteFileBrowserLayout} from './site-file-browser-layout'
 import {SiteHeader} from './site-header'
 import {Spinner} from './spinner'
+import {QueryBlockContent} from './query-block-content'
 import {toast} from './toast'
 import {UnreferencedDocuments} from './unreferenced-documents'
 import {useBlockScroll} from './use-block-scroll'
@@ -1733,6 +1740,8 @@ function DocumentBody({
   const draftOverlayAllowed = useDocumentSelector(selectDraftOverlayAllowed)
   const canEditCurrentRoute = useDocumentSelector(selectCanEditCurrentRoute)
   const shouldUseDraftOverlay = useDocumentSelector(selectShouldUseDraftOverlay)
+  const isDocumentCollection = useDocumentSelector(selectIsDocumentCollection)
+  const collectionQueryBlock = useDocumentSelector(selectCollectionQueryBlock)
   const send = useDocumentSend()
   const {beginEditIfNeeded} = useEditorGate()
   // Draft metadata (partial) overrides published metadata, same as the options panel.
@@ -2495,9 +2504,26 @@ function DocumentBody({
       ) : null}
 
       {!isMobile ? (
-        <div {...wrapperProps} className={cn(wrapperProps.className, 'flex-none', !showSidebars && 'justify-center')}>
-          {showSidebars && <div {...sidebarProps} className={cn(sidebarProps.className, '!h-auto')} />}
-          <div {...mainContentProps} className={cn(mainContentProps.className, 'flex flex-col')}>
+        <div
+          {...wrapperProps}
+          className={cn(
+            wrapperProps.className,
+            'flex-none',
+            !showSidebars && 'justify-center',
+            isDocumentCollection && '!block w-full',
+          )}
+        >
+          {showSidebars && !isDocumentCollection && (
+            <div {...sidebarProps} className={cn(sidebarProps.className, '!h-auto')} />
+          )}
+          <div
+            {...mainContentProps}
+            className={cn(
+              mainContentProps.className,
+              'flex flex-col',
+              isDocumentCollection && '!w-full !max-w-none px-5',
+            )}
+          >
             {isHomeDoc &&
               activeView !== 'all-documents' &&
               !siteMembers.isInitialLoading &&
@@ -2528,10 +2554,15 @@ function DocumentBody({
                 />
               ))}
           </div>
-          {showSidebars && <div {...sidebarProps} className={cn(sidebarProps.className, '!h-auto')} />}
+          {showSidebars && !isDocumentCollection && (
+            <div {...sidebarProps} className={cn(sidebarProps.className, '!h-auto')} />
+          )}
         </div>
       ) : (
-        <div className={cn('mx-auto flex w-full flex-col px-4')} style={{maxWidth: contentMaxWidth}}>
+        <div
+          className={cn('mx-auto flex w-full flex-col px-4')}
+          style={{maxWidth: isDocumentCollection ? undefined : contentMaxWidth}}
+        >
           {isHomeDoc &&
             activeView !== 'all-documents' &&
             !siteMembers.isInitialLoading &&
@@ -2566,7 +2597,7 @@ function DocumentBody({
 
       {/* DocumentTools - scrolls with the page; the border separates document
           identity above from document body below. Hidden when showActivity is false. */}
-      {showActivity && (
+      {showActivity && !isDocumentCollection && (
         <div className="px-5 py-1">
           <DocumentTools
             id={docId}
@@ -2624,46 +2655,50 @@ function DocumentBody({
       )}
 
       {/* Main content based on activeView */}
-      <div className={cn('flex-1', activeView !== 'content' && 'pb-60', isMobile && 'px-4')}>
-        <MainContent
-          docId={docId}
-          resourceId={'id' in route && typeof route.id === 'object' ? route.id : docId}
-          document={document}
-          activeView={activeView}
-          contentMaxWidth={contentMaxWidth}
-          wrapperProps={wrapperProps}
-          sidebarProps={sidebarProps}
-          mainContentProps={mainContentProps}
-          showSidebars={showSidebars}
-          showCollapsed={showCollapsed}
-          discussionsParams={discussionsParams}
-          suppressCommentEditor={suppressMainCommentEditor}
-          activityFilterEventType={route.key === 'activity' ? route.filterEventType : undefined}
-          onActivityFilterChange={handleMainActivityFilterChange}
-          blockCitations={blockCitations}
-          citationFragmentHighlights={citationFragmentHighlights}
-          onCitationFragmentClick={handleCitationFragmentClick}
-          onBlockCitationClick={handleBlockCitationClick}
-          onBlockCommentClick={handleBlockCommentClick}
-          onBlockSelect={handleBlockSelect}
-          onTextSelection={handleTextSelection}
-          isUnpublishedDraft={isUnpublishedDraft}
-          isBlockInPublishedVersion={isBlockInPublishedVersion}
-          CommentEditor={CommentEditor}
-          directory={directory.data}
-          siteUrl={siteUrl}
-          inlineCards={inlineCards}
-          inlineInsert={inlineInsert}
-          DocumentContentComponent={DocumentContentComponent}
-          onEditorReady={handleEditorReadyWrapped}
-          existingDraftContent={effectiveContent}
-          existingDraftCursorPosition={existingDraftCursorPosition}
-          ssrContentHTML={ssrContentHTML}
-          perspectiveAccountUid={perspectiveAccountUid}
-          linkExtensionOptions={linkExtensionOptions}
-          fileUpload={fileUpload}
-          draftVersionEntry={draftVersionEntry}
-        />
+      <div className={cn('flex-1', !isDocumentCollection && activeView !== 'content' && 'pb-60', isMobile && 'px-4')}>
+        {isDocumentCollection ? (
+          <DocumentCollectionTable docId={docId} queryBlock={collectionQueryBlock} canEdit={canEditCurrentRoute} />
+        ) : (
+          <MainContent
+            docId={docId}
+            resourceId={'id' in route && typeof route.id === 'object' ? route.id : docId}
+            document={document}
+            activeView={activeView}
+            contentMaxWidth={contentMaxWidth}
+            wrapperProps={wrapperProps}
+            sidebarProps={sidebarProps}
+            mainContentProps={mainContentProps}
+            showSidebars={showSidebars}
+            showCollapsed={showCollapsed}
+            discussionsParams={discussionsParams}
+            suppressCommentEditor={suppressMainCommentEditor}
+            activityFilterEventType={route.key === 'activity' ? route.filterEventType : undefined}
+            onActivityFilterChange={handleMainActivityFilterChange}
+            blockCitations={blockCitations}
+            citationFragmentHighlights={citationFragmentHighlights}
+            onCitationFragmentClick={handleCitationFragmentClick}
+            onBlockCitationClick={handleBlockCitationClick}
+            onBlockCommentClick={handleBlockCommentClick}
+            onBlockSelect={handleBlockSelect}
+            onTextSelection={handleTextSelection}
+            isUnpublishedDraft={isUnpublishedDraft}
+            isBlockInPublishedVersion={isBlockInPublishedVersion}
+            CommentEditor={CommentEditor}
+            directory={directory.data}
+            siteUrl={siteUrl}
+            inlineCards={inlineCards}
+            inlineInsert={inlineInsert}
+            DocumentContentComponent={DocumentContentComponent}
+            onEditorReady={handleEditorReadyWrapped}
+            existingDraftContent={effectiveContent}
+            existingDraftCursorPosition={existingDraftCursorPosition}
+            ssrContentHTML={ssrContentHTML}
+            perspectiveAccountUid={perspectiveAccountUid}
+            linkExtensionOptions={linkExtensionOptions}
+            fileUpload={fileUpload}
+            draftVersionEntry={draftVersionEntry}
+          />
+        )}
         {citationFragmentClick ? (
           <CitationFragmentPopover
             click={citationFragmentClick}
@@ -3139,6 +3174,98 @@ function DocumentMetadataPage({
       openFile={openFile}
       onCreateBlob={onCreateBlob}
     />
+  )
+}
+
+function DocumentCollectionTable({
+  docId,
+  queryBlock,
+  canEdit,
+}: {
+  docId: UnpackedHypermediaId
+  queryBlock: EditorBlock | null
+  canEdit: boolean
+}) {
+  const client = useUniversalClient()
+  const send = useDocumentSend()
+  const props = queryBlock?.type === 'query' ? queryBlock.props : undefined
+  const includes = useMemo<HMBlockQuery['attributes']['query']['includes']>(() => {
+    try {
+      const parsed = JSON.parse(props?.queryIncludes || '[]')
+      if (!Array.isArray(parsed) || !parsed.length) return []
+      return parsed.map((include) =>
+        include.space ? include : {...include, space: docId.uid, path: (docId.path ?? []).join('/')},
+      )
+    } catch {
+      return []
+    }
+  }, [docId.path, docId.uid, props?.queryIncludes])
+  const querySort = useMemo(() => {
+    try {
+      return JSON.parse(props?.querySort || '[]')
+    } catch {
+      return []
+    }
+  }, [props?.querySort])
+  const queryLimit = Number.parseInt(props?.queryLimit || '', 10) || undefined
+  const query = useQuery(
+    queryQueryBlock(client, includes.length ? {query: {includes, sort: querySort, limit: queryLimit}} : null),
+  )
+  const tableConfig = useMemo<HMQueryTableConfig | undefined>(() => {
+    try {
+      return props?.tableConfig ? JSON.parse(props.tableConfig) : undefined
+    } catch {
+      return undefined
+    }
+  }, [props?.tableConfig])
+  const firstSort = querySort[0]
+  const sortIds: Record<string, string> = {
+    Title: 'title',
+    Path: 'path',
+    CreateTime: 'created',
+    UpdateTime: 'updated',
+  }
+  const tableSorting = firstSort?.term
+    ? [{id: sortIds[firstSort.term] ?? 'updated', desc: firstSort.reverse ?? false}]
+    : []
+
+  return (
+    <div className="w-full px-5 pb-8">
+      <QueryBlockContent
+        items={query.data?.results ?? []}
+        style="Table"
+        accountsMetadata={query.data?.accountsMetadata ?? {}}
+        interactionSummaries={query.data?.interactionSummaries ?? {}}
+        isDiscovering={query.isLoading}
+        tableConfig={tableConfig}
+        tableSorting={tableSorting}
+        onTableConfigChange={
+          canEdit
+            ? (config) => send({type: 'collection.query.change', props: {tableConfig: JSON.stringify(config)}})
+            : undefined
+        }
+        onTableSortingChange={
+          canEdit
+            ? (sorting) => {
+                const first = sorting[0]
+                const terms: Record<string, string> = {
+                  title: 'Title',
+                  path: 'Path',
+                  created: 'CreateTime',
+                  updated: 'UpdateTime',
+                }
+                const term = first ? terms[first.id] : undefined
+                if (term) {
+                  send({
+                    type: 'collection.query.change',
+                    props: {querySort: JSON.stringify([{term, reverse: first?.desc ?? false}])},
+                  })
+                }
+              }
+            : undefined
+        }
+      />
+    </div>
   )
 }
 

--- a/frontend/packages/ui/src/site-file-browser.tsx
+++ b/frontend/packages/ui/src/site-file-browser.tsx
@@ -7,7 +7,7 @@ import {
   flattenTree,
   getAncestorPathKeys,
 } from '@shm/shared/utils/all-documents-tree'
-import {ChevronDown, ChevronRight, Lock, Search} from 'lucide-react'
+import {ChevronDown, ChevronRight, Grid3X3, Lock, Search} from 'lucide-react'
 import {useEffect, useMemo, useState} from 'react'
 import {Button} from './button'
 import {Input} from './components/input'
@@ -125,7 +125,9 @@ export function SiteFileBrowser({siteId, activeDocumentId, onNavigate, onPrefetc
                       onClick={() => onNavigate(doc.id)}
                       className="hover:bg-accent/60 focus-visible:ring-ring flex h-6 min-w-0 flex-1 items-center gap-1.5 rounded-md px-1.5 text-left text-sm outline-none focus-visible:ring-2"
                     >
-                      {doc.visibility === 'PRIVATE' ? (
+                      {doc.metadata.type === 'Collection' ? (
+                        <Grid3X3 aria-label="Document collection" className="size-3 shrink-0" />
+                      ) : doc.visibility === 'PRIVATE' ? (
                         <Lock aria-label="Private document" className="size-3 shrink-0" />
                       ) : null}
                       <span className="truncate">{titleOf(doc)}</span>


### PR DESCRIPTION
## Summary
- Add document collection draft creation from the New menu with seeded Collection metadata and a default table query.
- Render document collections as a full-width table-first view with editable table configuration and sorting persisted to drafts.
- Normalize incomplete collections to include a table query, add conversion back to normal documents, and polish collection header/sidebar affordances.