### PR TITLE
Host-side exec watchdog, leveled logging, and the perf squeeze plan

### DIFF
--- a/agents/docs/multi-server-architecture.md
+++ b/agents/docs/multi-server-architecture.md
@@ -1,0 +1,67 @@
+# Multi-Server Architecture
+
+How the agents service grows past one box, in three phases that can each stop and hold. Written against the 2026-08-29
+production baseline: one 4-vCPU host running `agents-stable`/`-staging`/`-dev`, Caddy, SearXNG, and Crawl4AI, saturated
+by a single heavy dev agent (see [perf-squeeze-plan.md](perf-squeeze-plan.md)).
+
+## Why this shape
+
+The service has a lucky property: **all durable state is per-account** (SQLite rows and a state directory, both keyed by
+account). Nothing global needs a shared database, so scaling is sharding-by-account plus stateless helpers — never a
+distributed-consensus problem. The expensive, bursty work (sandbox microVMs, headless Chromium) is also cleanly
+separable from the latency-sensitive work (signed API, WebSocket streaming, trigger polling).
+
+## Phase 1 — one box, contained (now)
+
+Compose CPU limits per container; Crawl4AI moved to its own small node the day memory gets tight. No architecture
+change. Holds as long as total sandbox demand fits ~2–3 dedicated vCPUs.
+
+## Phase 2 — split execution from the control plane
+
+Add an **exec host**: a cheap dedicated-vCPU KVM machine running a thin daemon that exposes the existing `CodeExecutor`
+contract (`execute(request) → result` plus availability) over HTTP with a bearer token on the internal network.
+`SEED_AGENTS_EXEC_BACKEND=remote` + a URL selects it; the microsandbox embedding, watchdog, and (planned) long-lived VM
+pool all live behind the same interface, so agents code does not change.
+
+- The control plane goes back to being small and steady: API, WS streaming, polling, SQLite.
+- Exec capacity scales by adding exec hosts; the control plane round-robins agents across them with sticky assignment
+  per agent (so the long-lived VM pool stays warm).
+- The agent's memory workspace must reach the exec host: sync directory snapshots on demand (rsync-style,
+  content-addressed) rather than a network filesystem — executions are bursty and localized, and the workspace is
+  already the durable copy.
+
+This is the phase that lets ion "ramp up" without touching anyone's chat latency. One exec host ≈ one more ion running
+flat out.
+
+## Phase 3 — shard the control plane by account
+
+When one control plane saturates (thousands of accounts / heavy WS fan-out): run N agents servers, each owning a subset
+of accounts with its own SQLite + data dir. A routing layer (Caddy `map` on account id, or a 20-line router service)
+sends signed envelopes and WS subscriptions to the owning shard. Moving an account = copy its rows + state dir, flip the
+route. No shared state, no cross-shard traffic; triggers and runs already scope to accounts.
+
+## Scaling & cost model (Hetzner-style pricing, 2026)
+
+| Role          | Machine                      | ~€/mo | Capacity                                     |
+| ------------- | ---------------------------- | ----- | -------------------------------------------- |
+| Control plane | 4 shared vCPU / 8 GB (CPX31) | ~16   | thousands of accounts; light, steady CPU     |
+| Exec host     | 4 dedi vCPU / 16 GB (CCX23)  | ~25   | 3–4 concurrent heavy sandboxes (1 vCPU each) |
+| Crawl node    | 2 vCPU / 8 GB                | ~8    | SearXNG + Crawl4AI                           |
+
+Rules of thumb:
+
+- **Cost scales with concurrent sandbox vCPUs, not with accounts** — roughly **€6–8/month per always-on concurrent
+  sandbox vCPU**. An idle agent costs pennies (rows in SQLite); a compiling agent costs a vCPU.
+- Provider tokens dwarf infrastructure at every phase: one ion-class agent at ~220 requests/hour spends more on tokens
+  per day than an exec host costs per month. Infra should therefore never be the reason to throttle an agent that model
+  budget wants running.
+- Phase 2 with one exec host ≈ **€50/mo total** and supports today's load with an ion running continuously; each further
+  ion-equivalent adds ~€25/mo. Phase 3 adds ~€16/mo per control-plane shard, needed only at large account counts.
+
+## What we deliberately avoid
+
+- Shared/networked SQLite, or a migration to Postgres "for scale" — per-account sharding makes it unnecessary until far
+  beyond current horizons.
+- Kubernetes — three roles × compose × Terraform stays legible; revisit only if exec hosts are autoscaled.
+- Scheduling sandboxes on the control plane "because there is spare CPU" — that spare CPU is the latency budget for
+  everyone's triggers and streams; Phase 2 exists to protect it.

--- a/agents/docs/operations.md
+++ b/agents/docs/operations.md
@@ -157,6 +157,7 @@ Config source: `agents/src/config.ts`.
 | `SEED_AGENTS_EXEC_TIMEOUT_SECS`         | `60`                   | Default per-execution timeout (tool may request up to 300s).                                       |
 | `SEED_AGENTS_EXEC_ALLOW_NETWORK`        | `true`                 | Sandbox internet access. Set `false`/`off`/`0` to isolate sandboxes.                               |
 | `SEED_AGENTS_EXEC_DNS`                  | `1.1.1.1,8.8.8.8`      | Comma-separated DNS resolvers used inside execution sandboxes.                                     |
