### PR TITLE
fix(desktop,ui): preserve document title when a draft exists

### DIFF
--- a/frontend/apps/desktop/src/models/documents.ts
+++ b/frontend/apps/desktop/src/models/documents.ts
@@ -351,7 +351,9 @@ export function usePublishResource(
 
           const allChanges = [
             ...navigationChanges,
-            ...getDocAttributeChanges(expandObjectRemovals(draft.metadata, editDocument?.metadata)),
+            ...getDocAttributeChanges(
+              expandObjectRemovals({...editDocument?.metadata, ...draft.metadata}, editDocument?.metadata),
+            ),
             ...changes.changes,
             ...deleteChanges,
           ]

--- a/frontend/packages/ui/src/site-file-browser.tsx
+++ b/frontend/packages/ui/src/site-file-browser.tsx
@@ -1,5 +1,5 @@
 import type {HMDocumentInfo, HMListedDraft, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
-import {getMetadataName, hmId} from '@shm/shared'
+import {hmId} from '@shm/shared'
 import {isDraftPlaceholderPath, type HMListedDraftWithLocation} from '@shm/shared/draft-breadcrumb-context'
 import {useDirectoryWithDrafts} from '@shm/shared/models/entity'
 import {
@@ -31,7 +31,7 @@ export interface SiteFileBrowserProps {
 }
 
 function titleOf(doc: HMDocumentInfo) {
-  return getMetadataName(doc.metadata) || doc.path?.at(-1) || 'Untitled'
+  return doc.metadata?.name || doc.path?.at(-1) || 'Untitled Document'
 }
 
 /** Renders the searchable, expandable document hierarchy for a site. */


### PR DESCRIPTION
## Summary

When editing an existing document, the draft is created with an empty `metadata: {}` overlay. Publishing then compares that partial overlay against the published document's metadata and emits a `setAttribute(['name'], nullValue)` for every published key the draft lacks — including `name` — so untouched titles are silently deleted.

This PR fixes the publish path to compute attribute changes from the *effective* metadata (`{...publishedMetadata, ...draftMetadata}`), so missing keys in the draft overlay are treated as unchanged rather than deleted.

It also fixes `titleOf` in `site-file-browser.tsx`: `getMetadataName` always returns the truthy string `"Untitled Document"`, making the `|| doc.path?.at(-1)` fallback unreachable. The file browser already merges draft metadata over published metadata on `main`, so this restores the path-slug fallback for documents without a title.

## Changes

- `frontend/apps/desktop/src/models/documents.ts`: pass effective metadata to `getDocAttributeChanges`.
- `frontend/packages/ui/src/site-file-browser.tsx`: use `doc.metadata?.name` directly so the path fallback works.

## Related

- Upstream issue: seed-hypermedia/seed#1035

Link to Devin session: https://app.devin.ai/sessions/997f7a81c905476795923045405e7ebb
Open in Devin Desktop: https://app.devin.ai/desktop/session/997f7a81c905476795923045405e7ebb?variant=devin
Requested by: @horacioh
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/horacioh/seed/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
