### PR TITLE
Keep workflow effects ahead of terminal status

### DIFF
--- a/agents/src/workflow-host.test.ts
+++ b/agents/src/workflow-host.test.ts
@@ -284,6 +284,67 @@ describe('workflow host', () => {
     expect(outcome).toEqual({type: 'succeeded', output: [1, 2, 3]})
   })
 
+  test('workflow failure waits for sibling parallel effects to finish', async () => {
+    let resolveSlow!: (value: unknown) => void
+    const slowStarted = Promise.withResolvers<void>()
+    const {adapters, journal} = fakeAdapters({
+      source: `export default async function (input, ctx) {
+        await ctx.parallel([
+          () => ctx.call('slow', {}),
+          () => { throw new Error('parallel failed') },
+        ])
+      }`,
+      callTool: () =>
+        new Promise((resolve) => {
+          resolveSlow = resolve
+          slowStarted.resolve()
+        }),
+    })
+
+    let settled = false
+    const outcomePromise = runWorkflowVM(adapters).then((outcome) => {
+      settled = true
+      return outcome
+    })
+    await slowStarted.promise
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(settled).toBe(false)
+    expect(journal.filter((entry) => entry.kind === 'result')).toHaveLength(0)
+
+    resolveSlow({ok: true})
+    const outcome = await outcomePromise
+    expect(outcome).toMatchObject({type: 'failed', error: {message: 'parallel failed'}})
+    expect(journal.filter((entry) => entry.kind === 'result')).toHaveLength(1)
+  })
+
+  test('cancellation wins when an in-flight tool later succeeds', async () => {
+    let canceled = false
+    let releaseTool!: () => void
+    const toolStarted = Promise.withResolvers<void>()
+    const {adapters} = fakeAdapters({
+      source: `export default async function (input, ctx) {
+        await ctx.call('slow', {})
+        return 'done'
+      }`,
+      callTool: async () => {
+        toolStarted.resolve()
+        await new Promise<void>((resolve) => {
+          releaseTool = resolve
+        })
+        return {ok: true}
+      },
+      isCanceled: () => canceled,
+    })
+
+    const outcomePromise = runWorkflowVM(adapters)
+    await toolStarted.promise
+    canceled = true
+    releaseTool()
+
+    expect(await outcomePromise).toEqual({type: 'canceled'})
+  })
+
   test('replay returns journaled results without re-executing tools, byte-identical output', async () => {
     const source = `export default async function (input, ctx) {
       const one = await ctx.call('op', {step: 1})

--- a/agents/src/workflow-host.ts
+++ b/agents/src/workflow-host.ts
@@ -402,6 +402,7 @@ export async function runWorkflowVM(adapters: WorkflowAdapters): Promise<Workflo
   const deliveries: Delivery[] = []
   const inflight = new Map<number, Promise<void>>()
   let finished: {ok: boolean; value: unknown} | null = null
+  let cancellationRequested = false
   const parkState: {
     timer: {wakeAt: number} | null
     event: {waitId: string; timeoutAt?: number; label?: string; answerWith?: string} | null
@@ -875,6 +876,15 @@ export async function runWorkflowVM(adapters: WorkflowAdapters): Promise<Workflo
         }
         continue
       }
+      cancellationRequested ||= adapters.isCanceled()
+      if ((finished || cancellationRequested) && inflight.size > 0) {
+        // Effects already issued by a failing parallel sibling or a canceled run cannot be stopped.
+        // Keep the run non-terminal until they are journaled so tools and children cannot mutate
+        // external state or append results after clients have observed completion.
+        await Promise.race(inflight.values())
+        continue
+      }
+      if (cancellationRequested) return {type: 'canceled'}
       if (finished) {
         const done: {ok: boolean; value: unknown} = finished
         if (done.ok) {
@@ -912,7 +922,6 @@ export async function runWorkflowVM(adapters: WorkflowAdapters): Promise<Workflo
           },
         }
       }
-      if (adapters.isCanceled()) return {type: 'canceled'}
       if (continuation.requested && inflight.size === 0) {
         return {type: 'continued', state: continuation.requested.state}
       }


### PR DESCRIPTION
# Keep workflow effects ahead of terminal status

## Summary

- keep failed or canceled workflows non-terminal until already-issued effects finish and journal their results
- latch observed cancellation so draining effects cannot turn a canceled run back into success
- cover fail-fast parallel siblings and cancellation racing a successful tool

## Why

`ctx.parallel` uses fail-fast `Promise.all`, but sibling tool and child effects cannot be canceled. The host returned a failed outcome while those effects were still running, so external mutations and journal appends could happen after clients observed a terminal run. A related ordering bug allowed a cancellation accepted during a tool call to finish as success.

## Validation

- New parallel-effect regression fails on `main` before the fix (`settled` is `true` while the sibling tool is unresolved).
- `bun test src/workflow-host.test.ts` — 35 passed
- `bun test` with the persistent Bun/Node toolchains on `PATH` — 348 passed
- `bun run format:check` — passed
- `git diff --check` — passed
- `bun run typecheck` exceeded the microVM execution ceiling without diagnostics

This supersedes the narrower `ion/prefer-cancellation-over-success` / `9a42541` patch.
