### PR TITLE
fix(ui): use resolved doc version for inline comments

### DIFF
--- a/frontend/packages/ui/src/__tests__/resource-page-common.test.ts
+++ b/frontend/packages/ui/src/__tests__/resource-page-common.test.ts
@@ -418,6 +418,17 @@ describe('getCommentsPanelTarget', () => {
     })
   })
 
+  it('uses the resolved document version when an inline-comments panel targets the same unpinned document', () => {
+    const resolvedMainDocId = hmId('alice', {path: ['embedded-doc'], version: 'resolved-version'})
+    const panelRoute: Extract<NavRoute, {key: 'document'}>['panel'] = {
+      key: 'comments',
+      id: mainDocId,
+      targetBlockId: 'paragraph',
+    }
+
+    expect(getCommentsPanelTarget(resolvedMainDocId, panelRoute).docId.version).toBe('resolved-version')
+  })
+
   it('uses the main document when no comments panel is open or another panel type is open', () => {
     expect(getCommentsPanelTarget(mainDocId, null)).toEqual({docId: mainDocId, openComment: undefined})
     expect(

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -499,9 +499,16 @@ export function getCommentsPanelTarget(
   docId: UnpackedHypermediaId,
   panelRoute: DocumentPanelRoute | null,
 ): {docId: UnpackedHypermediaId; openComment?: string} {
-  return panelRoute?.key === 'comments'
-    ? {docId: panelRoute.id ?? docId, openComment: panelRoute.openComment}
-    : {docId, openComment: undefined}
+  if (panelRoute?.key !== 'comments') return {docId, openComment: undefined}
+
+  const panelDocId = panelRoute.id ?? docId
+  return {
+    docId:
+      panelDocId.id === docId.id && !panelDocId.version && docId.version
+        ? {...panelDocId, version: docId.version}
+        : panelDocId,
+    openComment: panelRoute.openComment,
+  }
 }
 
 /** Selects the action controls shown for document content. */


### PR DESCRIPTION
## Summary
- Fix inline comment panels opened on unpinned documents to use the document's resolved version when targeting the same document.
- Prevent comment lookup mismatches that could cause the inline comment box to fail to appear.
- Add test coverage for same-document inline comment panels with resolved document versions.

fixes #996

---

Fixes #996