### PR TITLE
feat(agents): session continuation (continue_session verb, projection manifest, context meter)

### DIFF
--- a/agents/docs/readme.md
+++ b/agents/docs/readme.md
@@ -128,6 +128,8 @@ Important incomplete work:
 10. [Model providers](./model-providers.md) — provider records, secrets, OpenAI execution, unsupported providers.
 11. [Tools](./tools.md) — tool-call lifecycle and `read` behavior.
     - [MCP servers](./mcp.md) — remote MCP servers as tool documents: discovery, projection, runtime, actions, UI.
+    - [Session continuation](./session-continuation.md) — `continue_session`: fresh successor sessions at semantic
+      boundaries instead of compaction; projection manifests, context meter, guarded navigation.
 12. [Prompt injection map](./prompt-injection-map.md) — where hosted-agent and desktop-assistant prompts are defined,
     assembled, and sent to providers.
 13. [Security](./security.md) — current security model and hardening gaps.

--- a/agents/docs/security.md
+++ b/agents/docs/security.md
@@ -77,6 +77,13 @@ Account-owned tables include `account_id`:
 
 Session events do not store account ID directly; the server verifies ownership through the parent session.
 
+## Agent isolation
+
+Agents of the same account do not read each other's state. The `thread:` address (reads and listings) and continuation
+`session_events` sources reach only the calling agent's own threads; memory and tools are per-agent by construction
+(`state_dir`). Until a deliberate inter-agent interaction model exists, agents communicate over public interfaces —
+documents and comments on the hypermedia network — never by inspecting one another's transcripts.
+
 ## Secrets
 
 `SetSecret` accepts key bytes, encrypts them, and returns only redacted metadata. `CreateSigningIdentity` generates a

--- a/agents/docs/session-continuation.md
+++ b/agents/docs/session-continuation.md
@@ -91,7 +91,8 @@ is not a typed child (`return_result`). Scripts never see it.
   `modelContextWindow(providerType, modelId)` (`model-capabilities.ts`, also used for Pi's model registration). Guidance
   escalates at 70% and 85%.
 - Recall: `read thread:<id>` now prints `[seq]`-prefixed lines, accepts `{fromSeq, toSeq, limit}`, and reports the
-  thread's `continuedFrom`/`continuedTo`.
+  thread's `continuedFrom`/`continuedTo`. Thread reads and cited `session_events` sources reach only this agent's own
+  threads: agents do not read each other's state and communicate over public interfaces instead.
 - Per turn, everywhere: a `<session_status title="…">description</session_status>` block (`sessionStatusBlock`) so the
   `status` verb is a deliberate change, never a restatement — a successor keeps the title and description its
   predecessor gave it. Title = what the whole session is about (a dramatic shift is a continuation, not a rename);

--- a/agents/docs/session-continuation.md
+++ b/agents/docs/session-continuation.md
@@ -1,0 +1,129 @@
+# Session continuation
+
+> Shipped 2026-09-01. Implements Ion's proposal
+> [Session Continuation](https://hyper.media/hm/z6MkpVa5nMUR5ZaUEyV1SE48KTNbwTuHRd83RwLgMKc4nGU3/ion/system/session-continuation):
+> no rolling-summary compaction; an agent continues into a fresh session at a semantic boundary, and the handoff is a
+> durable, inspectable projection.
+
+Seed never compacts a conversation by replacing its early history with a summary. When a transcript stops being the
+right working context — the user changed subject, a phase ended, they want to refocus on one thread, they asked for it,
+or the model's context is filling — the agent carries the conversation into a **successor** session with the
+`continue_session` verb. The predecessor keeps its complete transcript; the successor starts from a **projection**: the
+agent's handoff, the exact initiating message, and exact excerpts, with everything else linked and recallable.
+
+## Vocabulary
+
+- **Continuation** — the durable, user-visible transition: predecessor → continuation edge → successor. Distinct from
+  parent/child (delegation that returns to its parent). A continuation becomes the foreground conversation.
+- **Projection** — the successor's first model context: a purpose-built view with exact references back to sources.
+  Derived context, not canonical history.
+- **Manifest** — the record of what the projection was built from (`SessionContinuationManifest`), stored on the edge.
+
+## Data model
+
+`session_continuations` (`sqlite-schema.sql`): one row per edge — `predecessor_session_id`, `successor_session_id`
+(unique: a session has one immediate predecessor), `origin_session_id` (the first session of the chain), `tool_call_id`
+(unique with the predecessor: the idempotency key), `initiating_event_id`, `reason`, `manifest_cbor`. A predecessor may
+have several successors (someone came back and branched); `SessionInfo.continuedTo` advertises the newest.
+
+`SessionInfo` carries `continuedFrom` / `continuedTo` (`SessionContinuationLink`: continuation id, other session id and
+title, reason, time). `GetSessionResponse.contextWindow` is the model's window so clients can draw the context meter.
+`MessageSessionResponse.continuedToSessionId` tells the sending client where the answer went.
+
+Successor events, appended in the creation transaction:
+
+1. `{type: 'message', role: 'user', actor: 'system'}` — the projection (below). Rendered as the handoff card, never as a
+   bubble.
+2. The initiating user message, copied **verbatim** (content, rawMarkdown, blocks, contextLines, attachments) with
+   `meta.continuedFrom = {sessionId, eventId, seq}`. Attachments are hard-linked into the successor's attachment dir
+   (`linkSessionAttachment`) so `attachment:<id>` keeps resolving.
+
+The predecessor's transcript gains nothing but the `continue_session` `tool_call`/`tool_result` pair the run loop writes
+anyway; the transition card renders from that pair.
+
+## The verb
+
+`continue_session({reason, title, description, handoff, sources?, transfer?})` — `tool-registry.ts`. `title` and
+`description` are **required** and set by the predecessor's agent, the way the `status` verb names a session
+(`title_source = 'agent'`, so the fallback namer stays out). `handoff` is prose for a colleague who has read nothing:
+purpose, currentRequest, establishedFacts, decisions, openQuestions, nextActions, cautions. `sources` are exact
+breadcrumbs: `resource` (hm://, ipfs://, http), `memory` (`~/memory/…`, must exist), `session_events`/`session_event`
+(seq ranges of a thread, as `read thread:<id>` shows them; validated against the thread). `transfer.plan` is `carry`
+(default when the checklist has unfinished steps — it is copied with its owner cleared, so the successor's run adopts
+it) or `close`/`omit`.
+
+Availability (`canContinueSession` in `#runPiAgent`): a run exists, it is not a delegated child (`parentRunId`), and it
+is not a typed child (`return_result`). Scripts never see it.
+
+## Runtime (`#continueSessionFromAgent`)
+
+1. **Replay** — a row for `(predecessor, tool_call_id)` returns the existing successor and ends the turn.
+2. **Validate** — reason/title/description/handoff shapes; refuse while children spawned this turn are parked; refuse
+   from a delegated child; cap successors per predecessor (`MAX_SESSION_CONTINUATIONS_PER_SESSION`); find the
+   **initiating event** (newest user- or trigger-authored user message) and refuse when it carries `meta.continuedFrom`
+   — the session was just continued and nobody has said anything new, so continuing again would loop; validate sources.
+3. **Compile the projection** (`compileContinuationProjection`, pure): lineage block, handoff, source list, then within
+   `CONTINUATION_PROJECTION_BUDGET_BYTES`: the cited ranges of this thread as `<excerpt>` blocks, then the most recent
+   conversational exchanges before the initiating message as `<recent_exchanges>`. Whatever does not fit is listed as
+   omitted — linked, not loaded. Every excerpt line is `[seq] who: text` (`transcriptEventLine`, shared with
+   `read thread:`), escaped with `escapeActionFraming` like any model-authored text handed back inside a frame.
+4. **Create atomically** — successor session (title, description, model override copied, plan carried), edge row with
+   the manifest, the two successor events.
+5. **End this turn, start the next** — `runningSession.continuation` + `completeAfterTools`: Pi's next provider request
+   is refused (`onPayload` throws, the designed ending), `#runPiAgent` throws `SessionContinuedError`,
+   `#executeAgentRun` returns `succeeded` with `{continuedToSessionId, continuationId}` and skips obligations (nothing
+   is owed here any more). The successor's run is enqueued on the interactive queue with the copied message as its
+   `userEventIds`.
+6. **Emit** — `session-change` for both sessions (the predecessor now has `continuedTo`, the successor `continuedFrom`),
+   `account-change` reasons `session-updated` and `session-continued`.
+
+## What the agent is told
+
+- System prompt (`SESSION_CONTINUATION_PROMPT`): what a continuation is, that transcripts are never compacted, when to
+  continue, that calling the verb ends the turn and the successor answers, and that `read thread:<id>` recalls exact
+  material.
+- The verb contract: the triggers in detail (topic change, phase change, refocus, context pressure, user request), when
+  NOT to (unresolved side effects, delegated children, plain follow-ups), what the successor receives, how to write the
+  handoff, that title/description are its to set.
+- Per turn, where continuing is possible: a `<context_usage tokens window percent>` block (`contextUsageBlock`),
+  rendered fresh like `<plan_state>` and never stored. Tokens are the last turn's prompt size —
+  `input + cacheRead + cacheWrite` stamped on the newest assistant message's `meta.usage`; the window comes from
+  `modelContextWindow(providerType, modelId)` (`model-capabilities.ts`, also used for Pi's model registration). Guidance
+  escalates at 70% and 85%.
+- Recall: `read thread:<id>` now prints `[seq]`-prefixed lines, accepts `{fromSeq, toSeq, limit}`, and reports the
+  thread's `continuedFrom`/`continuedTo`.
+- Per turn, everywhere: a `<session_status title="…">description</session_status>` block (`sessionStatusBlock`) so the
+  `status` verb is a deliberate change, never a restatement — a successor keeps the title and description its
+  predecessor gave it. Title = what the whole session is about (a dramatic shift is a continuation, not a rename);
+  description = the live status, updated freely (description-only calls are the norm). The `status` tool row shows the
+  description in full.
+
+## UI
+
+- **Context meter** (`ContextUsageMeter`): a small pie in the session header (and the assistant sidebar) — muted, amber
+  from 70%, red from 85% — computed client-side from the same assistant `meta.usage` and `contextWindow`.
+- **Predecessor**: the `continue_session` row renders as a transition row (`ContinuationTransitionCard`): chevron,
+  "Continued in “title” (reason)", _Open session_ on the right, and a hover info bubble opening every detail of the
+  handoff. A refused call keeps error styling. Typing in a continued session is still allowed and branches. Session
+  lists show a "Continued in …" chip.
+- **Successor**: a `ContinuationHeader` pill (Continued from “…”, the way back) and the projection rendered as
+  `ContinuationHandoffCard` (handoff markdown, sources, loaded excerpts on demand). The replayed user message carries a
+  "From previous session" chip.
+- **Automatic navigation** (`useFollowContinuation`): a client moves to the successor only if it was following the turn
+  — it saw the session streaming or sent the message (the send response's `continuedToSessionId` navigates immediately).
+  Fires once per successor; Back returns to the predecessor without being redirected again. Other clients see the card
+  and the notice.
+
+## Failure and recovery
+
+- Refused continuation (child, loop, parked children, bad input): the tool result is an error the model reads and the
+  transcript shows; nothing is created.
+- Crash between the edge and the successor run: the edge and successor exist; the run is enqueued after the transaction
+  and, if lost, the successor is a normal session whose replayed message can be retried.
+- Replayed tool call: the same successor, by `(predecessor, tool_call_id)`.
+
+## Not yet
+
+Phase 3 of the proposal: budget estimates before continuing, recommended ranges, purpose-specific projections, and
+measuring repeated recalls of omitted sources. Forks (branching from an earlier point by a person) do not share the edge
+yet.

--- a/agents/docs/tools.md
+++ b/agents/docs/tools.md
@@ -145,26 +145,28 @@ type ReadInput = {
 }
 ```
 
-| address             | behavior                                                                                                                                                                                                             |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `~/memory/<path>`   | file content, or a directory listing (`{entries: [{path, type, size}]}`) for a directory address                                                                                                                     |
-| `~/tools/<name>`    | one tool's full contract as markdown; `~/tools/` alone lists everything callable                                                                                                                                     |
-| `~/triggers/<name>` | one trigger — source, prompt markdown, status, continuation, recent firings; `~/triggers/` lists all, with the write contract inline                                                                                 |
-| `~/self`            | the agent's own record: definition (name, model, provider, reasoning level, system prompt), grants, signing-key names, triggers, memory summary, session count, and guidance on what it can change itself            |
-| `hm://…`            | a hypermedia document or comment, markdown by default                                                                                                                                                                |
-| `ipfs://<cid>`      | fetches through the configured `/ipfs/` gateway into memory (default path `ipfs/<cid>`) and returns it                                                                                                               |
-| `https://…`         | resolved as hypermedia first, then read as a web page                                                                                                                                                                |
-| `activity:`         | the activity feed via `ListEvents`, filtered by `options`                                                                                                                                                            |
-| `attachment:<id>`   | a session-private attachment (images are returned as image content to vision models)                                                                                                                                 |
-| `thread:<id>`       | a conversation transcript (its last 200 events) rendered as markdown                                                                                                                                                 |
-| `thread:`           | lists the account's conversations, newest first; `options.query` searches titles plus a bounded scan (4000 most recent events) of message text with snippets, `options.agentId` filters, `options.limit` caps at 100 |
-| `run:<id>`          | a run's public record, plus `sourceText` for script runs                                                                                                                                                             |
+| address             | behavior                                                                                                                                                                                                  |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `~/memory/<path>`   | file content, or a directory listing (`{entries: [{path, type, size}]}`) for a directory address                                                                                                          |
+| `~/tools/<name>`    | one tool's full contract as markdown; `~/tools/` alone lists everything callable                                                                                                                          |
+| `~/triggers/<name>` | one trigger — source, prompt markdown, status, continuation, recent firings; `~/triggers/` lists all, with the write contract inline                                                                      |
+| `~/self`            | the agent's own record: definition (name, model, provider, reasoning level, system prompt), grants, signing-key names, triggers, memory summary, session count, and guidance on what it can change itself |
+| `hm://…`            | a hypermedia document or comment, markdown by default                                                                                                                                                     |
+| `ipfs://<cid>`      | fetches through the configured `/ipfs/` gateway into memory (default path `ipfs/<cid>`) and returns it                                                                                                    |
+| `https://…`         | resolved as hypermedia first, then read as a web page                                                                                                                                                     |
+| `activity:`         | the activity feed via `ListEvents`, filtered by `options`                                                                                                                                                 |
+| `attachment:<id>`   | a session-private attachment (images are returned as image content to vision models)                                                                                                                      |
+| `thread:<id>`       | a conversation transcript (its last 200 events) rendered as markdown                                                                                                                                      |
+| `thread:`           | lists THIS AGENT's conversations, newest first; `options.query` searches titles plus a bounded scan (4000 most recent events) of message text with snippets, `options.limit` caps at 100                  |
+| `run:<id>`          | a run's public record, plus `sourceText` for script runs                                                                                                                                                  |
 
 Unrecognized addresses fail with the supported list (`api-service.ts:7350`).
 
-`thread:` and `run:` are scoped by **account**, not by agent (`readThreadAddress`, `threadsListing`, `readRunAddress`).
-One agent can list, search, and read the transcripts and runs of every other agent on the same account — deliberate, so
-an agent asked "what did my research agent find yesterday?" can answer (see `security.md`).
+`thread:` reads and listings are scoped to the **agent's own threads** (`readThreadAddress`, `threadsListing`): agents
+do not read each other's state, whatever account they share — they communicate over public interfaces (documents,
+comments) until a deliberate inter-agent contract exists. `run:` remains account-scoped (`readRunAddress`). One agent
+can list, search, and read the transcripts and runs of every other agent on the same account — deliberate, so an agent
+asked "what did my research agent find yesterday?" can answer (see `security.md`).
 
 **Tool contracts.** A read of `~/tools/<name>` resolves verbs from the registry and everything else from the agent's
 tool documents. A builtin the agent has not been granted reads as "no tool named …" plus the listing, so grants are not

--- a/agents/docs/tools.md
+++ b/agents/docs/tools.md
@@ -493,6 +493,17 @@ another turn (`api-service.ts:2640`).
 
 ---
 
+## `continue_session`
+
+Carries the conversation into a fresh **successor** session and ends the turn; the successor's run answers the user.
+`{reason, title, description, handoff: {purpose, currentRequest, establishedFacts?, decisions?, openQuestions?, nextActions?, cautions?}, sources?, transfer?: {plan}}`.
+`title` and `description` are required — the predecessor names the successor exactly as the `status` verb would
+(`title_source = 'agent'`). Available to a foreground conversation with a live run; never to a delegated child (typed or
+not) or a script. Idempotent on the tool call id. The predecessor's transcript is untouched; the successor opens with a
+runtime-generated projection (lineage, the handoff, cited and recent excerpts) followed by the initiating user message
+copied verbatim. Each turn where the verb is available also carries a `<context_usage>` block. Full account:
+[`session-continuation.md`](./session-continuation.md).
+
 ## The user holds the same verbs
 
 `InvokeSessionTool` (`agents/protocol/src/index.ts:616`) runs `read`, `write`, or `call` **as the user** on the

--- a/agents/protocol/src/index.ts
+++ b/agents/protocol/src/index.ts
@@ -1118,6 +1118,85 @@ export type SessionInfo = {
    * can see inside without opening the transcript.
    */
   description?: string
+  /**
+   * Set on a session created by `continue_session`: the predecessor this session carries work
+   * forward from. The predecessor's transcript is complete and unchanged; this session began from
+   * a projection of it (see {@link SessionContinuationManifest}).
+   */
+  continuedFrom?: SessionContinuationLink
+  /**
+   * Set on a session the agent has continued out of: the latest successor. The session stays
+   * readable (and writable — writing here branches), but the foreground conversation moved on.
+   */
+  continuedTo?: SessionContinuationLink
+}
+
+/** Why an agent carried a conversation into a fresh session. */
+export type SessionContinuationReason =
+  | 'topic_change'
+  | 'phase_change'
+  | 'refocus'
+  | 'context_pressure'
+  | 'user_request'
+  | 'other'
+
+/** One end of a continuation edge, as seen from the other session. */
+export type SessionContinuationLink = {
+  continuationId: string
+  sessionId: string
+  title?: string
+  reason: SessionContinuationReason
+  createdAt: number
+}
+
+/** The agent-authored orientation a successor session starts from. Narrative, not state. */
+export type SessionContinuationHandoff = {
+  purpose: string
+  currentRequest: string
+  establishedFacts?: string[]
+  decisions?: string[]
+  openQuestions?: string[]
+  nextActions?: string[]
+  cautions?: string[]
+}
+
+/** An exact, inspectable pointer the handoff cites — never a paraphrase of it. */
+export type SessionContinuationSource =
+  | {kind: 'session_events'; sessionId: string; fromSeq: number; toSeq: number; relevance: string}
+  | {kind: 'session_event'; sessionId: string; seq: number; relevance: string}
+  | {kind: 'resource'; url: string; version?: string; blockId?: string; relevance: string}
+  | {kind: 'memory'; path: string; relevance: string}
+
+/**
+ * The projection manifest: exactly what the successor's first context was built from, and what
+ * stayed linked but cold. Stored on the continuation edge and rendered by "View handoff", so the
+ * system can always explain a successor's starting point instead of asking anyone to trust it.
+ */
+export type SessionContinuationManifest = {
+  continuationId: string
+  predecessorSessionId: string
+  successorSessionId: string
+  /** The first session in the chain of continuations this one descends from. */
+  originSessionId: string
+  /** The user (or trigger) message whose answer belongs in the successor. */
+  initiatingEvent: {id: string; seq: number}
+  /** The predecessor's `continue_session` tool call this edge was created by. */
+  toolCallId: string
+  reason: SessionContinuationReason
+  createdAt: number
+  handoff: SessionContinuationHandoff
+  /** Sources the agent cited, plus the runtime's own selection. */
+  sources: SessionContinuationSource[]
+  /** Predecessor event ranges whose text was loaded into the successor's first context. */
+  included: Array<{fromSeq: number; toSeq: number; bytes: number}>
+  /** Cited sources that did not fit the budget: linked, reachable, not loaded. */
+  omitted: SessionContinuationSource[]
+  /** What structured state crossed the edge. */
+  transfer: {plan: 'carry' | 'close' | 'omit'}
+  /** Bytes of projection text placed in the successor's first context. */
+  projectionBytes: number
+  /** Version of the projection compiler that built this manifest. */
+  compiler: string
 }
 
 /** Lifecycle status of a durable run. */
@@ -1345,6 +1424,11 @@ export type SessionEventMeta = {
   usage?: AgentRunUsage
   /** Wall time this message or tool call took, in milliseconds. */
   durationMs?: number
+  /**
+   * On a user message a continuation replayed into its successor: the exact predecessor event it
+   * is a verbatim copy of. The message is the user's, not a paraphrase — this is its provenance.
+   */
+  continuedFrom?: {sessionId: string; eventId: string; seq: number}
 }
 
 /** Durable event payloads stored for a session. */
@@ -2015,6 +2099,11 @@ export type GetSessionResponse = {
   triggerContext?: AgentSessionTriggerContext
   /** Set when `limit` cut older events out of the response; page them with `beforeSeq`. */
   hasMoreBefore?: boolean
+  /**
+   * The context window (tokens) of the model this session runs on, so a client can show how much
+   * of it the last turn used (the prompt size is stamped on each assistant message's `meta.usage`).
+   */
+  contextWindow?: number
 }
 
 /** Successful response for `GetSessionEvent`: one event, never truncated. */
@@ -2033,6 +2122,11 @@ export type MessageSessionResponse = {
    * turn streams over WS).
    */
   assistantEventId: string
+  /**
+   * Set when the turn ended by continuing into a fresh session: the answer to this message is
+   * being produced there. A client following the turn should move to that session.
+   */
+  continuedToSessionId?: string
 }
 
 /** Successful response for `RetrySession`. */

--- a/agents/protocol/src/model-capabilities.test.ts
+++ b/agents/protocol/src/model-capabilities.test.ts
@@ -1,0 +1,28 @@
+import {describe, expect, test} from 'bun:test'
+import {DEFAULT_MODEL_CONTEXT_WINDOW, modelContextWindow} from './model-capabilities'
+
+describe('modelContextWindow', () => {
+  test('anthropic models are 200k, with the 1m tier marked by suffix', () => {
+    expect(modelContextWindow('anthropic', 'claude-sonnet-4-5')).toBe(200_000)
+    expect(modelContextWindow('anthropic', 'claude-fable-5')).toBe(200_000)
+    expect(modelContextWindow('anthropic', 'claude-sonnet-4-5[1m]')).toBe(1_000_000)
+  })
+
+  test('openai families', () => {
+    expect(modelContextWindow('openai', 'gpt-5')).toBe(400_000)
+    expect(modelContextWindow('openai', 'gpt-5-mini')).toBe(400_000)
+    expect(modelContextWindow('openai', 'gpt-4o')).toBe(128_000)
+    expect(modelContextWindow('openai', 'gpt-4.1')).toBe(1_047_576)
+    expect(modelContextWindow('openai', 'o3')).toBe(200_000)
+  })
+
+  test('google gemini is a million tokens', () => {
+    expect(modelContextWindow('google', 'gemini-2.5-pro')).toBe(1_048_576)
+  })
+
+  test('unknown providers and models fall back to the conservative default', () => {
+    expect(modelContextWindow('openai', 'gpt-test')).toBe(DEFAULT_MODEL_CONTEXT_WINDOW)
+    expect(modelContextWindow('ollama', 'llama3')).toBe(DEFAULT_MODEL_CONTEXT_WINDOW)
+    expect(DEFAULT_MODEL_CONTEXT_WINDOW).toBe(128_000)
+  })
+})

--- a/agents/protocol/src/model-capabilities.ts
+++ b/agents/protocol/src/model-capabilities.ts
@@ -51,3 +51,38 @@ export function modelSupportsImageInput(providerType: string, modelId: string): 
       return false
   }
 }
+
+/** Default assumed for models no heuristic recognizes; conservative on purpose. */
+export const DEFAULT_MODEL_CONTEXT_WINDOW = 128_000
+
+/**
+ * The context window (tokens) of a model, by the same provider-id heuristics as the input
+ * capabilities above. Used to tell the model — and show the user — how full its context is, so
+ * continuation can be decided while there is still room to write a careful handoff. Errs low
+ * for unknown ids: a meter that reads a little high is a safer failure than one that reads
+ * "plenty of room" as the provider starts rejecting requests.
+ */
+export function modelContextWindow(providerType: string, modelId: string): number {
+  switch (providerType) {
+    case 'anthropic': {
+      // Every current Claude generation is 200k; the [1m] beta suffix marks the million-token tier.
+      if (/\[1m\]|-1m\b/.test(modelId)) return 1_000_000
+      return 200_000
+    }
+    case 'openai': {
+      if (/^gpt-4\.1/.test(modelId)) return 1_047_576
+      const gpt = modelId.match(/^gpt-(\d+)/)
+      if (gpt && Number(gpt[1]) >= 5) return 400_000
+      if (/^gpt-4o|^chatgpt-4o|^gpt-4-turbo/.test(modelId)) return 128_000
+      if (/^o[134]/.test(modelId)) return 200_000
+      if (/^codex|^gpt-5.*codex/.test(modelId)) return 272_000
+      return DEFAULT_MODEL_CONTEXT_WINDOW
+    }
+    case 'google': {
+      if (/^gemini-/.test(modelId)) return 1_048_576
+      return DEFAULT_MODEL_CONTEXT_WINDOW
+    }
+    default:
+      return DEFAULT_MODEL_CONTEXT_WINDOW
+  }
+}

--- a/agents/protocol/src/tool-registry.ts
+++ b/agents/protocol/src/tool-registry.ts
@@ -103,7 +103,7 @@ const readVerb = {
     '- `https://…` — read a public web page as markdown.',
     '- `activity:` — the recent activity feed; filter with options {authors, eventTypes, resource, pageSize, pageToken}.',
     '- `attachment:<id>` — a file attached to this conversation (images are shown to you when the model supports it).',
-    "- `thread:<id>` — another conversation transcript of yours, as `[seq] who: text` lines (newest 200 by default; options {fromSeq, toSeq} select an exact range — the way to recall material a continuation handoff cites — and {limit} caps the count), with its continuation lineage. `thread:` alone lists your account's conversations, newest first; options {query} searches titles and message text, {agentId} filters to one agent, {limit} caps results. `run:<id>` — a run journal.",
+    "- `thread:<id>` — another of YOUR OWN conversation transcripts, as `[seq] who: text` lines (newest 200 by default; options {fromSeq, toSeq} select an exact range — the way to recall material a continuation handoff cites — and {limit} caps the count), with its continuation lineage. `thread:` alone lists your conversations, newest first; options {query} searches titles and message text, {limit} caps results. Other agents' threads are not reachable — talk to other agents through documents and comments. `run:<id>` — a run journal.",
     'Directory listings return {entries: [{path, type, size}]}; memory file reads return {content}. Prefer reading exactly what you need; directory listings are cheap, whole trees are not.',
   ].join('\n'),
   inputSchema: {
@@ -124,7 +124,7 @@ const readVerb = {
       options: {
         type: 'object',
         description:
-          'Source-specific options: activity filters {authors, eventTypes, resource, pageSize, pageToken}; thread listing {query, agentId, limit}; thread transcript {fromSeq, toSeq, limit}; ipfs {path} to choose the memory destination.',
+          'Source-specific options: activity filters {authors, eventTypes, resource, pageSize, pageToken}; thread listing {query, limit}; thread transcript {fromSeq, toSeq, limit}; ipfs {path} to choose the memory destination.',
       },
     },
     required: ['address'],

--- a/agents/protocol/src/tool-registry.ts
+++ b/agents/protocol/src/tool-registry.ts
@@ -103,7 +103,7 @@ const readVerb = {
     '- `https://…` — read a public web page as markdown.',
     '- `activity:` — the recent activity feed; filter with options {authors, eventTypes, resource, pageSize, pageToken}.',
     '- `attachment:<id>` — a file attached to this conversation (images are shown to you when the model supports it).',
-    "- `thread:<id>` — another conversation transcript of yours. `thread:` alone lists your account's conversations, newest first; options {query} searches titles and message text, {agentId} filters to one agent, {limit} caps results. `run:<id>` — a run journal.",
+    "- `thread:<id>` — another conversation transcript of yours, as `[seq] who: text` lines (newest 200 by default; options {fromSeq, toSeq} select an exact range — the way to recall material a continuation handoff cites — and {limit} caps the count), with its continuation lineage. `thread:` alone lists your account's conversations, newest first; options {query} searches titles and message text, {agentId} filters to one agent, {limit} caps results. `run:<id>` — a run journal.",
     'Directory listings return {entries: [{path, type, size}]}; memory file reads return {content}. Prefer reading exactly what you need; directory listings are cheap, whole trees are not.',
   ].join('\n'),
   inputSchema: {
@@ -124,7 +124,7 @@ const readVerb = {
       options: {
         type: 'object',
         description:
-          'Source-specific options: activity filters {authors, eventTypes, resource, pageSize, pageToken}; thread listing {query, agentId, limit}; ipfs {path} to choose the memory destination.',
+          'Source-specific options: activity filters {authors, eventTypes, resource, pageSize, pageToken}; thread listing {query, agentId, limit}; thread transcript {fromSeq, toSeq, limit}; ipfs {path} to choose the memory destination.',
       },
     },
     required: ['address'],
@@ -428,7 +428,7 @@ const statusVerb = {
   name: 'status',
   label: 'Status',
   description:
-    'Update this session\'s title and description — the one-line label and one-or-two-sentence summary shown in session lists and read by any parent session or teammate checking on your work. Call it once early, as soon as you know what the conversation is about (a specific title beats a generic one: "Migrate billing cron to Postgres", not "Help with code"), and again whenever the focus shifts or a milestone is reached so the description reflects what is going on right now and what is left. Keep the description to what an outside reader needs: current objective, progress, blockers. When the task is finished, call it one final time so the description states the outcome rather than the intent — an idle session whose status still says what you were about to do misleads whoever checks on it. Omit a field to leave it unchanged. A title the user typed themselves is never overwritten.',
+    'Update this session\'s title and/or description as they appear in session lists and to any parent session or teammate checking on your work. They are two different things. The TITLE names what this whole session is about — the activity, not the current step ("Migrate billing cron to Postgres", not "Help with code"); set it once early, refine it gently if your understanding sharpens, and if the work shifts dramatically that is a continue_session, not a rename. The DESCRIPTION is the live status — one or two sentences on what is happening right now, how far along it is, and what is blocked — and it can change a lot: update it at milestones, when the focus moves within the session, and one final time when the work finishes so it states the outcome rather than the intent (an idle session whose status still says what you were about to do misleads whoever checks on it). Pass only the fields you are changing; passing just a description is the normal case. Each turn shows the current values in a <session_status> block: call this to change them, never to restate them. A title the user typed themselves is never overwritten, and a session a continuation already named needs no call until its status actually moves.',
   inputSchema: {
     type: 'object',
     additionalProperties: false,
@@ -441,6 +441,130 @@ const statusVerb = {
     },
   },
   render: {kind: 'hidden', label: 'Status', color: 'hidden', summaryArg: 'title'},
+  runtimes: ['agent-service'],
+} satisfies SeedToolMetadata
+
+const continueSessionVerb = {
+  name: 'continue_session',
+  label: 'Continue',
+  description: [
+    'Carry this conversation into a FRESH session and answer the user there. Call it INSTEAD of replying when the current transcript is no longer the right working context. This session is never compacted or rewritten: its history stays complete and unchanged, a new session is created linked to it, the user is moved there, and the successor run answers the current message. Your turn here ends the moment you call it — do not write a reply first; the successor gives the reply.',
+    'Reach for it at semantic boundaries, not on a token count:',
+    '- the user changes to a substantially different subject (`topic_change`);',
+    '- one phase of the work is done and the next begins — research finished, implementation starts; a task completed, a new one requested (`phase_change`);',
+    '- the user wants to get back to something earlier, or to focus on one thread of a sprawling conversation, and a clean context built around that thread would serve better than scrolling through everything else (`refocus`);',
+    '- old tool traffic or abandoned tangents crowd out what matters now (`refocus`);',
+    '- the user asks for it (`user_request`);',
+    '- the `<context_usage>` block shows the context nearly full (roughly 70% or more), or you notice the model losing track of earlier facts (`context_pressure`). Do not wait until it is completely full: continue while there is room to write a careful handoff. Continuing at 40% for a real subject change is right; splitting a coherent single task at 60% just because of the number is not.',
+    'Do NOT continue while side effects are unresolved: finish or explicitly account for in-flight work first (delegated children still running, a write you have not confirmed). Do not continue from a delegated child session — a child reports back with its result. Do not continue when the user is simply following up on the same work with the same working set; that is the conversation working as intended.',
+    'The successor starts with: its normal system prompt and tools; a runtime-generated lineage block naming this session (it can `read thread:<id>` to recall anything exact); your handoff; the exact text of the message that caused the continuation; and short excerpts of the most recent exchanges. Everything else from here is reachable but NOT loaded, so the handoff must stand on its own: write it for a capable colleague who has read none of this conversation. Put in `establishedFacts` the concrete things learned (names, ids, URLs, numbers, what worked and what failed); in `decisions` what was chosen and why; in `nextActions` what the successor should do first. Cite `sources` — hm:// resources, memory files, thread event ranges — for anything the successor might need exactly rather than as your summary.',
+    '`title` and `description` name the successor as it will appear in session lists; they are required and are yours to set, the way the status verb sets them: a specific title ("Migrate billing cron to Postgres", not "Continued conversation") and a one-or-two-sentence description of what the successor is about to do.',
+    '`transfer.plan` says what happens to the live checklist: `carry` copies it into the successor (default when it has unfinished steps), `close` leaves it here as history. Structured state — identity, grants, model, attachments — is carried by the runtime, not by your prose.',
+  ].join('\n'),
+  inputSchema: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      reason: {
+        type: 'string',
+        enum: ['topic_change', 'phase_change', 'refocus', 'context_pressure', 'user_request', 'other'],
+        description: 'Why the conversation is moving to a fresh session.',
+      },
+      title: {
+        type: 'string',
+        minLength: 1,
+        description: 'Title of the successor session, at most eight words, specific to what it will do.',
+      },
+      description: {
+        type: 'string',
+        minLength: 1,
+        description: 'One or two sentences: what the successor session is about and what it will do first.',
+      },
+      handoff: {
+        type: 'object',
+        additionalProperties: false,
+        description: 'Orientation for the successor, written for a colleague who has read none of this conversation.',
+        properties: {
+          purpose: {type: 'string', minLength: 1, description: 'What the successor session is for.'},
+          currentRequest: {
+            type: 'string',
+            minLength: 1,
+            description:
+              'What the user is asking for right now, in your words. (The exact user message is also replayed verbatim.)',
+          },
+          establishedFacts: {
+            type: 'array',
+            items: {type: 'string'},
+            description: 'Concrete facts learned here: names, ids, URLs, numbers, what worked, what failed.',
+          },
+          decisions: {type: 'array', items: {type: 'string'}, description: 'What was decided, and why.'},
+          openQuestions: {type: 'array', items: {type: 'string'}, description: 'What is still unresolved.'},
+          nextActions: {
+            type: 'array',
+            items: {type: 'string'},
+            description: 'What the successor should do first, in order.',
+          },
+          cautions: {type: 'array', items: {type: 'string'}, description: 'Pitfalls, constraints, things not to do.'},
+        },
+        required: ['purpose', 'currentRequest'],
+      },
+      sources: {
+        type: 'array',
+        description:
+          'Exact references the successor may need: {kind: "resource", url, relevance} for hm:// or web content; {kind: "memory", path, relevance} for a memory file; {kind: "session_events", fromSeq, toSeq, relevance} or {kind: "session_event", seq, relevance} for a range of this thread (seqs as shown by read thread:<id>). Each carries a one-line relevance.',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            kind: {type: 'string', enum: ['resource', 'memory', 'session_events', 'session_event']},
+            url: {type: 'string'},
+            version: {type: 'string'},
+            blockId: {type: 'string'},
+            path: {type: 'string'},
+            sessionId: {type: 'string', description: 'Defaults to this session.'},
+            fromSeq: {type: 'number'},
+            toSeq: {type: 'number'},
+            seq: {type: 'number'},
+            relevance: {type: 'string', minLength: 1},
+          },
+          required: ['kind', 'relevance'],
+        },
+      },
+      transfer: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          plan: {
+            type: 'string',
+            enum: ['carry', 'close', 'omit'],
+            description: 'carry: copy the live checklist into the successor. close/omit: leave it here as history.',
+          },
+        },
+      },
+    },
+    required: ['reason', 'title', 'description', 'handoff'],
+  },
+  outputSchema: {
+    type: 'object',
+    properties: {
+      continuationId: {type: 'string'},
+      successorSessionId: {type: 'string'},
+      title: {type: 'string'},
+    },
+  },
+  render: {
+    kind: 'generic',
+    label: 'Continue',
+    pendingLabel: 'Continuing',
+    color: 'violet',
+    primaryArg: 'title',
+    summaryArg: 'title',
+    details: [
+      {label: 'Handoff', source: 'input', path: 'handoff'},
+      {label: 'Sources', source: 'input', path: 'sources'},
+      {label: 'Result', source: 'output'},
+    ],
+  },
   runtimes: ['agent-service'],
 } satisfies SeedToolMetadata
 
