### PR TITLE
Fast session loads: wire truncation, lazy full events, no double replay

### DIFF
--- a/agents/docs/perf-squeeze-plan.md
+++ b/agents/docs/perf-squeeze-plan.md
@@ -86,6 +86,37 @@ provider latency per turn. That is why compaction matters even if bytes were fre
 - A modest host upgrade (4 → 8 vCPU) roughly doubles the safe live-VM cap in workstream 3; worth taking, but the
   cold-compile fix dwarfs it.
 
+### 6. Session load wire size — DONE
+
+Opening a session was transferring the whole transcript with **full tool payloads** — measured in production: one
+116-event session weighed 22.5 MB because three `call` results carried multi-megabyte outputs (the largest: 9.5 MB, a
+code exec reporting 64,617 `changedFiles` entries). The bytes were paid four times per open: pure-JS CBOR decode on the
+server, re-encode into WS/HTTP frames, transfer through Caddy/TLS, and pure-JS decode again in the renderer — and the
+assistant panel subscribed without `afterSeq`, so the socket replayed the whole transcript a second time on top of the
+`GetSession` fetch. Indexing was never the problem (`UNIQUE(session_id, seq)` covers every transcript query); event
+counts are modest (≤ ~500/session) — the payload bytes were.
+
+The fix, at every layer:
+
+- **Source cap**: code-exec reports at most 200 `changedFiles` plus a true `changedFilesTotal`.
+- **Wire truncation**: `GetSession`, subscription replay, and live append fan-out cap giant strings (16 KB) and arrays
+  (200 entries) per event, marking the event `truncated`. Events under 64 KB encoded skip the walk. Durable storage is
+  untouched.
+- **On-demand full fetch**: new `GetSessionEvent` action returns one event whole; the tool info dialog shows a "Load
+  full data" affordance on truncated payloads.
+- **No double replay**: both session views now subscribe only after the initial `GetSession` lands and resume with
+  `afterSeq`.
+- **Tail pagination (server support)**: `GetSession` accepts `limit`/`beforeSeq` and reports `hasMoreBefore`, so clients
+  can load the tail first when transcripts grow; the UI still loads whole transcripts for now, which is fine once events
+  are size-bounded.
+- **System prompt cache**: `GetSession` was re-resolving the agent's prompt blocks on every call — including fetching
+  remote hm:// documents the prompt embeds. Resolved markdown is now cached per agent (5 min TTL, keyed by the blocks).
+
+**Follow-up (planned): spill oversized outputs at append time.** A multi-megabyte durable event still costs every
+`#piMessages` decode (every model turn) even though the provider payload is capped. Store outputs above a threshold as
+files under the agent's state dir with a preview + pointer in the event. This also makes the 22 MB legacy sessions cheap
+to re-open server-side.
+
 ## Sequencing
 
 1. ~~Watchdog~~, ~~log levels~~ (this branch) → deploy, confirm poll-cycle overruns stop.

--- a/agents/protocol/src/index.ts
+++ b/agents/protocol/src/index.ts
@@ -212,6 +212,7 @@ export type UnsignedAgentAction =
   | UpdateSession
   | DeleteSession
   | GetSession
+  | GetSessionEvent
   | MessageSession
   | InvokeSessionTool
   | UploadSessionAttachment
@@ -870,11 +871,29 @@ export type DeleteSession = {
   sessionId: string
 }
 
-/** Loads one session plus durable events, optionally after a sequence. */
+/**
+ * Loads one session plus durable events, optionally after a sequence.
+ *
+ * Oversized event payloads are truncated on the wire (marked `truncated` on the event); fetch a
+ * single full event with `GetSessionEvent`. `limit` returns only the LAST `limit` events of the
+ * selected range (the transcript tail) and sets `hasMoreBefore` when older events were cut;
+ * page older history with `beforeSeq`.
+ */
 export type GetSession = {
   _: 'GetSession'
   sessionId: string
   afterSeq?: number
+  /** Only events with seq strictly below this are returned. */
+  beforeSeq?: number
+  /** Maximum events returned, counted from the end of the selected range. */
+  limit?: number
+}
+
+/** Loads one durable session event in full, bypassing the wire-size truncation of `GetSession`. */
+export type GetSessionEvent = {
+  _: 'GetSessionEvent'
+  sessionId: string
+  seq: number
 }
 
 /** Appends a user message and asks the agent to respond. */
@@ -1276,6 +1295,12 @@ export type SessionEvent = {
   seq: number
   event: SessionEventPayload
   createdAt: number
+  /**
+   * The payload was cut down for transport (giant strings/arrays elided) — the durable event is
+   * intact on the server; fetch it whole with `GetSessionEvent`. Multi-megabyte tool outputs
+   * otherwise make every session load, replay, and live append pay for bytes nobody is reading.
+   */
+  truncated?: boolean
 }
 
 /**
@@ -1984,6 +2009,14 @@ export type GetSessionResponse = {
   events: SessionEvent[]
   systemPromptMarkdown: string
   triggerContext?: AgentSessionTriggerContext
+  /** Set when `limit` cut older events out of the response; page them with `beforeSeq`. */
+  hasMoreBefore?: boolean
+}
+
+/** Successful response for `GetSessionEvent`: one event, never truncated. */
+export type GetSessionEventResponse = {
+  _: 'GetSessionEventResponse'
+  event: SessionEvent
 }
 
 /** Successful response for `MessageSession`. */
@@ -2156,6 +2189,7 @@ export type AgentResponse =
   | UpdateSessionResponse
   | DeleteSessionResponse
   | GetSessionResponse
+  | GetSessionEventResponse
   | MessageSessionResponse
   | InvokeSessionToolResponse
   | UploadSessionAttachmentResponse

