### PR TITLE
seed-docs sync signs with an exported .hmkey.json (SEED_CLI_KEYFILE)

### DIFF
--- a/.github/workflows/sync-seed-docs.yml
+++ b/.github/workflows/sync-seed-docs.yml
@@ -1,9 +1,9 @@
 name: Repo HM sync (seed-docs)
 
 # Publishes seed-docs/ to its Hypermedia site whenever main changes it.
-# Signs with SEED_DOCS_MNEMONIC (a repository secret): the site is that key's
-# own space. Documents are updated block by block; unchanged pages publish
-# nothing.
+# Signs with SEED_DOCS_KEYFILE (a repository secret holding the contents of an
+# unencrypted .hmkey.json, as exported by the app): the site is that key's own
+# space. Documents are updated block by block; unchanged pages publish nothing.
 
 on:
   workflow_dispatch:
@@ -36,10 +36,10 @@ jobs:
       - name: Publish seed-docs to hyper.media
         working-directory: frontend/apps/cli
         env:
-          SEED_CLI_MNEMONIC: ${{ secrets.SEED_DOCS_MNEMONIC }}
+          SEED_CLI_KEYFILE: ${{ secrets.SEED_DOCS_KEYFILE }}
         run: |
-          if [ -z "$SEED_CLI_MNEMONIC" ]; then
-            echo "SEED_DOCS_MNEMONIC secret is not set; skipping publish."
+          if [ -z "$SEED_CLI_KEYFILE" ]; then
+            echo "SEED_DOCS_KEYFILE secret is not set; skipping publish."
             exit 0
           fi
           bun run src/index.ts space import self --dir ../../../seed-docs --server https://hyper.media

--- a/frontend/apps/cli/README.md
+++ b/frontend/apps/cli/README.md
@@ -538,7 +538,8 @@ seed-cli space import <space> --dir <path> [--dry-run] [-k, --key <name>]
 
 Publishes the directory into the space. Each file is diffed by block id against the current document and published as a
 change on its existing history; unchanged documents produce nothing. A file without ids is matched to the existing
-document by position. In CI, set `SEED_CLI_MNEMONIC` to sign without a stored key and use `self` as the space.
+document by position. In CI, sign without a stored key by setting `SEED_CLI_KEYFILE` to the contents of an unencrypted
+`.hmkey.json` (or `SEED_CLI_MNEMONIC` to a BIP-39 phrase) and use `self` as the space.
 
 ### space dev
 

--- a/frontend/apps/cli/src/utils/key-derivation.ts
+++ b/frontend/apps/cli/src/utils/key-derivation.ts
@@ -18,8 +18,7 @@ import {sha512} from '@noble/hashes/sha512'
 
 // Configure ed25519 to use sha512
 ed25519.etc.sha512Sync = (...m) => sha512(ed25519.etc.concatBytes(...m))
-ed25519.etc.sha512Async = async (...m) =>
-  sha512(ed25519.etc.concatBytes(...m))
+ed25519.etc.sha512Async = async (...m) => sha512(ed25519.etc.concatBytes(...m))
 
 // Derivation path from backend/core/mnemonic.go
 // 104109 = 'h' (104) + 'm' (109) - stands for Hypermedia
