### PR TITLE
fix(agents): keep the API responsive under concurrent runs

### DIFF
--- a/agents/src/agent-memory.test.ts
+++ b/agents/src/agent-memory.test.ts
@@ -12,6 +12,7 @@ import {
   readMemoryFile,
   resolveMemoryPath,
   summarizeMemoryTopLevel,
+  summarizeMemoryTopLevelAsync,
   writeMemoryFile,
 } from '@/agent-memory'
 
@@ -175,20 +176,40 @@ describe('agent memory', () => {
   })
 
   test('summarizes the top level without expanding subfolders', async () => {
-    withStateDir((stateDir) => {
+    await withStateDir(async (stateDir) => {
       writeMemoryFile(stateDir, 'MEMORY.md', 'index')
       writeMemoryFile(stateDir, 'notes/a.md', 'aa')
       writeMemoryFile(stateDir, 'notes/deep/b.md', 'bbb')
       writeMemoryFile(stateDir, 'media/pic.png', new Uint8Array(4))
 
+      // The summary walk stops at MAX_MEMORY_SUMMARY_DEPTH: notes/deep/ is seen but not entered,
+      // so its file is absent, the counts read as minimums, and the result flags truncation.
       const summary = summarizeMemoryTopLevel(stateDir)
-      expect(summary.totalFiles).toBe(4)
-      expect(summary.truncated).toBe(false)
+      expect(summary.totalFiles).toBe(3)
+      expect(summary.truncated).toBe(true)
       expect(summary.entries).toEqual([
         {name: 'MEMORY.md', type: 'file', size: 5},
         {name: 'media', type: 'dir', size: 4, fileCount: 1},
-        {name: 'notes', type: 'dir', size: 5, fileCount: 2},
+        {name: 'notes', type: 'dir', size: 2, fileCount: 1},
       ])
+
+      // The async rollup used by background refreshes reports the same result.
+      expect(await summarizeMemoryTopLevelAsync(stateDir)).toEqual(summary)
+    })
+  })
+
+  test('the depth budget skips a deep subtree without hiding its siblings', () => {
+    withStateDir((stateDir) => {
+      writeMemoryFile(stateDir, 'store/aa/bb/cc/huge.bin', new Uint8Array(8))
+      writeMemoryFile(stateDir, 'zz-notes/keep.md', 'kept')
+
+      const listed = listMemory(stateDir, {maxDepth: 2})
+      expect(listed.truncated).toBe(true)
+      const paths = listed.entries.map((entry) => entry.path)
+      // store/aa is listed but not entered; the later sibling tree is still fully visited.
+      expect(paths).toContain('store/aa')
+      expect(paths).not.toContain('store/aa/bb')
+      expect(paths).toContain('zz-notes/keep.md')
     })
   })
 

--- a/agents/src/agent-memory.ts
+++ b/agents/src/agent-memory.ts
@@ -173,21 +173,26 @@ function assertNoSymlinkComponents(stateDir: string, relPath: string): void {
  *
  * The walk is synchronous on the server's only thread, so it must stay bounded no matter what an
  * agent has written: `maxEntries` stops the walk once that many entries have been collected and
- * flags the result `truncated`. (An agent once imported a 192k-file source tree into memory; the
- * unbounded walk froze the event loop for 6–8 seconds per call.) When truncated, `totalBytes`
- * covers only the visited files.
+ * flags the result `truncated`, and `maxDepth` stops it from descending past that many directory
+ * levels (an unentered directory also flags `truncated`). (An agent once imported a 192k-file
+ * source tree into memory; the unbounded walk froze the event loop for 6–8 seconds per call.)
+ * When truncated, `totalBytes` covers only the visited files.
  */
 export function listMemory(
   stateDir: string,
-  options: {maxEntries?: number} = {},
+  options: {maxEntries?: number; maxDepth?: number} = {},
 ): {entries: AgentMemoryEntry[]; totalBytes: number; truncated: boolean} {
   const maxEntries = options.maxEntries ?? Number.MAX_SAFE_INTEGER
+  const maxDepth = options.maxDepth ?? Number.MAX_SAFE_INTEGER
   const root = memoryRootPath(stateDir)
   assertNoSymlinkComponents(stateDir, '')
   const entries: AgentMemoryEntry[] = []
   let totalBytes = 0
+  // The entry budget aborts the walk outright; the depth budget only skips a subtree and keeps
+  // walking siblings, so a deep corner cannot hide the rest of the memory from the listing.
+  let aborted = false
   let truncated = false
-  const walk = (dirAbs: string, dirRel: string): void => {
+  const walk = (dirAbs: string, dirRel: string, depth: number): void => {
     let names: fs.Dirent[]
     try {
       names = fs.readdirSync(dirAbs, {withFileTypes: true})
@@ -196,6 +201,7 @@ export function listMemory(
     }
     for (const dirent of names) {
       if (entries.length >= maxEntries) {
+        aborted = true
         truncated = true
         return
       }
@@ -205,8 +211,12 @@ export function listMemory(
       if (dirent.isDirectory()) {
         const stat = statOrNull(abs)
         entries.push({path: rel, type: 'dir', size: 0, updatedAt: stat?.mtimeMs ? Math.round(stat.mtimeMs) : 0})
-        walk(abs, rel)
-        if (truncated) return
+        if (depth < maxDepth) {
+          walk(abs, rel, depth + 1)
+          if (aborted) return
+        } else {
+          truncated = true
+        }
       } else if (dirent.isFile()) {
         const stat = statOrNull(abs)
         if (!stat) continue
@@ -215,7 +225,62 @@ export function listMemory(
       }
     }
   }
-  walk(root, '')
+  walk(root, '', 1)
+  entries.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))
+  return {entries, totalBytes, truncated}
+}
+
+/**
+ * Async variant of {@link listMemory} for background rollups: the same bounds and results, but
+ * every directory read and stat awaits, so a large tree shares the event loop with request
+ * handling instead of blocking it.
+ */
+export async function listMemoryAsync(
+  stateDir: string,
+  options: {maxEntries?: number; maxDepth?: number} = {},
+): Promise<{entries: AgentMemoryEntry[]; totalBytes: number; truncated: boolean}> {
+  const maxEntries = options.maxEntries ?? Number.MAX_SAFE_INTEGER
+  const maxDepth = options.maxDepth ?? Number.MAX_SAFE_INTEGER
+  const root = memoryRootPath(stateDir)
+  assertNoSymlinkComponents(stateDir, '')
+  const entries: AgentMemoryEntry[] = []
+  let totalBytes = 0
+  let aborted = false
+  let truncated = false
+  const walk = async (dirAbs: string, dirRel: string, depth: number): Promise<void> => {
+    let names: fs.Dirent[]
+    try {
+      names = await fs.promises.readdir(dirAbs, {withFileTypes: true})
+    } catch {
+      return
+    }
+    for (const dirent of names) {
+      if (entries.length >= maxEntries) {
+        aborted = true
+        truncated = true
+        return
+      }
+      const rel = dirRel ? `${dirRel}/${dirent.name}` : dirent.name
+      const abs = path.join(dirAbs, dirent.name)
+      if (dirent.isSymbolicLink()) continue
+      if (dirent.isDirectory()) {
+        const stat = await statOrNullAsync(abs)
+        entries.push({path: rel, type: 'dir', size: 0, updatedAt: stat?.mtimeMs ? Math.round(stat.mtimeMs) : 0})
+        if (depth < maxDepth) {
+          await walk(abs, rel, depth + 1)
+          if (aborted) return
+        } else {
+          truncated = true
+        }
+      } else if (dirent.isFile()) {
+        const stat = await statOrNullAsync(abs)
+        if (!stat) continue
+        totalBytes += stat.size
+        entries.push(fileEntry(rel, stat))
+      }
+    }
+  }
+  await walk(root, '', 1)
   entries.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))
   return {entries, totalBytes, truncated}
 }
@@ -419,7 +484,7 @@ export type AgentMemoryTopLevelEntry = {
   type: 'file' | 'dir'
   /** File size in bytes; total bytes of contained files for directories. */
   size: number
-  /** Number of files inside, for directories. */
+  /** Number of files inside, for directories; a minimum for trees deeper than the summary depth. */
   fileCount?: number
 }
 
@@ -432,17 +497,49 @@ export type AgentMemoryTopLevelEntry = {
 export const MAX_MEMORY_SUMMARY_ENTRIES = 10_000
 
 /**
- * Summarizes the top level of the agent's memory for automatic system-prompt injection: root
- * files and directories (with contained file counts), without listing subfolder contents.
- * Aggregated in one pass over a bounded walk; a truncated walk yields minimum counts/sizes.
+ * Depth budget for the summary walk. The summary only names root entries with rough counts, so
+ * descending further buys nothing — and agents park entire dev environments (a pnpm store, an
+ * imported source tree) in memory, where a deep walk melts the event loop for a line the model
+ * skims. Two levels keeps the counts meaningful for note-shaped memories while a deeper tree
+ * simply reads as a minimum.
  */
-export function summarizeMemoryTopLevel(stateDir: string): {
+export const MAX_MEMORY_SUMMARY_DEPTH = 2
+
+/** Result shape shared by the sync and async memory summaries. */
+export type AgentMemorySummary = {
   entries: AgentMemoryTopLevelEntry[]
   totalFiles: number
   totalBytes: number
   truncated: boolean
-} {
-  const {entries, totalBytes, truncated} = listMemory(stateDir, {maxEntries: MAX_MEMORY_SUMMARY_ENTRIES})
+}
+
+/**
+ * Summarizes the top level of the agent's memory for automatic system-prompt injection: root
+ * files and directories (with contained file counts), without listing subfolder contents.
+ * Aggregated in one pass over a bounded walk; a truncated walk yields minimum counts/sizes.
+ */
+export function summarizeMemoryTopLevel(stateDir: string): AgentMemorySummary {
+  return aggregateTopLevel(
+    listMemory(stateDir, {maxEntries: MAX_MEMORY_SUMMARY_ENTRIES, maxDepth: MAX_MEMORY_SUMMARY_DEPTH}),
+  )
+}
+
+/** Async {@link summarizeMemoryTopLevel} for background rollups that must not block the loop. */
+export async function summarizeMemoryTopLevelAsync(stateDir: string): Promise<AgentMemorySummary> {
+  return aggregateTopLevel(
+    await listMemoryAsync(stateDir, {maxEntries: MAX_MEMORY_SUMMARY_ENTRIES, maxDepth: MAX_MEMORY_SUMMARY_DEPTH}),
+  )
+}
+
+function aggregateTopLevel({
+  entries,
+  totalBytes,
+  truncated,
+}: {
+  entries: AgentMemoryEntry[]
+  totalBytes: number
+  truncated: boolean
+}): AgentMemorySummary {
   const top: AgentMemoryTopLevelEntry[] = []
   const dirs = new Map<string, AgentMemoryTopLevelEntry>()
   let totalFiles = 0
@@ -522,6 +619,14 @@ function concatBytes(chunks: Uint8Array[], total: number): Uint8Array {
 function statOrNull(target: string): fs.Stats | null {
   try {
     return fs.statSync(target)
+  } catch {
+    return null
+  }
+}
+
+async function statOrNullAsync(target: string): Promise<fs.Stats | null> {
+  try {
+    return await fs.promises.stat(target)
   } catch {
     return null
   }

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -8177,19 +8177,56 @@ type SpaceIndexInput = {
 const spaceIndexCache = new Map<string, string>()
 
 /**
- * The memory-summary walk runs on the server's only thread, and the space index is invalidated on
- * every memory write — with concurrent runs writing memory each turn, an eager re-walk melted
- * production (9 runs kept a 200k-file memory in a constant 10k-entry synchronous walk cycle). So
- * each walk earns a hold proportional to what it cost ({@link MEMORY_SUMMARY_HOLD_FACTOR}× its
- * duration, capped at a minute): a walk cheaper than {@link MEMORY_SUMMARY_FREE_WALK_MS} earns no
- * hold at all — a small memory stays exactly fresh — while a pathological one re-walks at most
- * once per cap. Within the hold a rebuild reuses the last line; the counts read as minimums
- * anyway (see {@link agentMemory.summarizeMemoryTopLevel}).
+ * The memory-summary walk used to run on the server's only thread on every prompt build, and the
+ * space index is invalidated on every memory write — with concurrent runs writing memory each
+ * turn, that melted production (9 runs kept a 200k-file memory in a constant 10k-entry
+ * synchronous walk cycle). The rollup is now adaptive: each walk earns a hold proportional to
+ * what it cost ({@link MEMORY_SUMMARY_HOLD_FACTOR}× its duration, capped at a minute). A walk
+ * cheaper than {@link MEMORY_SUMMARY_FREE_WALK_MS} earns no hold — a small memory stays exactly
+ * fresh, synchronously. A memory whose last walk was expensive never walks on the prompt path
+ * again: the stale line is served and a background refresh (the async walk, which yields to the
+ * loop) updates it. The counts read as minimums anyway (see
+ * {@link agentMemory.summarizeMemoryTopLevel}).
  */
 const MEMORY_SUMMARY_HOLD_FACTOR = 100
 const MEMORY_SUMMARY_FREE_WALK_MS = 5
 const MEMORY_SUMMARY_MAX_HOLD_MS = 60_000
-const memorySummaryCache = new Map<string, {line: string; walkedAt: number; holdMs: number}>()
+const memorySummaryCache = new Map<string, {line: string; walkedAt: number; holdMs: number; refreshing?: boolean}>()
+
+function formatMemoryLine(summary: agentMemory.AgentMemorySummary): string {
+  if (!summary.entries.length) return 'memory/ — empty'
+  const top = summary.entries
+    .slice(0, 12)
+    .map((entry) => (entry.type === 'dir' ? `${entry.name}/(${entry.fileCount ?? 0})` : entry.name))
+    .join(' · ')
+  return `memory/ — ${summary.totalFiles} file${summary.totalFiles === 1 ? '' : 's'}: ${top}${
+    summary.entries.length > 12 ? ' · …' : ''
+  }`
+}
+
+/** Refreshes one memory line off the prompt path; at most one refresh per state dir in flight. */
+function scheduleMemorySummaryRefresh(stateDir: string): void {
+  const cached = memorySummaryCache.get(stateDir)
+  if (cached?.refreshing) return
+  if (cached) cached.refreshing = true
+  void (async () => {
+    const walkStart = performance.now()
+    let line = 'memory/ — empty'
+    try {
+      line = formatMemoryLine(await agentMemory.summarizeMemoryTopLevelAsync(stateDir))
+    } catch {}
+    const walkMs = performance.now() - walkStart
+    const holdMs =
+      walkMs < MEMORY_SUMMARY_FREE_WALK_MS
+        ? 0
+        : Math.min(walkMs * MEMORY_SUMMARY_HOLD_FACTOR, MEMORY_SUMMARY_MAX_HOLD_MS)
+    const changed = memorySummaryCache.get(stateDir)?.line !== line
+    memorySummaryCache.set(stateDir, {line, walkedAt: Date.now(), holdMs})
+    // The line is baked into cached space indexes; drop them so the next prompt picks it up. The
+    // rest of an index rebuild is a few small SQL reads.
+    if (changed) spaceIndexCache.clear()
+  })()
+}
 
 export function invalidateSpaceIndex(accountId: string, agentId?: string): void {
   for (const key of spaceIndexCache.keys()) {
@@ -8229,23 +8266,20 @@ export function buildSpaceIndex(input: SpaceIndexInput): string {
     }
   }
 
-  let memoryLine = 'memory/ — empty'
+  let memoryLine: string
   const cachedSummary = memorySummaryCache.get(input.stateDir)
   if (cachedSummary && Date.now() - cachedSummary.walkedAt < cachedSummary.holdMs) {
     memoryLine = cachedSummary.line
+  } else if (cachedSummary && cachedSummary.holdMs > 0) {
+    // The last walk was expensive: serve the stale line and refresh off the prompt path.
+    memoryLine = cachedSummary.line
+    scheduleMemorySummaryRefresh(input.stateDir)
   } else {
+    // Unknown or known-cheap memory: walk now so the line is exactly fresh.
     const walkStart = performance.now()
+    memoryLine = 'memory/ — empty'
     try {
-      const summary = agentMemory.summarizeMemoryTopLevel(input.stateDir)
-      if (summary.entries.length) {
-        const top = summary.entries
-          .slice(0, 12)
-          .map((entry) => (entry.type === 'dir' ? `${entry.name}/(${entry.fileCount ?? 0})` : entry.name))
-          .join(' · ')
-        memoryLine = `memory/ — ${summary.totalFiles} file${summary.totalFiles === 1 ? '' : 's'}: ${top}${
-          summary.entries.length > 12 ? ' · …' : ''
-        }`
-      }
+      memoryLine = formatMemoryLine(agentMemory.summarizeMemoryTopLevel(input.stateDir))
     } catch {}
     const walkMs = performance.now() - walkStart
     const holdMs =

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -771,6 +771,8 @@ export class Service {
       subscriptionAuth?: boolean
       /** Generate titles for untitled sessions with a dedicated model call (default off: tests mock providers). */
       titleGeneration?: boolean
+      /** Run-queue concurrency caps; see {@link runs.RunQueue} for the defaults. */
+      runQueue?: {maxConcurrentModelRuns?: number; maxConcurrentWorkflows?: number}
     } = {},
   ) {
     this.#db = db
@@ -785,6 +787,8 @@ export class Service {
     this.#subscriptionAuthEnabled = options.subscriptionAuth ?? false
     this.#titleGenerationEnabled = options.titleGeneration ?? false
     this.#runQueue = new runs.RunQueue(db, {
+      maxConcurrentModelRuns: options.runQueue?.maxConcurrentModelRuns,
+      maxConcurrentWorkflows: options.runQueue?.maxConcurrentWorkflows,
       executors: {
         agent: (run) => this.#executeAgentRun(run),
         workflow: (run) => this.#executeWorkflowRun(run),
@@ -8172,6 +8176,21 @@ type SpaceIndexInput = {
 
 const spaceIndexCache = new Map<string, string>()
 
+/**
+ * The memory-summary walk runs on the server's only thread, and the space index is invalidated on
+ * every memory write — with concurrent runs writing memory each turn, an eager re-walk melted
+ * production (9 runs kept a 200k-file memory in a constant 10k-entry synchronous walk cycle). So
+ * each walk earns a hold proportional to what it cost ({@link MEMORY_SUMMARY_HOLD_FACTOR}× its
+ * duration, capped at a minute): a walk cheaper than {@link MEMORY_SUMMARY_FREE_WALK_MS} earns no
+ * hold at all — a small memory stays exactly fresh — while a pathological one re-walks at most
+ * once per cap. Within the hold a rebuild reuses the last line; the counts read as minimums
+ * anyway (see {@link agentMemory.summarizeMemoryTopLevel}).
+ */
+const MEMORY_SUMMARY_HOLD_FACTOR = 100
+const MEMORY_SUMMARY_FREE_WALK_MS = 5
+const MEMORY_SUMMARY_MAX_HOLD_MS = 60_000
+const memorySummaryCache = new Map<string, {line: string; walkedAt: number; holdMs: number}>()
+
 export function invalidateSpaceIndex(accountId: string, agentId?: string): void {
   for (const key of spaceIndexCache.keys()) {
     if (key.startsWith(agentId ? `${accountId}/${agentId}#` : `${accountId}/`)) {
@@ -8211,18 +8230,30 @@ export function buildSpaceIndex(input: SpaceIndexInput): string {
   }
 
   let memoryLine = 'memory/ — empty'
-  try {
-    const summary = agentMemory.summarizeMemoryTopLevel(input.stateDir)
-    if (summary.entries.length) {
-      const top = summary.entries
-        .slice(0, 12)
-        .map((entry) => (entry.type === 'dir' ? `${entry.name}/(${entry.fileCount ?? 0})` : entry.name))
-        .join(' · ')
-      memoryLine = `memory/ — ${summary.totalFiles} file${summary.totalFiles === 1 ? '' : 's'}: ${top}${
-        summary.entries.length > 12 ? ' · …' : ''
-      }`
-    }
-  } catch {}
+  const cachedSummary = memorySummaryCache.get(input.stateDir)
+  if (cachedSummary && Date.now() - cachedSummary.walkedAt < cachedSummary.holdMs) {
+    memoryLine = cachedSummary.line
+  } else {
+    const walkStart = performance.now()
+    try {
+      const summary = agentMemory.summarizeMemoryTopLevel(input.stateDir)
+      if (summary.entries.length) {
+        const top = summary.entries
+          .slice(0, 12)
+          .map((entry) => (entry.type === 'dir' ? `${entry.name}/(${entry.fileCount ?? 0})` : entry.name))
+          .join(' · ')
+        memoryLine = `memory/ — ${summary.totalFiles} file${summary.totalFiles === 1 ? '' : 's'}: ${top}${
+          summary.entries.length > 12 ? ' · …' : ''
+        }`
+      }
+    } catch {}
+    const walkMs = performance.now() - walkStart
+    const holdMs =
+      walkMs < MEMORY_SUMMARY_FREE_WALK_MS
+        ? 0
+        : Math.min(walkMs * MEMORY_SUMMARY_HOLD_FACTOR, MEMORY_SUMMARY_MAX_HOLD_MS)
+    memorySummaryCache.set(input.stateDir, {line: memoryLine, walkedAt: Date.now(), holdMs})
+  }
 
   const triggers = input.db
     .query<{name: string; enabled: number}, [string, string]>(

--- a/agents/src/config.ts
+++ b/agents/src/config.ts
@@ -63,6 +63,12 @@ export type Config = {
     /** Upstream DNS nameservers for sandbox name resolution. */
     dnsServers: string[]
   }
+  runQueue: {
+    /** Model-backed runs executed concurrently. Everything shares one event loop, so size this to the host. */
+    maxConcurrentModelRuns: number
+    /** Workflow runs executed concurrently (they mostly park waiting on children). */
+    maxConcurrentWorkflows: number
+  }
 }
 
 /** Parsed command-line flags accepted by the Agents service. */
@@ -89,6 +95,8 @@ export type Flags = {
   'exec-timeout-secs': number
   'exec-allow-network': string
   'exec-dns': string
+  'max-concurrent-model-runs': number
+  'max-concurrent-workflows': number
   'log-level': string
 }
 
@@ -117,6 +125,8 @@ export function flags(env: NodeJS.ProcessEnv = process.env): Flags {
     'exec-timeout-secs': Number(env.SEED_AGENTS_EXEC_TIMEOUT_SECS) || 60,
     'exec-allow-network': env.SEED_AGENTS_EXEC_ALLOW_NETWORK ?? '',
     'exec-dns': env.SEED_AGENTS_EXEC_DNS || '',
+    'max-concurrent-model-runs': Number(env.SEED_AGENTS_MAX_CONCURRENT_MODEL_RUNS) || 8,
+    'max-concurrent-workflows': Number(env.SEED_AGENTS_MAX_CONCURRENT_WORKFLOWS) || 32,
     'log-level': env.SEED_AGENTS_LOG_LEVEL || 'info',
   }
 }
@@ -153,7 +163,9 @@ export function parseArgs(argv: string[] = process.argv.slice(2), env: NodeJS.Pr
       key === 'activity-max-pages' ||
       key === 'exec-cpus' ||
       key === 'exec-memory-mib' ||
-      key === 'exec-timeout-secs'
+      key === 'exec-timeout-secs' ||
+      key === 'max-concurrent-model-runs' ||
+      key === 'max-concurrent-workflows'
     ) {
       parsed[key] = parsePositiveInteger(value, key)
     } else {
@@ -199,6 +211,16 @@ export function create(pflags: Flags): Config {
       timeoutSecs: parsePositiveInteger(String(pflags['exec-timeout-secs']), 'exec-timeout-secs'),
       allowNetwork: isNetworkEnabled(pflags['exec-allow-network']),
       dnsServers: parseDnsServers(pflags['exec-dns']),
+    },
+    runQueue: {
+      maxConcurrentModelRuns: parsePositiveInteger(
+        String(pflags['max-concurrent-model-runs']),
+        'max-concurrent-model-runs',
+      ),
+      maxConcurrentWorkflows: parsePositiveInteger(
+        String(pflags['max-concurrent-workflows']),
+        'max-concurrent-workflows',
+      ),
     },
     subscriptionAuth: pflags['subscription-auth'],
     titleGeneration: pflags['session-title-generation'],

--- a/agents/src/main.ts
+++ b/agents/src/main.ts
@@ -395,6 +395,7 @@ async function main(): Promise<void> {
     exec: cfg.exec,
     subscriptionAuth: cfg.subscriptionAuth,
     titleGeneration: cfg.titleGeneration,
+    runQueue: cfg.runQueue,
   })
   const activityMonitor = new ActivityMonitor(db, svc, cfg.activity)
   const scheduleMonitor = new ScheduleMonitor(svc, {pollIntervalMs: cfg.activity.pollIntervalMs})

--- a/agents/src/sqlite-schema.sql
+++ b/agents/src/sqlite-schema.sql
@@ -162,6 +162,8 @@ CREATE TABLE session_events (
     UNIQUE (session_id, seq)
 ) WITHOUT ROWID;
 
+CREATE INDEX session_events_by_created ON session_events (created_at DESC);
+
 CREATE TABLE runs (
     id TEXT PRIMARY KEY,
     account_id TEXT NOT NULL REFERENCES accounts (id),

--- a/agents/src/sqlite.ts
+++ b/agents/src/sqlite.ts
@@ -13,6 +13,10 @@ export const BASELINE_SCHEMA_MIGRATION_VERSION = 0
 /** Prepend-only database migrations. */
 export const migrations: string[] = [
   // ======= IMPORTANT: Add new migrations below this line. =======
+  // Newest-first cross-session event reads (thread content search) used to sort the whole table
+  // with a temp b-tree, reading every event blob on the server's only thread. This index lets
+  // those reads walk recency order directly and stop at their limit.
+  `CREATE INDEX session_events_by_created ON session_events (created_at DESC);`,
   // A firing whose continuation is a headless tool call or script starts a run instead of a
   // thread; this is where that run is linked from (session_id stays for thread firings).
   `ALTER TABLE trigger_firings ADD COLUMN run_id TEXT;`,
@@ -293,6 +297,14 @@ export function open(dbPath: string): OpenResult {
 export function openWithDatabase(db: Database): OpenResult {
   db.run('PRAGMA journal_mode = WAL')
   db.run('PRAGMA foreign_keys = ON')
+  // bun:sqlite is synchronous on the server's only thread, so every page-cache miss is a pread64
+  // on the event loop. The default 2MB page cache thrashes once session_events outgrows it (a
+  // 288MB production database sustained ~17k preads/sec rebuilding the same hot pages); a larger
+  // cache plus mmap keeps hot reads in memory, and in-memory temp stores keep ORDER BY spills off
+  // the loop too.
+  db.run('PRAGMA cache_size = -65536') // 64MB
+  db.run('PRAGMA mmap_size = 536870912') // 512MB
+  db.run('PRAGMA temp_store = MEMORY')
 
   if (isEmptyDatabase(db)) {
     initializeEmptyDatabase(db)


### PR DESCRIPTION
## What happened

Prod agents server became unusable today (30–45s for a bare 404) while Ion ran a 9-way parallel audit workflow. Diagnosed live on the box:

1. **Memory-summary walks on every turn** — Ion's memory held **201,492 files** (an imported `src/` tree, `toolchains/`, `.pnpm-store`, …). `buildSpaceIndex` → `summarizeMemoryTopLevel` walks up to 10k entries synchronously (~175ms measured), and every memory write invalidates the cache — 9 concurrent runs kept it walking continuously (60k `statx`/10s observed via strace).
2. **SQLite page-cache thrash** — after quarantining the giant memory dirs, strace showed **169k `pread64` in 10s**, all on `agents.sqlite` (288MB vs bun:sqlite's default 2MB page cache). All synchronous, all on the only thread.
3. **Thread search full-scans** — `ORDER BY e.created_at DESC LIMIT 4000` had no index: a temp b-tree sort over every event blob (131MB) per call.

With 8 concurrent model runs + microsandbox VMs pinning 4 host cores, loop utilization hit ~100% and request latency exploded by queueing.

## Fixes

- **Cost-proportional hold on memory-summary walks**: a walk earns a hold of 100× its duration (capped 60s; <5ms walks stay exactly fresh). A pathological memory can no longer monopolize the loop.
- **SQLite pragmas**: 64MB page cache, 512MB mmap, in-memory temp store.
- **New migration + baseline index** `session_events_by_created (created_at DESC)`; EXPLAIN confirms the thread-search now walks recency order and stops at its LIMIT.
- **Configurable run-queue caps**: `SEED_AGENTS_MAX_CONCURRENT_MODEL_RUNS` / `SEED_AGENTS_MAX_CONCURRENT_WORKFLOWS` (defaults unchanged: 8/32). Recommend setting model runs to ~3 on the current 4-core prod box.

## Ops already applied on prod (reversible)

- Moved Ion's `memory/{src,toolchains,worktrees,.pnpm-store,.cache}` (→ 201k→352 files) to `/data/agents/<agent>/memory-quarantine/` with a `QUARANTINE.md` note.
- Restarted `agents-stable` with the queued audit runs deferred (`not_before` = 20:28 UTC). Nothing cancelled.
- Latency recovered: 30–45s → ~1s.

## Testing

- `bun test`: 401 pass / 0 fail; `bun tsgo --noEmit` clean.
- Query plan verified on a migrated in-memory DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fkiUq95srysiati9AsjzU