### PR TITLE
Repo HM sync: lossless markdown ⇄ Hypermedia, seed-cli space export/import/dev, seed-docs published from CI

### DIFF
--- a/.github/workflows/sync-seed-docs.yml
+++ b/.github/workflows/sync-seed-docs.yml
@@ -1,0 +1,45 @@
+name: Sync seed-docs
+
+# Publishes seed-docs/ to its Hypermedia site whenever main changes it.
+# Signs with SEED_DOCS_MNEMONIC (a repository secret): the site is that key's
+# own space. Documents are updated block by block; unchanged pages publish
+# nothing.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'seed-docs/**'
+      - '.github/workflows/sync-seed-docs.yml'
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.10'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Publish seed-docs to hyper.media
+        working-directory: frontend/apps/cli
+        env:
+          SEED_CLI_MNEMONIC: ${{ secrets.SEED_DOCS_MNEMONIC }}
+        run: |
+          if [ -z "$SEED_CLI_MNEMONIC" ]; then
+            echo "SEED_DOCS_MNEMONIC secret is not set; skipping publish."
+            exit 0
+          fi
+          bun run src/index.ts space import self --dir ../../../seed-docs --server https://hyper.media

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+# Markdown mirrored to a Hypermedia space by `seed-cli space import/export`:
+# the files are the exporter's canonical form (one block per line, ids in
+# trailing comments), which prose wrapping would break.
+seed-docs/

--- a/frontend/apps/cli/README.md
+++ b/frontend/apps/cli/README.md
@@ -513,6 +513,45 @@ Returns the decoded IPLD block data as JSON.
 
 ---
 
+## Space Commands
+
+Mirror a whole space to a directory of markdown files and back. The markdown is the lossless dialect of
+`@seed-hypermedia/client` (`blocksToMarkdown` / `parseMarkdown`): every block type, annotation, attribute and metadata
+key survives a round trip, block ids ride in trailing `<!-- id:… -->` comments, and links between documents of the space
+are written as relative file links. The repository's `seed-docs/` folder is published this way from CI.
+
+### space export
+
+```
+seed-cli space export <space> --dir <path>
+```
+
+Writes every document of the space into the directory: the home document as `index.md`, a document at `/a/b` as
+`a/b.md`, and the schema blob a document defines (`metadata.schemaDefinition`) as `<file>.schema.json`. Only files whose
+content changed are touched. `<space>` may be `self` for the signing key's own space.
+
+### space import
+
+```
+seed-cli space import <space> --dir <path> [--dry-run] [-k, --key <name>]
+```
+
+Publishes the directory into the space. Each file is diffed by block id against the current document and published as a
+change on its existing history; unchanged documents produce nothing. A file without ids is matched to the existing
+document by position. In CI, set `SEED_CLI_MNEMONIC` to sign without a stored key and use `self` as the space.
+
+### space dev
+
+```
+seed-cli space dev --dir <path> [--api <url>] [--daemon <url>] [--interval <ms>] [--no-push]
+```
+
+Edit the directory in the desktop dev app: a throwaway key is created under `<path>/.dev/` (self-ignored) and registered
+in the app's daemon, the directory is published there, and every document published in the app is written straight back
+to the directory. Nothing reaches the network.
+
+---
+
 ## Account Commands
 
 All account commands live under `seed-cli account <subcommand>`.
@@ -905,8 +944,8 @@ Keys come from two sources:
 
 - **The vault** (`vault.json`) — the encrypted identity store of the Seed desktop app and daemon. The CLI auto-detects
   it (or use `--vault <path>` / `SEED_VAULT_PATH` / `seed-cli config --vault-path`), unlocks it with the secret in the
-  OS keychain (or `SEED_VAULT_KEK` on headless machines), and can sign with any identity in it. Read-only: the CLI
-  never modifies the vault.
+  OS keychain (or `SEED_VAULT_KEK` on headless machines), and can sign with any identity in it. Read-only: the CLI never
+  modifies the vault.
 - **The OS keyring** (macOS Keychain / Linux libsecret) — the legacy store, still used for keys the CLI creates itself.
 
 The vault wins when a name exists in both. `key list` shows each key's `source`. See `docs/KEYS.md` for details.

--- a/frontend/apps/cli/src/commands/space.ts
+++ b/frontend/apps/cli/src/commands/space.ts
@@ -1,0 +1,85 @@
+/**
+ * `space export` / `space import`: mirror a whole space to a directory of
+ * markdown files and back. See utils/space-sync.ts for the mapping and the
+ * update semantics.
+ */
+import type {Command} from 'commander'
+import {resolve} from 'path'
+import {unpackHmId} from '@shm/shared/utils/entity-id-url'
+import {getClient} from '../index'
+import {printError, printInfo, printSuccess} from '../output'
+import {keyOptions, resolveSigningKey} from '../utils/keys'
+import {createSignerFromKey} from '../utils/signer'
+import {exportSpace, importSpace} from '../utils/space-sync'
+
+function spaceUid(id: string): string {
+  const unpacked = unpackHmId(id.startsWith('hm://') ? id : `hm://${id}`)
+  if (!unpacked) throw new Error(`Invalid space id: ${id}`)
+  if (unpacked.path && unpacked.path.length) throw new Error(`Expected a space id, got a document path: ${id}`)
+  return unpacked.uid
+}
+
+export function registerSpaceCommands(program: Command) {
+  const space = program.command('space').description('Mirror a whole space to a directory of markdown files and back')
+
+  space
+    .command('export <space>')
+    .description('Write every document of a space to <dir> as lossless markdown (plus defined schemas)')
+    .requiredOption('-d, --dir <path>', 'Target directory')
+    .action(async (id: string, options, cmd) => {
+      const globalOpts = cmd.optsWithGlobals()
+      try {
+        const uid = spaceUid(id)
+        const client = getClient(globalOpts)
+        const dir = resolve(options.dir)
+        const result = await exportSpace({client, uid, dir, log: globalOpts.quiet ? undefined : printInfo})
+        if (!globalOpts.quiet) {
+          printSuccess(
+            `Exported hm://${uid} to ${dir}: ${result.written.length} written, ${result.unchanged.length} unchanged, ${result.skipped.length} skipped`,
+          )
+        }
+      } catch (error) {
+        printError((error as Error).message)
+        process.exit(1)
+      }
+    })
+
+  space
+    .command('import <space>')
+    .description('Publish the markdown files in <dir> into a space, updating existing documents by block id')
+    .requiredOption('-d, --dir <path>', 'Source directory')
+    .option('-k, --key <name>', 'Signing key name or account ID')
+    .option('--dry-run', 'Report what would change without publishing')
+    .action(async (id: string, options, cmd) => {
+      const globalOpts = cmd.optsWithGlobals()
+      try {
+        const account = spaceUid(id)
+        const client = getClient(globalOpts)
+        const key = await resolveSigningKey(options.key, keyOptions(globalOpts))
+        if (key.accountId !== account) {
+          throw new Error(
+            `Key ${key.accountId} does not own space ${account}. Importing with a delegated key is not supported yet.`,
+          )
+        }
+        const dir = resolve(options.dir)
+        const result = await importSpace({
+          client,
+          signer: createSignerFromKey(key),
+          account,
+          dir,
+          dryRun: !!options.dryRun,
+          log: globalOpts.quiet ? undefined : printInfo,
+        })
+        if (!globalOpts.quiet) {
+          printSuccess(
+            `${options.dryRun ? 'Would publish' : 'Published'} to hm://${account}: ${result.created.length} created, ${
+              result.updated.length
+            } updated, ${result.unchanged.length} unchanged, ${result.skipped.length} skipped`,
+          )
+        }
+      } catch (error) {
+        printError((error as Error).message)
+        process.exit(1)
+      }
+    })
+}

--- a/frontend/apps/cli/src/commands/space.ts
+++ b/frontend/apps/cli/src/commands/space.ts
@@ -1,16 +1,27 @@
 /**
- * `space export` / `space import`: mirror a whole space to a directory of
- * markdown files and back. See utils/space-sync.ts for the mapping and the
- * update semantics.
+ * `space export` / `space import` / `space dev`: mirror a whole space to a
+ * directory of markdown files and back, and edit that directory in the Seed
+ * app. See utils/space-sync.ts for the file mapping and the update semantics.
+ *
+ *   seed-cli space export hm://<uid> --dir ./docs
+ *   seed-cli space import hm://<uid> --dir ./docs [--dry-run]
+ *   seed-cli space import self --dir ./docs        # the signing key's own space
+ *   seed-cli space dev --dir ./docs                # local editing loop (desktop dev app)
  */
-import type {Command} from 'commander'
-import {resolve} from 'path'
+import {createGrpcWebTransport} from '@connectrpc/connect-web'
+import {createSeedClient} from '@seed-hypermedia/client'
+import {createGRPCClient} from '@shm/shared/grpc-client'
 import {unpackHmId} from '@shm/shared/utils/entity-id-url'
+import type {Command} from 'commander'
+import {spawnSync} from 'node:child_process'
+import {existsSync, mkdirSync, readFileSync, writeFileSync} from 'node:fs'
+import {resolve} from 'node:path'
 import {getClient} from '../index'
-import {printError, printInfo, printSuccess} from '../output'
+import {printError, printInfo, printSuccess, printWarning} from '../output'
+import {deriveKeyPairFromMnemonic, generateMnemonic, type KeyPair} from '../utils/key-derivation'
 import {keyOptions, resolveSigningKey} from '../utils/keys'
 import {createSignerFromKey} from '../utils/signer'