@@ -468,6 +592,7 @@ export const seedVerbRegistry = {
   delegate: delegateVerb,
   plan: planVerb,
   status: statusVerb,
+  continue_session: continueSessionVerb,
   return_result: returnResultTool,
 } as const
 

--- a/agents/src/api-service.test.ts
+++ b/agents/src/api-service.test.ts
@@ -3177,7 +3177,12 @@ describe('api service', () => {
         await apisvc.createSignedEnvelope(account, {
           action: {
             _: 'CreateAgent',
-            definition: {name: 'Agent', systemPrompt: 'ok', modelProvider: 'openai', model: 'gpt'},
+            definition: {
+              name: 'Agent',
+              systemPrompt: 'You are the scheduling persona.',
+              modelProvider: 'openai',
+              model: 'gpt',
+            },
           },
         }),
       )
@@ -3213,7 +3218,7 @@ describe('api service', () => {
         expect(JSON.stringify(body.messages)).toContain('Run the scheduled task.')
         expect(JSON.stringify(body.messages)).toContain('schedule')
         const systemMessage = body.messages.find((message: {role?: string}) => message.role === 'system')
-        expect(systemMessage?.content).toContain('ok')
+        expect(systemMessage?.content).toContain('You are the scheduling persona.')
         expect(systemMessage?.content).toContain('You are the isolated scheduler worker.')
         return openAIStreamResponse([
           {id: 'chat-schedule', choices: [{delta: {content: 'Scheduled task handled.'}}]},
@@ -3282,7 +3287,7 @@ describe('api service', () => {
         openAICallCount += 1
         const body = JSON.parse(String(init?.body))
         const systemMessage = body.messages.find((message: {role?: string}) => message.role === 'system')
-        expect(systemMessage?.content).not.toContain('ok')
+        expect(systemMessage?.content).not.toContain('You are the scheduling persona.')
         expect(systemMessage?.content).toContain('You are only the isolated worker.')
         return openAIStreamResponse([
           {id: 'chat-isolated', choices: [{delta: {content: 'Isolated task handled.'}}]},
@@ -4055,6 +4060,7 @@ describe('api service', () => {
             'delegate',
             'plan',
             'status',
+            'continue_session',
           ])
           return openAIStreamResponse([
             {id: 'chat-1', choices: [{delta: {content: "I'll read it first.\n"}}]},
@@ -4295,7 +4301,7 @@ describe('api service', () => {
       // First provider request advertises exactly the verb surface (delegate is run-backed).
       expect(
         (openAIBodies[0]?.tools as Array<{function?: {name?: string}}>)?.map((tool) => tool.function?.name),
-      ).toEqual(['read', 'write', 'call', 'delegate', 'plan', 'status'])
+      ).toEqual(['read', 'write', 'call', 'delegate', 'plan', 'status', 'continue_session'])
       // The follow-up request carries the tool result (with the SearXNG URL) after its tool call.
       const followUpMessages = openAIBodies[1]?.messages as Array<Record<string, unknown>>
       expect(followUpMessages.some((message) => message.role === 'tool')).toBe(true)
@@ -4393,6 +4399,7 @@ describe('api service', () => {
             'delegate',
             'plan',
             'status',
+            'continue_session',
           ])
           expect(JSON.stringify(body.tools)).toContain('hm://<account>/<path>')
           expect(JSON.stringify(body.messages)).toContain('Writer Bot')

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -7721,13 +7721,23 @@ export class Service {
     return sessionContinuationLinksOf(this.#db, accountId, sessionId)
   }
 
-  /** The context window of the model a session runs on (its override, else the agent's model). */
+  /**
+   * The context window of the model a session runs on (its override, else the agent's model) —
+   * from the SAME resolution the run itself registers with Pi, so the meter and the runtime's
+   * <context_usage> block never disagree: the Codex subscription catalog for subscription
+   * providers, the shared per-model heuristics otherwise.
+   */
   #sessionContextWindow(accountId: string, definition: api.AgentDefinition, session: api.SessionInfo): number {
     const effective = this.#definitionForSession(accountId, definition, session)
     const providerRow = this.#db
-      .query<{type: string}, [string, string]>(`SELECT type FROM model_providers WHERE account_id = ? AND name = ?`)
+      .query<{config_cbor: Uint8Array}, [string, string]>(
+        `SELECT config_cbor FROM model_providers WHERE account_id = ? AND name = ?`,
+      )
       .get(accountId, effective.modelProvider)
-    return modelContextWindow(providerRow?.type ?? '', effective.model)
+    if (!providerRow) return modelContextWindow('', effective.model)
+    const provider = cbor.decode<api.ModelProviderConfig>(providerRow.config_cbor)
+    const subscription = provider.authMode === 'subscription'
+    return piModelForDefinition(provider.type, '', effective, {subscription}).contextWindow
   }
 
   #getSessionTriggerContext(accountId: string, sessionId: string): api.AgentSessionTriggerContext | null {

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -3800,7 +3800,7 @@ export class Service {
       runningSession.completeAfterTools = true
       return continuationToolOutput(outcome)
     }
-    const input = normalizeContinueSessionInput(raw)
+    const input = normalizeContinueSessionInput(raw, sessionId)
     if (runningSession.parkToolCallIds?.length) {
       throw new APIError(
         400,
@@ -3849,7 +3849,7 @@ export class Service {
       )
     }
     const stateDir = this.#agentMemoryStateDir(accountId, agentId)
-    const sources = this.#validateContinuationSources(accountId, sessionId, events, stateDir, input.sources)
+    const sources = this.#validateContinuationSources(accountId, agentId, sessionId, events, stateDir, input.sources)
     const originSessionId = this.#continuationOriginOf(accountId, sessionId)
     const plan = this.#storedSessionPlan(accountId, sessionId)
     const planTransfer: 'carry' | 'close' | 'omit' =
@@ -4029,6 +4029,7 @@ export class Service {
    */
   #validateContinuationSources(
     accountId: string,
+    agentId: string,
     sessionId: string,
     events: api.SessionEvent[],
     stateDir: string,
@@ -4038,10 +4039,14 @@ export class Service {
     const threadMaxSeq = (id: string): number => {
       const known = maxSeqOf.get(id)
       if (known !== undefined) return known
+      // Any thread of this agent is citable, whoever's account it sits under; so is any thread of
+      // this account. A thread outside both is unreachable to the successor and must not be cited.
       const owned = this.#db
-        .query<{n: number}, [string, string]>(`SELECT COUNT(*) AS n FROM sessions WHERE account_id = ? AND id = ?`)
-        .get(accountId, id)
-      if (!owned?.n) throw new APIError(400, `Source thread ${id} is not one of this account's threads`)
+        .query<{n: number}, [string, string, string]>(
+          `SELECT COUNT(*) AS n FROM sessions WHERE id = ? AND (account_id = ? OR agent_id = ?)`,
+        )
+        .get(id, accountId, agentId)
+      if (!owned?.n) throw new APIError(400, `Source thread ${id} does not exist, or belongs to another agent`)
       const max =
         this.#db
           .query<{max: number | null}, [string]>(`SELECT MAX(seq) AS max FROM session_events WHERE session_id = ?`)
@@ -10479,11 +10484,13 @@ function readThreadAddress(
   sessionId: string,
   options: Record<string, unknown> = {},
 ): Record<string, unknown> {
+  // Any thread of this agent is readable, whichever account it sits under, and so is any thread
+  // of this account — the same reach a continuation may cite.
   const session = context.db
-    .query<{id: string; title: string | null; description: string | null; agent_id: string}, [string, string]>(
-      `SELECT id, title, description, agent_id FROM sessions WHERE account_id = ? AND id = ?`,
+    .query<{id: string; title: string | null; description: string | null; agent_id: string}, [string, string, string]>(
+      `SELECT id, title, description, agent_id FROM sessions WHERE id = ? AND (account_id = ? OR agent_id = ?)`,
     )
-    .get(context.accountId, sessionId)
+    .get(sessionId, context.accountId, context.agentId)
   if (!session) throw new APIError(404, `No thread ${sessionId}`)
   const fromSeq = Number.isInteger(options.fromSeq) ? Number(options.fromSeq) : undefined
   const toSeq = Number.isInteger(options.toSeq) ? Number(options.toSeq) : undefined
@@ -13377,8 +13384,11 @@ type ContinueSessionInput = {
   transfer?: {plan?: 'carry' | 'close' | 'omit'}
 }
 
-/** Validates continue_session input: what the agent must supply, bounded like the status verb. */
-function normalizeContinueSessionInput(raw: unknown): ContinueSessionInput {
+/**
+ * Validates continue_session input: what the agent must supply, bounded like the status verb.
+ * Thread sources default to `defaultSessionId` — the session being continued — when they name none.
+ */
+function normalizeContinueSessionInput(raw: unknown, defaultSessionId: string): ContinueSessionInput {
   const input = isPlainRecord(raw) ? raw : {}
   if (!CONTINUATION_REASONS.includes(input.reason as api.SessionContinuationReason)) {
     throw new APIError(400, `continue_session needs a reason: one of ${CONTINUATION_REASONS.join(', ')}`)
@@ -13415,7 +13425,8 @@ function normalizeContinueSessionInput(raw: unknown): ContinueSessionInput {
     for (const entry of input.sources) {
       if (!isPlainRecord(entry)) throw new APIError(400, 'Each source must be an object')
       const relevance = normalizeBoundedString(entry.relevance, 'source.relevance', MAX_SESSION_DESCRIPTION_BYTES)
-      const sessionId = typeof entry.sessionId === 'string' && entry.sessionId.trim() ? entry.sessionId.trim() : ''
+      const sessionId =
+        typeof entry.sessionId === 'string' && entry.sessionId.trim() ? entry.sessionId.trim() : defaultSessionId
       switch (entry.kind) {
         case 'resource':
           sources.push({

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -4039,14 +4039,15 @@ export class Service {
     const threadMaxSeq = (id: string): number => {
       const known = maxSeqOf.get(id)
       if (known !== undefined) return known
-      // Any thread of this agent is citable, whoever's account it sits under; so is any thread of
-      // this account. A thread outside both is unreachable to the successor and must not be cited.
+      // Only this agent's own threads are citable. Agents do not read each other's state — they
+      // communicate over public interfaces (documents, comments) until a deliberate inter-agent
+      // contract exists.
       const owned = this.#db
-        .query<{n: number}, [string, string, string]>(
-          `SELECT COUNT(*) AS n FROM sessions WHERE id = ? AND (account_id = ? OR agent_id = ?)`,
-        )
-        .get(id, accountId, agentId)
-      if (!owned?.n) throw new APIError(400, `Source thread ${id} does not exist, or belongs to another agent`)
+        .query<{n: number}, [string, string]>(`SELECT COUNT(*) AS n FROM sessions WHERE id = ? AND agent_id = ?`)
+        .get(id, agentId)
+      if (!owned?.n) {
+        throw new APIError(400, `Source thread ${id} does not exist, or is not one of this agent's threads`)
+      }
       const max =
         this.#db
           .query<{max: number | null}, [string]>(`SELECT MAX(seq) AS max FROM session_events WHERE session_id = ?`)
@@ -10484,13 +10485,13 @@ function readThreadAddress(
   sessionId: string,
   options: Record<string, unknown> = {},
 ): Record<string, unknown> {
-  // Any thread of this agent is readable, whichever account it sits under, and so is any thread
-  // of this account — the same reach a continuation may cite.
+  // Only this agent's own threads are readable — the same reach a continuation may cite. Agents
+  // do not read each other's state; they communicate over public interfaces.
   const session = context.db
-    .query<{id: string; title: string | null; description: string | null; agent_id: string}, [string, string, string]>(
-      `SELECT id, title, description, agent_id FROM sessions WHERE id = ? AND (account_id = ? OR agent_id = ?)`,
+    .query<{id: string; title: string | null; description: string | null; agent_id: string}, [string, string]>(
+      `SELECT id, title, description, agent_id FROM sessions WHERE id = ? AND agent_id = ?`,
     )
-    .get(sessionId, context.accountId, context.agentId)
+    .get(sessionId, context.agentId)
   if (!session) throw new APIError(404, `No thread ${sessionId}`)
   const fromSeq = Number.isInteger(options.fromSeq) ? Number(options.fromSeq) : undefined
   const toSeq = Number.isInteger(options.toSeq) ? Number(options.toSeq) : undefined
@@ -10947,13 +10948,15 @@ function readSelfAddress(context: AgentServicePiToolContext): Record<string, unk
 }
 
 /**
- * Lists (and searches) the account's conversations for `read thread:` with no id. Search covers
+ * Lists (and searches) THIS AGENT's conversations for `read thread:` with no id. Other agents'
+ * threads are not listed — agents do not read each other's state, whatever account they share —
+ * and the legacy {agentId} option is inert. Search covers
  * titles and, bounded, recent message text — enough to find "that thread where we discussed X"
  * without scanning the whole log history.
  */
 function threadsListing(context: AgentServicePiToolContext, options: Record<string, unknown>): Record<string, unknown> {
   const limit = boundedInteger(options.limit, 25, 1, 100)
-  const agentId = typeof options.agentId === 'string' && options.agentId ? options.agentId : undefined
+  const agentId = context.agentId
   const query = typeof options.query === 'string' ? options.query.trim().toLowerCase() : ''
 
   type ThreadRow = {
@@ -10981,12 +10984,8 @@ function threadsListing(context: AgentServicePiToolContext, options: Record<stri
       }),
   )
   const loadThreads = (ids?: string[]): ThreadRow[] => {
-    const conditions = ['account_id = ?']
-    const params: (string | number)[] = [context.accountId]
-    if (agentId) {
-      conditions.push('agent_id = ?')
-      params.push(agentId)
-    }
+    const conditions = ['account_id = ?', 'agent_id = ?']
+    const params: (string | number)[] = [context.accountId, agentId]
     if (ids) {
       if (ids.length === 0) return []
       conditions.push(`id IN (${ids.map(() => '?').join(', ')})`)

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -6,6 +6,7 @@ import {
   sessionEventActor,
   isReasoningLevel,
   modelReasoningSupport,
+  modelContextWindow,
   modelSupportsImageInput,
   normalizeSeedToolName,
   seedAssistantSystemPrompt,
@@ -139,6 +140,20 @@ const MAX_SESSION_SPAWN_DEPTH = 3
 const MAX_SESSION_SPAWNS_PER_SESSION = 10
 /** Bound on the agent-maintained session description (status verb). */
 const MAX_SESSION_DESCRIPTION_BYTES = 1024
+/** Successors one session may be continued into; beyond this a loop is likelier than a branch. */
+const MAX_SESSION_CONTINUATIONS_PER_SESSION = 8
+/** Text budget for the projection message a successor session starts from. */
+const CONTINUATION_PROJECTION_BUDGET_BYTES = 40 * 1024
+/** Recent predecessor exchanges the projection compiler offers when the budget allows. */
+const CONTINUATION_RECENT_EVENTS = 16
+/** Per-excerpt cap inside a projection, so one giant message cannot eat the whole budget. */
+const CONTINUATION_EXCERPT_MAX_CHARS = 2_000
+/** Name of the projection compiler recorded on every manifest it writes. */
+const CONTINUATION_PROJECTION_COMPILER = 'projection/1'
+/** Context fullness at which the runtime starts telling the model to continue. */
+const CONTEXT_PRESSURE_WARN_FRACTION = 0.7
+/** Context fullness at which the runtime tells the model to continue before answering. */
+const CONTEXT_PRESSURE_URGENT_FRACTION = 0.85
 
 /** Dedicated title-generation model calls a session gets per process before the runtime stops trying. */
 const MAX_TITLE_GENERATION_ATTEMPTS = 3
@@ -287,6 +302,24 @@ class SessionParkedError extends Error {
   }
 }
 
+/**
+ * Thrown out of a Pi run when the turn ended by continuing into a successor session: the answer
+ * to the current message belongs to the successor's run, so this run stops after the tool batch
+ * without producing one of its own.
+ */
+class SessionContinuedError extends Error {
+  constructor(readonly continuation: SessionContinuationOutcome) {
+    super('Agent run continued into a successor session')
+  }
+}
+
+/** What a `continue_session` call left behind for the run that made it. */
+type SessionContinuationOutcome = {
+  continuationId: string
+  successorSessionId: string
+  title: string
+}
+
 type RunningSession = {
   accountId: string
   abort?: () => Promise<void>
@@ -299,6 +332,8 @@ type RunningSession = {
   subResultRetries?: number
   /** Set when the turn should end after the current tool batch (result delivered). */
   completeAfterTools?: boolean
+  /** Set by `continue_session`: the turn ends after this tool batch and the successor answers. */
+  continuation?: SessionContinuationOutcome
 }
 
 /** Validated delegate tool input for a model child, embedded in the child run's `input` so the run is self-describing. */
@@ -2574,7 +2609,11 @@ export class Service {
     const hasMore = rows.length > pageSize
     const page = hasMore ? rows.slice(0, pageSize) : rows
     const sessions = page.map((session) =>
-      sessionRowToInfo(session, this.#getSessionTriggerContext(session.account_id, session.id) ?? undefined),
+      sessionRowToInfo(
+        session,
+        this.#getSessionTriggerContext(session.account_id, session.id) ?? undefined,
+        this.#sessionContinuationLinks(session.account_id, session.id),
+      ),
     )
     const referencedAgentIds = new Set(sessions.map((session) => session.agentId))
     const agents = this.#listAgents(accountId).agents.filter((agent) => referencedAgentIds.has(agent.id))
@@ -3203,6 +3242,10 @@ export class Service {
       runId?: string
       titleSource?: 'system' | 'agent'
       modelOverride?: api.SessionModelOverride
+      /** Agent-authored description, set at creation by a continuation's predecessor. */
+      description?: string
+      /** A checklist carried across a continuation edge, already re-stamped for the new session. */
+      plan?: runs.RunPlanState
     } = {},
   ): api.CreateSessionResponse {
     const agent = this.#db
@@ -3221,8 +3264,8 @@ export class Service {
       rawTitle === undefined ? null : normalizeBoundedString(rawTitle, 'Session title', MAX_NAME_BYTES)
     const title = normalizedTitle && isPlaceholderSessionTitle(normalizedTitle) ? null : normalizedTitle
     this.#db.run(
-      `INSERT INTO sessions (id, account_id, agent_id, title, title_source, status, parent_session_id, run_id, model_override_cbor, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO sessions (id, account_id, agent_id, title, title_source, status, parent_session_id, run_id, model_override_cbor, description, plan_cbor, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         sessionId,
         accountId,
@@ -3233,6 +3276,8 @@ export class Service {
         opts.parentSessionId ?? null,
         opts.runId ?? null,
         opts.modelOverride ? cbor.encode(opts.modelOverride) : null,
+        opts.description ?? null,
+        opts.plan ? cbor.encode(opts.plan) : null,
         now,
         now,
       ],
@@ -3551,6 +3596,27 @@ export class Service {
   }
 
   /** The plan as currently stored, or undefined for a session that has never published one. */
+  /**
+   * The prompt size of the session's most recent model turn — input plus cache reads and writes,
+   * which together are the whole context the provider was sent — from the usage stamped on the
+   * last assistant message. Undefined until a turn has completed.
+   */
+  #lastPromptTokens(sessionId: string): number | undefined {
+    const rows = this.#db
+      .query<{event_cbor: Uint8Array}, [string]>(
+        `SELECT event_cbor FROM session_events WHERE session_id = ? ORDER BY seq DESC LIMIT 60`,
+      )
+      .all(sessionId)
+    for (const row of rows) {
+      const payload = cbor.decode<{type?: string; role?: string; meta?: api.SessionEventMeta}>(row.event_cbor)
+      if (payload.type !== 'message' || payload.role !== 'assistant') continue
+      const usage = payload.meta?.usage
+      if (!usage) continue
+      return usage.input + usage.cacheRead + usage.cacheWrite
+    }
+    return undefined
+  }
+
   #storedSessionPlan(accountId: string, sessionId: string): runs.RunPlanState | undefined {
     const row = this.#db
       .query<{plan_cbor: Uint8Array | null}, [string, string]>(
@@ -3695,6 +3761,320 @@ export class Service {
       })
     }
     return session
+  }
+
+  /**
+   * continue_session verb: carries this conversation into a fresh successor session.
+   *
+   * The predecessor is never rewritten. In one transaction the successor is created (titled and
+   * described by the predecessor's agent), the continuation edge and its projection manifest are
+   * stored, the checklist is carried when asked, and the successor's first two events are
+   * appended: a runtime-generated lineage block with the agent's handoff and exact excerpts, then
+   * the user's initiating message copied VERBATIM with its provenance. The successor's run starts
+   * right after, and this turn ends after its tool batch — the answer is produced over there.
+   *
+   * Idempotent on the tool call id: a replayed call returns the successor it already made.
+   */
+  #continueSessionFromAgent(
+    accountId: string,
+    run: runs.RunRecord,
+    sessionId: string,
+    agentId: string,
+    runningSession: RunningSession,
+    toolCallId: string,
+    raw: unknown,
+  ): Record<string, unknown> {
+    const replayed = this.#db
+      .query<{id: string; successor_session_id: string}, [string, string]>(
+        `SELECT id, successor_session_id FROM session_continuations WHERE predecessor_session_id = ? AND tool_call_id = ?`,
+      )
+      .get(sessionId, toolCallId)
+    if (replayed) {
+      const successor = this.#getSessionInfo(accountId, replayed.successor_session_id)
+      const outcome: SessionContinuationOutcome = {
+        continuationId: replayed.id,
+        successorSessionId: replayed.successor_session_id,
+        title: successor?.title ?? '',
+      }
+      runningSession.continuation = outcome
+      runningSession.completeAfterTools = true
+      return continuationToolOutput(outcome)
+    }
+    const input = normalizeContinueSessionInput(raw)
+    if (runningSession.parkToolCallIds?.length) {
+      throw new APIError(
+        400,
+        'Cannot continue while children delegated this turn are still running: wait for their results, or account for them explicitly, then continue.',
+      )
+    }
+    if (run.parentRunId) {
+      throw new APIError(
+        400,
+        'A delegated child does not continue into a new session: finish the task and report back to the parent instead.',
+      )
+    }
+    const session = this.#db
+      .query<SessionRow, [string, string]>(
+        `SELECT id, account_id, agent_id, title, status, parent_session_id, run_id, plan_cbor, model_override_cbor, description,
+                0 AS child_count, created_at, updated_at
+         FROM sessions WHERE account_id = ? AND id = ?`,
+      )
+      .get(accountId, sessionId)
+    if (!session) throw new APIError(404, 'Session not found')
+    const successorsSoFar =
+      this.#db
+        .query<{n: number}, [string]>(
+          `SELECT COUNT(*) AS n FROM session_continuations WHERE predecessor_session_id = ?`,
+        )
+        .get(sessionId)?.n ?? 0
+    if (successorsSoFar >= MAX_SESSION_CONTINUATIONS_PER_SESSION) {
+      throw new APIError(
+        400,
+        `This session has already been continued ${MAX_SESSION_CONTINUATIONS_PER_SESSION} times; answer here instead.`,
+      )
+    }
+    const events = this.#db
+      .query<SessionEventRow, [string]>(
+        `SELECT id, session_id, seq, event_cbor, created_at FROM session_events WHERE session_id = ? ORDER BY seq ASC`,
+      )
+      .all(sessionId)
+      .map(sessionEventRowToInfo)
+    const initiating = findContinuationInitiatingEvent(events)
+    if (!initiating) throw new APIError(400, 'Nothing to continue: this session has no user message to carry forward.')
+    const initiatingPayload = initiating.event as {meta?: api.SessionEventMeta}
+    if (initiatingPayload.meta?.continuedFrom) {
+      throw new APIError(
+        400,
+        'This session was itself just continued and has had no new user message since. Answer here; continuing again would loop.',
+      )
+    }
+    const stateDir = this.#agentMemoryStateDir(accountId, agentId)
+    const sources = this.#validateContinuationSources(accountId, sessionId, events, stateDir, input.sources)
+    const originSessionId = this.#continuationOriginOf(accountId, sessionId)
+    const plan = this.#storedSessionPlan(accountId, sessionId)
+    const planTransfer: 'carry' | 'close' | 'omit' =
+      input.transfer?.plan ?? (plan && !isPlanFullySettled(plan) ? 'carry' : 'omit')
+    const continuationId = crypto.randomUUID()
+    const now = Date.now()
+    const projection = compileContinuationProjection({
+      continuationId,
+      predecessor: {id: sessionId, title: session.title},
+      originSessionId,
+      initiating,
+      reason: input.reason,
+      handoff: input.handoff,
+      sources,
+      events,
+      budgetBytes: CONTINUATION_PROJECTION_BUDGET_BYTES,
+    })
+    const modelOverride = session.model_override_cbor
+      ? cbor.decode<api.SessionModelOverride>(session.model_override_cbor)
+      : undefined
+    const transaction = this.#db.transaction(() => {
+      const created = this.#createSessionOnce(accountId, agentId, input.title, {
+        parentSessionId: session.parent_session_id ?? undefined,
+        titleSource: 'agent',
+        ...(modelOverride ? {modelOverride} : {}),
+        description: input.description,
+        ...(planTransfer === 'carry' && plan ? {plan: {...plan, ownerRunId: undefined, settledAt: undefined}} : {}),
+      })
+      const successorSessionId = created.sessionId
+      const manifest: api.SessionContinuationManifest = {
+        continuationId,
+        predecessorSessionId: sessionId,
+        successorSessionId,
+        originSessionId,
+        initiatingEvent: {id: initiating.id, seq: initiating.seq},
+        toolCallId,
+        reason: input.reason,
+        createdAt: now,
+        handoff: input.handoff,
+        sources: projection.sources,
+        included: projection.included,
+        omitted: projection.omitted,
+        transfer: {plan: planTransfer},
+        projectionBytes: Buffer.byteLength(projection.content),
+        compiler: CONTINUATION_PROJECTION_COMPILER,
+      }
+      this.#db.run(
+        `INSERT INTO session_continuations (id, account_id, agent_id, predecessor_session_id, successor_session_id,
+           origin_session_id, tool_call_id, initiating_event_id, reason, manifest_cbor, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          continuationId,
+          accountId,
+          agentId,
+          sessionId,
+          successorSessionId,
+          originSessionId,
+          toolCallId,
+          initiating.id,
+          input.reason,
+          cbor.encode(manifest),
+          now,
+        ],
+      )
+      // The successor's opening: lineage + handoff + excerpts as one system-authored message, then
+      // the user's own message, verbatim, so the model answers the user and not the runtime.
+      this.#appendSessionEvent(
+        accountId,
+        agentId,
+        successorSessionId,
+        {type: 'message', role: 'user', actor: 'system', content: projection.content},
+        now,
+      )
+      const original = initiating.event as Extract<api.SessionEventPayload, {type: 'message'}>
+      const attachments = (original.attachments ?? []).flatMap((attachment) => {
+        try {
+          sessionAttachments.linkSessionAttachment(stateDir, sessionId, successorSessionId, attachment.id)
+          return [attachment]
+        } catch (error) {
+          console.warn('[agents/runtime] continuation could not carry attachment', {
+            attachmentId: attachment.id,
+            error: error instanceof Error ? error.message : String(error),
+          })
+          return []
+        }
+      })
+      const copied = this.#appendSessionEvent(
+        accountId,
+        agentId,
+        successorSessionId,
+        {
+          type: 'message',
+          role: 'user',
+          content: original.content,
+          ...(original.rawMarkdown !== undefined ? {rawMarkdown: original.rawMarkdown} : {}),
+          ...(original.blocks ? {blocks: original.blocks} : {}),
+          ...(original.contextLines ? {contextLines: original.contextLines} : {}),
+          ...(attachments.length > 0 ? {attachments} : {}),
+          actor: sessionEventActor(initiating.event),
+          meta: {
+            ...(original.meta ?? {}),
+            continuedFrom: {sessionId, eventId: initiating.id, seq: initiating.seq},
+          },
+        },
+        now + 1,
+      )
+      return {successorSessionId, copiedEventId: copied.id}
+    })
+    const {successorSessionId, copiedEventId} = transaction()
+    const outcome: SessionContinuationOutcome = {continuationId, successorSessionId, title: input.title}
+    runningSession.continuation = outcome
+    runningSession.completeAfterTools = true
+    console.info('[agents/runtime] session continued', {
+      accountId,
+      agentId,
+      predecessorSessionId: sessionId,
+      successorSessionId,
+      continuationId,
+      reason: input.reason,
+      initiatingSeq: initiating.seq,
+      projectionBytes: Buffer.byteLength(projection.content),
+      included: projection.included,
+      omitted: projection.omitted.length,
+    })
+    // Both ends changed shape: the successor now carries continuedFrom, the predecessor continuedTo.
+    for (const id of [sessionId, successorSessionId]) {
+      const info = this.#getSessionInfo(accountId, id)
+      if (info) this.#emit({type: 'session-change', accountId, session: info})
+    }
+    this.#emit({type: 'account-change', accountId, reason: 'session-updated', agentId, sessionId})
+    this.#emit({type: 'account-change', accountId, reason: 'session-continued', agentId, sessionId: successorSessionId})
+    // The successor answers. Its run is a fresh interactive turn on its own session; the user's
+    // client follows the continuedTo link the predecessor now advertises.
+    const original = initiating.event as {rawMarkdown?: string; content?: string}
+    this.#runQueue.enqueue({
+      accountId,
+      kind: 'agent',
+      origin: 'agent',
+      agentId,
+      sessionId: successorSessionId,
+      title: sessionTitleFromPrompt(original.rawMarkdown ?? original.content ?? input.title),
+      input: {
+        kind: 'session-message',
+        userEventIds: [copiedEventId],
+        queuedBehindAnotherTurn: false,
+        continuedFrom: {sessionId, continuationId},
+      },
+      queue: 'interactive',
+      maxAttempts: 1,
+      dispatch: true,
+    })
+    return continuationToolOutput(outcome)
+  }
+
+  /** Walks predecessor links back to the first session of a continuation chain. */
+  #continuationOriginOf(accountId: string, sessionId: string): string {
+    let current = sessionId
+    for (let hops = 0; hops < 10_000; hops += 1) {
+      const row = this.#db
+        .query<{origin_session_id: string}, [string, string]>(
+          `SELECT origin_session_id FROM session_continuations WHERE account_id = ? AND successor_session_id = ?`,
+        )
+        .get(accountId, current)
+      if (!row) return current
+      // Origins are stored on every edge, so one hop reaches it; the loop is only for a stored
+      // origin that is itself a successor (never written, but never trusted either).
+      if (row.origin_session_id === current) return current
+      current = row.origin_session_id
+    }
+    return current
+  }
+
+  /**
+   * Checks every cited source is something the successor can actually reach: a well-formed
+   * resource URL, a memory file that exists, or a seq range inside a thread of this account.
+   * A handoff that cites what is not there is exactly the lossy breadcrumb this exists to prevent.
+   */
+  #validateContinuationSources(
+    accountId: string,
+    sessionId: string,
+    events: api.SessionEvent[],
+    stateDir: string,
+    raw: api.SessionContinuationSource[],
+  ): api.SessionContinuationSource[] {
+    const maxSeqOf = new Map<string, number>([[sessionId, events.at(-1)?.seq ?? 0]])
+    const threadMaxSeq = (id: string): number => {
+      const known = maxSeqOf.get(id)
+      if (known !== undefined) return known
+      const owned = this.#db
+        .query<{n: number}, [string, string]>(`SELECT COUNT(*) AS n FROM sessions WHERE account_id = ? AND id = ?`)
+        .get(accountId, id)
+      if (!owned?.n) throw new APIError(400, `Source thread ${id} is not one of this account's threads`)
+      const max =
+        this.#db
+          .query<{max: number | null}, [string]>(`SELECT MAX(seq) AS max FROM session_events WHERE session_id = ?`)
+          .get(id)?.max ?? 0
+      maxSeqOf.set(id, max)
+      return max
+    }
+    return raw.map((source) => {
+      if (source.kind === 'resource') {
+        if (!/^(hm:\/\/|ipfs:\/\/|https?:\/\/)/.test(source.url)) {
+          throw new APIError(400, `Source url must be hm://, ipfs://, or http(s)://: ${source.url}`)
+        }
+        return source
+      }
+      if (source.kind === 'memory') {
+        const {relPath, absPath} = agentMemory.resolveMemoryPath(stateDir, source.path.replace(/^~\/memory\/?/, ''))
+        if (!fs.existsSync(absPath)) throw new APIError(400, `Source memory file does not exist: ${source.path}`)
+        return {...source, path: `~/memory/${relPath}`}
+      }
+      const max = threadMaxSeq(source.sessionId)
+      if (source.kind === 'session_event') {
+        if (source.seq < 1 || source.seq > max)
+          throw new APIError(400, `Source seq ${source.seq} is outside thread ${source.sessionId} (1..${max})`)
+        return source
+      }
+      if (source.fromSeq < 1 || source.toSeq > max || source.fromSeq > source.toSeq) {
+        throw new APIError(
+          400,
+          `Source range ${source.fromSeq}..${source.toSeq} is outside thread ${source.sessionId} (1..${max})`,
+        )
+      }
+      return source
+    })
   }
 
   /**
@@ -4116,8 +4496,13 @@ export class Service {
       return {_: 'MessageSessionResponse', sessionId, assistantEventId: ''}
     }
     if (final.status === 'succeeded' || final.status === 'canceled') {
-      const output = (final.output ?? {}) as {assistantEventId?: string}
-      return {_: 'MessageSessionResponse', sessionId, assistantEventId: output.assistantEventId ?? ''}
+      const output = (final.output ?? {}) as {assistantEventId?: string; continuedToSessionId?: string}
+      return {
+        _: 'MessageSessionResponse',
+        sessionId,
+        assistantEventId: output.assistantEventId ?? '',
+        ...(output.continuedToSessionId ? {continuedToSessionId: output.continuedToSessionId} : {}),
+      }
     }
     if (final.status === 'failed') {
       const error = final.error ?? {code: 'run-failed', message: 'Agent run failed'}
@@ -4215,6 +4600,17 @@ export class Service {
         }
         return {type: 'succeeded', output: turnOutput(spec, assistantEvent)}
       } catch (error) {
+        if (error instanceof SessionContinuedError) {
+          // Nothing is owed here any more — plan, typed result, obligations — the successor
+          // carries what was chosen to carry, and this run's record says where it went.
+          return {
+            type: 'succeeded',
+            output: {
+              continuedToSessionId: error.continuation.successorSessionId,
+              continuationId: error.continuation.continuationId,
+            },
+          }
+        }
         if (error instanceof SessionParkedError) {
           const pending = (runningSession.parkToolCallIds ?? []).filter(
             (toolCallId) => !this.#sessionHasToolResult(sessionId, toolCallId),
@@ -5939,6 +6335,7 @@ export class Service {
       : ''
     const userActionsPrompt =
       '\n\nYour user holds the same verbs you do, on this same conversation log. Entries tagged <user_action>/<user_action_result> are actions the user ran themselves — read their results as shared ground truth you can build on without re-running them.'
+    const continuationPrompt = `\n\n${SESSION_CONTINUATION_PROMPT}`
     // Advertise delegation model choice only when there is actually a choice: the active pair plus
     // at least one other enabled model. `definition` may already carry a session override; the
     // enabled list is untouched by overrides, so the full menu is always shown.
@@ -5952,7 +6349,7 @@ export class Service {
         )}. When you delegate, pass \`model\` so each child runs on the model its task deserves: route simple, mechanical, or high-volume subtasks (extraction, reformatting, short summaries, routine lookups) to a cheaper/faster model, and route work that needs deep reasoning, difficult code, or careful judgment to the strongest enabled model — even when that is not the model you are running on. Judge tiers by model family and name. Omit \`model\` when the child should simply inherit its agent's configured model.`
       : ''
     const conversationMembersPrompt = await this.#conversationMembersPrompt(accountId, agentId)
-    const basePrompt = `${systemPrompt}\n\n${sharedPrompt}${memoryPrompt}${modelChoicePrompt}${userActionsPrompt}${conversationMembersPrompt}${spaceIndex}`
+    const basePrompt = `${systemPrompt}\n\n${sharedPrompt}${memoryPrompt}${modelChoicePrompt}${userActionsPrompt}${continuationPrompt}${conversationMembersPrompt}${spaceIndex}`
     if (!signingKeys.length) return basePrompt
     const identities = signingKeys.flatMap((name) => {
       const row = this.#db
@@ -6070,6 +6467,18 @@ export class Service {
     // A session-level model override replaces the definition's model settings for this whole run.
     definition = this.#definitionForSession(accountId, definition, session)
     const subSessionOutputSchema = run ? this.#spawnContextForRun(run).spec?.output : undefined
+    // Continuation needs a run to end and a conversation that is the foreground: a delegated child
+    // (awaited by a parent, typed or not) reports back instead of moving on.
+    const canContinueSession = run !== undefined && !run.parentRunId && !subSessionOutputSchema
+    const continuationToolContext: Pick<AgentServicePiToolContext, 'continueSession'> = (() => {
+      if (!canContinueSession || run === undefined || runningSession === undefined) return {}
+      const liveRun = run
+      const live = runningSession
+      return {
+        continueSession: (toolCallId: string, input: unknown) =>
+          this.#continueSessionFromAgent(accountId, liveRun, sessionId, session.agentId, live, toolCallId, input),
+      }
+    })()
     const {provider, authStorage, modelRegistry, model} = await this.#piProviderRuntime(accountId, definition)
 
     const cwd = this.#dataDir
@@ -6151,6 +6560,7 @@ export class Service {
           }),
         setSessionPlan: (plan) => this.#setSessionPlanFromAgent(accountId, sessionId, plan, run?.id),
         setSessionStatus: (status) => this.#setSessionStatusFromAgent(accountId, sessionId, status),
+        ...continuationToolContext,
         startSession: (input) => this.#startSessionFromAgent(accountId, sessionId, session.agentId, input, run),
         callableTools: enabledCallables,
         publishEnabled: publishGrantEnabled(definition),
@@ -6175,6 +6585,8 @@ export class Service {
         ...(run !== undefined ? [seedVerbRegistry.delegate.name] : []),
         seedVerbRegistry.plan.name,
         seedVerbRegistry.status.name,
+        // A foreground conversation may carry itself into a successor; a delegated child may not.
+        ...(canContinueSession ? [seedVerbRegistry.continue_session.name] : []),
         // Typed delegate children must deliver their result through this tool.
         ...(subSessionOutputSchema ? [seedVerbRegistry.return_result.name] : []),
       ],
@@ -6293,6 +6705,18 @@ export class Service {
     if (planIsHistory) this.#retireSettledSessionPlan(accountId, sessionId, storedPlan)
     const planBlock = planIsHistory ? undefined : planStateBlock(storedPlan)
     if (planBlock) replayMessages.push({role: 'user', content: planBlock, timestamp: Date.now()})
+    // How full the context is, from the last turn's prompt size against the model's window. Like
+    // the plan block: rendered fresh, never stored — a measurement, not a transcript event. Only
+    // where continuing is possible; a delegated child has no use for the number.
+    const contextBlock = canContinueSession
+      ? contextUsageBlock(this.#lastPromptTokens(sessionId), model.contextWindow)
+      : undefined
+    if (contextBlock) replayMessages.push({role: 'user', content: contextBlock, timestamp: Date.now()})
+    // What the session is currently called and said to be doing, so the status verb is a change
+    // the model makes on purpose rather than a restatement it makes by habit. Same rule as the
+    // plan block: rendered fresh from session state, never stored.
+    const statusBlock = sessionStatusBlock(this.#getSessionInfo(accountId, sessionId))
+    if (statusBlock) replayMessages.push({role: 'user', content: statusBlock, timestamp: Date.now()})
     piSession.state.messages = replayMessages as never
     let partialId = crypto.randomUUID()
     let partialText = ''
@@ -6602,6 +7026,12 @@ export class Service {
       // The turn ended by design: sub-sessions were spawned and the run parks on them.
       if (partialText.trim()) flushPartialAssistantMessage()
       throw new SessionParkedError()
+    }
+    if (runningSession.continuation) {
+      // The turn moved into a successor session: whatever text streamed before the call stays
+      // here, and the answer itself is the successor run's to give.
+      if (partialText.trim()) flushPartialAssistantMessage()
+      throw new SessionContinuedError(runningSession.continuation)
     }
     if (runningSession.completeAfterTools && runningSession.subResult) {
       // Typed result delivered; the abort that ended the loop is success, not an error.
@@ -6994,11 +7424,16 @@ export class Service {
     const triggerContext = this.#getSessionTriggerContext(accountId, sessionId)
     return {
       _: 'GetSessionResponse',
-      session: sessionRowToInfo(session, triggerContext ?? undefined),
+      session: sessionRowToInfo(
+        session,
+        triggerContext ?? undefined,
+        this.#sessionContinuationLinks(accountId, sessionId),
+      ),
       events,
       systemPromptMarkdown: await this.#agentSystemPrompt(accountId, agent.id, definition, agent.state_dir),
       ...(triggerContext ? {triggerContext} : {}),
       ...(hasMoreBefore ? {hasMoreBefore} : {}),
+      contextWindow: this.#sessionContextWindow(accountId, definition, sessionRowToInfo(session)),
     }
   }
 
@@ -7252,13 +7687,41 @@ export class Service {
          FROM sessions WHERE account_id = ? AND id = ?`,
       )
       .get(accountId, sessionId)
-    return session ? sessionRowToInfo(session, this.#getSessionTriggerContext(accountId, sessionId) ?? undefined) : null
+    return session
+      ? sessionRowToInfo(
+          session,
+          this.#getSessionTriggerContext(accountId, sessionId) ?? undefined,
+          this.#sessionContinuationLinks(accountId, sessionId),
+        )
+      : null
   }
 
   #sessionRowsToInfo(accountId: string, sessions: SessionRow[]): api.SessionInfo[] {
     return sessions.map((session) =>
-      sessionRowToInfo(session, this.#getSessionTriggerContext(accountId, session.id) ?? undefined),
+      sessionRowToInfo(
+        session,
+        this.#getSessionTriggerContext(accountId, session.id) ?? undefined,
+        this.#sessionContinuationLinks(accountId, session.id),
+      ),
     )
+  }
+
+  /**
+   * The continuation edges touching one session: the predecessor it was continued from, and the
+   * latest successor it was continued into. A predecessor may have several successors (someone
+   * came back and branched again); the newest is the one advertised as "where this went".
+   */
+  #sessionContinuationLinks(accountId: string, sessionId: string): SessionContinuationLinks {
+    return sessionContinuationLinksOf(this.#db, accountId, sessionId)
+  }
+
+  /** The context window of the model a session runs on (its override, else the agent's model). */
+  #sessionContextWindow(accountId: string, definition: api.AgentDefinition, session: api.SessionInfo): number {
+    const effective = this.#definitionForSession(accountId, definition, session)
+    const providerRow = this.#db
+      .query<{type: string}, [string, string]>(`SELECT type FROM model_providers WHERE account_id = ? AND name = ?`)
+      .get(accountId, effective.modelProvider)
+    return modelContextWindow(providerRow?.type ?? '', effective.model)
   }
 
   #getSessionTriggerContext(accountId: string, sessionId: string): api.AgentSessionTriggerContext | null {
@@ -8489,7 +8952,49 @@ function agentTriggerRowToInfo(row: AgentTriggerRow): api.AgentTriggerInfo {
   }
 }
 
-function sessionRowToInfo(row: SessionRow, triggerContext?: api.AgentSessionTriggerContext): api.SessionInfo {
+/** Both ends of a session's continuation edges, as {@link api.SessionInfo} carries them. */
+type SessionContinuationLinks = Pick<api.SessionInfo, 'continuedFrom' | 'continuedTo'>
+
+/**
+ * The continuation edges touching one session: the predecessor it was continued from, and the
+ * latest successor it was continued into. A predecessor may have several successors (someone
+ * came back and branched again); the newest is the one advertised as "where this went".
+ */
+function sessionContinuationLinksOf(db: Database, accountId: string, sessionId: string): SessionContinuationLinks {
+  type EdgeRow = {id: string; other_id: string; other_title: string | null; reason: string; created_at: number}
+  const from = db
+    .query<EdgeRow, [string, string]>(
+      `SELECT c.id, c.predecessor_session_id AS other_id, p.title AS other_title, c.reason, c.created_at
+         FROM session_continuations c LEFT JOIN sessions p ON p.id = c.predecessor_session_id
+        WHERE c.account_id = ? AND c.successor_session_id = ?`,
+    )
+    .get(accountId, sessionId)
+  const to = db
+    .query<EdgeRow, [string, string]>(
+      `SELECT c.id, c.successor_session_id AS other_id, s.title AS other_title, c.reason, c.created_at
+         FROM session_continuations c LEFT JOIN sessions s ON s.id = c.successor_session_id
+        WHERE c.account_id = ? AND c.predecessor_session_id = ?
+        ORDER BY c.created_at DESC LIMIT 1`,
+    )
+    .get(accountId, sessionId)
+  const link = (row: EdgeRow): api.SessionContinuationLink => ({
+    continuationId: row.id,
+    sessionId: row.other_id,
+    ...(row.other_title ? {title: row.other_title} : {}),
+    reason: normalizeContinuationReason(row.reason),
+    createdAt: row.created_at,
+  })
+  return {
+    ...(from ? {continuedFrom: link(from)} : {}),
+    ...(to ? {continuedTo: link(to)} : {}),
+  }
+}
+
+function sessionRowToInfo(
+  row: SessionRow,
+  triggerContext?: api.AgentSessionTriggerContext,
+  continuation: SessionContinuationLinks = {},
+): api.SessionInfo {
   return {
     id: row.id,
     account: row.account_id,
@@ -8502,6 +9007,8 @@ function sessionRowToInfo(row: SessionRow, triggerContext?: api.AgentSessionTrig
     ...(row.model_override_cbor ? {modelOverride: cbor.decode<api.SessionModelOverride>(row.model_override_cbor)} : {}),
     ...(row.description ? {description: row.description} : {}),
     ...(row.child_count > 0 ? {childSessionCount: row.child_count} : {}),
+    ...(continuation.continuedFrom ? {continuedFrom: continuation.continuedFrom} : {}),
+    ...(continuation.continuedTo ? {continuedTo: continuation.continuedTo} : {}),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     ...(triggerContext
@@ -9600,7 +10107,7 @@ function piModelForDefinition(
     // Image input gates whether view_attachment returns actual image content to the model.
     input: modelSupportsImageInput(type, definition.model) ? ['text', 'image'] : ['text'],
     cost: {input: 0, output: 0, cacheRead: 0, cacheWrite: 0},
-    contextWindow: 128000,
+    contextWindow: modelContextWindow(type, definition.model),
     maxTokens: 16384,
   }
 }
@@ -9665,6 +10172,12 @@ export type AgentServicePiToolContext = WriteToolContext & {
   setSessionPlan?: (plan: unknown) => api.SessionInfo
   /** status verb: sets the session's agent-maintained title and/or description. Absent in session-less contexts. */
   setSessionStatus?: (status: unknown) => api.SessionInfo
+  /**
+   * continue_session verb: creates the successor session from a projection of this one, starts
+   * its run, and ends this turn after the tool batch. Absent where there is no run to end (a
+   * script context, a runless invocation) or where continuing is wrong (a delegated child).
+   */
+  continueSession?: (toolCallId: string, input: unknown) => unknown
   /** delegate (model child): spawns an awaited child run + session and parks the calling turn on it. */
   spawnSubSession?: (toolCallId: string, input: unknown) => unknown
   /** delegate {script}: lints + spawns a script child run and parks the calling turn on it. */
@@ -9955,41 +10468,62 @@ function readAttachmentAddress(context: AgentServicePiToolContext, attachmentId:
 }
 
 /** Reads a thread address: a compact transcript of one of this account's sessions. */
-function readThreadAddress(context: AgentServicePiToolContext, sessionId: string): Record<string, unknown> {
+/**
+ * Reads one of the account's threads: metadata, its continuation lineage, and a page of its
+ * transcript rendered as `[seq] who: text` lines. The default page is the newest 200 events;
+ * options {fromSeq, toSeq} select an exact range (as cited by a continuation manifest) and
+ * {limit} caps how many events come back.
+ */
+function readThreadAddress(
+  context: AgentServicePiToolContext,
+  sessionId: string,
+  options: Record<string, unknown> = {},
+): Record<string, unknown> {
   const session = context.db
     .query<{id: string; title: string | null; description: string | null; agent_id: string}, [string, string]>(
       `SELECT id, title, description, agent_id FROM sessions WHERE account_id = ? AND id = ?`,
     )
     .get(context.accountId, sessionId)
   if (!session) throw new APIError(404, `No thread ${sessionId}`)
-  const rows = context.db
-    .query<SessionEventRow, [string]>(
-      `SELECT id, session_id, seq, event_cbor, created_at FROM session_events WHERE session_id = ? ORDER BY seq DESC LIMIT 200`,
-    )
-    .all(sessionId)
-    .reverse()
-    .map(sessionEventRowToInfo)
-  const lines = rows.map((row) => {
-    const event = row.event as {type?: string; role?: string; content?: unknown; name?: string; message?: string}
-    if (event.type === 'message') {
-      const content = typeof event.content === 'string' ? event.content : JSON.stringify(event.content)
-      return `**${event.role ?? 'unknown'}**: ${content}`
-    }
-    if (event.type === 'tool_call') return `→ tool call ${event.name ?? ''}`
-    if (event.type === 'tool_result') return `← tool result ${event.name ?? ''}`
-    if (event.type === 'error') return `⚠ error: ${event.message ?? ''}`
-    return `(${event.type ?? 'event'})`
-  })
+  const fromSeq = Number.isInteger(options.fromSeq) ? Number(options.fromSeq) : undefined
+  const toSeq = Number.isInteger(options.toSeq) ? Number(options.toSeq) : undefined
+  const limit = Math.max(1, Math.min(1_000, Number.isInteger(options.limit) ? Number(options.limit) : 200))
+  const rows =
+    fromSeq !== undefined || toSeq !== undefined
+      ? context.db
+          .query<SessionEventRow, [string, number, number, number]>(
+            `SELECT id, session_id, seq, event_cbor, created_at FROM session_events
+             WHERE session_id = ? AND seq >= ? AND seq <= ? ORDER BY seq ASC LIMIT ?`,
+          )
+          .all(sessionId, fromSeq ?? 1, toSeq ?? Number.MAX_SAFE_INTEGER, limit)
+          .map(sessionEventRowToInfo)
+      : context.db
+          .query<SessionEventRow, [string, number]>(
+            `SELECT id, session_id, seq, event_cbor, created_at FROM session_events WHERE session_id = ? ORDER BY seq DESC LIMIT ?`,
+          )
+          .all(sessionId, limit)
+          .reverse()
+          .map(sessionEventRowToInfo)
+  const lines = rows.map((row) => transcriptEventLine(row, 4_000))
   const markdown = lines.join('\n\n')
   const bounded =
     markdown.length > MAX_TOOL_RESULT_BYTES
       ? `[earlier events truncated]\n\n${markdown.slice(-MAX_TOOL_RESULT_BYTES)}`
       : markdown
+  const lineage = sessionContinuationLinksOf(context.db, context.accountId, sessionId)
+  const range = rows.length ? `seq ${rows[0]!.seq}–${rows.at(-1)!.seq}` : 'no events'
   return {
-    summary: `Thread "${session.title ?? sessionId}": ${rows.length} recent events.`,
+    summary: `Thread "${session.title ?? sessionId}": ${rows.length} events (${range}).`,
     sessionId,
     title: session.title,
     ...(session.description ? {description: session.description} : {}),
+    ...(lineage.continuedFrom
+      ? {continuedFrom: {...lineage.continuedFrom, thread: `thread:${lineage.continuedFrom.sessionId}`}}
+      : {}),
+    ...(lineage.continuedTo
+      ? {continuedTo: {...lineage.continuedTo, thread: `thread:${lineage.continuedTo.sessionId}`}}
+      : {}),
+    ...(rows.length ? {fromSeq: rows[0]!.seq, toSeq: rows.at(-1)!.seq} : {}),
     markdown: bounded,
   }
 }
@@ -10673,7 +11207,7 @@ export async function executeReadVerb(
     const threadId = address.slice('thread:'.length).trim()
     // A bare `thread:` lists (and with options.query searches) the account's conversations.
     if (!threadId) return threadsListing(context, options)
-    return readThreadAddress(context, threadId)
+    return readThreadAddress(context, threadId, options)
   }
   if (address.startsWith('run:')) return readRunAddress(context, address.slice('run:'.length))
 
@@ -11511,6 +12045,15 @@ function createAgentServicePiTools(context: AgentServicePiToolContext): pi.ToolD
         ...(session.title ? {title: session.title} : {}),
         ...(session.description ? {description: session.description} : {}),
       }
+    }),
+    defineSeedPiTool(seedVerbRegistry.continue_session, (params, toolCallId) => {
+      if (!context.continueSession) {
+        throw new APIError(
+          400,
+          'continue_session is not available here: only a foreground conversation with a live run can continue, never a delegated child or a script.',
+        )
+      }
+      return context.continueSession(toolCallId, params)
     }),
     defineSeedPiTool(
       context.returnResultSchema
@@ -12754,6 +13297,459 @@ function collapseMemoryPath(rawPath: string): string | undefined {
 
 /** Derives a human-readable document title from a memory file name, e.g. notes/weekly-update.md → "Weekly update". */
 /** Derives a session title from the first line of a start_session prompt. */
+// ---------------------------------------------------------------------------------------------
+// Session continuation: the projection compiler and the model-facing framing around it. The
+// continuation itself is a Service method (#continueSessionFromAgent); everything here is pure.
+// ---------------------------------------------------------------------------------------------
+
+/**
+ * What every foreground agent is told about continuation, once, in its system prompt. The verb's
+ * own contract carries the detailed triggers; this is the mental model — what a continuation IS,
+ * so the model reaches for it as a normal move and not as an emergency.
+ */
+const SESSION_CONTINUATION_PROMPT = [
+  'Conversations are never compacted or summarized behind your back: this transcript is the complete record and stays that way. When it stops being the right working context, you continue the conversation in a fresh session with the `continue_session` verb — the user changed subject, a phase of the work ended and a new one begins, they want to get back to or focus on one thread of a long conversation, they asked for a fresh start, or your context is getting full. A continuation is a normal, visible move, not a failure: the user is carried to the new session automatically and experiences one continuous interaction, this session stays readable and linked, and the new session starts from the handoff you write plus the exact text of the message being answered. Calling it ends your turn here; the successor session answers the user, so call it instead of replying, not after.',
+  'Each turn may begin with a <context_usage> block measuring how full your context is. Treat it as one input to a semantic decision: continue at a natural boundary well before the context fills (around 70% is the time to look for one), and prefer a continuation to letting earlier facts fall off the edge. A successor can always recall exact earlier material with `read thread:<id>` (options {fromSeq, toSeq}), so a continuation reduces what is loaded, never what is reachable.',
+].join(' ')
+
+/**
+ * The session's current title and description as the model should see them this turn. The title
+ * names what the whole session is about; the description is the live status. A session with
+ * neither (freshly created, not yet named) gets the block too, saying so — the one time the
+ * status verb is asked for unprompted.
+ */
+function sessionStatusBlock(session: api.SessionInfo | null): string | undefined {
+  if (!session) return undefined
+  const title = session.title ? escapeActionFraming(session.title) : undefined
+  const description = session.description ? escapeActionFraming(session.description) : undefined
+  const lines = [
+    `<session_status${title ? ` title="${title.replace(/"/g, '&quot;')}"` : ''}>`,
+    description ?? '(no description yet)',
+    title || description
+      ? 'This is how the session appears in session lists right now. The title names what this whole session is about and should stay stable; if the work shifts dramatically, that is a continue_session, not a rename. The description is the live status: update it (description alone is fine) whenever progress, blockers, or the outcome change what an outside reader should see — and never call status just to restate what is already here.'
+      : 'This session has no title or description yet. Once you know what it is about, call the status verb once to name it and describe what you are doing; after that, update the description as the status changes and leave the title unless the focus truly moves.',
+    '</session_status>',
+  ]
+  return lines.join('\n')
+}
+
+/** The per-turn context measurement, framed for the model. Nothing when no turn has run yet. */
+function contextUsageBlock(promptTokens: number | undefined, contextWindow: number): string | undefined {
+  if (promptTokens === undefined || contextWindow <= 0) return undefined
+  const fraction = Math.min(1, promptTokens / contextWindow)
+  const percent = Math.round(fraction * 100)
+  const guidance =
+    fraction >= CONTEXT_PRESSURE_URGENT_FRACTION
+      ? 'Your context is nearly full. Unless this message is a one-line wrap-up, call continue_session NOW with a thorough handoff instead of answering here — the successor session will answer.'
+      : fraction >= CONTEXT_PRESSURE_WARN_FRACTION
+        ? 'Context pressure: continue_session at the next natural boundary — now, if this message starts anything new or shifts focus. Write the handoff while you still have room to do it well.'
+        : 'No pressure yet. Continue only at a semantic boundary (subject change, phase change, refocus, user request).'
+  return [
+    `<context_usage tokens="${promptTokens}" window="${contextWindow}" percent="${percent}">`,
+    `Your last turn's prompt was about ${percent}% of this model's ${contextWindow.toLocaleString(
+      'en-US',
+    )}-token context window. ${guidance}`,
+    '</context_usage>',
+  ].join('\n')
+}
+
+const CONTINUATION_REASONS: readonly api.SessionContinuationReason[] = [
+  'topic_change',
+  'phase_change',
+  'refocus',
+  'context_pressure',
+  'user_request',
+  'other',
+]
+
+function normalizeContinuationReason(raw: unknown): api.SessionContinuationReason {
+  return CONTINUATION_REASONS.includes(raw as api.SessionContinuationReason)
+    ? (raw as api.SessionContinuationReason)
+    : 'other'
+}
+
+type ContinueSessionInput = {
+  reason: api.SessionContinuationReason
+  title: string
+  description: string
+  handoff: api.SessionContinuationHandoff
+  sources: api.SessionContinuationSource[]
+  transfer?: {plan?: 'carry' | 'close' | 'omit'}
+}
+
+/** Validates continue_session input: what the agent must supply, bounded like the status verb. */
+function normalizeContinueSessionInput(raw: unknown): ContinueSessionInput {
+  const input = isPlainRecord(raw) ? raw : {}
+  if (!CONTINUATION_REASONS.includes(input.reason as api.SessionContinuationReason)) {
+    throw new APIError(400, `continue_session needs a reason: one of ${CONTINUATION_REASONS.join(', ')}`)
+  }
+  const title = normalizeBoundedString(input.title, 'Successor session title', MAX_NAME_BYTES)
+  const description = normalizeBoundedString(
+    input.description,
+    'Successor session description',
+    MAX_SESSION_DESCRIPTION_BYTES,
+  )
+  const handoffRaw = isPlainRecord(input.handoff) ? input.handoff : {}
+  const list = (value: unknown, label: string): string[] | undefined => {
+    if (value === undefined || value === null) return undefined
+    if (!Array.isArray(value)) throw new APIError(400, `handoff.${label} must be a list of strings`)
+    const items = value
+      .filter((item): item is string => typeof item === 'string')
+      .map((item) => item.trim())
+      .filter(Boolean)
+      .map((item) => normalizeBoundedString(item, `handoff.${label} entry`, MAX_MESSAGE_TEXT_BYTES))
+    return items.length ? items : undefined
+  }
+  const handoff: api.SessionContinuationHandoff = {
+    purpose: normalizeBoundedString(handoffRaw.purpose, 'handoff.purpose', MAX_MESSAGE_TEXT_BYTES),
+    currentRequest: normalizeBoundedString(handoffRaw.currentRequest, 'handoff.currentRequest', MAX_MESSAGE_TEXT_BYTES),
+  }
+  for (const key of ['establishedFacts', 'decisions', 'openQuestions', 'nextActions', 'cautions'] as const) {
+    const items = list(handoffRaw[key], key)
+    if (items) handoff[key] = items
+  }
+  const sources: api.SessionContinuationSource[] = []
+  if (input.sources !== undefined && input.sources !== null) {
+    if (!Array.isArray(input.sources)) throw new APIError(400, 'sources must be a list')
+    if (input.sources.length > 64) throw new APIError(400, 'At most 64 sources may be cited')
+    for (const entry of input.sources) {
+      if (!isPlainRecord(entry)) throw new APIError(400, 'Each source must be an object')
+      const relevance = normalizeBoundedString(entry.relevance, 'source.relevance', MAX_SESSION_DESCRIPTION_BYTES)
+      const sessionId = typeof entry.sessionId === 'string' && entry.sessionId.trim() ? entry.sessionId.trim() : ''
+      switch (entry.kind) {
+        case 'resource':
+          sources.push({
+            kind: 'resource',
+            url: normalizeBoundedString(entry.url, 'source.url', MAX_NAME_BYTES * 8),
+            ...(typeof entry.version === 'string' && entry.version ? {version: entry.version} : {}),
+            ...(typeof entry.blockId === 'string' && entry.blockId ? {blockId: entry.blockId} : {}),
+            relevance,
+          })
+          break
+        case 'memory':
+          sources.push({
+            kind: 'memory',
+            path: normalizeBoundedString(entry.path, 'source.path', MAX_NAME_BYTES * 4),
+            relevance,
+          })
+          break
+        case 'session_event': {
+          const seq = Number(entry.seq)
+          if (!Number.isInteger(seq)) throw new APIError(400, 'session_event source needs an integer seq')
+          sources.push({kind: 'session_event', sessionId, seq, relevance})
+          break
+        }
+        case 'session_events': {
+          const fromSeq = Number(entry.fromSeq)
+          const toSeq = Number(entry.toSeq)
+          if (!Number.isInteger(fromSeq) || !Number.isInteger(toSeq)) {
+            throw new APIError(400, 'session_events source needs integer fromSeq and toSeq')
+          }
+          sources.push({kind: 'session_events', sessionId, fromSeq, toSeq, relevance})
+          break
+        }
+        default:
+          throw new APIError(400, `Unknown source kind: ${String(entry.kind)}`)
+      }
+    }
+  }
+  const transferRaw = isPlainRecord(input.transfer) ? input.transfer : undefined
+  const plan = transferRaw?.plan
+  if (plan !== undefined && plan !== 'carry' && plan !== 'close' && plan !== 'omit') {
+    throw new APIError(400, 'transfer.plan must be carry, close, or omit')
+  }
+  return {
+    reason: input.reason as api.SessionContinuationReason,
+    title,
+    description,
+    handoff,
+    sources,
+    ...(plan ? {transfer: {plan}} : {}),
+  }
+}
+
+/**
+ * The message a continuation answers: the latest user-authored (or trigger-authored) message on
+ * the log. A runtime-authored user-role message (a continuation prompt, a projection) is not a
+ * request and never qualifies.
+ */
+function findContinuationInitiatingEvent(events: api.SessionEvent[]): api.SessionEvent | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index]!
+    const payload = event.event as {type?: string; role?: string}
+    if (payload.type !== 'message' || payload.role !== 'user') continue
+    const actor = sessionEventActor(event.event as never)
+    if (actor === 'user' || actor === 'trigger') return event
+  }
+  return undefined
+}
+
+function continuationToolOutput(outcome: SessionContinuationOutcome): Record<string, unknown> {
+  return {
+    summary: `Continued into "${outcome.title}" (thread:${outcome.successorSessionId}). This turn ends here; the successor session is answering the user.`,
+    continuationId: outcome.continuationId,
+    successorSessionId: outcome.successorSessionId,
+    title: outcome.title,
+  }
+}
+
+/**
+ * One transcript event as a line the model can read and cite: `[seq] who: text`. Shared by the
+ * projection compiler and `read thread:<id>`, so what a successor sees in its handoff and what it
+ * recalls later have the same shape and the same seq numbers.
+ */
+function transcriptEventLine(event: api.SessionEvent, maxChars: number): string {
+  const payload = event.event as {
+    type?: string
+    role?: string
+    content?: unknown
+    name?: string
+    input?: unknown
+    output?: unknown
+    error?: string
+    message?: string
+    title?: string
+  }
+  const clip = (text: string): string =>
+    text.length > maxChars ? `${text.slice(0, maxChars)}… [${text.length - maxChars} more chars]` : text
+  const tag = `[${event.seq}]`
+  if (payload.type === 'message') {
+    const actor = sessionEventActor(event.event as never)
+    const who = payload.role === 'assistant' ? 'assistant' : actor === 'user' ? 'user' : actor
+    const content = typeof payload.content === 'string' ? payload.content : JSON.stringify(payload.content)
+    return `${tag} ${who}: ${clip(content ?? '')}`
+  }
+  if (payload.type === 'tool_call') {
+    const detail = summarizeToolArgs(payload.input)
+    return `${tag} → ${payload.name ?? 'tool'}${detail ? ` ${clip(detail)}` : ''}`
+  }
+  if (payload.type === 'tool_spawn') return `${tag} ↳ ${payload.name ?? 'delegate'} spawned "${payload.title ?? ''}"`
+  if (payload.type === 'tool_result') {
+    const text = payload.error ?? getToolOutputSummaryText(payload.output)
+    return `${tag} ← ${payload.name ?? 'tool'}${payload.error ? ' failed' : ''}: ${clip(text)}`
+  }
+  if (payload.type === 'error') return `${tag} ⚠ error: ${clip(payload.message ?? '')}`
+  return `${tag} (${payload.type ?? 'event'})`
+}
+
+/** A tool output's `summary` line when it has one, else a compact JSON rendering. */
+function getToolOutputSummaryText(output: unknown): string {
+  if (isPlainRecord(output) && typeof output.summary === 'string') return output.summary
+  if (typeof output === 'string') return output
+  if (output === undefined) return ''
+  try {
+    return JSON.stringify(output)
+  } catch {
+    return String(output)
+  }
+}
+
+type ContinuationProjectionInput = {
+  continuationId: string
+  predecessor: {id: string; title: string | null}
+  originSessionId: string
+  initiating: api.SessionEvent
+  reason: api.SessionContinuationReason
+  handoff: api.SessionContinuationHandoff
+  sources: api.SessionContinuationSource[]
+  /** The predecessor's full event log, ascending. */
+  events: api.SessionEvent[]
+  budgetBytes: number
+}
+
+type ContinuationProjection = {
+  content: string
+  /** Every source on the manifest: the agent's, plus what the runtime selected. */
+  sources: api.SessionContinuationSource[]
+  included: Array<{fromSeq: number; toSeq: number; bytes: number}>
+  omitted: api.SessionContinuationSource[]
+}
+
+/**
+ * Builds the successor's opening message from exact material, in the order the budget is spent:
+ * lineage, the agent's handoff, the cited source list (always, it is small), the cited thread
+ * ranges as excerpts, then the most recent exchanges before the initiating message. Whatever
+ * does not fit is listed as omitted on the manifest: linked, reachable with `read thread:`, and
+ * not loaded. The initiating message itself is not excerpted here — it is replayed verbatim as
+ * the next event, with its provenance.
+ */
+function compileContinuationProjection(input: ContinuationProjectionInput): ContinuationProjection {
+  const escape = escapeActionFraming
+  const predecessorTitle = input.predecessor.title ? escape(input.predecessor.title) : ''
+  const head = [
+    '<session_continuation>',
+    `  <origin session="${input.originSessionId}" />`,
+    `  <predecessor session="${input.predecessor.id}" title="${predecessorTitle.replace(/"/g, '&quot;')}" edge="${
+      input.continuationId
+    }" />`,
+    `  <initiating_event id="${input.initiating.id}" seq="${input.initiating.seq}" />`,
+    `  <projection manifest="${input.continuationId}" reason="${input.reason}" />`,
+    `  This session continues the conversation "${
+      predecessorTitle || input.predecessor.id
+    }". That transcript is complete and unchanged; recall any of it exactly with \`read thread:${
+      input.predecessor.id
+    }\` (options {fromSeq, toSeq} select a range by the [seq] numbers shown below). The handoff and excerpts here are a projection chosen for this session's purpose, not the record. The user's message that caused this continuation follows this block verbatim — answer it here, as the same continuous conversation.`,
+    `  Your predecessor already named and described this session (see <session_status>); do not call the status verb to restate that.`,
+    '</session_continuation>',
+  ]
+  const section = (title: string, items: string[] | undefined): string[] =>
+    items?.length ? [`## ${title}`, ...items.map((item) => `- ${escape(item)}`), ''] : []
+  const handoff = [
+    '<handoff>',
+    '## Purpose',
+    escape(input.handoff.purpose),
+    '',
+    '## Current request',
+    escape(input.handoff.currentRequest),
+    '',
+    ...section('Established facts', input.handoff.establishedFacts),
+    ...section('Decisions', input.handoff.decisions),
+    ...section('Open questions', input.handoff.openQuestions),
+    ...section('Next actions', input.handoff.nextActions),
+    ...section('Cautions', input.handoff.cautions),
+    '</handoff>',
+  ]
+  const describeSource = (source: api.SessionContinuationSource): string => {
+    switch (source.kind) {
+      case 'resource':
+        return `resource ${source.url}${source.version ? ` @${source.version}` : ''}${
+          source.blockId ? `#${source.blockId}` : ''
+        } — ${escape(source.relevance)}`
+      case 'memory':
+        return `memory ${source.path} — ${escape(source.relevance)}`
+      case 'session_event':
+        return `thread:${source.sessionId} seq ${source.seq} — ${escape(source.relevance)}`
+      case 'session_events':
+        return `thread:${source.sessionId} seq ${source.fromSeq}–${source.toSeq} — ${escape(source.relevance)}`
+    }
+  }
+  const eventsBySeq = new Map(input.events.map((event) => [event.seq, event]))
+  const included: ContinuationProjection['included'] = []
+  const omitted: api.SessionContinuationSource[] = []
+  const loadedSeqs = new Set<number>()
+  const excerptBlocks: string[] = []
+  let spent = Buffer.byteLength([...head, '', ...handoff].join('\n'))
+  const sourceLines = input.sources.map((source) => `- ${describeSource(source)}`)
+  // The source list is small and always present: it is the breadcrumb trail.
+  spent += Buffer.byteLength(['<sources>', ...sourceLines, '</sources>'].join('\n')) + 2
+
+  const renderRange = (fromSeq: number, toSeq: number, label: string): {text: string; bytes: number} | null => {
+    const lines: string[] = []
+    for (let seq = fromSeq; seq <= toSeq; seq += 1) {
+      const event = eventsBySeq.get(seq)
+      if (!event || seq === input.initiating.seq) continue
+      lines.push(escape(transcriptEventLine(event, CONTINUATION_EXCERPT_MAX_CHARS)))
+    }
+    if (!lines.length) return null
+    const text = [
+      `<excerpt thread="${input.predecessor.id}" from_seq="${fromSeq}" to_seq="${toSeq}" why="${label.replace(
+        /"/g,
+        '&quot;',
+      )}">`,
+      ...lines,
+      '</excerpt>',
+    ].join('\n')
+    return {text, bytes: Buffer.byteLength(text) + 2}
+  }
+
+  // Cited ranges of THIS thread, in the agent's order. Ranges of other threads stay as links.
+  for (const source of input.sources) {
+    if (source.kind !== 'session_events' && source.kind !== 'session_event') continue
+    if (source.sessionId !== input.predecessor.id) continue
+    const fromSeq = source.kind === 'session_event' ? source.seq : source.fromSeq
+    const toSeq = source.kind === 'session_event' ? source.seq : source.toSeq
+    const rendered = renderRange(fromSeq, toSeq, escape(source.relevance))
+    if (!rendered) continue
+    if (spent + rendered.bytes > input.budgetBytes) {
+      omitted.push(source)
+      continue
+    }
+    spent += rendered.bytes
+    excerptBlocks.push(rendered.text)
+    included.push({fromSeq, toSeq, bytes: rendered.bytes})
+    for (let seq = fromSeq; seq <= toSeq; seq += 1) loadedSeqs.add(seq)
+  }
+
+  // Recent exchanges: the last conversational messages before the initiating one, newest first
+  // until the budget is spent, then presented in order. Runtime-authored messages (plan reminders,
+  // obligation notices) are not conversation and are skipped.
+  const recent: api.SessionEvent[] = []
+  for (let index = input.events.length - 1; index >= 0 && recent.length < CONTINUATION_RECENT_EVENTS; index -= 1) {
+    const event = input.events[index]!
+    if (event.seq >= input.initiating.seq || loadedSeqs.has(event.seq)) continue
+    const payload = event.event as {type?: string; role?: string}
+    if (payload.type !== 'message') continue
+    if (payload.role === 'user' && sessionEventActor(event.event as never) === 'system') continue
+    if (payload.role !== 'user' && payload.role !== 'assistant') continue
+    recent.push(event)
+  }
+  recent.reverse()
+  const recentLines: string[] = []
+  let recentBytes = 0
+  const frame =
+    Buffer.byteLength(
+      `<recent_exchanges thread="${input.predecessor.id}" from_seq="000000" to_seq="000000">\n</recent_exchanges>`,
+    ) + 2
+  for (let index = recent.length - 1; index >= 0; index -= 1) {
+    const line = escape(transcriptEventLine(recent[index]!, CONTINUATION_EXCERPT_MAX_CHARS))
+    const bytes = Buffer.byteLength(line) + 1
+    if (spent + frame + recentBytes + bytes > input.budgetBytes) break
+    recentLines.unshift(line)
+    recentBytes += bytes
+  }
+  const runtimeSources: api.SessionContinuationSource[] = [
+    {
+      kind: 'session_event',
+      sessionId: input.predecessor.id,
+      seq: input.initiating.seq,
+      relevance: 'runtime: the initiating user message, replayed verbatim into the successor',
+    },
+  ]
+  if (recentLines.length) {
+    const kept = recent.slice(recent.length - recentLines.length)
+    const fromSeq = kept[0]!.seq
+    const toSeq = kept.at(-1)!.seq
+    const block = [
+      `<recent_exchanges thread="${input.predecessor.id}" from_seq="${fromSeq}" to_seq="${toSeq}">`,
+      ...recentLines,
+      '</recent_exchanges>',
+    ].join('\n')
+    excerptBlocks.push(block)
+    included.push({fromSeq, toSeq, bytes: Buffer.byteLength(block) + 2})
+    runtimeSources.push({
+      kind: 'session_events',
+      sessionId: input.predecessor.id,
+      fromSeq,
+      toSeq,
+      relevance: 'runtime: the most recent exchanges before the initiating message',
+    })
+  } else if (recent.length) {
+    runtimeSources.push({
+      kind: 'session_events',
+      sessionId: input.predecessor.id,
+      fromSeq: recent[0]!.seq,
+      toSeq: recent.at(-1)!.seq,
+      relevance: 'runtime: recent exchanges (not loaded — budget)',
+    })
+    omitted.push(runtimeSources.at(-1)!)
+  }
+  const content = [
+    ...head,
+    '',
+    ...handoff,
+    '',
+    '<sources>',
+    ...(sourceLines.length ? sourceLines : ['- (none cited by the agent)']),
+    ...runtimeSources.map((source) => `- ${describeSource(source)}`),
+    ...(omitted.length
+      ? ['', `Not loaded (budget), still reachable with read thread:: ${omitted.map(describeSource).join('; ')}`]
+      : []),
+    '</sources>',
+    ...(excerptBlocks.length ? ['', ...excerptBlocks] : []),
+  ].join('\n')
+  return {content, sources: [...input.sources, ...runtimeSources], included, omitted}
+}
+
 function sessionTitleFromPrompt(prompt: string): string {
   const firstLine = prompt.split('\n', 1)[0]!.replace(/\s+/g, ' ').trim()
   if (!firstLine) return 'Agent-started session'

--- a/agents/src/session-attachments.ts
+++ b/agents/src/session-attachments.ts
@@ -151,6 +151,34 @@ export function readSessionAttachment(
   }
 }
 
+/**
+ * Makes one session's attachment available under another session by identity: the content file
+ * is hard-linked (copied when the filesystem refuses) and the metadata duplicated, so a message a
+ * continuation replays into its successor keeps `attachment:<id>` readable there. Ids are content
+ * hashes, so nothing about the attachment changes — only where it is reachable from.
+ */
+export function linkSessionAttachment(
+  stateDir: string,
+  fromSessionId: string,
+  toSessionId: string,
+  attachmentId: string,
+): SessionAttachmentInfo {
+  const source = attachmentPaths(stateDir, fromSessionId, attachmentId)
+  const target = attachmentPaths(stateDir, toSessionId, attachmentId)
+  const info = readAttachmentMeta(source.meta)
+  if (!info) throw new SessionAttachmentError(404, `Attachment not found: ${attachmentId}`)
+  fs.mkdirSync(path.dirname(target.bin), {recursive: true})
+  if (!fs.existsSync(target.bin)) {
+    try {
+      fs.linkSync(source.bin, target.bin)
+    } catch {
+      fs.copyFileSync(source.bin, target.bin)
+    }
+  }
+  if (!fs.existsSync(target.meta)) fs.copyFileSync(source.meta, target.meta)
+  return info
+}
+
 /** Removes every attachment stored for a session. Safe to call when none exist. */
 export function deleteSessionAttachments(stateDir: string, sessionId: string): void {
   fs.rmSync(sessionAttachmentsDir(stateDir, sessionId), {recursive: true, force: true})

--- a/agents/src/session-continuation.test.ts
+++ b/agents/src/session-continuation.test.ts
@@ -110,7 +110,11 @@ const CONTINUE_ARGS = {
     decisions: ['Lisbon over Porto because of flight availability'],
     nextActions: ['Shortlist three venues', 'Draft a two-day agenda'],
   },
-  sources: [{kind: 'resource', url: 'hm://z6MkTest/notes', relevance: 'agenda draft'}],
+  sources: [
+    {kind: 'resource', url: 'hm://z6MkTest/notes', relevance: 'agenda draft'},
+    // No sessionId: the range is of the session being continued.
+    {kind: 'session_events', fromSeq: 1, toSeq: 1, relevance: 'the opening question'},
+  ],
 }
 
 /**
@@ -218,6 +222,7 @@ describe('continue_session', () => {
     expect(manifest.sources).toEqual(
       expect.arrayContaining([
         expect.objectContaining({kind: 'resource', url: 'hm://z6MkTest/notes'}),
+        expect.objectContaining({kind: 'session_events', sessionId: predecessorId, fromSeq: 1, toSeq: 1}),
         expect.objectContaining({kind: 'session_event', sessionId: predecessorId, seq: manifest.initiatingEvent.seq}),
         expect.objectContaining({kind: 'session_events', sessionId: predecessorId}),
       ]),
@@ -292,6 +297,9 @@ describe('continue_session', () => {
     expect(projection).toContain(CONTINUE_ARGS.handoff.purpose)
     expect(projection).toContain('Budget is 20k EUR')
     expect(projection).toContain('hm://z6MkTest/notes')
+    // The cited range was loaded as an exact excerpt, and the manifest says so.
+    expect(projection).toContain('<excerpt thread="' + predecessorId + '" from_seq="1" to_seq="1"')
+
     expect(projection).toContain('<recent_exchanges')
     expect(projection).toContain('How is the venue survey going?')
     // The initiating message is not excerpted — it is replayed as its own event next.

--- a/agents/src/session-continuation.test.ts
+++ b/agents/src/session-continuation.test.ts
@@ -1,0 +1,375 @@
+import {Database} from 'bun:sqlite'
+import {afterEach, describe, expect, mock, test} from 'bun:test'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import * as apisvc from '@/api-service'
+import type * as api from '@/api'
+import * as blobs from '@shm/shared/blobs'
+import {decode as cborDecode} from '@/cbor'
+import * as sqlite from '@/sqlite'
+
+/**
+ * Session continuation end to end: the agent calls continue_session, the predecessor keeps its
+ * complete transcript and grows a continuedTo link, a successor is created with the title and
+ * description the agent chose, its opening is the projection plus the user's exact message, and
+ * its own run answers. Driven through the real run queue with a canned provider, because the
+ * whole point is that the turn ENDS in one session and the answer lands in the other.
+ */
+
+const cleanups: Array<() => void> = []
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()?.()
+})
+
+type Harness = {
+  db: Database
+  accountId: string
+  agentId: string
+  account: ReturnType<typeof blobs.generateNobleKeyPair>
+  service: apisvc.Service
+  send: (action: unknown) => Promise<api.AgentResponse>
+}
+
+async function createHarness(): Promise<Harness> {
+  const db = new Database(':memory:', {create: true, strict: true})
+  if (!sqlite.openWithDatabase(db).ok) throw new Error('unexpected schema mismatch')
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-continuation-test-'))
+  const account = blobs.generateNobleKeyPair()
+  const service = new apisvc.Service(db, dataDir, {})
+  const send = async (action: unknown) =>
+    service.message(await apisvc.createSignedEnvelope(account, {action: action as never}))
+  await send({_: 'SetSecret', name: 'openai-key', value: new TextEncoder().encode('sk-test')})
+  await send({_: 'SetModelProvider', name: 'openai', provider: {type: 'openai', secretRefs: {apiKey: 'openai-key'}}})
+  const created = await send({
+    _: 'CreateAgent',
+    definition: {name: 'Planner', systemPrompt: 'ok', modelProvider: 'openai', model: 'gpt-test'},
+  })
+  if (created._ !== 'CreateAgentResponse') throw new Error('unexpected response')
+  cleanups.push(() => {
+    service.stopRunQueue()
+    db.close()
+    fs.rmSync(dataDir, {recursive: true, force: true})
+  })
+  return {db, accountId: blobs.principalToString(account.principal), agentId: created.agentId, account, service, send}
+}
+
+type Chunk = Record<string, unknown>
+
+function sse(chunks: Chunk[]): Response {
+  return new Response(chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join('') + 'data: [DONE]\n\n', {
+    headers: {'content-type': 'text/event-stream'},
+  })
+}
+
+function textReply(id: string, text: string, promptTokens: number): Chunk[] {
+  return [
+    {id, choices: [{index: 0, delta: {role: 'assistant', content: text}}]},
+    {
+      id,
+      choices: [{index: 0, delta: {}, finish_reason: 'stop'}],
+      usage: {prompt_tokens: promptTokens, completion_tokens: 5, total_tokens: promptTokens + 5},
+    },
+  ]
+}
+
+function toolCallReply(id: string, callId: string, name: string, args: unknown, promptTokens: number): Chunk[] {
+  return [
+    {
+      id,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            role: 'assistant',
+            tool_calls: [{index: 0, id: callId, type: 'function', function: {name, arguments: ''}}],
+          },
+        },
+      ],
+    },
+    {
+      id,
+      choices: [{index: 0, delta: {tool_calls: [{index: 0, function: {arguments: JSON.stringify(args)}}]}}],
+    },
+    {
+      id,
+      choices: [{index: 0, delta: {}, finish_reason: 'tool_calls'}],
+      usage: {prompt_tokens: promptTokens, completion_tokens: 20, total_tokens: promptTokens + 20},
+    },
+  ]
+}
+
+const CONTINUE_ARGS = {
+  reason: 'topic_change',
+  title: 'Plan the Lisbon offsite',
+  description: 'Booking venue and agenda for the October offsite.',
+  handoff: {
+    purpose: 'Organize the October team offsite in Lisbon.',
+    currentRequest: 'The user wants to start planning the Lisbon offsite now.',
+    establishedFacts: ['Team is 12 people', 'Budget is 20k EUR'],
+    decisions: ['Lisbon over Porto because of flight availability'],
+    nextActions: ['Shortlist three venues', 'Draft a two-day agenda'],
+  },
+  sources: [{kind: 'resource', url: 'hm://z6MkTest/notes', relevance: 'agenda draft'}],
+}
+
+/**
+ * The canned provider. Bodies are inspected, never parsed as a real client would: the first
+ * request that is not a successor turn and mentions Lisbon continues; a successor turn first tries
+ * to continue AGAIN (which the loop guard must refuse) and then answers; everything else is small
+ * talk with a stamped usage so the next turn carries a <context_usage> block.
+ */
+function installProvider(): {requests: string[]} {
+  const requests: string[] = []
+  let successorAttempts = 0
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
+    const body = String(init?.body ?? '')
+    requests.push(body)
+    if (body.includes('<session_continuation>')) {
+      successorAttempts += 1
+      if (successorAttempts === 1) {
+        return sse(toolCallReply('chat-loop', 'call_cont_2', 'continue_session', CONTINUE_ARGS, 3_000))
+      }
+      return sse(textReply('chat-successor', 'Answering in the successor.', 3_200))
+    }
+    if (body.includes('Lisbon')) {
+      return sse(toolCallReply('chat-continue', 'call_cont_1', 'continue_session', CONTINUE_ARGS, 90_000))
+    }
+    return sse(textReply('chat-small', 'Sure, the venue survey is done.', 1_000))
+  }) as unknown as typeof fetch
+  cleanups.push(() => {
+    globalThis.fetch = originalFetch
+  })
+  return {requests}
+}
+
+async function until<T>(read: () => T | undefined, timeoutMs = 5_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    const value = read()
+    if (value !== undefined) return value
+    if (Date.now() > deadline) throw new Error('condition never held')
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}
+
+function eventsOf(response: api.AgentResponse): Array<api.SessionEvent & {event: Record<string, unknown>}> {
+  if (response._ !== 'GetSessionResponse') throw new Error(`unexpected: ${response._}`)
+  return response.events as never
+}
+
+describe('continue_session', () => {
+  test('carries the conversation into a titled successor that answers, leaving the predecessor intact', async () => {
+    const harness = await createHarness()
+    const provider = installProvider()
+    const created = await harness.send({_: 'CreateSession', agentId: harness.agentId})
+    if (created._ !== 'CreateSessionResponse') throw new Error('unexpected response')
+    const predecessorId = created.sessionId
+
+    // An ordinary first turn, so the projection has recent exchanges to excerpt and the next turn
+    // has a measured context.
+    const first = await harness.send({
+      _: 'MessageSession',
+      sessionId: predecessorId,
+      content: [{type: 'text', text: 'How is the venue survey going?'}],
+    })
+    if (first._ !== 'MessageSessionResponse') throw new Error('unexpected response')
+    expect(first.assistantEventId).not.toBe('')
+    expect(first.continuedToSessionId).toBeUndefined()
+
+    const switching = "Actually, let's switch to planning the Lisbon offsite instead."
+    const second = await harness.send({
+      _: 'MessageSession',
+      sessionId: predecessorId,
+      content: [{type: 'text', text: switching}],
+    })
+    if (second._ !== 'MessageSessionResponse') throw new Error('unexpected response')
+    expect(second.continuedToSessionId).toBeTruthy()
+    const successorId = second.continuedToSessionId!
+    await harness.service.drainTriggerSessions()
+
+    // The predecessor's second request was measured: its earlier turn stamped usage.
+    const secondRequest = provider.requests.find(
+      (body) => body.includes('Lisbon') && !body.includes('<session_continuation>'),
+    )
+    expect(secondRequest).toBeDefined()
+    expect(secondRequest).toContain('<context_usage tokens=')
+    expect(secondRequest).toContain('continue_session')
+
+    // Exactly one edge, despite the successor's own attempt to continue again.
+    const edges = harness.db
+      .query<{id: string; manifest_cbor: Uint8Array; reason: string; successor_session_id: string}, [string]>(
+        `SELECT id, manifest_cbor, reason, successor_session_id FROM session_continuations WHERE predecessor_session_id = ?`,
+      )
+      .all(predecessorId)
+    expect(edges).toHaveLength(1)
+    expect(edges[0]!.successor_session_id).toBe(successorId)
+    expect(harness.db.query<{n: number}, []>(`SELECT COUNT(*) AS n FROM session_continuations`).get()?.n).toBe(1)
+    const manifest = cborDecode<api.SessionContinuationManifest>(edges[0]!.manifest_cbor)
+    expect(manifest.compiler).toBe('projection/1')
+    expect(manifest.predecessorSessionId).toBe(predecessorId)
+    expect(manifest.successorSessionId).toBe(successorId)
+    expect(manifest.originSessionId).toBe(predecessorId)
+    expect(manifest.reason).toBe('topic_change')
+    expect(manifest.toolCallId).toBe('call_cont_1')
+    expect(manifest.handoff.purpose).toBe(CONTINUE_ARGS.handoff.purpose)
+    expect(manifest.initiatingEvent.seq).toBeGreaterThan(0)
+    expect(manifest.sources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({kind: 'resource', url: 'hm://z6MkTest/notes'}),
+        expect.objectContaining({kind: 'session_event', sessionId: predecessorId, seq: manifest.initiatingEvent.seq}),
+        expect.objectContaining({kind: 'session_events', sessionId: predecessorId}),
+      ]),
+    )
+    expect(manifest.included.length).toBeGreaterThan(0)
+    expect(manifest.omitted).toEqual([])
+    expect(manifest.transfer).toEqual({plan: 'omit'})
+    expect(manifest.projectionBytes).toBeGreaterThan(0)
+
+    // Predecessor: complete transcript plus the edge.
+    const predecessor = await harness.send({_: 'GetSession', sessionId: predecessorId})
+    if (predecessor._ !== 'GetSessionResponse') throw new Error('unexpected response')
+    expect(predecessor.session.continuedTo).toMatchObject({
+      continuationId: edges[0]!.id,
+      sessionId: successorId,
+      title: 'Plan the Lisbon offsite',
+      reason: 'topic_change',
+    })
+    expect(predecessor.session.continuedFrom).toBeUndefined()
+    const predecessorEvents = eventsOf(predecessor)
+    const initiating = predecessorEvents.find(
+      (event) => event.event.type === 'message' && event.event.content === switching,
+    )
+    expect(initiating).toBeDefined()
+    expect(initiating!.seq).toBe(manifest.initiatingEvent.seq)
+    expect(initiating!.id).toBe(manifest.initiatingEvent.id)
+    const call = predecessorEvents.find(
+      (event) => event.event.type === 'tool_call' && event.event.name === 'continue_session',
+    )
+    expect(call).toBeDefined()
+    expect(call!.event.id).toBe('call_cont_1')
+    const result = predecessorEvents.find(
+      (event) => event.event.type === 'tool_result' && event.event.toolCallId === 'call_cont_1',
+    )
+    expect(result).toBeDefined()
+    expect(result!.event.error).toBeUndefined()
+    expect(result!.event.output).toMatchObject({successorSessionId: successorId, continuationId: edges[0]!.id})
+    // The earlier plain turn is still there, untouched.
+    expect(
+      predecessorEvents.some(
+        (event) => event.event.type === 'message' && event.event.content === 'Sure, the venue survey is done.',
+      ),
+    ).toBe(true)
+
+    // Successor: named by the predecessor, opened by the projection and the exact user message.
+    const successor = await harness.send({_: 'GetSession', sessionId: successorId})
+    if (successor._ !== 'GetSessionResponse') throw new Error('unexpected response')
+    expect(successor.session.title).toBe('Plan the Lisbon offsite')
+    expect(successor.session.description).toBe('Booking venue and agenda for the October offsite.')
+    expect(successor.session.parentSessionId).toBeUndefined()
+    expect(successor.session.continuedFrom).toMatchObject({
+      continuationId: edges[0]!.id,
+      sessionId: predecessorId,
+      reason: 'topic_change',
+    })
+    expect(successor.session.continuedTo).toBeUndefined()
+    expect(successor.contextWindow).toBe(128_000)
+    expect(
+      harness.db
+        .query<{title_source: string}, [string]>(`SELECT title_source FROM sessions WHERE id = ?`)
+        .get(successorId)?.title_source,
+    ).toBe('agent')
+    const successorEvents = eventsOf(successor)
+    const opening = successorEvents[0]!.event
+    expect(opening).toMatchObject({type: 'message', role: 'user', actor: 'system'})
+    const projection = String(opening.content)
+    expect(projection).toContain('<session_continuation>')
+    expect(projection).toContain(`<predecessor session="${predecessorId}"`)
+    expect(projection).toContain(`<origin session="${predecessorId}"`)
+    expect(projection).toContain(`read thread:${predecessorId}`)
+    expect(projection).toContain('<handoff>')
+    expect(projection).toContain(CONTINUE_ARGS.handoff.purpose)
+    expect(projection).toContain('Budget is 20k EUR')
+    expect(projection).toContain('hm://z6MkTest/notes')
+    expect(projection).toContain('<recent_exchanges')
+    expect(projection).toContain('How is the venue survey going?')
+    // The initiating message is not excerpted — it is replayed as its own event next.
+    expect(projection).not.toContain(switching)
+    const replayed = successorEvents[1]!.event
+    expect(replayed).toMatchObject({type: 'message', role: 'user', content: switching})
+    expect(replayed.meta).toMatchObject({
+      continuedFrom: {sessionId: predecessorId, eventId: initiating!.id, seq: initiating!.seq},
+    })
+
+    // The successor tried to continue again with no new user message: refused, then it answered.
+    const settled = await until(() => {
+      const rows = harness.db
+        .query<{event_cbor: Uint8Array}, [string]>(
+          `SELECT event_cbor FROM session_events WHERE session_id = ? ORDER BY seq ASC`,
+        )
+        .all(successorId)
+        .map((row) => cborDecode<Record<string, unknown>>(row.event_cbor))
+      return rows.some((event) => event.type === 'message' && event.content === 'Answering in the successor.')
+        ? rows
+        : undefined
+    })
+    const refused = settled.find((event) => event.type === 'tool_result' && event.toolCallId === 'call_cont_2')
+    expect(refused).toBeDefined()
+    expect(String(refused!.error)).toContain('would loop')
+    expect(harness.db.query<{n: number}, []>(`SELECT COUNT(*) AS n FROM session_continuations`).get()?.n).toBe(1)
+    const successorRequest = provider.requests.find((body) => body.includes('<session_continuation>'))
+    expect(successorRequest).toBeDefined()
+    expect(successorRequest).toContain(switching)
+
+    // Both are foreground conversations in the list.
+    const listed = await harness.send({_: 'ListSessions', agentId: harness.agentId})
+    if (listed._ !== 'ListSessionsResponse') throw new Error('unexpected response')
+    const ids = listed.sessions.map((session: api.SessionInfo) => session.id)
+    expect(ids).toContain(predecessorId)
+    expect(ids).toContain(successorId)
+    const listedPredecessor = listed.sessions.find((session: api.SessionInfo) => session.id === predecessorId)
+    expect(listedPredecessor?.continuedTo?.sessionId).toBe(successorId)
+  })
+
+  test('a call with a bogus reason is refused and the turn stays in this session', async () => {
+    const harness = await createHarness()
+    const requests: string[] = []
+    let calls = 0
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
+      requests.push(String(init?.body ?? ''))
+      calls += 1
+      if (calls === 1) {
+        return sse(
+          toolCallReply('chat-bogus', 'call_bogus', 'continue_session', {...CONTINUE_ARGS, reason: 'bogus'}, 500),
+        )
+      }
+      return sse(textReply('chat-after', 'Staying here then.', 600))
+    }) as unknown as typeof fetch
+    cleanups.push(() => {
+      globalThis.fetch = originalFetch
+    })
+    const created = await harness.send({_: 'CreateSession', agentId: harness.agentId})
+    if (created._ !== 'CreateSessionResponse') throw new Error('unexpected response')
+    const response = await harness.send({
+      _: 'MessageSession',
+      sessionId: created.sessionId,
+      content: [{type: 'text', text: 'Move on please.'}],
+    })
+    if (response._ !== 'MessageSessionResponse') throw new Error('unexpected response')
+    expect(response.continuedToSessionId).toBeUndefined()
+    expect(response.assistantEventId).not.toBe('')
+    const session = await harness.send({_: 'GetSession', sessionId: created.sessionId})
+    const events = eventsOf(session)
+    const refused = events.find(
+      (event) => event.event.type === 'tool_result' && event.event.toolCallId === 'call_bogus',
+    )
+    expect(refused).toBeDefined()
+    expect(String(refused!.event.error)).toContain('reason')
+    expect(events.some((event) => event.event.type === 'message' && event.event.content === 'Staying here then.')).toBe(
+      true,
+    )
+    expect(harness.db.query<{n: number}, []>(`SELECT COUNT(*) AS n FROM session_continuations`).get()?.n).toBe(0)
+  })
+})

--- a/agents/src/sqlite-schema.sql
+++ b/agents/src/sqlite-schema.sql
@@ -125,6 +125,27 @@ CREATE INDEX sessions_by_agent ON sessions (agent_id, updated_at DESC);
 
 CREATE INDEX sessions_by_parent ON sessions (parent_session_id, created_at);
 
+-- A continuation edge: an agent carried a conversation from the predecessor into a fresh
+-- successor session (continue_session). Distinct from parent/child (delegation that returns):
+-- the successor becomes the foreground conversation. The manifest is the successor's exact
+-- starting point — handoff, cited sources, what was loaded and what was left cold.
+CREATE TABLE session_continuations (
+    id TEXT PRIMARY KEY,
+    account_id TEXT NOT NULL REFERENCES accounts (id),
+    agent_id TEXT NOT NULL REFERENCES agents (id),
+    predecessor_session_id TEXT NOT NULL REFERENCES sessions (id),
+    successor_session_id TEXT NOT NULL UNIQUE REFERENCES sessions (id),
+    origin_session_id TEXT NOT NULL,
+    tool_call_id TEXT NOT NULL,
+    initiating_event_id TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    manifest_cbor BLOB NOT NULL,
+    created_at INTEGER NOT NULL,
+    UNIQUE (predecessor_session_id, tool_call_id)
+) WITHOUT ROWID;
+
+CREATE INDEX session_continuations_by_predecessor ON session_continuations (predecessor_session_id, created_at DESC);
+
 CREATE TABLE trigger_firings (
     id TEXT PRIMARY KEY,
     account_id TEXT NOT NULL REFERENCES accounts (id),

--- a/agents/src/sqlite.test.ts
+++ b/agents/src/sqlite.test.ts
@@ -65,6 +65,7 @@ describe('sqlite', () => {
             '',
           )
           .replace(/CREATE INDEX sessions_by_parent ON sessions \(parent_session_id, created_at\);\n\n/u, '')
+          .replace(/-- A continuation edge[\s\S]*?CREATE TABLE trigger_firings/u, 'CREATE TABLE trigger_firings')
           .replace(/    capability_cid TEXT,\n/u, '')
           .replace(/    public_read INTEGER NOT NULL DEFAULT 0,\n/u, '')
           .replace(/    public_chat INTEGER NOT NULL DEFAULT 0,\n/u, '')
@@ -93,6 +94,7 @@ describe('sqlite', () => {
       expect(tableExists(db, 'agent_triggers')).toBe(true)
       expect(tableExists(db, 'trigger_firings')).toBe(true)
       expect(tableExists(db, 'webhook_trigger_credentials')).toBe(true)
+      expect(tableExists(db, 'session_continuations')).toBe(true)
       expect(columnExists(db, 'trigger_firings', 'body_digest')).toBe(true)
       expect(columnExists(db, 'trigger_firings', 'run_id')).toBe(true)
       expect(tableExists(db, 'activity_watermarks')).toBe(true)

--- a/agents/src/sqlite.ts
+++ b/agents/src/sqlite.ts
@@ -13,6 +13,23 @@ export const BASELINE_SCHEMA_MIGRATION_VERSION = 0
 /** Prepend-only database migrations. */
 export const migrations: string[] = [
   // ======= IMPORTANT: Add new migrations below this line. =======
+  // Session continuation: the typed predecessor/successor edge continue_session creates, with the
+  // projection manifest that says exactly what the successor started from.
+  `CREATE TABLE session_continuations (
+      id TEXT PRIMARY KEY,
+      account_id TEXT NOT NULL REFERENCES accounts (id),
+      agent_id TEXT NOT NULL REFERENCES agents (id),
+      predecessor_session_id TEXT NOT NULL REFERENCES sessions (id),
+      successor_session_id TEXT NOT NULL UNIQUE REFERENCES sessions (id),
+      origin_session_id TEXT NOT NULL,
+      tool_call_id TEXT NOT NULL,
+      initiating_event_id TEXT NOT NULL,
+      reason TEXT NOT NULL,
+      manifest_cbor BLOB NOT NULL,
+      created_at INTEGER NOT NULL,
+      UNIQUE (predecessor_session_id, tool_call_id)
+  ) WITHOUT ROWID;
+  CREATE INDEX session_continuations_by_predecessor ON session_continuations (predecessor_session_id, created_at DESC);`,
   // Newest-first cross-session event reads (thread content search) used to sort the whole table
   // with a temp b-tree, reading every event blob on the server's only thread. This index lets
   // those reads walk recency order directly and stop at their limit.

--- a/frontend/apps/desktop/src/__tests__/agent-session-rows.test.ts
+++ b/frontend/apps/desktop/src/__tests__/agent-session-rows.test.ts
@@ -824,3 +824,108 @@ describe('symmetric log actors', () => {
     expect(row.message.parts?.[0]).toMatchObject({actor: 'user'})
   })
 })
+
+describe('continuation rows', () => {
+  const projection = [
+    '<session_continuation>',
+    '  <origin session="session-0" />',
+    '  <predecessor session="session-0" title="Rethink compaction" edge="edge-1" />',
+    '  <initiating_event id="event-9" seq="9" />',
+    '  <projection manifest="edge-1" reason="topic_change" />',
+    '  This session continues the conversation "Rethink compaction".',
+    '</session_continuation>',
+    '',
+    '<handoff>',
+    '## Purpose',
+    'Write the continuation proposal.',
+    '',
+    '## Current request',
+    'Draft the doc.',
+    '</handoff>',
+    '',
+    '<sources>',
+    '- resource hm://z6Mk/notes — agenda',
+    '- thread:session-0 seq 9 — runtime: the initiating user message, replayed verbatim into the successor',
+    '</sources>',
+    '',
+    '<recent_exchanges thread="session-0" from_seq="5" to_seq="8">',
+    '[5] user: earlier question',
+    '[6] assistant: earlier answer',
+    '</recent_exchanges>',
+  ].join('\n')
+
+  it('turns the projection message into a handoff card row, not a chat bubble', () => {
+    const rows = buildAgentSessionChatRows(
+      [
+        event(1, {type: 'message', role: 'user', actor: 'system', content: projection}),
+        event(2, {
+          type: 'message',
+          role: 'user',
+          content: 'Draft the doc.',
+          meta: {continuedFrom: {sessionId: 'session-0', eventId: 'event-9', seq: 9}},
+        }),
+      ],
+      CONTEXT,
+    )
+    expect(rows).toHaveLength(2)
+    const card = rows[0]!
+    if (card.kind !== 'continuation') throw new Error('expected a continuation row')
+    expect(card.projection).toMatchObject({
+      originSessionId: 'session-0',
+      predecessorSessionId: 'session-0',
+      predecessorTitle: 'Rethink compaction',
+      continuationId: 'edge-1',
+      initiatingSeq: 9,
+      reason: 'topic_change',
+    })
+    expect(card.projection.handoffMarkdown).toContain('## Purpose')
+    expect(card.projection.handoffMarkdown).toContain('Write the continuation proposal.')
+    expect(card.projection.sources).toEqual([
+      'resource hm://z6Mk/notes — agenda',
+      'thread:session-0 seq 9 — runtime: the initiating user message, replayed verbatim into the successor',
+    ])
+    expect(card.projection.excerpts.startsWith('<recent_exchanges')).toBe(true)
+    const replayed = rows[1]!
+    if (replayed.kind !== 'message') throw new Error('expected the replayed user message')
+    expect(replayed.message.actor).toBe('user')
+    expect(replayed.message.content).toBe('Draft the doc.')
+    expect(replayed.message.meta?.continuedFrom).toEqual({sessionId: 'session-0', eventId: 'event-9', seq: 9})
+  })
+
+  it('leaves a user-authored message that merely mentions the tag as a plain bubble', () => {
+    const rows = buildAgentSessionChatRows(
+      [event(1, {type: 'message', role: 'user', content: '<session_continuation> is a thing the runtime writes'})],
+      CONTEXT,
+    )
+    expect(rows[0]?.kind).toBe('message')
+  })
+
+  it('keeps the continue_session call and its result on one row for the transition card', () => {
+    const rows = buildAgentSessionChatRows(
+      [
+        event(1, {
+          type: 'tool_call',
+          id: 'call-1',
+          name: 'continue_session',
+          input: {reason: 'topic_change', title: 'Plan the offsite', description: 'Venue and agenda.', handoff: {}},
+        }),
+        event(2, {
+          type: 'tool_result',
+          toolCallId: 'call-1',
+          name: 'continue_session',
+          output: {successorSessionId: 'session-2', title: 'Plan the offsite', continuationId: 'edge-2'},
+        }),
+      ],
+      CONTEXT,
+    )
+    expect(rows).toHaveLength(1)
+    const row = rows[0]!
+    if (row.kind !== 'message') throw new Error('expected a message row')
+    expect(row.message.parts?.[0]).toMatchObject({
+      type: 'tool',
+      name: 'continue_session',
+      args: {title: 'Plan the offsite'},
+      rawOutput: {successorSessionId: 'session-2'},
+    })
+  })
+})

--- a/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
@@ -438,6 +438,31 @@ describe('assistant message rendering', () => {
     cleanupRendered(root, container)
   })
 
+  it('names a called lambda by its own name, and an MCP tool by server · tool', () => {
+    const lambda = renderToolPart({
+      type: 'tool',
+      id: 'tool-call-lambda',
+      name: 'call',
+      args: {tool: 'word_count', input: {text: 'one two three'}},
+      rawOutput: {summary: 'Counted 3 words.', word_count: 3},
+    })
+    expect(lambda.container.textContent).toContain('word_count')
+    expect(lambda.container.textContent).toContain('Counted 3 words.')
+    expect(lambda.container.textContent).not.toContain('Call')
+    cleanupRendered(lambda.root, lambda.container)
+
+    const mcp = renderToolPart({
+      type: 'tool',
+      id: 'tool-call-mcp',
+      name: 'call',
+      args: {tool: 'github__list_issues', input: {repo: 'seed'}},
+      rawOutput: {summary: '2 open issues.'},
+    })
+    expect(mcp.container.textContent).toContain('github · list_issues')
+    expect(mcp.container.textContent).not.toContain('Call')
+    cleanupRendered(mcp.root, mcp.container)
+  })
+
   it('renders the registry-defined comment.create write UI', () => {
     const {container, root} = renderToolPart({
       type: 'tool',
@@ -552,10 +577,13 @@ describe('assistant message rendering', () => {
     const title = findButton(container, (element) => element.textContent === 'Research Acme')
     expect(title).toBeTruthy()
     click(title)
-    expect(mockState.clickNavigate).toHaveBeenCalledWith(
-      {key: 'agent-session', sessionId: 'child-session-1', serverUrl: 'http://localhost:3050'},
-      expect.anything(),
-    )
+    // Session opens route through useOpenAgentSession, so the assistant panel can keep them
+    // in the panel; with no override in scope it falls through to plain navigation.
+    expect(mockState.navigate).toHaveBeenCalledWith({
+      key: 'agent-session',
+      sessionId: 'child-session-1',
+      serverUrl: 'http://localhost:3050',
+    })
     // Opening the sub-session is not a request to expand the row.
     expect(findButton(container, (element) => element.getAttribute('title') === 'Show tool details')).toBeTruthy()
 

--- a/frontend/apps/mobile/src/agents/screens/AgentSessionScreen.tsx
+++ b/frontend/apps/mobile/src/agents/screens/AgentSessionScreen.tsx
@@ -190,6 +190,15 @@ export function AgentSessionScreen({navigation, route}: Props) {
                   onOpenChild={(child) => openChildSession(navigation, child, serverUrl)}
                 />
               )
+            case 'continuation':
+              return (
+                <Label key={row.key} size="sm" tone="muted" style={styles.empty}>
+                  Continued from{' '}
+                  {row.projection.predecessorTitle ? `“${row.projection.predecessorTitle}”` : 'the previous session'}
+                  {' — '}
+                  {row.projection.handoffMarkdown.split('\n').find((line) => line && !line.startsWith('#')) ?? ''}
+                </Label>
+              )
             default:
               return null
           }

--- a/frontend/packages/ui/src/agents/agent-session-rows.ts
+++ b/frontend/packages/ui/src/agents/agent-session-rows.ts
@@ -8,6 +8,7 @@ import {
   type SessionEventPayload,
 } from './client'
 import {type ChatBubbleMessage} from './chat-parts'
+import {isContinuationProjection, parseContinuationProjection, type ContinuationProjectionView} from './continuation'
 import {type ChatToolChild, type ChatToolPart} from './chat-parts'
 import {sessionEventActor} from '@seed-hypermedia/agents-protocol'
 import type {HMBlockNode} from '@seed-hypermedia/client/hm-types'
@@ -32,6 +33,17 @@ export type AgentSessionChatRow =
     }
   | {key: string; kind: 'error'; message: string; createdAt?: number}
   | {key: string; kind: 'raw'; event: SessionEvent; createdAt?: number}
+  | {
+      /**
+       * The projection a successor session opened with — the runtime's lineage block plus the
+       * agent's handoff and loaded excerpts. Rendered as the handoff card, never as a chat bubble:
+       * it is what the model started from, not something anyone said.
+       */
+      key: string
+      kind: 'continuation'
+      projection: ContinuationProjectionView
+      createdAt?: number
+    }
   | {
       key: string
       kind: 'run-record'
@@ -429,6 +441,22 @@ export function buildAgentSessionChatRows(
       runId?: string
       sessionId?: string
       title?: string
+    }
+
+    if (
+      payload.type === 'message' &&
+      payload.role === 'user' &&
+      typeof payload.content === 'string' &&
+      sessionEventActor(event.event) === 'system' &&
+      isContinuationProjection(payload.content)
+    ) {
+      rows.push({
+        key: event.id,
+        kind: 'continuation',
+        createdAt: event.createdAt,
+        projection: parseContinuationProjection(payload.content),
+      })
+      continue
     }
 
     if (payload.type === 'message' && typeof payload.content === 'string') {

--- a/frontend/packages/ui/src/agents/assistant-panel.tsx
+++ b/frontend/packages/ui/src/agents/assistant-panel.tsx
@@ -67,6 +67,13 @@ import {
   X,
 } from 'lucide-react'
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {
+  ContextUsageMeter,
+  ContinuationHandoffCard,
+  ContinuationHeader,
+  sessionContextTokens,
+  useFollowContinuation,
+} from './continuation'
 import {agentAccessCanChat, agentAccessCanWrite} from './access'
 import {AgentRunStatusBar, useRunStartedAt} from './agent-run-status'
 import {AgentErrorRow, AssistantMessageParts, ChatMessageBubble} from './message-rendering'
@@ -402,6 +409,7 @@ export function AssistantPanel({
           sessionRef={activeSession}
           accountUid={accountUid}
           composerRef={composerRef}
+          onOpenSession={(sessionId) => selectSession({serverUrl: activeSession.serverUrl, sessionId})}
         />
       ) : activeAgent ? (
         <AssistantDraftChat
@@ -780,10 +788,13 @@ function AssistantSessionChat({
   sessionRef,
   accountUid,
   composerRef,
+  onOpenSession,
 }: {
   sessionRef: AssistantSessionRef
   accountUid: string | null | undefined
   composerRef: React.MutableRefObject<AgentsRichEditorSubmitHandle | null>
+  /** Switches the panel to another session of this server (a continuation's successor or predecessor). */
+  onOpenSession?: (sessionId: string) => void
 }) {
   const {serverUrl, sessionId} = sessionRef
   const navigate = useNavigate()
@@ -824,6 +835,14 @@ function AssistantSessionChat({
   const ownRun = useRun(serverUrl, accountUid, parentSessionId ? session.data?.session.runId : undefined)
   const hasLiveRun = !!ownRun.data && !TERMINAL_RUN_STATUSES.has(ownRun.data.status)
   const isDrivenByParent = !!parentSessionId && (isStreaming || hasLiveRun)
+  // Continuation: the panel follows the turn into its successor like the full page does.
+  const sessionInfo = session.data?.session
+  const followContinuation = useFollowContinuation({
+    session: sessionInfo,
+    isStreaming,
+    onFollow: useCallback((link) => onOpenSession?.(link.sessionId), [onOpenSession]),
+  })
+  const contextTokens = useMemo(() => sessionContextTokens(session.data?.events), [session.data?.events])
   const events = session.data?.events
   const sessionRuns = useSessionRuns(serverUrl, accountUid, sessionId)
   const rows = useMemo(
@@ -868,9 +887,24 @@ function AssistantSessionChat({
           index === 0 && contextLines ? {...message, contextLines} : message,
         ),
       )
-      messageSession.mutate({sessionId, message: messages})
+      followContinuation.markFollowing()
+      messageSession.mutate(
+        {sessionId, message: messages},
+        {
+          onSuccess: (result) => {
+            if (result._ === 'MessageSessionResponse' && result.continuedToSessionId) {
+              followContinuation.followNow({
+                continuationId: '',
+                sessionId: result.continuedToSessionId,
+                reason: 'other',
+                createdAt: Date.now(),
+              })
+            }
+          },
+        },
+      )
     },
-    [accountUid, messageSession, serverUrl, sessionId],
+    [accountUid, followContinuation, messageSession, serverUrl, sessionId],
   )
 
   // Retry is offered on a trailing error only, and survives its own in-flight state: the row goes
@@ -897,7 +931,19 @@ function AssistantSessionChat({
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
+      {sessionInfo?.continuedFrom ? (
+        <ContinuationHeader
+          compact
+          link={sessionInfo.continuedFrom}
+          onOpenPredecessor={() => onOpenSession?.(sessionInfo.continuedFrom!.sessionId)}
+        />
+      ) : null}
       <SessionSummaryBanner compact description={session.data?.session.description} />
+      {contextTokens !== undefined && session.data?.contextWindow ? (
+        <div className="border-border flex flex-none justify-end border-b px-3 py-1">
+          <ContextUsageMeter tokens={contextTokens} contextWindow={session.data.contextWindow} size={14} />
+        </div>
+      ) : null}
       <div
         ref={autoScroll.containerRef}
         onScroll={autoScroll.handleScroll}
@@ -945,6 +991,16 @@ function AssistantSessionChat({
                   onOpenSession={(childSessionId, childAgentId) =>
                     navigate({key: 'agent-session', agentId: childAgentId, sessionId: childSessionId, serverUrl})
                   }
+                />
+              )
+            }
+            if (row.kind === 'continuation') {
+              return (
+                <ContinuationHandoffCard
+                  key={row.key}
+                  compact
+                  projection={row.projection}
+                  onOpenPredecessor={onOpenSession}
                 />
               )
             }

--- a/frontend/packages/ui/src/agents/assistant-panel.tsx
+++ b/frontend/packages/ui/src/agents/assistant-panel.tsx
@@ -944,11 +944,6 @@ function AssistantSessionChat({
           />
         ) : null}
         <SessionSummaryBanner compact description={session.data?.session.description} />
-        {contextTokens !== undefined && session.data?.contextWindow ? (
-          <div className="border-border flex flex-none justify-end border-b px-3 py-1">
-            <ContextUsageMeter tokens={contextTokens} contextWindow={session.data.contextWindow} size={14} />
-          </div>
-        ) : null}
         <div
           ref={autoScroll.containerRef}
           onScroll={autoScroll.handleScroll}
@@ -1089,7 +1084,8 @@ function AssistantSessionChat({
         {/* The active model for THIS session: the same per-session override switcher as the full
           session page, so changing it here never touches the agent's default. */}
         {session.data ? (
-          <div className="flex flex-none items-center justify-end px-3 pb-2">
+          <div className="flex flex-none items-center justify-end gap-2 px-3 pb-2">
+            <ContextUsageMeter tokens={contextTokens} contextWindow={session.data.contextWindow} size={16} />
             <SessionModelBadge
               agent={agentDetail.data?.agent}
               agentId={session.data.session.agentId}

--- a/frontend/packages/ui/src/agents/assistant-panel.tsx
+++ b/frontend/packages/ui/src/agents/assistant-panel.tsx
@@ -74,6 +74,7 @@ import {
   sessionContextTokens,
   useFollowContinuation,
 } from './continuation'
+import {OpenAgentSessionContext} from './open-session-context'
 import {agentAccessCanChat, agentAccessCanWrite} from './access'
 import {AgentRunStatusBar, useRunStartedAt} from './agent-run-status'
 import {AgentErrorRow, AssistantMessageParts, ChatMessageBubble} from './message-rendering'
@@ -929,167 +930,178 @@ function AssistantSessionChat({
     }
   }
 
+  // Everything rendered under this transcript opens sessions IN THE PANEL: a continuation's
+  // successor, a delegate child, a predecessor. Cmd/shift-click still spawns a full window.
+  const openInPanel = useCallback((targetSessionId: string) => onOpenSession?.(targetSessionId), [onOpenSession])
   return (
-    <div className="flex flex-1 flex-col overflow-hidden">
-      {sessionInfo?.continuedFrom ? (
-        <ContinuationHeader
-          compact
-          link={sessionInfo.continuedFrom}
-          onOpenPredecessor={() => onOpenSession?.(sessionInfo.continuedFrom!.sessionId)}
-        />
-      ) : null}
-      <SessionSummaryBanner compact description={session.data?.session.description} />
-      {contextTokens !== undefined && session.data?.contextWindow ? (
-        <div className="border-border flex flex-none justify-end border-b px-3 py-1">
-          <ContextUsageMeter tokens={contextTokens} contextWindow={session.data.contextWindow} size={14} />
-        </div>
-      ) : null}
-      <div
-        ref={autoScroll.containerRef}
-        onScroll={autoScroll.handleScroll}
-        className="relative flex-1 overflow-x-hidden overflow-y-auto px-3 py-2"
-      >
-        <div ref={autoScroll.contentRef} className="flex min-h-full flex-col">
-          {rows.length === 0 && !isStreaming ? (
-            <div className="text-muted-foreground flex flex-1 items-center justify-center text-xs">
-              {/* While the transcript is on its way, the empty-state prompt would be a lie about a
+    <OpenAgentSessionContext.Provider value={onOpenSession ? openInPanel : null}>
+      <div className="flex flex-1 flex-col overflow-hidden">
+        {sessionInfo?.continuedFrom ? (
+          <ContinuationHeader
+            compact
+            link={sessionInfo.continuedFrom}
+            onOpenPredecessor={() => onOpenSession?.(sessionInfo.continuedFrom!.sessionId)}
+          />
+        ) : null}
+        <SessionSummaryBanner compact description={session.data?.session.description} />
+        {contextTokens !== undefined && session.data?.contextWindow ? (
+          <div className="border-border flex flex-none justify-end border-b px-3 py-1">
+            <ContextUsageMeter tokens={contextTokens} contextWindow={session.data.contextWindow} size={14} />
+          </div>
+        ) : null}
+        <div
+          ref={autoScroll.containerRef}
+          onScroll={autoScroll.handleScroll}
+          className="relative flex-1 overflow-x-hidden overflow-y-auto px-3 py-2"
+        >
+          <div ref={autoScroll.contentRef} className="flex min-h-full flex-col">
+            {rows.length === 0 && !isStreaming ? (
+              <div className="text-muted-foreground flex flex-1 items-center justify-center text-xs">
+                {/* While the transcript is on its way, the empty-state prompt would be a lie about a
                   session that may be full of messages — hold quiet, then a tiny spinner. */}
-              {session.isLoading ? <DelayedSpinner /> : 'Send a message to start chatting'}
-            </div>
-          ) : null}
-          {rows.map((row) => {
-            if (row.kind === 'message')
-              return (
-                <ChatMessageBubble
-                  key={row.key}
-                  message={row.message}
-                  liveActivity={chatRowHasPendingToolCall(row) ? live.activity : undefined}
-                  serverUrl={serverUrl}
-                  accountUid={accountUid}
-                  agentId={session.data?.session.agentId}
-                />
-              )
-            if (row.kind === 'error') {
-              return (
-                <AgentErrorRow
-                  key={row.key}
-                  compact
-                  message={row.message}
-                  onRetry={row.key === retryableRowKey ? handleRetry : undefined}
-                  retryPending={retrySession.isPending}
-                />
-              )
-            }
-            if (row.kind === 'run-record') {
-              return (
-                <RunRecordCard
-                  key={row.key}
-                  serverUrl={serverUrl}
-                  accountUid={accountUid}
-                  runId={row.run.id}
-                  plan={row.plan}
-                  onOpenSession={(childSessionId, childAgentId) =>
-                    navigate({key: 'agent-session', agentId: childAgentId, sessionId: childSessionId, serverUrl})
-                  }
-                />
-              )
-            }
-            if (row.kind === 'continuation') {
-              return (
-                <ContinuationHandoffCard
-                  key={row.key}
-                  compact
-                  projection={row.projection}
-                  onOpenPredecessor={onOpenSession}
-                />
-              )
-            }
-            return null
-          })}
-          {live.text ? (
-            <AssistantMessageParts parts={[{type: 'text', text: live.text}]} isStreaming={isStreaming} />
-          ) : null}
-          {isStreaming && !(live.activity?.phase === 'tool' && rows.some(chatRowHasPendingToolCall)) ? (
-            // Hidden while a pending tool row is showing its own live status, to avoid two spinners.
-            <AgentRunStatusBar startedAt={runStartedAt} activity={live.activity} usage={live.usage} />
-          ) : null}
-          {autoScroll.showScrollButton ? (
-            <div className="pointer-events-none sticky bottom-2 flex justify-center">
-              <button
-                onClick={autoScroll.scrollToBottom}
-                className="bg-muted border-border text-foreground pointer-events-auto rounded-full border p-1.5 shadow-lg"
-                aria-label="Scroll to latest message"
-              >
-                <ArrowDown className="size-4" />
-              </button>
-            </div>
-          ) : null}
+                {session.isLoading ? <DelayedSpinner /> : 'Send a message to start chatting'}
+              </div>
+            ) : null}
+            {rows.map((row) => {
+              if (row.kind === 'message')
+                return (
+                  <ChatMessageBubble
+                    key={row.key}
+                    message={row.message}
+                    liveActivity={chatRowHasPendingToolCall(row) ? live.activity : undefined}
+                    serverUrl={serverUrl}
+                    accountUid={accountUid}
+                    agentId={session.data?.session.agentId}
+                  />
+                )
+              if (row.kind === 'error') {
+                return (
+                  <AgentErrorRow
+                    key={row.key}
+                    compact
+                    message={row.message}
+                    onRetry={row.key === retryableRowKey ? handleRetry : undefined}
+                    retryPending={retrySession.isPending}
+                  />
+                )
+              }
+              if (row.kind === 'run-record') {
+                return (
+                  <RunRecordCard
+                    key={row.key}
+                    serverUrl={serverUrl}
+                    accountUid={accountUid}
+                    runId={row.run.id}
+                    plan={row.plan}
+                    onOpenSession={(childSessionId, childAgentId) =>
+                      onOpenSession
+                        ? onOpenSession(childSessionId)
+                        : navigate({key: 'agent-session', agentId: childAgentId, sessionId: childSessionId, serverUrl})
+                    }
+                  />
+                )
+              }
+              if (row.kind === 'continuation') {
+                return (
+                  <ContinuationHandoffCard
+                    key={row.key}
+                    compact
+                    projection={row.projection}
+                    onOpenPredecessor={onOpenSession}
+                  />
+                )
+              }
+              return null
+            })}
+            {live.text ? (
+              <AssistantMessageParts parts={[{type: 'text', text: live.text}]} isStreaming={isStreaming} />
+            ) : null}
+            {isStreaming && !(live.activity?.phase === 'tool' && rows.some(chatRowHasPendingToolCall)) ? (
+              // Hidden while a pending tool row is showing its own live status, to avoid two spinners.
+              <AgentRunStatusBar startedAt={runStartedAt} activity={live.activity} usage={live.usage} />
+            ) : null}
+            {autoScroll.showScrollButton ? (
+              <div className="pointer-events-none sticky bottom-2 flex justify-center">
+                <button
+                  onClick={autoScroll.scrollToBottom}
+                  className="bg-muted border-border text-foreground pointer-events-auto rounded-full border p-1.5 shadow-lg"
+                  aria-label="Scroll to latest message"
+                >
+                  <ArrowDown className="size-4" />
+                </button>
+              </div>
+            ) : null}
+          </div>
         </div>
-      </div>
 
-      <SessionRunCard
-        compact
-        serverUrl={serverUrl}
-        accountUid={accountUid}
-        sessionId={sessionId}
-        sessionPlan={session.data?.session.plan}
-        frozenRunIds={frozenRuns}
-        readOnly={!canWrite}
-        onOpenSession={(childSessionId, childAgentId) =>
-          navigate({key: 'agent-session', agentId: childAgentId, sessionId: childSessionId, serverUrl})
-        }
-      />
+        <SessionRunCard
+          compact
+          serverUrl={serverUrl}
+          accountUid={accountUid}
+          sessionId={sessionId}
+          sessionPlan={session.data?.session.plan}
+          frozenRunIds={frozenRuns}
+          readOnly={!canWrite}
+          onOpenSession={(childSessionId, childAgentId) =>
+            onOpenSession
+              ? onOpenSession(childSessionId)
+              : navigate({key: 'agent-session', agentId: childAgentId, sessionId: childSessionId, serverUrl})
+          }
+        />
 
-      {/* No focus-on-mount here: session chats mount with the panel itself (e.g. on app launch),
+        {/* No focus-on-mount here: session chats mount with the panel itself (e.g. on app launch),
           where stealing focus from the document would be wrong. Focus is imperative, via the
           panel's new-chat flows. */}
-      <AgentRichMessageComposer
-        isBusy={isBusy}
-        isStreaming={isStreaming}
-        disabledMessage={
-          readOnly ? (
-            'You have read-only access to this agent.'
-          ) : isDrivenByParent ? (
-            <SubSessionDrivenNotice
-              parentTitle={parentSession.data?.session.title}
-              onOpenParent={() =>
-                navigate({
-                  key: 'agent-session',
-                  agentId: parentSession.data?.session.agentId,
-                  sessionId: parentSessionId!,
-                  serverUrl,
-                })
-              }
-            />
-          ) : undefined
-        }
-        stopPending={stopSession.isPending}
-        serverUrl={serverUrl}
-        accountId={accountUid ?? null}
-        sessionId={sessionId}
-        agentTools={agentDetail.data?.agent.definition.tools}
-        agentToolsLoading={agentDetail.isLoading}
-        focusOnMount={false}
-        canInvokeTools={canWrite}
-        composerHandleRef={composerRef}
-        onSend={handleSend}
-        onStop={() => void handleStop()}
-      />
-      {/* The active model for THIS session: the same per-session override switcher as the full
+        <AgentRichMessageComposer
+          isBusy={isBusy}
+          isStreaming={isStreaming}
+          disabledMessage={
+            readOnly ? (
+              'You have read-only access to this agent.'
+            ) : isDrivenByParent ? (
+              <SubSessionDrivenNotice
+                parentTitle={parentSession.data?.session.title}
+                onOpenParent={() =>
+                  onOpenSession
+                    ? onOpenSession(parentSessionId!)
+                    : navigate({
+                        key: 'agent-session',
+                        agentId: parentSession.data?.session.agentId,
+                        sessionId: parentSessionId!,
+                        serverUrl,
+                      })
+                }
+              />
+            ) : undefined
+          }
+          stopPending={stopSession.isPending}
+          serverUrl={serverUrl}
+          accountId={accountUid ?? null}
+          sessionId={sessionId}
+          agentTools={agentDetail.data?.agent.definition.tools}
+          agentToolsLoading={agentDetail.isLoading}
+          focusOnMount={false}
+          canInvokeTools={canWrite}
+          composerHandleRef={composerRef}
+          onSend={handleSend}
+          onStop={() => void handleStop()}
+        />
+        {/* The active model for THIS session: the same per-session override switcher as the full
           session page, so changing it here never touches the agent's default. */}
-      {session.data ? (
-        <div className="flex flex-none items-center justify-end px-3 pb-2">
-          <SessionModelBadge
-            agent={agentDetail.data?.agent}
-            agentId={session.data.session.agentId}
-            serverUrl={serverUrl}
-            sessionId={sessionId}
-            modelOverride={session.data.session.modelOverride}
-            canWrite={canWrite}
-          />
-        </div>
-      ) : null}
-    </div>
+        {session.data ? (
+          <div className="flex flex-none items-center justify-end px-3 pb-2">
+            <SessionModelBadge
+              agent={agentDetail.data?.agent}
+              agentId={session.data.session.agentId}
+              serverUrl={serverUrl}
+              sessionId={sessionId}
+              modelOverride={session.data.session.modelOverride}
+              canWrite={canWrite}
+            />
+          </div>
+        ) : null}
+      </div>
+    </OpenAgentSessionContext.Provider>
   )
 }
 

--- a/frontend/packages/ui/src/agents/client.ts
+++ b/frontend/packages/ui/src/agents/client.ts
@@ -23,6 +23,10 @@ export type AgentInviteInfo = AgentsProtocol.AgentInviteInfo
 export type SessionInfo = AgentsProtocol.SessionInfo
 /** Per-session model configuration overriding the agent definition's model. */
 export type SessionModelOverride = AgentsProtocol.SessionModelOverride
+
+export type SessionContinuationLink = AgentsProtocol.SessionContinuationLink
+
+export type SessionContinuationReason = AgentsProtocol.SessionContinuationReason
 /** Compact trigger attribution attached to sessions created by triggers. */
 export type AgentSessionTriggerSummary = AgentsProtocol.AgentSessionTriggerSummary
 /** Full trigger context passed into a trigger-created session. */

--- a/frontend/packages/ui/src/agents/continuation.tsx
+++ b/frontend/packages/ui/src/agents/continuation.tsx
@@ -94,12 +94,11 @@ export function ContextUsageMeter({
         : 'text-muted-foreground'
   const radius = 8
   const circumference = 2 * Math.PI * radius
-  const label = `Context ${percent}% full`
-  const detail = `${tokens.toLocaleString('en-US')} of ${contextWindow.toLocaleString(
+  const label = `${tokens.toLocaleString('en-US')} of ${contextWindow.toLocaleString(
     'en-US',
   )} tokens used (${percent}%)`
   return (
-    <Tooltip content={`${label}\n${detail}`} contentClassName="whitespace-pre-line text-left" asChild>
+    <Tooltip content={label} asChild>
       <span className={cn('inline-flex shrink-0 items-center', tone, className)} aria-label={label} role="img">
         <svg width={size} height={size} viewBox="0 0 20 20" className="shrink-0">
           <circle cx="10" cy="10" r={radius} fill="none" stroke="currentColor" strokeOpacity="0.2" strokeWidth="3" />

--- a/frontend/packages/ui/src/agents/continuation.tsx
+++ b/frontend/packages/ui/src/agents/continuation.tsx
@@ -68,7 +68,8 @@ const CONTEXT_URGENT_FRACTION = 0.85
 /**
  * The context meter: a small pie showing how much of the model's window the last turn used.
  * Muted while there is room, amber as it nears the point where the agent should continue, red
- * when it is nearly full. Renders nothing until there is a measurement.
+ * when it is nearly full. Just the pie — the exact tokens and percentage live in its hover
+ * tooltip. Renders nothing until there is a measurement.
  */
 export function ContextUsageMeter({
   tokens,
@@ -95,7 +96,7 @@ export function ContextUsageMeter({
   const label = `Context: ${formatTokenCount(tokens)} of ${formatTokenCount(contextWindow)} tokens used (${percent}%)`
   return (
     <span
-      className={cn('inline-flex shrink-0 items-center gap-1.5 text-[11px] tabular-nums', tone, className)}
+      className={cn('inline-flex shrink-0 items-center', tone, className)}
       title={label}
       aria-label={label}
       role="img"
@@ -115,7 +116,6 @@ export function ContextUsageMeter({
           transform="rotate(-90 10 10)"
         />
       </svg>
-      <span>{percent}%</span>
     </span>
   )
 }

--- a/frontend/packages/ui/src/agents/continuation.tsx
+++ b/frontend/packages/ui/src/agents/continuation.tsx
@@ -94,17 +94,10 @@ export function ContextUsageMeter({
         : 'text-muted-foreground'
   const radius = 8
   const circumference = 2 * Math.PI * radius
-  const remaining = Math.max(0, contextWindow - tokens)
   const label = `Context ${percent}% full`
-  const detail = [
-    `${tokens.toLocaleString('en-US')} of ${contextWindow.toLocaleString('en-US')} tokens used (${percent}%)`,
-    `${remaining.toLocaleString('en-US')} tokens (${Math.max(0, 100 - percent)}%) remaining`,
-    fraction >= CONTEXT_URGENT_FRACTION
-      ? 'Nearly full — the agent should continue to a fresh session now.'
-      : fraction >= CONTEXT_WARN_FRACTION
-        ? 'Getting full — the agent will continue to a fresh session at the next natural boundary.'
-        : 'The agent continues to a fresh session at a natural boundary, around 70% full.',
-  ].join('\n')
+  const detail = `${tokens.toLocaleString('en-US')} of ${contextWindow.toLocaleString(
+    'en-US',
+  )} tokens used (${percent}%)`
   return (
     <Tooltip content={`${label}\n${detail}`} contentClassName="whitespace-pre-line text-left" asChild>
       <span className={cn('inline-flex shrink-0 items-center', tone, className)} aria-label={label} role="img">

--- a/frontend/packages/ui/src/agents/continuation.tsx
+++ b/frontend/packages/ui/src/agents/continuation.tsx
@@ -1,0 +1,634 @@
+import {type SessionContinuationLink, type SessionEvent, type SessionInfo} from './client'
+import {type ChatToolPart} from './chat-parts'
+import {Markdown} from './markdown'
+import {formatTokenCount} from './agent-run-status'
+import {useNavigate} from './navigation'
+import {Button} from '@shm/ui/button'
+import {Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle} from '@shm/ui/components/dialog'
+import {cn} from '@shm/ui/utils'
+import {ArrowRight, ChevronDown, ChevronRight, CornerLeftUp, GitBranch, Info, Split} from 'lucide-react'
+import {useEffect, useRef, useState} from 'react'
+
+/**
+ * Session continuation, as the surfaces show it.
+ *
+ * A continuation is the agent carrying a conversation into a fresh session: the predecessor keeps
+ * its whole transcript and ends with a transition card; the successor opens with a banner naming
+ * where it came from and a handoff card (the exact projection the model started from); and a
+ * client that was following the predecessor's turn moves to the successor on its own. Everything
+ * here is a view over durable state — the `continuedFrom`/`continuedTo` links on SessionInfo, the
+ * `continue_session` tool row, and the projection message — so a reload shows the same story.
+ */
+
+export const CONTINUATION_REASON_LABELS: Record<string, string> = {
+  topic_change: 'New topic',
+  phase_change: 'New phase',
+  refocus: 'Refocused',
+  context_pressure: 'Context was full',
+  user_request: 'Requested',
+  other: 'Continued',
+}
+
+/** The reason as a parenthetical, or nothing when there is nothing specific to say (`other`). */
+export function continuationReasonLabel(reason: string | undefined): string | undefined {
+  if (!reason || reason === 'other') return undefined
+  const label = CONTINUATION_REASON_LABELS[reason]
+  return label ? `(${label})` : undefined
+}
+
+// ---------------------------------------------------------------------------------------------
+// Context usage
+// ---------------------------------------------------------------------------------------------
+
+/**
+ * How full the model's context was on the session's last completed turn: the prompt size stamped
+ * on the newest assistant message (input plus cache reads and writes — the whole prompt as the
+ * provider counted it). Undefined until a turn has completed.
+ */
+export function sessionContextTokens(events: SessionEvent[] | undefined): number | undefined {
+  if (!events) return undefined
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const payload = events[index]!.event as {
+      type?: string
+      role?: string
+      meta?: {usage?: {input: number; cacheRead: number; cacheWrite: number}}
+    }
+    if (payload.type !== 'message' || payload.role !== 'assistant') continue
+    const usage = payload.meta?.usage
+    if (!usage) continue
+    return usage.input + usage.cacheRead + usage.cacheWrite
+  }
+  return undefined
+}
+
+/** Fractions at which the meter changes tone; mirrors the runtime's own pressure thresholds. */
+const CONTEXT_WARN_FRACTION = 0.7
+const CONTEXT_URGENT_FRACTION = 0.85
+
+/**
+ * The context meter: a small pie showing how much of the model's window the last turn used.
+ * Muted while there is room, amber as it nears the point where the agent should continue, red
+ * when it is nearly full. Renders nothing until there is a measurement.
+ */
+export function ContextUsageMeter({
+  tokens,
+  contextWindow,
+  size = 18,
+  className,
+}: {
+  tokens: number | undefined
+  contextWindow: number | undefined
+  size?: number
+  className?: string
+}) {
+  if (tokens === undefined || !contextWindow) return null
+  const fraction = Math.max(0, Math.min(1, tokens / contextWindow))
+  const percent = Math.round(fraction * 100)
+  const tone =
+    fraction >= CONTEXT_URGENT_FRACTION
+      ? 'text-destructive'
+      : fraction >= CONTEXT_WARN_FRACTION
+        ? 'text-amber-600 dark:text-amber-400'
+        : 'text-muted-foreground'
+  const radius = 8
+  const circumference = 2 * Math.PI * radius
+  const label = `Context: ${formatTokenCount(tokens)} of ${formatTokenCount(contextWindow)} tokens used (${percent}%)`
+  return (
+    <span
+      className={cn('inline-flex shrink-0 items-center gap-1.5 text-[11px] tabular-nums', tone, className)}
+      title={label}
+      aria-label={label}
+      role="img"
+    >
+      <svg width={size} height={size} viewBox="0 0 20 20" className="shrink-0">
+        <circle cx="10" cy="10" r={radius} fill="none" stroke="currentColor" strokeOpacity="0.2" strokeWidth="3" />
+        <circle
+          cx="10"
+          cy="10"
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="3"
+          strokeDasharray={circumference}
+          strokeDashoffset={circumference * (1 - fraction)}
+          strokeLinecap="butt"
+          transform="rotate(-90 10 10)"
+        />
+      </svg>
+      <span>{percent}%</span>
+    </span>
+  )
+}
+
+// ---------------------------------------------------------------------------------------------
+// The projection message, parsed for display
+// ---------------------------------------------------------------------------------------------
+
+/** The successor's opening message, split into the parts the handoff card shows. */
+export type ContinuationProjectionView = {
+  originSessionId?: string
+  predecessorSessionId?: string
+  predecessorTitle?: string
+  continuationId?: string
+  initiatingSeq?: number
+  reason?: string
+  /** The agent-authored handoff, as markdown. */
+  handoffMarkdown: string
+  /** The cited and runtime-selected sources, one per line. */
+  sources: string[]
+  /** Loaded excerpts of the predecessor, verbatim as the model saw them. */
+  excerpts: string
+  /** The whole message, for the raw view. */
+  raw: string
+}
+
+const PROJECTION_OPEN = '<session_continuation>'
+
+/** Whether a message is a continuation projection (the runtime's opening message in a successor). */
+export function isContinuationProjection(content: string | undefined): boolean {
+  return typeof content === 'string' && content.trimStart().startsWith(PROJECTION_OPEN)
+}
+
+function attr(block: string, tag: string, name: string): string | undefined {
+  const match = block.match(new RegExp(`<${tag}\\b[^>]*?\\b${name}="([^"]*)"`))
+  return match ? match[1]!.replace(/&quot;/g, '"') : undefined
+}
+
+function inner(content: string, tag: string): string | undefined {
+  const match = content.match(new RegExp(`<${tag}>\\n?([\\s\\S]*?)\\n?</${tag}>`))
+  return match ? unescapeFraming(match[1]!) : undefined
+}
+
+/**
+ * The runtime escapes `<` in model-authored text it hands back inside a frame (so a handoff line
+ * cannot close the frame early); the reader wants the text as written.
+ */
+function unescapeFraming(text: string): string {
+  return text.replace(/\\u003c/g, '<')
+}
+
+/** Parses a projection message into its parts; tolerant of anything it does not recognize. */
+export function parseContinuationProjection(content: string): ContinuationProjectionView {
+  const lineage = inner(content, 'session_continuation') ?? ''
+  const initiatingSeq = Number(attr(lineage, 'initiating_event', 'seq'))
+  const handoff = inner(content, 'handoff') ?? ''
+  const sourcesBlock = inner(content, 'sources') ?? ''
+  const sources = sourcesBlock
+    .split('\n')
+    .map((line) => line.replace(/^-\s*/, '').trim())
+    .filter(Boolean)
+  const excerptStart = content.search(/<(excerpt|recent_exchanges)\b/)
+  return {
+    originSessionId: attr(lineage, 'origin', 'session'),
+    predecessorSessionId: attr(lineage, 'predecessor', 'session'),
+    predecessorTitle: attr(lineage, 'predecessor', 'title') || undefined,
+    continuationId: attr(lineage, 'predecessor', 'edge'),
+    initiatingSeq: Number.isFinite(initiatingSeq) ? initiatingSeq : undefined,
+    reason: attr(lineage, 'projection', 'reason'),
+    handoffMarkdown: handoff,
+    sources,
+    excerpts: excerptStart >= 0 ? content.slice(excerptStart) : '',
+    raw: content,
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Following a continuation
+// ---------------------------------------------------------------------------------------------
+
+/**
+ * Moves a client to the successor when the session it is showing gets continued — but only a
+ * client that was following the turn: it saw the session streaming (or sent the message itself).
+ * Someone reading an old transcript when another window continues it is not yanked away; the
+ * transition card and the notice above the composer still show where it went. Fires once per
+ * successor, so Back returns to the predecessor without being redirected again.
+ */
+export function useFollowContinuation({
+  session,
+  isStreaming,
+  onFollow,
+}: {
+  session: SessionInfo | undefined
+  isStreaming: boolean
+  onFollow: (link: SessionContinuationLink) => void
+}) {
+  const followingRef = useRef(false)
+  const followedRef = useRef<string | null>(null)
+  const sessionId = session?.id
+  useEffect(() => {
+    followingRef.current = false
+    followedRef.current = null
+  }, [sessionId])
+  useEffect(() => {
+    if (isStreaming) followingRef.current = true
+  }, [isStreaming])
+  const successorId = session?.continuedTo?.sessionId
+  useEffect(() => {
+    if (!session?.continuedTo || !successorId) return
+    if (!followingRef.current || followedRef.current === successorId) return
+    followedRef.current = successorId
+    onFollow(session.continuedTo)
+  }, [onFollow, session?.continuedTo, successorId])
+  /** Marks this client as following the turn (call when it sends a message). */
+  return {
+    markFollowing: () => {
+      followingRef.current = true
+    },
+    /** Follows a successor id the send response named, once. */
+    followNow: (link: SessionContinuationLink) => {
+      if (followedRef.current === link.sessionId) return
+      followedRef.current = link.sessionId
+      onFollow(link)
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Surfaces
+// ---------------------------------------------------------------------------------------------
+
+/**
+ * Banner at the top of a successor session: where it came from, and the way back. The handoff
+ * itself is the first card of the transcript, right below.
+ */
+export function ContinuationHeader({
+  link,
+  compact,
+  onOpenPredecessor,
+}: {
+  link: SessionContinuationLink
+  compact?: boolean
+  onOpenPredecessor: () => void
+}) {
+  return (
+    <div
+      className={cn('flex flex-none flex-col gap-2', compact ? 'px-3 pt-2' : 'pt-3')}
+      aria-label="Continued from a previous session"
+    >
+      <button
+        type="button"
+        className="bg-muted hover:bg-muted/70 text-muted-foreground hover:text-foreground flex max-w-full items-center gap-1.5 self-start rounded-full px-2.5 py-1 text-xs"
+        onClick={onOpenPredecessor}
+        title="Back to the previous session"
+      >
+        <CornerLeftUp className="size-3 flex-none" />
+        <span className="min-w-0 truncate">Continued from {link.title ? `“${link.title}”` : 'previous session'}</span>
+      </button>
+    </div>
+  )
+}
+
+/**
+ * The handoff as the tool input carries it, in the same markdown shape the runtime compiles into
+ * the successor's projection — so the predecessor's card and the successor's card read alike.
+ */
+export function handoffMarkdownFromArgs(args: Record<string, unknown> | undefined): string {
+  const handoff = (args?.handoff ?? {}) as Record<string, unknown>
+  const section = (title: string, value: unknown): string[] => {
+    if (typeof value === 'string' && value.trim()) return [`## ${title}`, value, '']
+    if (Array.isArray(value) && value.length) return [`## ${title}`, ...value.map((item) => `- ${String(item)}`), '']
+    return []
+  }
+  return [
+    ...section('Purpose', handoff.purpose),
+    ...section('Current request', handoff.currentRequest),
+    ...section('Established facts', handoff.establishedFacts),
+    ...section('Decisions', handoff.decisions),
+    ...section('Open questions', handoff.openQuestions),
+    ...section('Next actions', handoff.nextActions),
+    ...section('Cautions', handoff.cautions),
+  ].join('\n')
+}
+
+/** The cited sources as the tool input carries them, one line each, as the projection lists them. */
+export function sourceLinesFromArgs(args: Record<string, unknown> | undefined): string[] {
+  const sources = Array.isArray(args?.sources) ? (args!.sources as Array<Record<string, unknown>>) : []
+  return sources.map((source) => {
+    const where =
+      source.kind === 'resource'
+        ? `resource ${String(source.url ?? '')}`
+        : source.kind === 'memory'
+          ? `memory ${String(source.path ?? '')}`
+          : source.kind === 'session_event'
+            ? `thread seq ${String(source.seq ?? '')}`
+            : `thread seq ${String(source.fromSeq ?? '')}–${String(source.toSeq ?? '')}`
+    return `${where} — ${String(source.relevance ?? '')}`
+  })
+}
+
+/** One rendering of a handoff for both ends of the edge: the markdown, then the source list. */
+export function HandoffBody({handoffMarkdown, sources}: {handoffMarkdown: string; sources: string[]}) {
+  return (
+    <div className="flex shrink-0 flex-col gap-3">
+      <div className="bg-background/70 max-h-96 shrink-0 overflow-auto rounded-md border px-3 py-2 text-xs [&_h2]:mt-2 [&_h2]:mb-1 [&_h2]:text-[11px] [&_h2]:font-semibold [&_h2]:tracking-[0.12em] [&_h2]:uppercase [&_h2:first-child]:mt-0">
+        <Markdown>{handoffMarkdown}</Markdown>
+      </div>
+      {sources.length ? (
+        <div>
+          <div className="text-muted-foreground mb-1 text-[10px] font-medium tracking-[0.18em] uppercase">Sources</div>
+          <ul className="bg-background/70 rounded-md border px-3 py-2 text-xs">
+            {sources.map((source, index) => (
+              <li key={index} className="py-0.5 break-all">
+                {source}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+/**
+ * The transition row that ends a predecessor's transcript: the `continue_session` call, rendered
+ * as where the conversation went. It reads like a tool row — chevron, one line, a hover info
+ * bubble — but stands on its own, because it is a bigger event than any tool call. Expanding
+ * shows the handoff; the info bubble opens every detail. A refused call keeps error styling.
+ */
+export function ContinuationTransitionCard({
+  item,
+  onOpenSuccessor,
+  onInspect,
+}: {
+  item: ChatToolPart
+  onOpenSuccessor?: (sessionId: string) => void
+  /** Opens the full-details dialog (owned by the transcript renderer, which has the event metadata). */
+  onInspect?: () => void
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const args = item.args
+  const output = (item.rawOutput ?? {}) as {successorSessionId?: string; title?: string}
+  const title = String(args?.title ?? output.title ?? 'a new session')
+  const reason = typeof args?.reason === 'string' ? args.reason : undefined
+  const reasonLabel = continuationReasonLabel(reason)
+  const isPending = item.result === undefined && item.rawOutput === undefined
+  const successorId = output.successorSessionId
+  return (
+    <div
+      className={cn(
+        'group/controw my-1.5 mr-6 rounded-lg border px-2 py-1.5 text-xs',
+        item.isError
+          ? 'border-destructive/30 bg-destructive/5'
+          : 'border-violet-200 bg-violet-50 dark:border-violet-900 dark:bg-violet-950/40',
+      )}
+    >
+      {/* The whole line toggles the handoff; inner buttons stop propagation. */}
+      <div
+        className="flex min-w-0 cursor-pointer items-center gap-1.5 select-none"
+        onClick={() => setExpanded((current) => !current)}
+      >
+        <button
+          type="button"
+          title={expanded ? 'Hide handoff' : 'Show handoff'}
+          aria-expanded={expanded}
+          onClick={(event) => {
+            event.stopPropagation()
+            setExpanded((current) => !current)
+          }}
+          className="hover:bg-background/70 rounded p-0.5"
+        >
+          {expanded ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+        </button>
+        <Split
+          className={cn(
+            'size-3.5 shrink-0',
+            item.isError ? 'text-destructive' : 'text-violet-700 dark:text-violet-300',
+          )}
+        />
+        <span className="min-w-0 truncate text-sm font-medium">
+          {item.isError ? 'Continuation refused' : isPending ? 'Continuing in' : 'Continued in'} “{title}”
+        </span>
+        {reasonLabel ? <span className="text-muted-foreground shrink-0">{reasonLabel}</span> : null}
+        <div className="ml-auto flex shrink-0 items-center gap-1.5">
+          {successorId && onOpenSuccessor ? (
+            <Button
+              size="sm"
+              variant="default"
+              onClick={(event) => {
+                event.stopPropagation()
+                onOpenSuccessor(successorId)
+              }}
+            >
+              Open session
+              <ArrowRight className="ml-1 size-3.5" />
+            </Button>
+          ) : null}
+          <button
+            type="button"
+            title="View every detail of this handoff"
+            onClick={(event) => {
+              event.stopPropagation()
+              onInspect?.()
+            }}
+            className="hover:bg-background/70 text-muted-foreground hover:text-foreground bg-background/60 rounded-full border p-0.75 opacity-0 transition-opacity group-hover/controw:opacity-100 focus-visible:opacity-100"
+          >
+            <Info className="size-3" />
+          </button>
+        </div>
+      </div>
+      {item.isError && item.result ? (
+        <pre className="text-destructive mt-1 whitespace-pre-wrap">{item.result}</pre>
+      ) : null}
+      {expanded ? (
+        <div className="mt-2 border-t pt-2">
+          <HandoffBody handoffMarkdown={handoffMarkdownFromArgs(args)} sources={sourceLinesFromArgs(args)} />
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+/**
+ * The handoff row that opens a successor's transcript: the projection the model started from,
+ * in place of the raw `<session_continuation>` text. Same shape as the transition row on the
+ * other end — chevron, one line, a hover info bubble — because it is the same event seen from
+ * here. Expanding shows the handoff; the info bubble opens every detail, lineage and excerpts
+ * included.
+ */
+export function ContinuationHandoffCard({
+  projection,
+  compact,
+  onOpenPredecessor,
+  id,
+}: {
+  projection: ContinuationProjectionView
+  compact?: boolean
+  onOpenPredecessor?: (sessionId: string) => void
+  id?: string
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const [detailsOpen, setDetailsOpen] = useState(false)
+  const predecessorId = projection.predecessorSessionId
+  const reasonLabel = continuationReasonLabel(projection.reason)
+  return (
+    <div
+      id={id}
+      className={cn(
+        'group/controw my-1.5 rounded-lg border border-violet-200 bg-violet-50 px-2 py-1.5 text-xs dark:border-violet-900 dark:bg-violet-950/40',
+        compact ? '' : 'mr-6',
+      )}
+    >
+      {/* The whole line toggles the handoff; inner buttons stop propagation. */}
+      <div
+        className="flex min-w-0 cursor-pointer items-center gap-1.5 select-none"
+        onClick={() => setExpanded((current) => !current)}
+      >
+        <button
+          type="button"
+          title={expanded ? 'Hide handoff' : 'Show handoff'}
+          aria-expanded={expanded}
+          onClick={(event) => {
+            event.stopPropagation()
+            setExpanded((current) => !current)
+          }}
+          className="hover:bg-background/70 rounded p-0.5"
+        >
+          {expanded ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+        </button>
+        <GitBranch className="size-3.5 shrink-0 text-violet-700 dark:text-violet-300" />
+        <span className="min-w-0 truncate text-sm font-medium">
+          Handoff from {projection.predecessorTitle ? `“${projection.predecessorTitle}”` : 'the previous session'}
+        </span>
+        {reasonLabel ? <span className="text-muted-foreground shrink-0">{reasonLabel}</span> : null}
+        <div className="ml-auto flex shrink-0 items-center gap-1.5">
+          {predecessorId && onOpenPredecessor ? (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={(event) => {
+                event.stopPropagation()
+                onOpenPredecessor(predecessorId)
+              }}
+            >
+              <CornerLeftUp className="mr-1 size-3.5" />
+              Open session
+            </Button>
+          ) : null}
+          <button
+            type="button"
+            title="View every detail of this handoff"
+            onClick={(event) => {
+              event.stopPropagation()
+              setDetailsOpen(true)
+            }}
+            className="hover:bg-background/70 text-muted-foreground hover:text-foreground bg-background/60 rounded-full border p-0.75 opacity-0 transition-opacity group-hover/controw:opacity-100 focus-visible:opacity-100"
+          >
+            <Info className="size-3" />
+          </button>
+        </div>
+      </div>
+      {expanded ? (
+        <div className="mt-2 border-t pt-2">
+          <HandoffBody handoffMarkdown={projection.handoffMarkdown} sources={projection.sources} />
+        </div>
+      ) : null}
+      <ContinuationProjectionDialog projection={projection} open={detailsOpen} onOpenChange={setDetailsOpen} />
+    </div>
+  )
+}
+
+/**
+ * Every detail of a successor's starting point: the lineage (origin, predecessor, edge, the
+ * initiating message's seq), the handoff and sources, the exact excerpts that were loaded, and
+ * the raw projection text the model was given. The decision's own metadata — model, tokens,
+ * timing — lives on the predecessor's transition row, where the decision was made.
+ */
+function ContinuationProjectionDialog({
+  projection,
+  open,
+  onOpenChange,
+}: {
+  projection: ContinuationProjectionView
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const lineage: Array<[string, string | undefined]> = [
+    ['Origin session', projection.originSessionId],
+    ['Predecessor session', projection.predecessorSessionId],
+    ['Continuation', projection.continuationId],
+    ['Initiating message', projection.initiatingSeq !== undefined ? `seq ${projection.initiatingSeq}` : undefined],
+    ['Reason', projection.reason],
+  ]
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] w-[min(44rem,calc(100vw-2rem))]">
+        <DialogHeader>
+          <DialogTitle>
+            Handoff from {projection.predecessorTitle ? `“${projection.predecessorTitle}”` : 'the previous session'}
+          </DialogTitle>
+          <DialogDescription>
+            What this session started from — the projection, exactly as the model received it.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex shrink-0 flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <div className="text-muted-foreground text-[10px] font-medium tracking-[0.18em] uppercase">Lineage</div>
+            <div className="bg-muted grid gap-x-4 gap-y-1 rounded-md p-2 sm:grid-cols-2">
+              {lineage
+                .filter((row): row is [string, string] => !!row[1])
+                .map(([label, value]) => (
+                  <div key={label} className="flex min-w-0 items-baseline justify-between gap-2 text-xs">
+                    <span className="text-muted-foreground shrink-0">{label}</span>
+                    <span className="min-w-0 text-right font-medium break-all" title={value}>
+                      {value}
+                    </span>
+                  </div>
+                ))}
+            </div>
+          </div>
+          <HandoffBody handoffMarkdown={projection.handoffMarkdown} sources={projection.sources} />
+          {projection.excerpts ? (
+            <div className="space-y-1">
+              <div className="text-muted-foreground text-[10px] font-medium tracking-[0.18em] uppercase">
+                Loaded excerpts
+              </div>
+              <pre className="bg-muted max-h-64 overflow-auto rounded-xl p-3 text-[11px] whitespace-pre-wrap">
+                {projection.excerpts}
+              </pre>
+            </div>
+          ) : null}
+          <div className="space-y-1">
+            <div className="text-muted-foreground text-[10px] font-medium tracking-[0.18em] uppercase">Projection</div>
+            <pre className="bg-muted max-h-64 overflow-auto rounded-xl p-3 text-[11px] whitespace-pre-wrap">
+              {projection.raw}
+            </pre>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+/** Small chip on a user message a continuation replayed: it is the user's own words, carried over. */
+export function ContinuedMessageChip({
+  continuedFrom,
+  serverUrl,
+}: {
+  continuedFrom: {sessionId: string; eventId: string}
+  serverUrl?: string
+}) {
+  const navigate = useNavigate()
+  return (
+    <button
+      type="button"
+      className="text-muted-foreground hover:text-foreground mt-1 flex items-center gap-1 text-[10px]"
+      onClick={() => {
+        if (serverUrl) navigate({key: 'agent-session', sessionId: continuedFrom.sessionId, serverUrl})
+      }}
+      title="This message was carried over from the previous session"
+    >
+      <CornerLeftUp className="size-3" />
+      From previous session
+    </button>
+  )
+}
+
+/** The chip a session list shows on a predecessor: where it went. */
+export function ContinuedListChip({link}: {link: SessionContinuationLink}) {
+  return (
+    <span className="bg-muted text-muted-foreground mt-2 inline-flex max-w-full items-center gap-1 rounded-full px-2 py-0.5 text-xs">
+      <Split className="size-3 flex-none" />
+      <span className="min-w-0 truncate">Continued in {link.title ? `“${link.title}”` : 'a new session'}</span>
+    </span>
+  )
+}

--- a/frontend/packages/ui/src/agents/continuation.tsx
+++ b/frontend/packages/ui/src/agents/continuation.tsx
@@ -2,7 +2,7 @@ import {type SessionContinuationLink, type SessionEvent, type SessionInfo} from 
 import {type ChatToolPart} from './chat-parts'
 import {Markdown} from './markdown'
 import {formatTokenCount} from './agent-run-status'
-import {useNavigate} from './navigation'
+import {useOpenAgentSession} from './open-session-context'
 import {Button} from '@shm/ui/button'
 import {Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle} from '@shm/ui/components/dialog'
 import {cn} from '@shm/ui/utils'
@@ -286,7 +286,9 @@ export function ContinuationHeader({
         title="Back to the previous session"
       >
         <CornerLeftUp className="size-3 flex-none" />
-        <span className="min-w-0 truncate">Continued from {link.title ? `“${link.title}”` : 'previous session'}</span>
+        <span className="min-w-0 break-words">
+          Continued from {link.title ? `“${link.title}”` : 'previous session'}
+        </span>
       </button>
     </div>
   )
@@ -380,15 +382,16 @@ export function ContinuationTransitionCard({
   return (
     <div
       className={cn(
-        'group/controw my-1.5 mr-6 rounded-lg border px-2 py-1.5 text-xs',
+        'group/controw @container my-1.5 mr-6 rounded-lg border px-2 py-1.5 text-xs',
         item.isError
           ? 'border-destructive/30 bg-destructive/5'
           : 'border-violet-200 bg-violet-50 dark:border-violet-900 dark:bg-violet-950/40',
       )}
     >
-      {/* The whole line toggles the handoff; inner buttons stop propagation. */}
+      {/* The whole line toggles the handoff; inner buttons stop propagation. The line WRAPS —
+          a title must stay readable in the panel's width, not fit or vanish. */}
       <div
-        className="flex min-w-0 cursor-pointer items-center gap-1.5 select-none"
+        className="flex min-w-0 cursor-pointer flex-wrap items-center gap-x-1.5 gap-y-1 select-none"
         onClick={() => setExpanded((current) => !current)}
       >
         <button
@@ -409,10 +412,13 @@ export function ContinuationTransitionCard({
             item.isError ? 'text-destructive' : 'text-violet-700 dark:text-violet-300',
           )}
         />
-        <span className="min-w-0 truncate text-sm font-medium">
+        <span className="min-w-0 text-sm font-medium break-words">
           {item.isError ? 'Continuation refused' : isPending ? 'Continuing in' : 'Continued in'} “{title}”
         </span>
-        {reasonLabel ? <span className="text-muted-foreground shrink-0">{reasonLabel}</span> : null}
+        {/* The reason is a garnish: hidden where the row is too narrow to carry it. */}
+        {reasonLabel ? (
+          <span className="text-muted-foreground hidden shrink-0 @[26rem]:inline">{reasonLabel}</span>
+        ) : null}
         <div className="ml-auto flex shrink-0 items-center gap-1.5">
           {successorId && onOpenSuccessor ? (
             <Button
@@ -478,13 +484,13 @@ export function ContinuationHandoffCard({
     <div
       id={id}
       className={cn(
-        'group/controw my-1.5 rounded-lg border border-violet-200 bg-violet-50 px-2 py-1.5 text-xs dark:border-violet-900 dark:bg-violet-950/40',
+        'group/controw @container my-1.5 rounded-lg border border-violet-200 bg-violet-50 px-2 py-1.5 text-xs dark:border-violet-900 dark:bg-violet-950/40',
         compact ? '' : 'mr-6',
       )}
     >
-      {/* The whole line toggles the handoff; inner buttons stop propagation. */}
+      {/* The whole line toggles the handoff and WRAPS; inner buttons stop propagation. */}
       <div
-        className="flex min-w-0 cursor-pointer items-center gap-1.5 select-none"
+        className="flex min-w-0 cursor-pointer flex-wrap items-center gap-x-1.5 gap-y-1 select-none"
         onClick={() => setExpanded((current) => !current)}
       >
         <button
@@ -500,10 +506,12 @@ export function ContinuationHandoffCard({
           {expanded ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
         </button>
         <GitBranch className="size-3.5 shrink-0 text-violet-700 dark:text-violet-300" />
-        <span className="min-w-0 truncate text-sm font-medium">
+        <span className="min-w-0 text-sm font-medium break-words">
           Handoff from {projection.predecessorTitle ? `“${projection.predecessorTitle}”` : 'the previous session'}
         </span>
-        {reasonLabel ? <span className="text-muted-foreground shrink-0">{reasonLabel}</span> : null}
+        {reasonLabel ? (
+          <span className="text-muted-foreground hidden shrink-0 @[26rem]:inline">{reasonLabel}</span>
+        ) : null}
         <div className="ml-auto flex shrink-0 items-center gap-1.5">
           {predecessorId && onOpenPredecessor ? (
             <Button
@@ -621,14 +629,12 @@ export function ContinuedMessageChip({
   continuedFrom: {sessionId: string; eventId: string}
   serverUrl?: string
 }) {
-  const navigate = useNavigate()
+  const openSession = useOpenAgentSession()
   return (
     <button
       type="button"
       className="text-muted-foreground hover:text-foreground mt-1 flex items-center gap-1 text-[10px]"
-      onClick={() => {
-        if (serverUrl) navigate({key: 'agent-session', sessionId: continuedFrom.sessionId, serverUrl})
-      }}
+      onClick={() => openSession({sessionId: continuedFrom.sessionId, serverUrl})}
       title="This message was carried over from the previous session"
     >
       <CornerLeftUp className="size-3" />

--- a/frontend/packages/ui/src/agents/continuation.tsx
+++ b/frontend/packages/ui/src/agents/continuation.tsx
@@ -197,11 +197,15 @@ export function parseContinuationProjection(content: string): ContinuationProjec
 // ---------------------------------------------------------------------------------------------
 
 /**
- * Moves a client to the successor when the session it is showing gets continued — but only a
- * client that was following the turn: it saw the session streaming (or sent the message itself).
- * Someone reading an old transcript when another window continues it is not yanked away; the
- * transition card and the notice above the composer still show where it went. Fires once per
- * successor, so Back returns to the predecessor without being redirected again.
+ * Moves a client to the successor when the session it is showing gets continued — but only on the
+ * TRANSITION, and only for a client that was following the turn.
+ *
+ * The transition: `continuedTo` was absent when this client loaded the session and then appeared.
+ * A session that already had a successor when it was opened is one the person chose to come back
+ * to (to read it, or to branch by writing there), and is never redirected — that is what the
+ * transition row is for. Following the turn: this client saw the session streaming, or sent the
+ * message itself (the send response names the successor directly). Fires once per successor, so
+ * Back returns to the predecessor without being redirected again.
  */
 export function useFollowContinuation({
   session,
@@ -214,27 +218,37 @@ export function useFollowContinuation({
 }) {
   const followingRef = useRef(false)
   const followedRef = useRef<string | null>(null)
+  /** The successor the session already had when this client first loaded it (null: none). */
+  const baselineRef = useRef<{sessionId: string; successorId: string | null} | null>(null)
   const sessionId = session?.id
+  const successorId = session?.continuedTo?.sessionId ?? null
   useEffect(() => {
     followingRef.current = false
     followedRef.current = null
+    baselineRef.current = null
   }, [sessionId])
   useEffect(() => {
     if (isStreaming) followingRef.current = true
   }, [isStreaming])
-  const successorId = session?.continuedTo?.sessionId
   useEffect(() => {
-    if (!session?.continuedTo || !successorId) return
+    if (!session) return
+    if (baselineRef.current?.sessionId !== session.id) {
+      // First sight of this session on this client: whatever successor it has now is history.
+      baselineRef.current = {sessionId: session.id, successorId}
+      return
+    }
+    if (!session.continuedTo || !successorId) return
+    if (successorId === baselineRef.current.successorId) return
     if (!followingRef.current || followedRef.current === successorId) return
     followedRef.current = successorId
     onFollow(session.continuedTo)
-  }, [onFollow, session?.continuedTo, successorId])
-  /** Marks this client as following the turn (call when it sends a message). */
+  }, [onFollow, session, successorId])
   return {
+    /** Marks this client as following the turn (call when it sends a message). */
     markFollowing: () => {
       followingRef.current = true
     },
-    /** Follows a successor id the send response named, once. */
+    /** Follows a successor the send response named, once. */
     followNow: (link: SessionContinuationLink) => {
       if (followedRef.current === link.sessionId) return
       followedRef.current = link.sessionId

--- a/frontend/packages/ui/src/agents/continuation.tsx
+++ b/frontend/packages/ui/src/agents/continuation.tsx
@@ -1,10 +1,11 @@
 import {type SessionContinuationLink, type SessionEvent, type SessionInfo} from './client'
 import {type ChatToolPart} from './chat-parts'
 import {Markdown} from './markdown'
-import {formatTokenCount} from './agent-run-status'
+
 import {useOpenAgentSession} from './open-session-context'
 import {Button} from '@shm/ui/button'
 import {Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle} from '@shm/ui/components/dialog'
+import {Tooltip} from '@shm/ui/tooltip'
 import {cn} from '@shm/ui/utils'
 import {ArrowRight, ChevronDown, ChevronRight, CornerLeftUp, GitBranch, Info, Split} from 'lucide-react'
 import {useEffect, useRef, useState} from 'react'
@@ -93,30 +94,37 @@ export function ContextUsageMeter({
         : 'text-muted-foreground'
   const radius = 8
   const circumference = 2 * Math.PI * radius
-  const label = `Context: ${formatTokenCount(tokens)} of ${formatTokenCount(contextWindow)} tokens used (${percent}%)`
+  const remaining = Math.max(0, contextWindow - tokens)
+  const label = `Context ${percent}% full`
+  const detail = [
+    `${tokens.toLocaleString('en-US')} of ${contextWindow.toLocaleString('en-US')} tokens used (${percent}%)`,
+    `${remaining.toLocaleString('en-US')} tokens (${Math.max(0, 100 - percent)}%) remaining`,
+    fraction >= CONTEXT_URGENT_FRACTION
+      ? 'Nearly full — the agent should continue to a fresh session now.'
+      : fraction >= CONTEXT_WARN_FRACTION
+        ? 'Getting full — the agent will continue to a fresh session at the next natural boundary.'
+        : 'The agent continues to a fresh session at a natural boundary, around 70% full.',
+  ].join('\n')
   return (
-    <span
-      className={cn('inline-flex shrink-0 items-center', tone, className)}
-      title={label}
-      aria-label={label}
-      role="img"
-    >
-      <svg width={size} height={size} viewBox="0 0 20 20" className="shrink-0">
-        <circle cx="10" cy="10" r={radius} fill="none" stroke="currentColor" strokeOpacity="0.2" strokeWidth="3" />
-        <circle
-          cx="10"
-          cy="10"
-          r={radius}
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="3"
-          strokeDasharray={circumference}
-          strokeDashoffset={circumference * (1 - fraction)}
-          strokeLinecap="butt"
-          transform="rotate(-90 10 10)"
-        />
-      </svg>
-    </span>
+    <Tooltip content={`${label}\n${detail}`} contentClassName="whitespace-pre-line text-left" asChild>
+      <span className={cn('inline-flex shrink-0 items-center', tone, className)} aria-label={label} role="img">
+        <svg width={size} height={size} viewBox="0 0 20 20" className="shrink-0">
+          <circle cx="10" cy="10" r={radius} fill="none" stroke="currentColor" strokeOpacity="0.2" strokeWidth="3" />
+          <circle
+            cx="10"
+            cy="10"
+            r={radius}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeDasharray={circumference}
+            strokeDashoffset={circumference * (1 - fraction)}
+            strokeLinecap="butt"
+            transform="rotate(-90 10 10)"
+          />
+        </svg>
+      </span>
+    </Tooltip>
   )
 }
 

--- a/frontend/packages/ui/src/agents/detail.tsx
+++ b/frontend/packages/ui/src/agents/detail.tsx
@@ -53,6 +53,7 @@ import {
 } from './models'
 import {describeAgentError} from './errors'
 import {SessionStatusDot, SubSessionsDisclosure} from './session-children'
+import {ContinuedListChip} from './continuation'
 import {useSelectedAccountId} from './account'
 import {useClickNavigate, useNavigate} from './navigation'
 import {markdownBlockNodesToHMBlockNodes, parseMarkdown} from '@seed-hypermedia/client'
@@ -2831,6 +2832,7 @@ function SessionListItem({
           </SizableText>
         ) : null}
       </button>
+      {session.continuedTo ? <ContinuedListChip link={session.continuedTo} /> : null}
       {session.startedByTrigger ? (
         <button
           type="button"

--- a/frontend/packages/ui/src/agents/message-rendering.tsx
+++ b/frontend/packages/ui/src/agents/message-rendering.tsx
@@ -40,6 +40,7 @@ import {Button} from '@shm/ui/button'
 import {HMIcon} from '@shm/ui/hm-icon'
 import {cn} from '@shm/ui/utils'
 import {
+  Activity,
   BookOpenText,
   Bot,
   ChevronDown,
@@ -62,6 +63,14 @@ import React, {Fragment, Suspense, useMemo, useState} from 'react'
 import {Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle} from '@shm/ui/components/dialog'
 import {Popover, PopoverContent, PopoverTrigger} from '@shm/ui/components/popover'
 import {Markdown} from './markdown'
+import {
+  ContinuationTransitionCard,
+  ContinuedMessageChip,
+  HandoffBody,
+  continuationReasonLabel,
+  handoffMarkdownFromArgs,
+  sourceLinesFromArgs,
+} from './continuation'
 
 /** Renders a chat message bubble shared by the assistant panel and Agents session UI. */
 export const ChatMessageBubble = React.memo(function ChatMessageBubble({
@@ -109,6 +118,9 @@ export const ChatMessageBubble = React.memo(function ChatMessageBubble({
               <Markdown>{message.content || ''}</Markdown>
             )}
             {message.contextLines?.length ? <MessageContextInfo lines={message.contextLines} /> : null}
+            {message.meta?.continuedFrom ? (
+              <ContinuedMessageChip continuedFrom={message.meta.continuedFrom} serverUrl={serverUrl} />
+            ) : null}
           </div>
           {rawMarkdown ? <RawMarkdownButton onClick={() => setShowRawMarkdown(true)} /> : null}
           <UserMessageOrigin meta={message.meta} />
@@ -290,6 +302,14 @@ export const AssistantMessageParts = React.memo(function AssistantMessageParts({
     : -1
 
   return parts.map((part, index) => {
+    if (part.type === 'tool' && part.name === 'continue_session') {
+      // The conversation moved on from here: a transition card, not a tool row.
+      return <ContinuationTransitionRow key={`${part.id}:${index}`} item={part} serverUrl={serverUrl} />
+    }
+    if (part.type === 'tool' && part.name === 'status') {
+      // The agent's own account of the session: the description is the point, so it is shown whole.
+      return <StatusUpdateRow key={`${part.id}:${index}`} item={part} />
+    }
     if (part.type === 'tool') {
       return (
         <ToolCallItem
@@ -316,6 +336,125 @@ export const AssistantMessageParts = React.memo(function AssistantMessageParts({
     )
   })
 })
+
+/**
+ * A `status` call as the transcript shows it. The description is a status line the reader is
+ * meant to read, so it is rendered in full rather than clipped into a one-line tool row; a new
+ * title, when one was set, leads. A description-only update is the common case.
+ */
+function StatusUpdateRow({item}: {item: ChatToolPart}) {
+  const title = getToolString(item.args, 'title')
+  const description = getToolString(item.args, 'description')
+  const isPending = item.result === undefined && item.rawOutput === undefined
+  return (
+    <div
+      className={cn(
+        'my-1 mr-6 rounded-lg border px-3 py-2 text-xs',
+        item.isError ? 'border-destructive/30 bg-destructive/5' : 'border-border bg-muted/40',
+      )}
+    >
+      {/* The header line is the title when the call set one; "Status" only when it did not. */}
+      <div className="flex items-center gap-1.5">
+        {isPending ? (
+          <Loader2 className="text-muted-foreground size-3 shrink-0 animate-spin" />
+        ) : (
+          <Activity className="text-muted-foreground size-3 shrink-0" />
+        )}
+        {title ? (
+          <span className="text-foreground min-w-0 text-sm font-medium">{title}</span>
+        ) : (
+          <span className="text-muted-foreground text-[10px] font-medium tracking-[0.18em] uppercase">Status</span>
+        )}
+        {item.isError ? <ToolChip tone="error">Failed</ToolChip> : null}
+      </div>
+      {description ? (
+        <p className="text-foreground/85 mt-1 text-[13px] leading-5 whitespace-pre-wrap">{description}</p>
+      ) : null}
+      {item.isError && item.result ? (
+        <pre className="text-destructive mt-1 whitespace-pre-wrap">{item.result}</pre>
+      ) : null}
+    </div>
+  )
+}
+
+/** The `continue_session` row: where the conversation went, with a way there and every detail behind ⓘ. */
+function ContinuationTransitionRow({item, serverUrl}: {item: ChatToolPart; serverUrl?: string}) {
+  const navigate = useNavigate()
+  const [detailsOpen, setDetailsOpen] = useState(false)
+  return (
+    <>
+      <ContinuationTransitionCard
+        item={item}
+        onOpenSuccessor={serverUrl ? (sessionId) => navigate({key: 'agent-session', sessionId, serverUrl}) : undefined}
+        onInspect={() => setDetailsOpen(true)}
+      />
+      <ContinuationDetailsDialog item={item} open={detailsOpen} onOpenChange={setDetailsOpen} />
+    </>
+  )
+}
+
+/**
+ * Every detail of a continuation: who decided it and what it cost (the same metadata block as any
+ * tool call — model, provider, tokens, timing), the handoff as written, its sources, and the exact
+ * call and result payloads.
+ */
+function ContinuationDetailsDialog({
+  item,
+  open,
+  onOpenChange,
+}: {
+  item: ChatToolPart
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const args = item.args
+  const output = (item.rawOutput ?? {}) as {successorSessionId?: string; title?: string}
+  const title = String(args?.title ?? output.title ?? 'a new session')
+  const description = typeof args?.description === 'string' ? args.description : undefined
+  const reason = continuationReasonLabel(typeof args?.reason === 'string' ? args.reason : undefined)
+  const transfer = args?.transfer as {plan?: string} | undefined
+  const rawOutput = item.rawOutput ?? item.result
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] w-[min(44rem,calc(100vw-2rem))]">
+        <DialogHeader>
+          <DialogTitle>Continued in “{title}”</DialogTitle>
+          <DialogDescription>
+            {[reason, description].filter(Boolean).join(' ') || 'The handoff this session ended with.'}
+          </DialogDescription>
+        </DialogHeader>
+        {/* Plain flow, not a min-h-0 grid: the dialog body scrolls as a whole, and every section
+            keeps its own height instead of collapsing under the flex column. */}
+        <div className="flex shrink-0 flex-col gap-3">
+          <EventMetaSection
+            meta={item.meta}
+            times={
+              item.calledAt || item.completedAt ? {startedAt: item.calledAt, completedAt: item.completedAt} : undefined
+            }
+          />
+          <HandoffBody handoffMarkdown={handoffMarkdownFromArgs(args)} sources={sourceLinesFromArgs(args)} />
+          {transfer?.plan ? (
+            <div className="text-muted-foreground text-xs">
+              Checklist: {transfer.plan === 'carry' ? 'carried into the successor' : 'left here as history'}
+            </div>
+          ) : null}
+          <div className="space-y-1">
+            <div className="text-muted-foreground text-[10px] font-medium tracking-[0.18em] uppercase">Call</div>
+            <pre className="bg-muted max-h-64 overflow-auto rounded-xl p-3 text-[11px] whitespace-pre-wrap">
+              {formatToolDebugValue(args)}
+            </pre>
+          </div>
+          <div className="space-y-1">
+            <div className="text-muted-foreground text-[10px] font-medium tracking-[0.18em] uppercase">Result</div>
+            <pre className="bg-muted max-h-64 overflow-auto rounded-xl p-3 text-[11px] whitespace-pre-wrap">
+              {formatToolDebugValue(rawOutput)}
+            </pre>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
 
 /**
  * A failed turn, as the transcript shows it — with a way back when it is the last thing that

--- a/frontend/packages/ui/src/agents/message-rendering.tsx
+++ b/frontend/packages/ui/src/agents/message-rendering.tsx
@@ -25,6 +25,7 @@ import {
   type ToolRowSummary,
 } from './tool-summary'
 import {useOpenUrl} from './navigation'
+import {useOpenAgentSession} from './open-session-context'
 import {useFullAgentSessionEvent, useRun, useRunTree, useSessionAttachmentDataUrls, useSessionRuns} from './models'
 import {Notice} from '@shm/ui/notice'
 import {descendantsOf, isTerminalRun, RunTimerProgress, RunWorkHierarchy, useRunTreeView} from './run-work'
@@ -33,7 +34,7 @@ import {useRouteLink} from '@shm/shared/routing'
 import {hmId} from '@shm/shared/utils/entity-id-url'
 import {ParkedRunActions} from './run-parked-actions'
 import {useSelectedAccountId} from './account'
-import {useClickNavigate, useNavigate} from './navigation'
+import {useClickNavigate} from './navigation'
 import {getAgentsPlatform} from './platform'
 import type {HMBlockNode} from '@seed-hypermedia/client/hm-types'
 import {Button} from '@shm/ui/button'
@@ -379,13 +380,13 @@ function StatusUpdateRow({item}: {item: ChatToolPart}) {
 
 /** The `continue_session` row: where the conversation went, with a way there and every detail behind ⓘ. */
 function ContinuationTransitionRow({item, serverUrl}: {item: ChatToolPart; serverUrl?: string}) {
-  const navigate = useNavigate()
+  const openSession = useOpenAgentSession()
   const [detailsOpen, setDetailsOpen] = useState(false)
   return (
     <>
       <ContinuationTransitionCard
         item={item}
-        onOpenSuccessor={serverUrl ? (sessionId) => navigate({key: 'agent-session', sessionId, serverUrl}) : undefined}
+        onOpenSuccessor={(sessionId) => openSession({sessionId, serverUrl})}
         onInspect={() => setDetailsOpen(true)}
       />
       <ContinuationDetailsDialog item={item} open={detailsOpen} onOpenChange={setDetailsOpen} />
@@ -690,6 +691,7 @@ function useToolLinkOpener() {
   const {serverUrl, agentId} = React.useContext(ToolRowContext)
   const openUrl = useOpenUrl()
   const clickNavigate = useClickNavigate()
+  const openSession = useOpenAgentSession()
 
   return {
     /** False when the target needs context this row does not have — the label stays plain text. */
@@ -705,7 +707,7 @@ function useToolLinkOpener() {
         return
       }
       if (target.type === 'session') {
-        clickNavigate({key: 'agent-session', sessionId: target.sessionId, serverUrl}, event as never)
+        openSession({sessionId: target.sessionId, serverUrl, event})
         return
       }
       if (!agentId) return
@@ -879,7 +881,10 @@ function getRowToolMetadata(item: ChatToolPart): SeedToolMetadata | undefined {
   if (item.name !== 'call') return getSeedTool(item.name) ?? promotedDocumentToolMetadata(item.name)
   const called = getToolString(item.args, 'tool')
   const metadata = called ? getSeedTool(called) : undefined
-  if (!metadata) return getSeedTool(item.name)
+  // A callee outside the registry — an authored lambda, an MCP projection — still names the row:
+  // "Call" says what the verb did, not what was called. Its promoted metadata already reads the
+  // nested `input` and the executor's own summary, so nothing needs rebasing.
+  if (!metadata) return (called ? promotedDocumentToolMetadata(called) : undefined) ?? getSeedTool(item.name)
   const nest = (path?: string) => (path ? `input.${path}` : 'input')
   const {render} = metadata
   return {
@@ -2044,12 +2049,12 @@ function OpenRunLink({runId, serverUrl}: {runId: string; serverUrl: string}) {
 
 /** The way into a child's own transcript, honouring cmd/shift-click like every other session row. */
 function OpenTranscriptLink({sessionId, serverUrl}: {sessionId: string; serverUrl: string}) {
-  const clickNavigate = useClickNavigate()
+  const openSession = useOpenAgentSession()
   return (
     <button
       type="button"
       className="text-primary self-start text-[11px] hover:underline"
-      onClick={(event) => clickNavigate({key: 'agent-session', sessionId, serverUrl}, event)}
+      onClick={(event) => openSession({sessionId, serverUrl, event})}
     >
       Open transcript →
     </button>
@@ -2116,7 +2121,7 @@ function DelegateRunView({
   /** The run record when the caller already holds a live copy of it, so it is not fetched twice. */
   seed?: RunInfo
 }) {
-  const navigate = useNavigate()
+  const openSession = useOpenAgentSession()
   const direct = useRun(serverUrl, accountUid, seedRun ? undefined : runId)
   const seed = seedRun ?? direct.data ?? undefined
   // A finished run never changes again: no socket, no tree query, on a transcript full of them.
@@ -2140,7 +2145,7 @@ function DelegateRunView({
         journal={liveState.journal}
         liveState={liveState}
         compact
-        onOpenSession={(childSessionId) => navigate({key: 'agent-session', sessionId: childSessionId, serverUrl})}
+        onOpenSession={(childSessionId) => openSession({sessionId: childSessionId, serverUrl})}
         renderToolPart={(part) => (
           <ToolCallLine item={part} serverUrl={serverUrl} accountUid={accountUid} agentId={focus.agentId} />
         )}
@@ -2214,7 +2219,7 @@ export function ToolCallLine({
 }) {
   const [expanded, setExpanded] = useState(false)
   const [detailsOpen, setDetailsOpen] = useState(false)
-  const clickNavigate = useClickNavigate()
+  const openSession = useOpenAgentSession()
   const reportedSessionId = getToolSessionId(item)
   const metadata = getRowToolMetadata(item)
   const render = metadata?.render
@@ -2337,9 +2342,7 @@ export function ToolCallLine({
                     title={`Open ${summary}`}
                     // clickNavigate honours cmd/shift-click into a new window, like every other
                     // session row in the app.
-                    onOpen={(event) =>
-                      clickNavigate({key: 'agent-session', sessionId: childSessionId, serverUrl}, event)
-                    }
+                    onOpen={(event) => openSession({sessionId: childSessionId, serverUrl, event})}
                   />
                 ) : (
                   <span className="text-foreground/75 min-w-0 truncate">{summary}</span>

--- a/frontend/packages/ui/src/agents/models.ts
+++ b/frontend/packages/ui/src/agents/models.ts
@@ -114,10 +114,17 @@ function applyAgentToCaches(serverUrl: string, accountUid: string, agent: AgentI
  */
 function applySessionToCaches(serverUrl: string, accountUid: string, session: SessionInfo): void {
   const client = getQueryClient()
+  let modelChanged = false
   client.setQueriesData({queryKey: ['agents', 'session', serverUrl, accountUid, session.id]}, (old: any) => {
     if (!old || old._ !== 'GetSessionResponse') return old
+    // GetSessionResponse carries model-derived fields beside the session (contextWindow); a model
+    // override change makes them stale, and only a refetch recomputes them.
+    if (JSON.stringify(old.session?.modelOverride ?? null) !== JSON.stringify(session.modelOverride ?? null)) {
+      modelChanged = true
+    }
     return {...old, session}
   })
+  if (modelChanged) invalidateQueries(['agents', 'session', serverUrl, accountUid, session.id])
   client.setQueriesData({queryKey: ['agents', 'sessions', serverUrl, accountUid]}, (old: any) => {
     if (!Array.isArray(old)) return old
     if (!old.some((entry: AgentSessionListEntry) => entry.session.id === session.id)) {

--- a/frontend/packages/ui/src/agents/open-session-context.tsx
+++ b/frontend/packages/ui/src/agents/open-session-context.tsx
@@ -1,0 +1,45 @@
+import {createContext, useContext} from 'react'
+import {useNavigate} from './navigation'
+
+/**
+ * How the surface hosting a transcript opens another agent session.
+ *
+ * The main window navigates; the assistant panel swaps its own selected session instead —
+ * following a continuation, opening a delegate child, or stepping back to a predecessor from the
+ * panel must all stay in the panel. Components that open sessions read this through
+ * {@link useOpenAgentSession} and never navigate directly, so they behave correctly on both
+ * surfaces without threading a callback through every layer.
+ */
+export const OpenAgentSessionContext = createContext<((sessionId: string, agentId?: string) => void) | null>(null)
+
+/**
+ * Opens an agent session the way the hosting surface wants: the panel's override when inside the
+ * assistant panel, main-window navigation otherwise. Cmd/shift-click always spawns a full window,
+ * matching every other session row in the app; a given `event` is consumed either way.
+ */
+export function useOpenAgentSession() {
+  const override = useContext(OpenAgentSessionContext)
+  const navigate = useNavigate()
+  const spawn = useNavigate('spawn')
+  return (target: {
+    sessionId: string
+    serverUrl?: string
+    agentId?: string
+    event?: {metaKey?: boolean; shiftKey?: boolean; preventDefault?: () => void; stopPropagation?: () => void}
+  }) => {
+    target.event?.preventDefault?.()
+    target.event?.stopPropagation?.()
+    const route = {
+      key: 'agent-session' as const,
+      sessionId: target.sessionId,
+      ...(target.agentId ? {agentId: target.agentId} : {}),
+      serverUrl: target.serverUrl,
+    }
+    if (target.event?.metaKey || target.event?.shiftKey) {
+      if (target.serverUrl) spawn(route)
+      return
+    }
+    if (override) return override(target.sessionId, target.agentId)
+    if (target.serverUrl) navigate(route)
+  }
+}

--- a/frontend/packages/ui/src/agents/session.tsx
+++ b/frontend/packages/ui/src/agents/session.tsx
@@ -2,6 +2,13 @@ import {agentAccessCanChat, agentAccessCanWrite} from './access'
 import {type AgentRunActivity, type AgentSessionTriggerContext} from './client'
 import {AgentRunStatusBar, useRunStartedAt} from './agent-run-status'
 import {SessionSummaryBanner} from './session-children'
+import {
+  ContextUsageMeter,
+  ContinuationHandoffCard,
+  ContinuationHeader,
+  sessionContextTokens,
+  useFollowContinuation,
+} from './continuation'
 import {useChatAutoScroll} from './chat-autoscroll'
 import {describeAgentError} from './errors'
 import {AgentErrorRow, AssistantMessageParts, ChatMessageBubble} from './message-rendering'
@@ -252,6 +259,19 @@ function AgentSessionPage({
   const ownRun = useRun(serverUrl, selectedAccountId, parentSessionId ? session.data?.session.runId : undefined)
   const hasLiveRun = !!ownRun.data && !TERMINAL_RUN_STATUSES.has(ownRun.data.status)
   const isDrivenByParent = !!parentSessionId && (isAgentStreaming || hasLiveRun)
+  // Continuation: follow the turn into its successor when this client was watching it, and show
+  // how full the model's context is so a coming continuation is no surprise.
+  const sessionInfo = session.data?.session
+  const openSuccessor = useCallback(
+    (successorId: string) => navigate({key: 'agent-session', agentId, sessionId: successorId, serverUrl}),
+    [agentId, navigate, serverUrl],
+  )
+  const followContinuation = useFollowContinuation({
+    session: sessionInfo,
+    isStreaming: !!isAgentStreaming,
+    onFollow: useCallback((link) => openSuccessor(link.sessionId), [openSuccessor]),
+  })
+  const contextTokens = useMemo(() => sessionContextTokens(session.data?.events), [session.data?.events])
   const triggerActivityRoute = useMemo(
     () => (session.data?.triggerContext ? getTriggerActivityRoute(session.data.triggerContext) : null),
     [session.data?.triggerContext],
@@ -334,13 +354,22 @@ function AgentSessionPage({
         // The stamped drafts carry the clientMessageIds the optimistic rows were keyed with, so the
         // server's echo replaces those rows instead of rendering beside them.
         if (selectedAccountId) messages = addOptimisticSessionMessage(serverUrl, selectedAccountId, sessionId, messages)
+        followContinuation.markFollowing()
         const result = await messageSession.mutateAsync({sessionId, message: messages})
         if (result._ !== 'MessageSessionResponse') throw new Error('Unexpected message response')
+        if (result.continuedToSessionId) {
+          followContinuation.followNow({
+            continuationId: '',
+            sessionId: result.continuedToSessionId,
+            reason: 'other',
+            createdAt: Date.now(),
+          })
+        }
       } catch (error) {
         toast.error(error instanceof Error ? error.message : 'Could not send message')
       }
     },
-    [messageSession, selectedAccountId, serverUrl, sessionId],
+    [followContinuation, messageSession, selectedAccountId, serverUrl, sessionId],
   )
 
   async function handleSendMessage(message: AgentSessionDraftMessage) {
@@ -398,6 +427,7 @@ function AgentSessionPage({
           <>
             {deleteSessionDialog.content}
             {systemPromptDialog.content}
+            <ContextUsageMeter tokens={contextTokens} contextWindow={session.data?.contextWindow} className="mr-1" />
             <SessionModelBadge
               agent={agent.data?.agent}
               agentId={session.data?.session.agentId ?? agentId}
@@ -501,6 +531,12 @@ function AgentSessionPage({
                     serverUrl,
                   })
                 }
+              />
+            ) : null}
+            {sessionInfo?.continuedFrom ? (
+              <ContinuationHeader
+                link={sessionInfo.continuedFrom}
+                onOpenPredecessor={() => openSuccessor(sessionInfo.continuedFrom!.sessionId)}
               />
             ) : null}
             <SessionSummaryBanner description={session.data.session.description} />
@@ -744,6 +780,18 @@ const AgentSessionChatRow = React.memo(function AgentSessionChatRow({
         runId={row.run.id}
         plan={row.plan}
         onOpenSession={onOpenSession}
+      />
+    )
+  }
+
+  if (row.kind === 'continuation') {
+    // What this session started from: the handoff, readable and inspectable, in place of the raw
+    // projection text the model was given.
+    return (
+      <ContinuationHandoffCard
+        id="continuation-handoff"
+        projection={row.projection}
+        onOpenPredecessor={onOpenSession ? (predecessorId) => onOpenSession(predecessorId) : undefined}
       />
     )
   }


### PR DESCRIPTION
Implements Ion's [Session Continuation](https://hyper.media/hm/z6MkpVa5nMUR5ZaUEyV1SE48KTNbwTuHRd83RwLgMKc4nGU3/ion/system/session-continuation) proposal (Phase 1 + 2): no rolling-summary compaction. At a semantic boundary the agent calls `continue_session` and the conversation carries into a fresh successor session; the predecessor's transcript is untouched and the successor starts from an inspectable projection.

Full write-up: `agents/docs/session-continuation.md`.

## Backend (`agents/`)
- **`continue_session` verb** — `{reason, title, description, handoff, sources?, transfer?}`. Title and description are required and set by the predecessor (as the `status` verb would). Available only to a foreground conversation with a live run; refuses delegated children, parked children, and loops (no new user message since the last continuation). Idempotent on the tool call id.
- **`session_continuations`** table + migration; `SessionInfo.continuedFrom/continuedTo`; `GetSessionResponse.contextWindow`; `MessageSessionResponse.continuedToSessionId`.
- **Projection compiler** — lineage block → handoff → sources → cited `<excerpt>` ranges → `<recent_exchanges>`, within a byte budget; whatever doesn't fit is listed as omitted on the manifest (linked, not loaded). The initiating user message is replayed verbatim with `meta.continuedFrom`; attachments are hard-linked by identity.
- **Prompting** — system-prompt paragraph on what a continuation is; per-turn `<context_usage tokens window percent>` (escalates at 70/85%) and `<session_status>` blocks, rendered fresh like `<plan_state>` and never stored. `modelContextWindow()` heuristics replace the flat 128k window.
- **Status verb reworded** — title = what the whole session is about (a dramatic shift is a continuation, not a rename); description = live status, updated freely, description-only calls are the norm; a continued session keeps the name its predecessor gave it.
- **Recall** — `read thread:<id>` prints `[seq] who: text` lines, accepts `{fromSeq, toSeq, limit}`, reports lineage.

## UI
- **Context meter** (pie) in the session header and assistant sidebar — muted → amber (70%) → red (85%).
- **Transition row** in the predecessor and **handoff row** in the successor, both tool-row style: chevron expands the handoff, *Open session* on the right, hover ⓘ opens every detail (model/tokens/timing on the predecessor side; lineage, excerpts, and raw projection on the successor side). Reason shown as a parenthetical, hidden for `other`.
- **Status rows** now show the description in full, with the title in the header slot when set.
- **Guarded auto-navigation** into the successor only for a client that was following the turn; Back still works. Replayed message gets a "From previous session" chip; session lists show a "Continued in …" chip.

## Tests
- `agents/src/session-continuation.test.ts` — end-to-end through a mocked provider stream: continuation, loop guard, manifest, `<context_usage>`, verbatim replay, successor answer, `ListSessions`.
- `agents/protocol/src/model-capabilities.test.ts`, sqlite baseline migration test, desktop row tests (3 new).
- `bun check` clean; `@shm/ui`, desktop, and mobile typecheck. Full agents suite has the same 5 pre-existing/flaky failures as `main` (3 delegate tests fail identically on a clean checkout; 2 MCP tests pass in isolation).

## Not in this PR (Phase 3)
Pre-continuation budget estimates, recommended ranges, purpose-specific projections, recall-quality metrics; forks don't share the edge. Agent-initiated continuation needs no approval (visible, reversible transition) — easy to gate later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6uegXVmH8PdidCLM2uDYA