+| `SEED_AGENTS_LOG_LEVEL`                 | `info`                 | Minimum log level (`debug`, `info`, `warn`, `error`). `debug` re-enables hot-path lines.           |
 
 CLI flags override env/defaults:
 
@@ -496,7 +497,15 @@ not browser origin.
 ## Diagnostics and logs
 
 Current logs intentionally include IDs, counts, statuses, sizes, timings, trigger sources, and compact activity metadata
-— not secrets or full message/session content. Activity trigger diagnostics use:
+— not secrets or full message/session content.
+
+Logging is leveled (`agents/src/log.ts`, `SEED_AGENTS_LOG_LEVEL` / `--log-level`, default `info`). The per-event hot
+paths — every WebSocket partial (`publish partial`, `send partial`, `skip partial`) and every no-op activity poll
+(`Polling feed`, `Feed page received`, `Processing feed events` with nothing new) — log at `debug` and are silent by
+default: measured in production, they were ~90% of ~440k lines/hour. Set the level to `debug` when tracing streaming or
+trigger delivery.
+
+Activity trigger diagnostics use:
 
 - `[Agents Activity] Polling feed`
 - `[Agents Activity] Feed page received`

--- a/agents/docs/perf-squeeze-plan.md
+++ b/agents/docs/perf-squeeze-plan.md
@@ -1,0 +1,97 @@
+# Performance Squeeze Plan
+
+Goal: let heavy autonomous agents (ion-class dev agents) **ramp up** on the current hardware by removing the bottlenecks
+a production investigation (2026-08-29) actually measured, in order of impact. The companion doc
+[multi-server-architecture.md](multi-server-architecture.md) covers what to do when squeezing is no longer enough.
+
+## What production showed
+
+One 4-vCPU host runs all three agents containers plus Caddy, SearXNG, and Crawl4AI. A single dev agent (openai-codex,
+~10 concurrent sub-sessions) produced:
+
+- **Sustained 104–145% CPU** on `agents-stable` for 33 hours: ~190 sandbox executions/hour, each a fresh 1-vCPU microVM
+  running greps, edits, test runs, and TypeScript compiles against a repo checkout in `/workspace`.
+- **Timeouts not enforced**: a `timeout_secs: 60` compile ran 153s; successive VMs lived 3–5 minutes at ~110% CPU.
+  (Fixed: host-side watchdog in `code-exec.ts`.)
+- **~91 GB network egress in 33h** (bursts of 1.6 MB/s): session context re-sent to the provider on each of ~220
+  requests/hour across fat dev sessions.
+- **~440k log lines/hour**, ~90% per-delta WS lines and no-op poll lines. (Fixed: leveled logging, hot paths at
+  `debug`.)
+- **Knock-on starvation**: activity poll cycles blowing their 60s budget (`poll tick failed … timed out`), so mention
+  triggers for every other account were delayed or skipped — the "server is slow" everyone feels.
+
+## Workstreams
+
+### 1. Execution timeouts — DONE
+
+Host-side watchdog (`EXEC_TIMEOUT_GRACE_MS`) races every execution; a guest that outlives its SDK timeout is killed ~5s
+past the deadline and the model gets the collected output plus a clear note. Teardown is bounded (stop gets 5s, then
+hard kill) so a wedged VM can never hang a tool call.
+
+### 2. Log volume — DONE
+
+`SEED_AGENTS_LOG_LEVEL` (default `info`); per-partial WS lines and no-op poll lines moved to `debug`. Expected: ~440k
+lines/hour → a few thousand.
+
+**Follow-up (planned): per-agent log files.** Route run/session diagnostics to `data/agents/<agentId>/logs/<date>.log`
+(size-capped, rotated), keeping the process stdout for service-level lines only. This makes one noisy agent greppable in
+isolation and keeps `docker logs` readable. Cheap to add in the leveled logger now that all hot sites route through it.
+
+### 3. Session-scoped long-lived sandboxes — the big CPU lever (PLANNED)
+
+Today every `execute` boots a **fresh ephemeral microVM**: no warm page cache, no installed packages, no incremental
+compiler state. For a dev agent this is the dominant waste — every `bun tsgo --noEmit` is a cold compile of the whole
+repo (150s+), where a warm incremental check is seconds. The fix is to reuse the VM:
+
+- **Pool keyed by `(accountId, agentId)`** — never shared across accounts. An `execute` call checks the pool; hit → run
+  in the live VM, miss → boot one and park it after.
+- **Idle TTL** (~10 min) and **pool caps**: max N live VMs host-wide (start: 3 on the current box), max 1 per agent, LRU
+  eviction. Evicting is always safe: `/workspace` is a bind mount, so durable state survives; only guest RAM (installed
+  system packages, running daemons) is lost, which is today's behavior on every call.
+- **Per-call watchdog unchanged**: the workstream-1 deadline applies per execution; a timed-out command is killed inside
+  the VM (or the VM recycled if the guest is wedged) without discarding the warm pool entry unless the VM itself is
+  unhealthy.
+- **Semantics change, documented in the tool prompt**: processes and installed packages MAY survive between calls on a
+  best-effort basis (the `pip install --target /workspace/pylibs` advice stays, since eviction can happen any time).
+  Background processes are the new risk: a lingering `bun test --watch` pins the VM's vCPU. Mitigation: kill the process
+  group after each call by default; an explicit `keep_running` opt-in can come later if agents need servers.
+- **CPU fairness**: VMs stay at 1 vCPU. The host-wide live-VM cap is what bounds total sandbox CPU; make it configurable
+  (`SEED_AGENTS_EXEC_MAX_VMS`) so a bigger exec host can raise it.
+
+Expected effect: ion-style loops (edit → typecheck → test) go from ~1 cold vCPU-minute per step to seconds, which is
+simultaneously **faster ramp-up for the agent and less load on the host**.
+
+### 4. Network egress / provider traffic (PLANNED)
+
+The 91 GB is request bodies: every model turn re-uploads the whole session. Levers, best first:
+
+1. **Server-side conversation state** — the openai-codex provider speaks the Responses API, which supports
+   `store: true` + `previous_response_id`: send only the new turn, the provider keeps the context. This collapses
+   per-turn upload from O(session) to O(delta) — the single biggest egress and serialization win. Needs Pi SDK support
+   verification per provider; fall back where unsupported.
+2. **Context compaction** — dev sessions accumulate 64 KB tool results that stop mattering after a few turns. Summarize
+   or elide tool results older than N turns (keep the model-visible note that they were elided). Cuts upload bytes AND
+   the JSON serialization burning the event loop during streaming.
+3. **Sub-session hygiene** — the runtime already offers delegation with fresh contexts; tool prompts should keep nudging
+   long-running work into children instead of one ever-growing transcript.
+
+Note: egress bandwidth itself is nearly free on the VPS; the real costs are event-loop serialization time, TLS CPU, and
+provider latency per turn. That is why compaction matters even if bytes were free.
+
+### 5. Host containment quick wins (ops, SeedInfra)
+
+- `cpus: 2.5` on `agents-stable` (and `1` on staging/dev) in the compose template in `seed_infra/agentic/main.tf`, so
+  one tenant cannot starve trigger polling for every account. Watchtower, SearXNG, and Crawl4AI already idle near zero;
+  Crawl4AI's Chromium is the first thing to move off-host if memory gets tight (it holds ~0.5 GB resident).
+- A modest host upgrade (4 → 8 vCPU) roughly doubles the safe live-VM cap in workstream 3; worth taking, but the
+  cold-compile fix dwarfs it.
+
+## Sequencing
+
+1. ~~Watchdog~~, ~~log levels~~ (this branch) → deploy, confirm poll-cycle overruns stop.
+2. Compose CPU limits (SeedInfra PR) — 30 minutes of work, immediate protection.
+3. Long-lived sandbox pool — the ramp-up enabler; design above, ~2–3 days including tests.
+4. Egress: verify `previous_response_id` support in the Pi SDK path, then compaction.
+5. Per-agent log files.
+6. Re-measure (same probes: `docker stats`, per-thread top, poll-cycle logs, `/proc/net/dev` deltas) and decide whether
+   the [multi-server transition](multi-server-architecture.md) is needed yet.

