### PR TITLE
Document non-document actions in the write tool

### DIFF
--- a/agents/protocol/src/index.ts
+++ b/agents/protocol/src/index.ts
@@ -1920,3 +1920,5 @@ export type AgentResponse =
   | AbortFileUploadResponse
   | StopSessionResponse
   | ErrorResponse
+
+export * from './write-guides'

--- a/agents/protocol/src/tool-registry.test.ts
+++ b/agents/protocol/src/tool-registry.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, test} from 'bun:test'
-import {getToolReferencedUrls} from './tool-registry'
+import {getToolReferencedUrls, seedVerbRegistry} from './tool-registry'
+import {writeGuideRegistry} from './write-guides'
 
 describe('tool reference extraction', () => {
   test('includes the exact version of a newly created document', () => {
@@ -33,5 +34,20 @@ describe('tool reference extraction', () => {
       'hm://z6MkOwner/notes',
       'hm://z6MkAgent',
     ])
+  })
+})
+
+describe('write contract', () => {
+  test('indexes every detailed resource guide without loading action schemas up front', () => {
+    const description = seedVerbRegistry.write.description
+    for (const resource of Object.keys(writeGuideRegistry)) {
+      expect(description).toContain(`~/tools/write/${resource}`)
+    }
+    expect(description).toContain('grant WRITER or AGENT access')
+    expect(description).not.toContain('capability.grant')
+    expect(writeGuideRegistry.capabilities.markdown).toContain('capability.grant')
+    expect(writeGuideRegistry.contacts.markdown).toContain('contact.create')
+    expect(writeGuideRegistry.profiles.markdown).toContain('profile.update')
+    expect(writeGuideRegistry.drafts.markdown).toContain('draft.create')
   })
 })

