### PR TITLE
fix(editor): lower block tool overlay z-index

### DIFF
--- a/frontend/packages/editor/src/blocknote/react/BlockHoverActions/BlockHoverActionsPositioner.test.tsx
+++ b/frontend/packages/editor/src/blocknote/react/BlockHoverActions/BlockHoverActionsPositioner.test.tsx
@@ -155,6 +155,7 @@ describe('BlockHoverActionsPositioner', () => {
 
     expect(card.className).toContain('flex-col')
     expect(wrapper.dataset.bnBlockHoverActions).toBe('true')
+    expect(wrapper.style.zIndex).toBe('10')
     expect(wrapper.style.left).toBe('24px')
     expect(wrapper.style.paddingLeft).toBe('')
     expect(container.querySelector('[data-bn-block-hover-bridge="true"]')).toBeNull()

--- a/frontend/packages/editor/src/blocknote/react/BlockHoverActions/BlockHoverActionsPositioner.test.tsx
+++ b/frontend/packages/editor/src/blocknote/react/BlockHoverActions/BlockHoverActionsPositioner.test.tsx
@@ -183,6 +183,30 @@ describe('BlockHoverActionsPositioner', () => {
     expect(wrapper.style.paddingLeft).toBe('')
   })
 
+  it('hides actions when their block scrolls outside the document viewport', () => {
+    const viewport = document.createElement('div')
+    viewport.dataset.slot = 'scroll-area-viewport'
+    Object.defineProperty(viewport, 'getBoundingClientRect', {
+      value: () => ({...rect(100, 500), bottom: 500, height: 400}),
+    })
+    document.body.appendChild(viewport)
+    viewport.appendChild(editorDom)
+
+    const block = document.createElement('div')
+    block.dataset.id = 'block-1'
+    appendPublishedContent(block)
+    editorDom.appendChild(block)
+
+    renderPositioner()
+
+    act(() => {
+      listeners[0]({show: true, blockId: 'block-1', referenceRect: rect(80, 200)})
+    })
+
+    expect(container.querySelector('[data-bn-block-hover-actions="true"]')).toBeNull()
+    viewport.remove()
+  })
+
   it('uses ProseMirror block revision state when the DOM has no data-revision attribute', () => {
     const block = document.createElement('div')
     block.dataset.id = 'block-1'

--- a/frontend/packages/editor/src/blocknote/react/BlockHoverActions/BlockHoverActionsPositioner.tsx
+++ b/frontend/packages/editor/src/blocknote/react/BlockHoverActions/BlockHoverActionsPositioner.tsx
@@ -178,6 +178,11 @@ export function BlockHoverActionsPositioner<BSchema extends BlockSchema = BlockS
 
   const rect = hoverState.referenceRect
   const blockId = hoverState.blockId
+  const scrollViewport = editor.prosemirrorView?.dom.closest('[data-slot="scroll-area-viewport"]')
+  if (scrollViewport) {
+    const viewportRect = scrollViewport.getBoundingClientRect()
+    if (rect.top < viewportRect.top || rect.top >= viewportRect.bottom) return null
+  }
   if (!canReferenceBlock) {
     return null
   }

--- a/frontend/packages/editor/src/blocknote/react/BlockHoverActions/BlockHoverActionsPositioner.tsx
+++ b/frontend/packages/editor/src/blocknote/react/BlockHoverActions/BlockHoverActionsPositioner.tsx
@@ -197,13 +197,13 @@ export function BlockHoverActionsPositioner<BSchema extends BlockSchema = BlockS
         position: 'fixed',
         top: anchorRect.top,
         right: VIEWPORT_PADDING_PX,
-        zIndex: 50,
+        zIndex: 10,
       }
     : {
         position: 'fixed',
         top: anchorRect.top,
         left: anchorLeft,
-        zIndex: 50,
+        zIndex: 10,
       }
 
   return (

--- a/frontend/packages/editor/src/blocknote/react/SideMenu/components/SideMenuPositioner.tsx
+++ b/frontend/packages/editor/src/blocknote/react/SideMenu/components/SideMenuPositioner.tsx
@@ -155,6 +155,7 @@ export const SideMenuPositioner = <BSchema extends BlockSchema = DefaultBlockSch
         content={sideMenuElement}
         getReferenceClientRect={getReferenceClientRect}
         interactive={true}
+        zIndex={10}
         visible={show}
         animation={'fade'}
         offset={[topOffset, rightOffset]}

--- a/frontend/packages/ui/src/__tests__/document-top-bar.test.tsx
+++ b/frontend/packages/ui/src/__tests__/document-top-bar.test.tsx
@@ -82,6 +82,7 @@ describe('DocumentTopBar', () => {
     )
 
     expect(container.querySelector('nav[aria-label="Breadcrumb"]')).not.toBeNull()
+    expect(container.querySelector('[data-document-top-bar]')?.className).toContain('z-40')
     expect(container.querySelector('[aria-current="page"]')?.textContent).toBe('Doc')
     expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent === 'Publish')).toBe(true)
   })
@@ -97,6 +98,8 @@ describe('DocumentTopBar', () => {
 
     const status = container.querySelector('[data-document-status]')
     const breadcrumbs = container.querySelector('nav[aria-label="Breadcrumb"]')
+    expect(container.querySelector('[data-document-top-bar]')?.className).toContain('relative')
+    expect(container.querySelector('[data-document-top-bar]')?.className).toContain('z-40')
     expect(status?.textContent).toBe('Private')
     expect(status?.parentElement?.contains(breadcrumbs)).toBe(true)
     expect(breadcrumbs?.className).not.toContain('flex-1')

--- a/frontend/packages/ui/src/document-top-bar.tsx
+++ b/frontend/packages/ui/src/document-top-bar.tsx
@@ -35,10 +35,10 @@ export function DocumentTopBar({
     <div
       data-document-top-bar=""
       className={cn(
-        'border-border dark:bg-background flex h-12 w-full shrink-0 items-center gap-2 bg-white px-4',
+        'border-border dark:bg-background relative z-40 flex h-12 w-full shrink-0 items-center gap-2 bg-white px-4',
         // The border is the only separator; nothing is elevated over the content.
         'border-b',
-        isMobile && 'sticky top-0 z-30',
+        isMobile && 'sticky top-0',
       )}
     >
       <div className="flex min-w-0 flex-1 items-center gap-2">

--- a/frontend/packages/ui/src/site-header.tsx
+++ b/frontend/packages/ui/src/site-header.tsx
@@ -194,7 +194,7 @@ export function SiteHeader({
     <header
       ref={headerRef}
       className={cn(
-        'border-border dark:bg-background z-20 flex w-full transform-gpu border-b bg-white px-4 py-2 transition-transform duration-200',
+        'border-border dark:bg-background relative z-40 flex w-full transform-gpu border-b bg-white px-4 py-2 transition-transform duration-200',
         {
           'flex-col': isCenterLayout,
           'flex-row items-center': !isCenterLayout,

--- a/frontend/packages/ui/src/titlebar.tsx
+++ b/frontend/packages/ui/src/titlebar.tsx
@@ -6,7 +6,7 @@ import {cn} from './utils'
 export const TitlebarWrapper = ({className, children, ...props}: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      'z-50 m-0 flex min-h-[40px] w-full flex-none flex-col items-stretch justify-center bg-transparent px-0 py-0',
+      'relative z-50 m-0 flex min-h-[40px] w-full flex-none flex-col items-stretch justify-center bg-transparent px-0 py-0',
       className,
     )}
     {...props}


### PR DESCRIPTION
## Summary
- Lower the block hover actions and side menu overlays so they no longer render above higher-priority UI.
- Add test coverage confirming the block hover actions wrapper uses the reduced z-index.

## Related
- fixes #1023

---

Fixes #1023