### PR TITLE
Full provenance in tool, workflow, and message info dialogs

### DIFF
--- a/agents/protocol/src/index.ts
+++ b/agents/protocol/src/index.ts
@@ -1343,7 +1343,18 @@ export type SessionEventPayload =
       /** Origin metadata for user messages, or model/provider/usage/timing for assistant messages. */
       meta?: SessionEventMeta
     }
-  | {type: 'tool_call'; id: string; name: string; input: unknown; actor?: SessionActor}
+  | {
+      type: 'tool_call'
+      id: string
+      name: string
+      input: unknown
+      actor?: SessionActor
+      /**
+       * Model/provider of the turn that issued this call, and that turn's token usage. Stamped at
+       * append time; absent on legacy events and on calls appended outside a model turn.
+       */
+      meta?: SessionEventMeta
+    }
   | {
       /**
        * A `delegate` call spawned its child. Appended the moment the child exists — before it has
@@ -1368,7 +1379,11 @@ export type SessionEventPayload =
       output?: unknown
       error?: string
       actor?: SessionActor
-      /** How long the tool took. Absent on legacy events and on results appended by a child's finalizer. */
+      /**
+       * How long the tool took, plus the issuing turn's model/provider/usage. On results appended
+       * by a child's finalizer (sub-sessions, workflows) the duration spans the whole delegation
+       * and the usage is the child run's own total. Absent on legacy events.
+       */
       meta?: SessionEventMeta
     }
   | {type: 'error'; message: string; actor?: SessionActor}

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -5083,12 +5083,19 @@ export class Service {
     // Append the durable result at most once, but ALWAYS resolve the wait: a crash (or double
     // resolution) can leave the tool_result written while the parent still parks on the call.
     const alreadyAnswered = this.#sessionHasToolResult(parent.sessionId, parentToolCallId)
+    const childMeta = delegationMeta(child)
     if (!alreadyAnswered) {
       this.#appendSessionEvent(
         child.accountId,
         parent.agentId ?? '',
         parent.sessionId,
-        {type: 'tool_result', toolCallId: parentToolCallId, name: toolName, output: result},
+        {
+          type: 'tool_result',
+          toolCallId: parentToolCallId,
+          name: toolName,
+          output: result,
+          ...(childMeta ? {meta: childMeta} : {}),
+        },
         Date.now(),
       )
     } else if (child.status === 'succeeded' && child.sessionId) {
@@ -6180,6 +6187,16 @@ export class Service {
       ...(turnUsageForMeta ? {usage: {...turnUsageForMeta}} : {}),
       durationMs: Math.max(0, Date.now() - turnStartedAt),
     })
+    // Provenance for tool events: which model/provider issued the call and what its turn cost.
+    // No duration here — the tool's own span is stamped on the result once it is known.
+    const toolTurnMeta = (): api.SessionEventMeta | undefined => {
+      const meta: api.SessionEventMeta = {
+        ...(definition.model ? {model: definition.model} : {}),
+        ...(model.provider ? {provider: model.provider} : {}),
+        ...(turnUsageForMeta ? {usage: {...turnUsageForMeta}} : {}),
+      }
+      return Object.keys(meta).length ? meta : undefined
+    }
 
     const appendAssistantMessage = (content: string): void => {
       if (!content.trim()) return
@@ -6294,11 +6311,18 @@ export class Service {
           },
         })
         appendedToolCalls.add(event.toolCallId)
+        const callMeta = toolTurnMeta()
         this.#appendSessionEvent(
           accountId,
           session.agentId,
           sessionId,
-          {type: 'tool_call', id: event.toolCallId, name: event.toolName, input: event.args},
+          {
+            type: 'tool_call',
+            id: event.toolCallId,
+            name: event.toolName,
+            input: event.args,
+            ...(callMeta ? {meta: callMeta} : {}),
+          },
           Date.now(),
         )
         return
