### PR TITLE
fix(docker): pin pnpm in web/notify images to package.json's packageManager

### DIFF
--- a/frontend/apps/notify/Dockerfile
+++ b/frontend/apps/notify/Dockerfile
@@ -18,10 +18,13 @@ ENV NOTIFY_SENTRY_RELEASE=${COMMIT_HASH}
 ENV NOTIFY_SENTRY_ENVIRONMENT=production
 
 RUN apk add --no-cache git python3 make g++
-RUN npm install -g pnpm
 WORKDIR /app
 RUN apk add --no-cache libc6-compat
 COPY . .
+# Pin pnpm to the version declared in package.json's `packageManager` (same source
+# pnpm/action-setup uses in CI). An unpinned `npm install -g pnpm` pulls the latest major,
+# which can refuse to install against an older lockfile (ERR_PNPM_PNPM_ENGINE_IDENTITY_UNVERIFIABLE).
+RUN npm install -g "pnpm@$(node -p "require('./package.json').packageManager.split('@')[1]")"
 
 
 RUN rm -rf ./frontend/apps/desktop

--- a/frontend/apps/web/Dockerfile
+++ b/frontend/apps/web/Dockerfile
@@ -18,10 +18,13 @@ ENV SITE_SENTRY_RELEASE=${COMMIT_HASH}
 ENV SITE_SENTRY_ENVIRONMENT=production
 
 RUN apk add --no-cache git python3 make g++
-RUN npm install -g pnpm
 WORKDIR /app
 RUN apk add --no-cache libc6-compat
 COPY . .
+# Pin pnpm to the version declared in package.json's `packageManager` (same source
+# pnpm/action-setup uses in CI). An unpinned `npm install -g pnpm` pulls the latest major,
+# which can refuse to install against an older lockfile (ERR_PNPM_PNPM_ENGINE_IDENTITY_UNVERIFIABLE).
+RUN npm install -g "pnpm@$(node -p "require('./package.json').packageManager.split('@')[1]")"
 
 
 RUN rm -rf ./frontend/apps/desktop


### PR DESCRIPTION
## Problem

The `docker-web` and `docker-notify` jobs in **Dev - Docker Images** started failing ([run 32990436392](https://github.com/seed-hypermedia/seed/actions/runs/32990436392/job/98249698834)):

```
Error: ERR_PNPM_PNPM_ENGINE_IDENTITY_UNVERIFIABLE
  × verify the package manager identity
  ╰─▶ Cannot verify the identity of the @pnpm/exe.linux-x64 native binary: it
      is missing from pnpm-lock.yaml.
```

Not a GitHub outage: both Dockerfiles run an unpinned `npm install -g pnpm`, and pnpm 11 just became `latest` on npm. pnpm 11 verifies the package manager identity against `pnpm-lock.yaml`, which our 10.x lockfile (`packageManager: pnpm@10.32.0`) doesn't carry.

## Fix

Install the version declared in `package.json`'s `packageManager` — the same source `pnpm/action-setup` already reads everywhere else in CI — so the images can't drift from the lockfile again. The install moves after `COPY . .` so `package.json` is available; it's ~2s and `COPY` already invalidates every later layer, so no cache is lost.

## Verification

Built the `builder` stage of both images locally with `--build-arg PREBUILT=true` (stops right after the failing `pnpm install --frozen-lockfile` step):

- web: installs `pnpm@10.32.0`, `pnpm install --frozen-lockfile` ✅
- notify: installs `pnpm@10.32.0`, `pnpm install --frozen-lockfile` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014p5QHQ7rxNkxcW3JQMLZgw
