### PR TITLE
Avoid crashing when deriving peer IDs from principals

### DIFF
--- a/backend/core/principal.go
+++ b/backend/core/principal.go
@@ -43,10 +43,7 @@ func (p Principal) PeerID() (peer.ID, error) {
 	if err != nil {
 		return "", err
 	}
-	_ = pk
-	panic("TODO")
-
-	// return pk.PeerID(), nil
+	return peer.IDFromPublicKey(pk.Libp2pKey())
 }
 
 // Explode splits the principal into it's multicodec and raw key bytes.

--- a/backend/core/principal_test.go
+++ b/backend/core/principal_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,4 +12,26 @@ func TestPrincipalUnsafeString(t *testing.T) {
 	me, err := DecodePrincipal("z6Mkv1LjkRosErBhmqrkmb5sDxXNs6EzBDSD8ktywpYLLGuC")
 	require.NoError(t, err)
 	require.Equal(t, string(me), string(me.UnsafeString()))
+}
+
+func TestPrincipalPeerID(t *testing.T) {
+	keyPair, err := GenerateKeyPair(Ed25519, rand.Reader)
+	require.NoError(t, err)
+
+	got, err := keyPair.Principal().PeerID()
+	require.NoError(t, err)
+	require.Equal(t, keyPair.PeerID(), got)
+}
+
+func TestPrincipalPeerIDRejectsUnsupportedECDSA(t *testing.T) {
+	keyPair, err := GenerateKeyPair(ECDSA, rand.Reader)
+	require.NoError(t, err)
+
+	_, err = keyPair.Principal().PeerID()
+	require.Error(t, err)
+}
+
+func TestPrincipalPeerIDRejectsInvalidPrincipal(t *testing.T) {
+	_, err := Principal("not a principal").PeerID()
+	require.Error(t, err)
 }


### PR DESCRIPTION
## What was broken

`core.Principal` is Seed's compact, serialized representation of a public key. Code that has only stored or network-provided principal bytes needs `Principal.PeerID()` to recover the libp2p peer ID used to address that device on the P2P network.

The method successfully decoded a valid principal and then executed `panic("TODO")`. In real-world terms, asking Seed to turn a valid device identity into the network address for that device could terminate the entire daemon/process instead of returning a peer ID or an error. This is especially dangerous because malformed input already returned an error normally—the crash happened specifically for valid input that reached the unfinished branch.

The concrete consumer this API was designed for is device discovery from account delegations: the P2P invoice code reads a delegate principal from storage, derives its peer ID, and then opens a network client to that device. That invoice implementation is currently commented out, so I did **not** find an active production call site that triggers the panic today. This PR removes the latent process-crash before that path, or another caller of this exported method, is enabled.

The unfinished method arrived with the new `Principal` representation in #1003. This PR is intentionally narrow: it completes that method rather than changing principal storage or peer addressing.

## How the fix works

After `DecodePublicKey` validates and parses the principal, the method now:

1. converts Seed's `PublicKey` wrapper to its libp2p public-key representation;
2. asks libp2p to derive the canonical `peer.ID`;
3. returns libp2p's error instead of crashing when conversion is unsupported or invalid.

For Seed's normal Ed25519 device keys, the derived ID is tested against `KeyPair.PeerID()` to prove both routes produce exactly the same network identity.

Seed's generated ECDSA keys currently use P-224 data while the principal codec/decoder expects a 33-byte P-256 key. That combination cannot be decoded into a libp2p peer identity. The test therefore documents the actual behavior—an error, not a panic—rather than pretending ECDSA conversion succeeds.

## Behavior before and after

| Input | Before | After |
| --- | --- | --- |
| Valid Ed25519 device principal | process panic (`TODO`) | canonical libp2p peer ID |
| Unsupported ECDSA principal | decode/conversion error | decode/conversion error |
| Malformed principal bytes | decode error | decode error |

## Validation

- `go test ./backend/core -count=1`
- focused `TestPrincipalPeerID*` coverage
- `gofmt` check for both touched files
- `git diff --check`

## Agent session

The investigation, initial failed ECDSA assumption, correction, validation, and PR delivery are recorded in [the originating Ion session](https://seed.hyper.media/hm/agents/session/5087ba60-e98d-427d-af6b-cd42b40b93cf?server=https%3A%2F%2Fagentic.seed.hyper.media&agent=0d941d24-aca1-4eb9-990c-0a41097e9667).