--- a/agents/src/api-service.test.ts
+++ b/agents/src/api-service.test.ts
@@ -2815,6 +2815,113 @@ describe('api service', () => {
     }
   })
 
+  test('GetSession truncates oversized events on the wire, pages with limit, and GetSessionEvent returns the whole thing', async () => {
+    const {db, dataDir, cleanup} = createTestState()
+    try {
+      const account = blobs.generateNobleKeyPair()
+      const svc = new apisvc.Service(db, dataDir)
+      await setDefaultProvider(svc, account)
+      const createdAgent = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {
+            _: 'CreateAgent',
+            definition: {name: 'Agent', systemPrompt: 'ok', modelProvider: 'openai', model: 'gpt'},
+          },
+        }),
+      )
+      if (createdAgent._ !== 'CreateAgentResponse') throw new Error('unexpected response')
+      const createdSession = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {_: 'CreateSession', agentId: createdAgent.agentId},
+        }),
+      )
+      if (createdSession._ !== 'CreateSessionResponse') throw new Error('unexpected response')
+
+      const giantOutput = {
+        summary: 'ok',
+        stdout: 'x'.repeat(200_000),
+        changedFiles: Array.from({length: 5_000}, (_, i) => ({path: `file-${i}`, change: 'added'})),
+      }
+      const insert = db.prepare(
+        `INSERT INTO session_events (id, session_id, seq, event_cbor, created_at) VALUES (?, ?, ?, ?, ?)`,
+      )
+      insert.run(
+        'event-1',
+        createdSession.sessionId,
+        1,
+        cbor.encode({type: 'message', role: 'user', content: 'hi'}),
+        100,
+      )
+      insert.run(
+        'event-2',
+        createdSession.sessionId,
+        2,
+        cbor.encode({type: 'tool_result', toolCallId: 'c1', name: 'call', output: giantOutput}),
+        101,
+      )
+      insert.run(
+        'event-3',
+        createdSession.sessionId,
+        3,
+        cbor.encode({type: 'message', role: 'assistant', content: 'done'}),
+        102,
+      )
+
+      const session = await svc.message(
+        await apisvc.createSignedEnvelope(account, {action: {_: 'GetSession', sessionId: createdSession.sessionId}}),
+      )
+      if (session._ !== 'GetSessionResponse') throw new Error('unexpected response')
+      expect(session.events).toHaveLength(3)
+      expect(session.hasMoreBefore).toBeUndefined()
+      // Small events pass through untouched, without a truncation marker.
+      expect(session.events[0]).toMatchObject({seq: 1, event: {content: 'hi'}})
+      expect(session.events[0]?.truncated).toBeUndefined()
+      // The giant one is cut: strings capped, arrays elided, marker set — and it is SMALL now.
+      const wireEvent = session.events[1]
+      if (!wireEvent) throw new Error('missing event')
+      expect(wireEvent.truncated).toBe(true)
+      const wireOutput = (wireEvent.event as {output: typeof giantOutput}).output
+      expect(wireOutput.summary).toBe('ok')
+      expect(wireOutput.stdout.length).toBeLessThan(20_000)
+      expect(wireOutput.stdout).toContain('[truncated: 200000 chars]')
+      expect(wireOutput.changedFiles).toHaveLength(200)
+      expect(cbor.encode(wireEvent).length).toBeLessThan(apisvc.WIRE_EVENT_BYTE_BUDGET)
+
+      // limit returns the transcript TAIL and flags older history.
+      const tail = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {_: 'GetSession', sessionId: createdSession.sessionId, limit: 2},
+        }),
+      )
+      if (tail._ !== 'GetSessionResponse') throw new Error('unexpected response')
+      expect(tail.events.map((event) => event.seq)).toEqual([2, 3])
+      expect(tail.hasMoreBefore).toBe(true)
+      const older = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {_: 'GetSession', sessionId: createdSession.sessionId, beforeSeq: 2, limit: 10},
+        }),
+      )
+      if (older._ !== 'GetSessionResponse') throw new Error('unexpected response')
+      expect(older.events.map((event) => event.seq)).toEqual([1])
+      expect(older.hasMoreBefore).toBeUndefined()
+
+      // The durable event is intact and reachable in full.
+      const full = await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {_: 'GetSessionEvent', sessionId: createdSession.sessionId, seq: 2},
+        }),
+      )
+      if (full._ !== 'GetSessionEventResponse') throw new Error('unexpected response')
+      expect(full.event.truncated).toBeUndefined()
+      const fullOutput = (full.event.event as {output: typeof giantOutput}).output
+      expect(fullOutput.stdout.length).toBe(200_000)
+      expect(fullOutput.changedFiles).toHaveLength(5_000)
+    } finally {
+      db.close()
+      cleanup()
+    }
+  })
+
   test('resolves system prompt embeds in session prompt markdown', async () => {
     const {db, dataDir, cleanup} = createTestState()
     const originalFetch = globalThis.fetch
@@ -7460,6 +7567,7 @@ describe('api service', () => {
               durationMs: 1,
               truncated: false,
               changedFiles: [],
+              changedFilesTotal: 0,
             }
           },
         },

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -111,6 +111,8 @@ import * as path from 'node:path'
 import * as nodeCrypto from 'node:crypto'
 
 const MAX_NAME_BYTES = 256
+/** How long a resolved system prompt (which may embed fetched remote docs) is served from cache. */
+const RESOLVED_PROMPT_CACHE_TTL_MS = 5 * 60 * 1000
 /**
  * Entry cap for the full recursive `ListAgentMemory` walk. The walk is synchronous on the
  * server's only thread, so it must stay bounded against pathological memories (an imported
@@ -671,6 +673,12 @@ export class Service {
   readonly #namingSessions = new Set<string>()
   /** Title generation attempts per session this process, so a failing provider is not re-asked forever. */
   readonly #titleAttempts = new Map<string, number>()
+  /**
+   * Resolved system-prompt markdown per agent. Resolution can FETCH remote hm:// documents the
+   * prompt embeds, and it runs on every GetSession (each session open, each WS resubscribe) — so
+   * it is cached against the prompt blocks' JSON with a short TTL to pick up remote doc edits.
+   */
+  readonly #resolvedSystemPromptCache = new Map<string, {source: string; value: string; expiresAt: number}>()
   /** Chunked uploads staged on disk, keyed by upload id. Abandoned uploads expire after a TTL. */
   readonly #uploads = new Map<string, StagedFileUpload>()
   /** Pending provider OAuth sign-ins (StartProviderOAuth … GetProviderOAuthStatus). */
@@ -979,7 +987,15 @@ export class Service {
       case 'DeleteSession':
         return this.#deleteSession(accountId, envelope.action.sessionId)
       case 'GetSession':
-        return await this.#getSession(accountId, envelope.action.sessionId, envelope.action.afterSeq)
+        return await this.#getSession(
+          accountId,
+          envelope.action.sessionId,
+          envelope.action.afterSeq,
+          envelope.action.beforeSeq,
+          envelope.action.limit,
+        )
+      case 'GetSessionEvent':
+        return this.#getSessionEvent(accountId, envelope.action.sessionId, envelope.action.seq)
       case 'InvokeSessionTool':
         return this.#invokeSessionTool(
           accountId,
@@ -1128,6 +1144,7 @@ export class Service {
         if (action.parentSessionId) return fromSession(action.parentSessionId)
         return actorAccountId
       case 'GetSession':
+      case 'GetSessionEvent':
       case 'ReadSessionAttachment':
         return fromSession(action.sessionId)
       case 'UpdateSession':
@@ -5782,10 +5799,20 @@ export class Service {
     stateDir?: string,
   ): Promise<string> {
     const signingKeys = definition.signingKeys || (definition.signingKey ? [definition.signingKey] : [])
-    const systemPrompt = await promptBlocksToResolvedMarkdown(
-      normalizeSystemPromptBlocks(definition.systemPrompt),
-      createSeedClient(this.#hmServerUrl),
-    )
+    const promptBlocks = normalizeSystemPromptBlocks(definition.systemPrompt)
+    const promptSource = safeJSONStringify(promptBlocks)
+    const cachedPrompt = this.#resolvedSystemPromptCache.get(agentId)
+    let systemPrompt: string
+    if (cachedPrompt && cachedPrompt.source === promptSource && cachedPrompt.expiresAt > Date.now()) {
+      systemPrompt = cachedPrompt.value
+    } else {
+      systemPrompt = await promptBlocksToResolvedMarkdown(promptBlocks, createSeedClient(this.#hmServerUrl))
+      this.#resolvedSystemPromptCache.set(agentId, {
+        source: promptSource,
+        value: systemPrompt,
+        expiresAt: Date.now() + RESOLVED_PROMPT_CACHE_TTL_MS,
+      })
+    }
     const sharedPrompt = seedAssistantSystemPrompt({
       currentTime: new Date().toISOString(),
     })
@@ -6778,9 +6805,21 @@ export class Service {
     }
   }
 
-  async #getSession(accountId: string, sessionId: string, afterSeq?: number): Promise<api.GetSessionResponse> {
+  async #getSession(
+    accountId: string,
+    sessionId: string,
+    afterSeq?: number,
+    beforeSeq?: number,
+    limit?: number,
+  ): Promise<api.GetSessionResponse> {
     if (afterSeq !== undefined && (!Number.isInteger(afterSeq) || afterSeq < 0)) {
       throw new APIError(400, 'afterSeq must be a non-negative integer')
+    }
+    if (beforeSeq !== undefined && (!Number.isInteger(beforeSeq) || beforeSeq < 1)) {
+      throw new APIError(400, 'beforeSeq must be a positive integer')
+    }
+    if (limit !== undefined && (!Number.isInteger(limit) || limit < 1)) {
+      throw new APIError(400, 'limit must be a positive integer')
     }
     const session = this.#db
       .query<SessionRow, [string, string]>(
@@ -6792,12 +6831,25 @@ export class Service {
       .get(accountId, sessionId)
     if (!session) throw new APIError(404, 'Session not found')
 
-    const events = this.#db
-      .query<SessionEventRow, [string, number]>(
-        `SELECT id, session_id, seq, event_cbor, created_at
-         FROM session_events WHERE session_id = ? AND seq > ? ORDER BY seq ASC`,
+    // Selected newest-first when a limit applies so the response is the transcript TAIL (the part
+    // a session view renders first); re-sorted ascending below either way.
+    type WireEventRow = SessionEventRow & {byte_length: number}
+    const eventRows = this.#db
+      .query<WireEventRow, (string | number)[]>(
+        `SELECT id, session_id, seq, event_cbor, created_at, LENGTH(event_cbor) AS byte_length
+         FROM session_events WHERE session_id = ? AND seq > ?${beforeSeq !== undefined ? ' AND seq < ?' : ''}
+         ORDER BY seq ${limit !== undefined ? 'DESC LIMIT ?' : 'ASC'}`,
       )
-      .all(sessionId, afterSeq ?? 0)
+      .all(
+        sessionId,
+        afterSeq ?? 0,
+        ...(beforeSeq !== undefined ? [beforeSeq] : []),
+        ...(limit !== undefined ? [limit] : []),
+      )
+    if (limit !== undefined) eventRows.reverse()
+    const hasMoreBefore =
+      limit !== undefined && eventRows.length === limit && (eventRows[0]?.seq ?? 0) > (afterSeq ?? 0) + 1
+    const events = eventRows.map((row) => truncateSessionEventForWire(sessionEventRowToInfo(row), row.byte_length))
 
     const agent = this.#db
       .query<AgentRow, [string, string]>(
@@ -6811,10 +6863,26 @@ export class Service {
     return {
       _: 'GetSessionResponse',
       session: sessionRowToInfo(session, triggerContext ?? undefined),
-      events: events.map(sessionEventRowToInfo),
+      events,
       systemPromptMarkdown: await this.#agentSystemPrompt(accountId, agent.id, definition, agent.state_dir),
       ...(triggerContext ? {triggerContext} : {}),
+      ...(hasMoreBefore ? {hasMoreBefore} : {}),
     }
+  }
+
+  #getSessionEvent(accountId: string, sessionId: string, seq: number): api.GetSessionEventResponse {
+    if (!Number.isInteger(seq) || seq < 1) throw new APIError(400, 'seq must be a positive integer')
+    const session = this.#db
+      .query<{id: string}, [string, string]>(`SELECT id FROM sessions WHERE account_id = ? AND id = ?`)
+      .get(accountId, sessionId)
+    if (!session) throw new APIError(404, 'Session not found')
+    const row = this.#db
+      .query<SessionEventRow, [string, number]>(
+        `SELECT id, session_id, seq, event_cbor, created_at FROM session_events WHERE session_id = ? AND seq = ?`,
+      )
+      .get(sessionId, seq)
+    if (!row) throw new APIError(404, 'Session event not found')
+    return {_: 'GetSessionEventResponse', event: sessionEventRowToInfo(row)}
   }
 
   async #withAsyncIdempotency<T extends api.AgentResponse>(
@@ -8234,6 +8302,65 @@ function sessionEventRowToInfo(row: SessionEventRow): api.SessionEvent {
     event: cbor.decode(row.event_cbor),
     createdAt: row.created_at,
   }
+}
+
+/**
+ * A single durable event may carry a multi-megabyte tool output (a code exec that touched tens of
+ * thousands of files, a huge web fetch). Any string kept on the wire must stay well under this, so
+ * a transcript of hundreds of events costs kilobytes to load, not tens of megabytes.
+ */
+const WIRE_STRING_LIMIT = 16 * 1024
+/** Arrays inside an event payload are elided past this many entries on the wire. */
+const WIRE_ARRAY_LIMIT = 200
+/** Payloads encoded smaller than this skip the truncation walk entirely. */
+export const WIRE_EVENT_BYTE_BUDGET = 64 * 1024
+
+/** Truncates one value for transport, returning the input object unchanged when nothing was cut. */
+function truncateValueForWire(value: unknown, changed: {did: boolean}): unknown {
+  if (typeof value === 'string') {
+    if (value.length <= WIRE_STRING_LIMIT) return value
+    changed.did = true
+    return `${value.slice(0, WIRE_STRING_LIMIT)}… [truncated: ${value.length} chars]`
+  }
+  if (value instanceof Uint8Array) {
+    if (value.length <= WIRE_STRING_LIMIT) return value
+    changed.did = true
+    return value.slice(0, WIRE_STRING_LIMIT)
+  }
+  if (Array.isArray(value)) {
+    const bounded = value.length > WIRE_ARRAY_LIMIT ? value.slice(0, WIRE_ARRAY_LIMIT) : value
+    if (bounded.length < value.length) changed.did = true
+    let out: unknown[] | undefined
+    for (let i = 0; i < bounded.length; i++) {
+      const next = truncateValueForWire(bounded[i], changed)
+      if (next !== bounded[i] && !out) out = bounded.slice(0, i)
+      if (out) out.push(next)
+    }
+    return out ?? bounded
+  }
+  if (value && typeof value === 'object') {
+    let out: Record<string, unknown> | undefined
+    for (const [key, entry] of Object.entries(value)) {
+      const next = truncateValueForWire(entry, changed)
+      if (next !== entry && !out) out = {...(value as Record<string, unknown>)}
+      if (out) out[key] = next
+    }
+    return out ?? value
+  }
+  return value
+}
+
+/**
+ * Caps an event's payload for transport. The durable event is untouched; clients that need the
+ * whole thing fetch it with `GetSessionEvent`. `encodedBytes` (the stored blob's length, when the
+ * caller has it) lets small events skip the walk — live appends pass undefined and always walk,
+ * which is cheap because a just-appended event is almost always small.
+ */
+export function truncateSessionEventForWire(info: api.SessionEvent, encodedBytes?: number): api.SessionEvent {
+  if (encodedBytes !== undefined && encodedBytes <= WIRE_EVENT_BYTE_BUDGET) return info
+  const changed = {did: false}
+  const event = truncateValueForWire(info.event, changed) as api.SessionEventPayload
+  return changed.did ? {...info, event, truncated: true} : info
 }
 
 /** Collapses any value into a short single-line string for verbose server logs. */
@@ -10802,14 +10929,17 @@ async function executeLambdaTool(
       )
     }
   }
-  const changeSummary = execution.changedFiles.length
-    ? `, ${execution.changedFiles.length} memory file${execution.changedFiles.length === 1 ? '' : 's'} changed`
+  const changeSummary = execution.changedFilesTotal
+    ? `, ${execution.changedFilesTotal} memory file${execution.changedFilesTotal === 1 ? '' : 's'} changed`
     : ''
   return {
     summary: `Ran ${doc.name} (${execution.durationMs}ms${changeSummary}).`,
     result,
     ...(logs ? {logs} : {}),
     ...(execution.changedFiles.length ? {changedFiles: execution.changedFiles} : {}),
+    ...(execution.changedFilesTotal > execution.changedFiles.length
+      ? {changedFilesTotal: execution.changedFilesTotal}
+      : {}),
     durationMs: execution.durationMs,
   }
 }
@@ -11014,8 +11144,8 @@ export async function executeCallVerb(
       // non-zero exit, and memory files touched. Mechanics (runtime, duration) stay in the details.
       const notes = [
         ...(result.exitCode === 0 ? [] : [`exit ${result.exitCode}`]),
-        ...(result.changedFiles.length
-          ? [`${result.changedFiles.length} memory file${result.changedFiles.length === 1 ? '' : 's'} changed`]
+        ...(result.changedFilesTotal
+          ? [`${result.changedFilesTotal} memory file${result.changedFilesTotal === 1 ? '' : 's'} changed`]
           : []),
       ]
       const lead = description || `Ran ${runtime} code`

--- a/agents/src/code-exec.test.ts
+++ b/agents/src/code-exec.test.ts
@@ -289,6 +289,24 @@ describe('code exec', () => {
         {path: 'gone.md', change: 'removed'},
         {path: 'new.md', change: 'added'},
       ])
+      expect(result.changedFilesTotal).toBe(3)
+    })
+  })
+
+  test('caps the reported change list while keeping the true total', async () => {
+    await withStateDir(async (stateDir) => {
+      const call: FakeCall = {mounts: []}
+      const executor = createCodeExecutor(defaultCodeExecConfig(), async () =>
+        fakeSdk(call, {
+          onExec: () => {
+            for (let i = 0; i < 250; i++) writeMemoryFile(stateDir, `bulk-${String(i).padStart(3, '0')}.md`, 'x')
+          },
+        }),
+      )
+      const result = await executor.execute({stateDir, runtime: 'python', code: 'x'})
+      expect(result.changedFiles).toHaveLength(200)
+      expect(result.changedFilesTotal).toBe(250)
+      expect(result.changedFiles[0]).toEqual({path: 'bulk-000.md', change: 'added'})
     })
   })
 