@@ -38,10 +37,7 @@ export type KeyPair = {
 /**
  * Derives account ID from BIP39 mnemonic
  */
-export function deriveAccountIdFromMnemonic(
-  mnemonic: string | string[],
-  passphrase = ''
-): string {
+export function deriveAccountIdFromMnemonic(mnemonic: string | string[], passphrase = ''): string {
   const keyPair = deriveKeyPairFromMnemonic(mnemonic, passphrase)
   return keyPair.accountId
 }
@@ -49,14 +45,9 @@ export function deriveAccountIdFromMnemonic(
 /**
  * Derives full keypair from BIP39 mnemonic
  */
-export function deriveKeyPairFromMnemonic(
-  mnemonic: string | string[],
-  passphrase = ''
-): KeyPair {
+export function deriveKeyPairFromMnemonic(mnemonic: string | string[], passphrase = ''): KeyPair {
   // Normalize mnemonic to string
-  const mnemonicString = Array.isArray(mnemonic)
-    ? mnemonic.join(' ')
-    : mnemonic
+  const mnemonicString = Array.isArray(mnemonic) ? mnemonic.join(' ') : mnemonic
 
   // 1. Convert mnemonic to BIP39 seed
   const seed = bip39.mnemonicToSeedSync(mnemonicString, passphrase)
@@ -65,17 +56,24 @@ export function deriveKeyPairFromMnemonic(
   const masterKey = SLIP10.fromSeed(seed)
   const derivedKey = masterKey.derive(KEY_DERIVATION_PATH)
 
-  // 3. Get Ed25519 keys
-  const privateKey = derivedKey.key
+  // 3. Ed25519 keys from the derived 32-byte seed
+  return keyPairFromPrivateKey(derivedKey.key)
+}
+
+/**
+ * Builds the full keypair from a raw 32-byte Ed25519 private key (seed), the
+ * form stored in the keyring, the vault and `.hmkey.json` files.
+ */
+export function keyPairFromPrivateKey(privateKey: Uint8Array): KeyPair {
+  if (privateKey.length !== 32) {
+    throw new Error(`invalid private key length: expected 32 bytes, got ${privateKey.length}`)
+  }
   const publicKey = ed25519.getPublicKey(privateKey)
 
-  // 4. Encode public key with multicodec prefix
-  const publicKeyWithPrefix = new Uint8Array([
-    ...ED25519_MULTICODEC_PREFIX,
-    ...publicKey,
-  ])
+  // Encode public key with multicodec prefix
+  const publicKeyWithPrefix = new Uint8Array([...ED25519_MULTICODEC_PREFIX, ...publicKey])
 
-  // 5. Encode as multibase base58btc (starts with 'z')
+  // Encode as multibase base58btc (starts with 'z')
   const accountId = base58btc.encode(publicKeyWithPrefix)
 
   return {

--- a/frontend/apps/cli/src/utils/keys.test.ts
+++ b/frontend/apps/cli/src/utils/keys.test.ts
@@ -95,6 +95,62 @@ beforeEach(() => {
 
 afterEach(() => {
   delete process.env.SEED_VAULT_PATH
+  delete process.env.SEED_CLI_KEYFILE
+  delete process.env.SEED_CLI_MNEMONIC
+})
+
+/** An unencrypted `.hmkey.json` payload for a test key, as the app exports it. */
+function keyfileJson(key: TestKey, publicKey = key.accountId): string {
+  return JSON.stringify({
+    createTime: '2026-01-01T00:00:00.000Z',
+    publicKey,
+    keyB64: Buffer.from(key.privateKey).toString('base64'),
+  })
+}
+
+describe('signing key from the environment', () => {
+  test('SEED_CLI_KEYFILE (an exported .hmkey.json) wins over every stored key', async () => {
+    state.vaultAccounts = [asVaultAccount(vaultMain)]
+    state.keyringKeys = [keyringMain]
+    const envKey = makeKey('ci', 9)
+    process.env.SEED_CLI_KEYFILE = keyfileJson(envKey)
+    const key = await resolveSigningKey(undefined, OPTS)
+    expect(key.source).toBe('env')
+    expect(key.accountId).toBe(envKey.accountId)
+    expect(key.privateKey).toEqual(envKey.privateKey)
+    // --key may name the same account, or the env key itself, but nothing else.
+    expect((await resolveSigningKey(envKey.accountId, OPTS)).accountId).toBe(envKey.accountId)
+    expect((await resolveSigningKey('env', OPTS)).accountId).toBe(envKey.accountId)
+    await expect(resolveSigningKey('main', OPTS)).rejects.toThrow('SEED_CLI_KEYFILE is set')
+  })
+
+  test('SEED_CLI_KEYFILE rejects a key file whose publicKey does not match its key', async () => {
+    const envKey = makeKey('ci', 9)
+    process.env.SEED_CLI_KEYFILE = keyfileJson(envKey, makeKey('other', 8).accountId)
+    await expect(resolveSigningKey(undefined, OPTS)).rejects.toThrow('publicKey does not match')
+  })
+
+  test('SEED_CLI_KEYFILE rejects an encrypted key file with guidance', async () => {
+    const envKey = makeKey('ci', 9)
+    const payload = {...JSON.parse(keyfileJson(envKey)), encryption: {kdf: 'argon2id', cipher: 'xchacha20poly1305'}}
+    process.env.SEED_CLI_KEYFILE = JSON.stringify(payload)
+    await expect(resolveSigningKey(undefined, OPTS)).rejects.toThrow('export it without a password')
+  })
+
+  test('SEED_CLI_KEYFILE rejects junk', async () => {
+    process.env.SEED_CLI_KEYFILE = 'not json'
+    await expect(resolveSigningKey(undefined, OPTS)).rejects.toThrow('SEED_CLI_KEYFILE is not a usable .hmkey.json')
+  })
+
+  test('SEED_CLI_MNEMONIC still works, and both at once is an error', async () => {
+    process.env.SEED_CLI_MNEMONIC =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+    const key = await resolveSigningKey(undefined, OPTS)
+    expect(key.source).toBe('env')
+    expect(key.accountId.startsWith('z')).toBe(true)
+    process.env.SEED_CLI_KEYFILE = keyfileJson(makeKey('ci', 9))
+    await expect(resolveSigningKey(undefined, OPTS)).rejects.toThrow('use one')
+  })
 })
 
 describe('resolveSigningKey precedence', () => {

--- a/frontend/apps/cli/src/utils/keys.ts
+++ b/frontend/apps/cli/src/utils/keys.ts
@@ -12,10 +12,11 @@
  * are the daemon's job. Key creation/removal in the CLI stays on the keyring.
  */
 
+import * as keyfile from '@seed-hypermedia/client/keyfile'
 import {loadLocalVaultAccounts, type VaultLocalAccount} from '@seed-hypermedia/client/vault-local'
 import {loadConfig} from '../config'
 import {printWarning} from '../output'
-import {deriveKeyPairFromMnemonic} from './key-derivation'
+import {deriveKeyPairFromMnemonic, keyPairFromPrivateKey} from './key-derivation'
 import {getDefaultKey, getKey, listKeys, type KeyringKey} from './keyring'
 
 export type KeySource = 'vault' | 'keyring' | 'env'
@@ -106,15 +107,16 @@ export async function findDefaultKey(opts: KeyOptions): Promise<ResolvedKey | nu
 export async function resolveSigningKey(keyFlag: string | undefined, opts: KeyOptions): Promise<ResolvedKey> {
   const envHint = opts.dev ? ' --dev' : ''
 
-  // Non-interactive environments (CI) pass the key as a mnemonic in
-  // SEED_CLI_MNEMONIC; it wins over every stored key.
-  const envMnemonic = process.env.SEED_CLI_MNEMONIC?.trim()
-  if (envMnemonic) {
-    const pair = deriveKeyPairFromMnemonic(envMnemonic)
-    if (keyFlag && keyFlag !== 'env' && keyFlag !== pair.accountId) {
-      throw new Error(`SEED_CLI_MNEMONIC is set (account ${pair.accountId}) but --key ${keyFlag} was requested.`)
+  // Non-interactive environments (CI) pass the key in the environment; it
+  // wins over every stored key.
+  const envKey = await resolveEnvKey()
+  if (envKey) {
+    if (keyFlag && keyFlag !== 'env' && keyFlag !== envKey.pair.accountId) {
+      throw new Error(
+        `${envKey.variable} is set (account ${envKey.pair.accountId}) but --key ${keyFlag} was requested.`,
+      )
     }
-    return {name: 'env', ...pair, source: 'env'}
+    return {name: 'env', ...envKey.pair, source: 'env'}
   }
 
   if (keyFlag) {
@@ -133,6 +135,38 @@ export async function resolveSigningKey(keyFlag: string | undefined, opts: KeyOp
     )
   }
   return key
+}
+
+/**
+ * Reads a signing key from the environment, for CI and other non-interactive
+ * runs. SEED_CLI_KEYFILE holds the contents of an unencrypted `.hmkey.json`
+ * (the format the app and vault export), SEED_CLI_MNEMONIC a BIP-39 phrase.
+ * A raw key cannot be turned back into a mnemonic, so exported keys use the
+ * former. Setting both is a configuration error.
+ */
+async function resolveEnvKey(): Promise<{variable: string; pair: ReturnType<typeof keyPairFromPrivateKey>} | null> {
+  const envKeyfile = process.env.SEED_CLI_KEYFILE?.trim()
+  const envMnemonic = process.env.SEED_CLI_MNEMONIC?.trim()
+  if (envKeyfile && envMnemonic) {
+    throw new Error('Both SEED_CLI_KEYFILE and SEED_CLI_MNEMONIC are set; use one.')
+  }
+  if (envKeyfile) {
+    let seed: Uint8Array
+    try {
+      const payload = keyfile.parse(envKeyfile)
+      if (payload.encryption) {
+        throw new Error('the key file is password-encrypted; export it without a password')
+      }
+      seed = (await keyfile.load(envKeyfile)).seed
+    } catch (error) {
+      throw new Error(`SEED_CLI_KEYFILE is not a usable .hmkey.json: ${(error as Error).message}`)
+    }
+    return {variable: 'SEED_CLI_KEYFILE', pair: keyPairFromPrivateKey(seed)}
+  }
+  if (envMnemonic) {
+    return {variable: 'SEED_CLI_MNEMONIC', pair: deriveKeyPairFromMnemonic(envMnemonic)}
+  }
+  return null
 }
 
 /** Lists all known keys: vault identities first, then keyring keys. */

--- a/seed-docs/cli.md
+++ b/seed-docs/cli.md
@@ -19,7 +19,7 @@ seed-cli space import hm://<uid> --dir ./seed-docs --dry-run
 seed-cli space import self --dir ./seed-docs
 ```
 
-Publishes the directory into the space, updating existing documents block by block. `self` means the signing key's own space. The signing key comes from the vault or keyring, or from the `SEED_CLI_MNEMONIC` environment variable, which is how CI signs. <!-- id:zcB4OI7D -->
+Publishes the directory into the space, updating existing documents block by block. `self` means the signing key's own space. The signing key comes from the vault or keyring, or from the environment, which is how CI signs: `SEED_CLI_KEYFILE` holds the contents of an unencrypted `.hmkey.json` exported from the app, or `SEED_CLI_MNEMONIC` holds a BIP-39 phrase. <!-- id:zcB4OI7D -->
 
 # space dev <!-- id:dpshaoY4 -->
 


### PR DESCRIPTION
Follow-up to #1038. The `sync-seed-docs` workflow ran once on main and skipped publishing because its secret was never set. The site key exists as an exported `.hmkey.json`, and a raw key cannot be converted back into a mnemonic, so the mnemonic-only secret could never have been filled from it.

- `seed-cli` reads `SEED_CLI_KEYFILE`, the contents of an unencrypted `.hmkey.json`, as a signing key. It takes precedence over stored keys like `SEED_CLI_MNEMONIC` does; encrypted files, a `publicKey` that does not match the key, junk, and both variables at once all fail with a pointed error. Unit tests cover each case.
- The workflow passes the `SEED_DOCS_KEYFILE` repository secret through that variable.
- README and seed-docs/cli.md describe both variables.

Verified locally: `space import self --dir seed-docs --dry-run --server https://hyper.media` with a throwaway key file resolves the key from the environment and plans the three pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VdZxHPePVSrtbbGwE4eey
