### PR TITLE
fix(ui): enable mobile card option taps

### DIFF
--- a/frontend/packages/ui/src/__tests__/dropdown-menu.test.tsx
+++ b/frontend/packages/ui/src/__tests__/dropdown-menu.test.tsx
@@ -4,6 +4,7 @@ import {createRoot, type Root} from 'react-dom/client'
 import {act} from 'react-dom/test-utils'
 import {afterEach, beforeEach, describe, expect, it} from 'vitest'
 import {DropdownMenu, DropdownMenuTrigger} from '../components/dropdown-menu'
+import {OptionsDropdown} from '../options-dropdown'
 ;(globalThis as typeof globalThis & {React?: typeof React; IS_REACT_ACT_ENVIRONMENT?: boolean}).React = React
 ;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -50,5 +51,20 @@ describe('DropdownMenuTrigger', () => {
 
     const trigger = container.querySelector('[data-slot="dropdown-menu-trigger"]')
     expect(trigger?.className).toContain('data-[state=open]:opacity-100')
+  })
+})
+
+describe('OptionsDropdown', () => {
+  it('only hides hover actions on devices that support hover', () => {
+    act(() => {
+      root.render(<OptionsDropdown hiddenUntilItemHover menuItems={[{key: 'open', label: 'Open', icon: <span />}]} />)
+    })
+
+    const trigger = container.querySelector('[data-slot="dropdown-menu-trigger"]')
+    const actionContainer = trigger?.parentElement
+
+    expect(actionContainer?.className).toContain('hover-hover:opacity-0')
+    expect(actionContainer?.className).toContain('hover-hover:group-hover/item:opacity-100')
+    expect(actionContainer?.className.split(' ')).not.toContain('opacity-0')
   })
 })

--- a/frontend/packages/ui/src/options-dropdown.tsx
+++ b/frontend/packages/ui/src/options-dropdown.tsx
@@ -166,8 +166,8 @@ export function OptionsDropdown({
   return (
     <div
       className={cn(
-        'flex group-hover/item:opacity-100',
-        !popoverState.open && hiddenUntilItemHover ? 'opacity-0' : 'opacity-100',
+        'hover-hover:group-hover/item:opacity-100 flex',
+        !popoverState.open && hiddenUntilItemHover ? 'hover-hover:opacity-0' : 'opacity-100',
         className,
         popoverState.open && '!opacity-100',
       )}


### PR DESCRIPTION
## Summary
- Keeps card option controls tappable on touch devices by only applying hover-hidden opacity on hover-capable devices.
- Preserves the existing reveal-on-hover behavior for desktop and keeps open dropdowns visible.
- Adds test coverage for the mobile-safe hover visibility classes.

fixes #883

---

Fixes #883