### PR TITLE
fix(agents): self-heal migrations whose schema objects already exist

### DIFF
--- a/agents/src/sqlite.test.ts
+++ b/agents/src/sqlite.test.ts
@@ -150,6 +150,33 @@ describe('sqlite', () => {
     }
   })
 
+  test('self-heals a stale migration version whose objects already exist, still applying what is missing', () => {
+    // The inverse of the missing-table repair: a database migrated under a divergent branch
+    // ordering already holds most pending migrations' objects while the count claims they are all
+    // pending. This is exactly the state that crash-looped a dev database on boot ("table
+    // webhook_trigger_credentials already exists") — and that database also genuinely lacked
+    // trigger_firings.run_id, so skipping whole migrations would trade the crash for "no such
+    // column". Statement-wise replay must skip only what exists and apply the rest.
+    const db = createMemoryDatabase()
+    try {
+      db.run(sqlite.schema.replace(/    body_digest BLOB,\n    run_id TEXT,\n/u, '    body_digest BLOB,\n'))
+      db.run(`INSERT INTO server_config (key, value) VALUES (?, ?)`, [
+        sqlite.SCHEMA_MIGRATION_VERSION_KEY,
+        String(sqlite.BASELINE_SCHEMA_MIGRATION_VERSION),
+      ])
+      expect(columnExists(db, 'trigger_firings', 'run_id')).toBe(false)
+
+      const result = sqlite.openWithDatabase(db)
+      expect(result.ok).toBe(true)
+      expect(getConfigValue(db, sqlite.SCHEMA_MIGRATION_VERSION_KEY)).toBe(String(sqlite.desiredVersion))
+      // The genuinely missing piece of a partially-present migration was still applied.
+      expect(columnExists(db, 'trigger_firings', 'run_id')).toBe(true)
+      expect(tableExists(db, 'webhook_trigger_credentials')).toBe(true)
+    } finally {
+      db.close()
+    }
+  })
+
   test('rejects databases with missing, legacy, invalid, or future migration versions', () => {
     const cases: Array<{name: string; setup: (db: Database) => void; current: number}> = [
       {

--- a/agents/src/sqlite.ts
+++ b/agents/src/sqlite.ts
@@ -498,6 +498,12 @@ function parseSchemaMigrationVersion(value: string): number | null {
   return parsed
 }
 
+/** Whether an error proves a migration's schema object is already present (table, index, or column). */
+function isSchemaExistsError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return /already exists|duplicate column name/iu.test(message)
+}
+
 function applyPendingMigrations(db: Database, currentVersion: number): void {
   const pendingMigrations = migrations.slice(currentVersion)
   if (pendingMigrations.length === 0) return
@@ -514,6 +520,20 @@ function applyPendingMigrations(db: Database, currentVersion: number): void {
         db.run(`RELEASE ${savepoint}`)
       } catch (error) {
         db.run(`ROLLBACK TO ${savepoint}`)
+        // The version is only a count, so it is not a reliable coordinate across branches: a
+        // database migrated under a branch whose Nth migration differs from main's Nth can already
+        // hold this migration's objects while the count claims the migration is pending — the
+        // mirror of the missing-table state ensureBaselineTables repairs. The schema objects are
+        // the truth: replay the migration one statement at a time, skipping exactly the statements
+        // whose object already exists (a divergent database can hold PART of a migration, so
+        // skipping the whole migration would silently drop the rest). Any other failure still
+        // aborts the boot.
+        if (isSchemaExistsError(error)) {
+          applyMigrationTolerantly(db, migration, nextVersion)
+          setServerConfigValue(db, SCHEMA_MIGRATION_VERSION_KEY, String(nextVersion))
+          db.run(`RELEASE ${savepoint}`)
+          continue
+        }
         db.run(`RELEASE ${savepoint}`)
         throw error
       }
@@ -522,6 +542,23 @@ function applyPendingMigrations(db: Database, currentVersion: number): void {
   } catch (error) {
     db.run('ROLLBACK')
     throw error
+  }
+}
+
+/** Replays one migration statement-wise, skipping only statements whose schema object already exists. */
+function applyMigrationTolerantly(db: Database, migration: string, version: number): void {
+  for (const statement of dedent(migration).split(/;\s*\n/u)) {
+    const sql = statement.trim().replace(/;+$/u, '')
+    if (!sql) continue
+    try {
+      db.run(`${sql};`)
+    } catch (error) {
+      if (!isSchemaExistsError(error)) throw error
+      console.warn('[agents/sqlite] migration statement skipped: its schema object already exists', {
+        version,
+        statement: sql.split('\n')[0],
+      })
+    }
   }
 }
 


### PR DESCRIPTION
## The crash

Dev agents server crash-looped on boot with `SQLiteError: table webhook_trigger_credentials already exists`.

## Root cause

The migration version is just a count, so it's not a reliable coordinate across branches: this database was migrated under a feature-branch ordering, so it already held `webhook_trigger_credentials`, `body_digest`, and `mcp_servers` while its stored version (18) claimed those migrations were pending. Boot re-ran the `CREATE TABLE` and died. This is the mirror image of the missing-table state that `ensureBaselineTables` (17362b5b2) already repairs.

Crucially the divergence was **partial**: the same database genuinely lacked `trigger_firings.run_id`. So neither naive fix works — re-running the migration crashes, and skipping it (or hand-stamping the version) trades the boot crash for `no such column: run_id` at runtime.

## The fix

When a pending migration fails with an object-already-exists error (`already exists` / `duplicate column name`), replay that migration one statement at a time, skipping exactly the statements whose object is present and applying the rest, then count it as applied (with a warning per skipped statement). Any other failure still aborts the boot. The schema objects are the truth; the count is bookkeeping.

## Validation

- New test models the exact crashed state (full schema minus `run_id`, version stamped 0): boots, stamps `desiredVersion`, and the genuinely-missing column is applied.
- Ran the fixed `open()` against a **copy of the actual crashed dev database**: `OK version: 20, trigger_firings.run_id present: true`.
- Full agents suite 391 pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bwThptdnZqMbQMzd1h5jF