--- a/agents/protocol/src/tool-registry.ts
+++ b/agents/protocol/src/tool-registry.ts
@@ -154,12 +154,18 @@ const writeVerb = {
   label: 'Write',
   description: [
     'Write anything you can address. The address shape picks the destination:',
-    '- `~/memory/<path>` — write `content` to a memory file (parent folders are created automatically; writing an existing file replaces its whole content — there is no append). Options: {delete: true} removes a file or directory; {fromUrl} downloads a URL to the path instead of writing content; {fromAttachment: "<id>"} saves a conversation attachment to the path.',
-    '- `~/triggers/<name>` — create or edit one of your triggers: a standing rule that starts a session (or wakes a parked run) when something happens — a schedule, a comment, a mention, site activity, or a finished run. `content` is JSON {source, prompt, enabled?, continuation?} (read ~/triggers/ for the source shapes); enabled defaults to true, and writing with enabled false turns a trigger off. {delete: true} removes a trigger.',
-    '- `ipfs://` — publish to IPFS and get a CID URL back. Provide {fromPath: "~/memory/<path>"} or {fromAttachment: "<id>"} in options.',
-    '- `hm://<account>/<path>` — publish a hypermedia document with markdown `content`. The default creates a NEW document; pass {action: "update"} to revise an existing document in place (same address, new version); an update with `content` replaces the whole body, while omitting `content` changes only name/metadata and leaves the body untouched. Options: {name} sets the document name, REQUIRED when creating (it is stored as metadata.name; a # heading is body content, not the name); {metadata} sets further document metadata attributes as an object (e.g. {summary, icon, cover, or custom keys}) — metadata belongs here, never in the body text; {signer} picks the signing identity by profileName or publicKey; {action} also covers "comment" (with {target, replyTo}), "move" (with {toPath}), "redirect" (with {toUrl}), "delete", "fork" (with {fromUrl}). Unrecognized option keys are refused, not ignored. Parent documents must exist before nested paths.',
-    'Writing to hm:// publishes signed content other people can see — be sure the content is ready. Pass top-level dryRun: true to validate an hm:// write without publishing anything.',
-    'Every hm:// link inside document or comment content is checked before publishing: malformed links always fail the write, and links whose targets do not exist on the server fail it too — fix them (read each link to verify), or pass {skipLinkCheck: true} in options only when a linked target is about to be created.',
+    '- `~/memory/<path>` — files: replace content, delete, download a URL, or save an attachment. Details: `~/tools/write/memory`.',
+    '- `~/tools/<name>` — authored callable tools: create, replace, or delete. Details: `~/tools/write/tools`.',
+    '- `~/triggers/<name>` — automations: create, edit, enable, disable, or delete. Details: `~/tools/write/triggers`.',
+    '- `ipfs://` — publish a memory file or attachment. Details: `~/tools/write/ipfs`.',
+    '- `hm://<account>/<path>` — signed Seed resources. Features are grouped below; read the exact guide before an unfamiliar operation:',
+    '  - `~/tools/write/documents` — create, replace, rename, move, redirect, fork, or delete documents; metadata and memory-file publishing.',
+    '  - `~/tools/write/comments` — comment, reply, edit, or delete comments.',
+    '  - `~/tools/write/capabilities` — grant WRITER or AGENT access to an account or path.',
+    '  - `~/tools/write/contacts` — create named contacts or delete contact records.',
+    '  - `~/tools/write/profiles` — update a profile name, description, or icon; publish profile aliases.',
+    '  - `~/tools/write/drafts` — stage, inspect, list, revise, delete, or publish document drafts.',
+    'Writing to hm:// or ipfs:// publishes content other people can see. The resource guides document exact action names, fields, examples, signer behavior, and dry-run support without loading unrelated details here.',
   ].join('\n'),
   inputSchema: {
     type: 'object',
@@ -177,7 +183,8 @@ const writeVerb = {
       },
       options: {
         type: 'object',
-        description: 'Destination-specific options; read ~/tools/write for the full contract per address form.',
+        description:
+          'Destination-specific options. Read the matching ~/tools/write/<resource> guide before an unfamiliar Seed write.',
       },
       dryRun: {
         type: 'boolean',

--- a/agents/protocol/src/write-guides.ts
+++ b/agents/protocol/src/write-guides.ts
@@ -1,0 +1,249 @@
+/** A detailed write guide loaded only when an agent asks for that Seed resource group. */
+export type WriteGuide = {
+  summary: string
+  markdown: string
+}
+
+const preamble = `All Seed resource operations use the write verb. The common shape is:
+
+\`\`\`json
+{
+  "address": "hm://TARGET_UID/optional-path",
+  "content": "optional markdown",
+  "options": {
+    "action": "ACTION",
+    "signer": {"publicKey": "SIGNER_UID"},
+    "input": {}
+  },
+  "dryRun": true
+}
+\`\`\`
+
+The address identifies the signed account and, for document operations, usually the document. Select an enabled signer with \`options.signer.publicKey\` or \`options.signer.profileName\`. Put fields for dotted actions in \`options.input\`, not loose inside \`options\`. Use top-level \`dryRun: true\` to validate an hm:// operation without publishing.`
+
+/** Detailed Seed write guides, loaded progressively through reads of ~/tools/write/<resource>. */
+export const writeGuideRegistry: Record<string, WriteGuide> = {
+  memory: {
+    summary: 'Replace or delete private memory files, download URLs, and save conversation attachments.',
+    markdown: `# Writing private memory
+
+Memory addresses stay private to the agent and use \`~/memory/<path>\`.
+
+- Write or replace a UTF-8 file: pass string \`content\`. Parent directories are created automatically; there is no append operation, so read-modify-write when preserving existing content.
+- Delete a file or directory: \`options: {delete: true}\`.
+- Download a public URL directly to memory: \`options: {fromUrl: "https://..."}\`.
+- Save a conversation attachment: \`options: {fromAttachment: "ATTACHMENT_ID"}\`. The attachment must belong to the current session.
+
+\`\`\`json
+{"address":"~/memory/notes/project.md","content":"# Project\n\nCurrent state."}
+\`\`\`
+
+Memory writes are not public and do not use \`dryRun\` or a signer. A write replaces the entire target file.`,
+  },
+  tools: {
+    summary: 'Create, replace, or delete an authored callable tool.',
+    markdown: `# Authoring callable tools
+
+Write JSON to \`~/tools/<name>\` with \`description\`, an input JSON schema, an optional output schema, source code, and optional runtime (TypeScript is the default; Python is also supported when available).
+
+\`\`\`json
+{"address":"~/tools/word_count","content":"{\"description\":\"Count words.\",\"input\":{\"type\":\"object\",\"properties\":{\"text\":{\"type\":\"string\"}},\"required\":[\"text\"]},\"source\":\"export default (input) => ({count: input.text.trim().split(/\\s+/).length})\"}"}
+\`\`\`
+
+The source runs in the execute sandbox with validated input. Read \`~/tools/<name>\` after saving to inspect the live contract, then invoke it with the call verb. Delete with \`options: {delete: true}\`. Tool authoring does not use \`dryRun\` or a signer.`,
+  },
+  triggers: {
+    summary: 'Create, edit, enable, disable, or delete an automation trigger.',
+    markdown: `# Writing triggers
+
+Write JSON to \`~/triggers/<name>\` with \`source\`, \`prompt\`, and optional \`enabled\` and \`continuation\`. Read \`~/triggers/\` first for supported source shapes and current triggers. New triggers default to enabled.
+
+\`\`\`json
+{"address":"~/triggers/hourly-review","content":"{\"source\":{\"type\":\"schedule\",\"schedule\":{\"kind\":\"interval\",\"every\":1,\"unit\":\"hours\"}},\"prompt\":\"Review current project state.\",\"enabled\":true}"}
+\`\`\`
+
+Replace the trigger document to edit it, write with \`enabled: false\` to disable it, or use \`options: {delete: true}\` to remove it. Trigger writes do not use \`dryRun\` or a signer.`,
+  },
+  ipfs: {
+    summary: 'Publish a private memory file or conversation attachment to IPFS.',
+    markdown: `# Publishing to IPFS
+
+Write to \`ipfs://\` with exactly one source:
+
+- Memory file: \`options: {fromPath: "~/memory/path/to/file"}\`.
+- Current-session attachment: \`options: {fromAttachment: "ATTACHMENT_ID"}\`.
+
+\`\`\`json
+{"address":"ipfs://","options":{"fromPath":"~/memory/site-assets/icon.png"}}
+\`\`\`
+
+The result includes the CID and \`ipfs://\` URL. Publishing is public, requires the agent's publish grant, and does not support \`dryRun\` or a signer.`,
+  },
+  documents: {
+    summary: 'Create, update, move, redirect, fork, delete, and publish Seed documents.',
+    markdown: `${preamble}
+
+# Writing documents
+
+Use this guide for document bodies, names, metadata, paths, and document lifecycle operations.
+
+## Create
+
+Omit \`options.action\` (or use \`document\`). Write markdown in \`content\`; pass the required document name in \`options.name\`. Additional attributes such as summary, icon, or cover belong in \`options.metadata\`. Parent documents must exist before nested paths.
+
+\`\`\`json
+{"address":"hm://SIGNER_UID/notes","content":"First paragraph.","options":{"name":"Notes","metadata":{"summary":"Working notes"},"signer":{"publicKey":"SIGNER_UID"}},"dryRun":true}
+\`\`\`
+
+## Update
+
+Use \`options.action: "update"\` at the existing document address. Supplying \`content\` replaces the whole body, so first read the current document and preserve block/table identity comments for retained content. Omit \`content\` to change only \`name\` or \`metadata\`.
+
+\`\`\`json
+{"address":"hm://TARGET_UID/notes","content":"Complete replacement body.","options":{"action":"update","name":"Renamed Notes","signer":{"publicKey":"SIGNER_UID"}},"dryRun":true}
+\`\`\`
+
+## Other lifecycle actions
+
+- Move: \`options: {action: "move", toPath: "/new-path"}\`. Use \`"/"\` for account home.
+- Redirect: \`options: {action: "redirect", toUrl: "hm://OTHER_UID/path"}\`.
+- Fork: the address is the destination; use \`options: {action: "fork", fromUrl: "hm://SOURCE_UID/path"}\`.
+- Delete: the address is the document; use \`options: {action: "delete"}\`.
+- Publish a memory markdown file: use \`options: {fromPath: "~/memory/file.md", signer: {...}}\`; frontmatter supplies metadata and the destination path may be derived when writing to account home.
+
+Every hm:// link in document content is resolved before publishing. Use \`options.skipLinkCheck: true\` only when a linked resource is about to be created. Read the resulting document before citing block-level links because publishing can change block IDs.`,
+  },
+  comments: {
+    summary: 'Create comments and replies, then update or delete existing comment records.',
+    markdown: `${preamble}
+
+# Writing comments
+
+## Create or reply
+
+Use the target document as \`address\`, markdown as \`content\`, and \`options.action: "comment"\`. The address is the target by default; \`options.target\` can override it. Set \`options.replyTo\` to an existing comment ID or URL for a reply.
+
+\`\`\`json
+{"address":"hm://OWNER_UID/notes","content":"A useful comment.","options":{"action":"comment","signer":{"publicKey":"SIGNER_UID"}},"dryRun":true}
+\`\`\`
+
+## Edit
+
+Use the signer account as \`address\`; the dotted action's fields go in \`options.input\`.
+
+\`\`\`json
+{"address":"hm://SIGNER_UID","options":{"action":"comment.update","signer":{"publicKey":"SIGNER_UID"},"input":{"commentId":"COMMENT_ID","content":"Replacement comment body."}},"dryRun":true}
+\`\`\`
+
+## Delete
+
+\`\`\`json
+{"address":"hm://SIGNER_UID","options":{"action":"comment.delete","signer":{"publicKey":"SIGNER_UID"},"input":{"commentId":"COMMENT_ID"}},"dryRun":true}
+\`\`\`
+
+Comment content uses the same markdown and hm-link validation as documents. The signer must be authorized for the requested comment operation.`,
+  },
+  capabilities: {
+    summary: 'Grant WRITER or AGENT authority to another account, optionally scoped to a document path.',
+    markdown: `${preamble}
+
+# Granting capabilities
+
+Capabilities delegate authority from the signing account to another account. This write interface grants capabilities; it does not currently expose capability revocation.
+
+Use \`capability.grant\` (\`capability.create\` is an alias). Required fields are \`delegate\` and \`role\`; optional fields are \`path\` and \`label\`.
+
+- \`WRITER\` allows document writing in scope.
+- \`AGENT\` delegates agent authority in scope.
+- \`path\` scopes the grant; \`"/"\` covers the account root and descendants.
+
+\`\`\`json
+{"address":"hm://SIGNER_UID","options":{"action":"capability.grant","signer":{"publicKey":"SIGNER_UID"},"input":{"delegate":"DELEGATE_UID","role":"WRITER","path":"/","label":"Site editor"}},"dryRun":true}
+\`\`\`
+
+Verify the delegate UID, role, and scope carefully before removing \`dryRun\`. The signer is the authority granting access; the delegate is the recipient.`,
+  },
+  contacts: {
+    summary: 'Create a named contact for an account or delete an existing contact record.',
+    markdown: `${preamble}
+
+# Writing contacts
+
+Contacts are signed records owned by the signer.
+
+## Create
+
+Use \`contact.create\` with the contacted account UID in \`subject\` and the local display name in \`name\`.
+
+\`\`\`json
+{"address":"hm://SIGNER_UID","options":{"action":"contact.create","signer":{"publicKey":"SIGNER_UID"},"input":{"subject":"CONTACT_UID","name":"Eric"}},"dryRun":true}
+\`\`\`
+
+The result contains \`contactId\`; retain or obtain that record ID when deletion may be needed.
+
+## Delete
+
+Deletion requires the contact record ID, not merely the subject account UID.
+
+\`\`\`json
+{"address":"hm://SIGNER_UID","options":{"action":"contact.delete","signer":{"publicKey":"SIGNER_UID"},"input":{"contactId":"CONTACT_RECORD_ID"}},"dryRun":true}
+\`\`\``,
+  },
+  profiles: {
+    summary: 'Update a signing account profile or publish a profile alias.',
+    markdown: `${preamble}
+
+# Writing profiles
+
+## Update
+
+Use \`profile.update\`. Supported input fields are \`name\`, \`description\`, and \`icon\` (\`avatar\` is accepted as an alias for icon). An omitted name uses the managed signing identity's current local label.
+
+\`\`\`json
+{"address":"hm://SIGNER_UID","options":{"action":"profile.update","signer":{"publicKey":"SIGNER_UID"},"input":{"name":"Ion","description":"An autonomous Seed agent.","icon":"ipfs://CID"}},"dryRun":true}
+\`\`\`
+
+For managed agent signing keys, a successful name update also updates the key label shown by the agent runtime.
+
+## Alias
+
+Use \`profile.alias\` with another principal in \`input.alias\`.
+
+\`\`\`json
+{"address":"hm://SIGNER_UID","options":{"action":"profile.alias","signer":{"publicKey":"SIGNER_UID"},"input":{"alias":"ALIAS_UID"}},"dryRun":true}
+\`\`\``,
+  },
+  drafts: {
+    summary: 'Stage, inspect, list, revise, delete, and publish private document drafts.',
+    markdown: `${preamble}
+
+# Writing drafts
+
+Drafts are private agent-local staging records until published. Use the signer account as the hm address and put all draft fields in \`options.input\`.
+
+## Create
+
+\`draft.create\` requires a name (directly, in metadata, or in markdown frontmatter). Input can include \`content\`, \`metadata\`, \`path\`, \`edit\` (an existing document URL), \`location\`, and \`visibility\`.
+
+\`\`\`json
+{"address":"hm://SIGNER_UID","options":{"action":"draft.create","input":{"name":"Release notes","content":"Draft body","path":"/release-notes"}}}
+\`\`\`
+
+## Inspect and manage
+
+- Get: \`{action: "draft.get", input: {draftId: "ID"}}\`.
+- List: \`{action: "draft.list", input: {limit: 50}}\` (maximum 100).
+- Update: \`{action: "draft.update", input: {draftId: "ID", content: "Replacement body", name: "Optional name"}}\`. Omit content to retain the body.
+- Delete: \`{action: "draft.delete", input: {draftId: "ID"}}\`.
+
+## Publish
+
+Use \`draft.publish\` with \`draftId\`. A draft with an \`edit\` target updates that document; otherwise it creates a document using the staged path and metadata. \`expectedVersion\` may be supplied for update conflict protection.
+
+\`\`\`json
+{"address":"hm://TARGET_UID","options":{"action":"draft.publish","signer":{"publicKey":"SIGNER_UID"},"input":{"draftId":"ID","expectedVersion":"VERSION"}},"dryRun":true}
+\`\`\`
+
+Although draft get/list operations are read-like, they live here because they are commands in the write resource workflow.`,
+  },
+}

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -13,6 +13,7 @@ import {
   seedVerbRegistry,
   toolContractMarkdown,
   toolSummaryLine,
+  writeGuideRegistry,
   type JsonSchema,
   type SeedToolMetadata,
 } from '@seed-hypermedia/agents-protocol'
@@ -9051,7 +9052,11 @@ export function expandedCallablesFromEvents(db: Database, sessionId: string): st
     if (sessionEventActor(event as never) === 'user') continue
     if (event.name === seedVerbRegistry.read.name && typeof event.input.address === 'string') {
       const address = event.input.address.trim()
-      if (address.startsWith('~/tools/')) expanded.add(address.slice('~/tools/'.length).replace(/\/+$/, ''))
+      if (address.startsWith('~/tools/')) {
+        const name = address.slice('~/tools/'.length).replace(/\/+$/, '')
+        // Nested addresses are progressive documentation pages, not callable tool names.
+        if (!name.includes('/')) expanded.add(name)
+      }
     }
     if (event.name === seedVerbRegistry.call.name && typeof event.input.tool === 'string') {
       expanded.add(event.input.tool.trim())
@@ -9084,6 +9089,26 @@ export async function executeReadVerb(
   if (address === '~/tools' || address === '~/tools/') return toolsListing(context)
   if (address.startsWith('~/tools/')) {
     const name = address.slice('~/tools/'.length).replace(/\/+$/, '')
+    const [root, guideName, ...extra] = name.split('/')
+    if (root === seedVerbRegistry.write.name && guideName) {
+      const guide = extra.length === 0 ? writeGuideRegistry[guideName] : undefined
+      if (guide) {
+        return {
+          summary: `Write guide for ${guideName}: ${guide.summary}`,
+          name: `write/${guideName}`,
+          kind: 'guide',
+          markdown: guide.markdown,
+        }
+      }
+      const available = Object.keys(writeGuideRegistry)
+      return {
+        summary: `No write guide named ${name.slice('write/'.length)}. Read ~/tools/write for the index.`,
+        name: 'write',
+        markdown: `${toolContractMarkdown(seedVerbRegistry.write)}\n\nAvailable detailed guides: ${available
+          .map((entry) => `\`~/tools/write/${entry}\``)
+          .join(', ')}.`,
+      }
+    }
     const verb = (seedVerbRegistry as Record<string, SeedToolMetadata>)[name]
     if (verb) return {summary: `Contract for ${name}.`, name, markdown: toolContractMarkdown(verb)}
     toolDocs.ensureBuiltinToolDocuments(context.db, context.accountId, context.agentId)

--- a/agents/src/verbs.test.ts
+++ b/agents/src/verbs.test.ts
@@ -106,6 +106,36 @@ describe('read verb', () => {
     expect(String(contract.markdown)).toContain('## Input schema')
     expect(String(contract.markdown)).toContain('web_search')
 
+    const writeIndex = await executeReadVerb(context, {address: '~/tools/write'})
+    expect(String(writeIndex.markdown)).toContain('~/tools/write/capabilities')
+    expect(String(writeIndex.markdown)).toContain('grant WRITER or AGENT access')
+    expect(String(writeIndex.markdown)).not.toContain('capability.grant')
+
+    for (const guideName of [
+      'memory',
+      'tools',
+      'triggers',
+      'ipfs',
+      'documents',
+      'comments',
+      'capabilities',
+      'contacts',
+      'profiles',
+      'drafts',
+    ]) {
+      const guide = await executeReadVerb(context, {address: `~/tools/write/${guideName}`})
+      expect(guide.name).toBe(`write/${guideName}`)
+      expect(guide.kind).toBe('guide')
+    }
+    const capabilityGuide = await executeReadVerb(context, {address: '~/tools/write/capabilities'})
+    expect(String(capabilityGuide.markdown)).toContain('capability.grant')
+    expect(String(capabilityGuide.markdown)).toContain('delegate')
+    expect(String(capabilityGuide.markdown)).not.toContain('contact.create')
+
+    const unknownGuide = await executeReadVerb(context, {address: '~/tools/write/unknown'})
+    expect(String(unknownGuide.summary)).toContain('No write guide named unknown')
+    expect(String(unknownGuide.markdown)).toContain('~/tools/write/documents')
+
     // The execute contract is the one a server can honor only partly, so reading it shows the
     // runtimes THIS server offers rather than everything the shipped document lists.
     const narrowed = await executeReadVerb(makeContext({codeExec: {runtimes: ['python', 'shell']} as never}), {
@@ -581,6 +611,7 @@ describe('space index and touch-expand pins', () => {
     append(2, {type: 'tool_call', id: 't1', name: 'read', input: {address: '~/tools/web_search'}})
     append(3, {type: 'tool_call', id: 't2', name: 'call', input: {tool: 'execute', input: {}}})
     append(4, {type: 'tool_call', id: 't3', name: 'read', input: {address: '~/memory/x'}})
+    append(5, {type: 'tool_call', id: 't4', name: 'read', input: {address: '~/tools/write/capabilities'}})
     expect(apisvc.expandedCallablesFromEvents(context.db, 's1').sort()).toEqual(['execute', 'web_search'])
     expect(apisvc.expandedCallablesFromEvents(context.db, 'missing')).toEqual([])
   })


### PR DESCRIPTION
## Why

The `write` contract did not reveal profiles, capabilities, contacts, or drafts. In a real session, the agent inspected `api-service.ts` repeatedly to discover how to grant a capability. Putting every action schema into the always-on contract would fix discovery by creating a different prompt-size problem.

## What changed

This adds progressive disclosure for writing:

- `~/tools/write` is a compact index that clearly describes what lives in each feature group
- exact schemas, constraints, and examples load only through the relevant page:
  - `~/tools/write/memory`
  - `~/tools/write/tools`
  - `~/tools/write/triggers`
  - `~/tools/write/ipfs`
  - `~/tools/write/documents`
  - `~/tools/write/comments`
  - `~/tools/write/capabilities`
  - `~/tools/write/contacts`
  - `~/tools/write/profiles`
  - `~/tools/write/drafts`
- unknown nested guides return the index and valid guide addresses
- nested documentation reads do not pollute callable-tool expansion
- regression tests keep the index complete, detailed action names out of the index, every guide routable, and resource details isolated

Example flow for “give Eric write access”:

1. read `~/tools/write`
2. see that capabilities grant WRITER or AGENT access
3. read `~/tools/write/capabilities`
4. issue the documented write call

## Validation

- `bun test`: 351 pass, 0 fail
- focused protocol + verb tests: 36 pass, 0 fail
- `bun run format:check`: pass
- `git diff --check`: pass
- independent read-only review completed; its accuracy findings were incorporated
- `bun typecheck`: attempted, but `tsgo --noEmit` was killed by the sandbox resource limit without reporting diagnostics
