### PR TITLE
fix(editor): prevent duplicate Safari list markers

### DIFF
--- a/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/Block-css.test.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/Block-css.test.ts
@@ -1,0 +1,19 @@
+import {readFileSync} from 'node:fs'
+import {resolve} from 'node:path'
+import {describe, expect, it} from 'vitest'
+
+const css = readFileSync(resolve(__dirname, 'Block.module.css'), 'utf8')
+
+describe('list marker layout', () => {
+  it('disables layout containment on native list items', () => {
+    expect(css).toMatch(
+      /\.blockChildren\[data-list-type='Unordered'\]\s*>\s*\.blockNode,\s*\.blockChildren\[data-list-type='Ordered'\]\s*>\s*\.blockNode\s*\{[^}]*contain:\s*none;/s,
+    )
+  })
+
+  it('does not render a marker for an invisible structural slot', () => {
+    expect(css).toMatch(
+      /\.blockChildren\[data-list-type='Unordered'\]\s*>\s*\.blockNode:has\(> \.blockContent\[data-content-type='slot'\]\),\s*\.blockChildren\[data-list-type='Ordered'\]\s*>\s*\.blockNode:has\(> \.blockContent\[data-content-type='slot'\]\)\s*\{[^}]*display:\s*block\s*!important;/s,
+    )
+  })
+})

--- a/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/Block.module.css
+++ b/frontend/packages/editor/src/blocknote/core/extensions/Blocks/nodes/Block.module.css
@@ -174,6 +174,22 @@ NESTED BLOCKS
   display: list-item !important;
 }
 
+/* WebKit duplicates native markers when layout containment is applied to
+ * list items, especially when their text wraps. Keep containment on regular
+ * blocks, but opt semantic list items out. */
+.blockChildren[data-list-type='Unordered'] > .blockNode,
+.blockChildren[data-list-type='Ordered'] > .blockNode {
+  contain: none;
+}
+
+/* A Slot only carries a nested group. It has no visible content of its own,
+ * so rendering its wrapper as a list item gives Safari an extra marker that
+ * it aligns with the first visible descendant. */
+.blockChildren[data-list-type='Unordered'] > .blockNode:has(> .blockContent[data-content-type='slot']),
+.blockChildren[data-list-type='Ordered'] > .blockNode:has(> .blockContent[data-content-type='slot']) {
+  display: block !important;
+}
+
 .blockChildren[data-list-type='Unordered'] > span[data-decoration-type='link-dropdown'] {
   display: list-item !important;
 }


### PR DESCRIPTION
## Summary
- Fixes Safari rendering of duplicate list markers in document lists when content wraps.
- Prevents invisible structural slots from rendering extra list bullets.
- Adds CSS regression coverage for the list marker layout rules.

## Issues
- fixes #830

---

Fixes #830