### PR TITLE
fix(web,shared): bound every redirect follower against cyclic redirect chains

### DIFF
--- a/frontend/packages/shared/src/__tests__/resource-loader.test.ts
+++ b/frontend/packages/shared/src/__tests__/resource-loader.test.ts
@@ -1,0 +1,124 @@
+import {Code, ConnectError} from '@connectrpc/connect'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+import {HMNotFoundError} from '../models/entity'
+import {MAX_REDIRECT_HOPS} from '../redirects'
+import {createResourceResolver, HMRedirectCycleError} from '../resource-loader'
+import {hmId} from '../utils/entity-id-url'
+
+const docA = hmId('uid1', {path: ['doc-a']})
+const docB = hmId('uid1', {path: ['doc-b']})
+const docC = hmId('uid1', {path: ['doc-c']})
+
+/** The daemon reports a redirect Ref as a FailedPrecondition error naming the target. */
+function redirectError(fromIri: string, to: ReturnType<typeof hmId>, options?: {republish?: boolean}) {
+  return new ConnectError(
+    `document '${fromIri}' has a redirect to ${to.id} (republish = ${options?.republish ? 'true' : 'false'})`,
+    Code.FailedPrecondition,
+  )
+}
+
+function notFoundError(iri: string) {
+  return new ConnectError(`document not found: ${iri}`, Code.NotFound)
+}
+
+function documentResponse() {
+  return {
+    kind: {
+      case: 'document' as const,
+      value: {
+        toJson: () => ({
+          account: 'uid1',
+          path: '/doc-c',
+          version: 'v1',
+          authors: [],
+          content: [],
+          metadata: {},
+          genesis: 'genesis1',
+          createTime: '2026-01-01T00:00:00Z',
+          updateTime: '2026-01-01T00:00:00Z',
+        }),
+      },
+    },
+  }
+}
+
+function createMockGrpcClient(handler: (iri: string) => any) {
+  const getResource = vi.fn(async ({iri}: {iri: string}) => handler(iri))
+  return {client: {resources: {getResource}} as any, getResource}
+}
+
+beforeEach(() => {
+  // prepareHMDocument logs schema fallbacks for the minimal fixture document
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('createResourceResolver', () => {
+  test('follows a redirect chain that ends at a document', async () => {
+    const {client, getResource} = createMockGrpcClient((iri) => {
+      if (iri === docA.id) throw redirectError(docA.id, docB)
+      if (iri === docB.id) throw redirectError(docB.id, docC)
+      return documentResponse()
+    })
+
+    const result = await createResourceResolver(client)(docA)
+
+    expect(result.type).toBe('document')
+    expect(getResource).toHaveBeenCalledTimes(3)
+  })
+
+  test('propagates not-found at the end of a redirect chain', async () => {
+    const {client, getResource} = createMockGrpcClient((iri) => {
+      if (iri === docA.id) throw redirectError(docA.id, docB)
+      throw notFoundError(iri)
+    })
+
+    await expect(createResourceResolver(client)(docA)).rejects.toBeInstanceOf(HMNotFoundError)
+    expect(getResource).toHaveBeenCalledTimes(2)
+  })
+
+  test('throws HMRedirectCycleError on a two-document cycle instead of looping forever', async () => {
+    const {client, getResource} = createMockGrpcClient((iri) => {
+      if (iri === docA.id) throw redirectError(docA.id, docB)
+      if (iri === docB.id) throw redirectError(docB.id, docA)
+      throw new Error(`unexpected request: ${iri}`)
+    })
+
+    const error = await createResourceResolver(client)(docA).then(
+      () => null,
+      (e) => e,
+    )
+
+    expect(error).toBeInstanceOf(HMRedirectCycleError)
+    expect(error.message).toContain('Redirect cycle detected')
+    expect(error.chain).toEqual([docA.id, docB.id, docA.id])
+    // one fetch per distinct address — the cycle is detected before refetching
+    expect(getResource).toHaveBeenCalledTimes(2)
+  })
+
+  test('throws HMRedirectCycleError on a self-redirect', async () => {
+    const {client, getResource} = createMockGrpcClient((iri) => {
+      throw redirectError(iri, docA)
+    })
+
+    await expect(createResourceResolver(client)(docA)).rejects.toBeInstanceOf(HMRedirectCycleError)
+    expect(getResource).toHaveBeenCalledTimes(1)
+  })
+
+  test('gives up on an acyclic chain longer than MAX_REDIRECT_HOPS', async () => {
+    const ids = Array.from({length: MAX_REDIRECT_HOPS + 3}, (_, i) => hmId('uid1', {path: [`hop-${i}`]}))
+    const {client, getResource} = createMockGrpcClient((iri) => {
+      const idx = ids.findIndex((id) => id.id === iri)
+      if (idx >= 0 && idx < ids.length - 1) throw redirectError(iri, ids[idx + 1]!)
+      return documentResponse()
+    })
+
+    const error = await createResourceResolver(client)(ids[0]!).then(
+      () => null,
+      (e) => e,
+    )
+
+    expect(error).toBeInstanceOf(HMRedirectCycleError)
+    expect(error.message).toContain('Too many redirects')
+    expect(getResource).toHaveBeenCalledTimes(MAX_REDIRECT_HOPS + 1)
+  })
+})

--- a/frontend/packages/shared/src/models/__tests__/queries.test.ts
+++ b/frontend/packages/shared/src/models/__tests__/queries.test.ts
@@ -162,6 +162,37 @@ describe('queryResource', () => {
     expect(client.request).toHaveBeenCalledTimes(6)
   })
 
+  test('returns an error when redirects form a cycle instead of burning all hops', async () => {
+    const client = createMockClient((_key, input) => {
+      if (input.id === docA.id) return redirectResponse(docA, docB)
+      if (input.id === docB.id) return redirectResponse(docB, docA)
+      throw new Error(`Unexpected request: ${input.id}`)
+    })
+
+    const result = await queryResource(client, docA).queryFn!()
+
+    expect(result).toMatchObject({
+      type: 'error',
+      id: docA,
+      message: 'Redirect cycle detected while resolving resource',
+    })
+    // the cycle is detected as soon as an address repeats, before refetching it
+    expect(client.request).toHaveBeenCalledTimes(2)
+  })
+
+  test('returns an error when a document redirects to itself', async () => {
+    const client = createMockClient(() => redirectResponse(docA, docA))
+
+    const result = await queryResource(client, docA).queryFn!()
+
+    expect(result).toMatchObject({
+      type: 'error',
+      id: docA,
+      message: 'Redirect cycle detected while resolving resource',
+    })
+    expect(client.request).toHaveBeenCalledTimes(1)
+  })
+
   test('does not copy source version onto redirect target', async () => {
     const versionedDocA = hmId('uid1', {path: ['old-name'], version: 'v123'})
     const client = createMockClient((_key, input) => {

--- a/frontend/packages/shared/src/models/entity.ts
+++ b/frontend/packages/shared/src/models/entity.ts
@@ -24,6 +24,7 @@ import {useInfiniteQuery, useQueries, useQuery, useQueryClient, UseQueryOptions}
 import {useEffect, useMemo, useRef, useState} from 'react'
 import {DocumentInfo, RedirectErrorDetails} from '../client'
 import {DISCOVERY_TIMEOUT_MS} from '../constants'
+import {MAX_REDIRECT_HOPS} from '../redirects'
 import {useUniversalAppContext, useUniversalClient} from '../routing'
 import {useStream} from '../use-stream'
 import {createWebHMUrl, entityQueryPathToHmIdPath, extractViewTermFromUrl, hmId, latestId, unpackHmId} from '../utils'
@@ -317,15 +318,25 @@ export function useResolvedResource(
     queryFn: async ({signal}: {signal?: AbortSignal} = {}): Promise<HMResolvedResource | null> => {
       if (!id) return null
 
-      async function loadResolvedResource(id: UnpackedHypermediaId): Promise<HMResolvedResource | null> {
-        let resource = await client.request('Resource', id, {signal})
+      // Redirects are daemon-served data, so the chain can be cyclic — bound the walk
+      // instead of recursing, or a cycle spins forever.
+      const visited = new Set<string>()
+      let current = id
+      while (true) {
+        if (visited.has(current.id)) {
+          throw new Error(`Redirect cycle detected while resolving ${id.id}`)
+        }
+        if (visited.size > MAX_REDIRECT_HOPS) {
+          throw new Error(`Too many redirects while resolving ${id.id} (limit ${MAX_REDIRECT_HOPS})`)
+        }
+        visited.add(current.id)
+        const resource = await client.request('Resource', current, {signal})
         if (resource?.type === 'redirect') {
-          return await loadResolvedResource(resource.redirectTarget)
+          current = resource.redirectTarget
+          continue
         }
         return resource as HMResolvedResource
       }
-
-      return await loadResolvedResource(id)
     },
     ...options,
   })

--- a/frontend/packages/shared/src/models/queries.ts
+++ b/frontend/packages/shared/src/models/queries.ts
@@ -26,6 +26,7 @@ import type {
   UnpackedHypermediaId,
 } from '@seed-hypermedia/client/hm-types'
 import {HMQueryBlockPayloadSchema, HMQueryResultSchema, HMResourceSchema} from '@seed-hypermedia/client/hm-types'
+import {MAX_REDIRECT_HOPS} from '../redirects'
 import type {UniversalClient} from '../universal-client'
 import {hmIdPathToEntityQueryPath} from '../utils'
 import {hmId} from '../utils/entity-id-url'
@@ -79,12 +80,18 @@ export function queryResource(client: UniversalClient, id: UnpackedHypermediaId 
         // Republish refs are special: they should render the target content while
         // preserving the source route/ID, so the omnibar and navigation stay on
         // the republished path instead of being treated like a move redirect.
-        let maxRedirects = 5
-        while (res?.type === 'redirect' && maxRedirects-- > 0) {
+        // Redirects are daemon-served data, so the chain can be cyclic — stop on a
+        // revisited address instead of burning hops on a loop that cannot resolve.
+        const visited = new Set<string>([id.id])
+        while (res?.type === 'redirect' && visited.size <= MAX_REDIRECT_HOPS) {
           const nextTarget = {
             ...res.redirectTarget,
             hostname: res.redirectTarget.hostname || res.id.hostname || id.hostname,
           }
+          if (visited.has(nextTarget.id)) {
+            return {type: 'error', id, message: 'Redirect cycle detected while resolving resource'}
+          }
+          visited.add(nextTarget.id)
           if (res.republish && !republishSourceId) {
             republishSourceId = res.id
           }

--- a/frontend/packages/shared/src/redirects.ts
+++ b/frontend/packages/shared/src/redirects.ts
@@ -1,0 +1,9 @@
+/**
+ * Maximum redirect hops any resolver may follow before giving up.
+ *
+ * Redirect Refs are data served by the daemon, so a chain can be arbitrarily long or
+ * even cyclic (A→B→C→A). Every follower must bound its walk with this limit and stop
+ * early on a revisited address — an unbounded follower spins forever on a cycle,
+ * growing a promise chain that degrades the whole process.
+ */
+export const MAX_REDIRECT_HOPS = 5

--- a/frontend/packages/shared/src/resource-loader.ts
+++ b/frontend/packages/shared/src/resource-loader.ts
@@ -9,7 +9,8 @@ import {
   HMResourceTombstone,
   UnpackedHypermediaId,
 } from '@seed-hypermedia/client/hm-types'
-import {getErrorMessage, HMNotFoundError, HMRedirectError, HMResourceTombstoneError} from './models/entity'
+import {getErrorMessage, HMError, HMNotFoundError, HMRedirectError, HMResourceTombstoneError} from './models/entity'
+import {MAX_REDIRECT_HOPS} from './redirects'
 import {packHmId} from './utils'
 
 /**
@@ -74,25 +75,58 @@ export function createResourceFetcher(grpcClient: GRPCClient) {
 }
 
 /**
+ * A redirect chain that cannot end at a resource: it revisits an address (a cycle in
+ * the daemon's redirect data) or is longer than {@link MAX_REDIRECT_HOPS}. Never
+ * follow further after this — the chain is unresolvable by construction.
+ */
+export class HMRedirectCycleError extends HMError {
+  constructor(
+    public readonly chain: string[],
+    opts?: {limitExceeded?: boolean},
+  ) {
+    super(
+      opts?.limitExceeded
+        ? `Too many redirects while resolving resource (limit ${MAX_REDIRECT_HOPS}): ${chain.join(' -> ')}`
+        : `Redirect cycle detected: ${chain.join(' -> ')}`,
+    )
+  }
+}
+
+/**
  * Creates a resource resolver that follows redirects.
  * Returns document or comment (never redirect).
  * Throws HMNotFoundError if resource not found.
+ * Throws HMRedirectCycleError on a cyclic or over-long redirect chain — redirects are
+ * daemon-served data, so the walk must be bounded or a cycle spins it forever.
  */
 export function createResourceResolver(grpcClient: GRPCClient) {
   const fetchResource = createResourceFetcher(grpcClient)
 
   async function resolveResource(id: UnpackedHypermediaId): Promise<HMResolvedResource> {
-    const resource = await fetchResource(id)
-    if (resource.type === 'redirect') {
-      return resolveResource(resource.redirectTarget)
+    const visited = new Set<string>()
+    let current = id
+    while (true) {
+      const key = packHmId(current)
+      if (visited.has(key)) {
+        throw new HMRedirectCycleError([...visited, key])
+      }
+      if (visited.size > MAX_REDIRECT_HOPS) {
+        throw new HMRedirectCycleError([...visited], {limitExceeded: true})
+      }
+      visited.add(key)
+      const resource = await fetchResource(current)
+      if (resource.type === 'redirect') {
+        current = resource.redirectTarget
+        continue
+      }
+      if (resource.type === 'not-found') {
+        throw new HMNotFoundError()
+      }
+      if (resource.type === 'error') {
+        throw new Error(resource.message)
+      }
+      return resource
     }
-    if (resource.type === 'not-found') {
-      throw new HMNotFoundError()
-    }
-    if (resource.type === 'error') {
-      throw new Error(resource.message)
-    }
-    return resource
   }
   return resolveResource
 }

--- a/frontend/packages/shared/src/resource-loader.ts
+++ b/frontend/packages/shared/src/resource-loader.ts
@@ -108,10 +108,10 @@ export function createResourceResolver(grpcClient: GRPCClient) {
     while (true) {
       const key = packHmId(current)
       if (visited.has(key)) {
-        throw new HMRedirectCycleError([...visited, key])
+        throw new HMRedirectCycleError(Array.from(visited).concat(key))
       }
       if (visited.size > MAX_REDIRECT_HOPS) {
-        throw new HMRedirectCycleError([...visited], {limitExceeded: true})
+        throw new HMRedirectCycleError(Array.from(visited), {limitExceeded: true})
       }
       visited.add(key)
       const resource = await fetchResource(current)


### PR DESCRIPTION
## Incident

On 2026-08-27 the production web gateway became unresponsive (60s+ TTFB on all routes). Root cause: the daemon served a cyclic redirect chain —

```
hm://z6MkrWRo…/artrosis/mapa-de-conocimiento
  → hm://z6Mkrjvn…/artrosis/mapa-de-conocimiento
  → hm://z6Mkrjvn…/mapa-de-conocimiento
  → back to the first (republish = true)
```

`resolveResource` followed redirects by unbounded recursion, so a single page hit on a cycling document spun forever (~40 hops/sec). Each hop adopted another promise; V8's default async stack capture then walked that ever-growing chain on **every Error constructed anywhere in the process** (`CaptureAsyncStackTrace` + `JSPromise::status` = 72% of CPU in `perf`), pinning the event loop. Six accumulated loops were killed in-memory via the inspector to restore service; this PR is the durable fix.

## Change

Every redirect follower now walks iteratively, bounded by a shared `MAX_REDIRECT_HOPS`, and stops early on a revisited address:

- **`resolveResource`** (SSR + desktop): throws a typed `HMRedirectCycleError` carrying the chain, on a cycle or over-long chain.
- **`useResolvedResource`** (client): same guard, replacing unbounded recursion.
- **`queryResource`**: detects cycles as soon as an address repeats instead of burning all hops first.

`document-state.ts` already had a hop cap and is unchanged.

## Tests

7 new tests: chain-to-document, chain-to-not-found, 2-node cycle, self-redirect, over-long chain, and cycle/self-redirect through `queryResource` (asserting early detection by call count). Full `@shm/shared` suite passes (1041 tests); `shared` and `web` typecheck clean.

## Follow-up (not in this PR)

The daemon should not have emitted a cyclic redirect chain — likely related to the 2026-08-27 indexer changes (`collections are a shape the indexer derives` / Ref-capability revert). Needs a backend-side look; with this guard the frontend now renders a clear error for such documents instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkY4eVkv9tsLY31j4ZjGvV