### PR TITLE
feat(agents): tool rows say what a call is for — required execute description, optional call description, MCP subject

### DIFF
--- a/agents/docs/desktop-ui.md
+++ b/agents/docs/desktop-ui.md
@@ -251,10 +251,11 @@ duration, and turn token breakdown — total, input, output, cache read, cache w
 event recorded before the runtime stamped provenance shows no Details section at all rather than labelled blanks.
 
 Tool rows dispatch a purpose-built detail view per tool (`assistant-message-rendering.tsx:2034`): `delegate` shows the
-brief and the child's own work, `execute` shows the code with a live output tail, an address-bearing `read` or `write`
-shows the resolved target, and a hypermedia write command gets its own phrasing. A `call` row borrows the **called**
-tool's icon, label, and links, with input paths rebased under `input.` (`getRowToolMetadata`,
-`assistant-message-rendering.tsx:687`) — so it never reads "Call · execute".
+brief and the child's own work, `execute` rows read the agent's required one-line `description` of the run (live, then
+as the summary) and show the code with a live output tail, an address-bearing `read` or `write` shows the resolved
+target, and a hypermedia write command gets its own phrasing. A `call` row borrows the **called** tool's icon, label,
+and links, with input paths rebased under `input.` (`getRowToolMetadata`, `assistant-message-rendering.tsx:687`) — so it
+never reads "Call · execute".
 
 Other session-page behavior: optimistic user messages stamped with the selected account immediately, concurrent sends
 while the agent is busy (the server persists them immediately and serializes their model turns), live assistant partials

--- a/agents/docs/mcp.md
+++ b/agents/docs/mcp.md
@@ -79,9 +79,12 @@ palette verb (`InvokeSessionTool`) — and is absent nowhere a call could happen
 3. proxy the call over the pool with a 120s timeout;
 4. a server-reported error (`isError`) and any transport failure are **thrown**, so they land on the log as
    `tool_result.error` the model can react to;
