### PR TITLE
perf(agents): per-turn and per-session latency attribution

### DIFF
--- a/agents/protocol/src/index.ts
+++ b/agents/protocol/src/index.ts
@@ -1425,6 +1425,21 @@ export type SessionEventMeta = {
   /** Wall time this message or tool call took, in milliseconds. */
   durationMs?: number
   /**
+   * Provider timing for the model turn that produced this event, stamped once at turn end. This is
+   * where "the agent feels slow" becomes attributable per turn instead of only in process-wide
+   * aggregates: `turnMs` is provider request sent → assistant turn complete, `ttftMs` the slice of
+   * that spent waiting for the first streamed output event. Absent on legacy events and on events
+   * appended outside a model turn.
+   */
+  turn?: {
+    /** 1-based turn index within the run that produced this event. */
+    index?: number
+    /** Provider request sent → first streamed output event, in milliseconds. */
+    ttftMs?: number
+    /** Provider request sent → assistant turn complete, in milliseconds. */
+    turnMs?: number
+  }
+  /**
    * On a user message a continuation replayed into its successor: the exact predecessor event it
    * is a verbatim copy of. The message is the user's, not a paraphrase — this is its provenance.
    */

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -104,6 +104,7 @@ import type {
 import {hmIdPathToEntityQueryPath, unpackHmId} from '@seed-hypermedia/client/hm-types'
 import * as pi from '@mariozechner/pi-coding-agent'
 import {providerErrorReason, recordPerf, recordPerfCount} from '@/perf'
+import {sessionPerfRollup, type SessionPerfRollup} from '@/session-perf'
 import {getModels} from '@mariozechner/pi-ai'
 import type {OAuthCredentials} from '@mariozechner/pi-ai/oauth'
 import {openaiCodexOAuthProvider} from '@mariozechner/pi-ai/oauth'
@@ -5674,6 +5675,37 @@ export class Service {
     })
   }
 
