### PR TITLE
perf(agents): worker-isolated run execution — design + workflow-VM proof of concept

### DIFF
--- a/agents/build.ts
+++ b/agents/build.ts
@@ -11,7 +11,7 @@ process.chdir(path.dirname(fileURLToPath(import.meta.url)))
 await rm(OUTDIR, {recursive: true, force: true})
 
 const result = await Bun.build({
-  entrypoints: ['./src/main.ts'],
+  entrypoints: ['./src/main.ts', './src/workflow-worker-entry.ts'],
   outdir: OUTDIR,
   target: 'bun',
   minify: process.env.NODE_ENV === 'production',

--- a/agents/docs/worker-isolated-execution.md
+++ b/agents/docs/worker-isolated-execution.md
@@ -1,0 +1,121 @@
+# Worker-isolated run execution
+
+## The problem
+
+The agents server runs everything on one JavaScript event loop: the HTTP API, the WebSocket broadcast fan-out, the
+background poll loops, **and** the execution of every agent run and workflow. Because that loop is a single thread, any
+CPU-bound stretch of run execution blocks the API and WebSocket for its whole duration.
+
+Production profiling (bun's JSC sampler, symbolized through the build's source map) showed that under real load the loop
+is **CPU-saturated** — ~95% userspace JS, one core pinned — with `/api/health` (a handler that does nothing but reply)
+stalling **6–23 seconds** while 2 agent runs + 1 workflow are active. The costs are spread across the run path: CBOR
+encode/decode of session events, `#piMessages` re-decoding the whole session each turn, per-session serialization, and
+the QuickJS workflow VM.
+
+Earlier PRs removed large _fixed_ costs — a missing index (ListSessions 80× cheaper), native Ed25519 verify (idle CPU
+~8× lower), and batched WebSocket broadcasts. Those made the server fast **at rest**. But they cannot fix saturation
+under concurrent runs: you cannot yield your way out of a pegged core on a single thread. The only structural fix is
+**real parallelism** — move run execution off the request-serving loop.
+
+## Why this is a project, not a patch
+
+`#executeAgentRun` + `#runPiAgent` are ~1,150 lines and reference **40+ distinct `Service` members** — `#db`, `#emit`,
+`#runQueue`, session/plan management, sub-session spawning, trigger firing, title generation, and more — inside a
+14,700-line `Service` class. Moving agent-run execution to another thread means either relocating most of that class or
+building a message proxy for those 40+ methods, and coordinating SQLite writes and the microsandbox native addon across
+threads. That is a staged migration, not a single change.
+
+Two facts make it tractable:
+
+1. **Code execution is already out-of-process.** `execute` runs in microsandbox microVMs (separate `msb` processes); the
+   JS loop only orchestrates them with async I/O. So the thing to isolate is the _JS orchestration and
+   CBOR/serialization_, not the sandboxes.
+2. **The runtime already has a narrow effect boundary in one place — workflows.** The QuickJS workflow VM is a pure,
+   synchronous compute realm whose only host interaction is a small, serializable `WorkflowAdapters` contract. That is
+   the ideal first candidate.
+
+## Target architecture
+
+```
+                    ┌────────────────────────── main thread ──────────────────────────┐
+   HTTP / WS ─────► │  API handlers · WebSocket broadcast · RunQueue · SQLite writes    │
+                    │                         ▲            │                            │
+                    │                effect results   effect requests                   │
+                    └─────────────────────────┼────────────┼────────────────────────────┘
+                                              │            ▼
+                    ┌──────────────── run worker(s) ────────┼────────────────────────────┐
+                    │  CPU-bound execution: pi agent loop / QuickJS VM, CBOR, serialize   │
+                    │  no DB writes, no WS — every side effect crosses back as a message  │
+                    └────────────────────────────────────────────────────────────────────┘
+```
+
+- **Main thread** keeps ownership of everything shared and I/O-ish: the RunQueue and its leases, all SQLite writes,
+  WebSocket broadcast, trigger firing. It stays responsive because it does no CPU-bound run work.
+- **Run workers** do the CPU-bound execution and hold _no_ shared state. Every side effect (append an event, spawn a
+  child, execute a tool, update a plan) is a message to main, which performs it and replies. This is the same "compute
+  in the worker, effects on the owner" shape the workflow engine already uses internally.
+
+### Effect bridge
+
+The worker never touches the DB or the socket. It sends typed effect requests and awaits typed results:
+
+```
+worker → main   { id, op: 'callTool',  args }         main → worker  { id, ok, result }
+worker → main   { id, op: 'spawnAgent', args }         main → worker  { id, ok, result }
+worker → main   { id, op: 'appendEvent', args }        main → worker  { id, ok }
+...
+```
+
+Ordering is per-run FIFO. Effects that must be durable before the run is considered advanced (event appends, journal
+entries) are acked; the worker flushes all pending acks before it reports a terminal outcome.
+
+### Cancellation
+
+Run cancellation and the QuickJS fuel/interrupt check are **synchronous** and hot, so they cannot be a round-trip. A
+one-byte `SharedArrayBuffer` per run carries the cancel flag: main sets it, the worker's interrupt handler reads it
+inline. No message latency, no polling.
+
+### SQLite
+
+SQLite stays **single-writer on main**. Workers issue no writes directly; their effects become main-thread writes.
+Read-only queries a worker genuinely needs (rare) can use a separate read-only WAL connection, but the default is "all
+DB access is an effect." This sidesteps multi-writer coordination entirely.
+
+### microsandbox
+
+Unchanged. `execute` remains a `callTool` effect; main drives the microVM exactly as it does today. The addon is never
+loaded in a worker.
+
+## Phased migration
+
+| Phase                 | Scope                                                                                                                                                                                                  | Risk                                                            | Ships behind                    |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- | ------------------------------- |
+| **1 (this PR's POC)** | Workflow QuickJS VM in a worker via proxy-adapters                                                                                                                                                     | Low — clean existing boundary, default-off flag, workflows only | `SEED_AGENTS_WORKFLOW_WORKER=1` |
+| 2                     | Harden phase 1: worker pool/reuse, backpressure, crash recovery, metrics; enable by default                                                                                                            | Low–med                                                         | flag flips default-on           |
+| 3                     | Extract the agent-run _effect surface_ — enumerate the 40+ `Service` touches, group them into a stable effect contract (append event, spawn, resolve child, plan ops, status, title, trigger-complete) | Med — API-shape-preserving refactor, no behavior change         | internal                        |
+| 4                     | Run agent runs in workers over that contract, one worker per run, capped by the existing concurrency limits                                                                                            | High — the payoff and the hard part                             | `SEED_AGENTS_RUN_WORKER=1`      |
+| 5                     | Worker pool sizing, lifecycle, observability; enable by default; delete the in-process path                                                                                                            | Med                                                             | default-on                      |
+
+Each phase is independently shippable, flag-guarded, and validated in production before the next. No phase changes the
+wire API — message shapes and durable formats are unchanged throughout, so any client, and a rollback to the in-process
+path, keep working.
+
+## Phase 1 proof of concept (in this PR)
+
+The workflow VM is isolated first because `runWorkflowVM(adapters)` is _already_ parameterized by its entire host
+interaction. The POC runs that exact function, unchanged, inside a worker, supplying a **proxy `WorkflowAdapters`**
+whose every method posts a message to main and (for the async ones) awaits the reply. Main supplies the **real**
+adapters it already builds in `#executeWorkflowRun`. The journal stays on main; the worker gets the loaded entries at
+start and streams appends back. Cancellation uses a `SharedArrayBuffer`.
+
+Guarantees:
+
+- **Default off.** Without `SEED_AGENTS_WORKFLOW_WORKER=1`, execution is byte-for-byte the current in-process path. The
+  worker path is opt-in and reversible per-deploy.
+- **Identical semantics.** Same `runWorkflowVM`, same journal, same determinism/replay, same outcomes. The worker path
+  is a transport, not a rewrite.
+- **Measurable win.** With it on, a workflow's QuickJS compute no longer blocks the main loop; `/api/health` stays
+  responsive while a workflow burns CPU in its worker.
+
+This proves the effect-bridge + SharedArrayBuffer-cancel pattern end to end on the safest possible surface, so phases
+3–4 (agent runs) build on a demonstrated foundation.

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -47,9 +47,11 @@ import {
   normalizeRunPlan,
   runWorkflowVM,
   WORKFLOW_SOURCE_MAX_BYTES,
+  type WorkflowAdapters,
   type WorkflowChildResolution,
   type WorkflowJournalEntry,
 } from '@/workflow-host'
+import {runWorkflowInWorker} from '@/workflow-worker-host'
 import {executeWebRead, executeWebSearch, type WebToolsConfig} from '@/web-tools'
 import * as blobs from '@shm/shared/blobs'
 import {
@@ -5977,7 +5979,7 @@ export class Service {
 
     let outcome: Awaited<ReturnType<typeof runWorkflowVM>>
     try {
-      outcome = await runWorkflowVM({
+      const workflowAdapters: WorkflowAdapters = {
         runId: run.id,
         input: (run.input as {input?: unknown} | null)?.input ?? null,
         source: run.sourceText,
@@ -6098,7 +6100,14 @@ export class Service {
             }),
         },
         isCanceled: () => this.#workflowCancelFlags.has(run.id),
-      })
+      }
+      // Phase-1 worker isolation (docs/worker-isolated-execution.md): opt in with
+      // SEED_AGENTS_WORKFLOW_WORKER=1 to run the QuickJS VM off the main event loop. Off by default,
+      // the in-process path is byte-for-byte unchanged.
+      outcome =
+        process.env.SEED_AGENTS_WORKFLOW_WORKER === '1'
+          ? await runWorkflowInWorker(workflowAdapters, {emitPartial: (patch) => emitRunPartial(patch as never)})
+          : await runWorkflowVM(workflowAdapters)
     } finally {
       // Whatever MCP connections the script's calls opened close with the run.
       await mcpPool.close()

--- a/agents/src/workflow-worker-entry.ts
+++ b/agents/src/workflow-worker-entry.ts
@@ -1,0 +1,104 @@
+/**
+ * Worker entry for the workflow-in-worker proof of concept (see workflow-worker-host.ts and
+ * docs/worker-isolated-execution.md). Runs the unmodified {@link runWorkflowVM} with a proxy
+ * WorkflowAdapters that marshals every effect back to the main thread.
+ */
+import {runWorkflowVM, type WorkflowAdapters, type WorkflowJournalEntry} from './workflow-host'
+import {WORKFLOW_WORKER_CTRL} from './workflow-worker-host'
+
+type ErrShape = {message?: string; code?: string; detail?: unknown}
+function reviveError(e: ErrShape | undefined): Error {
+  const err = new Error(e?.message ?? 'error') as Error & {code?: string; detail?: unknown}
+  if (e?.code) err.code = e.code
+  if (e?.detail !== undefined) err.detail = e.detail
+  return err
+}
+
+const scope = self as unknown as {
+  postMessage: (m: unknown) => void
+  addEventListener: (t: 'message', cb: (ev: {data: unknown}) => void) => void
+}
+
+let msgId = 0
+const pending = new Map<number, {resolve: (v: unknown) => void; reject: (e: unknown) => void}>()
+
+scope.addEventListener('message', (ev) => {
+  const msg = ev.data as {t: string; [k: string]: unknown}
+  if (msg.t === 'init') {
+    void runInit(msg as unknown as InitMessage)
+    return
+  }
+  if (msg.t === 'call-done') {
+    const m = msg as unknown as {id: number; ok: boolean; result?: unknown; error?: ErrShape}
+    const p = pending.get(m.id)
+    if (!p) return
+    pending.delete(m.id)
+    m.ok ? p.resolve(m.result) : p.reject(reviveError(m.error))
+  }
+})
+
+type InitMessage = {
+  t: 'init'
+  sab: SharedArrayBuffer
+  runId: string
+  input: unknown
+  source: string
+  journal: WorkflowJournalEntry[]
+  config: {timerParkThresholdMs?: number; fuelMs?: number; memoryBytes?: number}
+}
+
+async function runInit(init: InitMessage): Promise<void> {
+  const ctrl = new Int32Array(init.sab)
+  const data = new Uint8Array(init.sab, WORKFLOW_WORKER_CTRL.CTRL_DATA_OFFSET)
+  const post = (m: unknown) => scope.postMessage(m)
+
+  const callAsync = (op: 'callTool' | 'awaitChild', args: unknown[]): Promise<unknown> =>
+    new Promise((resolve, reject) => {
+      const id = ++msgId
+      pending.set(id, {resolve, reject})
+      post({t: 'call', id, op, args})
+    })
+
+  // Synchronous round-trip: post the request, block on the generation counter, read the JSON reply.
+  const syncSpawn = (args: unknown[]): {childRunId: string; sessionId?: string} => {
+    const gen = Atomics.load(ctrl, WORKFLOW_WORKER_CTRL.CTRL_SYNC_GEN)
+    post({t: 'sync', op: 'spawnAgent', args})
+    Atomics.wait(ctrl, WORKFLOW_WORKER_CTRL.CTRL_SYNC_GEN, gen)
+    const len = Atomics.load(ctrl, WORKFLOW_WORKER_CTRL.CTRL_SYNC_LEN)
+    const ok = Atomics.load(ctrl, WORKFLOW_WORKER_CTRL.CTRL_SYNC_OK)
+    const parsed = JSON.parse(new TextDecoder().decode(data.subarray(0, len)))
+    if (!ok) throw reviveError(parsed as ErrShape)
+    return parsed as {childRunId: string; sessionId?: string}
+  }
+
+  const proxy: WorkflowAdapters = {
+    runId: init.runId,
+    input: init.input,
+    source: init.source,
+    journal: {
+      load: () => init.journal,
+      // Cap enforcement stays on main (its append throws journal-cap, which rejects the run there).
+      append: (entry) => post({t: 'journal', entry}),
+    },
+    effects: {
+      callTool: (tool, input, description) => callAsync('callTool', [tool, input, description]),
+      awaitChild: (childRunId) => callAsync('awaitChild', [childRunId]) as Promise<never>,
+      spawnAgent: (spec, stepLabel) => syncSpawn([spec, stepLabel]),
+      updatePlan: (plan) => post({t: 'void', op: 'updatePlan', args: [plan]}),
+      progress: (patch) => post({t: 'void', op: 'progress', args: [patch]}),
+      registerEventWait: (wait) => post({t: 'void', op: 'registerEventWait', args: [wait]}),
+    },
+    isCanceled: () => Atomics.load(ctrl, WORKFLOW_WORKER_CTRL.CTRL_CANCEL) === 1,
+    timerParkThresholdMs: init.config.timerParkThresholdMs,
+    fuelMs: init.config.fuelMs,
+    memoryBytes: init.config.memoryBytes,
+  }
+
+  try {
+    const outcome = await runWorkflowVM(proxy)
+    post({t: 'outcome', outcome})
+  } catch (error) {
+    const e = error as {message?: string; stack?: string}
+    post({t: 'fail', error: {message: e?.message ?? String(error), stack: e?.stack}})
+  }
+}

--- a/agents/src/workflow-worker-host.ts
+++ b/agents/src/workflow-worker-host.ts
@@ -1,0 +1,189 @@
+/**
+ * Phase-1 proof of concept for worker-isolated run execution (see docs/worker-isolated-execution.md).
+ *
+ * Runs the QuickJS workflow VM in a dedicated Worker thread so its CPU-bound compute no longer
+ * blocks the main event loop (the HTTP API and WebSocket broadcast). The worker executes the exact
+ * same {@link runWorkflowVM} with a *proxy* WorkflowAdapters whose every effect is marshalled back
+ * here; this side supplies the real adapters the service already builds. Nothing about the workflow
+ * contract, journal format, or determinism changes — this is a transport, not a rewrite.
+ *
+ * The bridge:
+ *  - async effects (callTool, awaitChild) → request/reply messages, awaited in the worker.
+ *  - void effects (updatePlan, progress, registerEventWait) and journal appends → ordered fire-and-
+ *    forget messages; message order guarantees they land before the terminal outcome message.
+ *  - the one *synchronous-returning* effect (spawnAgent) → a synchronous round-trip via
+ *    Atomics.wait on a SharedArrayBuffer, so the worker's pump gets its {childRunId} inline and the
+ *    existing #spawnWorkflowChildAgent (which can throw) is reused unchanged.
+ *  - isCanceled() and the fuel interrupt → a cancel byte in the SharedArrayBuffer, read inline.
+ *
+ * Gated by SEED_AGENTS_WORKFLOW_WORKER=1; off, the caller uses the in-process path unchanged.
+ */
+import {existsSync} from 'node:fs'
+import {fileURLToPath} from 'node:url'
+import type {WorkflowAdapters, WorkflowVMOutcome} from './workflow-host'
+
+/**
+ * Resolves the worker entry beside this module: `workflow-worker-entry.js` in the bundled build
+ * (Bun.build emits it as a sibling of main.js), `.ts` from source in dev and tests.
+ */
+function workerEntryUrl(): URL {
+  for (const ext of ['js', 'ts'] as const) {
+    const url = new URL(`./workflow-worker-entry.${ext}`, import.meta.url)
+    try {
+      if (existsSync(fileURLToPath(url))) return url
+    } catch {
+      /* fall through */
+    }
+  }
+  return new URL('./workflow-worker-entry.ts', import.meta.url)
+}
+
+/** Control SharedArrayBuffer layout (Int32 header + a data region for the sync-effect reply). */
+const CTRL_CANCEL = 0 // 1 once the run is canceled; read by the worker's isCanceled/interrupt
+const CTRL_SYNC_GEN = 1 // bumped by main to wake the worker's Atomics.wait after a sync effect
+const CTRL_SYNC_LEN = 2 // byte length of the JSON reply in the data region
+const CTRL_SYNC_OK = 3 // 1 = result, 0 = thrown error (encoded as {message, code})
+const CTRL_HEADER_INT32S = 4
+const CTRL_DATA_OFFSET = CTRL_HEADER_INT32S * 4
+const CTRL_SAB_BYTES = 64 * 1024
+
+type WorkerToHost =
+  | {t: 'call'; id: number; op: 'callTool' | 'awaitChild'; args: unknown[]}
+  | {t: 'void'; op: 'updatePlan' | 'progress' | 'registerEventWait'; args: unknown[]}
+  | {t: 'sync'; op: 'spawnAgent'; args: unknown[]}
+  | {t: 'journal'; entry: unknown}
+  | {t: 'partial'; patch: unknown}
+  | {t: 'outcome'; outcome: WorkflowVMOutcome}
+  | {t: 'fail'; error: {message: string; stack?: string}}
+
+/** Spawns the worker, wires the effect bridge to `adapters`, and resolves with the VM outcome. */
+export function runWorkflowInWorker(
+  adapters: WorkflowAdapters,
+  opts: {onCancelCheck?: () => boolean; emitPartial?: (patch: unknown) => void} = {},
+): Promise<WorkflowVMOutcome> {
+  const sab = new SharedArrayBuffer(CTRL_SAB_BYTES)
+  const ctrl = new Int32Array(sab)
+  const data = new Uint8Array(sab, CTRL_DATA_OFFSET)
+
+  const worker = new Worker(workerEntryUrl(), {type: 'module'})
+
+  // Reflect cancellation into the SharedArrayBuffer so the worker's synchronous interrupt sees it.
+  const cancelPoll = setInterval(() => {
+    if ((opts.onCancelCheck ?? adapters.isCanceled)()) Atomics.store(ctrl, CTRL_CANCEL, 1)
+  }, 50)
+  ;(cancelPoll as {unref?: () => void}).unref?.()
+
+  const replySync = (ok: boolean, value: unknown): void => {
+    const json = JSON.stringify(value ?? null)
+    const bytes = new TextEncoder().encode(json)
+    data.set(bytes.subarray(0, data.length))
+    Atomics.store(ctrl, CTRL_SYNC_LEN, Math.min(bytes.length, data.length))
+    Atomics.store(ctrl, CTRL_SYNC_OK, ok ? 1 : 0)
+    Atomics.add(ctrl, CTRL_SYNC_GEN, 1)
+    Atomics.notify(ctrl, CTRL_SYNC_GEN)
+  }
+
+  return new Promise<WorkflowVMOutcome>((resolve, reject) => {
+    let settled = false
+    const finish = (fn: () => void): void => {
+      if (settled) return
+      settled = true
+      clearInterval(cancelPoll)
+      worker.terminate()
+      fn()
+    }
+
+    worker.addEventListener('message', (ev: MessageEvent) => {
+      const msg = ev.data as WorkerToHost
+      switch (msg.t) {
+        case 'call': {
+          const fn = adapters.effects[msg.op] as (...a: unknown[]) => Promise<unknown>
+          Promise.resolve()
+            .then(() => fn(...msg.args))
+            .then(
+              (result) => worker.postMessage({t: 'call-done', id: msg.id, ok: true, result}),
+              (error) =>
+                worker.postMessage({
+                  t: 'call-done',
+                  id: msg.id,
+                  ok: false,
+                  error: serializeError(error),
+                }),
+            )
+          return
+        }
+        case 'void': {
+          try {
+            ;(adapters.effects[msg.op] as (...a: unknown[]) => void)(...msg.args)
+          } catch {
+            /* progress/plan updates are best-effort */
+          }
+          return
+        }
+        case 'sync': {
+          // Synchronous round-trip: run the effect and hand the reply back through the SAB.
+          try {
+            const result = (adapters.effects.spawnAgent as (...a: unknown[]) => unknown)(...msg.args)
+            replySync(true, result)
+          } catch (error) {
+            replySync(false, serializeError(error))
+          }
+          return
+        }
+        case 'journal': {
+          try {
+            adapters.journal.append(msg.entry as never)
+          } catch (error) {
+            // A journal-cap throw is enforced worker-side too; surface anything unexpected.
+            finish(() => reject(error))
+          }
+          return
+        }
+        case 'partial':
+          opts.emitPartial?.(msg.patch)
+          return
+        case 'outcome':
+          finish(() => resolve(msg.outcome))
+          return
+        case 'fail':
+          finish(() => reject(Object.assign(new Error(msg.error.message), {stack: msg.error.stack})))
+          return
+      }
+    })
+    worker.addEventListener('error', (ev: ErrorEvent) => finish(() => reject(ev.error ?? new Error(ev.message))))
+
+    worker.postMessage({
+      t: 'init',
+      sab,
+      runId: adapters.runId,
+      input: adapters.input,
+      source: adapters.source,
+      journal: adapters.journal.load(),
+      config: {
+        timerParkThresholdMs: adapters.timerParkThresholdMs,
+        fuelMs: adapters.fuelMs,
+        memoryBytes: adapters.memoryBytes,
+      },
+    })
+  })
+}
+
+function serializeError(error: unknown): {message: string; code?: string; detail?: unknown} {
+  if (error && typeof error === 'object') {
+    const e = error as {message?: unknown; code?: unknown; detail?: unknown}
+    return {
+      message: typeof e.message === 'string' ? e.message : String(error),
+      ...(typeof e.code === 'string' ? {code: e.code} : {}),
+      ...(e.detail !== undefined ? {detail: e.detail} : {}),
+    }
+  }
+  return {message: String(error)}
+}
+
+export const WORKFLOW_WORKER_CTRL = {
+  CTRL_CANCEL,
+  CTRL_SYNC_GEN,
+  CTRL_SYNC_LEN,
+  CTRL_SYNC_OK,
+  CTRL_DATA_OFFSET,
+}

--- a/agents/src/workflow-worker.test.ts
+++ b/agents/src/workflow-worker.test.ts
@@ -1,0 +1,153 @@
+import {describe, expect, test} from 'bun:test'
+import {runWorkflowVM, type WorkflowAdapters, type WorkflowJournalEntry} from '@/workflow-host'
+import {runWorkflowInWorker} from '@/workflow-worker-host'
+
+/** Minimal real adapters backed by in-test arrays; effects run on THIS (main) thread. */
+function adaptersFor(opts: {
+  source: string
+  input?: unknown
+  journal?: WorkflowJournalEntry[]
+  callTool?: WorkflowAdapters['effects']['callTool']
+  spawnAgent?: WorkflowAdapters['effects']['spawnAgent']
+  awaitChild?: WorkflowAdapters['effects']['awaitChild']
+}) {
+  const journal = opts.journal ?? []
+  const plans: unknown[] = []
+  const progress: unknown[] = []
+  const adapters: WorkflowAdapters = {
+    runId: 'wf-worker-test',
+    input: opts.input ?? null,
+    source: opts.source,
+    journal: {load: () => [...journal], append: (e) => void journal.push(e)},
+    effects: {
+      callTool: opts.callTool ?? (async () => ({ok: true})),
+      spawnAgent: opts.spawnAgent ?? (() => ({childRunId: 'child-1', sessionId: 'sess-1'})),
+      awaitChild: opts.awaitChild ?? (async () => ({status: 'succeeded', output: {text: 'done'}})),
+      updatePlan: (p) => void plans.push(p),
+      progress: (p) => void progress.push(p),
+      registerEventWait: () => {},
+    },
+    isCanceled: () => false,
+    fuelMs: 5_000,
+  }
+  return {adapters, journal, plans, progress}
+}
+
+describe('workflow-in-worker POC', () => {
+  test('pure workflow: worker output matches in-process', async () => {
+    const source = `export default async function (input, ctx) { return {sum: input.a + input.b, tag: 'ok'} }`
+    const inProcess = await runWorkflowVM(adaptersFor({source, input: {a: 2, b: 3}}).adapters)
+    const inWorker = await runWorkflowInWorker(adaptersFor({source, input: {a: 2, b: 3}}).adapters)
+    expect(inWorker).toEqual(inProcess)
+    expect(inWorker).toMatchObject({type: 'succeeded', output: {sum: 5, tag: 'ok'}})
+  })
+
+  test('tool call bridges to main and returns its result', async () => {
+    const calls: Array<{tool: string; input: unknown}> = []
+    const {adapters, journal} = adaptersFor({
+      source: `export default async function (input, ctx) { const r = await ctx.call('search', {q: 'hi'}); return {got: r} }`,
+      callTool: async (tool, input) => {
+        calls.push({tool, input})
+        return {hits: 3}
+      },
+    })
+    const outcome = await runWorkflowInWorker(adapters)
+    expect(outcome).toMatchObject({type: 'succeeded', output: {got: {hits: 3}}})
+    expect(calls).toEqual([{tool: 'search', input: {q: 'hi'}}])
+    // the call was journaled on main
+    expect(journal.some((e) => e.kind === 'result')).toBe(true)
+  })
+
+  test('spawnAgent (synchronous effect) round-trips via SharedArrayBuffer', async () => {
+    const spawned: unknown[] = []
+    const {adapters} = adaptersFor({
+      source: `export default async function (input, ctx) { const c = await ctx.agent({input: 'go'}); return {child: c} }`,
+      spawnAgent: (spec) => {
+        spawned.push(spec)
+        return {childRunId: 'child-xyz', sessionId: 'sess-xyz'}
+      },
+      awaitChild: async () => ({status: 'succeeded', output: {text: 'child done'}}),
+    })
+    const outcome = await runWorkflowInWorker(adapters)
+    expect(outcome).toMatchObject({type: 'succeeded'})
+    expect(spawned).toHaveLength(1)
+  })
+
+  test('a CPU-heavy workflow in the worker does NOT block the main event loop', async () => {
+    // Main-thread heartbeat: count how many 10ms ticks fire while the worker computes. If the worker
+    // blocked main, almost none would fire; if main stays free, they fire throughout. Counting ticks
+    // is robust to GC/scheduler jitter in a way a max-gap threshold is not.
+    let ticks = 0
+    const beat = setInterval(() => ticks++, 10)
+    try {
+      // Pure-arithmetic busy loop inside the VM (workflows have no Date/Math.random ambient authority).
+      const source = `export default async function (input, ctx) {
+        let x = 0; for (let i = 0; i < 3000000; i++) { x = (x + i) % 1000003 }
+        return {done: true, x}
+      }`
+      const startedAt = performance.now()
+      const outcome = await runWorkflowInWorker(adaptersFor({source}).adapters)
+      const elapsedMs = performance.now() - startedAt
+      expect(outcome).toMatchObject({type: 'succeeded', output: {done: true}})
+      // The compute was genuinely slow in QuickJS (proves the worker did real work off-thread)...
+      expect(elapsedMs).toBeGreaterThan(50)
+      // ...yet main kept ticking: if the worker had blocked the main thread, the timer would not
+      // have fired at all during the compute. A handful of ticks proves it stayed free. (A tighter
+      // bound would be flaky when this runs alongside the rest of the suite on a shared thread.)
+      expect(ticks).toBeGreaterThan(3)
+    } finally {
+      clearInterval(beat)
+    }
+  })
+
+  test('cancellation reaches the worker through the SharedArrayBuffer', async () => {
+    // A long compute; cancel it shortly after start. The cancel flag must interrupt the VM.
+    const source = `export default async function (input, ctx) {
+      let x = 0; for (let i = 0; i < 2000000000; i++) { x = (x + i) % 1000003 }
+      return {done: true}
+    }`
+    const {adapters} = adaptersFor({source})
+    let canceled = false
+    const withCancel: WorkflowAdapters = {...adapters, isCanceled: () => canceled}
+    setTimeout(() => {
+      canceled = true
+    }, 200)
+    const outcome = await runWorkflowInWorker(withCancel)
+    expect(outcome.type).toBe('canceled')
+  })
+
+  test('a throwing workflow surfaces as failed, not a crash', async () => {
+    const source = `export default async function (input, ctx) { throw new Error('boom') }`
+    const outcome = await runWorkflowInWorker(adaptersFor({source}).adapters)
+    expect(outcome.type).toBe('failed')
+    if (outcome.type === 'failed') expect(outcome.error.message).toContain('boom')
+  })
+
+  test('journal replay: a completed call is served from the journal, not re-executed', async () => {
+    let toolCalls = 0
+    // Run once to capture the journal the first execution wrote.
+    const first = adaptersFor({
+      source: `export default async function (input, ctx) { const r = await ctx.call('search', {q: 'x'}); return {r} }`,
+      callTool: async () => {
+        toolCalls++
+        return {hit: 1}
+      },
+    })
+    const out1 = await runWorkflowInWorker(first.adapters)
+    expect(out1).toMatchObject({type: 'succeeded', output: {r: {hit: 1}}})
+    expect(toolCalls).toBe(1)
+
+    // Replay from that journal: the tool must NOT be called again (deterministic replay).
+    const replay = adaptersFor({
+      source: `export default async function (input, ctx) { const r = await ctx.call('search', {q: 'x'}); return {r} }`,
+      journal: first.journal,
+      callTool: async () => {
+        toolCalls++
+        return {hit: 999}
+      },
+    })
+    const out2 = await runWorkflowInWorker(replay.adapters)
+    expect(out2).toMatchObject({type: 'succeeded', output: {r: {hit: 1}}}) // journaled value, not 999
+    expect(toolCalls).toBe(1) // no second call
+  })
+})


### PR DESCRIPTION
> **Stacked on #1032** (shares `api-service.ts`). The first commit here is the worker-isolation work; the three below it are #1032. Review after #1032, or review the top commit + `docs/` in isolation.

## Why

The agents server runs the HTTP API, WebSocket broadcast, and **every agent run and workflow on one event loop**. Production profiling showed that under a couple of concurrent runs the loop is **CPU-saturated** (95% userspace JS, one core pinned) and `/api/health` — a handler that does nothing but reply — stalls **6–23 seconds**. Earlier PRs removed large *fixed* costs (native verify, the session index, broadcast batching) and made the server fast at rest, but you cannot yield your way out of a saturated core on a single thread. The structural fix is **real parallelism**: move run execution off the request-serving loop.

## What's here

**1. Full design** — `agents/docs/worker-isolated-execution.md`. Main thread keeps the RunQueue, all SQLite writes, and WebSocket broadcast; run workers do CPU-bound execution and hold no shared state, sending every side effect back as a message. A four-phase migration (workflow VM → hardened → agent-run effect surface → agent runs in workers), each phase independently shippable, flag-guarded, and wire-compatible.

**2. Phase-1 proof of concept** — the **QuickJS workflow VM runs in a Worker**. It executes the *exact same* `runWorkflowVM` with a proxy `WorkflowAdapters` that marshals every effect back to main, which supplies the real adapters `#executeWorkflowRun` already builds. Journal, determinism, and outcomes are unchanged — this is a transport, not a rewrite.

- async effects (`callTool`, `awaitChild`) → request/reply messages
- void effects + journal appends → ordered fire-and-forget (message order guarantees they land before the terminal outcome)
- the one synchronous-returning effect (`spawnAgent`) → `Atomics.wait` round-trip on a SharedArrayBuffer, so `#spawnWorkflowChildAgent` (which can throw) is reused unchanged
- cancellation + the fuel interrupt → a cancel byte in the same buffer, read inline

**Gated by `SEED_AGENTS_WORKFLOW_WORKER=1`; off by default the in-process path is byte-for-byte unchanged.**

## Testing (thorough — automated + manual)

- **Unit** (`workflow-worker.test.ts`, 7 tests): worker output equals in-process · tool-call bridge · `spawnAgent` synchronous round-trip · a CPU-heavy workflow does **not** block the main loop · cancellation reaches the worker · a throwing workflow surfaces as `failed` · journal replay serves a completed call without re-executing it.
- **Integration**: the full workflow suite passes with `SEED_AGENTS_WORKFLOW_WORKER=1` — real `Service`, real DB journal, real sub-agent spawns, durable waits, model delegation, all through the worker.
- **Deployment (manual)**: `Bun.build` emits `dist/workflow-worker-entry.js` (the Dockerfile already copies all of `dist/`); the runtime resolves `.js` in the bundle and `.ts` in dev. Verified the **built chunk spawns and runs a workflow inside the production container image**.
- **Default (flag off) full suite: 456 pass / 0 fail.**

## Not in this PR

Phases 3–4 (agent runs in workers over an extracted effect contract) — the bigger payoff — build on this demonstrated pattern. See the design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fkiUq95srysiati9AsjzU