### PR TITLE
fix(daemon): serve IPFS files with a Content-Type derived from their bytes

### DIFF
--- a/backend/hmnet/filemanager.go
+++ b/backend/hmnet/filemanager.go
@@ -6,13 +6,16 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
+	"path"
 	"seed/backend/blob"
 	"seed/backend/ipfs"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/gabriel-vasile/mimetype"
 	"github.com/ipfs/boxo/blockservice"
 	blockstore "github.com/ipfs/boxo/blockstore"
 	"github.com/ipfs/boxo/exchange"
@@ -36,6 +39,17 @@ const (
 	PublicIPFSCacheControl = "public, max-age=29030400, immutable"
 	// PrivateIPFSCacheControl permits browser caching but prevents shared CDN caches from storing private content.
 	PrivateIPFSCacheControl = "private, max-age=29030400, immutable"
+	// DefaultContentType is served when the type of a file can't be determined.
+	DefaultContentType = "application/octet-stream"
+	// SandboxContentSecurityPolicy is sent with any file whose type could carry script (SVG, XML, text, unknown binaries),
+	// so that navigating to the file directly renders it in an opaque origin with no script execution.
+	// Without it, an uploaded SVG or HTML file would run as the daemon's own origin and could call its API.
+	// Loading such a file in <img> is unaffected: images never execute script anyway.
+	SandboxContentSecurityPolicy = "sandbox"
+
+	// sniffBytes is how much of the file is inspected to determine its type.
+	// This is what the detector reads at most; more doesn't improve accuracy.
+	sniffBytes = 3072
 )
 
 // PublicCIDChecker checks whether a CID is publicly cacheable.
@@ -146,11 +160,30 @@ func (fm *FileManager) GetFile(w http.ResponseWriter, r *http.Request) {
 		size = int64(len(n.RawData()))
 	}
 