--- a/agents/src/code-exec.ts
+++ b/agents/src/code-exec.ts
@@ -108,6 +108,8 @@ export type CodeExecResult = {
   durationMs: number
   /** Memory files added/modified/removed by the execution, from a before/after listing diff. */
   changedFiles: CodeExecFileChange[]
+  /** Real change count; exceeds `changedFiles.length` when the reported list was capped. */
+  changedFilesTotal: number
 }
 
 /** Structural slice of the microsandbox SDK used here, so tests can inject a fake. */
@@ -465,7 +467,7 @@ export function createCodeExecutor(
           stderr: stderr.text,
           truncated: stdout.truncated || stderr.truncated,
           durationMs: Date.now() - startedAt,
-          changedFiles: diffMemory(before.files, after.files),
+          ...diffMemory(before.files, after.files),
         }
       } finally {
         await teardownSandbox(sandbox, config.teardownTimeoutMs ?? EXEC_TEARDOWN_TIMEOUT_MS)
@@ -753,7 +755,17 @@ function snapshotMemory(stateDir: string): MemorySnapshot {
   return {files, totalBytes}
 }
 
-function diffMemory(before: Map<string, string>, after: Map<string, string>): CodeExecFileChange[] {
+/**
+ * Entry cap on the reported change list. An execution that rewrites a huge tree (a package
+ * install, a build) once produced a 64k-entry list that became a 10MB durable session event; past
+ * the cap the count in `changedFilesTotal` tells the whole story and the list is a sample.
+ */
+const MAX_REPORTED_CHANGED_FILES = 200
+
+function diffMemory(
+  before: Map<string, string>,
+  after: Map<string, string>,
+): {changedFiles: CodeExecFileChange[]; changedFilesTotal: number} {
   const changes: CodeExecFileChange[] = []
   for (const [path, stamp] of after) {
     const previous = before.get(path)
@@ -764,7 +776,7 @@ function diffMemory(before: Map<string, string>, after: Map<string, string>): Co
     if (!after.has(path)) changes.push({path, change: 'removed'})
   }
   changes.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))
-  return changes
+  return {changedFiles: changes.slice(0, MAX_REPORTED_CHANGED_FILES), changedFilesTotal: changes.length}
 }
 
 function boundOutput(text: string): {text: string; truncated: boolean} {

--- a/agents/src/main.ts
+++ b/agents/src/main.ts
@@ -309,12 +309,17 @@ async function main(): Promise<void> {
         clients: clients.size,
       })
     }
