### PR TITLE
fix(agents): delegate rows link into the child the moment it spawns

### DIFF
--- a/agents/docs/persistence.md
+++ b/agents/docs/persistence.md
@@ -408,6 +408,15 @@ type SessionEventPayload =
     }
   | {type: 'tool_call'; id: string; name: string; input: unknown; actor?: SessionActor}
   | {
+      type: 'tool_spawn'
+      toolCallId: string
+      name: string
+      runId: string
+      sessionId?: string
+      title: string
+      actor?: SessionActor
+    }
+  | {
       type: 'tool_result'
       toolCallId: string
       name: string
@@ -419,6 +428,11 @@ type SessionEventPayload =
   | {type: 'error'; message: string; actor?: SessionActor}
   | Record<string, unknown>
 ```
+
+`tool_spawn` is appended by `delegate` the moment its child exists — before the child has run a step — and names the
+child run (and session, for a model child). The call stays parked without a `tool_result` until the child finishes, so
+this event is what lets a transcript open the child while it works; it is not replayed to the model, and it never stands
+in for the result, which the child's finalizer appends later.
 
 `actor` and `meta` are both optional because events predating them exist. Never treat either as required structure:
 `sessionEventActor()` in the protocol package derives the actor of an older event from its shape (a user-role message is

--- a/agents/docs/troubleshooting.md
+++ b/agents/docs/troubleshooting.md
@@ -121,6 +121,15 @@ that finalized inside a crash window. If a session still shows `streaming`:
    any run id is the finer-grained kill switch (cascades to its subtree).
 4. Restarting the service is always safe: sweep + reconcile recover every documented crash window.
 
+## A delegate row says "Starting the child…" but the child is alive
+
+The row links into its child through the parent transcript's `tool_spawn` event, appended by `delegate` the moment the
+child run and session exist — so a live delegation is openable even while the child is still queued or its model is
+processing the prompt. Only a transcript from before that event (or a call whose spawn threw before the child was
+enqueued) falls back to finding the child through the run tree, where the child run's `parent_tool_call_id` names the
+call. If a row with a live child still shows the spinner text, check `GetSession` for a `tool_spawn` with that
+`toolCallId`; its absence means the server that ran the turn predates the event.
+
 ## Children ran but the parent never resumed
 
 Checklist, in order:

--- a/agents/protocol/src/index.ts
+++ b/agents/protocol/src/index.ts
@@ -1302,6 +1302,23 @@ export type SessionEventPayload =
     }
   | {type: 'tool_call'; id: string; name: string; input: unknown; actor?: SessionActor}
   | {
+      /**
+       * A `delegate` call spawned its child. Appended the moment the child exists — before it has
+       * run a single step — so the transcript names the child while the call is still parked on it
+       * and a client can open the child without discovering it through the run tree. The call's
+       * `tool_result` still arrives from the child's finalizer; this event never stands in for it.
+       */
+      type: 'tool_spawn'
+      toolCallId: string
+      name: string
+      /** The child run. Present for every kind of child. */
+      runId: string
+      /** The child's session. Present for model children; a script child has a run and no session. */
+      sessionId?: string
+      title: string
+      actor?: SessionActor
+    }
+  | {
       type: 'tool_result'
       toolCallId: string
       name: string

--- a/agents/src/api-service.test.ts
+++ b/agents/src/api-service.test.ts
@@ -5628,6 +5628,24 @@ describe('api service', () => {
       if (tree._ !== 'ListRunsResponse') throw new Error('unexpected response')
       const child = tree.runs.find((run) => run.depth === 1)
       expect(child?.status).toBe('succeeded')
+      // The parent transcript named its child the moment it spawned — durably, and before the
+      // result — so a client could open the child while it was riding out the outage.
+      const parentEvents = session.events.map(
+        (event) => event.event as {type?: string; id?: string; toolCallId?: string; name?: string},
+      )
+      const callIndex = parentEvents.findIndex((event) => event.type === 'tool_call' && event.name === 'delegate')
+      const spawnIndex = parentEvents.findIndex((event) => event.type === 'tool_spawn')
+      const resultIndex = parentEvents.findIndex((event) => event.type === 'tool_result' && event.name === 'delegate')
+      expect(callIndex).toBeGreaterThanOrEqual(0)
+      expect(spawnIndex).toBeGreaterThan(callIndex)
+      expect(spawnIndex).toBeLessThan(resultIndex)
+      expect(parentEvents[spawnIndex]).toMatchObject({
+        toolCallId: parentEvents[callIndex]!.id,
+        name: 'delegate',
+        runId: child!.id,
+        sessionId: child!.sessionId,
+        title: 'Worker',
+      })
       // The proof it was the QUEUE's doing: the same run row was claimed more than once.
       const attempts = db.query<{attempt: number}, [string]>(`SELECT attempt FROM runs WHERE id = ?`).get(child!.id)
         ?.attempt

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -4806,6 +4806,23 @@ export class Service {
       maxAttempts: AGENT_RUN_MAX_ATTEMPTS,
     })
     runningSession.parkToolCallIds = [...(runningSession.parkToolCallIds ?? []), toolCallId]
+    // The parent transcript names its child from this moment: the call stays parked (no
+    // tool_result) until the child finishes, and a client that had to discover the child through
+    // the run tree instead could sit on "starting" for the child's whole life.
+    this.#appendSessionEvent(
+      accountId,
+      parentAgentId,
+      parentSessionId,
+      {
+        type: 'tool_spawn',
+        toolCallId,
+        name: seedVerbRegistry.delegate.name,
+        runId: childRunId,
+        sessionId: session.sessionId,
+        title,
+      },
+      Date.now(),
+    )
     console.info('[agents/runtime] sub-session spawned', {
       accountId,
       parentRunId: parentRun.id,
@@ -5023,6 +5040,15 @@ export class Service {
       maxAttempts: 1,
     })
     runningSession.parkToolCallIds = [...(runningSession.parkToolCallIds ?? []), toolCallId]
+    // Same durable link a model child gets (see #spawnSubSession): the row can show the run's own
+    // work the moment it exists rather than after the run tree happens to be re-read.
+    this.#appendSessionEvent(
+      accountId,
+      parentAgentId,
+      parentSessionId,
+      {type: 'tool_spawn', toolCallId, name: seedVerbRegistry.delegate.name, runId: childRunId, title},
+      Date.now(),
+    )
     console.info('[agents/workflow] workflow spawned from chat', {
       accountId,
       parentRunId: parentRun.id,

--- a/frontend/apps/desktop/src/__tests__/agent-session-rows.test.ts
+++ b/frontend/apps/desktop/src/__tests__/agent-session-rows.test.ts
@@ -41,6 +41,73 @@ describe('buildAgentSessionChatRows', () => {
     expect(part).toMatchObject({args: {query: 'seed'}})
   })
 
+  it('folds a tool_spawn onto its delegate call, naming the child before any result exists', () => {
+    const rows = buildAgentSessionChatRows(
+      [
+        event(1, {type: 'tool_call', id: 'd1', name: 'delegate', input: {title: 'Researcher', brief: 'Go.'}}),
+        event(2, {
+          type: 'tool_spawn',
+          toolCallId: 'd1',
+          name: 'delegate',
+          runId: 'run-child',
+          sessionId: 'session-child',
+          title: 'Researcher',
+        }),
+      ],
+      CONTEXT,
+    )
+
+    // One row, still pending (the spawn is not a result), but it already knows its child.
+    expect(rows).toHaveLength(1)
+    const row = rows[0]!
+    if (row.kind !== 'message') throw new Error('expected a message row')
+    const part = row.message.parts?.[0]
+    expect(part).toMatchObject({
+      type: 'tool',
+      id: 'd1',
+      args: {title: 'Researcher', brief: 'Go.'},
+      child: {runId: 'run-child', sessionId: 'session-child', title: 'Researcher'},
+    })
+    expect(part && 'result' in part ? part.result : undefined).toBeUndefined()
+  })
+
+  it('keeps the spawned child on the row once the delegate result lands', () => {
+    const rows = buildAgentSessionChatRows(
+      [
+        event(1, {type: 'tool_call', id: 'd1', name: 'delegate', input: {title: 'Researcher'}}),
+        event(2, {type: 'tool_spawn', toolCallId: 'd1', name: 'delegate', runId: 'run-child', title: 'Researcher'}),
+        event(3, {type: 'tool_result', toolCallId: 'd1', name: 'delegate', output: {status: 'succeeded'}}),
+      ],
+      CONTEXT,
+    )
+
+    expect(rows).toHaveLength(1)
+    const row = rows[0]!
+    if (row.kind !== 'message') throw new Error('expected a message row')
+    expect(row.message.parts?.[0]).toMatchObject({
+      id: 'd1',
+      rawOutput: {status: 'succeeded'},
+      child: {runId: 'run-child', title: 'Researcher'},
+    })
+  })
+
+  it('a tool_spawn whose call event is missing still becomes a row into the child', () => {
+    const rows = buildAgentSessionChatRows(
+      [event(1, {type: 'tool_spawn', toolCallId: 'd1', name: 'delegate', runId: 'run-child', sessionId: 's-child'})],
+      CONTEXT,
+    )
+
+    expect(rows).toHaveLength(1)
+    const row = rows[0]!
+    if (row.kind !== 'message') throw new Error('expected a message row')
+    expect(row.message.parts?.[0]).toMatchObject({
+      type: 'tool',
+      id: 'd1',
+      name: 'delegate',
+      child: {runId: 'run-child', sessionId: 's-child'},
+    })
+  })
+
   it('renders a tool result with no preceding call as its own row', () => {
     const rows = buildAgentSessionChatRows(
       [event(1, {type: 'tool_result', toolCallId: 'orphan', name: 'read', output: {summary: 'Read it.'}})],

--- a/frontend/apps/desktop/src/pages/agents/__tests__/run-work.test.tsx
+++ b/frontend/apps/desktop/src/pages/agents/__tests__/run-work.test.tsx
@@ -671,6 +671,53 @@ describe('delegate expanded view', () => {
     )
   })
 
+  it('a delegate stamped with its child is a way in with no run-tree lookup at all', () => {
+    // The runtime stamps the child onto the call as it spawns. Nothing else is available here — no
+    // session runs, no tree — and the row must still open the child and show its work, so a child
+    // that is only warming up (queued, prompt processing) is never hidden behind "Starting the child…".
+    mockState.run = makeRun({
+      id: 'child-stamped',
+      status: 'queued',
+      rootRunId: 'turn-4',
+      parentRunId: 'turn-4',
+      sessionId: 'child-session-stamped',
+      parentToolCallId: 'call-stamped',
+      title: 'Researcher',
+      plan: {steps: [{id: 's1', label: 'Read the pricing page', status: 'pending'}]},
+    } as never)
+    render(
+      <ChatMessageBubble
+        message={{
+          role: 'assistant',
+          sessionId: 'session-1',
+          parts: [
+            {
+              type: 'tool',
+              id: 'call-stamped',
+              name: 'delegate',
+              args: {title: 'Researcher', brief: 'Go.'},
+              child: {runId: 'child-stamped', sessionId: 'child-session-stamped', title: 'Researcher'},
+            },
+          ],
+        }}
+        serverUrl="http://localhost:3050"
+        accountUid="account-1"
+      />,
+    )
+    const link = container.querySelector('button[title="Open Researcher"]')
+    expect(link).not.toBeNull()
+    click(link)
+    expect(mockState.navigate).toHaveBeenCalledWith(
+      {key: 'agent-session', sessionId: 'child-session-stamped', serverUrl: 'http://localhost:3050'},
+      expect.anything(),
+    )
+
+    click(container.querySelector('button[title="Show tool details"]'))
+    expect(container.textContent).toContain('Read the pricing page')
+    expect(container.textContent).toContain('Open transcript')
+    expect(container.textContent).not.toContain('Starting the child')
+  })
+
   it('a detached child that outlives its finished turn still resolves, to the newest continueAsNew link', () => {
     // Eric's live repro: "until I tell you to stop" spawned a detached monitoring workflow, the
     // turn succeeded, and the delegate row spun on "Starting the child…" forever — the child

--- a/frontend/packages/ui/src/agents/agent-session-rows.ts
+++ b/frontend/packages/ui/src/agents/agent-session-rows.ts
@@ -8,7 +8,7 @@ import {
   type SessionEventPayload,
 } from './client'
 import {type ChatBubbleMessage} from './chat-parts'
-import {type ChatToolPart} from './chat-parts'
+import {type ChatToolChild, type ChatToolPart} from './chat-parts'
 import {sessionEventActor} from '@seed-hypermedia/agents-protocol'
 import type {HMBlockNode} from '@seed-hypermedia/client/hm-types'
 
@@ -388,6 +388,10 @@ export function buildAgentSessionChatRows(
       contextLines?: unknown
       attachments?: unknown
       meta?: SessionEventMeta
+      /** tool_spawn: the child run and (for a model child) its session. */
+      runId?: string
+      sessionId?: string
+      title?: string
     }
 
     if (payload.type === 'message' && typeof payload.content === 'string') {
@@ -459,6 +463,50 @@ export function buildAgentSessionChatRows(
       }
       rows.push(row)
       toolRowsById.set(payload.id, row)
+      continue
+    }
+
+    if (payload.type === 'tool_spawn' && typeof payload.toolCallId === 'string' && typeof payload.runId === 'string') {
+      // The child's identity, folded onto the call it answers. The call event always lands first
+      // (it is appended when the tool starts, the spawn while it runs), but a transcript that lost
+      // the call still gets a row: the child exists, and this is the only way into it.
+      const child: ChatToolChild = {
+        runId: payload.runId,
+        ...(typeof payload.sessionId === 'string' ? {sessionId: payload.sessionId} : {}),
+        ...(typeof payload.title === 'string' ? {title: payload.title} : {}),
+      }
+      const existingRow = toolRowsById.get(payload.toolCallId)
+      if (existingRow) {
+        const existingPart = existingRow.message.parts?.[0] as ChatToolPart | undefined
+        existingRow.message = {
+          ...existingRow.message,
+          parts: [{...(existingPart || {type: 'tool', id: payload.toolCallId, name: 'delegate'}), child}],
+        }
+      } else {
+        const row: Extract<AgentSessionChatRow, {kind: 'message'}> = {
+          key: event.id,
+          kind: 'message',
+          createdAt: event.createdAt,
+          message: {
+            role: 'assistant',
+            parts: [
+              {
+                type: 'tool',
+                id: payload.toolCallId,
+                name: typeof payload.name === 'string' ? payload.name : 'delegate',
+                child,
+                actor: sessionEventActor(event.event),
+              },
+            ],
+            eventId: event.id,
+            sessionId: event.sessionId,
+            seq: event.seq,
+            shareUrl: buildAgentSessionEventUrl(context.serverUrl, context.agentId, context.sessionId, event.id),
+          },
+        }
+        rows.push(row)
+        toolRowsById.set(payload.toolCallId, row)
+      }
       continue
     }
 

--- a/frontend/packages/ui/src/agents/chat-parts.ts
+++ b/frontend/packages/ui/src/agents/chat-parts.ts
@@ -23,6 +23,16 @@ export type ChatTextPart = {
   text: string
 }
 
+/**
+ * The child a `delegate` call spawned, known from the moment it exists (the `tool_spawn` event).
+ * A model child has a session; a script child has only its run.
+ */
+export type ChatToolChild = {
+  runId: string
+  sessionId?: string
+  title?: string
+}
+
 /** A tool item within an assistant message, optionally updated with a result later. */
 export type ChatToolPart = {
   type: 'tool'
@@ -31,6 +41,11 @@ export type ChatToolPart = {
   args?: Record<string, unknown>
   result?: string
   rawOutput?: unknown
+  /**
+   * The child this delegation is parked on, stamped durably when it spawned — so the row is a way
+   * into the child's work for its whole life, not only once its result has come back.
+   */
+  child?: ChatToolChild
   /** Durable timestamp of the result event; the row itself stays positioned at the call event. */
   completedAt?: number
   /** The result was an error (validation failure, tool crash) — `result` holds the message. */

--- a/frontend/packages/ui/src/agents/message-rendering.tsx
+++ b/frontend/packages/ui/src/agents/message-rendering.tsx
@@ -1760,17 +1760,24 @@ function DelegateWorkDetails({
   const selectedAccountId = useSelectedAccountId()
   const {sessionId: transcriptSessionId} = React.useContext(ToolRowContext)
   const signingAccount = accountUid || selectedAccountId
-  const reportedRunId = getToolString(item.rawOutput, 'runId')
+  const reportedRunId = getToolString(item.rawOutput, 'runId') ?? item.child?.runId
   const brief = getToolString(item.args, 'brief')
   const isPending = item.result === undefined && item.rawOutput === undefined
   const typedOutput = getFirstToolValue(item.rawOutput, ['output'])
-  // A model child reports no runId until it comes back, so while it works the only link is the one
-  // the run itself carries. Only an unresolved call looks: a finished one always has its runId, so
-  // a transcript of them opens nothing. (On the session page these queries are the very ones the
-  // pinned card already holds, so resolving costs no extra traffic.)
-  const spawnedChild = useSpawnedChildRun(serverUrl, signingAccount, transcriptSessionId, item.id, isPending)
+  // The runtime stamps the child onto the call the moment it spawns (`item.child`), so a live
+  // delegation normally knows its run and session outright. Transcripts from before that stamp
+  // only name the child in its result — for those, while the call is still open, the run tree is
+  // the one place the link exists: the child run records the call that started it. (On the session
+  // page these queries are the very ones the pinned card already holds, so resolving costs no
+  // extra traffic.)
+  const spawnedChild = useSpawnedChildRun(
+    serverUrl,
+    signingAccount,
+    transcriptSessionId,
+    item.id,
+    isPending && !reportedRunId,
+  )
   const runId = reportedRunId ?? spawnedChild?.id
-  // Same for the transcript link: the child's session exists from the moment it spawns.
   const sessionId = getToolSessionId(item) ?? spawnedChild?.sessionId
 
   return (
@@ -1921,7 +1928,8 @@ function DelegateRunView({
  */
 function getToolSessionId(item: ChatToolPart): string | undefined {
   if (item.name !== 'delegate' && item.name !== 'sub_session') return undefined
-  return getToolString(item.rawOutput, 'sessionId')
+  // The result names the child once it is back; the spawn stamp names it from the start.
+  return getToolString(item.rawOutput, 'sessionId') ?? item.child?.sessionId
 }
 
 /**
@@ -1992,14 +2000,15 @@ export function ToolCallLine({
     : isScriptWorkflow
       ? 'Workflow'
       : render?.label || item.name
-  // An awaited delegation reports its child only when it finishes — but the child run records the
-  // call that started it the moment it spawns, so the row is a way in DURING the work, not after.
+  // The row is a way into the child DURING the work, not after: the runtime stamps the child onto
+  // the call as it spawns (`item.child`, read by getToolSessionId). Only a transcript from before
+  // that stamp falls back to the run tree, where the child run records the call that started it.
   const spawnedChild = useSpawnedChildRun(
     serverUrl,
     accountUid,
     sessionId,
     item.id,
-    isDelegateToolName(item.name) && isPending && !reportedSessionId,
+    isDelegateToolName(item.name) && isPending && !reportedSessionId && !item.child,
   )
   const childSessionId = reportedSessionId ?? spawnedChild?.sessionId
   const details = getToolDetails(item)


### PR DESCRIPTION
## Problem

When delegating, the parent's delegate row sat on **"Starting the child…"** for a very long time — often the child's entire life, including model warm-up and prompt processing — with no way to click into the sub-session.

The row's only *durable* knowledge of its child came from the call's `tool_result`, which the child's finalizer appends when the child **finishes**. Until then the UI had to discover the child by walking the parent's run tree (newest root run → tree query/socket → run whose `parentToolCallId` matches). That path depends on a 5s poll, a tree refetch that only happens on socket invalidations, and the right root being subscribed, so it frequently resolved only when the result arrived.

## Fix: the parent transcript names the child the moment it exists

- **Protocol**: new durable session event `tool_spawn {toolCallId, name, runId, sessionId?, title}`.
- **Server**: `#spawnSubSession` (model child → `runId` + `sessionId`) and `#spawnWorkflowFromChat` (script child → `runId`) append it to the parent transcript right after enqueueing the child. It streams over the existing `sessions/<id>` socket and is persisted, so reloads and other clients get it. Model replay ignores it (unknown types fall through); the real `tool_result` still comes from the finalizer.
- **Client**: `ChatToolPart.child` is folded onto the call row from the event. The collapsed row's title is a link into the child and the expanded view renders the child's run/plan immediately. Run-tree discovery stays only as a fallback for transcripts written before this event.
- **Docs**: `persistence.md` (event shape), `troubleshooting.md` (what to check if the spinner text ever reappears).

## Tests

- Server: the delegate outage test now asserts `tool_spawn` lands between the `tool_call` and `tool_result`, naming the child's real run and session.
- Rows builder: spawn folds onto the call (still pending), survives the later result, and an orphan spawn still becomes a row.
- Rendering: a delegate stamped with its child links into a `queued` child with **no** session runs and **no** tree available, and never shows "Starting the child".

Verified: agents typecheck + delegate/sub-session/workflow/replay server tests; ui/desktop/web typecheck; desktop vitest for the touched suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHRSfpsML8WBXGN2xHFVUj
