### PR TITLE
fix(ui): expose mobile file browser controls

### DIFF
--- a/frontend/apps/desktop/src/components/titlebar-common.tsx
+++ b/frontend/apps/desktop/src/components/titlebar-common.tsx
@@ -175,9 +175,10 @@ function NotificationButtonForAccount({accountUid}: {accountUid: string}) {
       >
         <Bell className="size-4" />
         {unreadCount > 0 ? (
-          <span className="flex h-5 min-w-5 items-center justify-center rounded-lg bg-red-500 px-1 text-[12px] font-bold text-white">
-            {unreadCount > 99 ? '99+' : unreadCount}
-          </span>
+          <>
+            <span aria-hidden="true" className="absolute top-1 right-1 size-2 rounded-full bg-red-500" />
+            <span className="sr-only">{unreadCount} unread notifications</span>
+          </>
         ) : null}
       </Button>
     </Tooltip>

--- a/frontend/apps/web/app/web-utils.tsx
+++ b/frontend/apps/web/app/web-utils.tsx
@@ -619,9 +619,10 @@ function NotifsButton() {
       >
         <Bell className="size-4" />
         {unreadCount > 0 ? (
-          <span className="flex h-5 min-w-5 items-center justify-center rounded-lg bg-red-500 px-1 text-[12px] font-bold text-white">
-            {unreadCount > 99 ? '99+' : unreadCount}
-          </span>
+          <>
+            <span aria-hidden="true" className="absolute top-1 right-1 size-2 rounded-full bg-red-500" />
+            <span className="sr-only">{unreadCount} unread notifications</span>
+          </>
         ) : null}
       </ButtonLink>
     </Tooltip>

--- a/frontend/packages/ui/src/__tests__/site-file-browser-layout.test.tsx
+++ b/frontend/packages/ui/src/__tests__/site-file-browser-layout.test.tsx
@@ -4,7 +4,7 @@ import {act} from 'react-dom/test-utils'
 import {createRoot, type Root} from 'react-dom/client'
 import {renderToString} from 'react-dom/server'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
-import {SiteFileBrowserLayout} from '../site-file-browser-layout'
+import {SiteFileBrowserLayout, useSiteFileBrowserControls} from '../site-file-browser-layout'
 ;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
 
 const mediaMock = vi.hoisted(() => ({value: {xs: false}}))
@@ -73,6 +73,15 @@ function renderLayout() {
       </SiteFileBrowserLayout>,
     )
   })