--- a/agents/docs/readme.md
+++ b/agents/docs/readme.md
@@ -145,6 +145,10 @@ Important incomplete work:
     that is only partly built.
 20. [Future projects](./future-projects.md) — larger future work packages.
 21. [Roadmap](./roadmap.md) — prioritized next steps and code-improvement opportunities.
+22. [Performance squeeze plan](./perf-squeeze-plan.md) — the measured 2026-08 production bottlenecks (sandbox CPU,
+    provider egress, log volume) and the workstreams removing them, including session-scoped long-lived sandboxes.
+23. [Multi-server architecture](./multi-server-architecture.md) — the three-phase path off a single host, with the
+    scaling and cost model.
 
 ## Canonical code entry points
 

--- a/agents/src/activity-monitor.ts
+++ b/agents/src/activity-monitor.ts
@@ -2,6 +2,7 @@ import type * as api from '@/api'
 import type * as apisvc from '@/api-service'
 import * as activityTriggers from '@/activity-triggers'
 import * as cbor from '@/cbor'
+import {log} from '@/log'
 import {PollLoop} from '@/poll-loop'
 import {createSeedClient, type SeedClient} from '@seed-hypermedia/client'
 import type {Database} from 'bun:sqlite'
@@ -92,7 +93,7 @@ export class ActivityMonitor {
     const fetched: activityTriggers.ActivityFeedEvent[] = []
     let pageToken: string | undefined
     try {
-      console.log('[Agents Activity] Polling feed', {
+      log.debug('[Agents Activity] Polling feed', {
         accountId,
         serverUrl: this.#options.hmServerUrl,
         pageSize: this.#options.pageSize,
@@ -117,7 +118,7 @@ export class ActivityMonitor {
         )
         const events = Array.isArray(response.events) ? (response.events as activityTriggers.ActivityFeedEvent[]) : []
         fetched.push(...events)
-        console.log('[Agents Activity] Feed page received', {
+        log.debug('[Agents Activity] Feed page received', {
           accountId,
           page: page + 1,
           events: events.length,
@@ -163,7 +164,8 @@ export class ActivityMonitor {
         const key = activityTriggers.activityEventKey(event)
         return !!key && !previous.seenKeys.includes(key)
       })
-      console.log('[Agents Activity] Processing feed events', {
+      // A poll that found nothing is the overwhelmingly common case; it logs only at debug.
+      ;(newEvents.length > 0 ? log.info : log.debug)('[Agents Activity] Processing feed events', {
         accountId,
         fetched: fetched.length,
         newEvents: newEvents.length,

--- a/agents/src/code-exec.test.ts
+++ b/agents/src/code-exec.test.ts
@@ -40,6 +40,7 @@ type FakeCall = {
   exec?: {cmd: string; args: string[]; timeoutMs?: number}
   stopped?: boolean
   killed?: boolean
+  streamKilled?: boolean
 }
 
 /** Fake microsandbox SDK capturing builder configuration and returning a canned exec output. */
@@ -49,6 +50,12 @@ function fakeSdk(
     output?: Partial<ExecOutputLike> & {stdoutText?: string; stderrText?: string}
     /** When set, the sandbox also offers execStreamWith replaying these events. */
     stream?: ExecStreamEventLike[]
+    /** After replaying `stream`, recv hangs forever instead of ending — a wedged guest. */
+    streamHangs?: boolean
+    /** Buffered execWith never resolves — a wedged guest with no streaming API. */
+    execHangs?: boolean
+    /** Graceful stop never resolves, forcing the kill escalation. */
+    stopHangs?: boolean
     onExec?: () => void
     createError?: Error
     execError?: Error
@@ -111,8 +118,15 @@ function fakeSdk(
                     if (behavior.execError) throw behavior.execError
                     const events = [...behavior.stream!]
                     return {
-                      recv: async () => events.shift() ?? null,
-                      kill: async () => {},
+                      recv: () => {
+                        const next = events.shift()
+                        if (next) return Promise.resolve(next)
+                        if (behavior.streamHangs) return new Promise<never>(() => {})
+                        return Promise.resolve(null)
+                      },
+                      kill: async () => {
+                        call.streamKilled = true
+                      },
                     }
                   },
                 }
@@ -129,6 +143,7 @@ function fakeSdk(
                 call.exec = exec
                 behavior.onExec?.()
                 if (behavior.execError) throw behavior.execError
+                if (behavior.execHangs) return new Promise<never>(() => {})
                 return {
                   code: behavior.output?.code ?? 0,
                   success: behavior.output?.success ?? true,
@@ -136,8 +151,10 @@ function fakeSdk(
                   stderr: () => behavior.output?.stderrText ?? '',
                 }
               },
-              stop: async () => {
+              stop: () => {
+                if (behavior.stopHangs) return new Promise<never>(() => {})
                 call.stopped = true
+                return Promise.resolve()
               },
               kill: async () => {
                 call.killed = true
@@ -339,6 +356,61 @@ describe('code exec', () => {
       expect(result.stdout).toBe('partial\n')
       expect(result.stderr).toContain('without an exit status')
       expect(call.stopped).toBe(true)
+    })
+  })
+
+  test('the host watchdog kills a streaming execution the sandbox fails to stop', async () => {
+    await withStateDir(async (stateDir) => {
+      const call: FakeCall = {mounts: []}
+      // The guest wedges: it emits some output, then the SDK's own timeout never fires and recv
+      // hangs forever — exactly the production failure this watchdog exists for.
+      const executor = createCodeExecutor({...defaultCodeExecConfig(), timeoutGraceMs: 50}, async () =>
+        fakeSdk(call, {
+          stream: [
+            {kind: 'started', pid: 42},
+            {kind: 'stdout', data: new TextEncoder().encode('compiling…\n')},
+          ],
+          streamHangs: true,
+        }),
+      )
+      const startedAt = Date.now()
+      const result = await executor.execute({stateDir, runtime: 'shell', code: 'sleep 999', timeoutSecs: 1})
+      expect(Date.now() - startedAt).toBeLessThan(5_000)
+      expect(result.exitCode).toBe(-1)
+      expect(result.success).toBe(false)
+      // The model still sees what ran before the kill, and why it ended.
+      expect(result.stdout).toBe('compiling…\n')
+      expect(result.stderr).toContain('killed by the server')
+      expect(call.streamKilled).toBe(true)
+      expect(call.stopped).toBe(true)
+    })
+  })
+
+  test('the host watchdog also bounds a buffered execution with no streaming API', async () => {
+    await withStateDir(async (stateDir) => {
+      const call: FakeCall = {mounts: []}
+      const executor = createCodeExecutor({...defaultCodeExecConfig(), timeoutGraceMs: 50}, async () =>
+        fakeSdk(call, {execHangs: true}),
+      )
+      const result = await executor.execute({stateDir, runtime: 'shell', code: 'sleep 999', timeoutSecs: 1})
+      expect(result.exitCode).toBe(-1)
+      expect(result.success).toBe(false)
+      expect(result.stderr).toContain('killed by the server')
+      expect(call.stopped).toBe(true)
+    })
+  })
+
+  test('teardown escalates to kill when the graceful stop hangs', async () => {
+    await withStateDir(async (stateDir) => {
+      const call: FakeCall = {mounts: []}
+      const executor = createCodeExecutor({...defaultCodeExecConfig(), teardownTimeoutMs: 50}, async () =>
+        fakeSdk(call, {stopHangs: true}),
+      )
+      const result = await executor.execute({stateDir, runtime: 'python', code: 'print("hi")'})
+      // The execution itself succeeded; a wedged stop must not lose the result or leak the VM.
+      expect(result.success).toBe(true)
+      expect(call.stopped).toBeUndefined()
+      expect(call.killed).toBe(true)
     })
   })
 

--- a/agents/src/code-exec.ts
+++ b/agents/src/code-exec.ts
@@ -25,6 +25,18 @@ export const MAX_EXEC_TIMEOUT_SECS = 300
 export const EXEC_OUTPUT_TAIL_CHARS = 2000
 /** Minimum interval between output-driven progress callbacks. */
 export const EXEC_PROGRESS_INTERVAL_MS = 250
+/**
+ * Extra wall-clock past the requested timeout before the host kills the execution itself.
+ *
+ * The sandbox SDK gets `.timeout()` and `.maxDuration()` and normally enforces them, but a guest
+ * that wedges the VM can outlive both (observed in production: a 60s-timeout compile running 150s+
+ * while pinning its vCPU). The host-side deadline is the backstop that cannot be ignored: it fires
+ * this grace period after the SDK's own timeout should have, kills the execution, and returns
+ * whatever output was collected.
+ */
+export const EXEC_TIMEOUT_GRACE_MS = 5_000
+/** How long sandbox teardown may take before escalating from a graceful stop to a hard kill. */
+export const EXEC_TEARDOWN_TIMEOUT_MS = 5_000
 
 /** Code-execution backend configuration. */
 export type CodeExecConfig = {
@@ -51,6 +63,10 @@ export type CodeExecConfig = {
   allowNetwork: boolean
   /** Upstream DNS nameservers for sandbox name resolution when networking is enabled. */
   dnsServers: string[]
+  /** Override for EXEC_TIMEOUT_GRACE_MS, so tests can exercise the watchdog without real waits. */
+  timeoutGraceMs?: number
+  /** Override for EXEC_TEARDOWN_TIMEOUT_MS, so tests can exercise stop→kill escalation quickly. */
+  teardownTimeoutMs?: number
 }
 
 /** Runtimes the execute tool can run code in. */
@@ -425,11 +441,14 @@ export function createCodeExecutor(
       try {
         const command = runtimeCommand(request.runtime, code)
         request.onProgress?.({stage: 'running'})
+        // The SDK gets the timeout too, but a wedged guest can outlive it; this deadline is the
+        // host-side backstop that always fires.
+        const deadlineMs = timeoutSecs * 1000 + (config.timeoutGraceMs ?? EXEC_TIMEOUT_GRACE_MS)
         let output: RawExecResult
         try {
           output = sandbox.execStreamWith
-            ? await runStreamingExec(sandbox, command, timeoutSecs, request.onProgress)
-            : await runBufferedExec(sandbox, command, timeoutSecs)
+            ? await runStreamingExec(sandbox, command, timeoutSecs, deadlineMs, request.onProgress)
+            : await runBufferedExec(sandbox, command, timeoutSecs, deadlineMs)
         } catch (error) {
           throw new CodeExecError(
             502,
@@ -449,11 +468,7 @@ export function createCodeExecutor(
           changedFiles: diffMemory(before.files, after.files),
         }
       } finally {
-        try {
-          await sandbox.stop()
-        } catch {
-          await sandbox.kill().catch(() => {})
-        }
+        await teardownSandbox(sandbox, config.teardownTimeoutMs ?? EXEC_TEARDOWN_TIMEOUT_MS)
       }
     },
   }
@@ -558,56 +573,139 @@ export function parseLambdaResult(stdout: string): {result?: unknown; hasResult:
   return {hasResult: false, logs: stdout.trim()}
 }
 
+/**
+ * A deadline the exec runners race against. `promise` resolves to the sentinel when the timer
+ * fires; `clear` stops the timer so a finished exec does not hold the process open.
+ */
+const EXEC_DEADLINE = Symbol('exec-deadline')
+
+function createDeadline(ms: number): {promise: Promise<typeof EXEC_DEADLINE>; clear: () => void} {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const promise = new Promise<typeof EXEC_DEADLINE>((resolve) => {
+    timer = setTimeout(() => resolve(EXEC_DEADLINE), ms)
+  })
+  return {promise, clear: () => clearTimeout(timer)}
+}
+
+/**
+ * Races a pending SDK call against the deadline. The loser is left to settle on its own; its
+ * rejection (if any) is marked handled so an already-abandoned exec cannot crash the process.
+ */
+function raceDeadline<T>(
+  pending: Promise<T>,
+  deadline: Promise<typeof EXEC_DEADLINE>,
+): Promise<T | typeof EXEC_DEADLINE> {
+  pending.catch(() => {})
+  return Promise.race([pending, deadline])
+}
+
+/** The result handed back when the host watchdog had to kill an execution. */
+function timedOutResult(timeoutSecs: number, stdout: string, stderr: string): RawExecResult {
+  const note = `[execution killed by the server: it exceeded its ${timeoutSecs}s timeout and the sandbox did not stop it]`
+  return {code: -1, success: false, stdout, stderr: stderr ? `${stderr}\n${note}` : note}
+}
+
 async function runBufferedExec(
   sandbox: SandboxLike,
   command: ExecCommand,
   timeoutSecs: number,
+  deadlineMs: number,
 ): Promise<RawExecResult> {
-  const output = await sandbox.execWith(command.cmd, (builder) =>
-    builder.args(command.args).timeout(timeoutSecs * 1000),
-  )
-  return {code: output.code, success: output.success, stdout: output.stdout(), stderr: output.stderr()}
+  const deadline = createDeadline(deadlineMs)
+  try {
+    const output = await raceDeadline(
+      sandbox.execWith(command.cmd, (builder) => builder.args(command.args).timeout(timeoutSecs * 1000)),
+      deadline.promise,
+    )
+    if (output === EXEC_DEADLINE) return timedOutResult(timeoutSecs, '', '')
+    return {code: output.code, success: output.success, stdout: output.stdout(), stderr: output.stderr()}
+  } finally {
+    deadline.clear()
+  }
 }
 
 /**
  * Runs the command through the streaming exec API, reporting a throttled tail of combined output
- * through `onProgress` as chunks arrive.
+ * through `onProgress` as chunks arrive. The whole exchange — handle creation included — races the
+ * host-side deadline; when it fires the execution is killed and the collected output returned.
  */
 async function runStreamingExec(
   sandbox: SandboxLike,
   command: ExecCommand,
   timeoutSecs: number,
+  deadlineMs: number,
   onProgress?: (progress: CodeExecProgress) => void,
 ): Promise<RawExecResult> {
-  const handle = await sandbox.execStreamWith!(command.cmd, (builder) =>
-    builder.args(command.args).timeout(timeoutSecs * 1000),
-  )
-  const stdout = createOutputCollector()
-  const stderr = createOutputCollector()
-  const tailDecoders = {stdout: new TextDecoder(), stderr: new TextDecoder()}
-  let tail = ''
-  let exitCode: number | null = null
-  let lastProgressAt = 0
-  for (let event = await handle.recv(); event !== null; event = await handle.recv()) {
-    if (event.kind === 'stdout' || event.kind === 'stderr') {
-      ;(event.kind === 'stdout' ? stdout : stderr).push(event.data)
-      tail = (tail + tailDecoders[event.kind].decode(event.data, {stream: true})).slice(-EXEC_OUTPUT_TAIL_CHARS)
-      const now = Date.now()
-      if (onProgress && now - lastProgressAt >= EXEC_PROGRESS_INTERVAL_MS) {
-        lastProgressAt = now
-        onProgress({stage: 'running', outputTail: tail})
+  const deadline = createDeadline(deadlineMs)
+  try {
+    const handle = await raceDeadline(
+      sandbox.execStreamWith!(command.cmd, (builder) => builder.args(command.args).timeout(timeoutSecs * 1000)),
+      deadline.promise,
+    )
+    if (handle === EXEC_DEADLINE) return timedOutResult(timeoutSecs, '', '')
+    const stdout = createOutputCollector()
+    const stderr = createOutputCollector()
+    const tailDecoders = {stdout: new TextDecoder(), stderr: new TextDecoder()}
+    let tail = ''
+    let exitCode: number | null = null
+    let lastProgressAt = 0
+    for (;;) {
+      const event = await raceDeadline(handle.recv(), deadline.promise)
+      if (event === EXEC_DEADLINE) {
+        // The kill is bounded too: it talks to the same wedged SDK the deadline just caught.
+        await settlesWithin(handle.kill(), EXEC_TEARDOWN_TIMEOUT_MS)
+        return timedOutResult(timeoutSecs, stdout.text(), stderr.text())
       }
-    } else if (event.kind === 'exited') {
-      exitCode = event.code
+      if (event === null) break
+      if (event.kind === 'stdout' || event.kind === 'stderr') {
+        ;(event.kind === 'stdout' ? stdout : stderr).push(event.data)
+        tail = (tail + tailDecoders[event.kind].decode(event.data, {stream: true})).slice(-EXEC_OUTPUT_TAIL_CHARS)
+        const now = Date.now()
+        if (onProgress && now - lastProgressAt >= EXEC_PROGRESS_INTERVAL_MS) {
+          lastProgressAt = now
+          onProgress({stage: 'running', outputTail: tail})
+        }
+      } else if (event.kind === 'exited') {
+        exitCode = event.code
+      }
     }
+    if (exitCode === null) {
+      // The stream ended without an exit status, e.g. the exec timeout killed the process.
+      const note = '[execution ended without an exit status — likely timed out]'
+      const stderrText = stderr.text()
+      return {code: -1, success: false, stdout: stdout.text(), stderr: stderrText ? `${stderrText}\n${note}` : note}
+    }
+    return {code: exitCode, success: exitCode === 0, stdout: stdout.text(), stderr: stderr.text()}
+  } finally {
+    deadline.clear()
   }
-  if (exitCode === null) {
-    // The stream ended without an exit status, e.g. the exec timeout killed the process.
-    const note = '[execution ended without an exit status — likely timed out]'
-    const stderrText = stderr.text()
-    return {code: -1, success: false, stdout: stdout.text(), stderr: stderrText ? `${stderrText}\n${note}` : note}
+}
+
+/**
+ * Stops the sandbox without letting teardown block the tool call: a graceful stop gets
+ * EXEC_TEARDOWN_TIMEOUT_MS, then the VM is killed outright. A kill that itself hangs is abandoned
+ * — the result must reach the model even if the SDK has wedged.
+ */
+async function teardownSandbox(sandbox: SandboxLike, timeoutMs: number): Promise<void> {
+  if (await settlesWithin(sandbox.stop(), timeoutMs)) return
+  await settlesWithin(sandbox.kill(), timeoutMs)
+}
+
+/** True when the promise fulfills within the window; false on rejection or timeout. Never throws. */
+async function settlesWithin(pending: Promise<unknown>, ms: number): Promise<boolean> {
+  const deadline = createDeadline(ms)
+  try {
+    const outcome = await raceDeadline(
+      pending.then(
+        () => true,
+        () => false,
+      ),
+      deadline.promise,
+    )
+    return outcome === true
+  } finally {
+    deadline.clear()
   }
-  return {code: exitCode, success: exitCode === 0, stdout: stdout.text(), stderr: stderr.text()}
 }
 
 type OutputCollector = {push(data: Uint8Array): void; text(): string}

--- a/agents/src/config.test.ts
+++ b/agents/src/config.test.ts
@@ -36,4 +36,13 @@ describe('config', () => {
       ipfsServerUrl: 'https://hyper.media',
     })
   })
+
+  test('log level defaults to info, honors env and flag, and rejects unknown levels', () => {
+    expect(config.create(config.flags({} as NodeJS.ProcessEnv)).logLevel).toBe('info')
+    expect(config.create(config.flags({SEED_AGENTS_LOG_LEVEL: 'debug'} as NodeJS.ProcessEnv)).logLevel).toBe('debug')
+    expect(config.create(config.parseArgs(['--log-level', 'warn'], {} as NodeJS.ProcessEnv)).logLevel).toBe('warn')
+    expect(() => config.create(config.flags({SEED_AGENTS_LOG_LEVEL: 'loud'} as NodeJS.ProcessEnv))).toThrow(
+      'Invalid log level',
+    )
+  })
 })

--- a/agents/src/config.ts
+++ b/agents/src/config.ts
@@ -12,11 +12,15 @@ export type Server = {
   port: number
 }
 
+import {parseLogLevel, type LogLevel} from '@/log'
+
 /** Runtime configuration for the Agents service. */
 export type Config = {
   http: Server
   dbPath: string
   dataDir: string
+  /** Minimum log level emitted; `debug` turns the per-delta/per-poll hot-path lines back on. */
+  logLevel: LogLevel
   /**
    * Offer subscription (OAuth) provider sign-in ("Sign in with ChatGPT").
    * Explicit opt-in: the flow needs a client that can catch the provider's
@@ -85,6 +89,7 @@ export type Flags = {
   'exec-timeout-secs': number
   'exec-allow-network': string
   'exec-dns': string
+  'log-level': string
 }
 
 /** Creates default flag values from the current environment. */
@@ -112,6 +117,7 @@ export function flags(env: NodeJS.ProcessEnv = process.env): Flags {
     'exec-timeout-secs': Number(env.SEED_AGENTS_EXEC_TIMEOUT_SECS) || 60,
     'exec-allow-network': env.SEED_AGENTS_EXEC_ALLOW_NETWORK ?? '',
     'exec-dns': env.SEED_AGENTS_EXEC_DNS || '',
+    'log-level': env.SEED_AGENTS_LOG_LEVEL || 'info',
   }
 }
 
@@ -171,6 +177,7 @@ export function create(pflags: Flags): Config {
     },
     dbPath: pflags['db-path'],
     dataDir: pflags['data-dir'],
+    logLevel: parseLogLevel(pflags['log-level']),
     activity: {
       hmServerUrl: normalizeHttpUrl(pflags['hm-server-url'], 'HM server URL'),
       ipfsServerUrl: normalizeHttpUrl(pflags['ipfs-server-url'] || pflags['hm-server-url'], 'IPFS server URL'),

--- a/agents/src/log.ts
+++ b/agents/src/log.ts
@@ -1,0 +1,51 @@
+/**
+ * Leveled logging for the Agents service.
+ *
+ * Production measurement (2026-08-29) put the server at ~440k log lines/hour, dominated by
+ * per-delta WebSocket lines and per-poll activity lines — noise that costs real CPU on a busy
+ * host and buries the lines an operator actually reads. Those hot-path sites now log at `debug`,
+ * which is off by default; everything an operator needs to follow the service (run lifecycle,
+ * trigger firings, subscriptions, warnings, errors) stays at `info` and above.
+ *
+ * The threshold is process-wide module state set once at startup from configuration
+ * (`SEED_AGENTS_LOG_LEVEL` / `--log-level`), so hot paths pay one integer compare per call and
+ * modules need no config threading.
+ */
+
+export const LOG_LEVELS = ['debug', 'info', 'warn', 'error'] as const
+export type LogLevel = (typeof LOG_LEVELS)[number]
+
+const RANK: Record<LogLevel, number> = {debug: 10, info: 20, warn: 30, error: 40}
+
+let threshold = RANK.info
+
+/** Parses a log level string, throwing on anything that is not a known level. */
+export function parseLogLevel(value: string): LogLevel {
+  const normalized = value.trim().toLowerCase()
+  if ((LOG_LEVELS as readonly string[]).includes(normalized)) return normalized as LogLevel
+  throw new Error(`Invalid log level: ${value} (expected ${LOG_LEVELS.join(', ')})`)
+}
+
+/** Sets the process-wide log threshold. Called once at startup from configuration. */
+export function setLogLevel(level: LogLevel): void {
+  threshold = RANK[level]
+}
+
+export const log = {
+  /** True when debug lines would be emitted, for callers that build expensive log payloads. */
+  get debugEnabled(): boolean {
+    return threshold <= RANK.debug
+  },
+  debug(...args: unknown[]): void {
+    if (threshold <= RANK.debug) console.log(...args)
+  },
+  info(...args: unknown[]): void {
+    if (threshold <= RANK.info) console.info(...args)
+  },
+  warn(...args: unknown[]): void {
+    if (threshold <= RANK.warn) console.warn(...args)
+  },
+  error(...args: unknown[]): void {
+    if (threshold <= RANK.error) console.error(...args)
+  },
+}

--- a/agents/src/main.ts
+++ b/agents/src/main.ts
@@ -2,6 +2,7 @@ import type * as api from '@/api'
 import {ActivityMonitor} from '@/activity-monitor'
 import * as apisvc from '@/api-service'
 import {getBuildInfo} from '@/build-info'
+import {log, setLogLevel} from '@/log'
 import {withTimeout} from '@/poll-loop'
 import {ScheduleMonitor} from '@/schedule-monitor'
 import * as cbor from '@/cbor'
@@ -225,11 +226,11 @@ function sendIfSubscribed(
   const accountWide = accountKey ? ws.data.subscriptions.has(accountKey) : false
   if (direct || accountWide) {
     if (event._ === 'appendPartial') {
-      console.info('[agents/ws] send partial', {...summarizeWSEvent(event), direct, accountWide})
+      log.debug('[agents/ws] send partial', {...summarizeWSEvent(event), direct, accountWide})
     }
     sendWS(ws, event)
   } else if (event._ === 'appendPartial') {
-    console.info('[agents/ws] skip partial; no subscription', {
+    log.debug('[agents/ws] skip partial; no subscription', {
       key,
       accountId: ws.data.accountId,
       subscriptions: Array.from(ws.data.subscriptions),
@@ -273,6 +274,7 @@ async function main(): Promise<void> {
   }
 
   const cfg = config.create(config.parseArgs())
+  setLogLevel(cfg.logLevel)
   const result = sqlite.open(cfg.dbPath)
 
   if (!result.ok) {
@@ -294,7 +296,7 @@ async function main(): Promise<void> {
   const clients = new Set<ServerWebSocket<WSData>>()
   const publish = (event: apisvc.ServiceEvent) => {
     if (event.type === 'session-partial') {
-      console.info('[agents/ws] publish partial', {
+      log.debug('[agents/ws] publish partial', {
         accountId: event.accountId,
         sessionId: event.sessionId,
         partialId: event.partialId,


### PR DESCRIPTION
## Why

Production (`agents-stable`) has been CPU-saturated: sandbox executions were routinely outliving their `timeout_secs` by minutes (observed: a 60s-timeout exec running 153s at ~110% CPU), because the SDK-side `.timeout()`/`.maxDuration()` are advisory — a wedged guest simply ignores them. The starved event loop then pushed activity poll cycles past their own 60s budget (`poll tick failed … Poll cycle aborted`), delaying triggers for every polled account. On top of that, the service was writing ~437k log lines/hour, dominated by per-delta WS publish lines and no-op poll lines.

## What

**1. Host-side watchdog for sandbox executions** (`code-exec.ts`)
- Every execute races against a host-side deadline of `timeout_secs + 5s grace` that the guest cannot ignore — streaming runs race handle creation and each `recv()`; buffered runs race `execWith`.
- On deadline: kill the exec handle, return the output collected so far with a clear `[execution killed by the server…]` marker, and tear the sandbox down with bounded stop→kill escalation (5s each) so a wedged VM can't leak.
- Abandoned promise rejections are marked handled so the race never produces unhandled-rejection noise.
- Tests cover the streaming watchdog kill, the buffered watchdog, and stop→kill escalation, using tight test-only grace/teardown overrides.

**2. Leveled logging** (`log.ts`, `config.ts`, `main.ts`, `activity-monitor.ts`)
- New module-level logger with `debug/info/warn/error`, configured via `SEED_AGENTS_LOG_LEVEL` env or `--log-level` flag (default `info`).
- The hot paths — `[agents/ws]` per-delta publish/send/skip lines and `[Agents Activity]` per-poll/no-op lines — move to debug. Poll lines with actual new events stay at info. This removes ~90% of production log volume.

**3. Docs**
- `agents/docs/perf-squeeze-plan.md`: the full findings from the production investigation and the remaining workstreams (session-scoped long-lived sandbox pool, egress reduction via delta uploads + context compaction, per-agent log files, host containment via compose `cpus:` limits).
- `agents/docs/multi-server-architecture.md`: how to split exec hosts from the control plane behind a `CodeExecutor` contract, with scaling and cost estimates.

## Testing

- `agents`: 377 pass, 0 fail (rebased on `9efb3b9d1`).
- `bun tsgo --noEmit` clean.
- New tests in `code-exec.test.ts` (watchdog behaviors) and `config.test.ts` (log-level parsing/env/flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P571wF9NS8bAV1xeskrsVa