@@ -6325,14 +6349,24 @@ export class Service {
             accountId,
             session.agentId,
             sessionId,
-            {type: 'tool_call', id: event.toolCallId, name: event.toolName, input: {}},
+            {
+              type: 'tool_call',
+              id: event.toolCallId,
+              name: event.toolName,
+              input: {},
+              ...(toolTurnMeta() ? {meta: toolTurnMeta()} : {}),
+            },
             Date.now(),
           )
         }
         // How long the tool actually ran, stamped while the start time is still in hand: the pair of
-        // event timestamps is a decent guess, but only the executor knows the real span.
-        const toolMeta: api.SessionEventMeta | undefined =
-          startedAt === undefined ? undefined : {durationMs: Math.max(0, Date.now() - startedAt)}
+        // event timestamps is a decent guess, but only the executor knows the real span. The issuing
+        // turn's model/provider/usage ride along so the result explains itself on its own.
+        const resultMeta: api.SessionEventMeta = {
+          ...toolTurnMeta(),
+          ...(startedAt === undefined ? {} : {durationMs: Math.max(0, Date.now() - startedAt)}),
+        }
+        const toolMeta: api.SessionEventMeta | undefined = Object.keys(resultMeta).length ? resultMeta : undefined
         this.#appendSessionEvent(
           accountId,
           session.agentId,
@@ -12654,6 +12688,30 @@ function normalizeOptionalNumber(value: unknown, label: string): number | undefi
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * What a finished delegation can say about itself on the parent's tool_result: how long the whole
+ * child run took (spawn to finish — the span the parent actually waited), which model it ran, and
+ * the tokens it spent, descendants included. Absent when the run recorded none of it.
+ */
+function delegationMeta(child: runs.RunRecord): api.SessionEventMeta | undefined {
+  const meta: api.SessionEventMeta = {}
+  if (child.model) meta.model = child.model
+  const endedAt = child.finishedAt ?? Date.now()
+  if (endedAt >= child.createdAt) meta.durationMs = endedAt - child.createdAt
+  if (child.usage) {
+    const kids = child.usage.children
+    const usage = {
+      input: child.usage.input + (kids?.input ?? 0),
+      output: child.usage.output + (kids?.output ?? 0),
+      cacheRead: child.usage.cacheRead + (kids?.cacheRead ?? 0),
+      cacheWrite: child.usage.cacheWrite + (kids?.cacheWrite ?? 0),
+      total: child.usage.total + (kids?.total ?? 0),
+    }
+    if (usage.total > 0) meta.usage = usage
+  }
+  return Object.keys(meta).length ? meta : undefined
 }
 
 function piAssistantText(message: {content?: unknown} | undefined): string {

--- a/frontend/apps/desktop/src/__tests__/agent-session-rows.test.ts
+++ b/frontend/apps/desktop/src/__tests__/agent-session-rows.test.ts
@@ -709,6 +709,36 @@ describe('symmetric log actors', () => {
     expect(metas[1]).toMatchObject({meta: {durationMs: 8_000, model: 'gpt-5-mini'}})
   })
 
+  it('merges the call stamp (model/provider/usage) with the result stamp (duration) into one tool meta', () => {
+    const usage = {input: 1200, output: 40, cacheRead: 0, cacheWrite: 0, total: 1240}
+    const rows = buildAgentSessionChatRows(
+      [
+        event(1, {
+          type: 'tool_call',
+          id: 'c1',
+          name: 'read',
+          input: {address: '~/memory/x'},
+          meta: {model: 'gpt-5-mini', provider: 'openai', usage},
+        }),
+        event(3, {
+          type: 'tool_result',
+          toolCallId: 'c1',
+          name: 'read',
+          output: {summary: 'Read.'},
+          meta: {durationMs: 950},
+        }),
+      ],
+      CONTEXT,
+    )
+    const row = rows[0]!
+    if (row.kind !== 'message') throw new Error('expected a message row')
+    const part = row.message.parts?.[0] as {meta?: unknown; calledAt?: number; completedAt?: number}
+    expect(part.meta).toEqual({model: 'gpt-5-mini', provider: 'openai', usage, durationMs: 950})
+    // The absolute times bound the execution: the info dialog shows both, not just the span.
+    expect(part.calledAt).toBe(row.createdAt)
+    expect(part.completedAt).toBe(part.calledAt! + 2)
+  })
+
   it('leaves a tool row with nothing to say carrying no stat block at all', () => {
     const rows = buildAgentSessionChatRows(
       [event(1, {type: 'tool_result', toolCallId: 'orphan', name: 'read', output: {summary: 'Read.'}})],

--- a/frontend/apps/desktop/src/__tests__/event-meta.test.ts
+++ b/frontend/apps/desktop/src/__tests__/event-meta.test.ts
@@ -1,0 +1,22 @@
+import {describe, expect, it} from 'vitest'
+import {eventMetaRows, formatEventTime} from '@shm/ui/agents/event-meta'
+
+describe('eventMetaRows', () => {
+  it('renders absolute times alongside the stamped stats, in reading order', () => {
+    const rows = eventMetaRows(
+      {model: 'gpt-5-mini', provider: 'openai', durationMs: 950},
+      {startedAt: 1_700_000_000_000, completedAt: 1_700_000_000_950},
+    )
+    expect(rows.map((row) => row.label)).toEqual(['Model', 'Provider', 'Started', 'Finished', 'Duration'])
+    expect(rows.find((row) => row.label === 'Started')?.value).toBe(formatEventTime(1_700_000_000_000))
+  })
+
+  it('shows a message send time even when the event carries no stamp at all', () => {
+    const rows = eventMetaRows(undefined, {sentAt: 1_700_000_000_000})
+    expect(rows).toEqual([{label: 'Time', value: formatEventTime(1_700_000_000_000)}])
+  })
+
+  it('still renders nothing when neither stamp nor times exist', () => {
+    expect(eventMetaRows(undefined, undefined)).toEqual([])
+  })
+})

--- a/frontend/apps/desktop/src/pages/agents/__tests__/run-work.test.tsx
+++ b/frontend/apps/desktop/src/pages/agents/__tests__/run-work.test.tsx
@@ -164,8 +164,12 @@ describe('journalToolParts', () => {
       name: 'web_search',
       summaryOverride: 'Checking the latest Bun release',
       rawOutput: {ok: 1},
+      // The journal's own timestamps bound the call, so the info dialog can show when and how long.
+      calledAt: 1,
+      completedAt: 2,
+      meta: {durationMs: 1},
     })
-    expect(parts[1]).toMatchObject({name: 'write', isError: true, result: 'disk full'})
+    expect(parts[1]).toMatchObject({name: 'write', isError: true, result: 'disk full', calledAt: 3, completedAt: 4})
   })
 })
 

