### PR TITLE
fix(ui): navigate browser entries to latest document versions

### DIFF
--- a/frontend/packages/ui/src/__tests__/site-file-browser.test.tsx
+++ b/frontend/packages/ui/src/__tests__/site-file-browser.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import type {HMDocumentInfo, HMListedDraft} from '@seed-hypermedia/client/hm-types'
 import {hmId} from '@shm/shared'
+import {latestId} from '@shm/shared/utils/entity-id-url'
 import {act} from 'react-dom/test-utils'
 import {createRoot, type Root} from 'react-dom/client'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
@@ -139,6 +140,7 @@ describe('SiteFileBrowser', () => {
 
   it('shows title matches as a flat list and navigates', () => {
     const install = makeDoc(['guides', 'install'], 'Install Seed')
+    install.id = hmId('site', {path: ['guides', 'install'], version: 'listed-version', latest: false})
     const onNavigate = vi.fn()
     const onPrefetch = vi.fn()
     useDirectoryWithDraftsMock.mockReturnValue({
@@ -171,10 +173,10 @@ describe('SiteFileBrowser', () => {
     )!
     act(() => result.dispatchEvent(new MouseEvent('pointerover', {bubbles: true})))
     act(() => result.focus())
-    expect(onPrefetch).toHaveBeenNthCalledWith(1, install.id)
-    expect(onPrefetch).toHaveBeenNthCalledWith(2, install.id)
+    expect(onPrefetch).toHaveBeenNthCalledWith(1, latestId(install.id))
+    expect(onPrefetch).toHaveBeenNthCalledWith(2, latestId(install.id))
     act(() => result.click())
-    expect(onNavigate).toHaveBeenCalledWith(install.id)
+    expect(onNavigate).toHaveBeenCalledWith(latestId(install.id))
   })
 
   it('hides search by default and focuses it when revealed', () => {

--- a/frontend/packages/ui/src/site-file-browser.tsx
+++ b/frontend/packages/ui/src/site-file-browser.tsx
@@ -2,6 +2,7 @@ import type {HMDocumentInfo, HMListedDraft, UnpackedHypermediaId} from '@seed-hy
 import {hmId} from '@shm/shared'
 import {isDraftPlaceholderPath, type HMListedDraftWithLocation} from '@shm/shared/draft-breadcrumb-context'
 import {useDirectoryWithDrafts} from '@shm/shared/models/entity'
+import {latestId} from '@shm/shared/utils/entity-id-url'
 import {
   buildDocumentTree,
   filterDocumentsByTitle,
@@ -214,6 +215,7 @@ export function SiteFileBrowser({
                 const isFiltered = !!query.trim()
                 const isActive = doc.id.id === activeDocumentId?.id
                 const isExpanded = row ? expandedPaths.has(row.pathKey) : false
+                const navigationId = unpublishedDraftIds.has(doc.id.id) ? doc.id : latestId(doc.id)
                 return (
                   <div
                     key={doc.id.id}
@@ -240,9 +242,9 @@ export function SiteFileBrowser({
                     <button
                       type="button"
                       aria-current={isActive ? 'page' : undefined}
-                      onPointerEnter={() => onPrefetch?.(doc.id)}
-                      onFocus={() => onPrefetch?.(doc.id)}
-                      onClick={() => onNavigate(doc.id)}
+                      onPointerEnter={() => onPrefetch?.(navigationId)}
+                      onFocus={() => onPrefetch?.(navigationId)}
+                      onClick={() => onNavigate(navigationId)}
                       className="hover:bg-accent/60 focus-visible:ring-ring flex h-6 min-w-0 flex-1 items-center gap-1.5 rounded-md px-1.5 text-left text-sm outline-none focus-visible:ring-2"
                     >
                       {doc.isCollection ? (


### PR DESCRIPTION
## Summary
- Navigate published Document Browser entries to their latest document URLs so browsing does not repeatedly trigger redirect alerts.
- Preserve unpublished draft navigation while applying latest-version prefetching and click behavior to listed documents.
- Add test coverage for search result navigation and prefetch targets.

---

Fixes #975