+}
+
+function MobileFileBrowserTrigger() {
+  const controls = useSiteFileBrowserControls()
+  return (
+    <button type="button" aria-label="Open file browser from content" onClick={() => controls?.setCollapsed(false)}>
+      Open files
+    </button>
+  )
 }
 
 describe('SiteFileBrowserLayout', () => {
@@ -188,5 +197,31 @@ describe('SiteFileBrowserLayout', () => {
     expect(drawer?.className).toContain('max-w-[80dvw]')
     expect(drawer?.className).toContain('shrink-0')
     expect(drawer?.className).toContain('motion-safe:slide-in-from-left')
+  })
+
+  it('lets page chrome open the mobile file browser', () => {
+    mediaMock.value = {xs: true}
+    const onMobileOpenChange = vi.fn()
+
+    act(() => {
+      root.render(
+        <SiteFileBrowserLayout
+          siteId={hmId('site')}
+          activeDocumentId={hmId('site')}
+          siteName="Site"
+          mobileOpen={false}
+          onMobileOpenChange={onMobileOpenChange}
+          onNavigate={vi.fn()}
+        >
+          <MobileFileBrowserTrigger />
+        </SiteFileBrowserLayout>,
+      )
+    })
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('[aria-label="Open file browser from content"]')?.click()
+    })
+
+    expect(onMobileOpenChange).toHaveBeenCalledWith(true)
   })
 })

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -1589,7 +1589,6 @@ export function PageShell({
         rightActions={rightActions}
         editNavPane={editNavPanePortalRef ? undefined : editNavPane}
         editNavPanePortalRef={editNavPanePortalRef}
-        onOpenFileBrowser={() => setIsFileBrowserOpen(true)}
       />
       <TransientResourceBanner error={transientResourceError ?? null} />
       <SiteFileBrowserLayout

--- a/frontend/packages/ui/src/site-file-browser-layout.tsx
+++ b/frontend/packages/ui/src/site-file-browser-layout.tsx
@@ -90,6 +90,14 @@ export function SiteFileBrowserLayout({
     }),
     [collapsed],
   )
+  const mobileControls = useMemo<SiteFileBrowserControls>(
+    () => ({
+      collapsed: !mobileOpen,
+      setCollapsed: (nextCollapsed) => onMobileOpenChange(!nextCollapsed),
+      claimRevealButton: () => () => {},
+    }),
+    [mobileOpen, onMobileOpenChange],
+  )
 
   useEffect(() => {
     setIsClient(true)
@@ -151,7 +159,7 @@ export function SiteFileBrowserLayout({
 
   if (isMobile) {
     return (
-      <>
+      <SiteFileBrowserContext.Provider value={mobileControls}>
         <div className="min-h-0 flex-1">{children}</div>
         {mobileOpen
           ? createPortal(
@@ -191,7 +199,7 @@ export function SiteFileBrowserLayout({
               document.body,
             )
           : null}
-      </>
+      </SiteFileBrowserContext.Provider>
     )
   }
 

--- a/frontend/packages/ui/src/site-header.tsx
+++ b/frontend/packages/ui/src/site-header.tsx
@@ -17,7 +17,7 @@ import {useResponsiveItems} from './use-responsive-items'
 
 import {IS_DESKTOP} from '@shm/shared/constants'
 import {useIsomorphicLayoutEffect} from '@shm/shared/utils/use-isomorphic-layout-effect'
-import {Activity, FolderTree, Lock} from 'lucide-react'
+import {Activity, Lock} from 'lucide-react'
 import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from './components/dropdown-menu'
 import {DocNavigationItem, DocumentOutline, DocumentSmallListItem, useNodesOutline} from './navigation'
 import {HeaderSearch, MobileSearch} from './search'
@@ -83,7 +83,6 @@ export function SiteHeader({
   notifyServiceHost: _notifyServiceHost,
   routeType,
   rightActions,
-  onOpenFileBrowser,
 }: {
   siteHomeId: UnpackedHypermediaId
   docId: UnpackedHypermediaId | null
@@ -106,7 +105,6 @@ export function SiteHeader({
   notifyServiceHost?: string
   routeType?: NavRoute['key']
   rightActions?: React.ReactNode
-  onOpenFileBrowser?: () => void
 }) {
   const [isMobileMenuOpen, _setIsMobileMenuOpen] = useState(false)
   const [isMobileSearchActive, setIsMobileSearchActive] = useState(false)
@@ -127,20 +125,6 @@ export function SiteHeader({
     : {document: siteHomeDocument ?? undefined, id: siteHomeId} // Non-home: use site home (may be undefined while loading)
   const headerSearch = (
     <>
-      {onOpenFileBrowser ? (
-        <Button
-          variant="ghost"
-          size="icon"
-          className="md:hidden"
-          aria-label="Open file browser"
-          onClick={() => {
-            setIsMobileMenuOpen(false)
-            onOpenFileBrowser()
-          }}
-        >
-          <FolderTree size={20} />
-        </Button>
-      ) : null}
       <Button
         variant="ghost"
         size="icon"
@@ -210,7 +194,7 @@ export function SiteHeader({
           'flex-start': !isCenterLayout,
         })}
       >
-        <div className={cn('flex overflow-hidden', isCenterLayout ? 'flex-1 justify-center' : 'shrink-0')}>
+        <div className={cn('flex min-w-0 overflow-hidden', isCenterLayout ? 'flex-1 justify-center' : '')}>
           <SiteLogo id={headerHomeId} metadata={draftMetadata || homeDoc.document?.metadata} />
         </div>
         {routeType != 'draft' && isCenterLayout ? (


### PR DESCRIPTION
## Summary
- Make mobile file browser controls available through the existing layout context so page chrome can open the drawer.
- Keep mobile header controls visible when space is constrained.
- Replace notification count badges with compact unread dots plus screen-reader text to reduce header overflow.

fixes #1028

---

Fixes #1028