+  /**
+   * Timing rollup for one session (`GET /api/perf/sessions/:id`): model vs tool vs idle time from
+   * the durable rows, no content. Null when the session does not exist — the caller 404s.
+   */
+  sessionPerf(sessionId: string): SessionPerfRollup | null {
+    const session = this.#db.query<{id: string}, [string]>(`SELECT id FROM sessions WHERE id = ?`).get(sessionId)
+    if (!session) return null
+    const runRows = this.#db
+      .query<
+        {id: string; status: string; created_at: number; started_at: number | null; finished_at: number | null},
+        [string]
+      >(`SELECT id, status, created_at, started_at, finished_at FROM runs WHERE session_id = ? ORDER BY created_at ASC`)
+      .all(sessionId)
+    const eventRows = this.#db
+      .query<SessionEventRow, [string]>(
+        `SELECT id, session_id, seq, event_cbor, created_at FROM session_events WHERE session_id = ? ORDER BY seq ASC`,
+      )
+      .all(sessionId)
+    return sessionPerfRollup(
+      sessionId,
+      runRows.map((row) => ({
+        id: row.id,
+        status: row.status,
+        createdAt: row.created_at,
+        startedAt: row.started_at,
+        finishedAt: row.finished_at,
+      })),
+      eventRows.map((row) => ({seq: row.seq, createdAt: row.created_at, event: cbor.decode(row.event_cbor)})),
+    )
+  }
+
   #sessionHasToolResult(sessionId: string, toolCallId: string): boolean {
     const rows = this.#db
       .query<SessionEventRow, [string]>(
@@ -6642,6 +6674,10 @@ export class Service {
     let lastRequestSentAt = 0
     let firstRequestSent = false
     let awaitingFirstOutput = false
+    // TTFT of the in-flight turn, held until message_end folds it into that turn's timing meta.
+    let lastTtftMs: number | undefined
+    // Bounded metric suffix (providers × configured models), same shape the error counters use.
+    const providerModelTag = `${model.provider}.${definition.model ?? 'default'}`
     piSession.agent.onPayload = (payload) => {
       // The next provider request is the tool batch's end: if this turn spawned sub-sessions (park)
       // or delivered its typed result, the turn is over — refuse to send another provider request.
@@ -6785,6 +6821,9 @@ export class Service {
     let assistantEvent: api.SessionEvent | undefined
     const appendedToolCalls = new Set<string>()
     const toolStartedAt = new Map<string, number>()
+    // Inner tool a `call` verb dispatched to, so `tool.call` splits into `tool.call.<inner>` and a
+    // slow callable (a web search, an execute) is visible instead of blurred into one span.
+    const toolInnerName = new Map<string, string>()
 
     const runStartedAt = Date.now()
     let turnCount = 0
@@ -6823,10 +6862,12 @@ export class Service {
     // is stamped on the event as it is written and the transcript stays able to explain itself.
     let turnStartedAt = Date.now()
     let turnUsageForMeta: api.AgentRunUsage | undefined
+    let turnTimingForMeta: NonNullable<api.SessionEventMeta['turn']> | undefined
     const messageMeta = (): api.SessionEventMeta => ({
       ...(definition.model ? {model: definition.model} : {}),
       ...(model.provider ? {provider: model.provider} : {}),
       ...(turnUsageForMeta ? {usage: {...turnUsageForMeta}} : {}),
+      ...(turnTimingForMeta ? {turn: {...turnTimingForMeta}} : {}),
       durationMs: Math.max(0, Date.now() - turnStartedAt),
     })
     // Provenance for tool events: which model/provider issued the call and what its turn cost.
@@ -6836,6 +6877,7 @@ export class Service {
         ...(definition.model ? {model: definition.model} : {}),
         ...(model.provider ? {provider: model.provider} : {}),
         ...(turnUsageForMeta ? {usage: {...turnUsageForMeta}} : {}),
+        ...(turnTimingForMeta ? {turn: {...turnTimingForMeta}} : {}),
       }
       return Object.keys(meta).length ? meta : undefined
     }
@@ -6855,6 +6897,7 @@ export class Service {
       // message is timed from here so no stretch of wall time is counted twice.
       turnStartedAt = Date.now()
       turnUsageForMeta = undefined
+      turnTimingForMeta = undefined
       partialId = crypto.randomUUID()
     }
 
@@ -6896,7 +6939,10 @@ export class Service {
       ) {
         awaitingFirstOutput = false
         const ttftMs = Date.now() - lastRequestSentAt
+        lastTtftMs = ttftMs
         recordPerf('provider.ttft', ttftMs)
+        // The same span tagged by provider+model, so one slow model is visible next to the blend.
+        recordPerf(`provider.ttft.${providerModelTag}`, ttftMs)
         logRun('provider first output', {ttftMs})
       }
       if (isTextDelta && event.type === 'message_update' && event.assistantMessageEvent.type === 'text_delta') {
@@ -6920,7 +6966,19 @@ export class Service {
           usage?: {input?: number; output?: number; cacheRead?: number; cacheWrite?: number}
         }
         turnCount += 1
-        if (lastRequestSentAt) recordPerf('provider.turn', Date.now() - lastRequestSentAt)
+        if (lastRequestSentAt) {
+          const turnMs = Date.now() - lastRequestSentAt
+          recordPerf('provider.turn', turnMs)
+          recordPerf(`provider.turn.${providerModelTag}`, turnMs)
+          // Stamped onto every event this turn appends, so a transcript can explain per turn where
+          // its wall time went (model vs tools) instead of only via process-wide aggregates.
+          turnTimingForMeta = {
+            index: turnCount,
+            ...(lastTtftMs !== undefined ? {ttftMs: lastTtftMs} : {}),
+            turnMs,
+          }
+          lastTtftMs = undefined
+        }
         const turnUsage = assistantMessage.usage
         if (turnUsage) {
           turnUsageForMeta = {
@@ -6974,6 +7032,14 @@ export class Service {
           suppressCurrentAssistantEndFallback = true
         }
         toolStartedAt.set(event.toolCallId, Date.now())
+        if (
+          event.toolName === seedVerbRegistry.call.name &&
+          isRecord(event.args) &&
+          typeof event.args.tool === 'string'
+        ) {
+          // Cardinality is bounded: only enabled callables and this agent's own documents dispatch.
+          toolInnerName.set(event.toolCallId, event.args.tool)
+        }
         logRun('tool call start', {
           tool: event.toolName,
           toolCallId: event.toolCallId,
@@ -7014,7 +7080,13 @@ export class Service {
         }
         const startedAt = toolStartedAt.get(event.toolCallId)
         toolStartedAt.delete(event.toolCallId)
-        if (startedAt !== undefined) recordPerf(`tool.${event.toolName}`, Date.now() - startedAt)
+        const innerName = toolInnerName.get(event.toolCallId)
+        toolInnerName.delete(event.toolCallId)
+        if (startedAt !== undefined) {
+          const toolMs = Date.now() - startedAt
+          recordPerf(`tool.${event.toolName}`, toolMs)
+          if (innerName) recordPerf(`tool.${event.toolName}.${innerName}`, toolMs)
+        }
         logRun(event.isError ? 'tool call failed' : 'tool call end', {
           tool: event.toolName,
           toolCallId: event.toolCallId,

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -103,7 +103,7 @@ import type {
 } from '@seed-hypermedia/client/hm-types'
 import {hmIdPathToEntityQueryPath, unpackHmId} from '@seed-hypermedia/client/hm-types'
 import * as pi from '@mariozechner/pi-coding-agent'
-import {providerErrorReason, recordPerf, recordPerfCount} from '@/perf'
+import {providerErrorReason, recordPerf, recordPerfCount, startPerfSpan} from '@/perf'
 import {sessionPerfRollup, type SessionPerfRollup} from '@/session-perf'
 import {getModels} from '@mariozechner/pi-ai'
 import type {OAuthCredentials} from '@mariozechner/pi-ai/oauth'
@@ -6552,7 +6552,11 @@ export class Service {
           this.#continueSessionFromAgent(accountId, liveRun, sessionId, session.agentId, live, toolCallId, input),
       }
     })()
+    // The request_gap sub-spans below (`prep.*`) name where pre-turn time goes; anything they do
+    // not cover shows up as the difference against `provider.request_gap` in the same snapshot.
+    const endProviderRuntimeSpan = startPerfSpan('prep.provider_runtime')
     const {provider, authStorage, modelRegistry, model} = await this.#piProviderRuntime(accountId, definition)
+    endProviderRuntimeSpan()
 
     const cwd = this.#dataDir
     // Retry policy belongs to the run queue (interactive turns fail fast, background runs ride the
@@ -6560,6 +6564,7 @@ export class Service {
     // timer that dispose() does not cancel, so it would replay the turn after the run finalized.
     const settingsManager = pi.SettingsManager.inMemory({compaction: {enabled: false}, retry: {enabled: false}})
     const agentStateDir = this.#agentMemoryStateDir(accountId, session.agentId)
+    const endSystemPromptSpan = startPerfSpan('prep.system_prompt')
     const resourceLoader = createSeedPiResourceLoader(
       await this.#agentSystemPrompt(
         accountId,
@@ -6569,6 +6574,7 @@ export class Service {
         run ? this.#spawnContextForRun(run).spec : undefined,
       ),
     )
+    endSystemPromptSpan()
     // Agents list execute_code by default; drop it silently when this host cannot run sandboxes
     // (unsupported platform, missing runtime) so the model never sees a tool that can only fail.
     const codeExecAvailable = (await this.#codeExec.availability()).available
@@ -6578,6 +6584,7 @@ export class Service {
     const enabledCallables = enabledCallableTools(definition, codeExecAvailable)
     // The agent's own documents — authored lambdas and the tools of its enabled MCP servers — are
     // promotable too; the projection is re-derived here so it matches the definition being run.
+    const endToolSyncSpan = startPerfSpan('prep.tool_sync')
     this.#syncAgentMcpTools(accountId, session.agentId, definition)
     const documentTools = new Set(
       toolDocs
@@ -6591,7 +6598,9 @@ export class Service {
     const expandedCallables = this.#expandedCallablesForSession(sessionId)
       .map(normalizeSeedToolName)
       .filter((name) => enabledCallables.includes(name) || documentTools.has(name))
+    endToolSyncSpan()
     const mcpPool = this.#createMcpPool(accountId)
+    const endPiSessionSpan = startPerfSpan('prep.pi_session')
     const {session: piSession} = await pi.createAgentSession({
       cwd,
       agentDir: path.join(this.#dataDir, 'pi'),
@@ -6667,6 +6676,7 @@ export class Service {
       sessionManager: pi.SessionManager.inMemory(cwd),
       settingsManager,
     })
+    endPiSessionSpan()
 
     const mergeModelDefaults = provider.modelDefaults
     // Provider latency markers, set as each request leaves and cleared by the first streamed
@@ -6710,7 +6720,9 @@ export class Service {
       if (mergeModelDefaults) next = mergePiPayloadDefaults(next, mergeModelDefaults)
       return next
     }
+    const endReplaySpan = startPerfSpan('prep.replay')
     const replayMessages = this.#piMessages(sessionId)
+    endReplaySpan()
     const runInput = run && isRecord(run.input) ? run.input : undefined
     const queuedUserEventIds =
       runInput?.queuedBehindAnotherTurn === true && Array.isArray(runInput.userEventIds)

--- a/agents/src/main.ts
+++ b/agents/src/main.ts
@@ -133,6 +133,13 @@ export function createAPIRoutes(svc: apisvc.Service): Bun.Serve.Routes<undefined
   // Aggregate latency stats (metric names and millisecond percentiles only — no ids, no content),
   // so "is this server slow, and where" is one curl away. Same exposure class as /api/health.
   const perf = () => Response.json(perfSnapshot(), {headers: corsHeaders()})
+  // Per-session timing rollup (tool names, counts, and milliseconds only — no content, no
+  // arguments). The full session UUID is required and unguessable; unknown ids 404.
+  const sessionPerf = (req: BunRequest) => {
+    const rollup = svc.sessionPerf(req.params.sessionId ?? '')
+    if (!rollup) return Response.json({error: 'Session not found'}, {status: 404, headers: corsHeaders()})
+    return Response.json(rollup, {headers: corsHeaders()})
+  }
   return {
     '/api/message': {OPTIONS: options, POST: message},
     '/agents/api/message': {OPTIONS: options, POST: message},
@@ -144,6 +151,8 @@ export function createAPIRoutes(svc: apisvc.Service): Bun.Serve.Routes<undefined
     '/agents/api/version': {GET: version},
     '/api/perf': {GET: perf},
     '/agents/api/perf': {GET: perf},
+    '/api/perf/sessions/:sessionId': {GET: sessionPerf},
+    '/agents/api/perf/sessions/:sessionId': {GET: sessionPerf},
   }
 }
 

--- a/agents/src/perf.ts
+++ b/agents/src/perf.ts
@@ -21,6 +21,10 @@
  * - `run.dispatch_delay`     — run became dispatchable → executor actually started
  * - `tool.<name>`            — each tool call's execution span, by tool name
  * - `tool.call.<inner>`      — the `call` verb's span split by the callable it dispatched to
+ * - `prep.provider_runtime` / `prep.system_prompt` / `prep.tool_sync` / `prep.pi_session` /
+ *   `prep.replay`            — the segments inside `provider.request_gap`, so the pre-turn silence
+ *                              the user waits through is attributable; unnamed remainder = gap
+ *                              minus these
  * - `provider.ttft.<provider>.<model>` / `provider.turn.<provider>.<model>` — the provider spans
  *   tagged by provider+model, so one slow model is visible next to the blend
  *

--- a/agents/src/perf.ts
+++ b/agents/src/perf.ts
@@ -20,6 +20,13 @@
  * - `exec.total`             — whole execute_code span as the model experiences it
  * - `run.dispatch_delay`     — run became dispatchable → executor actually started
  * - `tool.<name>`            — each tool call's execution span, by tool name
+ * - `tool.call.<inner>`      — the `call` verb's span split by the callable it dispatched to
+ * - `provider.ttft.<provider>.<model>` / `provider.turn.<provider>.<model>` — the provider spans
+ *   tagged by provider+model, so one slow model is visible next to the blend
+ *
+ * Per-session attribution lives elsewhere: each turn's ttft/turn duration is stamped on the
+ * session events it appends (`SessionEventMeta.turn`), and `GET /api/perf/sessions/:id` serves a
+ * rollup of one session's model vs tool vs idle time (see `session-perf.ts`).
  *
  * Counters (occurrences, not durations):
  * - `provider.error.<provider>.<model>.<reason>` — provider turn errors, reason normalized to the

--- a/agents/src/session-perf.test.ts
+++ b/agents/src/session-perf.test.ts
@@ -1,0 +1,117 @@
+import {describe, expect, test} from 'bun:test'
+
+import {sessionPerfRollup, type SessionPerfEventRow, type SessionPerfRunRow} from '@/session-perf'
+
+const SID = 'session-1'
+
+function run(id: string, createdAt: number, startedAt: number | null, finishedAt: number | null): SessionPerfRunRow {
+  return {id, status: finishedAt !== null ? 'succeeded' : 'running', createdAt, startedAt, finishedAt}
+}
+
+function ev(seq: number, createdAt: number, event: unknown): SessionPerfEventRow {
+  return {seq, createdAt, event}
+}
+
+describe('sessionPerfRollup', () => {
+  test('attributes gaps to model time inside runs and idle time outside them', () => {
+    const runs = [run('r1', 1000, 1000, 20_000)]
+    const events = [
+      ev(1, 1000, {type: 'message', role: 'user', content: 'hi'}),
+      // 5s gap before a tool_call inside the run window: the model was thinking.
+      ev(2, 6000, {type: 'tool_call', id: 'c1', name: 'call', input: {}}),
+      ev(3, 9000, {type: 'tool_result', toolCallId: 'c1', name: 'call', meta: {durationMs: 3000}}),
+      // 4s gap before the assistant message: model time again.
+      ev(4, 13_000, {type: 'message', role: 'assistant', content: 'done'}),
+      // 60s after the run finished, the user speaks: idle, not model.
+      ev(5, 80_000, {type: 'message', role: 'user', content: 'next'}),
+    ]
+    const rollup = sessionPerfRollup(SID, runs, events)
+    expect(rollup.totals.modelGapMs).toBe(9000)
+    expect(rollup.totals.idleMs).toBe(67_000)
+    expect(rollup.totals.activeMs).toBe(19_000)
+    expect(rollup.totals.toolMs).toBe(3000)
+    expect(rollup.tools.call).toEqual({count: 1, totalMs: 3000, maxMs: 3000})
+  })
+
+  test('accumulates exec boot overhead from tool_result outputs', () => {
+    const runs = [run('r1', 0, 0, 10_000)]
+    const events = [
+      ev(1, 100, {
+        type: 'tool_result',
+        toolCallId: 'c1',
+        name: 'call',
+        meta: {durationMs: 4000},
+        output: {bootMs: 1200},
+      }),
+      ev(2, 200, {
+        type: 'tool_result',
+        toolCallId: 'c2',
+        name: 'call',
+        meta: {durationMs: 3500},
+        output: {bootMs: 900},
+      }),
+      ev(3, 300, {type: 'tool_result', toolCallId: 'c3', name: 'read', meta: {durationMs: 50}, output: {content: 'x'}}),
+    ]
+    const rollup = sessionPerfRollup(SID, runs, events)
+    expect(rollup.totals.execBootMs).toBe(2100)
+    expect(rollup.totals.execBootCount).toBe(2)
+    expect(rollup.tools.read).toEqual({count: 1, totalMs: 50, maxMs: 50})
+  })
+
+  test('deduplicates per-turn timing stamped on several events of the same turn', () => {
+    const runs = [run('r1', 0, 0, 30_000)]
+    const turnMeta = {turn: {index: 1, ttftMs: 2000, turnMs: 8000}}
+    const events = [
+      ev(1, 1000, {type: 'tool_call', id: 'c1', name: 'read', input: {}, meta: turnMeta}),
+      ev(2, 1001, {type: 'tool_call', id: 'c2', name: 'read', input: {}, meta: turnMeta}),
+      ev(3, 1500, {type: 'tool_result', toolCallId: 'c1', name: 'read', meta: {...turnMeta, durationMs: 400}}),
+      ev(4, 9000, {
+        type: 'message',
+        role: 'assistant',
+        content: 'x',
+        meta: {turn: {index: 2, ttftMs: 1000, turnMs: 5000}},
+      }),
+    ]
+    const rollup = sessionPerfRollup(SID, runs, events)
+    expect(rollup.turns.count).toBe(2)
+    expect(rollup.turns.totalTurnMs).toBe(13_000)
+    expect(rollup.turns.totalTtftMs).toBe(3000)
+    expect(rollup.turns.maxTurnMs).toBe(8000)
+  })
+
+  test('same turn index in different runs counts separately', () => {
+    const runs = [run('r1', 0, 0, 5000), run('r2', 10_000, 10_000, 20_000)]
+    const events = [
+      ev(1, 1000, {type: 'message', role: 'assistant', content: 'a', meta: {turn: {index: 1, turnMs: 3000}}}),
+      ev(2, 11_000, {type: 'message', role: 'assistant', content: 'b', meta: {turn: {index: 1, turnMs: 4000}}}),
+    ]
+    const rollup = sessionPerfRollup(SID, runs, events)
+    expect(rollup.turns.count).toBe(2)
+    expect(rollup.turns.totalTurnMs).toBe(7000)
+  })
+
+  test('reports dispatch wait per run and survives malformed events', () => {
+    const runs = [run('r1', 1000, 61_000, 90_000), run('r2', 95_000, null, null)]
+    const events = [
+      ev(1, 61_000, {type: 'message', role: 'user', content: 'x'}),
+      ev(2, 62_000, 'not-an-object'),
+      ev(3, 63_000, {type: 'tool_result'}),
+    ]
+    const rollup = sessionPerfRollup(SID, runs, events)
+    expect(rollup.runs[0]).toEqual({id: 'r1', status: 'succeeded', dispatchWaitMs: 60_000, activeMs: 29_000})
+    expect(rollup.runs[1]).toEqual({id: 'r2', status: 'running', dispatchWaitMs: null, activeMs: null})
+    expect(rollup.tools.unknown?.count).toBe(1)
+    expect(rollup.eventCount).toBe(3)
+  })
+
+  test('an unfinished run window attributes ongoing gaps as model time', () => {
+    const runs = [run('r1', 0, 0, null)]
+    const events = [
+      ev(1, 100, {type: 'message', role: 'user', content: 'go'}),
+      ev(2, 30_100, {type: 'tool_call', id: 'c1', name: 'write', input: {}}),
+    ]
+    const rollup = sessionPerfRollup(SID, runs, events)
+    expect(rollup.totals.modelGapMs).toBe(30_000)
+    expect(rollup.totals.idleMs).toBe(0)
+  })
+})

--- a/agents/src/session-perf.ts
+++ b/agents/src/session-perf.ts
@@ -1,0 +1,158 @@
+/**
+ * Per-session latency rollup: turns one session's durable rows into the breakdown that answers
+ * "where did this session's wall time go" — model turns vs tool execution vs sandbox overhead vs
+ * waiting for the user — without anyone replaying the transcript by hand.
+ *
+ * Pure over already-decoded rows so it is unit-testable without a service harness; the API layer
+ * feeds it `runs` and `session_events` rows and serves the result at
+ * `GET /api/perf/sessions/:sessionId`. The rollup contains tool names, counts, and millisecond
+ * aggregates only — never message content, arguments, or outputs.
+ *
+ * Attribution model (event timestamps are append times):
+ * - The gap before a `tool_call` or assistant `message` inside a run window is model time: the
+ *   provider was streaming or thinking. Gaps outside every run window are the user's own pauses.
+ * - `tool_result` meta.durationMs is tool time, summed by tool name.
+ * - `tool_result` outputs that carry a numeric `bootMs` (code exec) accumulate sandbox boot
+ *   overhead, the slice a warm pool removes.
+ * - Events stamped with `meta.turn` (ttftMs/turnMs) additionally aggregate provider-side turn
+ *   timing exactly as the provider reported it, deduplicated per turn index.
+ */
+
+export type SessionPerfRunRow = {
+  id: string
+  status: string
+  createdAt: number
+  startedAt: number | null
+  finishedAt: number | null
+}
+
+export type SessionPerfEventRow = {
+  seq: number
+  createdAt: number
+  /** Decoded session event payload (`event_cbor`). Unknown shapes are counted, never trusted. */
+  event: unknown
+}
+
+export type SessionPerfToolStat = {count: number; totalMs: number; maxMs: number}
+
+export type SessionPerfRollup = {
+  sessionId: string
+  eventCount: number
+  runs: Array<{
+    id: string
+    status: string
+    /** Run became dispatchable → executor started (queueing, e.g. behind the concurrency cap). */
+    dispatchWaitMs: number | null
+    /** startedAt → finishedAt; null while the run is still going. */
+    activeMs: number | null
+  }>
+  totals: {
+    /** Sum of finished runs' active spans. */
+    activeMs: number
+    /** Gap time attributed to the model (before tool_calls / assistant messages inside runs). */
+    modelGapMs: number
+    /** Gap time outside every run window: the user reading, typing, or away. */
+    idleMs: number
+    /** Sum of all tool_result durations. */
+    toolMs: number
+    /** Sandbox cold-boot milliseconds buried inside tool time (what a warm pool removes). */
+    execBootMs: number
+    execBootCount: number
+  }
+  tools: Record<string, SessionPerfToolStat>
+  /** Provider-reported per-turn timing from meta.turn, present once events carry it. */
+  turns: {
+    count: number
+    totalTurnMs: number
+    totalTtftMs: number
+    maxTurnMs: number
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function asFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+/** Computes the rollup. `events` must be ordered by seq ascending; runs by createdAt. */
+export function sessionPerfRollup(
+  sessionId: string,
+  runs: SessionPerfRunRow[],
+  events: SessionPerfEventRow[],
+): SessionPerfRollup {
+  const runWindows = runs
+    .filter((run) => run.startedAt !== null)
+    .map((run) => ({start: run.startedAt!, end: run.finishedAt ?? Number.POSITIVE_INFINITY}))
+  const inRun = (at: number) => runWindows.some((w) => at >= w.start && at <= w.end)
+
+  const tools: Record<string, SessionPerfToolStat> = {}
+  const totals = {activeMs: 0, modelGapMs: 0, idleMs: 0, toolMs: 0, execBootMs: 0, execBootCount: 0}
+  const turnsSeen = new Set<string>()
+  const turns = {count: 0, totalTurnMs: 0, totalTtftMs: 0, maxTurnMs: 0}
+
+  let prevAt: number | null = null
+  for (const row of events) {
+    const event = isRecord(row.event) ? row.event : {}
+    const type = typeof event.type === 'string' ? event.type : undefined
+    const role = typeof event.role === 'string' ? event.role : undefined
+
+    if (prevAt !== null) {
+      const gap = Math.max(0, row.createdAt - prevAt)
+      const modelAuthored = type === 'tool_call' || (type === 'message' && role !== 'user')
+      if (modelAuthored) {
+        if (inRun(row.createdAt)) totals.modelGapMs += gap
+        else totals.idleMs += gap
+      } else if (!inRun(row.createdAt)) {
+        totals.idleMs += gap
+      }
+    }
+    prevAt = row.createdAt
+
+    const meta = isRecord(event.meta) ? event.meta : undefined
+    if (type === 'tool_result') {
+      const name = typeof event.name === 'string' ? event.name : 'unknown'
+      const durationMs = asFiniteNumber(meta?.durationMs) ?? 0
+      const stat = (tools[name] ??= {count: 0, totalMs: 0, maxMs: 0})
+      stat.count += 1
+      stat.totalMs += durationMs
+      if (durationMs > stat.maxMs) stat.maxMs = durationMs
+      totals.toolMs += durationMs
+      const output = isRecord(event.output) ? event.output : undefined
+      const bootMs = asFiniteNumber(output?.bootMs)
+      if (bootMs !== undefined) {
+        totals.execBootMs += bootMs
+        totals.execBootCount += 1
+      }
+    }
+
+    const turn = meta && isRecord(meta.turn) ? meta.turn : undefined
+    if (turn) {
+      const turnMs = asFiniteNumber(turn.turnMs)
+      const index = asFiniteNumber(turn.index)
+      // The same turn stamps every event it appends; count it once. Turn indexes restart per run,
+      // so the dedup key includes the nearest preceding run window start.
+      const windowStart = runWindows.filter((w) => w.start <= row.createdAt).at(-1)?.start ?? 0
+      const key = `${windowStart}:${index ?? row.seq}`
+      if (turnMs !== undefined && !turnsSeen.has(key)) {
+        turnsSeen.add(key)
+        turns.count += 1
+        turns.totalTurnMs += turnMs
+        turns.totalTtftMs += asFiniteNumber(turn.ttftMs) ?? 0
+        if (turnMs > turns.maxTurnMs) turns.maxTurnMs = turnMs
+      }
+    }
+  }
+
+  const runsOut = runs.map((run) => ({
+    id: run.id,
+    status: run.status,
+    dispatchWaitMs: run.startedAt !== null ? Math.max(0, run.startedAt - run.createdAt) : null,
+    activeMs: run.startedAt !== null && run.finishedAt !== null ? Math.max(0, run.finishedAt - run.startedAt) : null,
+  }))
+  totals.activeMs = runsOut.reduce((sum, run) => sum + (run.activeMs ?? 0), 0)
+
+  return {sessionId, eventCount: events.length, runs: runsOut, totals, tools, turns}
+}


### PR DESCRIPTION
## Why

Diagnosing session `dd886b91` on prod (the "why is the agent so slow" session): of **17.6 min of active run time, 74% (13 min) was waiting on the model** (`openai-codex` / `gpt-5.6-sol`, ~95 turns, worst single turn 97s), ~30% was tools, and inside the tool time ~80s was pure sandbox boot+teardown overhead (warm pool is merged but not enabled in prod). Getting that answer required hand-replaying `session_events` from a DB copy. This PR makes the same breakdown a single curl.

## What

- **`SessionEventMeta.turn`** `{index, ttftMs, turnMs}` — stamped on every event a model turn appends. Transcripts now durably explain per-turn provider latency.
- **Model-tagged provider spans** — `provider.ttft.<provider>.<model>` and `provider.turn.<provider>.<model>` alongside the blended spans (same bounded cardinality as the existing error counters).
- **`tool.call.<inner>`** — the `call` verb's span split by dispatched callable (execute vs web search etc. are no longer blurred together).
- **`GET /api/perf/sessions/:sessionId`** — per-session rollup: model-gap vs tool vs idle time, per-tool totals/max, exec `bootMs` overhead, per-run dispatch waits. Pure module (`session-perf.ts`) + unit tests; validated byte-for-byte against the real prod session copy. Serves timings, tool names, and counts only — no content or arguments; requires the full unguessable session UUID (same exposure philosophy as `/api/perf`, flagging for review).

## Test plan

- `bun test` — 462 pass (includes 6 new session-perf tests)
- `bun typecheck` clean
- Rollup output cross-checked against manual analysis of prod session `dd886b91` (identical numbers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwyvKXowqRuZJVKuGbizvX