### PR TITLE
fix(agents): list public agents' chats in the web sidebar, restore selection on reload, open into a new chat

### DIFF
--- a/frontend/apps/desktop/src/__tests__/assistant-new-session-selection.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/assistant-new-session-selection.test.tsx
@@ -71,9 +71,9 @@ describe('sidebar new-chat selection after CreateSession', () => {
     queryClient.clear()
   })
 
-  it('without the seed, a stale list resolves to the old session (the bug this guards)', () => {
+  it('without the seed, a stale list cannot place the new session, so it is not shown (the bug this guards)', () => {
     queryClient.setQueryData(listKey, [{serverUrl: SERVER, session: session('s-old', 100)}])
-    expect(resolveFromCaches('s-new').session).toEqual({serverUrl: SERVER, sessionId: 's-old'})
+    expect(resolveFromCaches('s-new').session).toBeNull()
   })
 
   it('the seed makes the resolver keep the just-created session over a stale list', () => {

--- a/frontend/apps/desktop/src/__tests__/assistant-panel-context.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/assistant-panel-context.test.tsx
@@ -19,6 +19,12 @@ const mockState = vi.hoisted(() => ({
   serverUrls: [] as string[],
   agentLists: [] as Array<{data: Array<{id: string; definition: {name: string; model: string}}>}>,
   sessionEntries: [] as Array<{serverUrl: string; session: Record<string, unknown>}>,
+  spaceAgents: {
+    agents: [] as Array<{serverUrl: string; agent: {id: string; definition: {name: string; model: string}}}>,
+    sessions: [] as Array<{serverUrl: string; session: Record<string, unknown>}>,
+    isLoading: false,
+  },
+  agentListsSettled: true,
   navigate: undefined as unknown as ReturnType<typeof vi.fn>,
   createAgentDialogMounts: 0,
   createAgentDialogInput: null as null | {onCreated?: (created: {serverUrl: string; agentId: string}) => void},
@@ -35,8 +41,9 @@ vi.mock('@shm/ui/agents/models', () => ({
   removeOptimisticSessionFromLists: vi.fn(),
   useAgentDetail: () => ({data: undefined, isLoading: false}),
   useRun: () => ({data: undefined}),
-  useAgentLists: () => mockState.agentLists,
-  useSpaceAgents: () => ({agents: [], isLoading: false}),
+  useAgentLists: () =>
+    mockState.agentLists.map((query) => ({...query, isSuccess: mockState.agentListsSettled, isError: false})),
+  useSpaceAgents: () => mockState.spaceAgents,
   useAgentServerUrls: () => ({data: mockState.serverUrls, isSuccess: true, isLoading: false}),
   useAgentSession: () => ({data: undefined}),
   useAgentWebSocketSubscription: () => ({text: ''}),
@@ -147,6 +154,13 @@ function clickText(text: string) {
   })
 }
 
+/** The "…" chat menu only renders beside an active session, so it tells a session from a draft. */
+function hasActiveSession() {
+  return Array.from(document.body.querySelectorAll('button')).some(
+    (element) => element.getAttribute('title') === 'Chat options',
+  )
+}
+
 beforeEach(() => {
   ;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
   container = document.createElement('div')
@@ -157,6 +171,8 @@ beforeEach(() => {
   mockState.createAgentDialogMounts = 0
   mockState.createAgentDialogInput = null
   mockState.serverUrls = [LOCAL, REMOTE]
+  mockState.spaceAgents = {agents: [], sessions: [], isLoading: false}
+  mockState.agentListsSettled = true
   mockState.agentLists = [
     {data: [{id: 'assistant', definition: {name: 'Assistant', model: 'claude-sonnet-5'}}]},
     {data: [{id: 'researcher', definition: {name: 'Researcher', model: 'gpt-5'}}]},
@@ -174,15 +190,27 @@ afterEach(() => {
 })
 
 describe('assistant sidebar agent context', () => {
-  it('opens straight into the default agent context with its newest session — no dialog', () => {
+  it('opens straight into the default agent context as a new chat, with its sessions listed — no dialog', () => {
     act(() => {
       root.render(<AssistantPanel />)
     })
-    // Local server is first, so its agent is the default context.
-    expect(document.body.textContent).toContain('Assistant')
+    // Local server is first, so its agent is the default context; nothing remembered means a
+    // draft, not whichever chat is newest.
+    expect(document.body.textContent).toContain('Send a message to start chatting with Assistant')
+    expect(hasActiveSession()).toBe(false)
+    expect(document.body.textContent).not.toContain('Doc questions')
+    clickText('New chat')
     expect(document.body.textContent).toContain('Doc questions')
     // The other agent's session must not leak into this context.
     expect(document.body.textContent).not.toContain('Web research')
+  })
+
+  it('restores the remembered session on mount', () => {
+    act(() => {
+      root.render(<AssistantPanel initialSessionId={`${LOCAL} | s-a1`} />)
+    })
+    expect(document.body.textContent).toContain('Doc questions')
+    expect(hasActiveSession()).toBe(true)
   })
 
   it('switches agent context from the top dropdown, grouped by server', () => {
@@ -195,7 +223,9 @@ describe('assistant sidebar agent context', () => {
     expect(document.body.textContent).toContain('agentic.seed.hyper.media')
 
     clickText('Researcher')
-    // Context switched: the researcher's newest session is now active.
+    // Context switched: a draft with the researcher, whose sessions are now the ones listed.
+    expect(document.body.textContent).toContain('Send a message to start chatting with Researcher')
+    clickText('New chat')
     expect(document.body.textContent).toContain('Web research')
     expect(document.body.textContent).not.toContain('Doc questions')
   })
@@ -281,9 +311,72 @@ describe('assistant sidebar agent context', () => {
     expect(document.activeElement?.tagName).toBe('TEXTAREA')
   })
 
-  it('offers session options in a menu on the session row, not a dedicated row', () => {
+  it('reopens in the remembered agent context, even one with no chats yet', () => {
+    // Web reload / desktop relaunch with the agent choice persisted: the context must be the chosen
+    // agent (an empty one, here), not the default first agent and not the stored session's agent.
+    mockState.agentLists[1]!.data.push({id: 'fresh', definition: {name: 'Fresh', model: 'gpt-5'}})
+    act(() => {
+      root.render(<AssistantPanel initialSessionId={`${LOCAL} | s-a1`} initialAgentId={`${REMOTE} | fresh`} />)
+    })
+    expect(document.body.textContent).toContain('Send a message to start chatting with Fresh')
+    expect(document.body.textContent).not.toContain('Doc questions')
+  })
+
+  it('reports the agent choice to the host so it can be persisted, and clears it with null', () => {
+    const onAgentChange = vi.fn()
+    act(() => {
+      root.render(<AssistantPanel onAgentChange={onAgentChange} />)
+    })
+    clickText('Assistant')
+    clickText('Researcher')
+    expect(onAgentChange).toHaveBeenCalledWith(`${REMOTE} | researcher`)
+  })
+
+  it('keeps the restored session — and its stored ref — while the agent lists are still loading', () => {
+    // The remote list owning the stored session has not answered. Previously the resolver settled
+    // on the local agent's newest and the sync-back effect wrote that (or null) over the stored
+    // ref, so a reload never actually restored the session the user was in.
+    mockState.agentListsSettled = false
+    mockState.agentLists = [{data: [{id: 'assistant', definition: {name: 'Assistant', model: 'claude-sonnet-5'}}]}]
+    mockState.sessionEntries = [
+      {serverUrl: LOCAL, session: {id: 's-a1', agentId: 'assistant', title: 'Doc questions', updatedAt: 300}},
+    ]
+    const onSessionChange = vi.fn()
+    act(() => {
+      root.render(<AssistantPanel initialSessionId={`${REMOTE} | s-r1`} onSessionChange={onSessionChange} />)
+    })
+    expect(onSessionChange).not.toHaveBeenCalled()
+    // The session picker still names the stored session as selected — nothing was swapped in.
+    expect(document.body.textContent).not.toContain('Doc questions')
+  })
+
+  it("lists a space agent's chats from its GetAgent answer, which the account-wide lists omit", () => {
+    const SPACE = 'https://agents.space.example'
+    mockState.spaceAgents = {
+      agents: [{serverUrl: SPACE, agent: {id: 'docs', definition: {name: 'Docs Helper', model: 'gpt-5'}}}],
+      sessions: [
+        {serverUrl: SPACE, session: {id: 's-d2', agentId: 'docs', title: 'Someone asked about tags', updatedAt: 900}},
+        {serverUrl: SPACE, session: {id: 's-d1', agentId: 'docs', title: 'My first question', updatedAt: 800}},
+      ],
+      isLoading: false,
+    }
     act(() => {
       root.render(<AssistantPanel />)
+    })
+    // The space agent leads, as a new chat — not somebody else's — with the chats one click away.
+    expect(document.body.textContent).toContain('Send a message to start chatting with Docs Helper')
+    expect(document.body.textContent).not.toContain('Someone asked about tags')
+    clickText('New chat')
+    expect(document.body.textContent).not.toContain('No chats with this agent yet')
+    expect(document.body.textContent).toContain('Someone asked about tags')
+    clickText('My first question')
+    expect(document.body.textContent).toContain('My first question')
+    expect(hasActiveSession()).toBe(true)
+  })
+
+  it('offers session options in a menu on the session row, not a dedicated row', () => {
+    act(() => {
+      root.render(<AssistantPanel initialSessionId={`${LOCAL} | s-a1`} />)
     })
     const options = Array.from(document.body.querySelectorAll('button')).filter(
       (element) => element.getAttribute('title') === 'Chat options',

--- a/frontend/apps/desktop/src/__tests__/assistant-selection.test.ts
+++ b/frontend/apps/desktop/src/__tests__/assistant-selection.test.ts
@@ -41,10 +41,12 @@ const sessions = [
 const base = {agents, sessions, chosenAgent: null, storedSession: null, isDraft: false}
 
 describe('resolveAssistantSelection', () => {
-  it('defaults to the first agent (local server first) and its newest session', () => {
+  it('defaults to the first agent (local server first) as a draft, with its sessions listed', () => {
+    // Nothing remembered means a new chat, never whichever chat happens to be newest — for a
+    // public agent that is somebody else's conversation.
     const result = resolveAssistantSelection(base)
     expect(result.agent?.agent.id).toBe('assistant')
-    expect(result.session).toEqual({serverUrl: LOCAL, sessionId: 's-a2'})
+    expect(result.session).toBeNull()
     expect(result.agentSessions.map((entry) => entry.session.id)).toEqual(['s-a2', 's-a1'])
   })
 
@@ -54,7 +56,7 @@ describe('resolveAssistantSelection', () => {
     expect(result.session).toEqual({serverUrl: REMOTE, sessionId: 's-r1'})
   })
 
-  it("lets an explicit agent choice override the stored session, landing on that agent's newest", () => {
+  it('lets an explicit agent choice override the stored session, landing on a draft with that agent', () => {
     const result = resolveAssistantSelection({
       ...base,
       storedSession: {serverUrl: LOCAL, sessionId: 's-a1'},
@@ -62,7 +64,8 @@ describe('resolveAssistantSelection', () => {
     })
     expect(result.agent?.agent.id).toBe('researcher')
     // Keeping s-a1 here would show one agent's transcript under another agent's header.
-    expect(result.session).toEqual({serverUrl: REMOTE, sessionId: 's-r2'})
+    expect(result.session).toBeNull()
+    expect(result.agentSessions.map((entry) => entry.session.id)).toEqual(['s-r2', 's-r1'])
   })
 
   it('drafting keeps the agent context but no active session', () => {
@@ -104,11 +107,90 @@ describe('resolveAssistantSelection', () => {
     expect(result.agentSessions).toEqual([])
   })
 
-  it("after deleting the active session, selects the agent's next newest — not the deleted one", () => {
+  it('holds a stored session whose agent has not been listed yet while the lists are still loading', () => {
+    // Launch: the local server answered first; the remote one (owning the stored session) has not.
+    // Settling on the local agent's newest here would be written back as the remembered selection.
+    const result = resolveAssistantSelection({
+      ...base,
+      agents: [agent(LOCAL, 'assistant', 'Assistant')],
+      storedSession: {serverUrl: REMOTE, sessionId: 's-r1'},
+      storedSessionAgentId: 'researcher',
+      agentsSettled: false,
+    })
+    expect(result.session).toEqual({serverUrl: REMOTE, sessionId: 's-r1'})
+  })
+
+  it('holds a stored session even before any agent is known, so the transcript shows at once', () => {
+    const result = resolveAssistantSelection({
+      ...base,
+      agents: [],
+      storedSession: {serverUrl: REMOTE, sessionId: 's-r1'},
+      agentsSettled: false,
+    })
+    expect(result.agent).toBeNull()
+    expect(result.session).toEqual({serverUrl: REMOTE, sessionId: 's-r1'})
+  })
+
+  it('moves on from a stored session once the lists have settled without its agent', () => {
+    const result = resolveAssistantSelection({
+      ...base,
+      agents: [agent(LOCAL, 'assistant', 'Assistant')],
+      storedSession: {serverUrl: REMOTE, sessionId: 's-r1'},
+      storedSessionAgentId: 'researcher',
+      agentsSettled: true,
+    })
+    expect(result.agent?.agent.id).toBe('assistant')
+    expect(result.session).toBeNull()
+  })
+
+  it('gives up a stored session the server refused, instead of holding it until its agent turns up', () => {
+    // Deleted from another window: the lists will never name it and its fetch answered 404.
+    const result = resolveAssistantSelection({
+      ...base,
+      sessions,
+      storedSession: {serverUrl: LOCAL, sessionId: 's-gone'},
+      storedSessionUnavailable: true,
+    })
+    expect(result.session).toBeNull()
+  })
+
+  it('holds the stored session while a remembered agent choice is still loading, then honors the choice', () => {
+    const loading = resolveAssistantSelection({
+      ...base,
+      agents: [agent(LOCAL, 'assistant', 'Assistant')],
+      storedSession: {serverUrl: LOCAL, sessionId: 's-a1'},
+      chosenAgent: {serverUrl: REMOTE, agentId: 'researcher'},
+      agentsSettled: false,
+    })
+    expect(loading.session).toEqual({serverUrl: LOCAL, sessionId: 's-a1'})
+
+    const settled = resolveAssistantSelection({
+      ...base,
+      storedSession: {serverUrl: LOCAL, sessionId: 's-a1'},
+      chosenAgent: {serverUrl: REMOTE, agentId: 'researcher'},
+      agentsSettled: true,
+    })
+    expect(settled.agent?.agent.id).toBe('researcher')
+    expect(settled.session).toBeNull()
+  })
+
+  it('a remembered agent with no chats yet opens as an empty context, not another agent', () => {
+    const result = resolveAssistantSelection({
+      ...base,
+      agents: [...agents, agent(REMOTE, 'fresh', 'Fresh')],
+      chosenAgent: {serverUrl: REMOTE, agentId: 'fresh'},
+    })
+    expect(result.agent?.agent.id).toBe('fresh')
+    expect(result.session).toBeNull()
+  })
+
+  it('after deleting the active session, opens a draft in the same context — not the deleted one', () => {
     // Delete flow: the session is removed from the cached lists and the stored selection cleared.
     const remaining = sessions.filter((entry) => entry.session.id !== 's-a2')
     const result = resolveAssistantSelection({...base, sessions: remaining, storedSession: null})
-    expect(result.session).toEqual({serverUrl: LOCAL, sessionId: 's-a1'})
+    expect(result.agent?.agent.id).toBe('assistant')
+    expect(result.session).toBeNull()
+    expect(result.agentSessions.map((entry) => entry.session.id)).toEqual(['s-a1'])
   })
 })
 

--- a/frontend/apps/web/app/__tests__/web-assistant-panel.test.tsx
+++ b/frontend/apps/web/app/__tests__/web-assistant-panel.test.tsx
@@ -23,7 +23,7 @@ vi.mock('@/client-lazy', () => ({
   clientLazy: () => () => <div data-testid="panel-content">PANEL</div>,
 }))
 
-import {AssistantPanelProvider, useAssistantPanel} from '../assistant-panel-state'
+import {AssistantPanelProvider, useAssistantAutoOpen, useAssistantPanel} from '../assistant-panel-state'
 import {publishSiteContext} from '../site-context-bridge'
 import {WebAssistantHost} from '../web-assistant-host'
 
@@ -42,6 +42,7 @@ let container: HTMLDivElement
 let root: Root
 let mountCount = 0
 let controls: ReturnType<typeof useAssistantPanel> | null = null
+let autoOpenAvailable = false
 
 function Page() {
   React.useEffect(() => {
@@ -52,6 +53,8 @@ function Page() {
 
 function Probe() {
   controls = useAssistantPanel()
+  // Stands in for the site header, which reports whether a signed-in reader has an agent to use.
+  useAssistantAutoOpen(autoOpenAvailable)
   return null
 }
 
@@ -77,6 +80,7 @@ beforeEach(() => {
   mockState.isMobile = false
   mountCount = 0
   controls = null
+  autoOpenAvailable = false
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
@@ -111,16 +115,62 @@ describe('web assistant panel', () => {
     act(() => {
       controls!.open()
       controls!.setSessionId('https://agents.example | s-1')
+      controls!.setAgentId('https://agents.example | docs')
     })
     expect(window.localStorage.getItem('seed.assistant.open')).toBe('1')
     expect(window.localStorage.getItem('seed.assistant.session')).toBe('https://agents.example | s-1')
+    expect(window.localStorage.getItem('seed.assistant.agent')).toBe('https://agents.example | docs')
 
     act(() => root.unmount())
     root = createRoot(container)
     act(() => root.render(<App />))
     expect(controls!.isOpen).toBe(true)
     expect(controls!.sessionId).toBe('https://agents.example | s-1')
+    expect(controls!.agentId).toBe('https://agents.example | docs')
     expect(container.querySelector('[data-testid="web-assistant-panel"]')).not.toBeNull()
+
+    // Clearing the choice clears the stored key too, so a stale agent does not come back later.
+    act(() => controls!.setAgentId(null))
+    expect(window.localStorage.getItem('seed.assistant.agent')).toBeNull()
+  })
+
+  it('remembers a close as a decision, so the panel stays closed on the next visit', () => {
+    act(() => root.render(<App />))
+    act(() => controls!.open())
+    act(() => controls!.close())
+    expect(window.localStorage.getItem('seed.assistant.open')).toBe('0')
+
+    act(() => root.unmount())
+    root = createRoot(container)
+    act(() => root.render(<App />))
+    expect(controls!.isOpen).toBe(false)
+    expect(controls!.openDecided).toBe(true)
+  })
+
+  it('stores no open preference until the reader makes one', () => {
+    act(() => root.render(<App />))
+    expect(controls!.openDecided).toBe(false)
+    expect(window.localStorage.getItem('seed.assistant.open')).toBeNull()
+  })
+
+  it('opens itself on first arrival once an agent is available, and only until the reader closes it', () => {
+    act(() => root.render(<App />))
+    expect(controls!.isOpen).toBe(false)
+    // The site header learns there is an agent to use (home loaded, reader signed in).
+    autoOpenAvailable = true
+    act(() => root.render(<App />))
+    expect(controls!.isOpen).toBe(true)
+    expect(window.localStorage.getItem('seed.assistant.open')).toBe('1')
+
+    act(() => controls!.close())
+    expect(controls!.isOpen).toBe(false)
+    // Still available, but the close was a decision: no re-opening on this or a later visit.
+    act(() => root.render(<App />))
+    expect(controls!.isOpen).toBe(false)
+    act(() => root.unmount())
+    root = createRoot(container)
+    act(() => root.render(<App />))
+    expect(controls!.isOpen).toBe(false)
   })
 
   it('does not overwrite a saved open state with the pre-hydration default', () => {

--- a/frontend/apps/web/app/assistant-panel-state.tsx
+++ b/frontend/apps/web/app/assistant-panel-state.tsx
@@ -10,11 +10,23 @@ import React, {createContext, useCallback, useContext, useEffect, useMemo, useRe
  * with it the panel host — and are mirrored to localStorage so a reload restores the panel the way
  * a desktop relaunch does. Storage is read after mount: the server and the first client render
  * agree on "closed", and the panel body is client-only anyway.
+ *
+ * Open state is a three-way preference: open, closed, or never decided. The distinction matters
+ * for first arrival — the panel opens itself once for a reader who has never chosen (see
+ * {@link useAssistantAutoOpen}), and only an actual close is remembered as "closed", so a visit
+ * that never surfaced the panel (signed out, on a phone) does not count as a decision.
  */
 export type AssistantPanelState = {
   isOpen: boolean
+  /**
+   * Whether the reader has ever opened or closed the panel: true once a preference is stored,
+   * false when none is, undefined until storage has been read. Only `false` invites auto-open.
+   */
+  openDecided: boolean | undefined
   /** Serialized `AssistantSessionRef` of the session the panel last showed, or null. */
   sessionId: string | null
+  /** Serialized agent ref the user last chose in the panel's agent dropdown, or null. */
+  agentId: string | null
   /**
    * Monotonic counter; each increment asks the panel to start a new chat. A counter rather than a
    * flag so a second click while a draft is already open re-focuses the composer.
@@ -26,10 +38,14 @@ export type AssistantPanelState = {
   /** Opens the panel (if needed) and starts a new chat in the last-used agent context. */
   requestNewChat: () => void
   setSessionId: (sessionId: string | null) => void
+  setAgentId: (agentId: string | null) => void
 }
 
 const OPEN_STORAGE_KEY = 'seed.assistant.open'
 const SESSION_STORAGE_KEY = 'seed.assistant.session'
+/** Stored open preference: '1' open, '0' closed; absent means never decided. */
+type OpenPreference = '1' | '0'
+const AGENT_STORAGE_KEY = 'seed.assistant.agent'
 
 function readStorage(key: string): string | null {
   try {
@@ -52,7 +68,9 @@ const AssistantPanelContext = createContext<AssistantPanelState | null>(null)
 
 export function AssistantPanelProvider({children}: {children: React.ReactNode}) {
   const [isOpen, setIsOpen] = useState(false)
+  const [openDecided, setOpenDecided] = useState<boolean | undefined>(undefined)
   const [sessionId, setSessionIdState] = useState<string | null>(null)
+  const [agentId, setAgentIdState] = useState<string | null>(null)
   const [newChatRequest, setNewChatRequest] = useState(0)
   // Nothing is written back until the stored values have been read, or the pre-hydration defaults
   // would clobber what the previous visit saved. State rather than a ref: a ref flipped inside the
@@ -62,8 +80,11 @@ export function AssistantPanelProvider({children}: {children: React.ReactNode}) 
   const [hydrated, setHydrated] = useState(false)
 
   useEffect(() => {
-    setIsOpen(readStorage(OPEN_STORAGE_KEY) === '1')
+    const storedOpen = readStorage(OPEN_STORAGE_KEY)
+    setIsOpen(storedOpen === '1')
+    setOpenDecided(storedOpen === '1' || storedOpen === '0')
     setSessionIdState(readStorage(SESSION_STORAGE_KEY))
+    setAgentIdState(readStorage(AGENT_STORAGE_KEY))
     setHydrated(true)
   }, [])
 
@@ -79,28 +100,70 @@ export function AssistantPanelProvider({children}: {children: React.ReactNode}) 
     setNewChatRequest(0)
   }, [location.pathname])
 
+  // Written only once decided: the pre-decision default would otherwise be stored as a "closed"
+  // preference on the first visit, and the panel would never get to introduce itself.
   useEffect(() => {
-    if (!hydrated) return
-    writeStorage(OPEN_STORAGE_KEY, isOpen ? '1' : null)
-  }, [hydrated, isOpen])
+    if (!hydrated || !openDecided) return
+    writeStorage(OPEN_STORAGE_KEY, (isOpen ? '1' : '0') satisfies OpenPreference)
+  }, [hydrated, openDecided, isOpen])
 
   useEffect(() => {
     if (!hydrated) return
     writeStorage(SESSION_STORAGE_KEY, sessionId)
   }, [hydrated, sessionId])
 
-  const open = useCallback(() => setIsOpen(true), [])
-  const close = useCallback(() => setIsOpen(false), [])
-  const toggle = useCallback(() => setIsOpen((prev) => !prev), [])
+  useEffect(() => {
+    if (!hydrated) return
+    writeStorage(AGENT_STORAGE_KEY, agentId)
+  }, [hydrated, agentId])
+
+  const open = useCallback(() => {
+    setIsOpen(true)
+    setOpenDecided(true)
+  }, [])
+  const close = useCallback(() => {
+    setIsOpen(false)
+    setOpenDecided(true)
+  }, [])
+  const toggle = useCallback(() => {
+    setIsOpen((prev) => !prev)
+    setOpenDecided(true)
+  }, [])
   const requestNewChat = useCallback(() => {
     setIsOpen(true)
+    setOpenDecided(true)
     setNewChatRequest((prev) => prev + 1)
   }, [])
   const setSessionId = useCallback((next: string | null) => setSessionIdState(next), [])
+  const setAgentId = useCallback((next: string | null) => setAgentIdState(next), [])
 
   const value = useMemo<AssistantPanelState>(
-    () => ({isOpen, sessionId, newChatRequest, open, close, toggle, requestNewChat, setSessionId}),
-    [isOpen, sessionId, newChatRequest, open, close, toggle, requestNewChat, setSessionId],
+    () => ({
+      isOpen,
+      openDecided,
+      sessionId,
+      agentId,
+      newChatRequest,
+      open,
+      close,
+      toggle,
+      requestNewChat,
+      setSessionId,
+      setAgentId,
+    }),
+    [
+      isOpen,
+      openDecided,
+      sessionId,
+      agentId,
+      newChatRequest,
+      open,
+      close,
+      toggle,
+      requestNewChat,
+      setSessionId,
+      setAgentId,
+    ],
   )
   return <AssistantPanelContext.Provider value={value}>{children}</AssistantPanelContext.Provider>
 }
@@ -111,14 +174,38 @@ export function useAssistantPanel(): AssistantPanelState {
   return context ?? INERT_STATE
 }
 
+/** Narrow viewports get the panel over the whole page, which is not something to spring on arrival. */
+const NARROW_VIEWPORT_QUERY = '(max-width: 660px)'
+
+/**
+ * Opens the panel on its own the first time a reader could use it.
+ *
+ * `available` is the host's word that there is an agent to talk to and someone signed in to talk
+ * to it. Only a reader who has never opened or closed the panel is introduced this way — once they
+ * close it, that is remembered and it stays closed until they ask for it. Phones are exempt: there
+ * the panel covers the page. The viewport is re-checked at the moment of opening, since the media
+ * hook settles a render after mount and an effect in that first pass would still read "wide".
+ */
+export function useAssistantAutoOpen(available: boolean) {
+  const {openDecided, open} = useAssistantPanel()
+  useEffect(() => {
+    if (!available || openDecided !== false) return
+    if (typeof window.matchMedia === 'function' && window.matchMedia(NARROW_VIEWPORT_QUERY).matches) return
+    open()
+  }, [available, openDecided, open])
+}
+
 const noop = () => {}
 const INERT_STATE: AssistantPanelState = {
   isOpen: false,
+  openDecided: true,
   sessionId: null,
+  agentId: null,
   newChatRequest: 0,
   open: noop,
   close: noop,
   toggle: noop,
   requestNewChat: noop,
   setSessionId: noop,
+  setAgentId: noop,
 }

--- a/frontend/apps/web/app/web-assistant-panel-content.tsx
+++ b/frontend/apps/web/app/web-assistant-panel-content.tsx
@@ -35,8 +35,10 @@ export default function WebAssistantPanelContent({
   return (
     <AssistantPanel
       initialSessionId={panel.sessionId}
+      initialAgentId={panel.agentId}
       newChatRequest={panel.newChatRequest}
       onSessionChange={panel.setSessionId}
+      onAgentChange={panel.setAgentId}
       onClose={onClose}
     />
   )

--- a/frontend/apps/web/app/web-utils.tsx
+++ b/frontend/apps/web/app/web-utils.tsx
@@ -30,7 +30,7 @@ import {HMIcon} from '@shm/ui/hm-icon'
 import {Add} from '@shm/ui/icons'
 import {JoinButton} from '@shm/ui/join-button'
 import {MobilePanelSheet} from '@shm/ui/mobile-panel-sheet'
-import {useAssistantPanel} from '@/assistant-panel-state'
+import {useAssistantAutoOpen, useAssistantPanel} from '@/assistant-panel-state'
 import {MenuItemType} from '@shm/ui/options-dropdown'
 import {createEmailSubscribersMenuItem} from '@shm/ui/site-email-subscribers'
 import {toast} from '@shm/ui/toast'
@@ -38,6 +38,7 @@ import {Tooltip} from '@shm/ui/tooltip'
 import {useAppDialog} from '@shm/ui/universal-dialog'
 import {useMedia} from '@shm/ui/use-media'
 import {cn} from '@shm/ui/utils'
+import {parseSpaceAgentIds} from '@shm/ui/agents/space-agents'
 import {
   Bell,
   Bot,
@@ -275,10 +276,14 @@ function PlaceholderAvatar({onClick}: {onClick: () => void}) {
  * included — into the initial bundle, which the assistant panel and the /hm/agents pages go out of
  * their way to avoid. `useResource` is already here via `useAccount`, so this costs nothing.
  */
-function useSiteAgentServerUrl(siteUid: string): string | null {
+function useSiteAgents(siteUid: string): {serverUrl: string | null; publishesAgents: boolean} {
   const home = useResource(hmId(siteUid))
-  const raw = home.data?.type === 'document' ? home.data.document?.metadata?.agentServerUrl : undefined
-  return typeof raw === 'string' && raw ? raw : null
+  const metadata = home.data?.type === 'document' ? home.data.document?.metadata : undefined
+  const raw = metadata?.agentServerUrl
+  return {
+    serverUrl: typeof raw === 'string' && raw ? raw : null,
+    publishesAgents: parseSpaceAgentIds(metadata?.spaceAgents).length > 0,
+  }
 }
 
 export function WebHeaderActions({siteUid}: {siteUid: string}) {
@@ -318,7 +323,11 @@ export function WebHeaderActions({siteUid}: {siteUid: string}) {
   // A space that names no agents server has nothing for its readers to talk to, so the entry point
   // is not offered while browsing it. It stays absent until the home document has loaded, so the
   // item appears late rather than appearing and then vanishing.
-  const hasSiteAgents = !!useSiteAgentServerUrl(siteUid)
+  const siteAgents = useSiteAgents(siteUid)
+  const hasSiteAgents = !!siteAgents.serverUrl
+  // First arrival: a signed-in reader of a space that publishes agents finds the panel already
+  // open, once, on a viewport wide enough to show it beside the page. Closing it is remembered.
+  useAssistantAutoOpen(!!keyPair && hasSiteAgents && siteAgents.publishesAgents && !isMobile)
 
   // Show the join button if not joined the site
   if (!keyPair) {

--- a/frontend/packages/ui/src/__tests__/space-agents-hook.test.tsx
+++ b/frontend/packages/ui/src/__tests__/space-agents-hook.test.tsx
@@ -18,6 +18,8 @@ const mockState = vi.hoisted(() => ({
   homeMetadata: {} as Record<string, unknown>,
   requests: [] as {serverUrl: string; accountUid: string; agentId: string}[],
   missingAgentIds: new Set<string>(),
+  sessionsByAgent: {} as Record<string, Array<Record<string, unknown>>>,
+  homeLoading: false,
 }))
 
 vi.mock('../agents/platform', () => ({
@@ -45,14 +47,18 @@ vi.mock('../agents/client', async (importOriginal) => ({
     return {
       _: 'GetAgentResponse',
       agent: {id: action.agentId, definition: {name: `Agent ${action.agentId}`}},
-      sessions: [],
+      sessions: mockState.sessionsByAgent[action.agentId] ?? [],
     }
   },
 }))
 vi.mock('@shm/shared/utils/navigation', () => ({useNavRouteOrNull: () => mockState.route}))
 vi.mock('@shm/shared/models/entity', () => ({
   useResource: (id: {uid: string} | undefined) =>
-    id ? {data: {type: 'document', document: {metadata: mockState.homeMetadata}}} : {data: undefined},
+    !id
+      ? {data: undefined, isLoading: true}
+      : mockState.homeLoading
+        ? {data: undefined, isLoading: true}
+        : {data: {type: 'document', document: {metadata: mockState.homeMetadata}}, isLoading: false},
 }))
 
 import {UniversalAppContext} from '@shm/shared/routing'
@@ -91,6 +97,8 @@ beforeEach(() => {
   mockState.homeMetadata = {}
   mockState.requests = []
   mockState.missingAgentIds = new Set()
+  mockState.sessionsByAgent = {}
+  mockState.homeLoading = false
   latest = null
   container = document.createElement('div')
   document.body.appendChild(container)
@@ -135,6 +143,37 @@ describe('useSpaceAgents', () => {
     mockState.originHomeId = {uid: 'origin-uid'}
     mockState.homeMetadata = {agentServerUrl: 'https://agents.space.example', spaceAgents: {only: 0}}
     await render()
+    expect(latest!.agents.map((option) => option.agent.id)).toEqual(['only'])
+  })
+
+  it("carries each agent's top-level sessions along, since no listing shows a reader those", async () => {
+    mockState.route = {key: 'document', id: {uid: 'space-uid', path: []}}
+    mockState.homeMetadata = {agentServerUrl: 'https://agents.space.example', spaceAgents: {docs: 0}}
+    mockState.sessionsByAgent = {
+      docs: [
+        {id: 's-2', agentId: 'docs', title: 'Latest', updatedAt: 200},
+        {id: 's-child', agentId: 'docs', title: 'Child', parentSessionId: 's-2', updatedAt: 150},
+        {id: 's-1', agentId: 'docs', title: 'First', updatedAt: 100},
+      ],
+    }
+    await render()
+    expect(latest!.sessions.map((entry) => entry.session.id)).toEqual(['s-2', 's-1'])
+    expect(latest!.sessions[0]!.serverUrl).toBe('https://agents.space.example')
+    expect(latest!.sessions[0]!.agent?.id).toBe('docs')
+  })
+
+  it('reports loading while the space home document is still on its way', async () => {
+    // Before the home loads nothing is known about what the space publishes; a caller settling its
+    // selection on "the lists are in" must not settle on this gap.
+    mockState.route = {key: 'document', id: {uid: 'space-uid', path: []}}
+    mockState.homeLoading = true
+    await render()
+    expect(latest!.isLoading).toBe(true)
+    expect(latest!.agents).toEqual([])
+    mockState.homeLoading = false
+    mockState.homeMetadata = {agentServerUrl: 'https://agents.space.example', spaceAgents: {only: 0}}
+    await render()
+    expect(latest!.isLoading).toBe(false)
     expect(latest!.agents.map((option) => option.agent.id)).toEqual(['only'])
   })
 

--- a/frontend/packages/ui/src/agents/assistant-panel.tsx
+++ b/frontend/packages/ui/src/agents/assistant-panel.tsx
@@ -69,7 +69,14 @@ import {agentAccessCanChat, agentAccessCanWrite} from './access'
 import {AgentRunStatusBar, useRunStartedAt} from './agent-run-status'
 import {AgentErrorRow, AssistantMessageParts, ChatMessageBubble} from './message-rendering'
 import {useChatAutoScroll} from './chat-autoscroll'
-import {decodeAssistantSessionRef, encodeAssistantSessionRef, type AssistantSessionRef} from './assistant-session-ref'
+import {
+  decodeAssistantAgentRef,
+  decodeAssistantSessionRef,
+  encodeAssistantAgentRef,
+  encodeAssistantSessionRef,
+  type AssistantSessionRef,
+} from './assistant-session-ref'
+import {AgentServerError} from './client'
 import {useAssistantWindowContextLines} from './assistant-window-context'
 import {AgentRichMessageComposer, SUB_SESSION_DRIVEN_MESSAGE, TERMINAL_RUN_STATUSES} from './rich-message-composer'
 import type {AgentsRichEditorSubmitHandle} from './platform'
@@ -91,14 +98,20 @@ import {SessionStatusDot, SessionSummaryBanner, SubSessionsDisclosure} from './s
  */
 export function AssistantPanel({
   initialSessionId,
+  initialAgentId,
   newChatRequest,
   onSessionChange,
+  onAgentChange,
   onClose,
 }: {
   /** Serialized {@link AssistantSessionRef} restored from window state. */
   initialSessionId?: string | null
+  /** Serialized agent ref (see `encodeAssistantAgentRef`) the user last chose, restored from window state. */
+  initialAgentId?: string | null
   newChatRequest?: number
   onSessionChange?: (sessionId: string | null) => void
+  /** Reports the user's explicit agent choice (serialized), for the host to persist beside the session. */
+  onAgentChange?: (agentId: string | null) => void
   /** Renders a close button in the header when the host has no other way to dismiss the panel. */
   onClose?: () => void
 }) {
@@ -106,10 +119,32 @@ export function AssistantPanel({
   const serverUrls = useAgentServerUrls()
   const localServerUrl = useLocalAgentServerUrl()
   const agentQueries = useAgentLists(serverUrls.data, accountUid)
-  const sessions = useAllAgentSessions(serverUrls.data, accountUid)
+  const ownSessions = useAllAgentSessions(serverUrls.data, accountUid)
   const navigate = useNavigate()
 
   const spaceAgents = useSpaceAgents(accountUid)
+
+  // The account-wide session lists never include a public agent's sessions — the space's agents
+  // reach a visitor through GetAgent instead, which carries them along. Merge both sources so the
+  // context of a space agent lists its chats (the visitor's own included) like any other agent.
+  const sessions = useMemo(() => {
+    if (spaceAgents.sessions.length === 0) return ownSessions
+    const seen = new Set(ownSessions.entries.map((entry) => `${entry.serverUrl}:${entry.session.id}`))
+    const extra = spaceAgents.sessions.filter((entry) => !seen.has(`${entry.serverUrl}:${entry.session.id}`))
+    if (extra.length === 0) return ownSessions
+    return {
+      ...ownSessions,
+      entries: [...ownSessions.entries, ...extra].sort((a, b) => b.session.updatedAt - a.session.updatedAt),
+    }
+  }, [ownSessions, spaceAgents.sessions])
+
+  // "No agents" and "not this agent" only mean something once every list has answered. Until then
+  // the remembered selection is held rather than resolved against a partial picture.
+  const agentsSettled =
+    !accountUid ||
+    (serverUrls.data !== undefined &&
+      !spaceAgents.isLoading &&
+      agentQueries.every((query) => query.isSuccess || query.isError))
 
   const agents: AssistantAgentOption[] = useMemo(
     () =>
@@ -123,7 +158,9 @@ export function AssistantPanel({
   )
 
   const [stored, setStoredRaw] = useState<AssistantSessionRef | null>(() => decodeAssistantSessionRef(initialSessionId))
-  const [chosenAgent, setChosenAgent] = useState<AssistantAgentKey | null>(null)
+  const [chosenAgent, setChosenAgentRaw] = useState<AssistantAgentKey | null>(() =>
+    decodeAssistantAgentRef(initialAgentId),
+  )
   const [isDraft, setIsDraft] = useState(false)
   const lastNewChatRequestRef = useRef(0)
   // Handle onto whichever rich composer is mounted (session chat or draft), for imperative focus.
@@ -139,6 +176,11 @@ export function AssistantPanel({
     chosenAgent,
     storedSession: stored,
     storedSessionAgentId: storedSessionQuery.data?.session.agentId,
+    // Only a refusal from the server gives the session up; a server that could not be reached may
+    // simply be down (the desktop's local one is still booting on launch), so the session is held
+    // and its fetch keeps polling.
+    storedSessionUnavailable: storedSessionQuery.error instanceof AgentServerError,
+    agentsSettled,
     isDraft,
   })
 
@@ -150,17 +192,27 @@ export function AssistantPanel({
     [onSessionChange],
   )
 
-  // Keep window state in step with what is actually shown (e.g. the resolver replaced a stored
-  // session from another agent with the active agent's newest). A draft is exempt: it shows no
+  const setChosenAgent = useCallback(
+    (key: AssistantAgentKey | null) => {
+      setChosenAgentRaw(key)
+      onAgentChange?.(key ? encodeAssistantAgentRef(key) : null)
+    },
+    [onAgentChange],
+  )
+
+  // Keep window state in step with what is actually shown (e.g. the resolver dropped a stored
+  // session that belongs to another agent after a context switch). A draft is exempt: it shows no
   // session by design, and the stored ref doubles as the record of which agent the user was last
   // in — clearing it would make every new chat forget its context and fall back to the first
-  // agent.
+  // agent. Nor is anything written while the agent lists are still loading: the resolver only
+  // holds the remembered session through that gap, and a null or substitute written back now would
+  // overwrite the very selection being restored.
   useEffect(() => {
-    if (isDraft) return
+    if (isDraft || !agentsSettled) return
     const resolved = selection.session
     const same = resolved?.serverUrl === stored?.serverUrl && resolved?.sessionId === stored?.sessionId
     if (!same && !(resolved === null && stored === null)) setStored(resolved)
-  }, [selection.session, stored, setStored, isDraft])
+  }, [selection.session, stored, setStored, isDraft, agentsSettled])
 
   const focusInput = useCallback(() => {
     composerRef.current?.focus({moveCursorToEnd: true})
@@ -341,7 +393,7 @@ export function AssistantPanel({
         />
       ) : (
         <div className="text-muted-foreground flex flex-1 items-center justify-center px-4 text-center text-xs">
-          {sessions.isLoading ? 'Loading…' : 'No agents yet. Create one from the Agents menu above.'}
+          {sessions.isLoading || !agentsSettled ? 'Loading…' : 'No agents yet. Create one from the Agents menu above.'}
         </div>
       )}
     </div>

--- a/frontend/packages/ui/src/agents/assistant-selection.ts
+++ b/frontend/packages/ui/src/agents/assistant-selection.ts
@@ -28,6 +28,19 @@ export type AssistantSelectionInput = {
   storedSession: AssistantSessionRef | null
   /** The stored session's agent as reported by its own fetch, for before the lists include it. */
   storedSessionAgentId?: string
+  /**
+   * True once the stored session's own fetch was answered with a refusal (deleted, or no longer
+   * readable): there is nothing left to wait for, so the selection moves on. A fetch that never
+   * reached the server leaves this false and the session held, since the server may just be down.
+   */
+  storedSessionUnavailable?: boolean
+  /**
+   * False while any agent list is still loading. A stored session (or chosen agent) whose agent is
+   * not in the lists yet is then held rather than replaced — the lists arrive one server at a time,
+   * and settling on whichever agent showed up first would make the remembered selection sticky
+   * for the wrong agent. Defaults to true.
+   */
+  agentsSettled?: boolean
   /** True when the user asked for a new chat: no session is active until the first send. */
   isDraft: boolean
 }
@@ -76,11 +89,14 @@ function findAgent(agents: AssistantAgentOption[], key: {serverUrl: string; agen
  *
  * Precedence for the agent: the user's explicit dropdown choice, then the agent owning the stored
  * session, then the first known agent (server order puts the local server first, so a fresh
- * install lands on the built-in Assistant). Precedence for the session: none while drafting, the
- * stored session when it belongs to the active agent, otherwise the agent's newest — so switching
- * agent contexts always lands somewhere sensible instead of showing another agent's transcript.
+ * install lands on the built-in Assistant). The session is the stored one when it belongs to the
+ * active agent, and otherwise none — a draft, ready for a new chat. Nothing is ever auto-selected
+ * from the list: a public agent's list is everybody's chats, and opening a fresh panel onto some
+ * stranger's conversation (or, after switching agents, onto whichever chat happened to be newest)
+ * is not where anyone wants to land. Earlier chats are one dropdown away.
  */
 export function resolveAssistantSelection(input: AssistantSelectionInput): AssistantSelection {
+  const agentsSettled = input.agentsSettled ?? true
   const storedEntry = input.storedSession
     ? input.sessions.find(
         (entry) =>
@@ -89,34 +105,33 @@ export function resolveAssistantSelection(input: AssistantSelectionInput): Assis
     : null
   const storedAgentId = storedEntry?.session.agentId ?? input.storedSessionAgentId
 
-  const agent =
-    (input.chosenAgent ? findAgent(input.agents, input.chosenAgent) : null) ??
-    (input.storedSession && storedAgentId
+  const chosen = input.chosenAgent ? findAgent(input.agents, input.chosenAgent) : null
+  const storedAgent =
+    input.storedSession && storedAgentId
       ? findAgent(input.agents, {serverUrl: input.storedSession.serverUrl, agentId: storedAgentId})
-      : null) ??
-    input.agents[0] ??
-    null
+      : null
+  const agent = chosen ?? storedAgent ?? input.agents[0] ?? null
 
   const agentSessions = agent
     ? input.sessions.filter((entry) => entry.serverUrl === agent.serverUrl && entry.session.agentId === agent.agent.id)
     : []
 
-  if (input.isDraft || !agent) return {agent, agentSessions, session: null}
+  if (input.isDraft) return {agent, agentSessions, session: null}
 
-  const storedBelongsToAgent =
-    !!input.storedSession && input.storedSession.serverUrl === agent.serverUrl && storedAgentId === agent.agent.id
-  // A stored session whose agent is still unknown (lists and its own fetch both pending) is kept:
-  // tearing it down on every launch just to re-select it a moment later would flash the UI.
-  const storedUndetermined = !!input.storedSession && !storedAgentId && !input.chosenAgent
+  const storedBelongsToAgent = !!agent && !!storedAgent && storedAgent === agent
+  // A stored session is kept while its place is still undetermined: its agent is unknown (lists and
+  // its own fetch both pending), or the lists are still arriving and have not named its agent —
+  // or the agent the user chose — yet. Tearing it down on every launch just to re-select it a
+  // moment later would flash the UI, and worse, the replacement would be written back as the
+  // remembered selection. A refusal from the server settles it the other way.
+  const chosenPending = !!input.chosenAgent && !chosen && !agentsSettled
+  const storedUndetermined =
+    !!input.storedSession &&
+    !input.storedSessionUnavailable &&
+    (chosenPending || (!input.chosenAgent && (!storedAgentId || !agentsSettled)))
 
   if (input.storedSession && (storedBelongsToAgent || storedUndetermined)) {
     return {agent, agentSessions, session: input.storedSession}
   }
-
-  const newest = agentSessions[0]
-  return {
-    agent,
-    agentSessions,
-    session: newest ? {serverUrl: newest.serverUrl, sessionId: newest.session.id} : null,
-  }
+  return {agent, agentSessions, session: null}
 }

--- a/frontend/packages/ui/src/agents/assistant-session-ref.ts
+++ b/frontend/packages/ui/src/agents/assistant-session-ref.ts
@@ -35,3 +35,26 @@ export function decodeAssistantSessionRef(value: string | null | undefined): Ass
   if (!serverUrl || !sessionId) return null
   return {serverUrl, sessionId}
 }
+
+/**
+ * Identity of an agent chosen in the assistant sidebar, serialized the same way as a session ref.
+ *
+ * The sidebar remembers the agent context the user last picked so a reload (or, on web, a return
+ * to the site) reopens in that context even when it holds no session yet — a draft with a freshly
+ * created or empty agent would otherwise fall back to whatever agent lists first.
+ */
+export type AssistantAgentRef = {
+  serverUrl: string
+  agentId: string
+}
+
+/** Serializes an agent reference for storage beside the session ref. */
+export function encodeAssistantAgentRef(ref: AssistantAgentRef): string {
+  return `${ref.serverUrl}${SEPARATOR}${ref.agentId}`
+}
+
+/** Parses a stored agent choice; null for anything unparseable. */
+export function decodeAssistantAgentRef(value: string | null | undefined): AssistantAgentRef | null {
+  const decoded = decodeAssistantSessionRef(value)
+  return decoded ? {serverUrl: decoded.serverUrl, agentId: decoded.sessionId} : null
+}

--- a/frontend/packages/ui/src/agents/client.ts
+++ b/frontend/packages/ui/src/agents/client.ts
@@ -202,6 +202,22 @@ function omitUndefined<T>(value: T): T {
   return output as T
 }
 
+/**
+ * An error the agent server answered with (as opposed to a failed connection).
+ *
+ * Callers that hold onto a remembered resource across transient outages use the distinction: a
+ * server that replied "not found" or "forbidden" has settled the question, while a fetch that never
+ * reached it has not.
+ */
+export class AgentServerError extends Error {
+  readonly status: number
+  constructor(message: string, status: number) {
+    super(message)
+    this.name = 'AgentServerError'
+    this.status = status
+  }
+}
+
 export async function sendAgentAction(input: {
   serverUrl: string
   accountUid: string
@@ -217,7 +233,10 @@ export async function sendAgentAction(input: {
   })
   const decoded = cbor.decode<AgentsResponse>(new Uint8Array(await res.arrayBuffer()))
   if (!res.ok || decoded._ === 'Error') {
-    throw new Error(decoded._ === 'Error' ? decoded.message : `Agent server request failed: HTTP ${res.status}`)
+    throw new AgentServerError(
+      decoded._ === 'Error' ? decoded.message : `Agent server request failed: HTTP ${res.status}`,
+      res.status,
+    )
   }
   return decoded
 }

--- a/frontend/packages/ui/src/agents/models.ts
+++ b/frontend/packages/ui/src/agents/models.ts
@@ -285,12 +285,16 @@ export function useAgentServerUrls() {
  * The desktop app sets no origin, so there it is the route or nothing. Code rendered outside a
  * navigation provider (settings windows) reads no space at all rather than throwing.
  */
-function useSiteHomeMetadata(): HMMetadata | undefined {
+function useSiteHomeMetadata(): {metadata: HMMetadata | undefined; isLoading: boolean} {
   const route = useNavRouteOrNull()
   const originHomeId = useContext(UniversalAppContext).originHomeId
   const siteUid = (route ? siteUidOfRoute(route) : undefined) ?? originHomeId?.uid
   const home = useResource(siteUid ? hmId(siteUid) : undefined)
-  return home.data?.type === 'document' ? home.data.document?.metadata : undefined
+  return {
+    metadata: home.data?.type === 'document' ? home.data.document?.metadata : undefined,
+    // A disabled query (no space in view) also reports loading; only a real fetch counts.
+    isLoading: !!siteUid && !!home.isLoading && home.data === undefined,
+  }
 }
 
 /**
@@ -301,7 +305,7 @@ function useSiteHomeMetadata(): HMMetadata | undefined {
  * It is never persisted into the user's configured list: it applies while viewing that site.
  */
 export function useSiteAdvertisedAgentServerUrl(): string | null {
-  const raw = useSiteHomeMetadata()?.agentServerUrl
+  const raw = useSiteHomeMetadata().metadata?.agentServerUrl
   return useMemo(() => (typeof raw === 'string' && raw ? tryNormalizeAgentServerUrl(raw) : null), [raw])
 }
 
@@ -321,12 +325,24 @@ export type SpaceAgentOption = {serverUrl: string; agent: AgentInfo}
  * deleted, made private, or moved should quietly offer one fewer agent, not an error where a chat
  * belongs. The queries share their cache key with {@link useAgentDetail}, so opening one of these
  * agents in the full view renders from what the panel already loaded.
+ *
+ * The same `GetAgent` answer carries every session of the agent, and that is the only way a reader
+ * gets to see them: the account-wide `ListSessions` the sidebar otherwise relies on covers agents
+ * the account owns or collaborates on, never public ones — so a visitor's own chats with a space's
+ * agent, let alone everybody else's, would stay hidden behind "no chats yet". They are returned
+ * here as list entries (top level only; children nest under their parent's disclosure) for the
+ * sidebar to merge into its session list.
+ *
+ * `isLoading` covers the space's home document as well as the agent fetches: until the home has
+ * loaded there is no way to know whether the space publishes anything, and callers that settle
+ * their selection on "the agent lists are in" must not settle on that gap.
  */
 export function useSpaceAgents(accountUid: string | null | undefined): {
   agents: SpaceAgentOption[]
+  sessions: AgentSessionListEntry[]
   isLoading: boolean
 } {
-  const metadata = useSiteHomeMetadata()
+  const {metadata, isLoading: isHomeLoading} = useSiteHomeMetadata()
   const rawServerUrl = metadata?.agentServerUrl
   const serverUrl = useMemo(
     () => (typeof rawServerUrl === 'string' && rawServerUrl ? tryNormalizeAgentServerUrl(rawServerUrl) : null),
@@ -351,13 +367,23 @@ export function useSpaceAgents(accountUid: string | null | undefined): {
       useErrorBoundary: false,
     })),
   })
+  const responses = queries.map((query) => query.data)
   const agents = serverUrl
-    ? queries
-        .map((query) => query.data?.agent)
+    ? responses
+        .map((response) => response?.agent)
         .filter((agent): agent is AgentInfo => !!agent)
         .map((agent) => ({serverUrl, agent}))
     : []
-  return {agents, isLoading: queries.some((query) => query.isLoading)}
+  const sessions: AgentSessionListEntry[] = serverUrl
+    ? responses.flatMap((response) =>
+        response
+          ? response.sessions
+              .filter((session) => !session.parentSessionId)
+              .map((session): AgentSessionListEntry => ({serverUrl, session, agent: response.agent}))
+          : [],
+      )
+    : []
+  return {agents, sessions, isLoading: isHomeLoading || queries.some((query) => query.isLoading)}
 }
 
 /** Account uid of the site a route is looking at, when the route is about a document. */
@@ -2585,6 +2611,13 @@ export function removeOptimisticSessionFromLists(serverUrl: string, accountUid: 
   getQueryClient().setQueriesData({queryKey: ['agents', 'sessions', serverUrl, accountUid]}, (old: any) => {
     if (!Array.isArray(old)) return old
     return old.filter((entry: AgentSessionListEntry) => entry.session.id !== sessionId)
+  })
+  // A space agent's sessions reach the sidebar through its cached GetAgent answer (see
+  // useSpaceAgents), so that copy of the list must forget the session too.
+  getQueryClient().setQueriesData({queryKey: ['agents', 'detail', serverUrl, accountUid]}, (old: any) => {
+    if (!old || old._ !== 'GetAgentResponse' || !Array.isArray(old.sessions)) return old
+    if (!old.sessions.some((session: SessionInfo) => session.id === sessionId)) return old
+    return {...old, sessions: old.sessions.filter((session: SessionInfo) => session.id !== sessionId)}
   })
 }
 


### PR DESCRIPTION
## Problems

Tested on the public "Epistemic Agent" at acm-hypertext.hyper.media with a fresh account:

1. **"No chats with this agent yet"** even though chats existed (and even after chatting). The sidebar lists sessions account-wide, and the server's account-wide `ListSessions` deliberately covers only agents the account owns or collaborates on — public-read agents are only admitted in the per-agent listing.
2. **Reload didn't restore the chat.** Web already saved the session to localStorage, but the panel's sync-back effect ran while agent lists were still loading: with no agents known the resolver returned `null`, which was written straight over the saved ref. The explicitly chosen agent was never persisted at all.
3. **A fresh panel opened onto the agent's newest chat** — for a public agent, somebody else's conversation.

## Changes

- `useSpaceAgents` now also returns the agents' top-level **sessions**, derived from the `GetAgent` response it already polls (the server returns every session of a public agent to any reader) — no extra requests. The sidebar merges them with the account-wide list. The optimistic delete helper prunes the cached `GetAgent` copy too.
- Resolver (`assistant-selection.ts`): new `agentsSettled` / `storedSessionUnavailable` inputs. A remembered session (or pending chosen agent) is **held** while lists are loading; the panel's write-back effect waits for the lists. A session the server refuses (404 etc.) is given up; a server that couldn't be reached is not (new `AgentServerError` carries the status).
- **No remembered session → draft (new chat)**, never "newest". Applies to first open, agent switches, and after deleting the active chat. Earlier chats stay one click away in the session dropdown.
- Web persists the **chosen agent** (`seed.assistant.agent`) next to the session, via new optional `initialAgentId` / `onAgentChange` props on `AssistantPanel` (desktop untouched; it benefits from the loading-race fix through the shared panel).
- **First-arrival auto-open**: `useAssistantAutoOpen` opens the panel once for a signed-in reader on a wide viewport when the space publishes agents. The open preference is now three-way (`'1'` / `'0'` / undecided): only an actual open/close is stored, so a signed-out or phone visit doesn't count as a decision, and a close is remembered.

## Tests

- Resolver: 7 new cases (hold while loading, refusal fallback, pending chosen agent, draft defaults).
- Panel: remembered agent restore, agent-change callback, no clobbering during load, space-agent chats listed, draft-by-default.
- `useSpaceAgents`: sessions carried through (children excluded), loading covers the home doc.
- Web panel state: close stored as `'0'`, undecided until chosen, auto-open once and never after a close.

`pnpm typecheck` clean for ui/web/desktop; ui (357), web (211), desktop (353) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3qMAzkS2n5WXESGxVy1Wi