+    // Truncated once per publish, not per client: a giant tool result would otherwise be encoded
+    // whole into a multi-megabyte frame for every subscriber.
+    const wireSessionEvent =
+      event.type === 'session-event' ? apisvc.truncateSessionEventForWire(event.event) : undefined
     for (const ws of clients) {
       if (event.type === 'session-event') {
-        sendIfSubscribed(ws, event.accountId, `sessions/${event.event.sessionId}`, {
+        const wireEvent = wireSessionEvent ?? event.event
+        sendIfSubscribed(ws, event.accountId, `sessions/${wireEvent.sessionId}`, {
           _: 'append',
-          key: `sessions/${event.event.sessionId}`,
-          event: event.event,
+          key: `sessions/${wireEvent.sessionId}`,
+          event: wireEvent,
         })
       } else if (event.type === 'session-partial') {
         sendIfSubscribed(ws, event.accountId, `sessions/${event.sessionId}`, {

--- a/agents/src/verbs.test.ts
+++ b/agents/src/verbs.test.ts
@@ -49,6 +49,7 @@ function makeContext(overrides: Partial<AgentServicePiToolContext> = {}): AgentS
       truncated: false,
       durationMs: 1,
       changedFiles: [],
+      changedFilesTotal: 0,
     }),
   } as unknown as CodeExecutor
   return {
@@ -362,6 +363,7 @@ describe('call verb', () => {
       truncated: false,
       durationMs: 3,
       changedFiles: [{path: 'x', change: 'added'}],
+      changedFilesTotal: 1,
     }))
     const context = makeContext({
       codeExec: {
@@ -405,6 +407,7 @@ describe('call verb', () => {
           truncated: false,
           durationMs: 5,
           changedFiles: [],
+          changedFilesTotal: 0,
         }),
       } as never,
     })
@@ -451,6 +454,7 @@ describe('call verb', () => {
         truncated: false,
         durationMs: 7,
         changedFiles: [{path: 'weather.json', change: 'added'}],
+        changedFilesTotal: 1,
       }
     })
     toolDocs.saveLambdaToolDocument(context.db, context.accountId, context.agentId, {
@@ -486,6 +490,7 @@ describe('call verb', () => {
       truncated: false,
       durationMs: 2,
       changedFiles: [],
+      changedFilesTotal: 0,
     }))
     toolDocs.saveLambdaToolDocument(context.db, context.accountId, context.agentId, {
       name: 'weather',
@@ -523,6 +528,7 @@ describe('call verb', () => {
       truncated: false,
       durationMs: 3,
       changedFiles: [],
+      changedFilesTotal: 0,
     }))
     toolDocs.saveLambdaToolDocument(context.db, context.accountId, context.agentId, {
       name: 'weather',

--- a/frontend/apps/desktop/src/__tests__/agent-session-rows.test.ts
+++ b/frontend/apps/desktop/src/__tests__/agent-session-rows.test.ts
@@ -739,6 +739,28 @@ describe('symmetric log actors', () => {
     expect(part.completedAt).toBe(part.calledAt! + 2)
   })
 
+  it('carries wire-truncation markers and event seqs so the dialog can fetch full payloads', () => {
+    const rows = buildAgentSessionChatRows(
+      [
+        event(1, {type: 'tool_call', id: 'c1', name: 'call', input: {tool: 'execute'}}),
+        {...event(2, {type: 'tool_result', toolCallId: 'c1', name: 'call', output: {summary: 'ok'}}), truncated: true},
+      ],
+      CONTEXT,
+    )
+    const row = rows[0]!
+    if (row.kind !== 'message') throw new Error('expected a message row')
+    const part = row.message.parts?.[0] as {
+      callSeq?: number
+      callTruncated?: boolean
+      resultSeq?: number
+      resultTruncated?: boolean
+    }
+    expect(part.callSeq).toBe(1)
+    expect(part.callTruncated).toBeUndefined()
+    expect(part.resultSeq).toBe(2)
+    expect(part.resultTruncated).toBe(true)
+  })
+
   it('leaves a tool row with nothing to say carrying no stat block at all', () => {
     const rows = buildAgentSessionChatRows(
       [event(1, {type: 'tool_result', toolCallId: 'orphan', name: 'read', output: {summary: 'Read.'}})],

--- a/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
@@ -81,6 +81,7 @@ vi.mock('@shm/ui/agents/models', () => ({
   useAgentRunTreeSubscription: () => ({runs: {}, progress: {}, activity: {}, journal: []}),
   useCancelRun: () => ({mutate: () => {}, isPending: false}),
   useSignalRun: () => ({mutate: () => {}, isPending: false}),
+  useFullAgentSessionEvent: () => ({data: undefined, isLoading: false, error: null}),
 }))
 
 import {AgentErrorRow, ChatMessageBubble} from '@shm/ui/agents/message-rendering'

--- a/frontend/packages/ui/src/agents/agent-session-rows.ts
+++ b/frontend/packages/ui/src/agents/agent-session-rows.ts
@@ -452,6 +452,8 @@ export function buildAgentSessionChatRows(
         args: isRecord(payload.input) ? payload.input : {input: payload.input},
         actor: sessionEventActor(event.event),
         calledAt: event.createdAt,
+        callSeq: event.seq,
+        ...(event.truncated ? {callTruncated: true} : {}),
         ...(payload.meta ? {meta: payload.meta} : {}),
       }
       const row: Extract<AgentSessionChatRow, {kind: 'message'}> = {
@@ -537,6 +539,8 @@ export function buildAgentSessionChatRows(
         rawOutput: payload.output,
         ...(explicitResultActor ? {actor: explicitResultActor} : {}),
         completedAt: event.createdAt,
+        resultSeq: event.seq,
+        ...(event.truncated ? {resultTruncated: true} : {}),
         ...(meta ? {meta} : {}),
         ...(payload.error ? {isError: true} : {}),
       }

--- a/frontend/packages/ui/src/agents/assistant-panel.tsx
+++ b/frontend/packages/ui/src/agents/assistant-panel.tsx
@@ -763,7 +763,16 @@ function AssistantSessionChat({
   const {serverUrl, sessionId} = sessionRef
   const navigate = useNavigate()
   const session = useAgentSession(serverUrl, accountUid, sessionId)
-  const live = useAgentWebSocketSubscription(serverUrl, accountUid, `sessions/${sessionId}`)
+  // Resume the socket after the last loaded event: without afterSeq the server replays the whole
+  // transcript over the socket on top of the GetSession fetch — the session loads twice. The
+  // subscription waits for the fetch so the race cannot resurrect the full replay.
+  const lastSeq = session.data?.events.filter((event) => event.seq !== Number.MAX_SAFE_INTEGER).at(-1)?.seq
+  const live = useAgentWebSocketSubscription(
+    serverUrl,
+    accountUid,
+    session.data ? `sessions/${sessionId}` : undefined,
+    lastSeq ?? 0,
+  )
   const messageSession = useMessageAgentSession(serverUrl, accountUid)
   const stopSession = useStopAgentSession(serverUrl, accountUid)
   const retrySession = useRetrySession(serverUrl, accountUid)

--- a/frontend/packages/ui/src/agents/chat-parts.ts
+++ b/frontend/packages/ui/src/agents/chat-parts.ts
@@ -48,6 +48,14 @@ export type ChatToolPart = {
   child?: ChatToolChild
   /** Durable timestamp of the call event — when the tool was invoked. */
   calledAt?: number
+  /** Sequence of the call event, so a truncated input can be fetched whole with GetSessionEvent. */
+  callSeq?: number
+  /** The call event's payload was wire-truncated; `args` is a preview of the durable input. */
+  callTruncated?: boolean
+  /** Sequence of the result event, so a truncated output can be fetched whole with GetSessionEvent. */
+  resultSeq?: number
+  /** The result event's payload was wire-truncated; `rawOutput` is a preview of the durable output. */
+  resultTruncated?: boolean
   /** Durable timestamp of the result event; the row itself stays positioned at the call event. */
   completedAt?: number
   /** The result was an error (validation failure, tool crash) — `result` holds the message. */

--- a/frontend/packages/ui/src/agents/message-rendering.tsx
+++ b/frontend/packages/ui/src/agents/message-rendering.tsx
@@ -25,7 +25,7 @@ import {
   type ToolRowSummary,
 } from './tool-summary'
 import {useOpenUrl} from './navigation'
-import {useRun, useRunTree, useSessionAttachmentDataUrls, useSessionRuns} from './models'
+import {useFullAgentSessionEvent, useRun, useRunTree, useSessionAttachmentDataUrls, useSessionRuns} from './models'
 import {Notice} from '@shm/ui/notice'
 import {descendantsOf, isTerminalRun, RunTimerProgress, RunWorkHierarchy, useRunTreeView} from './run-work'
 import {useAccount} from '@shm/shared/models/entity'
@@ -627,6 +627,43 @@ function ToolDetailText({value}: {value: string}) {
   )
 }
 
+/**
+ * A "this is a preview" note with the fetch trigger, shown under a wire-truncated payload. Owns
+ * the on-demand fetch so the query machinery mounts ONLY for truncated rows — the overwhelmingly
+ * common untruncated dialog stays a pure render with no data dependencies.
+ */
+function TruncatedPayloadNotice({
+  label,
+  seq,
+  onLoaded,
+}: {
+  label: string
+  seq: number | undefined
+  onLoaded: (payload: Record<string, unknown>) => void
+}) {
+  const {serverUrl, accountUid, sessionId} = React.useContext(ToolRowContext)
+  const [requested, setRequested] = useState(false)
+  const query = useFullAgentSessionEvent(serverUrl, accountUid, sessionId, seq, requested)
+  const payload = query.data?.event as Record<string, unknown> | undefined
+  React.useEffect(() => {
+    if (payload) onLoaded(payload)
+  }, [payload, onLoaded])
+  const loading = requested && query.isLoading
+  return (
+    <div className="text-muted-foreground flex items-center gap-2 text-[11px]">
+      <span>{query.error ? 'Could not load the full payload.' : `${label} is truncated for display.`}</span>
+      <button
+        type="button"
+        onClick={() => setRequested(true)}
+        disabled={loading}
+        className="text-foreground hover:bg-muted rounded border px-1.5 py-0.5 disabled:opacity-50"
+      >
+        {loading ? 'Loading…' : 'Load full data'}
+      </button>
+    </div>
+  )
+}
+
 function ToolCallDebugDialog({
   item,
   open,
@@ -636,6 +673,10 @@ function ToolCallDebugDialog({
   open: boolean
   onOpenChange: (open: boolean) => void
 }) {
+  const [fullCallPayload, setFullCallPayload] = useState<Record<string, unknown> | undefined>()
+  const [fullResultPayload, setFullResultPayload] = useState<Record<string, unknown> | undefined>()
+  const args = (fullCallPayload?.input as ChatToolPart['args'] | undefined) ?? item.args
+  const output = fullResultPayload?.output ?? item.rawOutput ?? item.result
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[85vh] w-[min(44rem,calc(100vw-2rem))]">
@@ -650,25 +691,31 @@ function ToolCallDebugDialog({
               item.calledAt || item.completedAt ? {startedAt: item.calledAt, completedAt: item.completedAt} : undefined
             }
           />
-          {typeof item.args?.script === 'string' && item.args.script ? (
+          {typeof args?.script === 'string' && args.script ? (
             <div className="min-h-0 space-y-1">
               <div className="text-muted-foreground text-[10px] font-medium tracking-[0.18em] uppercase">Script</div>
               <pre className="bg-muted max-h-64 overflow-auto rounded-xl p-3 font-mono text-[11px] whitespace-pre">
-                {item.args.script}
+                {args.script}
               </pre>
             </div>
           ) : null}
           <div className="min-h-0 space-y-1">
             <div className="text-muted-foreground text-[10px] font-medium tracking-[0.18em] uppercase">Input</div>
             <pre className="bg-muted max-h-48 overflow-auto rounded-xl p-3 text-[11px] whitespace-pre-wrap">
-              {formatToolDebugValue(item.args)}
+              {formatToolDebugValue(args)}
             </pre>
+            {item.callTruncated && !fullCallPayload ? (
+              <TruncatedPayloadNotice label="Input" seq={item.callSeq} onLoaded={setFullCallPayload} />
+            ) : null}
           </div>
           <div className="min-h-0 space-y-1">
             <div className="text-muted-foreground text-[10px] font-medium tracking-[0.18em] uppercase">Output</div>
             <pre className="bg-muted max-h-72 overflow-auto rounded-xl p-3 text-[11px] whitespace-pre-wrap">
-              {formatToolDebugValue(item.rawOutput ?? item.result)}
+              {formatToolDebugValue(output)}
             </pre>
+            {item.resultTruncated && !fullResultPayload ? (
+              <TruncatedPayloadNotice label="Output" seq={item.resultSeq} onLoaded={setFullResultPayload} />
+            ) : null}
           </div>
         </div>
       </DialogContent>

--- a/frontend/packages/ui/src/agents/models.ts
+++ b/frontend/packages/ui/src/agents/models.ts
@@ -2329,6 +2329,36 @@ export function useAgentSession(
   })
 }
 
+/**
+ * Fetches one durable session event in full. Session loads wire-truncate giant payloads (a
+ * multi-megabyte tool output would make every open slow); this is the on-demand path for the
+ * rare click that actually wants all of it.
+ */
+export function useFullAgentSessionEvent(
+  serverUrl: string | undefined,
+  accountUid: string | null | undefined,
+  sessionId: string | undefined,
+  seq: number | undefined,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: ['agents', 'session-event', serverUrl, accountUid, sessionId, seq],
+    queryFn: async () => {
+      const res = await sendAgentAction({
+        serverUrl: serverUrl!,
+        accountUid: accountUid!,
+        action: {_: 'GetSessionEvent', sessionId: sessionId!, seq: seq!},
+      })
+      if (res._ !== 'GetSessionEventResponse') throw new Error('Unexpected GetSessionEvent response')
+      return res.event
+    },
+    enabled: enabled && !!serverUrl && !!accountUid && !!sessionId && seq !== undefined,
+    staleTime: Infinity,
+    retry: false,
+    useErrorBoundary: false,
+  })
+}
+
 /** One session row in the merged, cross-server sidebar list. */
 export type AgentSessionListEntry = {
   /** Server the session lives on. Part of its identity — session ids are only unique per server. */

--- a/frontend/packages/ui/src/agents/session.tsx
+++ b/frontend/packages/ui/src/agents/session.tsx
@@ -189,7 +189,14 @@ function AgentSessionPage({
   const deleteSessionDialog = useAppDialog(DeleteAgentSessionDialog, {isAlert: true})
   const systemPromptDialog = useAppDialog(SystemPromptDialog)
   const lastSeq = session.data?.events.filter((event) => event.seq !== Number.MAX_SAFE_INTEGER).at(-1)?.seq
-  const liveState = useAgentWebSocketSubscription(serverUrl, selectedAccountId, `sessions/${sessionId}`, lastSeq)
+  // The subscription waits for the initial GetSession: subscribing with no afterSeq makes the
+  // server replay the whole transcript over the socket on top of the fetch.
+  const liveState = useAgentWebSocketSubscription(
+    serverUrl,
+    selectedAccountId,
+    session.data ? `sessions/${sessionId}` : undefined,
+    lastSeq ?? 0,
+  )
   // Account-wide events too: run changes publish on `runs/<rootRunId>` and agent/trigger changes on
   // their own keys, none of which the session subscription receives — and with no polling, these
   // events are what keep the run state and agent header fresh here.


### PR DESCRIPTION
## Why

Opening a session in production was painfully slow. Measured on `agents-stable`: one 116-event session weighed **22.5 MB** because three `call` tool results carried multi-megabyte outputs — the largest a **9.5 MB** event holding 64,617 `changedFiles` entries from a single code execution. Those bytes were paid four times per open (pure-JS CBOR decode on the server's only thread, re-encode into frames, TLS transfer, pure-JS decode in the renderer), and then **paid again**: the assistant panel subscribed with no `afterSeq`, so the socket replayed the entire transcript on top of the `GetSession` fetch. `GetSession` also re-resolved the agent's system prompt on every call, which can fetch remote hm:// documents.

Indexing was ruled out: `UNIQUE(session_id, seq)` already covers every transcript query, and event counts are modest (≤ ~500/session). Pagination alone wouldn't have helped — one 10 MB event still sinks the load. The problem was payload bytes.

## What

**Source cap** — code-exec now reports at most 200 `changedFiles` plus a true `changedFilesTotal`, so a build that rewrites a huge tree can't mint multi-megabyte durable events again.

**Wire truncation** — `GetSession`, subscription replay, and the live append fan-out cap giant payloads per event (16 KB strings, 200-entry arrays) and mark the event `truncated`. Events under 64 KB encoded skip the walk entirely (the stored blob length is the guard, no extra decode). Durable rows are untouched; the 22.5 MB session now loads as ~100 KB.

**On-demand full fetch** — new `GetSessionEvent` action returns one durable event whole. The tool info dialog shows a "Load full data" affordance under truncated inputs/outputs; the query machinery only mounts for truncated rows.

**No double replay** — both session views subscribe only after the initial `GetSession` resolves and resume with `afterSeq`, so the socket delivers only what the fetch didn't.

**Tail pagination (server support)** — `GetSession` accepts `limit`/`beforeSeq` and reports `hasMoreBefore`. The UI still loads full transcripts (fine once events are size-bounded); the protocol is ready for tail-first loading when transcripts grow.

**System prompt cache** — resolved prompt markdown is cached per agent (5 min TTL, keyed by the prompt blocks), removing remote doc fetches from the session-open path.

`agents/docs/perf-squeeze-plan.md` gains workstream 6 documenting the measurements and the follow-up (spilling oversized outputs to disk at append time, which would also cut the per-model-turn decode cost of legacy giant events).

## Testing

- agents: 390 pass, 0 fail (new coverage: wire truncation + limit/beforeSeq/hasMoreBefore + GetSessionEvent round-trip; changedFiles cap with true total)
- desktop vitest: 763 pass; the 1 failure (`agents-live-titling.integration.test.tsx`) fails identically on clean origin/main in this environment
- `bun tsgo --noEmit` (agents) and `tsc` (UI package) clean; Prettier clean on all touched frontend files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P571wF9NS8bAV1xeskrsVa