--- a/frontend/packages/ui/src/agents/agent-session-rows.ts
+++ b/frontend/packages/ui/src/agents/agent-session-rows.ts
@@ -349,17 +349,20 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 /**
  * A tool row's provenance, preferring what the runtime stamped and filling only the gap it left.
+ * The call event carries the issuing turn's model/provider/usage, the result event the execution
+ * span — one row needs both, with the result's word winning wherever they overlap.
  *
  * Returns nothing at all when nothing is known, so the info dialog can tell "no stats" from "stats
  * that are all blank" — a legacy row with no timings must render no section, not empty labels.
  */
 function resolveToolMeta(
-  stamped: SessionEventMeta | undefined,
+  callStamped: SessionEventMeta | undefined,
+  resultStamped: SessionEventMeta | undefined,
   derivedDurationMs: number | undefined,
 ): SessionEventMeta | undefined {
-  const durationMs = stamped?.durationMs ?? derivedDurationMs
-  if (!stamped && durationMs === undefined) return undefined
-  return {...stamped, ...(durationMs === undefined ? {} : {durationMs})}
+  const durationMs = resultStamped?.durationMs ?? callStamped?.durationMs ?? derivedDurationMs
+  if (!callStamped && !resultStamped && durationMs === undefined) return undefined
+  return {...callStamped, ...resultStamped, ...(durationMs === undefined ? {} : {durationMs})}
 }
 
 /** Converts durable session events into chat rows, pairing tool calls with their results. */