-5. the result is `{summary, text?, result?, images?, durationMs}` — `text` is the joined text content (bounded at 256
-   KiB), `result` is the server's `structuredContent`. Image content rides to vision models as inline parts; the durable
-   event keeps only the count.
+5. the result is `{summary, argument?, text?, result?, images?, durationMs}` — `argument` is the call's first string
+   argument short enough (≤ 80 chars) to name what happened, `summary` is `<tool> · <argument>` (or "Ran <tool> on the
+   <server> MCP server" without one), `text` is the joined text content (bounded at 256 KiB), `result` is the server's
+   `structuredContent`. Image content rides to vision models as inline parts; the durable event keeps only the count.
+   The chat row shows `summary` on a `call` row and just `argument` on a promoted row (whose label already names the
+   server and tool); a `description` on the `call` outranks both.
 
 **Promotion** covers remote tools: once `read ~/tools/github__create_issue` or a `call` of it has entered the
 transcript, the next turn hands the provider that document's name, description, and schema as a first-class tool

--- a/agents/docs/tools.md
+++ b/agents/docs/tools.md
@@ -295,8 +295,14 @@ Other write behavior worth knowing:
 ## `call`
 
 ```ts
-type CallInput = {tool: string; input?: object}
+type CallInput = {tool: string; input?: object; description?: string}
 ```
+
+`description` is optional intent for the user — one short line the chat row shows instead of the raw input. It is read
+from the durable `tool_call` event and never passed to the tool (scripts have the same affordance as
+`ctx.call(tool, input, {description})`). It is not required: `search`, `web_search`, `read`, and `write` rows already
+name their subject, and MCP rows read the call's first short string argument. Only `execute`, whose input is opaque,
+requires a description in its own input.
 
 Dispatch order in `executeCallVerb` (`api-service.ts:7794`):
 

--- a/agents/docs/tools.md
+++ b/agents/docs/tools.md
@@ -337,11 +337,18 @@ Runs TypeScript, Python, or shell code in a hardware-isolated microVM with the a
 
 ```ts
 type ExecuteInput = {
+  description: string // required: one short line saying what the run is for, 3–120 chars
   runtime: 'ts' | 'python' | 'shell'
   code: string
   timeout_secs?: number // clamped to [1, 300]
 }
 ```
+
+- **`description` is required** and is what the user reads. Agents reach for `execute` constantly, and a row that says
+  "Ran python code (exit 0, 812ms)" tells the user nothing, so the contract demands the intent in one line ("Count words
+  across the notes folder") and a call without one answers with the contract like any other miss. The desktop row shows
+  the description live while the sandbox runs and afterwards as the summary, which leads with it and appends only what
+  changed the picture — a non-zero exit, memory files touched; runtime and duration stay in the expanded details.
 
 - `ts` runs `bun -e`, `python` runs `python -c`, `shell` runs `/bin/sh -c`. Nothing goes through a shell unless the
   runtime _is_ the shell: the sandbox takes an argv array, so code with quotes, newlines, or `$` needs no escaping

--- a/agents/protocol/src/tool-registry.ts
+++ b/agents/protocol/src/tool-registry.ts
@@ -594,6 +594,13 @@ const executeTool = {
     type: 'object',
     additionalProperties: false,
     properties: {
+      description: {
+        type: 'string',
+        minLength: 3,
+        maxLength: 120,
+        description:
+          'What this run does, in one short line the user reads instead of the code — say the intent, not the mechanics: "Count words across the notes folder", "Convert the cover photo to WebP", "Check whether the CSV has duplicate ids". Under 80 characters, no trailing period. Required.',
+      },
       runtime: {
         type: 'string',
         enum: ['ts', 'python', 'shell'],
@@ -607,7 +614,7 @@ const executeTool = {
         description: 'Optional timeout override in seconds. Defaults to the server limit (typically 60).',
       },
     },
-    required: ['runtime', 'code'],
+    required: ['description', 'runtime', 'code'],
   },
   outputSchema: {
     type: 'object',
@@ -636,8 +643,11 @@ const executeTool = {
     kind: 'write',
     label: 'Execute Code',
     color: 'amber',
-    primaryArg: 'runtime',
-    summaryArg: 'runtime',
+    // The row reads the agent's own one-line description of the run — live while the sandbox is
+    // up, and afterwards through the summary, which leads with it. Old transcripts without one
+    // fall back to the runtime name.
+    primaryArg: 'description',
+    summaryArg: 'description',
     summaryOutputPath: 'summary',
     details: [
       {label: 'Code', source: 'input', path: 'code'},

--- a/agents/protocol/src/tool-registry.ts
+++ b/agents/protocol/src/tool-registry.ts
@@ -255,6 +255,7 @@ const callVerb = {
   description: [
     'Invoke a tool by name with a JSON input. Your available tools are listed in your context with one-line summaries; read `~/tools/<name>` for a full contract.',
     'Calling a tool with missing or invalid input does not fail: the result is the tool contract itself — read it and call again correctly. Do not guess elaborate inputs for a tool you have not expanded.',
+    'When the input alone would not tell a reader what the call is for, add `description`: one short line of intent that the user sees as the row label instead of the raw input.',
   ].join('\n'),
   inputSchema: {
     type: 'object',
@@ -262,6 +263,13 @@ const callVerb = {
     properties: {
       tool: {type: 'string', minLength: 1, description: 'The tool name, as listed under ~/tools/.'},
       input: {type: 'object', description: "The tool's input, matching its contract."},
+      description: {
+        type: 'string',
+        minLength: 3,
+        maxLength: 120,
+        description:
+          'Optional one-line intent for the user ("Look up the repo\'s docs structure"), shown as the row label. Not passed to the tool.',
+      },
     },
     required: ['tool'],
   },

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -10224,6 +10224,9 @@ export async function executeCallVerb(
       return executeWebSearch(context.web, toolInput)
     case 'execute': {
       const runtime = typeof toolInput.runtime === 'string' ? toolInput.runtime : 'code'
+      // The agent's one-line account of the run is what the user reads in the row; the schema
+      // requires it, so a missing one has already answered with the contract above.
+      const description = typeof toolInput.description === 'string' ? toolInput.description.trim() : ''
       let result
       try {
         result = await context.codeExec.execute({
@@ -10234,7 +10237,7 @@ export async function executeCallVerb(
           onProgress: (progress) =>
             context.onToolProgress(seedVerbRegistry.call.name, {
               toolCallId,
-              detail: progress.stage === 'starting' ? 'Starting sandbox…' : `Running ${runtime} code…`,
+              detail: progress.stage === 'starting' ? 'Starting sandbox…' : `Running ${runtime}…`,
               outputTail: progress.outputTail,
             }),
         })
@@ -10243,11 +10246,17 @@ export async function executeCallVerb(
         throw error
       }
       if (result.changedFiles.length) context.onMemoryChange()
-      const changeSummary = result.changedFiles.length
-        ? `, ${result.changedFiles.length} memory file${result.changedFiles.length === 1 ? '' : 's'} changed`
-        : ''
+      // The summary leads with what the run was FOR and appends only what changed the picture: a
+      // non-zero exit, and memory files touched. Mechanics (runtime, duration) stay in the details.
+      const notes = [
+        ...(result.exitCode === 0 ? [] : [`exit ${result.exitCode}`]),
+        ...(result.changedFiles.length
+          ? [`${result.changedFiles.length} memory file${result.changedFiles.length === 1 ? '' : 's'} changed`]
+          : []),
+      ]
+      const lead = description || `Ran ${runtime} code`
       return {
-        summary: `Ran ${runtime} code (exit ${result.exitCode}, ${result.durationMs}ms${changeSummary}).`,
+        summary: notes.length ? `${lead} · ${notes.join(' · ')}` : lead,
         ...result,
       }
     }

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -10161,8 +10161,13 @@ async function executeMcpTool(
     throw new APIError(400, `Tool ${doc.name} reported an error: ${result.text || 'no details were given'}`)
   }
   const durationMs = Date.now() - startedAt
+  // The row reads the call's own argument when one is short enough to name what happened
+  // ("read_wiki_structure · facebook/react"); a promoted row, already labeled with the tool,
+  // shows just the argument. Duration stays in the details and the event meta.
+  const argument = firstShortStringArgument(toolInput)
   const output: Record<string, unknown> = {
-    summary: `Ran ${remoteName} on the ${server} MCP server (${durationMs}ms).`,
+    summary: argument ? `${remoteName} · ${argument}` : `Ran ${remoteName} on the ${server} MCP server`,
+    ...(argument ? {argument} : {}),
     ...(result.text ? {text: result.text} : {}),
     ...(result.structured !== undefined ? {result: result.structured} : {}),
     ...(result.images.length ? {images: result.images.length} : {}),
@@ -10177,7 +10182,29 @@ async function executeMcpTool(
   return output
 }
 
-/** Executes the call verb: contract-on-miss dispatch into the callable tool set. */
+/** Longest argument value a chat row will show in place of a tool summary. */
+const MAX_ROW_ARGUMENT_CHARS = 80
+
+/**
+ * The first string argument short enough to stand for the call in a chat row — a repo name, a
+ * query, a question. Arguments are read in the order the model wrote them, which tends to put the
+ * subject first; long strings (bodies, code) are skipped rather than truncated, since a cut-off
+ * body names nothing.
+ */
+export function firstShortStringArgument(input: Record<string, unknown>): string | undefined {
+  for (const value of Object.values(input)) {
+    if (typeof value !== 'string') continue
+    const trimmed = value.trim().replace(/\s+/g, ' ')
+    if (trimmed && trimmed.length <= MAX_ROW_ARGUMENT_CHARS) return trimmed
+  }
+  return undefined
+}
+
+/**
+ * Executes the call verb: contract-on-miss dispatch into the callable tool set. `description` is
+ * the model's optional one-line intent for the user; it is read by the chat row from the durable
+ * call event and never reaches the tool.
+ */
 export async function executeCallVerb(
   context: AgentServicePiToolContext,
   raw: unknown,

--- a/agents/src/verbs.test.ts
+++ b/agents/src/verbs.test.ts
@@ -820,12 +820,35 @@ describe('mcp tools through the call verb', () => {
     })
     seedMcp(context, 'weather', [forecastTool])
 
-    const result = await executeCallVerb(context, {tool: 'weather__forecast', input: {city: 'Lisbon'}}, 'tc-mcp')
+    const result = await executeCallVerb(
+      context,
+      {tool: 'weather__forecast', input: {city: 'Lisbon'}, description: 'Check the weather for the trip'},
+      'tc-mcp',
+    )
+    // The call-level description never reaches the server; the row reads it from the event.
     expect(calls).toEqual([['weather', 'forecast', {city: 'Lisbon'}]])
     expect(result.text).toBe('Sunny, 24°C')
     expect(result.result).toEqual({tempC: 24})
-    expect(String(result.summary)).toContain('Ran forecast on the weather MCP server')
+    // The summary names the call by its first short argument; a promoted row reads `argument` alone.
+    expect(result.summary).toBe('forecast · Lisbon')
+    expect(result.argument).toBe('Lisbon')
     expect(context.onToolProgress).toHaveBeenCalledWith('call', expect.objectContaining({toolCallId: 'tc-mcp'}))
+  })
+
+  test('a call whose arguments are long or non-string falls back to naming the server', async () => {
+    const context = makeContext({
+      mcp: {callTool: mock(async () => ({text: 'ok', images: [], isError: false}))},
+    })
+    seedMcp(context, 'notes', [{name: 'append'}])
+    const result = await executeCallVerb(
+      context,
+      {tool: 'notes__append', input: {count: 3, body: 'x'.repeat(200)}},
+      'tc-long',
+    )
+    expect(result.summary).toBe('Ran append on the notes MCP server')
+    expect(result.argument).toBeUndefined()
+    expect(apisvc.firstShortStringArgument({a: '  spaced   out  ', b: 'second'})).toBe('spaced out')
+    expect(apisvc.firstShortStringArgument({a: '', b: 'second'})).toBe('second')
   })
 
   test('a miss answers with the contract; server errors and transport failures are thrown', async () => {

--- a/agents/src/verbs.test.ts
+++ b/agents/src/verbs.test.ts
@@ -340,14 +340,50 @@ describe('call verb', () => {
         execute: executeSpy,
       } as never,
     })
-    const result = await executeCallVerb(
+    // No description: the contract comes back and nothing runs — the row the user reads is the
+    // description, so a run without one is a run the user cannot follow.
+    const undescribed = await executeCallVerb(
       context,
       {tool: 'execute', input: {runtime: 'python', code: 'print(1)'}},
+      'tc0',
+    )
+    expect(String(undescribed.summary)).toContain('did not match its contract')
+    expect(undescribed.validationErrors).toEqual(['$.description: required property is missing'])
+    expect(executeSpy).not.toHaveBeenCalled()
+
+    const result = await executeCallVerb(
+      context,
+      {tool: 'execute', input: {description: 'Count the words in notes', runtime: 'python', code: 'print(1)'}},
       'tc1',
     )
-    expect(String(result.summary)).toContain('Ran python code')
+    // The summary leads with the agent's own account of the run, then only what changed the picture.
+    expect(result.summary).toBe('Count the words in notes · 1 memory file changed')
     expect(executeSpy).toHaveBeenCalledTimes(1)
     expect(context.onMemoryChange).toHaveBeenCalled()
+  })
+
+  test('a failed execute keeps the description and adds the exit code', async () => {
+    const context = makeContext({
+      codeExec: {
+        runtimes: ['python', 'shell'],
+        availability: async () => ({available: true, runtimes: ['python', 'shell']}),
+        execute: async () => ({
+          exitCode: 2,
+          success: false,
+          stdout: '',
+          stderr: 'boom',
+          truncated: false,
+          durationMs: 5,
+          changedFiles: [],
+        }),
+      } as never,
+    })
+    const result = await executeCallVerb(
+      context,
+      {tool: 'execute', input: {description: 'Validate the CSV', runtime: 'python', code: 'raise SystemExit(2)'}},
+      'tc2',
+    )
+    expect(result.summary).toBe('Validate the CSV · exit 2')
   })
 
   test('the execute contract offers only the runtimes this server can actually run', async () => {
@@ -362,7 +398,11 @@ describe('call verb', () => {
     })
     // A model asking for TypeScript on a server with no bun image gets the contract back — with ts
     // absent from the enum — instead of a sandbox failure it cannot diagnose.
-    const result = await executeCallVerb(context, {tool: 'execute', input: {runtime: 'ts', code: 'x'}}, undefined)
+    const result = await executeCallVerb(
+      context,
+      {tool: 'execute', input: {description: 'Try TypeScript', runtime: 'ts', code: 'x'}},
+      undefined,
+    )
     expect(String(result.summary)).toContain('did not match its contract')
     expect(String(result.contract)).toContain('"python"')
     expect(String(result.contract)).not.toContain('"ts"')

--- a/frontend/packages/ui/src/agents/message-rendering.tsx
+++ b/frontend/packages/ui/src/agents/message-rendering.tsx
@@ -732,7 +732,9 @@ function promotedDocumentToolMetadata(name: string): SeedToolMetadata | undefine
     ...call,
     name,
     label,
-    render: {...call.render, label, primaryArg: undefined, summaryArg: undefined},
+    // The label already names the tool, so the row reads the executor's `argument` (an MCP
+    // call's subject) and falls back to its `summary` through getToolSummary.
+    render: {...call.render, label, primaryArg: undefined, summaryArg: undefined, summaryOutputPath: 'argument'},
   }
 }
 
@@ -760,6 +762,12 @@ function getToolLinks(item: ChatToolPart) {
 
 function getToolSummary(item: ChatToolPart): string | undefined {
   if (item.summaryOverride) return item.summaryOverride
+  // The model's own one-line intent on a `call` outranks anything derived from the input or the
+  // result — it is the row the user was meant to read.
+  if (item.name === 'call') {
+    const intent = getToolString(item.args, 'description')
+    if (intent) return intent
+  }
   const metadata = getRowToolMetadata(item)
   const outputSummary = firstInlinePathValue(item.rawOutput, metadata?.render.summaryOutputPath)
   if (outputSummary) return outputSummary
@@ -767,7 +775,8 @@ function getToolSummary(item: ChatToolPart): string | undefined {
   const inputSummary = firstInlinePathValue(item.args, metadata?.render.summaryArg || metadata?.render.primaryArg)
   if (inputSummary) return inputSummary
 
-  return item.result
+  // Any executor that wrote a `summary` field has said what happened better than raw result text.
+  return getToolString(item.rawOutput, 'summary') ?? item.result
 }
 
 function getToolDetails(item: ChatToolPart) {


### PR DESCRIPTION
## Summary

Agents use `execute` (and other tools) constantly, and rows summarized runs by their mechanics — `Ran python code (exit 0, 812ms)`, `Ran read_wiki_structure on the deepwiki MCP server (1738ms)`. Three changes so a row says what the call is *for*:

1. **`execute` requires `description`** — one short line (3–120 chars) of intent, first in the schema. A call without one gets the contract back (touch-expand) and nothing runs, so the model self-corrects. The row shows it live while the sandbox runs and afterwards as the summary, which leads with it and appends only what changed the picture (`· exit 2`, `· 3 memory files changed`). Runtime and duration stay in the details; old transcripts fall back to the runtime name.
2. **`call` accepts an optional `description`** — the same one-line intent for any tool whose input alone would not tell a reader what the call is for. Read by the chat row from the durable event, never passed to the tool (mirrors scripts' `ctx.call(..., {description})`). Not required: `search`/`web_search`/`read`/`write` rows already name their subject.
3. **MCP rows read the call's subject** — results carry `argument` (the first string argument ≤ 80 chars) and a summary of `<tool> · <argument>`: `read_wiki_structure · facebook/react`. A `call` row shows the summary; a promoted row, already labeled `server · tool`, shows just the argument. Any executor's `summary` field is now the row's last fallback before raw result text.

## Testing

- `verbs.test.ts`: description-less `execute` returns the contract (`$.description: required property is missing`) and never runs; success/failure summaries; `call.description` never reaches an MCP server; MCP summary/argument, and the fallback for long or non-string arguments.
- `bun check && bun test` — 368 pass; `@shm/ui` vitest — 379 pass; typecheck clean.
- Docs: `tools.md`, `mcp.md`, `desktop-ui.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3qMAzkS2n5WXESGxVy1Wi