-import {exportSpace, importSpace} from '../utils/space-sync'
+import {exportPath, exportSpace, importSpace, listSpaceVersions} from '../utils/space-sync'
 
 function spaceUid(id: string): string {
   const unpacked = unpackHmId(id.startsWith('hm://') ? id : `hm://${id}`)
@@ -20,16 +31,20 @@ function spaceUid(id: string): string {
 }
 
 export function registerSpaceCommands(program: Command) {
-  const space = program.command('space').description('Mirror a whole space to a directory of markdown files and back')
+  const space = program
+    .command('space')
+    .description('Mirror a whole space to a directory of markdown files and back, or edit it in the app')
 
   space
     .command('export <space>')
     .description('Write every document of a space to <dir> as lossless markdown (plus defined schemas)')
     .requiredOption('-d, --dir <path>', 'Target directory')
+    .option('-k, --key <name>', 'Signing key name or account ID (only used when <space> is "self")')
     .action(async (id: string, options, cmd) => {
       const globalOpts = cmd.optsWithGlobals()
       try {
-        const uid = spaceUid(id)
+        const uid =
+          id === 'self' ? (await resolveSigningKey(options.key, keyOptions(globalOpts))).accountId : spaceUid(id)
         const client = getClient(globalOpts)
         const dir = resolve(options.dir)
         const result = await exportSpace({client, uid, dir, log: globalOpts.quiet ? undefined : printInfo})
@@ -46,16 +61,18 @@ export function registerSpaceCommands(program: Command) {
 
   space
     .command('import <space>')
-    .description('Publish the markdown files in <dir> into a space, updating existing documents by block id')
+    .description(
+      'Publish the markdown files in <dir> into a space, updating existing documents by block id ("self" = the signing key\'s own space)',
+    )
     .requiredOption('-d, --dir <path>', 'Source directory')
     .option('-k, --key <name>', 'Signing key name or account ID')
     .option('--dry-run', 'Report what would change without publishing')
     .action(async (id: string, options, cmd) => {
       const globalOpts = cmd.optsWithGlobals()
       try {
-        const account = spaceUid(id)
         const client = getClient(globalOpts)
         const key = await resolveSigningKey(options.key, keyOptions(globalOpts))
+        const account = id === 'self' ? key.accountId : spaceUid(id)
         if (key.accountId !== account) {
           throw new Error(
             `Key ${key.accountId} does not own space ${account}. Importing with a delegated key is not supported yet.`,
@@ -82,4 +99,121 @@ export function registerSpaceCommands(program: Command) {
         process.exit(1)
       }
     })
+
+  space
+    .command('dev')
+    .description(
+      "Edit <dir> in the desktop dev app: publish it into the app's daemon under a throwaway key, then write every document you publish there back to <dir>",
+    )
+    .requiredOption('-d, --dir <path>', 'Directory of markdown files')
+    .option('--api <url>', 'Desktop app HTTP API', 'http://localhost:58004')
+    .option('--daemon <url>', 'Daemon gRPC-web endpoint', 'http://localhost:58001')
+    .option('--interval <ms>', 'Poll interval', '2000')
+    .option('--no-push', 'Do not publish the directory into the daemon first')
+    .action(async (options) => {
+      try {
+        await runDevLoop({
+          dir: resolve(options.dir),
+          apiUrl: options.api,
+          daemonUrl: options.daemon,
+          intervalMs: Number(options.interval),
+          push: options.push !== false,
+        })
+      } catch (error) {
+        printError((error as Error).message)
+        process.exit(1)
+      }
+    })
+}
+
+// ── dev: the local editing loop ───────────────────────────────────────────────
+//
+// The app is the editor; git is where you commit. The directory is published
+// into the daemon behind a running desktop dev app under a throwaway key, and
+// every document published in the app is written straight back. Nothing
+// reaches the network.
+
+/** The unencrypted dev key: a mnemonic in `<dir>/.dev/` (self-ignored), created on first use. */
+function loadOrCreateDevKey(dir: string): {keyPair: KeyPair; words: string[]; created: boolean} {
+  const devDir = resolve(dir, '.dev')
+  const file = resolve(devDir, 'dev-key.mnemonic')
+  let words: string[]
+  let created = false
+  if (existsSync(file)) {
+    words = readFileSync(file, 'utf8').trim().split(/\s+/)
+  } else {
+    words = generateMnemonic(12).split(' ')
+    mkdirSync(devDir, {recursive: true})
+    writeFileSync(resolve(devDir, '.gitignore'), '*\n')
+    writeFileSync(file, words.join(' ') + '\n', {mode: 0o600})
+    created = true
+  }
+  return {keyPair: deriveKeyPairFromMnemonic(words), words, created}
+}
+
+/** Make sure the daemon holds the dev key, so the app can edit as that account. */
+async function ensureDaemonKey(daemonUrl: string, words: string[], accountId: string) {
+  const grpc = createGRPCClient(createGrpcWebTransport({baseUrl: daemonUrl}))
+  const existing = await grpc.daemon.listKeys({})
+  if (existing.keys.some((k) => k.publicKey === accountId)) return
+  const name = `dev-${accountId.slice(-6)}`
+  await grpc.daemon.registerKey({mnemonic: words, name})
+  printInfo(`Registered key "${name}" in the daemon.`)
+}
+
+async function runDevLoop(opts: {dir: string; apiUrl: string; daemonUrl: string; intervalMs: number; push: boolean}) {
+  const {keyPair, words, created} = loadOrCreateDevKey(opts.dir)
+  const account = keyPair.accountId
+  printInfo(`Dev key: ${account}${created ? ' (new; saved under .dev/ in the directory)' : ''}`)
+  printInfo(`Daemon:  ${opts.daemonUrl}`)
+  printInfo(`API:     ${opts.apiUrl}`)
+
+  try {
+    await ensureDaemonKey(opts.daemonUrl, words, account)
+  } catch (err) {
+    throw new Error(
+      `Cannot reach the daemon at ${opts.daemonUrl} (${(err as Error).message}). Start the desktop dev app first.`,
+    )
+  }
+
+  const client = createSeedClient(opts.apiUrl)
+  const signer = createSignerFromKey(keyPair)
+
+  if (opts.push) {
+    printInfo('Publishing the directory into the local daemon...')
+    const result = await importSpace({client, signer, account, dir: opts.dir, log: printInfo})
+    printInfo(
+      `${result.created.length} created, ${result.updated.length} updated, ${result.unchanged.length} unchanged.`,
+    )
+  }
+
+  const url = `hm://${account}`
+  printSuccess(`Site: ${url}`)
+  printInfo('Open it in the desktop app (paste the URL in the omnibar). Edit and publish; files update here.')
+  spawnSync('open', [url], {stdio: 'ignore'})
+
+  let versions = await listSpaceVersions(client, account)
+  printInfo(`Watching ${versions.size} documents every ${opts.intervalMs}ms. Ctrl-C to stop.`)
+  for (;;) {
+    await new Promise((r) => setTimeout(r, opts.intervalMs))
+    let next: Map<string, string>
+    try {
+      next = await listSpaceVersions(client, account)
+    } catch (err) {
+      printWarning(`poll failed: ${(err as Error).message}`)
+      continue
+    }
+    for (const [path, version] of next) {
+      if (versions.get(path) === version) continue
+      const stamp = new Date().toLocaleTimeString()
+      try {
+        const written = await exportPath({client, uid: account, dir: opts.dir}, path)
+        for (const file of written) printInfo(`${stamp}  wrote ${file}`)
+        if (written.length === 0) printInfo(`${stamp}  ${path || '(home)'} republished, no file change`)
+      } catch (err) {
+        printWarning(`${path || '(home)'}: ${(err as Error).message}`)
+      }
+    }
+    versions = next
+  }
 }

--- a/frontend/apps/cli/src/index.ts
+++ b/frontend/apps/cli/src/index.ts
@@ -19,6 +19,7 @@ import {registerSearchCommand} from './commands/search'
 import {registerQueryCommands} from './commands/query'
 import {registerKeyCommands} from './commands/key'
 import {registerDraftCommands} from './commands/draft'
+import {registerSpaceCommands} from './commands/space'
 import {getCliVersion} from './version'
 
 const program = new Command()
@@ -105,6 +106,7 @@ registerContactCommands(program)
 registerAccountCommands(program)
 registerKeyCommands(program)
 registerDraftCommands(program)
+registerSpaceCommands(program)
 
 // Register top-level commands
 registerSearchCommand(program)

--- a/frontend/apps/cli/src/utils/block-diff.test.ts
+++ b/frontend/apps/cli/src/utils/block-diff.test.ts
@@ -150,9 +150,22 @@ describe('computeReplaceOps', () => {
 
     const replaceOps = ops.filter((o) => o.type === 'ReplaceBlock')
     expect(replaceOps).toHaveLength(0)
-    // Should still have MoveBlocks
+    // Same blocks in the same order under the same parent: nothing to move
+    // either, so an untouched document yields no ops at all.
+    expect(ops).toHaveLength(0)
+  })
+
+  test('reordered blocks produce a MoveBlocks', () => {
+    const old = [apiBlock('a', 'Paragraph', 'A'), apiBlock('b', 'Paragraph', 'B')]
+    const map = createBlocksMap(old)
+    const matched = [newBlock('b', 'Paragraph', 'B'), newBlock('a', 'Paragraph', 'A')]
+
+    const ops = computeReplaceOps(map, matched)
+
+    expect(ops.filter((o) => o.type === 'ReplaceBlock')).toHaveLength(0)
     const moveOps = ops.filter((o) => o.type === 'MoveBlocks')
-    expect(moveOps.length).toBeGreaterThanOrEqual(1)
+    expect(moveOps).toHaveLength(1)
+    expect((moveOps[0] as any).blocks).toEqual(['b', 'a'])
   })
 
   test('changed text produces ReplaceBlock', () => {
@@ -219,7 +232,12 @@ describe('computeReplaceOps', () => {
   test('nested children produce ops with correct parent', () => {
     const old = [apiBlockWithChildren('h1', 'Heading', 'Title', [apiBlock('p1', 'Paragraph', 'Old child')])]
     const map = createBlocksMap(old)
-    const matched = [newBlockWithChildren('h1', 'Heading', 'Title', [newBlock('p1', 'Paragraph', 'New child')])]
+    const matched = [
+      newBlockWithChildren('h1', 'Heading', 'Title', [
+        newBlock('p1', 'Paragraph', 'New child'),
+        newBlock('p2', 'Paragraph', 'Added child'),
+      ]),
+    ]
 
     const ops = computeReplaceOps(map, matched)
 
@@ -227,10 +245,10 @@ describe('computeReplaceOps', () => {
     const replaceOps = ops.filter((o) => o.type === 'ReplaceBlock')
     expect(replaceOps.some((o: any) => o.block.id === 'p1')).toBe(true)
 
-    // MoveBlocks for children should have parent 'h1'
+    // The children level changed (p2 is new), so its MoveBlocks has parent 'h1'
     const childMoves = ops.filter((o) => o.type === 'MoveBlocks' && (o as any).parent === 'h1')
     expect(childMoves).toHaveLength(1)
-    expect((childMoves[0] as any).blocks).toContain('p1')
+    expect((childMoves[0] as any).blocks).toEqual(['p1', 'p2'])
   })
 
   test('different annotation counts trigger ReplaceBlock', () => {

--- a/frontend/apps/cli/src/utils/keys.ts
+++ b/frontend/apps/cli/src/utils/keys.ts
@@ -15,9 +15,10 @@
 import {loadLocalVaultAccounts, type VaultLocalAccount} from '@seed-hypermedia/client/vault-local'
 import {loadConfig} from '../config'
 import {printWarning} from '../output'
+import {deriveKeyPairFromMnemonic} from './key-derivation'
 import {getDefaultKey, getKey, listKeys, type KeyringKey} from './keyring'
 
-export type KeySource = 'vault' | 'keyring'
+export type KeySource = 'vault' | 'keyring' | 'env'
 
 export type ResolvedKey = KeyringKey & {source: KeySource}
 
@@ -104,6 +105,17 @@ export async function findDefaultKey(opts: KeyOptions): Promise<ResolvedKey | nu
  */
 export async function resolveSigningKey(keyFlag: string | undefined, opts: KeyOptions): Promise<ResolvedKey> {
   const envHint = opts.dev ? ' --dev' : ''
+
+  // Non-interactive environments (CI) pass the key as a mnemonic in
+  // SEED_CLI_MNEMONIC; it wins over every stored key.
+  const envMnemonic = process.env.SEED_CLI_MNEMONIC?.trim()
+  if (envMnemonic) {
+    const pair = deriveKeyPairFromMnemonic(envMnemonic)
+    if (keyFlag && keyFlag !== 'env' && keyFlag !== pair.accountId) {
+      throw new Error(`SEED_CLI_MNEMONIC is set (account ${pair.accountId}) but --key ${keyFlag} was requested.`)
+    }
+    return {name: 'env', ...pair, source: 'env'}
+  }
 
   if (keyFlag) {
     const key = await findKey(keyFlag, opts)

--- a/frontend/apps/cli/src/utils/space-sync.ts
+++ b/frontend/apps/cli/src/utils/space-sync.ts
@@ -15,7 +15,7 @@
  * `<file>.schema.json` beside the document that defines it.
  */
 import {existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync} from 'node:fs'
-import {dirname, join, relative, resolve} from 'node:path'
+import {dirname, join, normalize, relative, resolve} from 'node:path'
 import {
   blocksToMarkdown,
   createChange,
@@ -32,10 +32,11 @@ import {
 import {
   computeReplaceOps,
   createBlocksMap,
+  matchBlockIds,
   rebindTableIdentities,
   toAPIBlockNode,
 } from '@seed-hypermedia/client/block-diff'
-import type {HMDocument, HMMetadata} from '@seed-hypermedia/client/hm-types'
+import type {HMBlockNode, HMDocument, HMMetadata} from '@seed-hypermedia/client/hm-types'
 import {hmId} from '@shm/shared/utils/entity-id-url'
 import {CID} from 'multiformats/cid'
 import {hmBlockNodeToBlockNode} from './block-diff'
@@ -50,12 +51,72 @@ export type SpaceLayout = {
   pathForFile(file: string): string | null
   /** File for the schema blob a document defines (`metadata.schemaDefinition`). Null skips it. */
   schemaFileFor(mdFile: string): string | null
+  /**
+   * File a link to a document path points at, for rewriting links between
+   * documents of the space as relative file links (and back). Null leaves the
+   * hm:// link as is.
+   */
+  fileForLinkPath?(path: string): string | null
 }
 
 export const defaultLayout: SpaceLayout = {
   fileForPath: (path) => (path === '' ? 'index.md' : path.replace(/^\//, '') + '.md'),
   pathForFile: (file) => (file === 'index.md' ? '' : '/' + file.replace(/\.md$/, '')),
   schemaFileFor: (mdFile) => mdFile.replace(/\.md$/, '.schema.json'),
+  fileForLinkPath: (path) => (path === '' ? 'index.md' : path.replace(/^\//, '') + '.md'),
+}
+
+// ─── Links between documents ─────────────────────────────────────────────────
+//
+// In the directory, documents link to each other with relative file links
+// (`[CLI](./cli.md)`), which render on GitHub and need no space id. In the
+// space they are hm:// links. Import and export rewrite between the two.
+
+type LinkVisitor = (link: string) => string
+
+/** Rewrite every block link and Link/Embed annotation link in a tree. */
+function rewriteLinks(nodes: HMBlockNode[], visit: LinkVisitor): HMBlockNode[] {
+  return nodes.map((node) => {
+    const block = {...(node.block as Record<string, unknown>)}
+    if (typeof block.link === 'string' && block.link) block.link = visit(block.link)
+    const anns = block.annotations as Array<Record<string, unknown>> | undefined
+    if (anns?.length) {
+      block.annotations = anns.map((a) => (typeof a.link === 'string' && a.link ? {...a, link: visit(a.link)} : a))
+    }
+    return {
+      ...node,
+      block: block as HMBlockNode['block'],
+      ...(node.children ? {children: rewriteLinks(node.children, visit)} : {}),
+    } as HMBlockNode
+  })
+}
+
+/** `./other.md` (relative to `file`) → `hm://<account>/<path>` when the layout knows the target. */
+function relativeToHmLinks(nodes: HMBlockNode[], file: string, account: string, layout: SpaceLayout): HMBlockNode[] {
+  const fileDir = dirname(file)
+  return rewriteLinks(nodes, (link) => {
+    const m = /^(\.{1,2}\/[^#?]*\.md|[^:/#?][^#?]*\.md)(#.*)?$/.exec(link)
+    if (!m) return link
+    const target = normalize(join(fileDir, m[1]!)).replace(/\\/g, '/')
+    const path = layout.pathForFile(target)
+    if (path === null) return link
+    return `hm://${account}${path}${m[2] || ''}`
+  })
+}
+
+/** `hm://<account>/<path>` → `./other.md` (relative to `file`) when the layout maps the path to a file. */
+function hmToRelativeLinks(nodes: HMBlockNode[], file: string, account: string, layout: SpaceLayout): HMBlockNode[] {
+  if (!layout.fileForLinkPath) return nodes
+  const fileDir = dirname(file)
+  return rewriteLinks(nodes, (link) => {
+    const m = new RegExp(`^hm://${account}(/[^#?]*)?(#.*)?$`).exec(link)
+    if (!m) return link
+    const target = layout.fileForLinkPath!(m[1] || '')
+    if (!target) return link
+    let rel = relative(fileDir, target).replace(/\\/g, '/')
+    if (!rel.startsWith('.')) rel = './' + rel
+    return rel + (m[2] || '')
+  })
 }
 
 // ─── Export ──────────────────────────────────────────────────────────────────
@@ -168,7 +229,8 @@ export async function exportDocument(
     result.skipped.push(path || '(home)')
     return result
   }
-  const md = blocksToMarkdown(doc, {ipfsGateway: false})
+  const content = hmToRelativeLinks(doc.content || [], file, doc.account, layout)
+  const md = blocksToMarkdown({...doc, content}, {ipfsGateway: false})
   const changed = writeIfChanged(resolve(opts.dir, file), md)
   ;(changed ? result.written : result.unchanged).push(file)
   log(`${changed ? 'wrote  ' : 'same   '} ${file}`)
@@ -310,7 +372,9 @@ export async function importSpace(opts: ImportOptions): Promise<ImportResult> {
     const raw = readFileSync(resolve(opts.dir, file), 'utf8')
     const {tree, metadata: fileMetadata} = parseMarkdown(raw)
     const metadata = opts.metadataFor ? opts.metadataFor(file, fileMetadata) : fileMetadata
-    const resolved = await resolveFileLinks(markdownBlockNodesToHMBlockNodes(tree))
+    const resolved = await resolveFileLinks(
+      relativeToHmLinks(markdownBlockNodesToHMBlockNodes(tree), file, opts.account, layout),
+    )
     const newTree = resolved.nodes.map(hmBlockNodeToBlockNode)
     const id = hmId(opts.account, {path: path ? path.replace(/^\//, '').split('/') : []})
 
@@ -352,7 +416,14 @@ export async function importSpace(opts: ImportOptions): Promise<ImportResult> {
     const oldDoc = base.document
     const oldNodes = (oldDoc.content || []).map(toAPIBlockNode)
     const oldMap = createBlocksMap(oldNodes)
-    const rebound = rebindTableIdentities(oldNodes, newTree)
+    // A hand-written file carries no block ids: match its blocks to the
+    // existing document by position, so edits update blocks in place instead
+    // of replacing the whole document every time. (A block's id is explicit
+    // when its comment appears in the source; prose mentioning `<!-- id:X -->`
+    // does not count.)
+    const hasIds = newTree.some((n) => raw.includes(`<!-- id:${n.block.id}`))
+    const matched = hasIds ? newTree : matchBlockIds(oldNodes, newTree)
+    const rebound = rebindTableIdentities(oldNodes, matched)
     const ops: DocumentOperation[] = computeReplaceOps(oldMap, rebound)
     const metaOp = metadataDiffOp(oldDoc.metadata as Record<string, unknown>, metadata as Record<string, unknown>)
     if (metaOp) ops.unshift(metaOp)

--- a/frontend/apps/cli/src/utils/space-sync.ts
+++ b/frontend/apps/cli/src/utils/space-sync.ts
@@ -1,0 +1,397 @@
+/**
+ * Space ⇄ directory sync: export every document of a space to markdown files
+ * (plus the schema blob a type document defines), and import a directory of
+ * markdown files back as document updates.
+ *
+ * The markdown is the lossless dialect of `@seed-hypermedia/client`
+ * (`blocksToMarkdown` / `parseMarkdown`), so a document exported and
+ * re-imported without edits produces no change at all. Imports diff by block
+ * id against the current document and publish a Change on its existing
+ * genesis; a path with no document yet gets a fresh one. Unchanged documents
+ * are skipped, so a sync never spams versions.
+ *
+ * A `SpaceLayout` maps document paths to files. The default layout puts the
+ * home document at `index.md` and `/a/b` at `a/b.md`; a schema blob goes to
+ * `<file>.schema.json` beside the document that defines it.
+ */
+import {existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync} from 'node:fs'
+import {dirname, join, relative, resolve} from 'node:path'
+import {
+  blocksToMarkdown,
+  createChange,
+  createChangeOps,
+  createVersionRef,
+  flattenToOperations,
+  markdownBlockNodesToHMBlockNodes,
+  parseMarkdown,
+  resolveEditableDocument,
+  type DocumentOperation,
+  type HMSigner,
+  type SeedClient,
+} from '@seed-hypermedia/client'
+import {
+  computeReplaceOps,
+  createBlocksMap,
+  rebindTableIdentities,
+  toAPIBlockNode,
+} from '@seed-hypermedia/client/block-diff'
+import type {HMDocument, HMMetadata} from '@seed-hypermedia/client/hm-types'
+import {hmId} from '@shm/shared/utils/entity-id-url'
+import {CID} from 'multiformats/cid'
+import {hmBlockNodeToBlockNode} from './block-diff'
+import {resolveFileLinks} from './file-links'
+
+// ─── Layout ──────────────────────────────────────────────────────────────────
+
+export type SpaceLayout = {
+  /** Local markdown file (relative to the directory) for a document path; '' is the home document. Null skips it. */
+  fileForPath(path: string, doc: HMDocument): string | null
+  /** Document path for a markdown file (relative to the directory). Null skips the file. */
+  pathForFile(file: string): string | null
+  /** File for the schema blob a document defines (`metadata.schemaDefinition`). Null skips it. */
+  schemaFileFor(mdFile: string): string | null
+}
+
+export const defaultLayout: SpaceLayout = {
+  fileForPath: (path) => (path === '' ? 'index.md' : path.replace(/^\//, '') + '.md'),
+  pathForFile: (file) => (file === 'index.md' ? '' : '/' + file.replace(/\.md$/, '')),
+  schemaFileFor: (mdFile) => mdFile.replace(/\.md$/, '.schema.json'),
+}
+
+// ─── Export ──────────────────────────────────────────────────────────────────
+
+export type ExportOptions = {
+  client: SeedClient
+  /** The space (account uid) to export. */
+  uid: string
+  dir: string
+  layout?: SpaceLayout
+  log?: (line: string) => void
+}
+
+export type ExportResult = {
+  written: string[]
+  unchanged: string[]
+  skipped: string[]
+}
+
+/** Every document in a space: the home document plus all descendants. */
+export async function listSpaceDocuments(client: SeedClient, uid: string): Promise<HMDocument[]> {
+  const docs: HMDocument[] = []
+  const home = await client.request('Resource', hmId(uid))
+  if (home.type === 'document') docs.push(home.document)
+  const query = await client.request('Query', {includes: [{space: uid, path: '', mode: 'AllDescendants'}]})
+  for (const info of query?.results || []) {
+    if (info.type !== 'document') continue
+    const res = await client.request('Resource', hmId(uid, {path: info.path}))
+    if (res.type === 'document') docs.push(res.document)
+  }
+  return docs
+}
+
+/** Write `content` to `file` unless it already holds exactly that. */
+function writeIfChanged(file: string, content: string): boolean {
+  if (existsSync(file) && readFileSync(file, 'utf8') === content) return false
+  mkdirSync(dirname(file), {recursive: true})
+  writeFileSync(file, content)
+  return true
+}
+
+/** The bare CID in an `ipfs://<cid>` metadata value. */
+export function ipfsCid(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const m = /^ipfs:\/\/([^/]+)/.exec(value)
+  return m ? m[1]! : null
+}
+
+/**
+ * Order-preserving JSON write: keys keep the order they have in the file on
+ * disk (new keys appended, sorted), so a re-exported schema that changed in
+ * one place produces a one-place diff. A semantically equal object is not
+ * rewritten at all.
+ */
+export function writeJsonPreservingOrder(file: string, value: unknown): boolean {
+  let existing: unknown = undefined
+  if (existsSync(file)) {
+    try {
+      existing = JSON.parse(readFileSync(file, 'utf8'))
+    } catch {
+      existing = undefined
+    }
+  }
+  if (existing !== undefined && deepEqual(existing, value)) return false
+  const ordered = reorderLike(value, existing)
+  mkdirSync(dirname(file), {recursive: true})
+  writeFileSync(file, JSON.stringify(ordered, null, 2) + '\n')
+  return true
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v)
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  if (Array.isArray(a) && Array.isArray(b)) return a.length === b.length && a.every((x, i) => deepEqual(x, b[i]))
+  if (isObject(a) && isObject(b)) {
+    const ka = Object.keys(a)
+    const kb = Object.keys(b)
+    return ka.length === kb.length && ka.every((k) => k in b && deepEqual(a[k], b[k]))
+  }
+  return false
+}
+
+function reorderLike(value: unknown, template: unknown): unknown {
+  if (Array.isArray(value)) {
+    const t = Array.isArray(template) ? template : []
+    return value.map((v, i) => reorderLike(v, t[i]))
+  }
+  if (!isObject(value)) return value
+  const t = isObject(template) ? template : {}
+  const out: Record<string, unknown> = {}
+  for (const k of Object.keys(t)) if (k in value) out[k] = reorderLike(value[k], t[k])
+  for (const k of Object.keys(value).sort()) if (!(k in out)) out[k] = reorderLike(value[k], undefined)
+  return out
+}
+
+/** Write one document (and the schema it defines) into the directory. */
+export async function exportDocument(
+  opts: Omit<ExportOptions, 'uid'>,
+  doc: HMDocument,
+  result: ExportResult = {written: [], unchanged: [], skipped: []},
+): Promise<ExportResult> {
+  const layout = opts.layout || defaultLayout
+  const log = opts.log || (() => {})
+  const path = doc.path || ''
+  const file = layout.fileForPath(path, doc)
+  if (!file) {
+    result.skipped.push(path || '(home)')
+    return result
+  }
+  const md = blocksToMarkdown(doc, {ipfsGateway: false})
+  const changed = writeIfChanged(resolve(opts.dir, file), md)
+  ;(changed ? result.written : result.unchanged).push(file)
+  log(`${changed ? 'wrote  ' : 'same   '} ${file}`)
+
+  const schemaCid = ipfsCid((doc.metadata as Record<string, unknown> | undefined)?.schemaDefinition)
+  const schemaFile = schemaCid ? layout.schemaFileFor(file) : null
+  if (schemaCid && schemaFile) {
+    const blob = await opts.client.request('GetCID', {cid: schemaCid})
+    const changedSchema = writeJsonPreservingOrder(resolve(opts.dir, schemaFile), blob.value)
+    ;(changedSchema ? result.written : result.unchanged).push(schemaFile)
+    log(`${changedSchema ? 'wrote  ' : 'same   '} ${schemaFile}`)
+  }
+  return result
+}
+
+export async function exportSpace(opts: ExportOptions): Promise<ExportResult> {
+  const result: ExportResult = {written: [], unchanged: [], skipped: []}
+  const docs = await listSpaceDocuments(opts.client, opts.uid)
+  for (const doc of docs) await exportDocument(opts, doc, result)
+  return result
+}
+
+/** Export the document at one path; returns the files written. */
+export async function exportPath(opts: ExportOptions, path: string): Promise<string[]> {
+  const res = await opts.client.request(
+    'Resource',
+    hmId(opts.uid, {path: path ? path.replace(/^\//, '').split('/') : []}),
+  )
+  if (res.type !== 'document') return []
+  const result = await exportDocument(opts, res.document)
+  return result.written
+}
+
+/** Current version of every document in a space, by path ('' = home). One Query + one Resource call. */
+export async function listSpaceVersions(client: SeedClient, uid: string): Promise<Map<string, string>> {
+  const versions = new Map<string, string>()
+  const home = await client.request('Resource', hmId(uid))
+  if (home.type === 'document') versions.set('', home.document.version)
+  const query = await client.request('Query', {includes: [{space: uid, path: '', mode: 'AllDescendants'}]})
+  for (const info of query?.results || []) {
+    if (info.type !== 'document') continue
+    versions.set('/' + info.path.join('/'), info.version)
+  }
+  return versions
+}
+
+// ─── Import ──────────────────────────────────────────────────────────────────
+
+export type ImportOptions = {
+  client: SeedClient
+  signer: HMSigner
+  /** The space (account uid) to publish into. */
+  account: string
+  dir: string
+  layout?: SpaceLayout
+  dryRun?: boolean
+  /** Capability CID when the signer is not the space owner. */
+  capability?: string
+  /** Adjust a file's metadata before publishing (e.g. inject schema bindings). */
+  metadataFor?: (file: string, metadata: HMMetadata) => HMMetadata
+  /** Restrict to these files (relative to dir). */
+  only?: string[]
+  log?: (line: string) => void
+}
+
+export type ImportResult = {
+  created: string[]
+  updated: string[]
+  unchanged: string[]
+  skipped: string[]
+}
+
+/** All markdown files under `dir`, relative, sorted. */
+export function listMarkdownFiles(dir: string): string[] {
+  const out: string[] = []
+  const walk = (d: string) => {
+    for (const entry of readdirSync(d).sort()) {
+      const full = join(d, entry)
+      if (statSync(full).isDirectory()) {
+        if (!entry.startsWith('.') && entry !== 'node_modules') walk(full)
+      } else if (entry.endsWith('.md')) {
+        out.push(relative(dir, full))
+      }
+    }
+  }
+  walk(dir)
+  return out
+}
+
+type Leaf = {key: string[]; value: string | number | boolean | null}
+
+/** Flatten metadata to attribute leaves, the shape SetAttributes takes. */
+function metadataLeaves(metadata: Record<string, unknown> | undefined, prefix: string[] = []): Leaf[] {
+  const out: Leaf[] = []
+  for (const [k, v] of Object.entries(metadata || {})) {
+    if (v === undefined) continue
+    const key = [...prefix, k]
+    if (v !== null && typeof v === 'object') out.push(...metadataLeaves(v as Record<string, unknown>, key))
+    else if (v === null || typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean')
+      out.push({key, value: v})
+  }
+  return out
+}
+
+/**
+ * The SetAttributes op turning `oldMetadata` into `newMetadata`: changed and
+ * added leaves are set, leaves missing from the new metadata are nulled.
+ */
+export function metadataDiffOp(
+  oldMetadata: Record<string, unknown> | undefined,
+  newMetadata: Record<string, unknown> | undefined,
+): DocumentOperation | null {
+  const oldLeaves = new Map(metadataLeaves(oldMetadata).map((l) => [l.key.join(' '), l.value]))
+  const attrs: Leaf[] = []
+  const seen = new Set<string>()
+  for (const leaf of metadataLeaves(newMetadata)) {
+    const k = leaf.key.join(' ')
+    seen.add(k)
+    if (!oldLeaves.has(k) || oldLeaves.get(k) !== leaf.value) attrs.push(leaf)
+  }
+  for (const [k] of oldLeaves) {
+    if (!seen.has(k)) attrs.push({key: k.split(' '), value: null})
+  }
+  return attrs.length ? {type: 'SetAttributes', attrs} : null
+}
+
+export async function importSpace(opts: ImportOptions): Promise<ImportResult> {
+  const layout = opts.layout || defaultLayout
+  const log = opts.log || (() => {})
+  const result: ImportResult = {created: [], updated: [], unchanged: [], skipped: []}
+  const files = opts.only ?? listMarkdownFiles(opts.dir)
+
+  for (const file of files) {
+    const path = layout.pathForFile(file)
+    if (path === null) {
+      result.skipped.push(file)
+      continue
+    }
+    const raw = readFileSync(resolve(opts.dir, file), 'utf8')
+    const {tree, metadata: fileMetadata} = parseMarkdown(raw)
+    const metadata = opts.metadataFor ? opts.metadataFor(file, fileMetadata) : fileMetadata
+    const resolved = await resolveFileLinks(markdownBlockNodesToHMBlockNodes(tree))
+    const newTree = resolved.nodes.map(hmBlockNodeToBlockNode)
+    const id = hmId(opts.account, {path: path ? path.replace(/^\//, '').split('/') : []})
+
+    const existing = await opts.client.request('Resource', id)
+    const label = path || '(home)'
+
+    if (existing.type === 'not-found') {
+      const ops: DocumentOperation[] = []
+      const metaOp = metadataDiffOp(undefined, metadata as Record<string, unknown>)
+      if (metaOp) ops.push(metaOp)
+      ops.push(...flattenToOperations(newTree))
+      log(`create  ${label}  (${file})`)
+      result.created.push(file)
+      if (opts.dryRun) continue
+      const {unsignedBytes, ts} = createChangeOps({ops})
+      const changeBlock = await createChange(unsignedBytes, opts.signer)
+      const ref = await createVersionRef(
+        {
+          space: opts.account,
+          path,
+          genesis: changeBlock.cid.toString(),
+          version: changeBlock.cid.toString(),
+          generation: Number(ts),
+          capability: opts.capability,
+        },
+        opts.signer,
+      )
+      await opts.client.publish({
+        blobs: [
+          {data: new Uint8Array(changeBlock.bytes), cid: changeBlock.cid.toString()},
+          ...ref.blobs,
+          ...resolved.blobs.map((b) => ({data: b.data, cid: b.cid})),
+        ],
+      })
+      continue
+    }
+
+    const base = await resolveEditableDocument(opts.client, id)
+    const oldDoc = base.document
+    const oldNodes = (oldDoc.content || []).map(toAPIBlockNode)
+    const oldMap = createBlocksMap(oldNodes)
+    const rebound = rebindTableIdentities(oldNodes, newTree)
+    const ops: DocumentOperation[] = computeReplaceOps(oldMap, rebound)
+    const metaOp = metadataDiffOp(oldDoc.metadata as Record<string, unknown>, metadata as Record<string, unknown>)
+    if (metaOp) ops.unshift(metaOp)
+
+    if (ops.length === 0) {
+      log(`same    ${label}`)
+      result.unchanged.push(file)
+      continue
+    }
+    log(`update  ${label}  (${file}: ${ops.length} op${ops.length === 1 ? '' : 's'})`)
+    result.updated.push(file)
+    if (opts.dryRun) continue
+
+    const state = base.state
+    const {unsignedBytes, ts} = createChangeOps({
+      ops,
+      genesisCid: CID.parse(state.genesis),
+      deps: state.heads.map((h) => CID.parse(h)),
+      depth: state.headDepth + 1,
+    })
+    const changeBlock = await createChange(unsignedBytes, opts.signer)
+    const ref = await createVersionRef(
+      {
+        space: opts.account,
+        path,
+        genesis: state.genesis,
+        version: changeBlock.cid.toString(),
+        generation: Number(ts),
+        capability: opts.capability,
+      },
+      opts.signer,
+    )
+    await opts.client.publish({
+      blobs: [
+        {data: new Uint8Array(changeBlock.bytes), cid: changeBlock.cid.toString()},
+        ...ref.blobs,
+        ...resolved.blobs.map((b) => ({data: b.data, cid: b.cid})),
+      ],
+    })
+  }
+  return result
+}

--- a/frontend/packages/client/__tests__/markdown-corpus.test.ts
+++ b/frontend/packages/client/__tests__/markdown-corpus.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Corpus check over the repo's `seed-docs/` folder (published to a Hypermedia
+ * site from CI): every markdown file must be a fixed point of the converter
+ * pair — export(import(export(md))) equals export(import(md)) with block ids
+ * masked. Skipped when the corpus is not present (e.g. the published npm
+ * package).
+ */
+import {existsSync, readdirSync, readFileSync, statSync} from 'node:fs'
+import {join, relative, resolve} from 'node:path'
+import {describe, expect, it} from 'vitest'
+import {blocksToMarkdown} from '../src/blocks-to-markdown'
+import type {HMDocument} from '../src/hm-types'
+import {markdownBlockNodesToHMBlockNodes, parseMarkdown} from '../src/markdown-to-blocks'
+
+const CORPUS = resolve(__dirname, '../../../../seed-docs')
+
+function toDoc(md: string): HMDocument {
+  const {tree, metadata} = parseMarkdown(md)
+  return {metadata, content: markdownBlockNodesToHMBlockNodes(tree)} as unknown as HMDocument
+}
+
+const maskIds = (s: string) => s.replace(/ ?<!-- (id|col|end):[^>]*-->/g, '')
+
+function markdownFiles(dir: string): string[] {
+  const out: string[] = []
+  const walk = (d: string) => {
+    for (const entry of readdirSync(d).sort()) {
+      const full = join(d, entry)
+      if (statSync(full).isDirectory()) {
+        if (!entry.startsWith('.')) walk(full)
+      } else if (entry.endsWith('.md')) out.push(relative(dir, full))
+    }
+  }
+  walk(dir)
+  return out
+}
+
+describe.skipIf(!existsSync(CORPUS))('seed-docs/ corpus round-trip', () => {
+  const files = existsSync(CORPUS) ? markdownFiles(CORPUS) : []
+  it.each(files)('%s is a fixed point', (file) => {
+    const src = readFileSync(resolve(CORPUS, file), 'utf8')
+    const once = blocksToMarkdown(toDoc(src), {ipfsGateway: false})
+    const twice = blocksToMarkdown(toDoc(once), {ipfsGateway: false})
+    expect(maskIds(twice)).toEqual(maskIds(once))
+  })
+})

--- a/frontend/packages/client/__tests__/markdown-lossless.test.ts
+++ b/frontend/packages/client/__tests__/markdown-lossless.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Lossless markdown round-trip: every block type, every annotation, every
+ * block attribute and every metadata key must survive
+ *
+ *   blocksToMarkdown → parseMarkdown → markdownBlockNodesToHMBlockNodes
+ *
+ * with an identical document, and the markdown itself must be a fixed point
+ * (exporting the re-imported document reproduces the same text).
+ *
+ * One `it` per feature so a failure names exactly what is lossy.
+ */
+import {describe, expect, it} from 'vitest'
+import {blocksToMarkdown} from '../src/blocks-to-markdown'
+import type {HMBlockNode, HMDocument, HMMetadata} from '../src/hm-types'
+import {markdownBlockNodesToHMBlockNodes, parseMarkdown} from '../src/markdown-to-blocks'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function doc(content: HMBlockNode[], metadata: HMMetadata = {}): HMDocument {
+  return {
+    account: 'test',
+    path: '',
+    version: 'v1',
+    metadata,
+    authors: [],
+    content,
+    createTime: {seconds: 0n, nanos: 0},
+    updateTime: {seconds: 0n, nanos: 0},
+    genesis: 'g1',
+  } as unknown as HMDocument
+}
+
+/**
+ * Canonical shape for comparison: drop empty `attributes`, empty
+ * `annotations`, empty `text`/`link`, and empty `children`, so that the two
+ * sides are compared on meaning rather than on which optional keys a
+ * producer happened to spell out.
+ */
+function canon(nodes: HMBlockNode[] | undefined): unknown[] {
+  return (nodes || []).map((n) => {
+    const b = n.block as Record<string, unknown>
+    const out: Record<string, unknown> = {type: b.type, id: b.id}
+    // Table cells never carry their id in markdown: a cell is identified by
+    // (row id, column id) and its block id is re-derived during update diffing.
+    if (b.type === 'Paragraph' && (b.attributes as Record<string, unknown> | undefined)?.columnId) delete out.id
+    if (b.text) out.text = b.text
+    if (b.link) out.link = b.link
+    const anns = (b.annotations as unknown[] | undefined) || []
+    if (anns.length) {
+      out.annotations = [...anns]
+        .map((a) => {
+          const ann = {...(a as Record<string, unknown>)}
+          if (ann.attributes && Object.keys(ann.attributes as object).length === 0) delete ann.attributes
+          return ann
+        })
+        .sort((x, y) => JSON.stringify(x).localeCompare(JSON.stringify(y)))
+    }
+    const attrs = {...((b.attributes as Record<string, unknown> | undefined) || {})}
+    for (const k of Object.keys(attrs)) if (attrs[k] === undefined) delete attrs[k]
+    if (Object.keys(attrs).length) out.attributes = attrs
+    const kids = canon(n.children)
+    if (kids.length) out.children = kids
+    return out
+  })
+}
+
+function reimport(md: string): {content: HMBlockNode[]; metadata: HMMetadata} {
+  const {tree, metadata} = parseMarkdown(md)
+  return {content: markdownBlockNodesToHMBlockNodes(tree), metadata}
+}
+
+/** Assert content round-trips and the markdown is a fixed point. */
+function expectLossless(content: HMBlockNode[], metadata: HMMetadata = {}) {
+  const md = blocksToMarkdown(doc(content, metadata), {ipfsGateway: false})
+  const back = reimport(md)
+  expect(canon(back.content)).toEqual(canon(content))
+  expect(back.metadata).toEqual(metadata)
+  const md2 = blocksToMarkdown(doc(back.content, back.metadata), {ipfsGateway: false})
+  expect(md2).toEqual(md)
+}
+
+const block = (b: Record<string, unknown>, children?: HMBlockNode[]): HMBlockNode =>
+  ({block: b, ...(children ? {children} : {})}) as unknown as HMBlockNode
+
+const p = (id: string, text: string, extra: Record<string, unknown> = {}, children?: HMBlockNode[]) =>
+  block({type: 'Paragraph', id, text, ...extra}, children)
+
+const h = (id: string, text: string, children?: HMBlockNode[]) =>
+  block({type: 'Heading', id, text, attributes: {childrenType: 'Group'}}, children)
+
+const ann = (type: string, starts: number[], ends: number[], extra: Record<string, unknown> = {}) => ({
+  type,
+  starts,
+  ends,
+  ...extra,
+})
+
+// ─── Text blocks ─────────────────────────────────────────────────────────────
+
+describe('lossless: text blocks', () => {
+  it('Paragraph', () => expectLossless([p('a1', 'Hello world')]))
+  it('Paragraph with a hard line break', () => expectLossless([p('a1', 'line one\nline two')]))
+  it('Heading', () => expectLossless([h('h1', 'Title', [p('a1', 'body')])]))
+  it('Heading levels follow nesting depth', () =>
+    expectLossless([h('h1', 'One', [h('h2', 'Two', [h('h3', 'Three', [p('a1', 'deep')])])])]))
+  it('Heading with no children', () => expectLossless([h('h1', 'Lonely'), p('a1', 'after')]))
+  it('Code with language', () =>
+    expectLossless([block({type: 'Code', id: 'c1', text: 'const x = 1\nconst y = 2', attributes: {language: 'ts'}})]))
+  it('Code without language', () => expectLossless([block({type: 'Code', id: 'c1', text: 'plain'})]))
+  it('Code nested under two headings keeps its indentation stable', () =>
+    expectLossless([
+      h('h1', 'One', [
+        h('h2', 'Two', [block({type: 'Code', id: 'c1', text: 'a\n  b\n    c', attributes: {language: 'txt'}})]),
+      ]),
+    ]))
+  it('Code whose text contains a fence', () =>
+    expectLossless([block({type: 'Code', id: 'c1', text: '```\nnested\n```', attributes: {language: 'md'}})]))
+  it('Math', () => expectLossless([block({type: 'Math', id: 'm1', text: 'x^2 + y^2 = z^2'})]))
+})
+
+// ─── Media blocks ────────────────────────────────────────────────────────────
+
+describe('lossless: media blocks', () => {
+  it('Image with caption', () =>
+    expectLossless([block({type: 'Image', id: 'i1', text: 'the caption', link: 'ipfs://bafyimg'})]))
+  it('Image without caption', () => expectLossless([block({type: 'Image', id: 'i1', link: 'ipfs://bafyimg'})]))
+  it('Image with width and name attributes', () =>
+    expectLossless([
+      block({type: 'Image', id: 'i1', text: 'cap', link: 'ipfs://bafyimg', attributes: {width: 400, name: 'pic.png'}}),
+    ]))
+  it('Image caption with annotations', () =>
+    expectLossless([
+      block({type: 'Image', id: 'i1', text: 'bold cap', link: 'ipfs://bafyimg', annotations: [ann('Bold', [0], [4])]}),
+    ]))
+  it('Video', () => expectLossless([block({type: 'Video', id: 'v1', link: 'ipfs://bafyvid'})]))
+  it('Video with playback attributes', () =>
+    expectLossless([
+      block({
+        type: 'Video',
+        id: 'v1',
+        link: 'ipfs://bafyvid',
+        attributes: {width: 640, name: 'clip.mp4', autoplay: true, loop: false, muted: true},
+      }),
+    ]))
+  it('File', () =>
+    expectLossless([
+      block({type: 'File', id: 'f1', link: 'ipfs://bafyfile', attributes: {name: 'notes.txt', size: 123}}),
+    ]))
+  it('File without name', () => expectLossless([block({type: 'File', id: 'f1', link: 'ipfs://bafyfile'})]))
+})
+
+// ─── Reference blocks ────────────────────────────────────────────────────────
+
+describe('lossless: reference blocks', () => {
+  it('Embed', () => expectLossless([block({type: 'Embed', id: 'e1', link: 'hm://z6Mkabc/path'})]))
+  it('Embed with view', () =>
+    expectLossless([block({type: 'Embed', id: 'e1', link: 'hm://z6Mkabc/path', attributes: {view: 'Card'}})]))
+  it('WebEmbed', () => expectLossless([block({type: 'WebEmbed', id: 'w1', link: 'https://x.com/seed/status/1'})]))
+  it('Button', () =>
+    expectLossless([
+      block({type: 'Button', id: 'b1', text: 'Click me', link: 'hm://z6Mkabc/path', attributes: {alignment: 'center'}}),
+    ]))
+  it('Button with name attribute', () =>
+    expectLossless([
+      block({type: 'Button', id: 'b1', text: 'Go', link: 'https://example.com', attributes: {name: 'cta'}}),
+    ]))
+  it('Nostr', () => expectLossless([block({type: 'Nostr', id: 'n1', link: 'nostr:nevent1abc'})]))
+  it('Query', () =>
+    expectLossless([
+      block({
+        type: 'Query',
+        id: 'q1',
+        attributes: {
+          style: 'Card',
+          columnCount: 2,
+          banner: false,
+          query: {
+            includes: [{space: 'z6Mkabc', path: '', mode: 'Children'}],
+            sort: [{term: 'UpdateTime', reverse: false}],
+            limit: 10,
+          },
+        },
+      }),
+    ]))
+  it('Query with table config', () =>
+    expectLossless([
+      block({
+        type: 'Query',
+        id: 'q1',
+        attributes: {
+          style: 'List',
+          columnCount: 3,
+          banner: true,
+          query: {includes: [{space: 'z6Mkabc', path: '/docs', mode: 'AllDescendants'}]},
+          table: {columns: [{key: 'name', label: 'Name'}]},
+        },
+      }),
+    ]))
+})
+
+// ─── Structure ───────────────────────────────────────────────────────────────
+
+describe('lossless: structure', () => {
+  it('paragraph with Group children', () =>
+    expectLossless([p('a1', 'parent', {attributes: {childrenType: 'Group'}}, [p('a2', 'child')])]))
+  it('paragraph with Unordered children', () =>
+    expectLossless([p('a1', 'parent', {attributes: {childrenType: 'Unordered'}}, [p('a2', 'one'), p('a3', 'two')])]))
+  it('paragraph with Ordered children', () =>
+    expectLossless([p('a1', 'parent', {attributes: {childrenType: 'Ordered'}}, [p('a2', 'one'), p('a3', 'two')])]))
+  it('paragraph with Blockquote children', () =>
+    expectLossless([p('a1', 'parent', {attributes: {childrenType: 'Blockquote'}}, [p('a2', 'quoted')])]))
+  it('invisible Unordered container', () =>
+    expectLossless([p('a1', '', {attributes: {childrenType: 'Unordered'}}, [p('a2', 'one'), p('a3', 'two')])]))
+  it('invisible Ordered container at document start', () =>
+    expectLossless([p('a1', '', {attributes: {childrenType: 'Ordered'}}, [p('a2', 'one')]), p('a4', 'after')]))
+  it('nested lists (list item with its own list)', () =>
+    expectLossless([
+      p('a1', '', {attributes: {childrenType: 'Unordered'}}, [
+        p('a2', 'one', {attributes: {childrenType: 'Unordered'}}, [p('a3', 'one.a'), p('a4', 'one.b')]),
+        p('a5', 'two'),
+      ]),
+    ]))
+  it('list item with a Group child (non-list nesting inside a list)', () =>
+    expectLossless([
+      p('a1', '', {attributes: {childrenType: 'Unordered'}}, [
+        p('a2', 'one', {attributes: {childrenType: 'Group'}}, [block({type: 'Code', id: 'c1', text: 'x'})]),
+      ]),
+    ]))
+  it('heading directly holding a list (childrenType on the heading)', () =>
+    expectLossless([
+      block({type: 'Heading', id: 'h1', text: 'T', attributes: {childrenType: 'Unordered'}}, [
+        p('a1', 'one'),
+        p('a2', 'two'),
+      ]),
+    ]))
+  it('non-heading block with children under a heading', () =>
+    expectLossless([
+      h('h1', 'T', [
+        p('a1', 'intro', {attributes: {childrenType: 'Group'}}, [p('a2', 'nested'), p('a3', 'more')]),
+        p('a4', 'sibling'),
+      ]),
+    ]))
+  it('Heading nested under a paragraph (heading level cannot express the parent)', () =>
+    expectLossless([
+      p('a1', 'parent', {attributes: {childrenType: 'Group'}}, [h('h1', 'Inner', [p('a2', 'body')])]),
+      p('a3', 'root again'),
+    ]))
+  it('columnCount on a Group parent', () =>
+    expectLossless([
+      p('a1', 'cols', {attributes: {childrenType: 'Group', columnCount: 2}}, [p('a2', 'left'), p('a3', 'right')]),
+    ]))
+  it('Slot', () =>
+    expectLossless([block({type: 'Slot', id: 's1', attributes: {childrenType: 'Group'}}, [p('a1', 'in slot')])]))
+  it('Table', () =>
+    expectLossless([
+      block({type: 'Table', id: 't1'}, [
+        block({type: 'TableColumn', id: 'c1'}),
+        block({type: 'TableColumn', id: 'c2'}),
+        block({type: 'TableRow', id: 'r0', attributes: {isHeader: true}}, [
+          p('x1', 'Name', {attributes: {columnId: 'c1'}}),
+          p('x2', 'Age', {attributes: {columnId: 'c2'}}),
+        ]),
+        block({type: 'TableRow', id: 'r1'}, [
+          p('x3', 'Alice', {attributes: {columnId: 'c1'}}),
+          p('x4', '30', {attributes: {columnId: 'c2'}}),
+        ]),
+      ]),
+    ]))
+  it('Table with column widths', () =>
+    expectLossless([
+      block({type: 'Table', id: 't1'}, [
+        block({type: 'TableColumn', id: 'c1', attributes: {width: 200}}),
+        block({type: 'TableRow', id: 'r1'}, [p('x1', 'only', {attributes: {columnId: 'c1'}})]),
+      ]),
+    ]))
+})
+
+// ─── Annotations ─────────────────────────────────────────────────────────────
+
+describe('lossless: annotations', () => {
+  const text = 'The quick brown fox'
+  const single = (type: string, extra: Record<string, unknown> = {}) => [
+    p('a1', text, {annotations: [ann(type, [4], [9], extra)]}),
+  ]
+  it('Bold', () => expectLossless(single('Bold')))
+  it('Italic', () => expectLossless(single('Italic')))
+  it('Underline', () => expectLossless(single('Underline')))
+  it('Strike', () => expectLossless(single('Strike')))
+  it('Code', () => expectLossless(single('Code')))
+  it('Link', () => expectLossless(single('Link', {link: 'https://example.com'})))
+  it('Link to hm://', () => expectLossless(single('Link', {link: 'hm://z6Mkabc/path'})))
+  it('Range', () => expectLossless(single('Range')))
+  it('TextColor', () => expectLossless(single('TextColor', {attributes: {value: '#ff0000'}})))
+  it('BackgroundColor', () => expectLossless(single('BackgroundColor', {attributes: {value: '#00ff00'}})))
+  it('TextSize', () => expectLossless(single('TextSize', {attributes: {value: 'large'}})))
+  it('TextFamily', () => expectLossless(single('TextFamily', {attributes: {value: 'mono'}})))
+  it('Embed (inline mention)', () =>
+    expectLossless([p('a1', 'see ￼ here', {annotations: [ann('Embed', [4], [5], {link: 'hm://z6Mkabc/path'})]})]))
+  it('overlapping Bold and Italic', () =>
+    expectLossless([p('a1', text, {annotations: [ann('Bold', [0], [9]), ann('Italic', [4], [15])]})]))
+  it('nested Bold inside Link', () =>
+    expectLossless([
+      p('a1', text, {annotations: [ann('Link', [4], [15], {link: 'https://x.y'}), ann('Bold', [4], [9])]}),
+    ]))
+  it('Bold in a Heading', () => expectLossless([h('h1', text, [p('a1', 'x')])]))
+  it('annotations in list items', () =>
+    expectLossless([
+      p('a1', '', {attributes: {childrenType: 'Unordered'}}, [p('a2', text, {annotations: [ann('Code', [4], [9])]})]),
+    ]))
+  it('text containing markdown syntax characters', () =>
+    expectLossless([p('a1', 'a * b ** c _d_ `e` [f](g) <h> # i | j \\ k')]))
+  it('text that begins with markdown block syntax', () =>
+    expectLossless([
+      p('a1', '- not a list'),
+      p('a2', '1. not ordered'),
+      p('a3', '# not heading'),
+      p('a4', '| not | table |'),
+    ]))
+})
+
+// ─── Metadata ────────────────────────────────────────────────────────────────
+
+describe('lossless: metadata', () => {
+  it('every documented key', () =>
+    expectLossless([p('a1', 'x')], {
+      name: 'Doc',
+      summary: 'A summary: with punctuation, "quotes" and #hashes',
+      icon: 'ipfs://bafyicon',
+      cover: 'ipfs://bafycover',
+      siteUrl: 'https://example.com',
+      layout: 'Seed/Experimental/Newspaper',
+      displayPublishTime: '2024-01-01',
+      displayAuthor: 'Someone',
+      seedExperimentalLogo: 'ipfs://bafylogo',
+      seedExperimentalHomeOrder: 'UpdatedFirst',
+      showOutline: true,
+      showActivity: false,
+      contentWidth: 'L',
+      childrenType: 'Ordered',
+      theme: {headerLayout: 'Center'},
+      importCategories: 'a,b',
+      importTags: 'c',
+    } as HMMetadata))
+  it('schema binding keys', () =>
+    expectLossless([p('a1', 'x')], {
+      name: 'Person',
+      schema: 'hm://z6Mkabc/person',
+      childrenSchema: 'ipfs://bafyschema',
+      schemaDefinition: 'ipfs://bafyschema2',
+    } as HMMetadata))
+  it('nested object metadata (spaceAgents, agentServerUrl)', () =>
+    expectLossless([p('a1', 'x')], {
+      name: 'Space',
+      agentServerUrl: 'https://agents.example.com',
+      spaceAgents: {ion: {name: 'Ion', enabled: true, models: ['a', 'b']}},
+    } as HMMetadata))
+  it('passthrough (unknown) metadata keys', () =>
+    expectLossless([p('a1', 'x')], {
+      name: 'Typed',
+      surname: 'Vicenti',
+      age: 42,
+      tags: ['x', 'y'],
+      nested: {deep: {value: null}},
+    } as HMMetadata))
+  it('empty metadata', () => expectLossless([p('a1', 'x')], {}))
+  it('name that looks like YAML', () => expectLossless([p('a1', 'x')], {name: 'yes: 1 - [two] {three}'} as HMMetadata))
+  it('multi-line summary', () => expectLossless([p('a1', 'x')], {summary: 'line one\nline two'} as HMMetadata))
+})

--- a/frontend/packages/client/__tests__/table-markdown.test.ts
+++ b/frontend/packages/client/__tests__/table-markdown.test.ts
@@ -103,7 +103,9 @@ describe('table emission', () => {
   it('emits the identity-carrying GFM dialect with row ids inside the last cell', () => {
     const md = blocksToMarkdown(doc([sampleTable()]))
     expect(md).toContain('<!-- id:TBL00001 -->')
-    expect(md).toContain('| Name <!-- col:COL00001 --> | Age <!-- col:COL00002 --> <!-- id:ROW00001 --> |')
+    expect(md).toContain(
+      '| Name <!-- col:COL00001 attrs:{"width":120} --> | Age <!-- col:COL00002 --> <!-- id:ROW00001 --> |',
+    )
     expect(md).toContain('| --- | --- |')
     expect(md).toContain('| Alice | 30 <!-- id:ROW00002 --> |')
     expect(md).toContain('| Bob | 25 <!-- id:ROW00003 --> |')
@@ -127,7 +129,7 @@ describe('table emission', () => {
     const header = table.children![2]!
     ;(header.block as {attributes?: Record<string, unknown>}).attributes = {}
     const md = blocksToMarkdown(doc([table]))
-    expect(md).toContain('| <!-- col:COL00001 --> | <!-- col:COL00002 --> |')
+    expect(md).toContain('| <!-- col:COL00001 attrs:{"width":120} --> | <!-- col:COL00002 --> |')
     // The previously-header row now emits as a body row with its id
     expect(md).toContain('| Name | Age <!-- id:ROW00001 --> |')
   })
@@ -150,13 +152,13 @@ describe('table emission', () => {
     expect(md).toContain('| a\\|b | line1<br>line2 <!-- id:ROW00002 --> |')
   })
 
-  it('drops a table with no columns instead of emitting a dangling id comment', () => {
+  it('keeps a table with no columns as a typed comment line', () => {
     const table: HMBlockNode = {
       block: {type: 'Table', id: 'TBLEMPTY', text: '', annotations: [], attributes: {}, link: '', revision: ''},
       children: [],
     } as unknown as HMBlockNode
     const md = blocksToMarkdown(doc([table, para('AFTER001', 'after')]))
-    expect(md).not.toContain('TBLEMPTY')
+    expect(md).toContain('<!-- id:TBLEMPTY type:Table -->')
     expect(md).toContain('after <!-- id:AFTER001 -->')
   })
 })

--- a/frontend/packages/client/src/block-diff.ts
+++ b/frontend/packages/client/src/block-diff.ts
@@ -90,7 +90,12 @@ export function matchBlockIds(oldNodes: APIBlockNode[], newNodes: BlockNode[]): 
       matchedId = oldNode.block.id
     }
 
-    const matchedChildren = matchBlockIds(oldNode?.children ?? [], newNode.children)
+    // A table's columns, rows and cells are bound to each other by id
+    // (cells reference columns via `columnId`), so positional renaming would
+    // break them. Only the table itself is matched here; its subtree is
+    // rebound as a unit by rebindTableIdentities.
+    const matchedChildren =
+      newNode.block.type === 'Table' ? newNode.children : matchBlockIds(oldNode?.children ?? [], newNode.children)
 
     return {
       block: {...newNode.block, id: matchedId},
@@ -346,6 +351,21 @@ export function computeReplaceOps(
   return ops
 }
 
+/** The ids of `parentId`'s children in the old document, in order. */
+function oldSiblingOrder(oldMap: BlocksMap, parentId: string): string[] {
+  const byLeft = new Map<string, string>()
+  for (const [id, entry] of Object.entries(oldMap)) {
+    if (entry.parent === parentId) byLeft.set(entry.left, id)
+  }
+  const order: string[] = []
+  let cur = byLeft.get('')
+  while (cur !== undefined && !order.includes(cur)) {
+    order.push(cur)
+    cur = byLeft.get(cur)
+  }
+  return order
+}
+
 function computeReplaceOpsInner(
   oldMap: BlocksMap,
   matchedTree: BlockNode[],
@@ -398,10 +418,12 @@ function computeReplaceOpsInner(
     }
   })
 
-  // Emit a single MoveBlocks for all blocks at this level.
-  // This positions them correctly under the parent in order.
-  // We always emit this to ensure correct ordering after changes.
-  if (blockIdsAtLevel.length > 0) {
+  // Emit a single MoveBlocks for all blocks at this level, positioning them
+  // under the parent in order — unless the level already reads exactly like
+  // this in the old document, so an untouched document yields no ops at all.
+  const oldOrder = oldSiblingOrder(oldMap, parentId)
+  const sameOrder = oldOrder.length === blockIdsAtLevel.length && blockIdsAtLevel.every((id, i) => oldOrder[i] === id)
+  if (blockIdsAtLevel.length > 0 && !sameOrder) {
     ops.push({
       type: 'MoveBlocks',
       blocks: blockIdsAtLevel,
@@ -426,6 +448,29 @@ function attrsEqual(a: Record<string, unknown>, b: Record<string, unknown>): boo
   return true
 }
 
+/** Deterministic annotation order: by first start, then longest first, then type. */
+function compareAnnotations(a: Record<string, unknown>, b: Record<string, unknown>): number {
+  const sa = (a.starts as number[] | undefined)?.[0] ?? 0
+  const sb = (b.starts as number[] | undefined)?.[0] ?? 0
+  const ea = (a.ends as number[] | undefined)?.[0] ?? 0
+  const eb = (b.ends as number[] | undefined)?.[0] ?? 0
+  return sa - sb || eb - ea || String(a.type).localeCompare(String(b.type))
+}
+
+/** An annotation reduced to its meaning: no empty link/attributes, fixed key order. */
+function canonicalAnnotation(ann: unknown): Record<string, unknown> {
+  const a = (ann || {}) as Record<string, unknown>
+  const out: Record<string, unknown> = {type: a.type, starts: a.starts, ends: a.ends}
+  if (a.link) out.link = a.link
+  const attrs = a.attributes as Record<string, unknown> | undefined
+  if (attrs && Object.keys(attrs).length > 0) {
+    const sorted: Record<string, unknown> = {}
+    for (const k of Object.keys(attrs).sort()) sorted[k] = attrs[k]
+    out.attributes = sorted
+  }
+  return out
+}
+
 /**
  * Compare old API block content with new parsed block content.
  * Returns true if they're semantically equal.
@@ -435,9 +480,10 @@ function isBlockContentEqual(old: APIBlock, newBlock: SeedBlock): boolean {
   if ((old.text || '') !== (newBlock.text || '')) return false
   if ((old.link || '') !== (newBlock.link || '')) return false
 
-  // Compare annotations
-  const oldAnn = old.annotations || []
-  const newAnn = newBlock.annotations || []
+  // Compare annotations semantically: the API spells out empty `link` /
+  // `attributes` and its own key order, the markdown parser does not.
+  const oldAnn = (old.annotations || []).map(canonicalAnnotation).sort(compareAnnotations)
+  const newAnn = (newBlock.annotations || []).map(canonicalAnnotation).sort(compareAnnotations)
   if (oldAnn.length !== newAnn.length) return false
   if (oldAnn.length > 0 && JSON.stringify(oldAnn) !== JSON.stringify(newAnn)) {
     return false

--- a/frontend/packages/client/src/blocks-to-markdown-slot.test.ts
+++ b/frontend/packages/client/src/blocks-to-markdown-slot.test.ts
@@ -22,14 +22,14 @@ describe('blocksToMarkdown Slot export', () => {
     const md = blocksToMarkdown(slotDoc('Unordered', ['one', 'two']))
     expect(md).toContain('- one')
     expect(md).toContain('- two')
-    // The invisible Slot itself must not leak any visible text.
-    expect(md).not.toContain('Slot')
+    // The invisible Slot is a comment-only line carrying its type.
+    expect(md).toContain('<!-- id:slot1 type:Slot -->\n- one')
   })
 
   it('emits a root Ordered Slot as markdown numbered items', () => {
     const md = blocksToMarkdown(slotDoc('Ordered', ['a', 'b']))
     expect(md).toContain('1. a')
-    expect(md).toContain('1. b')
+    expect(md).toContain('2. b')
   })
 
   it('emits a root Blockquote Slot as markdown blockquote items', () => {

--- a/frontend/packages/client/src/blocks-to-markdown.ts
+++ b/frontend/packages/client/src/blocks-to-markdown.ts
@@ -1,17 +1,21 @@
 /**
  * Seed block tree → Markdown formatter.
  *
- * Converts HMDocument/HMBlockNode trees to markdown with:
- *   - YAML frontmatter (always emitted, all HMMetadata fields)
- *   - Block IDs preserved as HTML comments (<!-- id:XXXXXXXX -->)
- *   - Inline annotations rendered as markdown formatting
+ * The lossless half of the markdown pair (see `markdown-to-blocks.ts` for the
+ * dialect). Converts HMDocument/HMBlockNode trees to markdown with:
+ *   - YAML frontmatter carrying every metadata key
+ *   - a trailing `<!-- id:X [type:T] [attrs:{…}] -->` comment on every block
+ *   - nesting by indentation, heading level by heading depth
+ *   - annotations as markdown markers, split at boundaries so they nest
  *
  * This module is purely synchronous and does NOT resolve embeds, mentions,
- * or queries over the network. For resolved output, use the CLI's wrapper
- * which adds a SeedClient-backed resolve layer on top.
+ * or queries over the network. For resolved output, see the
+ * `documentToResolvedMarkdown` family below, which is a display format and
+ * not round-trip safe.
  *
- * Round-trip compatible: output can be piped back through `parseMarkdown()`
- * to recreate the same document with block IDs preserved.
+ * Round-trip: `parseMarkdown(blocksToMarkdown(doc))` reproduces `doc`, and
+ * exporting that parse reproduces the same markdown. Use
+ * `{ipfsGateway: false}` to keep `ipfs://` links verbatim.
  */
 
 import type {SeedClient} from './client'
@@ -25,6 +29,7 @@ import type {
   UnpackedHypermediaId,
 } from './hm-types'
 import {unpackHmId} from './hm-types'
+import {stringify as stringifyYaml} from 'yaml'
 
 // ─── Options ─────────────────────────────────────────────────────────────────
 
@@ -35,86 +40,106 @@ export type BlocksToMarkdownOptions = {
 
 // ─── Frontmatter ─────────────────────────────────────────────────────────────
 
-/** HMMetadata keys that are strings (emitted as YAML scalars). */
-const FM_STRING_KEYS: (keyof HMMetadata)[] = [
+/**
+ * Metadata keys emitted first, in this order; every other key follows,
+ * sorted. Nested maps are sorted too, so the same metadata always yields
+ * the same frontmatter.
+ */
+const FM_KEY_ORDER = [
   'name',
   'summary',
-  'displayAuthor',
-  'displayPublishTime',
   'icon',
   'cover',
+  'displayAuthor',
+  'displayPublishTime',
+  'schema',
+  'childrenSchema',
+  'schemaDefinition',
   'siteUrl',
   'layout',
-  'seedExperimentalLogo',
-  'seedExperimentalHomeOrder',
+  'theme',
   'contentWidth',
   'childrenType',
+  'showOutline',
+  'showActivity',
+  'seedExperimentalLogo',
+  'seedExperimentalHomeOrder',
   'importCategories',
   'importTags',
 ]
 
-/** HMMetadata keys that are booleans (emitted as YAML true/false). */
-const FM_BOOLEAN_KEYS: (keyof HMMetadata)[] = ['showOutline', 'showActivity']
+function frontmatterKeyRank(key: string): number {
+  const idx = FM_KEY_ORDER.indexOf(key)
+  return idx === -1 ? FM_KEY_ORDER.length : idx
+}
 
 /**
- * Emit YAML frontmatter from HMMetadata.
- * Only includes fields that have defined, non-empty values.
- * System fields (authors, version, genesis, account) are NOT emitted.
+ * Emit YAML frontmatter from HMMetadata. Every defined key is emitted,
+ * including nested values and keys this client does not know about.
+ * System fields (authors, version, genesis, account) are not metadata and
+ * are never present here.
  */
 export function emitFrontmatter(metadata: HMMetadata): string {
-  const lines: string[] = []
-
-  // String fields
-  for (const key of FM_STRING_KEYS) {
-    const val = metadata[key]
-    if (val !== undefined && val !== '') {
-      lines.push(`${key}: ${JSON.stringify(val)}`)
-    }
-  }
-
-  // Boolean fields
-  for (const key of FM_BOOLEAN_KEYS) {
-    const val = metadata[key]
-    if (val !== undefined) {
-      lines.push(`${key}: ${val}`)
-    }
-  }
-
-  // Nested theme object
-  if (metadata.theme && typeof metadata.theme === 'object') {
-    const entries: string[] = []
-    if (metadata.theme.headerLayout !== undefined) {
-      entries.push(`  headerLayout: ${JSON.stringify(metadata.theme.headerLayout)}`)
-    }
-    if (entries.length > 0) {
-      lines.push('theme:')
-      lines.push(...entries)
-    }
-  }
-
-  if (lines.length === 0) return '---\n---\n'
-  return '---\n' + lines.join('\n') + '\n---\n'
+  const entries = Object.entries(metadata || {}).filter(([, v]) => v !== undefined)
+  if (entries.length === 0) return '---\n---\n'
+  const body = stringifyYaml(Object.fromEntries(entries), {
+    lineWidth: 0,
+    sortMapEntries: (a, b) => {
+      const ka = String(a.key)
+      const kb = String(b.key)
+      return frontmatterKeyRank(ka) - frontmatterKeyRank(kb) || ka.localeCompare(kb)
+    },
+  })
+  return '---\n' + body.replace(/\n$/, '') + '\n---\n'
 }
 
-// ─── Block ID helpers ────────────────────────────────────────────────────────
+// ─── Block comments ──────────────────────────────────────────────────────────
 
-/** Format a block ID as an inline HTML comment. */
+/** Stable-key JSON that can live inside an HTML comment (no `--`). */
+function commentJson(value: unknown): string {
+  return JSON.stringify(sortKeysDeep(value)).replace(/--/g, '-\\u002d')
+}
+
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeysDeep)
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const k of Object.keys(value as object).sort()) {
+      const v = (value as Record<string, unknown>)[k]
+      if (v !== undefined) out[k] = sortKeysDeep(v)
+    }
+    return out
+  }
+  return value
+}
+
+/** `<!-- id:X [type:T] [attrs:{…}] -->` */
+function blockComment(id: string, type?: string, attrs?: Record<string, unknown>): string {
+  let s = `<!-- id:${id}`
+  if (type) s += ` type:${type}`
+  if (attrs && Object.keys(attrs).length) s += ` attrs:${commentJson(attrs)}`
+  return s + ' -->'
+}
+
+/** Kept for the table emitter and the resolved emitter. */
 function idComment(id: string): string {
-  return `<!-- id:${id} -->`
+  return blockComment(id)
 }
 
-/**
- * Append a block ID comment to the first line of a markdown string.
- * If the string is empty, returns just the comment.
- */
-function appendIdToFirstLine(md: string, id: string): string {
-  const newline = md.indexOf('\n')
-  if (newline === -1) {
-    // Single line
-    return md ? `${md} ${idComment(id)}` : idComment(id)
+/** Block types with native markdown syntax; every other type is named in the comment. */
+const NATIVE_TYPES = new Set(['Paragraph', 'Heading', 'Code', 'Math', 'Image', 'Table'])
+
+/** Attributes expressed by syntax rather than in `attrs:`. */
+function isNativeAttribute(type: string, key: string, value: unknown, hasChildren: boolean): boolean {
+  if (key === 'childrenType') {
+    if (value === 'Unordered' || value === 'Ordered' || value === 'Blockquote') return true
+    // Group is the default for any block with children; only an explicit
+    // Group on a childless block needs spelling out.
+    if (value === 'Group') return hasChildren
+    return false
   }
-  // Multi-line: append to first line only
-  return `${md.slice(0, newline)} ${idComment(id)}${md.slice(newline)}`
+  if (type === 'Code' && key === 'language') return true
+  return false
 }
 
 // ─── Main entry point ────────────────────────────────────────────────────────
@@ -127,91 +152,62 @@ function appendIdToFirstLine(md: string, id: string): string {
  */
 export function blocksToMarkdown(doc: HMDocument, options?: BlocksToMarkdownOptions): string {
   const opts = {ipfsGateway: true, ...options}
-  const lines: string[] = []
+  const out: string[] = [emitFrontmatter(doc.metadata || {}).replace(/\n$/, '')]
+  renderNodes(doc.content || [], '', undefined, 0, opts, out)
+  return out.join('\n') + '\n'
+}
 
-  // Always emit frontmatter
-  lines.push(emitFrontmatter(doc.metadata || {}))
+type ChildrenType = string | undefined
 
-  // Content blocks
-  for (const node of doc.content) {
-    const blockMd = blockNodeToMarkdown(node, 0, opts)
-    if (blockMd) {
-      lines.push(blockMd)
-    }
-  }
+const LIST_TYPES = new Set(['Unordered', 'Ordered', 'Blockquote'])
 
-  return lines.join('\n')
+function markerFor(childrenType: ChildrenType, index: number): string {
+  if (childrenType === 'Unordered') return '- '
+  if (childrenType === 'Ordered') return `${index + 1}. `
+  if (childrenType === 'Blockquote') return '> '
+  return ''
 }
 
 /**
- * Convert a block node (with children) to markdown.
- *
- * Children are rendered based on `childrenType`:
- *   - Ordered/Unordered/Blockquote → prefixed list items
- *   - Group (default) → nested blocks
- *
- * Container blocks (empty text with childrenType like "Unordered")
- * get a standalone block ID comment on their own line before the
- * list content, since they have no visible text line to attach to.
+ * Render sibling blocks at indentation `ind`. Group siblings are separated
+ * by a blank line; list / quote items are not.
  */
-function blockNodeToMarkdown(node: HMBlockNode, depth: number, opts: Required<BlocksToMarkdownOptions>): string {
-  const block = node.block
-  const children = node.children || []
-
-  // Tables render their whole subtree (TableColumn/TableRow/cell blocks) as
-  // one GFM table — never recurse generically into their children.
-  if (block.type === 'Table') {
-    return tableToMarkdown(node, depth, (text, annotations) => applyAnnotations(text, annotations))
-  }
-
-  const childrenType = (block as {attributes?: {childrenType?: string}}).attributes?.childrenType
-
-  // Check if this is an invisible list container: an empty paragraph, or a
-  // Slot block.
-  const isListContainer =
-    (block.type === 'Paragraph' || block.type === 'Slot') &&
-    !block.text &&
-    (childrenType === 'Ordered' || childrenType === 'Unordered' || childrenType === 'Blockquote')
-
-  let result: string
-
-  if (isListContainer) {
-    // Standalone ID comment for the invisible container
-    result = idComment(block.id)
-  } else {
-    result = blockToMarkdown(block, depth, opts)
-  }
-
-  // Render children
-  for (const child of children) {
-    const childMd = blockNodeToMarkdown(child, depth + 1, opts)
-    if (childMd) {
-      if (childrenType === 'Ordered') {
-        // List items already have their block ID from blockToMarkdown
-        result += '\n' + indent(depth + 1) + '1. ' + childMd.trim()
-      } else if (childrenType === 'Unordered') {
-        result += '\n' + indent(depth + 1) + '- ' + childMd.trim()
-      } else if (childrenType === 'Blockquote') {
-        result += '\n' + indent(depth + 1) + '> ' + childMd.trim()
-      } else {
-        // Group children (default): blank-line separated so CommonMark
-        // parsers read each child as a distinct paragraph/block. A single
-        // newline would merge siblings into one soft-wrapped paragraph
-        // on re-import.
-        result += '\n\n' + childMd
-      }
+function renderNodes(
+  nodes: HMBlockNode[],
+  ind: string,
+  childrenType: ChildrenType,
+  headingDepth: number,
+  opts: Required<BlocksToMarkdownOptions>,
+  out: string[],
+): void {
+  const listy = LIST_TYPES.has(childrenType || '')
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i]!
+    if (i > 0 && !listy) out.push('')
+    const marker = markerFor(childrenType, i)
+    const wroteHeading = renderNode(node, ind, marker, headingDepth, opts, out)
+    // A heading's children sit at its own indentation, so a following
+    // non-heading sibling needs an explicit close.
+    const next = nodes[i + 1]
+    if (wroteHeading && next && next.block.type !== 'Heading') {
+      out.push(ind + `<!-- end:${node.block.id} -->`)
     }
   }
-
-  return result
 }
 
 /**
- * Convert a single block to markdown with its block ID embedded.
+ * Render one block and its children. Returns true when the block was
+ * written as a heading whose children share its indentation.
  */
-function blockToMarkdown(block: HMBlock, depth: number, opts: Required<BlocksToMarkdownOptions>): string {
-  const ind = indent(depth)
-  const b = block as {
+function renderNode(
+  node: HMBlockNode,
+  ind: string,
+  marker: string,
+  headingDepth: number,
+  opts: Required<BlocksToMarkdownOptions>,
+  out: string[],
+): boolean {
+  const block = node.block as {
     type: string
     id: string
     text?: string
@@ -219,82 +215,133 @@ function blockToMarkdown(block: HMBlock, depth: number, opts: Required<BlocksToM
     annotations?: HMAnnotation[]
     attributes?: Record<string, unknown>
   }
-  const text = b.text || ''
-  const link = b.link || ''
-  const annotations = b.annotations
-  const id = b.id
+  const children = node.children || []
+  const type = block.type
+  const text = block.text || ''
+  const link = block.link || ''
+  const attributes = block.attributes || {}
+  const childrenType = attributes.childrenType as ChildrenType
 
-  switch (block.type) {
+  // Tables render their whole subtree (TableColumn/TableRow/cell blocks) as
+  // one GFM table — never recurse generically into their children.
+  if (type === 'Table') {
+    const extra = extraAttributes(type, attributes, false)
+    const contentInd = ind + ' '.repeat(marker.length)
+    const table = tableToMarkdown(node, contentInd, (t, a) => renderInline(t, a, {atLineStart: false}))
+    // A table with no columns has no GFM form; the comment alone carries it.
+    out.push(ind + marker + blockComment(block.id, table ? undefined : 'Table', extra))
+    if (table) out.push(...table.split('\n'))
+    return false
+  }
+
+  const extra = extraAttributes(type, attributes, children.length > 0)
+  const comment = blockComment(block.id, NATIVE_TYPES.has(type) ? undefined : type, extra)
+  const contentInd = ind + ' '.repeat(marker.length)
+  let wroteHeading = false
+  let childInd = marker ? contentInd : ind + '  '
+  let childHeadingDepth = 0
+  let shorthand = false
+
+  switch (type) {
     case 'Paragraph': {
-      const rendered = ind + applyAnnotations(text, annotations)
-      return appendIdToFirstLine(rendered, id)
-    }
-
-    case 'Heading': {
-      const level = Math.min(depth + 1, 6)
-      const hashes = '#'.repeat(level)
-      const rendered = `${hashes} ${applyAnnotations(text, annotations)}`
-      return appendIdToFirstLine(rendered, id)
-    }
-
-    case 'Code': {
-      const lang = (b.attributes?.language as string) || ''
-      // ID on the opening fence line
-      return ind + '```' + lang + ' ' + idComment(id) + '\n' + ind + text + '\n' + ind + '```'
-    }
-
-    case 'Math': {
-      // ID on the $$ opener line
-      return ind + '$$ ' + idComment(id) + '\n' + ind + text + '\n' + ind + '$$'
-    }
-
-    case 'Image': {
-      const altText = text || 'image'
-      const imgUrl = formatMediaUrl(link, opts.ipfsGateway)
-      return ind + `![${altText}](${imgUrl}) ${idComment(id)}`
-    }
-
-    case 'Video': {
-      const videoUrl = formatMediaUrl(link, opts.ipfsGateway)
-      return ind + `[Video](${videoUrl}) ${idComment(id)}`
-    }
-
-    case 'File': {
-      const fileName = (b.attributes?.name as string) || 'file'
-      const fileUrl = formatMediaUrl(link, opts.ipfsGateway)
-      return ind + `[${fileName}](${fileUrl}) ${idComment(id)}`
-    }
-
-    case 'Embed': {
-      // Unresolved embed — render as blockquote link placeholder
-      return ind + `> [Embed: ${link}](${link}) ${idComment(id)}`
-    }
-
-    case 'WebEmbed': {
-      return ind + `[Web Embed](${link}) ${idComment(id)}`
-    }
-
-    case 'Button': {
-      const buttonText = text || 'Button'
-      return ind + `[${buttonText}](${link}) ${idComment(id)}`
-    }
-
-    case 'Query': {
-      // Unresolved query — render as HTML comment placeholder
-      return ind + `<!-- Query block --> ${idComment(id)}`
-    }
-
-    case 'Nostr': {
-      return ind + `[Nostr: ${link}](${link}) ${idComment(id)}`
-    }
-
-    default: {
-      if (text) {
-        return appendIdToFirstLine(ind + text, id)
+      if (!text && children.length && LIST_TYPES.has(childrenType || '') && !marker) {
+        // Invisible list container: a standalone comment, children follow
+        // at the same indentation as marker lines.
+        out.push(ind + comment)
+        shorthand = true
+        childInd = ind
+      } else if (!text) {
+        out.push(ind + marker + comment)
+      } else {
+        out.push(ind + marker + renderInline(text, block.annotations, {atLineStart: true}) + ' ' + comment)
       }
-      return ''
+      break
+    }
+    case 'Heading': {
+      const level = Math.min(headingDepth + 1, 6)
+      out.push(
+        ind +
+          marker +
+          '#'.repeat(level) +
+          ' ' +
+          renderInline(text, block.annotations, {atLineStart: false}) +
+          ' ' +
+          comment,
+      )
+      if (level < 6) {
+        wroteHeading = !marker
+        childInd = contentInd
+        childHeadingDepth = headingDepth + 1
+      } else {
+        childInd = contentInd + '  '
+      }
+      // A blank line between a heading and its content, as people write it.
+      if (children.length) out.push('')
+      break
+    }
+    case 'Code': {
+      const lang = (attributes.language as string) || ''
+      let fenceLen = 3
+      for (const m of text.matchAll(/`+/g)) fenceLen = Math.max(fenceLen, m[0].length + 1)
+      const fence = '`'.repeat(fenceLen)
+      out.push(ind + marker + fence + lang + ' ' + comment)
+      for (const line of text.split('\n')) out.push(line ? contentInd + line : '')
+      out.push(contentInd + fence)
+      break
+    }
+    case 'Math': {
+      out.push(ind + marker + '$$ ' + comment)
+      for (const line of text.split('\n')) out.push(line ? contentInd + line : '')
+      out.push(contentInd + '$$')
+      break
+    }
+    case 'Image': {
+      const alt = renderInline(text, block.annotations, {atLineStart: false})
+      out.push(ind + marker + `![${alt}](${renderUrl(formatMediaUrl(link, opts.ipfsGateway))}) ` + comment)
+      break
+    }
+    default: {
+      // A typed block: its visible form is whatever markdown can show.
+      const url = renderUrl(formatMediaUrl(link, opts.ipfsGateway))
+      let visible = ''
+      if (text && link) visible = `[${renderInline(text, block.annotations, {atLineStart: false})}](${url})`
+      else if (link) visible = `<${formatMediaUrl(link, opts.ipfsGateway)}>`
+      else if (text) visible = renderInline(text, block.annotations, {atLineStart: true})
+      out.push(ind + marker + (visible ? visible + ' ' : '') + comment)
+      if (!visible && children.length && LIST_TYPES.has(childrenType || '') && !marker) {
+        // Invisible container (e.g. a Slot holding a list): children follow
+        // as marker lines at the same indentation.
+        shorthand = true
+        childInd = ind
+      }
     }
   }
+
+  if (children.length) {
+    if (!shorthand && type !== 'Heading' && !LIST_TYPES.has(childrenType || '')) out.push('')
+    renderNodes(children, childInd, childrenType, childHeadingDepth, opts, out)
+  }
+  return wroteHeading
+}
+
+/** Attributes that go into the comment's `attrs:` because no syntax carries them. */
+function extraAttributes(
+  type: string,
+  attributes: Record<string, unknown>,
+  hasChildren: boolean,
+): Record<string, unknown> {
+  const extra: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value === undefined || value === null) continue
+    if (isNativeAttribute(type, key, value, hasChildren)) continue
+    extra[key] = value
+  }
+  return extra
+}
+
+/** Wrap a URL in `<…>` when it could not otherwise sit inside `(…)`. */
+function renderUrl(url: string): string {
+  return /[\s()<>]/.test(url) ? `<${url}>` : url
 }
 
 // ─── Table emission ──────────────────────────────────────────────────────────
@@ -330,13 +377,13 @@ type NormalizedTableRow = {
 }
 
 type NormalizedTable = {
-  columns: {id: string}[]
+  columns: {id: string; attributes?: Record<string, unknown>}[]
   rows: NormalizedTableRow[]
 }
 
 /** Normalize a Table block node the way the renderers do. */
 function normalizeTableNode(node: HMBlockNode): NormalizedTable {
-  const columns: {id: string}[] = []
+  const columns: {id: string; attributes?: Record<string, unknown>}[] = []
   const rows: NormalizedTableRow[] = []
 
   for (const child of node.children || []) {
@@ -346,7 +393,8 @@ function normalizeTableNode(node: HMBlockNode): NormalizedTable {
       attributes?: Record<string, unknown>
     }
     if (block?.type === 'TableColumn') {
-      columns.push({id: block.id})
+      const attributes = extraAttributes('TableColumn', block.attributes || {}, false)
+      columns.push(Object.keys(attributes).length ? {id: block.id, attributes} : {id: block.id})
     } else if (block?.type === 'TableRow') {
       const cells = new Map<string, {text: string; annotations?: HMAnnotation[]}>()
       for (const cellNode of child.children || []) {
@@ -383,18 +431,17 @@ function escapeCellText(s: string): string {
  * the delimiter row — required for strict-GFM renderers to recognize the
  * table at all. */
 function assembleTableMarkdown(
-  tableId: string,
-  columns: {id: string}[],
+  columns: {id: string; attributes?: Record<string, unknown>}[],
   header: {rowId?: string; cellTexts: string[]},
   bodyRows: {rowId: string; cellTexts: string[]}[],
   ind: string,
 ): string {
   const lines: string[] = []
-  lines.push(ind + idComment(tableId))
 
   const headerCells = columns.map((col, idx) => {
     const text = header.cellTexts[idx] || ''
-    return (text ? text + ' ' : '') + `<!-- col:${col.id} -->`
+    const attrs = col.attributes && Object.keys(col.attributes).length ? ` attrs:${commentJson(col.attributes)}` : ''
+    return (text ? text + ' ' : '') + `<!-- col:${col.id}${attrs} -->`
   })
   if (header.rowId) {
     headerCells[headerCells.length - 1] += ' ' + idComment(header.rowId)
@@ -418,7 +465,7 @@ function assembleTableMarkdown(
  */
 function tableToMarkdown(
   node: HMBlockNode,
-  depth: number,
+  ind: string,
   renderCell: (text: string, annotations: HMAnnotation[] | undefined) => string,
 ): string {
   const {columns, rows} = normalizeTableNode(node)
@@ -438,13 +485,7 @@ function tableToMarkdown(
     cellTexts: renderRowCells(row),
   }))
 
-  return assembleTableMarkdown(
-    node.block.id,
-    columns,
-    {rowId: headerRow?.id, cellTexts: renderRowCells(headerRow)},
-    bodyRows,
-    indent(depth),
-  )
+  return assembleTableMarkdown(columns, {rowId: headerRow?.id, cellTexts: renderRowCells(headerRow)}, bodyRows, ind)
 }
 
 /** Async twin of tableToMarkdown for the resolved emitter. */
@@ -472,91 +513,218 @@ async function tableToResolvedMarkdown(
     })),
   )
 
-  return assembleTableMarkdown(
-    node.block.id,
-    columns,
-    {rowId: headerRow?.id, cellTexts: await renderRowCells(headerRow)},
-    bodyRows,
-    indent(depth),
+  return (
+    resolvedIndent(depth) +
+    resolvedIdComment(node.block.id) +
+    '\n' +
+    assembleTableMarkdown(
+      columns,
+      {rowId: headerRow?.id, cellTexts: await renderRowCells(headerRow)},
+      bodyRows,
+      resolvedIndent(depth),
+    )
   )
 }
 
-// ─── Annotation rendering ────────────────────────────────────────────────────
+// ─── Inline rendering ────────────────────────────────────────────────────────
+//
+// Annotations become markdown markers. Because HM annotations may overlap
+// arbitrarily while markdown markers must nest, the text is split at every
+// annotation boundary and markers are closed and reopened around each run
+// as needed. The parser merges the pieces back (mergeAdjacentAnnotations).
+//
+// Code spans are literal, so they always sit innermost; an Embed annotation
+// is atomic (`<hm://…>`) and replaces its placeholder text.
 
-/**
- * Apply text annotations (bold, italic, links, etc.) to produce markdown.
- */
-function applyAnnotations(text: string, annotations: HMAnnotation[] | undefined): string {
-  if (!annotations || annotations.length === 0) {
-    return text
-  }
-
-  type Marker = {pos: number; type: 'open' | 'close'; annotation: HMAnnotation}
-  const markers: Marker[] = []
-
-  for (const ann of annotations) {
-    const starts = ann.starts || []
-    const ends = ann.ends || []
-
-    for (let i = 0; i < starts.length; i++) {
-      markers.push({pos: starts[i]!, type: 'open', annotation: ann})
-      if (ends[i] !== undefined) {
-        markers.push({pos: ends[i]!, type: 'close', annotation: ann})
-      }
-    }
-  }
-
-  markers.sort((a, b) => {
-    if (a.pos !== b.pos) return a.pos - b.pos
-    return a.type === 'open' ? -1 : 1
-  })
-
-  let result = ''
-  let lastPos = 0
-
-  for (const marker of markers) {
-    result += text.slice(lastPos, marker.pos)
-    lastPos = marker.pos
-    result += getAnnotationMarker(marker.annotation, marker.type)
-  }
-
-  result += text.slice(lastPos)
-  result = result.replace(/\uFFFC/g, '')
-
-  return result
+type Span = {
+  start: number
+  end: number
+  type: string
+  link?: string
+  attributes?: Record<string, unknown>
+  key: string
 }
 
-/**
- * Get markdown marker for an annotation open/close.
- */
-function getAnnotationMarker(ann: HMAnnotation, type: 'open' | 'close'): string {
-  switch (ann.type) {
-    case 'Bold':
-      return '**'
-    case 'Italic':
-      return '_'
-    case 'Strike':
-      return '~~'
-    case 'Code':
-      return '`'
-    case 'Underline':
-      return type === 'open' ? '<u>' : '</u>'
-    case 'Link':
-      if (type === 'open') {
-        return '['
-      } else {
-        return `](${ann.link || ''})`
-      }
-    case 'Embed': {
-      // CommonMark autolink: <url>. The ￼ placeholder inside the annotation
-      // range is stripped by applyAnnotations' final pass, so the emitted
-      // span becomes `<url>` with no literal text between brackets.
-      const link = 'link' in ann ? (ann.link as string) || '' : ''
-      return type === 'open' ? `<${link}` : '>'
-    }
-    default:
-      return ''
+type RenderInlineOptions = {
+  /** Escape characters that would start a block (heading, list, table…) at position 0. */
+  atLineStart: boolean
+}
+
+const SPAN_STYLE: Record<string, string> = {
+  TextColor: 'color',
+  BackgroundColor: 'background-color',
+  TextSize: 'font-size',
+  TextFamily: 'font-family',
+}
+
+function encodeHtmlAttr(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+/** Escape text so the inline parser reads it back verbatim. */
+function escapeInline(s: string, atLineStart: boolean): string {
+  let out = s.replace(/[\\`*_~\[\]<]/g, (c) => '\\' + c).replace(/\n/g, '<br>')
+  if (atLineStart) {
+    out = out.replace(/^(#|[-+>|$]|\d+[.)])/, (m) => (m.length === 1 ? '\\' + m : m.slice(0, -1) + '\\' + m.slice(-1)))
+    // Leading whitespace would read as indentation.
+    if (/^\s/.test(out)) out = '\\' + out
   }
+  return out
+}
+
+/** Trailing whitespace would be lost to the separator before the id comment: escape its last character. */
+function escapeTrailingWhitespace(s: string): string {
+  return /\s$/.test(s) ? s.slice(0, -1) + '\\' + s.slice(-1) : s
+}
+
+function spansFromAnnotations(text: string, annotations: HMAnnotation[] | undefined): Span[] {
+  const spans: Span[] = []
+  for (const ann of annotations || []) {
+    const a = ann as {
+      type: string
+      starts?: number[]
+      ends?: number[]
+      link?: string
+      attributes?: Record<string, unknown>
+    }
+    const starts = a.starts || []
+    const ends = a.ends || []
+    const link = a.link || undefined
+    const attributes = a.attributes && Object.keys(a.attributes).length ? a.attributes : undefined
+    const key = a.type + ' ' + (link ?? '') + ' ' + (attributes ? commentJson(attributes) : '')
+    for (let i = 0; i < starts.length; i++) {
+      const start = Math.max(0, starts[i]!)
+      const end = Math.min(text.length, ends[i] ?? -1)
+      if (end <= start) continue
+      spans.push({start, end, type: a.type, link, attributes, key})
+    }
+  }
+  // Merge touching / overlapping spans of the same kind.
+  spans.sort((x, y) => x.key.localeCompare(y.key) || x.start - y.start || x.end - y.end)
+  const merged: Span[] = []
+  for (const s of spans) {
+    const last = merged[merged.length - 1]
+    if (last && last.key === s.key && s.start <= last.end) last.end = Math.max(last.end, s.end)
+    else merged.push({...s})
+  }
+  return merged
+}
+
+/** Innermost-first ordering priority: code and embeds must be innermost. */
+function spanPriority(s: Span): number {
+  if (s.type === 'Embed') return 2
+  if (s.type === 'Code') return 1
+  return 0
+}
+
+/** Render text + annotations as inline markdown. */
+function renderInline(text: string, annotations: HMAnnotation[] | undefined, options: RenderInlineOptions): string {
+  const spans = spansFromAnnotations(text, annotations)
+  if (spans.length === 0) return escapeTrailingWhitespace(escapeInline(text, options.atLineStart))
+
+  const boundaries = new Set<number>([0, text.length])
+  for (const s of spans) {
+    boundaries.add(s.start)
+    boundaries.add(s.end)
+  }
+  const points = [...boundaries].sort((a, b) => a - b)
+
+  type Open = {span: Span; close: string}
+  const stack: Open[] = []
+  let out = ''
+
+  for (let p = 0; p < points.length - 1; p++) {
+    const pos = points[p]!
+    const next = points[p + 1]!
+    const active = spans.filter((s) => s.start <= pos && s.end >= next)
+
+    // Close everything that is not active for this run, reopening survivors.
+    const survivors: Span[] = []
+    let firstInactive = stack.findIndex((o) => !active.includes(o.span))
+    if (firstInactive === -1) firstInactive = stack.length
+    while (stack.length > firstInactive) {
+      const top = stack.pop()!
+      out += top.close
+      if (active.includes(top.span)) survivors.unshift(top.span)
+    }
+    const opening = [...survivors, ...active.filter((s) => !stack.some((o) => o.span === s) && !survivors.includes(s))]
+    opening.sort(
+      (a, b) => spanPriority(a) - spanPriority(b) || b.end - a.end || a.start - b.start || a.type.localeCompare(b.type),
+    )
+    // Code / Embed must be innermost even if they were already open.
+    const inner = stack.filter((o) => spanPriority(o.span) > 0)
+    if (opening.length && inner.length) {
+      for (const o of inner.reverse()) {
+        out += o.close
+        stack.splice(stack.indexOf(o), 1)
+        opening.push(o.span)
+      }
+      opening.sort(
+        (a, b) =>
+          spanPriority(a) - spanPriority(b) || b.end - a.end || a.start - b.start || a.type.localeCompare(b.type),
+      )
+    }
+    for (const s of opening) {
+      const chunk = text.slice(pos, next)
+      const [open, close] = markersFor(s, chunk, text)
+      out += open
+      stack.push({span: s, close})
+    }
+
+    const top = stack[stack.length - 1]
+    const chunk = text.slice(pos, next)
+    if (top?.span.type === 'Embed') {
+      // atomic: the marker carries the link, the placeholder text is dropped
+    } else if (top?.span.type === 'Code') {
+      out += chunk.replace(/\n/g, '<br>')
+    } else {
+      out += escapeInline(chunk, options.atLineStart && out === '')
+    }
+  }
+  while (stack.length) out += stack.pop()!.close
+  return escapeTrailingWhitespace(out)
+}
+
+/** Open/close markers for a span, given the chunk it is about to wrap. */
+function markersFor(s: Span, chunk: string, fullText: string): [string, string] {
+  switch (s.type) {
+    case 'Bold':
+      return ['**', '**']
+    case 'Italic':
+      return ['_', '_']
+    case 'Strike':
+      return ['~~', '~~']
+    case 'Underline':
+      return ['<u>', '</u>']
+    case 'Range':
+      return ['<mark>', '</mark>']
+    case 'Link':
+      return ['[', `](${renderUrl(s.link || '')})`]
+    case 'Embed':
+      return [`<${s.link || ''}>`, '']
+    case 'Code': {
+      // Fence longer than any backtick run in the whole span, and a space pad
+      // when the chunk starts/ends with a backtick or a space.
+      let fenceLen = 1
+      for (const m of fullText.slice(s.start, s.end).matchAll(/`+/g)) fenceLen = Math.max(fenceLen, m[0].length + 1)
+      const fence = '`'.repeat(fenceLen)
+      const pad = /^[` ]|[` ]$/.test(chunk) ? ' ' : ''
+      return [fence + pad, pad + fence]
+    }
+    default: {
+      const prop = SPAN_STYLE[s.type]
+      if (prop) {
+        const value = String((s.attributes as {value?: unknown} | undefined)?.value ?? '')
+        return [`<span style="${prop}:${encodeHtmlAttr(value)}">`, '</span>']
+      }
+      return ['', '']
+    }
+  }
+}
+
+/** Kept for the table emitter. */
+function applyAnnotations(text: string, annotations: HMAnnotation[] | undefined): string {
+  return renderInline(text, annotations, {atLineStart: false})
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/frontend/packages/client/src/markdown-to-blocks.ts
+++ b/frontend/packages/client/src/markdown-to-blocks.ts
@@ -1,22 +1,36 @@
 /**
  * Markdown → Seed block tree parser.
  *
- * Converts markdown content into a tree of Seed Hypermedia blocks
- * with proper hierarchy: headings contain their content as children,
- * lists use childrenType attributes, and inline formatting becomes
- * annotations.
+ * The inverse of `blocks-to-markdown.ts`. Together they form a lossless pair:
+ * any document exported with `blocksToMarkdown` parses back to the same
+ * document, and re-exporting that parse reproduces the same markdown.
  *
- * Supports:
- *   - YAML frontmatter (--- delimited) for metadata extraction
- *   - ![alt](url) image syntax for Image blocks
- *   - $$ delimited math blocks
- *   - Block ID preservation via <!-- id:XXXXXXXX --> HTML comments
- *   - `title:` as backward-compatible alias for `name:` in frontmatter
+ * Structure:
+ *   - Indentation carries nesting. A block's children sit two spaces deeper
+ *     (or at the content column of a list/quote marker).
+ *   - Heading children sit at the heading's own indentation, delimited by the
+ *     next heading of the same or higher level, an `<!-- end:ID -->` line, or
+ *     a dedent. Heading level is one more than the number of enclosing
+ *     headings at the same indentation.
+ *   - `- `, `1. ` and `> ` markers set the parent's `childrenType`
+ *     (Unordered / Ordered / Blockquote). Unmarked children are `Group`.
+ *   - A standalone `<!-- id:X -->` line is a block with no visible text (an
+ *     invisible list container, a Slot, a Query, a Table…). A list or quote
+ *     directly after it at the same indentation is its children.
+ *
+ * Identity and extras live in the trailing HTML comment:
+ *   `<!-- id:X type:T attrs:{...} -->`
+ * `type:` names a block type markdown cannot express (Video, File, Button,
+ * Embed, WebEmbed, Nostr, Query, Slot, …); `attrs:` is a JSON object of
+ * attributes with no native syntax.
+ *
+ * Plain, hand-written markdown (no comments) still parses sensibly: content
+ * after a heading nests under it, soft-wrapped lines join with a space, and
+ * ids are generated.
  */
-
 import {parse as parseYaml} from 'yaml'
-import type {HMBlockNode, HMMetadata} from './hm-types'
 import type {DocumentOperation} from './change'
+import type {HMBlockNode, HMMetadata} from './hm-types'
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -25,6 +39,7 @@ export type Annotation = {
   starts: number[]
   ends: number[]
   link?: string
+  attributes?: Record<string, unknown>
 }
 
 export type SeedBlock = {
@@ -68,54 +83,167 @@ type InlineParseResult = {
   annotations: Annotation[]
 }
 
+/** Style annotations carried by `<span style="prop:value">`. */
+const SPAN_STYLE_TO_TYPE: Record<string, string> = {
+  color: 'TextColor',
+  'background-color': 'BackgroundColor',
+  'font-size': 'TextSize',
+  'font-family': 'TextFamily',
+}
+
+const SPAN_TYPES = new Set(Object.values(SPAN_STYLE_TO_TYPE))
+
+function decodeHtmlAttr(s: string): string {
+  return s
+    .replace(/&quot;/g, '"')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+}
+
+type OpenSpan = {type: string; start: number; family?: string; link?: string; attributes?: Record<string, unknown>}
+
 /**
  * Parses inline markdown formatting into plain text + annotation spans.
- * Supports: **bold**, *italic*, `code`, [text](url)
+ *
+ * Supports `**bold**`, `_italic_` / `*italic*`, `~~strike~~`, `` `code` ``,
+ * `<u>`, `<mark>`, `<span style="…">`, `<br>`, `[text](url)`, `<url>`
+ * autolinks (hm:// → Embed, else Link) and backslash escapes. Markers are
+ * matched with a stack, so well-nested output from the emitter parses
+ * exactly; mis-nested hand-written input degrades gracefully.
  */
 export function parseInlineFormatting(raw: string): InlineParseResult {
   const annotations: Annotation[] = []
+  const stack: OpenSpan[] = []
   let text = ''
   let i = 0
 
+  const close = (span: OpenSpan) => {
+    if (text.length > span.start) {
+      const ann: Annotation = {type: span.type, starts: [span.start], ends: [text.length]}
+      if (span.link !== undefined) ann.link = span.link
+      if (span.attributes) ann.attributes = span.attributes
+      annotations.push(ann)
+    }
+  }
+
+  /** Close `kind` if open (closing and reopening anything above it), else open it. */
+  const toggle = (kind: string, family: string) => {
+    const idx = findLastIndex(stack, (s) => s.type === kind && s.family === family)
+    if (idx === -1) {
+      stack.push({type: kind, start: text.length, family})
+      return
+    }
+    const above = stack.splice(idx + 1)
+    for (const s of above.reverse()) close(s)
+    close(stack.pop()!)
+    for (const s of above.reverse()) stack.push({...s, start: text.length})
+  }
+
+  const closeType = (pred: (s: OpenSpan) => boolean) => {
+    const idx = findLastIndex(stack, pred)
+    if (idx === -1) return
+    const above = stack.splice(idx + 1)
+    for (const s of above.reverse()) close(s)
+    close(stack.pop()!)
+    for (const s of above.reverse()) stack.push({...s, start: text.length})
+  }
+
   while (i < raw.length) {
+    const ch = raw[i]!
+
     // Escaped character
-    if (raw[i] === '\\' && i + 1 < raw.length) {
+    if (ch === '\\' && i + 1 < raw.length) {
       text += raw[i + 1]
       i += 2
       continue
     }
 
-    // Inline image: ![alt](url) — skip the ! so it's not parsed as a link
-    // Block-level images are handled by the tokenizer; inline occurrences
-    // are treated as plain text with the URL since Seed has no inline image type.
-    if (raw[i] === '!' && i + 1 < raw.length && raw[i + 1] === '[') {
-      const closeBracket = findClosingBracket(raw, i + 1)
-      if (closeBracket !== -1 && closeBracket + 1 < raw.length && raw[closeBracket + 1] === '(') {
-        const closeParen = raw.indexOf(')', closeBracket + 2)
-        if (closeParen !== -1) {
-          // Emit alt text as plain text (no inline image annotation in Seed)
-          const altText = raw.slice(i + 2, closeBracket)
-          if (altText) {
-            text += altText
-          }
-          i = closeParen + 1
-          continue
+    // Code span: a run of N backticks closed by the next run of exactly N.
+    if (ch === '`') {
+      let n = 0
+      while (raw[i + n] === '`') n++
+      const closer = findBacktickRun(raw, i + n, n)
+      if (closer !== -1) {
+        let inner = raw.slice(i + n, closer)
+        // CommonMark: strip one space pad when both sides have it and the
+        // content is not all spaces.
+        if (inner.length >= 2 && inner.startsWith(' ') && inner.endsWith(' ') && inner.trim() !== '') {
+          inner = inner.slice(1, -1)
         }
+        inner = inner.replace(/<br\s*\/?>/g, '\n')
+        const start = text.length
+        text += inner
+        if (inner.length) annotations.push({type: 'Code', starts: [start], ends: [text.length]})
+        i = closer + n
+        continue
       }
+      text += raw.slice(i, i + n)
+      i += n
+      continue
     }
 
-    // Autolink: <scheme://...>
-    //
-    // CommonMark autolinks have a URI with a scheme, no whitespace, and
-    // balanced angle brackets. Two cases by scheme:
-    //   - hm://...  → Embed annotation on a U+FFFC placeholder. Embeds
-    //     point to hypermedia resources and are rendered by the editor
-    //     as inline mention chips.
-    //   - any other scheme (http, https, mailto, …) → Link annotation
-    //     spanning the visible URL text. The editor's mention renderer
-    //     would print "ERROR" for an Embed pointing at a non-hm URL,
-    //     so external autolinks must be plain links.
-    if (raw[i] === '<') {
+    // Emphasis runs: `**` bold, `*` italic; `__` bold, `_` italic.
+    if (ch === '*' || ch === '_') {
+      let n = 0
+      while (raw[i + n] === ch) n++
+      i += n
+      while (n > 0) {
+        if (n >= 2) {
+          toggle('Bold', ch)
+          n -= 2
+        } else {
+          toggle('Italic', ch)
+          n -= 1
+        }
+      }
+      continue
+    }
+
+    // Strike: ~~
+    if (ch === '~' && raw[i + 1] === '~') {
+      toggle('Strike', '~')
+      i += 2
+      continue
+    }
+
+    if (ch === '<') {
+      // Line break
+      const br = /^<br\s*\/?>/.exec(raw.slice(i))
+      if (br) {
+        text += '\n'
+        i += br[0].length
+        continue
+      }
+      // Underline / highlight tags
+      const tag = /^<(\/?)(u|mark)>/.exec(raw.slice(i))
+      if (tag) {
+        const type = tag[2] === 'u' ? 'Underline' : 'Range'
+        if (tag[1]) closeType((s) => s.type === type)
+        else stack.push({type, start: text.length, family: 'html'})
+        i += tag[0].length
+        continue
+      }
+      // Style span
+      const span = /^<span style="([a-z-]+):([^"]*)">/.exec(raw.slice(i))
+      if (span && SPAN_STYLE_TO_TYPE[span[1]!]) {
+        stack.push({
+          type: SPAN_STYLE_TO_TYPE[span[1]!]!,
+          start: text.length,
+          family: 'html',
+          attributes: {value: decodeHtmlAttr(span[2]!)},
+        })
+        i += span[0].length
+        continue
+      }
+      if (raw.startsWith('</span>', i)) {
+        closeType((s) => SPAN_TYPES.has(s.type))
+        i += 7
+        continue
+      }
+      // Autolink: <scheme:...>
+      //   hm://… → Embed annotation on a U+FFFC placeholder (inline mention)
+      //   anything else → Link annotation spanning the visible URL
       const end = raw.indexOf('>', i + 1)
       if (end !== -1) {
         const inner = raw.slice(i + 1, end)
@@ -123,20 +251,10 @@ export function parseInlineFormatting(raw: string): InlineParseResult {
           const start = text.length
           if (inner.startsWith('hm://')) {
             text += '￼'
-            annotations.push({
-              type: 'Embed',
-              starts: [start],
-              ends: [text.length],
-              link: inner,
-            })
+            annotations.push({type: 'Embed', starts: [start], ends: [text.length], link: inner})
           } else {
             text += inner
-            annotations.push({
-              type: 'Link',
-              starts: [start],
-              ends: [text.length],
-              link: inner,
-            })
+            annotations.push({type: 'Link', starts: [start], ends: [text.length], link: inner})
           }
           i = end + 1
           continue
@@ -144,420 +262,324 @@ export function parseInlineFormatting(raw: string): InlineParseResult {
       }
     }
 
+    // Inline image: ![alt](url) — Seed has no inline image type, keep the alt text.
+    if (ch === '!' && raw[i + 1] === '[') {
+      const link = readLink(raw, i + 1)
+      if (link) {
+        const parsed = parseInlineFormatting(link.label)
+        appendParsed(parsed)
+        i = link.end
+        continue
+      }
+    }
+
     // Link: [text](url)
-    if (raw[i] === '[') {
-      const closeBracket = findClosingBracket(raw, i)
-      if (closeBracket !== -1 && closeBracket + 1 < raw.length && raw[closeBracket + 1] === '(') {
-        const closeParen = raw.indexOf(')', closeBracket + 2)
-        if (closeParen !== -1) {
-          const linkText = raw.slice(i + 1, closeBracket)
-          const url = raw.slice(closeBracket + 2, closeParen)
-          const parsed = parseInlineFormatting(linkText)
-          const start = text.length
-          text += parsed.text
-          const end = text.length
-
-          // Shift nested annotations
-          for (const ann of parsed.annotations) {
-            annotations.push({
-              ...ann,
-              starts: ann.starts.map((s) => s + start),
-              ends: ann.ends.map((e) => e + start),
-            })
-          }
-
-          annotations.push({
-            type: 'Link',
-            starts: [start],
-            ends: [end],
-            link: url,
-          })
-
-          i = closeParen + 1
-          continue
-        }
-      }
-    }
-
-    // Bold: **text**
-    if (raw[i] === '*' && raw[i + 1] === '*') {
-      const end = raw.indexOf('**', i + 2)
-      if (end !== -1) {
-        const inner = raw.slice(i + 2, end)
-        const parsed = parseInlineFormatting(inner)
+    if (ch === '[') {
+      const link = readLink(raw, i)
+      if (link) {
+        const parsed = parseInlineFormatting(link.label)
         const start = text.length
-        text += parsed.text
-
-        for (const ann of parsed.annotations) {
-          annotations.push({
-            ...ann,
-            starts: ann.starts.map((s) => s + start),
-            ends: ann.ends.map((e) => e + start),
-          })
+        appendParsed(parsed)
+        if (text.length > start) {
+          annotations.push({type: 'Link', starts: [start], ends: [text.length], link: link.url})
         }
-
-        annotations.push({
-          type: 'Bold',
-          starts: [start],
-          ends: [text.length],
-        })
-
-        i = end + 2
+        i = link.end
         continue
       }
     }
 
-    // Italic: *text* (but not **)
-    if (raw[i] === '*' && raw[i + 1] !== '*') {
-      const end = findSingleDelimiter(raw, '*', i + 1)
-      if (end !== -1) {
-        const inner = raw.slice(i + 1, end)
-        const parsed = parseInlineFormatting(inner)
-        const start = text.length
-        text += parsed.text
-
-        for (const ann of parsed.annotations) {
-          annotations.push({
-            ...ann,
-            starts: ann.starts.map((s) => s + start),
-            ends: ann.ends.map((e) => e + start),
-          })
-        }
-
-        annotations.push({
-          type: 'Italic',
-          starts: [start],
-          ends: [text.length],
-        })
-
-        i = end + 1
-        continue
-      }
-    }
-
-    // Inline code: `text`
-    if (raw[i] === '`') {
-      const end = raw.indexOf('`', i + 1)
-      if (end !== -1) {
-        const start = text.length
-        text += raw.slice(i + 1, end)
-
-        annotations.push({
-          type: 'Code',
-          starts: [start],
-          ends: [text.length],
-        })
-
-        i = end + 1
-        continue
-      }
-    }
-
-    text += raw[i]
+    text += ch
     i++
   }
 
-  return {text, annotations}
+  // Unclosed markers: close them at the end of the text.
+  while (stack.length) close(stack.pop()!)
+
+  return {text, annotations: mergeAdjacentAnnotations(annotations)}
+
+  function appendParsed(parsed: InlineParseResult) {
+    const offset = text.length
+    text += parsed.text
+    for (const ann of parsed.annotations) {
+      annotations.push({
+        ...ann,
+        starts: ann.starts.map((s) => s + offset),
+        ends: ann.ends.map((e) => e + offset),
+      })
+    }
+  }
 }
 
-function findClosingBracket(s: string, openPos: number): number {
-  let depth = 0
-  for (let i = openPos; i < s.length; i++) {
-    if (s[i] === '[') depth++
-    if (s[i] === ']') {
-      depth--
-      if (depth === 0) return i
+function findLastIndex<T>(arr: T[], pred: (item: T) => boolean): number {
+  for (let i = arr.length - 1; i >= 0; i--) if (pred(arr[i]!)) return i
+  return -1
+}
+
+/** Find the next run of exactly `n` backticks at or after `from`. */
+function findBacktickRun(s: string, from: number, n: number): number {
+  let i = from
+  while (i < s.length) {
+    if (s[i] === '`') {
+      let k = 0
+      while (s[i + k] === '`') k++
+      if (k === n) return i
+      i += k
+    } else {
+      i++
     }
   }
   return -1
 }
-
-function findSingleDelimiter(s: string, delim: string, start: number): number {
-  for (let i = start; i < s.length; i++) {
-    if (s[i] === delim && s[i + 1] !== delim && (i === 0 || s[i - 1] !== delim)) {
-      return i
-    }
-  }
-  return -1
-}
-
-// ─── Block ID helpers ────────────────────────────────────────────────────────
-
-/** Regex matching a trailing ` <!-- id:XXXXXXXX -->` HTML comment. */
-const BLOCK_ID_RE = /\s*<!--\s*id:([A-Za-z0-9_-]+)\s*-->\s*$/
 
 /**
- * Strip a trailing block ID comment from a string.
- * Returns the cleaned string and the captured ID (or undefined).
+ * Read a `[label](url)` starting at `open` (the `[`). Brackets balance,
+ * escapes and code spans are skipped, the url may be `<…>`-wrapped.
  */
-function stripBlockId(s: string): {text: string; id?: string} {
-  const m = s.match(BLOCK_ID_RE)
-  if (m) {
-    return {text: s.slice(0, m.index!).trimEnd(), id: m[1]}
+function readLink(s: string, open: number): {label: string; url: string; end: number} | null {
+  let depth = 0
+  let i = open
+  let close = -1
+  while (i < s.length) {
+    const c = s[i]
+    if (c === '\\') {
+      i += 2
+      continue
+    }
+    if (c === '`') {
+      let n = 0
+      while (s[i + n] === '`') n++
+      const closer = findBacktickRun(s, i + n, n)
+      i = closer === -1 ? i + n : closer + n
+      continue
+    }
+    if (c === '[') depth++
+    else if (c === ']') {
+      depth--
+      if (depth === 0) {
+        close = i
+        break
+      }
+    }
+    i++
   }
+  if (close === -1 || s[close + 1] !== '(') return null
+  const label = s.slice(open + 1, close)
+  let j = close + 2
+  if (s[j] === '<') {
+    const gt = s.indexOf('>', j + 1)
+    if (gt === -1 || s[gt + 1] !== ')') return null
+    return {label, url: s.slice(j + 1, gt), end: gt + 2}
+  }
+  let parens = 0
+  while (j < s.length) {
+    const c = s[j]
+    if (c === '\\') {
+      j += 2
+      continue
+    }
+    if (c === '(') parens++
+    else if (c === ')') {
+      if (parens === 0) return {label, url: s.slice(close + 2, j), end: j + 1}
+      parens--
+    }
+    j++
+  }
+  return null
+}
+
+function annotationKey(a: Annotation): string {
+  return a.type + ' ' + (a.link ?? '') + ' ' + (a.attributes ? JSON.stringify(sortKeys(a.attributes)) : '')
+}
+
+/**
+ * Merge annotations of the same kind whose ranges touch or overlap into one
+ * contiguous range, and order the result deterministically. The emitter
+ * splits annotations at every boundary to keep markers well nested, so this
+ * is what makes `parse(emit(doc))` equal `doc`.
+ */
+export function mergeAdjacentAnnotations(annotations: Annotation[]): Annotation[] {
+  const byKey = new Map<string, {proto: Annotation; ranges: {s: number; e: number}[]}>()
+  for (const a of annotations) {
+    const key = annotationKey(a)
+    const entry = byKey.get(key) || {proto: a, ranges: []}
+    for (let i = 0; i < a.starts.length; i++) {
+      const s = a.starts[i]!
+      const e = a.ends[i]
+      if (e === undefined || e <= s) continue
+      entry.ranges.push({s, e})
+    }
+    byKey.set(key, entry)
+  }
+  const out: Annotation[] = []
+  for (const {proto, ranges} of byKey.values()) {
+    ranges.sort((a: {s: number; e: number}, b: {s: number; e: number}) => a.s - b.s || a.e - b.e)
+    const merged: {s: number; e: number}[] = []
+    for (const r of ranges) {
+      const last = merged[merged.length - 1]
+      if (last && r.s <= last.e) last.e = Math.max(last.e, r.e)
+      else merged.push({...r})
+    }
+    for (const r of merged) {
+      const ann: Annotation = {type: proto.type, starts: [r.s], ends: [r.e]}
+      if (proto.link !== undefined) ann.link = proto.link
+      if (proto.attributes) ann.attributes = proto.attributes
+      out.push(ann)
+    }
+  }
+  out.sort((a, b) => a.starts[0]! - b.starts[0]! || b.ends[0]! - a.ends[0]! || a.type.localeCompare(b.type))
+  return out
+}
+
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeys)
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const k of Object.keys(value as object).sort()) out[k] = sortKeys((value as Record<string, unknown>)[k])
+    return out
+  }
+  return value
+}
+
+// ─── Block comment helpers ───────────────────────────────────────────────────
+
+export type BlockComment = {id: string; type?: string; attrs?: Record<string, unknown>}
+
+const COMMENT_BODY = /<!--\s*id:([A-Za-z0-9_-]+)(?:\s+type:([A-Za-z0-9_-]+))?(?:\s+attrs:(\{.*\}))?\s*-->/
+/** Trailing ` <!-- id:X [type:T] [attrs:{…}] -->` at the end of a line (one separator space). */
+const TRAILING_COMMENT_RE = new RegExp(' ?' + COMMENT_BODY.source + '\\s*$')
+/** A line that is nothing but a block comment. */
+const STANDALONE_COMMENT_RE = new RegExp('^\\s*' + COMMENT_BODY.source + '\\s*$')
+/** `<!-- end:ID -->` closes the heading with that id. */
+const END_RE = /^\s*<!--\s*end:([A-Za-z0-9_-]+)\s*-->\s*$/
+
+function commentFromMatch(m: RegExpMatchArray): BlockComment {
+  const c: BlockComment = {id: m[1]!}
+  if (m[2]) c.type = m[2]
+  if (m[3]) {
+    try {
+      const parsed = JSON.parse(m[3])
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) c.attrs = parsed
+    } catch {
+      // malformed attrs: ignore, keep the id
+    }
+  }
+  return c
+}
+
+/** Strip a trailing block comment from a string. */
+function stripBlockComment(s: string): {text: string; comment?: BlockComment} {
+  const m = s.match(TRAILING_COMMENT_RE)
+  if (m) return {text: s.slice(0, m.index!), comment: commentFromMatch(m)}
   return {text: s}
 }
 
-/** Check if a line is a standalone block ID comment (nothing else). */
-const STANDALONE_ID_RE = /^\s*<!--\s*id:([A-Za-z0-9_-]+)\s*-->\s*$/
-
-// ─── Markdown block parser ───────────────────────────────────────────────────
-
-type RawBlock =
-  | {kind: 'heading'; level: number; text: string; id?: string}
-  | {kind: 'paragraph'; text: string; id?: string}
-  | {kind: 'code'; language: string; text: string; id?: string}
-  | {kind: 'image'; alt: string; url: string; id?: string}
-  | {kind: 'math'; text: string; id?: string}
-  | {kind: 'ul'; items: {text: string; id?: string}[]; containerId?: string}
-  | {kind: 'ol'; items: {text: string; id?: string}[]; containerId?: string}
-  | {kind: 'table'; lines: string[]; containerId?: string}
-
-/**
- * Parses raw markdown into a flat list of block tokens.
- *
- * Recognizes `<!-- id:XXXXXXXX -->` HTML comments:
- *   - Trailing on content lines → captured as block ID
- *   - On code/math fence openers → captured as block ID
- *   - On list items → captured as item ID
- *   - Standalone lines → saved as container ID for the next list
- */
-function tokenize(markdown: string): RawBlock[] {
-  const lines = markdown.split('\n')
-  const blocks: RawBlock[] = []
-  let i = 0
-  /** Pending container ID from a standalone <!-- id:... --> line. */
-  let pendingContainerId: string | undefined
-
-  while (i < lines.length) {
-    const line = lines[i]!
-
-    // Blank line — skip
-    if (line.trim() === '') {
-      i++
-      continue
-    }
-
-    // Standalone block ID comment (for list containers)
-    const standaloneMatch = line.match(STANDALONE_ID_RE)
-    if (standaloneMatch) {
-      pendingContainerId = standaloneMatch[1]
-      i++
-      continue
-    }
-
-    // Fenced code block: ```lang <!-- id:XXX -->
-    if (line.trim().startsWith('```')) {
-      const fenceContent = line.trim().slice(3).trim()
-      const {text: language, id} = stripBlockId(fenceContent)
-      const codeLines: string[] = []
-      i++
-      while (i < lines.length && !lines[i]!.trim().startsWith('```')) {
-        codeLines.push(lines[i]!)
-        i++
-      }
-      i++ // skip closing ```
-      blocks.push({kind: 'code', language, text: codeLines.join('\n'), id})
-      pendingContainerId = undefined
-      continue
-    }
-
-    // Math block: $$ <!-- id:XXX -->
-    if (line.trim().startsWith('$$')) {
-      const fenceContent = line.trim().slice(2).trim()
-      const {id} = stripBlockId(fenceContent)
-      const mathLines: string[] = []
-      i++
-      while (i < lines.length && !lines[i]!.trim().startsWith('$$')) {
-        mathLines.push(lines[i]!)
-        i++
-      }
-      i++ // skip closing $$
-      blocks.push({kind: 'math', text: mathLines.join('\n'), id})
-      pendingContainerId = undefined
-      continue
-    }
-
-    // Heading: # text <!-- id:XXX --> (indentation tolerated, like every other block kind)
-    const headingMatch = line.trim().match(/^(#{1,6})\s+(.+)$/)
-    if (headingMatch) {
-      const {text, id} = stripBlockId(headingMatch[2]!)
-      blocks.push({kind: 'heading', level: headingMatch[1]!.length, text, id})
-      i++
-      pendingContainerId = undefined
-      continue
-    }
-
-    // Standalone image: ![alt](url) <!-- id:XXX -->
-    const imageMatch = line.trim().match(/^!\[([^\]]*)\]\(([^)]+)\)(.*)$/)
-    if (imageMatch) {
-      let url = imageMatch[2]!
-      const trailing = imageMatch[3] || ''
-      const {id} = stripBlockId(trailing)
-      if (url && !url.match(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//)) {
-        url = `file://${url}`
-      }
-      blocks.push({kind: 'image', alt: imageMatch[1]!, url, id})
-      i++
-      pendingContainerId = undefined
-      continue
-    }
-
-    // Table (consecutive lines starting with |). A standalone
-    // <!-- id:... --> comment line right before the table carries the
-    // Table block id (same mechanism as list containers).
-    if (line.trim().startsWith('|')) {
-      const tableLines: string[] = []
-      while (i < lines.length && lines[i]!.trim().startsWith('|')) {
-        tableLines.push(lines[i]!)
-        i++
-      }
-      blocks.push({kind: 'table', lines: tableLines, containerId: pendingContainerId})
-      pendingContainerId = undefined
-      continue
-    }
-
-    // Unordered list: - item <!-- id:XXX -->
-    if (/^[-*+]\s+/.test(line.trim())) {
-      const items: {text: string; id?: string}[] = []
-      while (i < lines.length && /^[-*+]\s+/.test(lines[i]!.trim())) {
-        const raw = lines[i]!.trim().replace(/^[-*+]\s+/, '')
-        const {text, id} = stripBlockId(raw)
-        items.push({text, id})
-        i++
-      }
-      blocks.push({kind: 'ul', items, containerId: pendingContainerId})
-      pendingContainerId = undefined
-      continue
-    }
-
-    // Ordered list: 1. item <!-- id:XXX -->
-    if (/^\d+\.\s+/.test(line.trim())) {
-      const items: {text: string; id?: string}[] = []
-      while (i < lines.length && /^\d+\.\s+/.test(lines[i]!.trim())) {
-        const raw = lines[i]!.trim().replace(/^\d+\.\s+/, '')
-        const {text, id} = stripBlockId(raw)
-        items.push({text, id})
-        i++
-      }
-      blocks.push({kind: 'ol', items, containerId: pendingContainerId})
-      pendingContainerId = undefined
-      continue
-    }
-
-    // Paragraph — collect consecutive non-blank, non-special lines
-    const paraLines: string[] = []
-    while (
-      i < lines.length &&
-      lines[i]!.trim() !== '' &&
-      !lines[i]!.trim().startsWith('```') &&
-      !lines[i]!.trim().startsWith('$$') &&
-      !lines[i]!.trim().startsWith('#') &&
-      !lines[i]!.trim().startsWith('|') &&
-      !lines[i]!.match(STANDALONE_ID_RE) &&
-      !/^!\[([^\]]*)\]\(([^)]+)\)/.test(lines[i]!.trim()) &&
-      !/^[-*+]\s+/.test(lines[i]!.trim()) &&
-      !/^\d+\.\s+/.test(lines[i]!.trim())
-    ) {
-      // Leading indentation is emitter nesting depth, not content — keeping it
-      // would grow paragraph text by one indent level per markdown round trip.
-      paraLines.push(lines[i]!.trimStart())
-      i++
-    }
-    if (paraLines.length === 0) {
-      // The line looked special to the paragraph collector but matched no block
-      // branch above (e.g. "#nospace" or 7+ hashes). Consume it as paragraph text
-      // so the outer loop always makes progress.
-      paraLines.push(line.trimStart())
-      i++
-    }
-    // Block ID is on the first line of the paragraph
-    const firstLine = paraLines[0]!
-    const {text: cleanFirst, id} = stripBlockId(firstLine)
-    paraLines[0] = cleanFirst
-    blocks.push({kind: 'paragraph', text: paraLines.join('\n'), id})
-    pendingContainerId = undefined
-  }
-
-  return blocks
+/** Kept for callers that only need the id. */
+function stripBlockId(s: string): {text: string; id?: string} {
+  const {text, comment} = stripBlockComment(s)
+  return {text, id: comment?.id}
 }
 
-// ─── Tree builder ────────────────────────────────────────────────────────────
+// ─── Line model ──────────────────────────────────────────────────────────────
+
+type MarkerKind = 'Unordered' | 'Ordered' | 'Blockquote'
+
+type LineInfo = {
+  raw: string
+  /** Leading spaces. */
+  indent: number
+  /** List / quote marker text (`- `, `3. `, `> `) or ''. */
+  marker: string
+  markerKind?: MarkerKind
+  /** Column where the block's own content starts: indent + marker width. */
+  contentCol: number
+  /** The line after indentation and marker. */
+  rest: string
+  blank: boolean
+}
+
+const MARKER_RE = /^([-*+] |\d+[.)] |> )/
+
+function analyzeLine(raw: string): LineInfo {
+  // Only the leading run of blanks is indentation (a tab counts as two
+  // columns); whitespace inside the content is content.
+  const lead = /^[ \t]*/.exec(raw)![0]
+  const indent = lead.replace(/\t/g, '  ').length
+  let rest = raw.slice(lead.length)
+  const blank = rest.trim() === ''
+  let marker = ''
+  let markerKind: MarkerKind | undefined
+  const m = MARKER_RE.exec(rest)
+  if (m && !blank) {
+    marker = m[1]!
+    markerKind = marker === '> ' ? 'Blockquote' : /^\d/.test(marker) ? 'Ordered' : 'Unordered'
+    rest = rest.slice(marker.length)
+  }
+  return {raw, indent, marker, markerKind, contentCol: indent + marker.length, rest, blank}
+}
+
+// ─── Block builders ──────────────────────────────────────────────────────────
 
 function makeBlockNode(block: SeedBlock, children: BlockNode[] = []): BlockNode {
   return {block, children}
 }
 
-function createParagraphNode(rawText: string, id?: string): BlockNode {
+function baseBlock(
+  type: string,
+  comment: BlockComment | undefined,
+  text = '',
+  annotations: Annotation[] = [],
+): SeedBlock {
+  const block: SeedBlock = {type, id: comment?.id || generateBlockId(), text, annotations}
+  if (comment?.attrs && Object.keys(comment.attrs).length) block.attributes = {...comment.attrs}
+  return block
+}
+
+function createParagraphNode(rawText: string, comment?: BlockComment): BlockNode {
   const {text, annotations} = parseInlineFormatting(rawText)
-  return makeBlockNode({
-    type: 'Paragraph',
-    id: id || generateBlockId(),
-    text,
-    annotations,
-  })
+  return makeBlockNode(baseBlock('Paragraph', comment, text, annotations))
 }
 
-function createHeadingNode(rawText: string, id?: string): BlockNode {
+function createHeadingNode(rawText: string, comment?: BlockComment): BlockNode {
   const {text, annotations} = parseInlineFormatting(rawText)
-  return makeBlockNode(
-    {
-      type: 'Heading',
-      id: id || generateBlockId(),
-      text,
-      annotations,
-      childrenType: 'Group',
-    },
-    [],
-  )
+  return makeBlockNode(baseBlock('Heading', comment, text, annotations))
 }
 
-function createCodeNode(text: string, language: string, id?: string): BlockNode {
-  return makeBlockNode({
-    type: 'Code',
-    id: id || generateBlockId(),
-    text,
-    annotations: [],
-    language: language || undefined,
-  })
+function createCodeNode(text: string, language: string, comment?: BlockComment): BlockNode {
+  const block = baseBlock('Code', comment, text)
+  if (language) block.language = language
+  return makeBlockNode(block)
 }
 
-function createMathNode(text: string, id?: string): BlockNode {
-  return makeBlockNode({
-    type: 'Math',
-    id: id || generateBlockId(),
-    text,
-    annotations: [],
-  })
+function createMathNode(text: string, comment?: BlockComment): BlockNode {
+  return makeBlockNode(baseBlock('Math', comment, text))
 }
 
-function createImageNode(alt: string, url: string, id?: string): BlockNode {
-  return makeBlockNode({
-    type: 'Image',
-    id: id || generateBlockId(),
-    text: alt,
-    annotations: [],
-    link: url,
-  })
+function createImageNode(alt: string, url: string, comment?: BlockComment): BlockNode {
+  const {text, annotations} = parseInlineFormatting(alt)
+  const block = baseBlock('Image', comment, text, annotations)
+  block.link = url
+  return makeBlockNode(block)
 }
 
-function createListContainerNode(
-  items: BlockNode[],
-  listType: 'Unordered' | 'Ordered',
-  containerId?: string,
-): BlockNode {
-  // Invisible Paragraph container with childrenType set — the fallback shape
-  // when a list has no preceding text block to nest under (see parseMarkdown).
-  return makeBlockNode(
-    {
-      type: 'Paragraph',
-      id: containerId || generateBlockId(),
-      text: '',
-      annotations: [],
-      childrenType: listType,
-    },
-    items,
-  )
+/** A block whose type came from `type:` in its comment; text/link from the visible part. */
+function createTypedNode(visible: string, comment: BlockComment): BlockNode {
+  const block = baseBlock(comment.type!, comment)
+  const v = visible.trim()
+  const linkOnly = /^<([a-zA-Z][a-zA-Z0-9+.-]*:[^\s<>]*)>$/.exec(v)
+  const labeled = v.startsWith('[') ? readLink(v, 0) : null
+  if (linkOnly) {
+    block.link = linkOnly[1]!
+  } else if (labeled && labeled.end === v.length) {
+    const {text, annotations} = parseInlineFormatting(labeled.label)
+    block.text = text
+    block.annotations = annotations
+    block.link = labeled.url
+  } else if (v) {
+    const {text, annotations} = parseInlineFormatting(v)
+    block.text = text
+    block.annotations = annotations
+  }
+  return makeBlockNode(block)
 }
 
 // ─── Table parser ────────────────────────────────────────────────────────────
@@ -572,7 +594,7 @@ function createListContainerNode(
 // The markdown dialect keeps that identity through the round trip:
 //
 //   <!-- id:TABLEID -->                      (standalone line before the table)
-//   | Name <!-- col:c1 --> | Age <!-- col:c2 --> |
+//   | Name <!-- col:c1 --> | Age <!-- col:c2 attrs:{"width":120} --> |
 //   | --- | --- |
 //   | Alice | 30 | <!-- id:r1 -->            (row id after the final pipe)
 //
@@ -580,13 +602,12 @@ function createListContainerNode(
 // (row id, column id) against the previous document during update diffing.
 // Plain GFM tables with no comments parse fine — all ids are generated.
 
-/** Regex matching a `<!-- col:ID -->` column id comment inside a header cell. */
-const COL_ID_RE = /<!--\s*col:([A-Za-z0-9_-]+)\s*-->/
-
+/** Regex matching a `<!-- col:ID [attrs:{…}] -->` column comment inside a header cell. */
+const COL_ID_RE = /<!--\s*col:([A-Za-z0-9_-]+)(?:\s+attrs:(\{.*?\}))?\s*-->/
 /** Regex matching an `<!-- id:ID -->` comment anywhere inside a cell. */
 const CELL_ID_RE = /<!--\s*id:([A-Za-z0-9_-]+)\s*-->/
 
-type ParsedTableCell = {text: string; colId?: string}
+type ParsedTableCell = {text: string; colId?: string; colAttrs?: Record<string, unknown>}
 type ParsedTableRow = {cells: ParsedTableCell[]; id?: string}
 
 /**
@@ -628,12 +649,20 @@ function splitTableRow(line: string): ParsedTableRow {
       cellText = cellText.replace(idMatch[0], '')
     }
     let colId: string | undefined
+    let colAttrs: Record<string, unknown> | undefined
     const colMatch = cellText.match(COL_ID_RE)
     if (colMatch) {
       colId = colMatch[1]
+      if (colMatch[2]) {
+        try {
+          colAttrs = JSON.parse(colMatch[2])
+        } catch {
+          // ignore malformed column attrs
+        }
+      }
       cellText = cellText.replace(colMatch[0], '')
     }
-    return {text: cellText.trim(), colId}
+    return {text: cellText.trim(), colId, colAttrs}
   })
   return {cells, id: rowId}
 }
@@ -643,9 +672,9 @@ function isSeparatorRow(cells: ParsedTableCell[]): boolean {
   return cells.length > 0 && cells.every((c) => /^:?-+:?$/.test(c.text))
 }
 
-/** Convert `<br>` variants back to newlines, then parse inline formatting. */
+/** Parse a cell's inline formatting (the inline parser reads `<br>` as a newline). */
 function createTableCellNode(rawText: string, columnId: string): BlockNode {
-  const {text, annotations} = parseInlineFormatting(rawText.replace(/<br\s*\/?>/gi, '\n'))
+  const {text, annotations} = parseInlineFormatting(rawText)
   return makeBlockNode({
     type: 'Paragraph',
     id: generateBlockId(),
@@ -665,9 +694,8 @@ function createTableCellNode(rawText: string, columnId: string): BlockNode {
  * - Cells are created densely: every row gets one cell per column, so the
  *   written grid matches what the editor produces.
  */
-function createTableNode(lines: string[], containerId?: string): BlockNode {
+function createTableNode(lines: string[], comment?: BlockComment): BlockNode {
   const rawRows = lines.map(splitTableRow)
-
   let headerRow: ParsedTableRow | undefined
   let bodyRows: ParsedTableRow[]
   if (rawRows.length >= 2 && isSeparatorRow(rawRows[1]!.cells)) {
@@ -680,18 +708,19 @@ function createTableNode(lines: string[], containerId?: string): BlockNode {
 
   const headerCells = headerRow?.cells ?? []
   const colCount = Math.max(headerCells.length, ...bodyRows.map((r) => r.cells.length), 0)
-
   const columnIds: string[] = []
   for (let idx = 0; idx < colCount; idx++) {
     columnIds.push(headerCells[idx]?.colId || generateBlockId())
   }
 
-  const columnNodes: BlockNode[] = columnIds.map((id) =>
-    makeBlockNode({type: 'TableColumn', id, text: '', annotations: []}),
-  )
+  const columnNodes: BlockNode[] = columnIds.map((id, idx) => {
+    const block: SeedBlock = {type: 'TableColumn', id, text: '', annotations: []}
+    const attrs = headerCells[idx]?.colAttrs
+    if (attrs && Object.keys(attrs).length) block.attributes = {...attrs}
+    return makeBlockNode(block)
+  })
 
   const rowNodes: BlockNode[] = []
-
   // An all-empty header row (ignoring col: comments) encodes a headerless table.
   const hasHeaderRow = headerCells.some((c) => c.text !== '')
   if (headerRow && hasHeaderRow) {
@@ -709,7 +738,6 @@ function createTableNode(lines: string[], containerId?: string): BlockNode {
       ),
     )
   }
-
   for (const row of bodyRows) {
     const cells = columnIds.map((columnId, idx) => createTableCellNode(row.cells[idx]?.text ?? '', columnId))
     rowNodes.push(
@@ -725,15 +753,7 @@ function createTableNode(lines: string[], containerId?: string): BlockNode {
     )
   }
 
-  return makeBlockNode(
-    {
-      type: 'Table',
-      id: containerId || generateBlockId(),
-      text: '',
-      annotations: [],
-    },
-    [...columnNodes, ...rowNodes],
-  )
+  return makeBlockNode(baseBlock('Table', comment), [...columnNodes, ...rowNodes])
 }
 
 // ─── Frontmatter parser ──────────────────────────────────────────────────────
@@ -754,7 +774,7 @@ function coerceString(value: unknown): string | undefined {
   return String(value)
 }
 
-/** String-typed metadata keys that map 1:1 from frontmatter to HMMetadata. */
+/** String-typed metadata keys, coerced to strings when hand-written YAML types them otherwise. */
 const METADATA_STRING_KEYS = [
   'name',
   'summary',
@@ -767,235 +787,391 @@ const METADATA_STRING_KEYS = [
   'seedExperimentalLogo',
   'importCategories',
   'importTags',
+  'seedExperimentalHomeOrder',
+  'contentWidth',
+  'childrenType',
 ] as const
 
 /** Boolean-typed metadata keys. */
 const METADATA_BOOLEAN_KEYS = ['showOutline', 'showActivity'] as const
 
-/** Enum-typed metadata keys (stored as strings). */
-const METADATA_ENUM_KEYS = ['seedExperimentalHomeOrder', 'contentWidth', 'childrenType'] as const
-
 /**
  * Strip YAML frontmatter (--- delimited) from markdown content.
- * Returns the remaining content and any parsed metadata.
+ * Returns the remaining content and the parsed metadata.
  *
- * Frontmatter keys map 1:1 to HMMetadata field names (e.g. `name:`,
- * `displayAuthor:`, `displayPublishTime:`, `cover:`, etc.).
- *
- * Also accepts `title:` as a backward-compatible alias for `name:`.
+ * Every frontmatter key maps 1:1 to a metadata key, including nested values
+ * and keys this client does not know (schema-typed documents carry their
+ * own). `title:` is accepted as a backward-compatible alias for `name:`.
  */
 export function parseFrontmatter(markdown: string): {
   content: string
   metadata: HMMetadata
 } {
-  const trimmed = markdown.trimStart()
+  const trimmed = markdown.replace(/^﻿/, '')
   if (!trimmed.startsWith('---')) {
     return {content: markdown, metadata: {}}
   }
-
-  // Find the closing ---
-  const endIndex = trimmed.indexOf('\n---', 3)
-  if (endIndex === -1) {
+  const firstLineEnd = trimmed.indexOf('\n')
+  if (firstLineEnd === -1 || trimmed.slice(0, firstLineEnd).trim() !== '---') {
     return {content: markdown, metadata: {}}
   }
+  // Closing fence: a line that is exactly `---`.
+  const closeRe = /\n---[ \t]*(?:\n|$)/g
+  closeRe.lastIndex = firstLineEnd
+  const closeMatch = closeRe.exec(trimmed)
+  if (!closeMatch) {
+    return {content: markdown, metadata: {}}
+  }
+  const yamlBlock = trimmed.slice(firstLineEnd + 1, closeMatch.index)
+  const rest = trimmed.slice(closeMatch.index + closeMatch[0].length)
 
-  const yamlBlock = trimmed.slice(3, endIndex).trim()
-  const rest = trimmed.slice(endIndex + 4) // skip past \n---
-
-  const metadata: HMMetadata = {}
+  const metadata: Record<string, unknown> = {}
   try {
-    const parsed = parseYaml(yamlBlock) as Record<string, unknown> | null
+    const parsed = yamlBlock.trim() === '' ? {} : (parseYaml(yamlBlock) as Record<string, unknown> | null)
     if (!parsed || typeof parsed !== 'object') {
       return {content: rest, metadata}
     }
-
-    // String fields
-    for (const key of METADATA_STRING_KEYS) {
-      const val = coerceString(parsed[key])
-      if (val !== undefined) (metadata as Record<string, unknown>)[key] = val
+    for (const [key, value] of Object.entries(parsed)) {
+      if (value === undefined) continue
+      if (key === 'title') continue
+      metadata[key] = value
     }
-
     // Accept `title:` as backward-compat alias for `name:`
-    if (!metadata.name && parsed['title']) {
-      const val = coerceString(parsed['title'])
-      if (val !== undefined) metadata.name = val
+    if (metadata.name === undefined && parsed['title'] != null) {
+      metadata.name = coerceString(parsed['title'])
     }
-
-    // Boolean fields
+    for (const key of METADATA_STRING_KEYS) {
+      if (metadata[key] !== undefined && typeof metadata[key] !== 'string') metadata[key] = coerceString(metadata[key])
+    }
     for (const key of METADATA_BOOLEAN_KEYS) {
-      if (parsed[key] != null) (metadata as Record<string, unknown>)[key] = Boolean(parsed[key])
-    }
-
-    // Enum-like fields (stored as strings)
-    for (const key of METADATA_ENUM_KEYS) {
-      const val = coerceString(parsed[key])
-      if (val !== undefined) (metadata as Record<string, unknown>)[key] = val
-    }
-
-    // Nested theme object
-    if (parsed['theme'] && typeof parsed['theme'] === 'object') {
-      const themeInput = parsed['theme'] as Record<string, unknown>
-      const theme: {headerLayout?: 'Center' | ''} = {}
-      const hl = themeInput['headerLayout']
-      if (hl === 'Center' || hl === '') theme.headerLayout = hl
-      if (Object.keys(theme).length > 0) metadata.theme = theme
+      if (metadata[key] !== undefined && typeof metadata[key] !== 'boolean') metadata[key] = Boolean(metadata[key])
     }
   } catch {
     // Invalid YAML — ignore frontmatter, return content as-is
     return {content: markdown, metadata: {}}
   }
 
-  return {content: rest, metadata}
+  return {content: rest, metadata: metadata as HMMetadata}
 }
 
-// ─── Main entry point ────────────────────────────────────────────────────────
+// ─── Tree builder ────────────────────────────────────────────────────────────
+
+type Frame = {
+  /** The block whose children this frame collects; undefined for the root. */
+  node?: BlockNode
+  list: BlockNode[]
+  /** Indentation at which this frame's children sit. */
+  childIndent: number
+  /** Set for heading frames: closes on a heading of this level or higher at childIndent. */
+  headingLevel?: number
+  /** Set for invisible-container shorthand: children are marker lines at childIndent. */
+  shorthand?: MarkerKind
+  /** Marker kind of the last child added, or undefined when it had none. */
+  markerRun?: MarkerKind
+}
+
+const HEADING_RE = /^(#{1,6})\s+(.*)$/
+const isListType = (t: string | undefined): t is MarkerKind =>
+  t === 'Unordered' || t === 'Ordered' || t === 'Blockquote'
+const FENCE_RE = /^(`{3,})(.*)$/
+const IMAGE_START_RE = /^!\[/
+
+/** Does this (marker-stripped) line begin a block other than a plain paragraph? */
+function startsSpecialBlock(rest: string): boolean {
+  return (
+    HEADING_RE.test(rest) ||
+    FENCE_RE.test(rest) ||
+    rest.startsWith('$$') ||
+    IMAGE_START_RE.test(rest) ||
+    rest.startsWith('|') ||
+    STANDALONE_COMMENT_RE.test(rest) ||
+    END_RE.test(rest)
+  )
+}
 
 /**
  * Builds a hierarchical block tree from markdown.
  *
- * The hierarchy is determined by heading levels:
- * - H1 headings are root-level blocks; lower headings and content become children
- * - H2 headings become children of the preceding H1, etc.
- * - Content before the first heading goes to root level
- *
- * YAML frontmatter (--- delimited) is parsed for document metadata
- * (all HMMetadata fields) and stripped from the content before tokenizing.
- *
- * Block IDs from `<!-- id:XXXXXXXX -->` HTML comments are preserved.
- * When no ID is present, random 8-char IDs are generated.
+ * See the module header for the dialect. Frontmatter is parsed for document
+ * metadata and stripped from the content before tokenizing. Block IDs from
+ * `<!-- id:… -->` comments are preserved; absent ids are generated.
  */
 export function parseMarkdown(markdown: string): {
   tree: BlockNode[]
   metadata: HMMetadata
 } {
   const {content, metadata} = parseFrontmatter(markdown)
-  const tokens = tokenize(content)
-  const rootNodes: BlockNode[] = []
+  const lines = content.split('\n')
+  const infos = lines.map(analyzeLine)
+  const root: Frame = {list: [], childIndent: 0}
+  const stack: Frame[] = [root]
+  const top = () => stack[stack.length - 1]!
 
-  // heading stack: [{level, node}] — tracks current hierarchy
-  const headingStack: {level: number; node: BlockNode}[] = []
-
-  function currentParent(): BlockNode | undefined {
-    return headingStack.length > 0 ? headingStack[headingStack.length - 1]!.node : undefined
+  /** Pop frames the incoming line no longer belongs to. */
+  function adjustStack(info: LineInfo, headingLevel: number | undefined) {
+    while (stack.length > 1) {
+      const frame = top()
+      if (info.indent < frame.childIndent) {
+        stack.pop()
+        continue
+      }
+      if (info.indent === frame.childIndent) {
+        if (frame.shorthand) {
+          if (info.markerKind === frame.shorthand) break
+          stack.pop()
+          continue
+        }
+        if (frame.headingLevel !== undefined && headingLevel !== undefined && headingLevel <= frame.headingLevel) {
+          stack.pop()
+          continue
+        }
+        break
+      }
+      // Deeper than this frame's children: a child of the last block we
+      // added (which pushed its own frame), or sloppy hand-written
+      // indentation — either way it belongs in this frame.
+      break
+    }
   }
 
-  function currentSiblings(): BlockNode[] {
-    return currentParent()?.children ?? rootNodes
+  function isImplicitListStart(frame: Frame, kind: MarkerKind): boolean {
+    if (!frame.node) return true // root never holds list items directly
+    const parentType = frame.node.block.childrenType
+    if (parentType && parentType !== kind) return true
+    return frame.list.length > 0 && frame.markerRun !== kind
   }
 
-  /**
-   * A list merged directly into a heading (heading childrenType set to
-   * Unordered/Ordered) is only valid while the list is the heading's sole
-   * content — anything appended after it would render as another list item.
-   * When more content arrives, wrap the merged items back into an invisible
-   * container and restore the heading to a Group parent.
-   */
-  function unmergeHeadingList() {
-    const parent = currentParent()
-    if (!parent || parent.block.type !== 'Heading') return
-    const ct = parent.block.childrenType
-    if (ct !== 'Unordered' && ct !== 'Ordered') return
-    parent.children = [createListContainerNode(parent.children, ct)]
-    parent.block.childrenType = 'Group'
+  function nextNonBlank(from: number): LineInfo | undefined {
+    for (let j = from; j < infos.length; j++) if (!infos[j]!.blank) return infos[j]
+    return undefined
   }
 
-  function addToCurrentParent(node: BlockNode | BlockNode[]) {
-    unmergeHeadingList()
-    const nodes = Array.isArray(node) ? node : [node]
-    currentSiblings().push(...nodes)
-  }
+  let i = 0
+  while (i < infos.length) {
+    const info = infos[i]!
+    if (info.blank) {
+      i++
+      continue
+    }
 
-  /**
-   * The closest preceding text block a list can nest under:
-   *   - the previous sibling, when it is a childless text Paragraph, or
-   *   - the enclosing heading, when the list is its first content.
-   * Returns undefined when neither applies (start of document, after a
-   * non-text block, or under a parent already holding merged list items).
-   */
-  function findListTarget(): BlockNode | undefined {
-    const parent = currentParent()
-    const parentType = parent?.block.childrenType
-    if (parentType === 'Unordered' || parentType === 'Ordered') return undefined
-    const siblings = currentSiblings()
-    const prev = siblings[siblings.length - 1]
-    if (prev) {
+    // <!-- end:ID --> closes the heading (or any block) with that id.
+    const endMatch = END_RE.exec(info.rest)
+    if (endMatch && !info.marker) {
+      const idx = findLastIndex(stack, (f) => f.node?.block.id === endMatch[1])
+      if (idx > 0) stack.length = idx
+      i++
+      continue
+    }
+
+    const headingMatch = HEADING_RE.exec(info.rest)
+    adjustStack(info, headingMatch ? headingMatch[1]!.length : undefined)
+
+    let frame = top()
+
+    // A heading holding a merged list gets more, non-list content: wrap the
+    // list back into an invisible container so the heading stays a Group.
+    if (
+      !info.markerKind &&
+      !frame.shorthand &&
+      frame.node?.block.type === 'Heading' &&
+      frame.list.length > 0 &&
+      isListType(frame.node.block.childrenType)
+    ) {
+      const container = makeBlockNode(
+        {
+          type: 'Paragraph',
+          id: generateBlockId(),
+          text: '',
+          annotations: [],
+          childrenType: frame.node.block.childrenType,
+        },
+        frame.list.splice(0),
+      )
+      frame.list.push(container)
+      frame.node.block.childrenType = 'Group'
+      frame.markerRun = undefined
+    }
+
+    // A marker line with no explicit structure around it (hand-written
+    // markdown): nest under the preceding text paragraph, or start an
+    // invisible container.
+    if (info.markerKind && !frame.shorthand && isImplicitListStart(frame, info.markerKind)) {
+      const prev = frame.list[frame.list.length - 1]
       const canNest =
+        prev &&
         prev.block.type === 'Paragraph' &&
         prev.block.text !== '' &&
         prev.children.length === 0 &&
         !prev.block.childrenType
-      return canNest ? prev : undefined
-    }
-    return parent
-  }
-
-  function addList(items: {text: string; id?: string}[], listType: 'Unordered' | 'Ordered', containerId?: string) {
-    const itemNodes = items.map((item) => createParagraphNode(item.text, item.id))
-
-    // An explicit container id means the source markdown round-tripped a
-    // document that really has an invisible list container — keep that block
-    // so its identity survives updates. Otherwise nest the items under the
-    // closest text block instead of fabricating an empty paragraph.
-    if (!containerId) {
-      const target = findListTarget()
-      if (target) {
-        target.block.childrenType = listType
-        target.children.push(...itemNodes)
-        return
+      let target: BlockNode
+      if (canNest) {
+        target = prev
+      } else {
+        target = makeBlockNode({type: 'Paragraph', id: generateBlockId(), text: '', annotations: []})
+        frame.list.push(target)
+        frame.markerRun = undefined
       }
+      target.block.childrenType = info.markerKind
+      // The target's own frame (pushed when it was added) is stale: replace it.
+      if (stack.length > 1 && top().node === target) stack.pop()
+      stack.push({node: target, list: target.children, childIndent: info.indent, shorthand: info.markerKind})
+      frame = top()
     }
-    addToCurrentParent(createListContainerNode(itemNodes, listType, containerId))
+
+    const parsed = parseBlockAt(i)
+    i = parsed.next
+    const node = parsed.node
+
+    frame.list.push(node)
+    frame.markerRun = info.markerKind
+    if (info.markerKind && frame.node && !frame.node.block.childrenType) {
+      frame.node.block.childrenType = info.markerKind
+    }
+
+    // Push a frame for this block's children.
+    if (headingMatch) {
+      stack.push({node, list: node.children, childIndent: info.contentCol, headingLevel: headingMatch[1]!.length})
+    } else if (parsed.standalone && !info.marker) {
+      const following = nextNonBlank(i)
+      if (following && following.indent === info.indent && following.markerKind) {
+        stack.push({node, list: node.children, childIndent: info.indent, shorthand: following.markerKind})
+      } else {
+        stack.push({node, list: node.children, childIndent: info.indent + 2})
+      }
+    } else {
+      stack.push({node, list: node.children, childIndent: info.marker ? info.contentCol : info.indent + 2})
+    }
   }
 
-  for (const token of tokens) {
-    switch (token.kind) {
-      case 'heading': {
-        const headingNode = createHeadingNode(token.text, token.id)
+  // Blocks that got children without a marker are Group parents.
+  const finalize = (nodes: BlockNode[]) => {
+    for (const n of nodes) {
+      if (n.children.length && !n.block.childrenType && n.block.type !== 'Table' && n.block.type !== 'TableRow') {
+        n.block.childrenType = 'Group'
+      }
+      finalize(n.children)
+    }
+  }
+  finalize(root.list)
 
-        // Pop headings from stack that are at same level or deeper
-        while (headingStack.length > 0 && headingStack[headingStack.length - 1]!.level >= token.level) {
-          headingStack.pop()
+  return {tree: root.list, metadata}
+
+  /**
+   * Parse the block starting at line `start`. Returns the node and the index
+   * of the first line after it. `standalone` marks a comment-only line.
+   */
+  function parseBlockAt(start: number): {node: BlockNode; next: number; standalone: boolean} {
+    const info = infos[start]!
+    const rest = info.rest
+
+    // Standalone comment: an invisible block, or the id line of a table.
+    const standalone = STANDALONE_COMMENT_RE.exec(rest)
+    if (standalone) {
+      const comment = commentFromMatch(standalone)
+      const following = nextNonBlank(start + 1)
+      if (following && following.indent >= info.indent && following.rest.startsWith('|') && !following.marker) {
+        const tableLines: string[] = []
+        let j = start + 1
+        while (j < infos.length && infos[j]!.rest.startsWith('|') && !infos[j]!.blank) {
+          tableLines.push(infos[j]!.rest)
+          j++
         }
-
-        // Add heading to its parent (or root)
-        addToCurrentParent(headingNode)
-
-        // Push onto stack
-        headingStack.push({level: token.level, node: headingNode})
-        break
+        return {node: createTableNode(tableLines, comment), next: j, standalone: false}
       }
-
-      case 'paragraph':
-        addToCurrentParent(createParagraphNode(token.text, token.id))
-        break
-
-      case 'code':
-        addToCurrentParent(createCodeNode(token.text, token.language, token.id))
-        break
-
-      case 'math':
-        addToCurrentParent(createMathNode(token.text, token.id))
-        break
-
-      case 'image':
-        addToCurrentParent(createImageNode(token.alt, token.url, token.id))
-        break
-
-      case 'table':
-        addToCurrentParent(createTableNode(token.lines, token.containerId))
-        break
-
-      case 'ul':
-        addList(token.items, 'Unordered', token.containerId)
-        break
-
-      case 'ol':
-        addList(token.items, 'Ordered', token.containerId)
-        break
+      const type = comment.type || 'Paragraph'
+      return {node: makeBlockNode(baseBlock(type, comment)), next: start + 1, standalone: true}
     }
-  }
 
-  return {tree: rootNodes, metadata}
+    // Fenced code block: ```lang <!-- id:X -->
+    const fence = FENCE_RE.exec(rest)
+    if (fence) {
+      const fenceLen = fence[1]!.length
+      const {text: language, comment} = stripBlockComment(fence[2]!.trim())
+      const bodyLines: string[] = []
+      let j = start + 1
+      while (j < infos.length) {
+        const l = infos[j]!
+        const closing = /^(`{3,})\s*$/.exec(l.raw.trim())
+        if (closing && closing[1]!.length >= fenceLen && l.indent <= info.contentCol) break
+        bodyLines.push(stripIndent(l.raw, info.contentCol))
+        j++
+      }
+      j++ // closing fence
+      return {node: createCodeNode(bodyLines.join('\n'), language.trim(), comment), next: j, standalone: false}
+    }
+
+    // Math block: $$ <!-- id:X -->
+    if (rest.startsWith('$$')) {
+      const {comment} = stripBlockComment(rest.slice(2).trim())
+      const bodyLines: string[] = []
+      let j = start + 1
+      while (j < infos.length && infos[j]!.raw.trim() !== '$$') {
+        bodyLines.push(stripIndent(infos[j]!.raw, info.contentCol))
+        j++
+      }
+      j++
+      return {node: createMathNode(bodyLines.join('\n'), comment), next: j, standalone: false}
+    }
+
+    // Heading: # text <!-- id:X -->
+    const heading = HEADING_RE.exec(rest)
+    if (heading) {
+      const {text, comment} = stripBlockComment(heading[2]!)
+      if (comment?.type) return {node: createTypedNode(text, comment), next: start + 1, standalone: false}
+      return {node: createHeadingNode(text, comment), next: start + 1, standalone: false}
+    }
+
+    // Table without a preceding id line.
+    if (rest.startsWith('|')) {
+      const tableLines: string[] = []
+      let j = start
+      while (j < infos.length && infos[j]!.rest.startsWith('|') && !infos[j]!.blank) {
+        tableLines.push(infos[j]!.rest)
+        j++
+      }
+      return {node: createTableNode(tableLines), next: j, standalone: false}
+    }
+
+    // Everything else starts as a one-line block with an optional trailing comment.
+    const {text: visible, comment} = stripBlockComment(rest)
+
+    if (comment?.type) {
+      return {node: createTypedNode(visible, comment), next: start + 1, standalone: false}
+    }
+
+    // Standalone image: ![alt](url) <!-- id:X -->
+    if (IMAGE_START_RE.test(visible)) {
+      const link = readLink(visible, 1)
+      if (link && visible.slice(link.end).trim() === '') {
+        let url = link.url
+        if (url && !url.match(/^[a-zA-Z][a-zA-Z0-9+.-]*:/)) url = `file://${url}`
+        return {node: createImageNode(link.label, url, comment), next: start + 1, standalone: false}
+      }
+    }
+
+    // Paragraph. Hand-written soft-wrapped lines (no comment on the first
+    // line) join with a space, as CommonMark does.
+    let text = visible
+    let j = start + 1
+    if (!comment) {
+      while (j < infos.length) {
+        const l = infos[j]!
+        if (l.blank || l.marker || l.indent !== info.contentCol || startsSpecialBlock(l.rest)) break
+        const {text: more, comment: c} = stripBlockComment(l.rest)
+        if (c) break
+        text += ' ' + more
+        j++
+      }
+    }
+    return {node: createParagraphNode(text, comment), next: j, standalone: false}
+  }
+}
+
+/** Remove up to `n` leading spaces from a line. */
+function stripIndent(line: string, n: number): string {
+  let k = 0
+  while (k < n && line[k] === ' ') k++
+  return line.slice(k)
 }
 
 /**
@@ -1010,14 +1186,12 @@ export function markdownBlockNodesToHMBlockNodes(nodes: BlockNode[]): HMBlockNod
   return nodes.map((node) => {
     const {block} = node
     const attributes: Record<string, unknown> = {...block.attributes}
-
     if (block.childrenType !== undefined) {
       attributes.childrenType = block.childrenType
     }
     if (block.language !== undefined) {
       attributes.language = block.language
     }
-
     const hmBlock: Record<string, unknown> = {
       type: block.type,
       id: block.id,
@@ -1027,14 +1201,13 @@ export function markdownBlockNodesToHMBlockNodes(nodes: BlockNode[]): HMBlockNod
         starts: a.starts,
         ends: a.ends,
         ...(a.link !== undefined ? {link: a.link} : {}),
+        ...(a.attributes !== undefined ? {attributes: a.attributes} : {}),
       })),
       attributes,
     }
-
     if (block.link !== undefined) {
       hmBlock.link = block.link
     }
-
     return {
       block: hmBlock,
       children: node.children.length > 0 ? markdownBlockNodesToHMBlockNodes(node.children) : undefined,
@@ -1068,15 +1241,12 @@ export function flattenToOperations(tree: BlockNode[], parentId: string = ''): D
       text: node.block.text,
       annotations: node.block.annotations,
     }
-
     if (node.block.language !== undefined) {
       block['language'] = node.block.language
     }
-
     if (node.block.childrenType !== undefined) {
       block['childrenType'] = node.block.childrenType
     }
-
     if (node.block.link !== undefined) {
       block['link'] = node.block.link
     }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "scripts": {
     "test": "pnpm web:test && pnpm shared:test && pnpm desktop:test:unit",
+    "docs:dev": "cd frontend/apps/cli && bun run src/index.ts space dev --dir ../../../seed-docs",
+    "docs:push": "cd frontend/apps/cli && bun run src/index.ts space import self --dir ../../../seed-docs",
+    "docs:pull": "cd frontend/apps/cli && bun run src/index.ts space export self --dir ../../../seed-docs",
     "shared:test": "pnpm --filter @shm/shared test",
     "format:check": "pnpm -r --parallel run format:check && (cd agents && bun run format:check) && (cd vault && bun run format:check)",
     "typecheck": "pnpm -r --parallel run typecheck",

--- a/seed-docs/cli.md
+++ b/seed-docs/cli.md
@@ -1,0 +1,37 @@
+---
+name: CLI
+summary: The seed-cli commands that publish this folder, and how the repository uses them.
+---
+The Seed CLI lives at `frontend/apps/cli` and runs from source with `bun run src/index.ts`. The commands below are the ones this folder is published with.
+
+# space export
+
+```sh
+seed-cli space export hm://<uid> --dir ./seed-docs
+```
+
+Writes every document of the space into the directory as lossless markdown. Use it to bring edits made in the Seed app back into git.
+
+# space import
+
+```sh
+seed-cli space import hm://<uid> --dir ./seed-docs --dry-run
+seed-cli space import self --dir ./seed-docs
+```
+
+Publishes the directory into the space, updating existing documents block by block. `self` means the signing key's own space. The signing key comes from the vault or keyring, or from the `SEED_CLI_MNEMONIC` environment variable, which is how CI signs.
+
+# space dev
+
+```sh
+seed-cli space dev --dir ./seed-docs
+```
+
+Edit the directory in the desktop dev app. See [Markdown sync](./markdown-sync.md).
+
+# In this repository
+
+- `pnpm docs:dev` runs the editing loop for `seed-docs/`.
+- `pnpm docs:push` publishes `seed-docs/` to hyper.media with your key.
+- `pnpm docs:pull` writes the published site back into `seed-docs/`.
+- A commit to `main` that touches `seed-docs/` publishes it from CI.

--- a/seed-docs/index.md
+++ b/seed-docs/index.md
@@ -1,0 +1,12 @@
+---
+name: Seed developer docs
+summary: Documentation that lives next to the code, in this repository, and is published to the Hypermedia network from here.
+---
+These pages are markdown files checked into the Seed repository under `seed-docs/`. A commit to `main` publishes them to this site, so what you read here is exactly what the code ships with.
+
+The folder is also an example of a workflow: the markdown is the source of truth, but the Seed app can be the editor. See [Markdown sync](./markdown-sync.md) for how a directory of markdown files and a Hypermedia space mirror each other, and [CLI](./cli.md) for the commands.
+
+# Pages
+
+- [Markdown sync](./markdown-sync.md) — the lossless markdown dialect and the export, import and dev commands.
+- [CLI](./cli.md) — the `seed-cli` commands this folder is published with.

--- a/seed-docs/markdown-sync.md
+++ b/seed-docs/markdown-sync.md
@@ -1,0 +1,27 @@
+---
+name: Markdown sync
+summary: How a directory of markdown files and a Hypermedia space mirror each other without losing anything, and how to edit either side.
+---
+A Hypermedia document is a tree of typed blocks with annotations and metadata. Markdown has syntax for most of that and none for the rest. The sync keeps a directory of markdown files and a Hypermedia space in step by using a markdown dialect that carries everything a document can hold, so a document exported to a file and imported again is the same document, and a file exported from a document and re-exported is the same text.
+
+# The dialect
+
+Where markdown has syntax, the dialect uses it: headings, paragraphs, lists, block quotes, fenced code, math, images, links, tables, bold, italic, strikethrough and inline code all look like ordinary markdown and render fine on GitHub.
+
+Every block ends with an HTML comment carrying its identity, `<!-- id:X -->`. Identity is what makes an edit an update of an existing block instead of a replacement. Two optional keys ride in the same comment when markdown has no syntax for something: `type:` names a block type such as Video, File, Button, Embed or Query, and `attrs:` holds a JSON object of attributes such as an image width or a query definition. A block with nothing special looks like plain markdown plus its id.
+
+Nesting is indentation. A block's children sit two spaces deeper, or at the content column of a list marker. A heading's children follow it at the same indentation, and `<!-- end:X -->` closes a heading when a non-heading sibling follows. Frontmatter carries every metadata key of the document, including keys the client does not know about.
+
+Text is escaped so that markdown syntax characters survive, newlines inside a block are written as `<br>`, and style annotations that markdown lacks, such as underline, highlight and colors, are written as inline HTML tags.
+
+# Import and export
+
+`space export` writes every document of a space into a directory: the home document as `index.md` and a document at `/a/b` as `a/b.md`. It only touches files whose content changed. Links between documents of the space become relative file links, so they work on GitHub too.
+
+`space import` publishes a directory into a space. For each file it fetches the current document, diffs the blocks by id, and publishes a change on the document's existing history. Unchanged documents produce no change at all, so running it repeatedly never spams versions. A hand-written file with no ids is matched to the existing document by position, so editing a paragraph in place updates that paragraph rather than replacing the page. Relative links to other files in the directory become links to the corresponding documents.
+
+# Editing in the app
+
+`space dev` turns the desktop dev app into the editor for a directory. It creates a throwaway key under `.dev/` in the directory, registers it in the app's own daemon, publishes the directory there, and then watches the daemon. Every document you publish in the app is written straight back as a file, so `git diff` shows the edit within seconds. Nothing reaches the network until you import into a real space.
+
+While the loop runs, the app is the writer and git is where you commit.


### PR DESCRIPTION
## What

**Repo HM sync**: a directory of markdown files in the repository and a Hypermedia space as two forms of the same content, with the Seed app as an optional editor. Later work builds typed-schema publishing on top of this.

**Lossless markdown** (`@seed-hypermedia/client`): `blocksToMarkdown` / `parseMarkdown` are now a fixed point for any document. Every block type, annotation, attribute and metadata key survives a round trip. Plain markdown where markdown has syntax; identity and the rest in each block's trailing `<!-- id:X [type:T] [attrs:{…}] -->` comment. One test case per feature (67) plus a corpus test.

**block-diff**: an unchanged document is zero ops (MoveBlocks only when a level's order changed), annotations compare semantically, and table subtrees are left to `rebindTableIdentities`.

**`seed-cli space`**:
- `space export <space|self> --dir` writes every document as markdown (home → `index.md`, `/a/b` → `a/b.md`), touching only changed files.
- `space import <space|self> --dir [--dry-run]` publishes a directory back, diffing by block id on each document's existing history. Files without ids match positionally. Relative links between files ⇄ `hm://` links.
- `space dev --dir` edits the directory in the desktop dev app: a throwaway key under `<dir>/.dev/` (self-ignored) is registered in the app's daemon, the directory is published there, and every document published in the app is written straight back.
- `SEED_CLI_MNEMONIC` signs in CI.

**`seed-docs/`**: three developer docs checked into the repo and published to their Hypermedia site by `.github/workflows/sync-seed-docs.yml` on every push to `main`. `pnpm docs:dev`, `docs:push`, `docs:pull`.

## Setup needed after merge

1. Create a key for the docs site (`seed-cli key generate --name seed-docs --show-mnemonic`) and add its mnemonic as the `SEED_DOCS_MNEMONIC` repository secret. The site is that key's own space; the workflow skips itself while the secret is unset.
2. Optionally run the workflow once by hand (`workflow_dispatch`).

## Verified

Against a running desktop dev daemon: `space dev` created the three docs, `space export` reproduced the files modulo ids, and a dry-run import of the unchanged folder reported zero changes. Client suite green apart from two pre-existing failures (`client.test.ts` Search options, `vault-local.test.ts` well-known location) and the slow key-derivation timeouts under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFy4qKyaVjeQ2jWhA5jdTs
