### PR TITLE
Fix parallel workflow wait deadlines

### DIFF
--- a/agents/src/workflow-host.test.ts
+++ b/agents/src/workflow-host.test.ts
@@ -529,6 +529,66 @@ describe('workflow host', () => {
     expect(resumed.waits).toHaveLength(0)
   })
 
+  test('parallel waits park on a timed wait even when an untimed wait registers first', async () => {
+    const source = `export default async function (input, ctx) {
+      return ctx.parallel([
+        () => ctx.waitForEvent({signal: 'untimed'}),
+        () => ctx.waitForEvent({signal: 'timed'}, {timeoutMs: 20_000}),
+      ])
+    }`
+    const run = fakeAdapters({source})
+    const parked = await runWorkflowVM(run.adapters)
+    if (parked.type !== 'parked' || parked.wait.reason !== 'event') throw new Error('expected an event park')
+
+    expect(run.waits).toHaveLength(2)
+    const timedWait = run.waits.find((wait) => (wait.match as {signal?: string}).signal === 'timed')!
+    expect(parked.wait.waitId).toBe(timedWait.waitId)
+    expect(parked.wait.timeoutAt).toBe(timedWait.timeoutAt)
+  })
+
+  test('parallel timed waits park on the earliest deadline in either registration order', async () => {
+    for (const timeouts of [
+      [10_000, 20_000],
+      [20_000, 10_000],
+    ]) {
+      const source = `export default async function (input, ctx) {
+        return ctx.parallel([
+          () => ctx.waitForEvent({signal: 'first'}, {timeoutMs: ${timeouts[0]}}),
+          () => ctx.waitForEvent({signal: 'second'}, {timeoutMs: ${timeouts[1]}}),
+        ])
+      }`
+      const run = fakeAdapters({source})
+      const parked = await runWorkflowVM(run.adapters)
+      if (parked.type !== 'parked' || parked.wait.reason !== 'event') throw new Error('expected an event park')
+
+      expect(run.waits).toHaveLength(2)
+      const earliest = run.waits.reduce((left, right) => (left.timeoutAt! < right.timeoutAt! ? left : right))
+      expect(parked.wait.waitId).toBe(earliest.waitId)
+      expect(parked.wait.timeoutAt).toBe(earliest.timeoutAt)
+    }
+  })
+
+  test('parallel event waits and long sleeps park at the global earliest deadline', async () => {
+    for (const sleepMs of [5_000, 30_000]) {
+      const source = `export default async function (input, ctx) {
+        return ctx.parallel([
+          () => ctx.waitForEvent({signal: 'untimed'}),
+          () => ctx.waitForEvent({signal: 'timed'}, {timeoutMs: 10_000}),
+          () => ctx.sleep(${sleepMs}),
+        ])
+      }`
+      const run = fakeAdapters({source, timerParkThresholdMs: 1})
+      const parked = await runWorkflowVM(run.adapters)
+      if (parked.type !== 'parked' || parked.wait.reason !== 'event') throw new Error('expected an event park')
+
+      expect(run.waits).toHaveLength(2)
+      const timedWait = run.waits.find((wait) => (wait.match as {signal?: string}).signal === 'timed')!
+      const timer = run.journal.find((entry) => entry.kind === 'timer')!
+      expect(parked.wait.waitId).toBe(timedWait.waitId)
+      expect(parked.wait.timeoutAt).toBe(Math.min(timedWait.timeoutAt!, timer.wakeAt))
+    }
+  })
+
   test('a wait that runs out of time resolves as null on the next replay', async () => {
     const source = `export default async function (input, ctx) {
       const answer = await ctx.waitForEvent({signal: 'approved'}, {timeoutMs: 40})

--- a/agents/src/workflow-host.ts
+++ b/agents/src/workflow-host.ts
@@ -722,13 +722,20 @@ export async function runWorkflowVM(adapters: WorkflowAdapters): Promise<Workflo
           return
         }
         adapters.effects.registerEventWait({waitId, match, ...(timeoutAt === undefined ? {} : {timeoutAt})})
-        // Several parallel waits all register; the run parks on the first and any of them can wake it.
+        // Several parallel waits all register and any of them can wake the run. Park on the one
+        // with the earliest deadline, though, so an untimed or later first wait cannot suppress it.
         const answerWith = answerSignalFor(match)
-        parkState.event ??= {
-          waitId,
-          ...(timeoutAt === undefined ? {} : {timeoutAt}),
-          ...(label ? {label} : {}),
-          ...(answerWith === undefined ? {} : {answerWith}),
+        if (
+          !parkState.event ||
+          (timeoutAt !== undefined &&
+            (parkState.event.timeoutAt === undefined || timeoutAt < parkState.event.timeoutAt))
+        ) {
+          parkState.event = {
+            waitId,
+            ...(timeoutAt === undefined ? {} : {timeoutAt}),
+            ...(label ? {label} : {}),
+            ...(answerWith === undefined ? {} : {answerWith}),
+          }
         }
         return
       }


### PR DESCRIPTION
## Failure

Durable workflows can register several `ctx.waitForEvent` calls in parallel. The host correctly persists every registration, but it used the **first** registered wait as the parked run's representative deadline.

That makes registration order change runtime behavior:

- an untimed wait registered first can suppress a later timed wake entirely;
- a later deadline registered first can delay an earlier deadline;
- mixed event waits and long sleeps can park later than the earliest active wake.

This affects trigger continuations and other durable workflows that race events or combine approvals, timeouts, and sleeps. A parked run may therefore wake late or never wake without an external event.

## Root cause

`agents/src/workflow-host.ts` used `parkState.event ??=` after registering each wait. The registrations were all durable, but only the first wait's `timeoutAt` reached the final park decision.

## Fix

Keep registering every wait, but choose the parked event representative by the earliest defined `timeoutAt`:

- a timed wait replaces an untimed representative;
- an earlier timed wait replaces a later one;
- equal deadlines retain the first representative;
- the existing final selection still computes the minimum across the event deadline and long-sleep wake time.

No protocol, journal, or persisted-data shape changes.

## Before / after

Before, `[untimed wait, 10s wait]` parked without a deadline, and `[20s wait, 10s wait]` parked for 20 seconds. After, both park on the 10-second wait. Mixed long sleeps also preserve the global earliest wake.

## Validation

- Added regressions for untimed-first/timed-second waits.
- Added timed waits in both registration orders.
- Added event waits mixed with long sleeps on either side of the event deadline.
- `bun test src/workflow-host.test.ts`: **38 passed, 0 failed**.
- `bun run format:check`: passed.
- `git diff --check`: passed.

The full agents suite was attempted during implementation; unrelated environment-sensitive API/MCP/mention tests remained red. Full typecheck exceeded the constrained executor memory boundary, while a narrowed changed-file TypeScript check passed.

## Limits

This repairs scheduling of already-supported parallel waits. It does not change event-delivery guarantees or add transactional wake delivery.

## Provenance

Originating agent session: https://seed.hyper.media/hm/agents/session/eecbc548-a230-4b56-a276-69231593880d?server=https%3A%2F%2Fagentic.seed.hyper.media&agent=0d941d24-aca1-4eb9-990c-0a41097e9667
