### PR TITLE
fix(agents): tell continue_session to omit sessionId for own-thread sources

### DIFF
--- a/agents/protocol/src/tool-registry.ts
+++ b/agents/protocol/src/tool-registry.ts
@@ -511,7 +511,7 @@ const continueSessionVerb = {
       sources: {
         type: 'array',
         description:
-          'Exact references the successor may need: {kind: "resource", url, relevance} for hm:// or web content; {kind: "memory", path, relevance} for a memory file; {kind: "session_events", fromSeq, toSeq, relevance} or {kind: "session_event", seq, relevance} for a range of this thread (seqs as shown by read thread:<id>). Each carries a one-line relevance.',
+          'Exact references the successor may need: {kind: "resource", url, relevance} for hm:// or web content; {kind: "memory", path, relevance} for a memory file; {kind: "session_events", fromSeq, toSeq, relevance} or {kind: "session_event", seq, relevance} for events of THIS thread — leave sessionId out; you do not know your own thread id and the runtime fills it in. Only set sessionId to cite a different thread of yours whose `thread:<id>` you have actually seen (a predecessor named in your lineage block, or one you read with `read thread:<id>`); never guess or construct an id. Seqs are the [seq] numbers shown by read thread:<id>. Each carries a one-line relevance.',
         items: {
           type: 'object',
           additionalProperties: false,
@@ -521,7 +521,11 @@ const continueSessionVerb = {
             version: {type: 'string'},
             blockId: {type: 'string'},
             path: {type: 'string'},
-            sessionId: {type: 'string', description: 'Defaults to this session.'},
+            sessionId: {
+              type: 'string',
+              description:
+                'OMIT for this thread (the runtime fills in the current session; you do not know its id). Set only to a thread id you have seen verbatim — from your lineage block or a `read thread:<id>` result — to cite another thread of yours. A made-up or unseen id is rejected and the continuation fails.',
+            },
             fromSeq: {type: 'number'},
             toSeq: {type: 'number'},
             seq: {type: 'number'},

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -4070,7 +4070,10 @@ export class Service {
         .query<{n: number}, [string, string]>(`SELECT COUNT(*) AS n FROM sessions WHERE id = ? AND agent_id = ?`)
         .get(id, agentId)
       if (!owned?.n) {
-        throw new APIError(400, `Source thread ${id} does not exist, or is not one of this agent's threads`)
+        throw new APIError(
+          400,
+          `Source thread ${id} does not exist, or is not one of this agent's threads. To cite this session's own events, omit sessionId; only cite another thread by an id you have seen verbatim.`,
+        )
       }
       const max =
         this.#db


### PR DESCRIPTION
## Why

A prod continuation ([session dd886b91](https://agentic.seed.hyper.media/agents/510a1f97-aad2-4dd2-b03d-dc008725199a/sessions/dd886b91-30b0-4944-afb7-fee5b91c534e), seq 179–180) failed on its first `continue_session` call with:

```
Source thread 1c0142a9-ed2c-44e9-8204-d3138bd78b59 does not exist, or is not one of this agent's threads
```

The model wanted to cite seqs 1–19 of its **own** thread but does not know its own id (the prompt only names the predecessor), so it invented a UUID. The `sessionId` field was documented as just "Defaults to this session.", which reads as a default value rather than an instruction to omit. The retry without the source succeeded, at the cost of one ~83k-token turn.

## What

Prompting only, no behavior change:

- `agents/protocol/src/tool-registry.ts`: the `sources` and `sources[].sessionId` descriptions now say to **omit** `sessionId` for the current thread, set it only to a thread id seen verbatim (lineage block or `read thread:<id>`), and never guess.
- `agents/src/api-service.ts`: the rejection message adds the same steer so a slip self-corrects on retry.

## Checks

- `pnpm typecheck` in `agents/` (covers the protocol package; it has no typecheck script of its own)
- `bun test src/session-continuation.test.ts` (2 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHjnwU4r7hqXf16P5R554G