-	w.Header().Set("Content-Type", "application/octet-stream")
+	filename := r.URL.Query().Get("filename")
+
+	// IPFS addresses bytes, not files: nothing in the DAG says what the content is.
+	// The type is a property of the bytes, so derive it from them at the one place that serves them,
+	// rather than asking every writer to record it and every reader to trust that record.
+	// A download name, when the caller gives one, wins because it's what the user will see.
+	head, body, err := peekHead(response)
+	if err != nil {
+		fm.log.Warn("GetFile: failed to read file head", zap.Error(err), zap.String("cid", cidStr))
+		http.Error(w, "Could not read the data with the given CID: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	response = body
+	contentType := ContentTypeFor(filename, head)
+
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	if !isInertContentType(contentType) {
+		w.Header().Set("Content-Security-Policy", SandboxContentSecurityPolicy)
+	}
 	w.Header().Set("ETag", cidStr)
 	w.Header().Set("Cache-Control", fm.cacheControlForCID(ctx, cid))
 
-	if filename := r.URL.Query().Get("filename"); filename != "" {
+	if filename != "" {
 		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filename))
 	}
 
@@ -221,6 +254,86 @@ func (fm *FileManager) GetFile(w http.ResponseWriter, r *http.Request) {
 	if _, err := io.Copy(w, response); err != nil {
 		fm.log.Warn("GetFile: failed to write response in full", zap.Error(err), zap.String("cid", cidStr))
 	}
+}
+
+// peekHead reads the beginning of r for type detection and hands back a reader
+// positioned at the start of the content again. Seekable readers (UnixFS files,
+// raw blocks) are rewound so that range requests can still seek on them; anything
+// else gets the consumed bytes stitched back in front.
+func peekHead(r io.Reader) ([]byte, io.Reader, error) {
+	head := make([]byte, sniffBytes)
+	n, err := io.ReadFull(r, head)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return nil, nil, err
+	}
+	head = head[:n]
+
+	if s, ok := r.(io.Seeker); ok {
+		if _, err := s.Seek(0, io.SeekStart); err == nil {
+			return head, r, nil
+		}
+	}
+
+	return head, io.MultiReader(bytes.NewReader(head), r), nil
+}
+
+// ContentTypeFor determines the Content-Type to serve for a file.
+// A filename with a known extension takes precedence; otherwise the type is
+// detected from the leading bytes of the content, falling back to DefaultContentType.
+// Types that would render as a document on the daemon's origin (HTML) are downgraded to plain text.
+func ContentTypeFor(filename string, head []byte) string {
+	if ext := path.Ext(filename); ext != "" {
+		if t := mime.TypeByExtension(ext); t != "" {
+			return neuterContentType(t)
+		}
+	}
+
+	if len(head) == 0 {
+		return DefaultContentType
+	}
+
+	return neuterContentType(mimetype.Detect(head).String())
+}
+
+// neuterContentType replaces types the browser would render as an active document with plain text.
+// There's no reason for the daemon to ever serve a page, and doing so would be a stored XSS on its origin.
+func neuterContentType(contentType string) string {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return DefaultContentType
+	}
+
+	switch mediaType {
+	case "text/html", "application/xhtml+xml":
+		return "text/plain; charset=utf-8"
+	}
+
+	return contentType
+}
+
+// isInertContentType reports whether a type is rendered by the browser without
+// any possibility of script execution, so it needs no Content-Security-Policy.
+// SVG is an image that can carry <script>, so it's deliberately not in this set.
+func isInertContentType(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return false
+	}
+
+	if mediaType == "image/svg+xml" {
+		return false
+	}
+
+	switch {
+	case strings.HasPrefix(mediaType, "image/"),
+		strings.HasPrefix(mediaType, "video/"),
+		strings.HasPrefix(mediaType, "audio/"),
+		strings.HasPrefix(mediaType, "font/"),
+		mediaType == "application/pdf":
+		return true
+	}
+
+	return false
 }
 
 func (fm *FileManager) cacheControlForCID(ctx context.Context, c cid.Cid) string {

--- a/backend/hmnet/filemanager_contenttype_test.go
+++ b/backend/hmnet/filemanager_contenttype_test.go
@@ -1,0 +1,142 @@
+package hmnet
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContentTypeFor(t *testing.T) {
+	svg := []byte(`<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg" width="80" height="80"><rect width="80" height="80"/></svg>`)
+	png := []byte("\x89PNG\r\n\x1a\n\x00\x00\x00\x0dIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00")
+	html := []byte("<!DOCTYPE html><html><body><script>alert(1)</script></body></html>")
+	pdf := []byte("%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\n")
+	unknown := []byte{0x00, 0x01, 0x02, 0x03, 0xff, 0xfe, 0xfd, 0x7f, 0x80, 0x81}
+
+	tests := []struct {
+		name     string
+		filename string
+		head     []byte
+		want     string
+	}{
+		{name: "svg is detected from bytes", head: svg, want: "image/svg+xml"},
+		{name: "png is detected from bytes", head: png, want: "image/png"},
+		{name: "pdf is detected from bytes", head: pdf, want: "application/pdf"},
+		{name: "html is downgraded to plain text", head: html, want: "text/plain; charset=utf-8"},
+		{name: "unknown bytes fall back to octet-stream", head: unknown, want: DefaultContentType},
+		{name: "empty content falls back to octet-stream", head: nil, want: DefaultContentType},
+		{name: "filename extension wins over bytes", filename: "photo.jpg", head: png, want: "image/jpeg"},
+		{name: "filename extension is used for unknown bytes", filename: "report.pdf", head: unknown, want: "application/pdf"},
+		{name: "html extension is downgraded too", filename: "page.html", head: unknown, want: "text/plain; charset=utf-8"},
+		{name: "unknown extension falls back to bytes", filename: "logo.whatever", head: svg, want: "image/svg+xml"},
+		{name: "filename without extension falls back to bytes", filename: "logo", head: svg, want: "image/svg+xml"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, ContentTypeFor(tt.filename, tt.head))
+		})
+	}
+}
+
+func TestIsInertContentType(t *testing.T) {
+	require.True(t, isInertContentType("image/png"))
+	require.True(t, isInertContentType("image/jpeg"))
+	require.True(t, isInertContentType("video/mp4"))
+	require.True(t, isInertContentType("audio/mpeg"))
+	require.True(t, isInertContentType("font/woff2"))
+	require.True(t, isInertContentType("application/pdf"))
+	require.False(t, isInertContentType("image/svg+xml"))
+	require.False(t, isInertContentType("text/plain; charset=utf-8"))
+	require.False(t, isInertContentType("application/octet-stream"))
+	require.False(t, isInertContentType("text/xml"))
+	require.False(t, isInertContentType("application/json"))
+	require.False(t, isInertContentType(""))
+}
+
+func TestGetFileContentType(t *testing.T) {
+	server := makeManager(t, akey)
+	router := http.NewServeMux()
+	router.HandleFunc("/ipfs/file-upload", server.UploadFile)
+	router.HandleFunc("/ipfs/{cid}", server.GetFile)
+
+	upload := func(t *testing.T, data []byte) string {
+		res := makeRequest(t, "POST", "/ipfs/file-upload", data, router)
+		require.Equal(t, http.StatusCreated, res.Code)
+		return res.Body.String()
+	}
+
+	get := func(t *testing.T, url string, rangeHeader string) *httptest.ResponseRecorder {
+		req, err := http.NewRequest("GET", url, nil)
+		require.NoError(t, err)
+		if rangeHeader != "" {
+			req.Header.Set("Range", rangeHeader)
+		}
+		res := httptest.NewRecorder()
+		router.ServeHTTP(res, req)
+		return res
+	}
+
+	svg := []byte(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2400 800" width="80" height="80"><script>alert(1)</script><rect width="2400" height="800"/></svg>`)
+	png := []byte("\x89PNG\r\n\x1a\n\x00\x00\x00\x0dIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00")
+	html := []byte("<!DOCTYPE html><html><body><script>alert(1)</script></body></html>")
+	unknown := []byte{0x00, 0x01, 0x02, 0x03, 0xff, 0xfe, 0xfd, 0x7f, 0x80, 0x81}
+
+	t.Run("svg is served as an image, sandboxed", func(t *testing.T) {
+		cid := upload(t, svg)
+		res := get(t, "/ipfs/"+cid, "")
+		require.Equal(t, http.StatusOK, res.Code)
+		require.Equal(t, "image/svg+xml", res.Header().Get("Content-Type"))
+		require.Equal(t, "nosniff", res.Header().Get("X-Content-Type-Options"))
+		require.Equal(t, SandboxContentSecurityPolicy, res.Header().Get("Content-Security-Policy"))
+		require.Equal(t, svg, res.Body.Bytes())
+	})
+
+	t.Run("raster image is served without a sandbox", func(t *testing.T) {
+		cid := upload(t, png)
+		res := get(t, "/ipfs/"+cid, "")
+		require.Equal(t, http.StatusOK, res.Code)
+		require.Equal(t, "image/png", res.Header().Get("Content-Type"))
+		require.Equal(t, "nosniff", res.Header().Get("X-Content-Type-Options"))
+		require.Empty(t, res.Header().Get("Content-Security-Policy"))
+		require.Equal(t, png, res.Body.Bytes())
+	})
+
+	t.Run("html never renders as a page", func(t *testing.T) {
+		cid := upload(t, html)
+		res := get(t, "/ipfs/"+cid, "")
+		require.Equal(t, http.StatusOK, res.Code)
+		require.Equal(t, "text/plain; charset=utf-8", res.Header().Get("Content-Type"))
+		require.Equal(t, SandboxContentSecurityPolicy, res.Header().Get("Content-Security-Policy"))
+		require.Equal(t, html, res.Body.Bytes())
+	})
+
+	t.Run("unknown bytes stay octet-stream", func(t *testing.T) {
+		cid := upload(t, unknown)
+		res := get(t, "/ipfs/"+cid, "")
+		require.Equal(t, http.StatusOK, res.Code)
+		require.Equal(t, DefaultContentType, res.Header().Get("Content-Type"))
+		require.Equal(t, unknown, res.Body.Bytes())
+	})
+
+	t.Run("download name decides the type", func(t *testing.T) {
+		cid := upload(t, unknown)
+		res := get(t, "/ipfs/"+cid+"?filename=report.pdf", "")
+		require.Equal(t, http.StatusOK, res.Code)
+		require.Equal(t, "application/pdf", res.Header().Get("Content-Type"))
+		require.Equal(t, `attachment; filename="report.pdf"`, res.Header().Get("Content-Disposition"))
+		require.Equal(t, unknown, res.Body.Bytes())
+	})
+
+	t.Run("range requests keep the type and the offsets", func(t *testing.T) {
+		cid := upload(t, svg)
+		res := get(t, "/ipfs/"+cid, "bytes=10-29")
+		require.Equal(t, http.StatusPartialContent, res.Code)
+		require.Equal(t, "image/svg+xml", res.Header().Get("Content-Type"))
+		require.Equal(t, "bytes 10-29/"+strconv.Itoa(len(svg)), res.Header().Get("Content-Range"))
+		require.Equal(t, svg[10:30], res.Body.Bytes())
+	})
+}

--- a/frontend/apps/web/app/routes/hm.api.file.$.tsx
+++ b/frontend/apps/web/app/routes/hm.api.file.$.tsx
@@ -51,6 +51,12 @@ async function loadFile(params: Record<string, string | undefined>, request: Req
     if (contentRange) responseHeaders['Content-Range'] = contentRange
     const acceptRanges = response.headers.get('accept-ranges')
     if (acceptRanges) responseHeaders['Accept-Ranges'] = acceptRanges
+    // The daemon types files by their bytes, so an SVG now arrives as image/svg+xml.
+    // Keep its sandbox so a script inside it can't run on the site's origin.
+    const csp = response.headers.get('content-security-policy')
+    if (csp) responseHeaders['Content-Security-Policy'] = csp
+    const typeOptions = response.headers.get('x-content-type-options')
+    if (typeOptions) responseHeaders['X-Content-Type-Options'] = typeOptions
 
     return new Response(response.body, {
       status: response.status,

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/burdiyan/go/mainutil v0.0.0-20200124222818-6f87e0e684b6
 	github.com/fullstorydev/grpcui v1.4.3
 	github.com/fxamacker/cbor/v2 v2.7.0
+	github.com/gabriel-vasile/mimetype v1.4.13
 	github.com/getsentry/sentry-go v0.27.0
 	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
## Problem

`GET /ipfs/{cid}` answered every request with `application/octet-stream`. Chromium sniffs raster images inside `<img>`, so JPEG/PNG worked, but it deliberately does not sniff SVG — so every SVG image (covers, icons, inline images) rendered blank in the desktop app. Example: https://hyper.media/hm/z6MkpVa5nMUR5ZaUEyV1SE48KTNbwTuHRd83RwLgMKc4nGU3 — 18 of the 22 image placements on that page are two SVG blobs. Web was unaffected only because `/hm/api/image` rasterises everything through sharp.

The same missing header also caused:
- **Export as Markdown** naming every media file `foo.bin` (`mime.getExtension('application/octet-stream')` → `bin`)
- **Save file** dropping the extension when the block name has none (it already special-cases octet-stream)
- the **inspect page** showing SVGs as text (its "is this an image?" probe is an `<img>` load)

Not a sync issue — all CIDs were already local on both daemons.

## Fix

Detect the type from the leading bytes at the one place that serves them, using `gabriel-vasile/mimetype` (already an indirect dependency). This deliberately does *not* add a filename or mime attribute to blocks: that would be hidden data, redundant with the content, and something every writer (desktop, CLI, agents, mobile, importers) would have to keep correct forever. The type is a property of the bytes.

Precedence in `ContentTypeFor`:
1. `?filename=` extension (download name — visible to the user, already used by the File block)
2. byte detection
3. `application/octet-stream`

## Safety

Serving real types from the daemon origin (`localhost:56001`, which also hosts the API) means an uploaded SVG or HTML with `<script>` could otherwise execute against the daemon's own API when navigated to directly. So:
- `X-Content-Type-Options: nosniff` on every `/ipfs/` response
- `Content-Security-Policy: sandbox` on anything that isn't a raster image, video, audio, font, or PDF (SVG included — it can carry script)
- `text/html` / `xhtml` downgraded to `text/plain`

`<img>` loads are unaffected: images never execute script. The web `/hm/api/file` proxy forwards the two headers so the same guarantee holds on the site origin.

## Tests

`backend/hmnet/filemanager_contenttype_test.go`: precedence/downgrade/inert-set unit tests, plus handler tests for SVG (typed + sandboxed), PNG (no sandbox), HTML → plain text, unknown → octet-stream, `?filename=report.pdf`, and a Range request on an SVG keeping type and offsets. Existing `TestPostGet`/`TestRangeRequests` still pass.

## Follow-ups (not in this PR)

- Web's `/hm/api/image` could stop rasterising SVGs now that the daemon reports `image/svg+xml`.
- `save-cid-as-file.tsx`'s octet-stream special case can go once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011fyabXL7WrNoKcTjioRuSc