@@ -421,6 +424,7 @@ export function buildAgentSessionChatRows(
           // without the actor the transcript would show it as something the user typed.
           actor: sessionEventActor(event.event),
           meta: payload.meta,
+          createdAt: event.createdAt,
           content: displayContent,
           rawMarkdown: typeof payload.rawMarkdown === 'string' ? payload.rawMarkdown : payload.content,
           blocks: Array.isArray(payload.blocks) ? payload.blocks : undefined,
@@ -447,6 +451,8 @@ export function buildAgentSessionChatRows(
         name: payload.name,
         args: isRecord(payload.input) ? payload.input : {input: payload.input},
         actor: sessionEventActor(event.event),
+        calledAt: event.createdAt,
+        ...(payload.meta ? {meta: payload.meta} : {}),
       }
       const row: Extract<AgentSessionChatRow, {kind: 'message'}> = {
         key: event.id,
@@ -521,7 +527,8 @@ export function buildAgentSessionChatRows(
       // between the call and its result on the log — the same wall time, measured from outside.
       const derivedDurationMs =
         existingRow?.createdAt !== undefined ? Math.max(0, event.createdAt - existingRow.createdAt) : undefined
-      const meta = resolveToolMeta(payload.meta, derivedDurationMs)
+      const callStampedMeta = (existingRow?.message.parts?.[0] as ChatToolPart | undefined)?.meta
+      const meta = resolveToolMeta(callStampedMeta, payload.meta, derivedDurationMs)
       const resultPart: ChatToolPart = {
         type: 'tool',
         id: payload.toolCallId,

--- a/frontend/packages/ui/src/agents/chat-parts.ts
+++ b/frontend/packages/ui/src/agents/chat-parts.ts
@@ -46,6 +46,8 @@ export type ChatToolPart = {
    * into the child's work for its whole life, not only once its result has come back.
    */
   child?: ChatToolChild
+  /** Durable timestamp of the call event — when the tool was invoked. */
+  calledAt?: number
   /** Durable timestamp of the result event; the row itself stays positioned at the call event. */
   completedAt?: number
   /** The result was an error (validation failure, tool crash) — `result` holds the message. */
@@ -100,6 +102,8 @@ export type ChatBubbleMessage = {
   actor?: SessionActor
   /** User origin or model/provider/usage/timing, as the writer stamped it. */
   meta?: SessionEventMeta
+  /** Durable timestamp of the message event — when it was appended to the log. */
+  createdAt?: number
 }
 
 /** Appends streamed text while coalescing adjacent text fragments into one part. */

--- a/frontend/packages/ui/src/agents/event-meta.ts
+++ b/frontend/packages/ui/src/agents/event-meta.ts
@@ -31,6 +31,36 @@ export function formatTokenCount(tokens: number): string {
   return Math.round(tokens).toLocaleString('en-US')
 }
 
+/**
+ * An absolute event timestamp, second-precise, in the reader's locale and timezone. The date is
+ * always included: info dialogs get opened on transcripts hours or days old, where a bare clock
+ * time quietly misleads.
+ */
+export function formatEventTime(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return ''
+  return new Date(ms).toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+  })
+}
+
+/**
+ * When the event happened, as the dialogs label it: one instant for a message, start/finish for a
+ * tool call whose two durable events bound its execution.
+ */
+export type EventTimes = {
+  /** When a message was appended to the log. */
+  sentAt?: number
+  /** When a tool call was issued. */
+  startedAt?: number
+  /** When its result landed. */
+  completedAt?: number
+}
+
 /** Sum of the categories when the stamp did not carry its own total. */
 function usageTotal(usage: AgentRunUsage): number {
   if (typeof usage.total === 'number' && usage.total > 0) return usage.total
@@ -41,17 +71,29 @@ function usageTotal(usage: AgentRunUsage): number {
  * The rows an info dialog shows for one event: model, provider, timing, and the turn's token
  * breakdown. Empty when nothing is known — which is the signal to render no stats section at all.
  */
-export function eventMetaRows(meta: SessionEventMeta | undefined): EventMetaRow[] {
-  if (!meta) return []
+export function eventMetaRows(meta: SessionEventMeta | undefined, times?: EventTimes): EventMetaRow[] {
+  if (!meta && !times) return []
   const rows: EventMetaRow[] = []
-  if (meta.accountId) rows.push({label: 'Originator', value: meta.accountId})
-  if (meta.signerId) rows.push({label: 'Signer', value: meta.signerId})
-  if (meta.model) rows.push({label: 'Model', value: meta.model})
-  if (meta.provider) rows.push({label: 'Provider', value: meta.provider})
-  if (typeof meta.durationMs === 'number' && meta.durationMs >= 0) {
+  if (meta?.accountId) rows.push({label: 'Originator', value: meta.accountId})
+  if (meta?.signerId) rows.push({label: 'Signer', value: meta.signerId})
+  if (meta?.model) rows.push({label: 'Model', value: meta.model})
+  if (meta?.provider) rows.push({label: 'Provider', value: meta.provider})
+  if (times?.sentAt) {
+    const value = formatEventTime(times.sentAt)
+    if (value) rows.push({label: 'Time', value})
+  }
+  if (times?.startedAt) {
+    const value = formatEventTime(times.startedAt)
+    if (value) rows.push({label: 'Started', value})
+  }
+  if (times?.completedAt) {
+    const value = formatEventTime(times.completedAt)
+    if (value) rows.push({label: 'Finished', value})
+  }
+  if (typeof meta?.durationMs === 'number' && meta.durationMs >= 0) {
     rows.push({label: 'Duration', value: formatEventDuration(meta.durationMs)})
   }
-  const usage = meta.usage
+  const usage = meta?.usage
   if (usage) {
     const total = usageTotal(usage)
     if (total > 0) rows.push({label: 'Tokens', value: `${formatTokenCount(total)} tokens`})

--- a/frontend/packages/ui/src/agents/message-rendering.tsx
+++ b/frontend/packages/ui/src/agents/message-rendering.tsx
@@ -1,5 +1,5 @@
 import {type AgentRunActivity, type RunInfo, type SessionEventMeta} from './client'
-import {eventMetaRows} from './event-meta'
+import {eventMetaRows, type EventTimes} from './event-meta'
 import {
   buildLegacyChatMessageParts,
   type ChatBubbleMessage,
@@ -154,7 +154,7 @@ export const ChatMessageBubble = React.memo(function ChatMessageBubble({
                 <span className="bg-muted rounded px-2 py-1">Seq: {message.seq}</span>
               ) : null}
             </div>
-            <EventMetaSection meta={message.meta} />
+            <EventMetaSection meta={message.meta} times={message.createdAt ? {sentAt: message.createdAt} : undefined} />
             <pre className="bg-muted max-h-[50vh] overflow-auto rounded-md p-3 text-xs whitespace-pre-wrap">
               {rawMarkdown}
             </pre>
@@ -207,8 +207,8 @@ function SystemMessageRow({content, rawMarkdownButton}: {content: string; rawMar
  * Renders nothing when the event predates the stamp — an older transcript's dialog is smaller, not
  * broken, and a labelled row with nothing behind it would be worse than no row.
  */
-function EventMetaSection({meta}: {meta?: SessionEventMeta}) {
-  const rows = eventMetaRows(meta)
+function EventMetaSection({meta, times}: {meta?: SessionEventMeta; times?: EventTimes}) {
+  const rows = eventMetaRows(meta, times)
   if (!rows.length) return null
   return (
     <div className="flex flex-col gap-1.5">
@@ -644,7 +644,12 @@ function ToolCallDebugDialog({
           <DialogDescription>Raw tool call payload captured during the assistant response.</DialogDescription>
         </DialogHeader>
         <div className="grid min-h-0 gap-3">
-          <EventMetaSection meta={item.meta} />
+          <EventMetaSection
+            meta={item.meta}
+            times={
+              item.calledAt || item.completedAt ? {startedAt: item.calledAt, completedAt: item.completedAt} : undefined
+            }
+          />
           {typeof item.args?.script === 'string' && item.args.script ? (
             <div className="min-h-0 space-y-1">
               <div className="text-muted-foreground text-[10px] font-medium tracking-[0.18em] uppercase">Script</div>

--- a/frontend/packages/ui/src/agents/run-work.tsx
+++ b/frontend/packages/ui/src/agents/run-work.tsx
@@ -152,7 +152,16 @@ export function descendantsOf(runsById: Record<string, RunInfo>, focusRunId: str
  * row the chat renders, saying what the work WAS, with the tool name as the secondary fact.
  */
 export function journalToolParts(journal: RunJournalEntryInfo[]): ChatToolPart[] {
-  const resultsBySeq = new Map<string, {status?: string; output?: unknown; error?: {code?: string; message?: string}}>()
+  const resultsBySeq = new Map<
+    string,
+    {
+      status?: string
+      output?: unknown
+      error?: {code?: string; message?: string}
+      /** When the result was journaled — with the call's own timestamp it bounds the execution. */
+      createdAt: number
+    }
+  >()
   for (const entry of journal) {
     const payload = entry.entry as {
       kind?: string
@@ -162,7 +171,7 @@ export function journalToolParts(journal: RunJournalEntryInfo[]): ChatToolPart[]
       error?: {code?: string; message?: string}
     }
     if (payload.kind === 'result' && payload.callSeq !== undefined) {
-      resultsBySeq.set(`${entry.runId}:${payload.callSeq}`, payload)
+      resultsBySeq.set(`${entry.runId}:${payload.callSeq}`, {...payload, createdAt: entry.createdAt})
     }
   }
   const parts: ChatToolPart[] = []
@@ -188,10 +197,15 @@ export function journalToolParts(journal: RunJournalEntryInfo[]): ChatToolPart[]
         unknown
       >,
       ...(payload.description ? {summaryOverride: payload.description} : {}),
+      calledAt: entry.createdAt,
       ...(result
-        ? failed
-          ? {isError: true, result: result.error?.message ?? 'failed'}
-          : {rawOutput: result.output, result: safeStringify(result.output)}
+        ? {
+            completedAt: result.createdAt,
+            meta: {durationMs: Math.max(0, result.createdAt - entry.createdAt)},
+            ...(failed
+              ? {isError: true, result: result.error?.message ?? 'failed'}
+              : {rawOutput: result.output, result: safeStringify(result.output)}),
+          }
         : {}),
     })
   }


### PR DESCRIPTION
## What

Clicking the info bubble on a tool call previously showed only the model-generated input — no tokens, no provider, no timing. Now every info dialog (tool, workflow step, message) shows model, provider, token usage, absolute started/finished times, and duration.

## How

**Server** (`agents/`):
- `tool_call` events gain an optional `meta` stamp (protocol change): the issuing turn's model/provider/usage, written at `tool_execution_start`.
- `tool_result` events keep their measured `durationMs` and now repeat the turn stamp so either event alone is sufficient.
- Delegation results (sub-sessions **and** workflow children) — previously stamped with nothing — now carry the child run's model, spawn-to-finish duration, and token usage rolled up across descendants.

**UI** (`frontend/`):
- Tool rows merge the call and result stamps (result wins per field) and carry durable `calledAt`/`completedAt` timestamps.
- The shared meta table (`event-meta.ts`) gains Time/Started/Finished rows between Provider and Duration, formatted as absolute local times.
- Workflow journal rows derive start/finish/duration from their own journal timestamps.
- Message dialogs show the absolute send time.

Timestamp rows come from the durable log, so they appear on **existing transcripts** immediately; legacy tool rows still get a duration derived from call→result event distance. Model/provider/tokens on tool rows appear for activity written after deploy.

## Testing

- `agents`: 363 pass.
- Desktop vitest: 762 pass; the one failure (`agents-live-titling.integration.test.tsx`) fails identically on origin/main in this environment.
- UI package typecheck clean.
- New tests: meta merge in `agent-session-rows.test.ts`, journal timing in `run-work.test.tsx`, time rows in `event-meta.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P571wF9NS8bAV1xeskrsVa