### PR TITLE
fix(agents-ui): show runtime-created sessions on the agent page without a reload

### DIFF
--- a/frontend/packages/ui/src/__tests__/agent-account-change-invalidation.test.ts
+++ b/frontend/packages/ui/src/__tests__/agent-account-change-invalidation.test.ts
@@ -1,0 +1,58 @@
+import {QueryClient} from '@tanstack/react-query'
+import {registerQueryClient} from '@shm/shared/models/query-client'
+import {afterEach, describe, expect, test, vi} from 'vitest'
+import {invalidateForAccountChange} from '../agents/models'
+
+const serverUrl = 'https://agents.example'
+const accountUid = 'z6MkViewer'
+const agentId = 'agent-1'
+
+// The web app's query client: nothing refetches on mount, so an invalidation that only refetches
+// active queries leaves a cached-but-unmounted list stale until a full reload.
+function webQueryClient() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {staleTime: 30_000, refetchOnMount: false, refetchOnWindowFocus: false, refetchOnReconnect: false},
+    },
+  })
+  registerQueryClient(client)
+  return client
+}
+
+async function seedInactiveQuery(client: QueryClient, queryKey: unknown[]) {
+  const queryFn = vi.fn(async () => ({fetchedAt: Date.now()}))
+  // fetchQuery populates the cache without an observer: the same state as a page the user left.
+  await client.fetchQuery({queryKey, queryFn})
+  expect(queryFn).toHaveBeenCalledTimes(1)
+  return queryFn
+}
+
+afterEach(() => {
+  registerQueryClient(new QueryClient())
+})
+
+describe('invalidateForAccountChange', () => {
+  test('a session the runtime created refetches the agent page and session lists even while unmounted', async () => {
+    const client = webQueryClient()
+    const detail = await seedInactiveQuery(client, ['agents', 'detail', serverUrl, accountUid, agentId])
+    const list = await seedInactiveQuery(client, ['agents', 'sessions', serverUrl, accountUid])
+
+    invalidateForAccountChange(serverUrl, accountUid, {reason: 'session-created', agentId, sessionId: 'successor'})
+
+    await vi.waitFor(() => {
+      expect(detail).toHaveBeenCalledTimes(2)
+      expect(list).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  test('per-event churn still only refetches active queries', async () => {
+    const client = webQueryClient()
+    const detail = await seedInactiveQuery(client, ['agents', 'detail', serverUrl, accountUid, agentId])
+
+    invalidateForAccountChange(serverUrl, accountUid, {reason: 'session-event', agentId, sessionId: 'existing'})
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(detail).toHaveBeenCalledTimes(1)
+    expect(client.getQueryState(['agents', 'detail', serverUrl, accountUid, agentId])?.isInvalidated).toBe(true)
+  })
+})

--- a/frontend/packages/ui/src/agents/continuation.tsx
+++ b/frontend/packages/ui/src/agents/continuation.tsx
@@ -644,11 +644,16 @@ export function ContinuedMessageChip({
 }
 
 /** The chip a session list shows on a predecessor: where it went. */
-export function ContinuedListChip({link}: {link: SessionContinuationLink}) {
+/**
+ * Session-list chip on a successor: names the session it continues. Shown on the successor rather
+ * than the predecessor because a session can be continued many times — "continued in" would have
+ * to pick one — while every successor has exactly one predecessor.
+ */
+export function ContinuedFromListChip({link}: {link: SessionContinuationLink}) {
   return (
-    <span className="bg-muted text-muted-foreground mt-2 inline-flex max-w-full items-center gap-1 rounded-full px-2 py-0.5 text-xs">
+    <span className="bg-muted text-muted-foreground inline-flex max-w-full items-center gap-1 rounded-full px-2 py-0.5 text-xs">
       <Split className="size-3 flex-none" />
-      <span className="min-w-0 truncate">Continued in {link.title ? `“${link.title}”` : 'a new session'}</span>
+      <span className="min-w-0 truncate">Continued from {link.title ? `“${link.title}”` : 'an earlier session'}</span>
     </span>
   )
 }

--- a/frontend/packages/ui/src/agents/detail.tsx
+++ b/frontend/packages/ui/src/agents/detail.tsx
@@ -2824,11 +2824,11 @@ function SessionListItem({
           <SizableText weight="bold" className="min-w-0 flex-1 truncate">
             {session.title || 'Untitled session'}
           </SizableText>
-          <span className="flex max-w-[50%] flex-none flex-col items-end gap-1">
+          <span className="flex max-w-[50%] flex-none flex-wrap items-center justify-end gap-x-2 gap-y-1">
+            {session.continuedFrom ? <ContinuedFromListChip link={session.continuedFrom} /> : null}
             <SizableText size="sm" color="muted" className="whitespace-nowrap">
               {formattedDateMedium(new Date(session.updatedAt))}
             </SizableText>
-            {session.continuedFrom ? <ContinuedFromListChip link={session.continuedFrom} /> : null}
           </span>
         </span>
         {session.description ? (

--- a/frontend/packages/ui/src/agents/detail.tsx
+++ b/frontend/packages/ui/src/agents/detail.tsx
@@ -53,7 +53,7 @@ import {
 } from './models'
 import {describeAgentError} from './errors'
 import {SessionStatusDot, SubSessionsDisclosure} from './session-children'
-import {ContinuedListChip} from './continuation'
+import {ContinuedFromListChip} from './continuation'
 import {useSelectedAccountId} from './account'
 import {useClickNavigate, useNavigate} from './navigation'
 import {markdownBlockNodesToHMBlockNodes, parseMarkdown} from '@seed-hypermedia/client'
@@ -2817,14 +2817,19 @@ function SessionListItem({
   return (
     <div className="hover:bg-muted flex flex-col items-start rounded-lg px-3 py-2 transition-colors">
       <button type="button" className="flex w-full flex-col gap-0.5 text-left max-sm:min-h-10" onClick={onOpen}>
-        <span className="flex w-full items-center gap-3">
-          <SessionStatusDot status={session.status} />
+        <span className="flex w-full items-start gap-3">
+          <span className="flex h-5 flex-none items-center">
+            <SessionStatusDot status={session.status} />
+          </span>
           <SizableText weight="bold" className="min-w-0 flex-1 truncate">
             {session.title || 'Untitled session'}
           </SizableText>
-          <SizableText size="sm" color="muted" className="flex-none whitespace-nowrap">
-            {formattedDateMedium(new Date(session.updatedAt))}
-          </SizableText>
+          <span className="flex max-w-[50%] flex-none flex-col items-end gap-1">
+            <SizableText size="sm" color="muted" className="whitespace-nowrap">
+              {formattedDateMedium(new Date(session.updatedAt))}
+            </SizableText>
+            {session.continuedFrom ? <ContinuedFromListChip link={session.continuedFrom} /> : null}
+          </span>
         </span>
         {session.description ? (
           <SizableText size="sm" color="muted" className="line-clamp-3 w-full pl-5">
@@ -2832,7 +2837,6 @@ function SessionListItem({
           </SizableText>
         ) : null}
       </button>
-      {session.continuedTo ? <ContinuedListChip link={session.continuedTo} /> : null}
       {session.startedByTrigger ? (
         <button
           type="button"

--- a/frontend/packages/ui/src/agents/models.ts
+++ b/frontend/packages/ui/src/agents/models.ts
@@ -147,7 +147,11 @@ function applySessionToCaches(serverUrl: string, accountUid: string, session: Se
  * emit, so the client no longer refetches every agent query per event — that blanket invalidation
  * was most of the idle request load, and its refetch races flashed editing UIs to stale values.
  */
-function invalidateForAccountChange(
+/**
+ * Applies one `account/<uid>` change event to the query caches. Exported for tests: the refetch
+ * policy per reason is what keeps unmounted lists honest on the web client.
+ */
+export function invalidateForAccountChange(
   serverUrl: string,
   accountUid: string,
   value: {reason?: string; agentId?: string; sessionId?: string},
@@ -193,7 +197,21 @@ function invalidateForAccountChange(
       invalidateQueries(['agents', 'provider-models', serverUrl, accountUid])
       return
     case 'session-created':
-    case 'session-deleted':
+    case 'session-deleted': {
+      // A session the runtime created — a continuation successor, a trigger firing, start_session —
+      // usually arrives while the agent page and the sessions list are unmounted (the user is in the
+      // predecessor session). The web query client never refetches on mount, so an active-only
+      // invalidation would leave those cached lists without the new session until a full reload.
+      // Membership changes are rare enough to refetch even the inactive copies.
+      const refetchType = 'all'
+      invalidateQueries(['agents', 'sessions', serverUrl, accountUid], {refetchType})
+      if (sessionId) {
+        invalidateQueries(['agents', 'session', serverUrl, accountUid, sessionId])
+        invalidateQueries(['agents', 'child-sessions', serverUrl, accountUid], {refetchType})
+      }
+      if (agentId) invalidateQueries(['agents', 'detail', serverUrl, accountUid, agentId], {refetchType})
+      return
+    }
     case 'session-updated':
     case 'user-title-wins':
     case 'session-event':
@@ -1761,6 +1779,10 @@ export function useAgentDetail(
     enabled: !!serverUrl && !!accountUid && !!agentId,
     retry: false,
     useErrorBoundary: false,
+    // The sessions tab is a membership list. Any invalidation that landed while the page was away
+    // (a session the runtime created, a WebSocket gap) must be honored when it comes back, even on
+    // the web client, whose defaults never refetch on mount.
+    refetchOnMount: true,
   })
 }
 


### PR DESCRIPTION
## Problem

Continued sessions (and any other session the runtime creates: trigger firings, `start_session`) did not appear in the agent page's sessions list. The server returns them — `GetAgent` has no filter, and the prod DB has every successor under the same agent and account — so the gap is client-side cache staleness:

1. The user is in the predecessor session when `continue_session` fires, so the agent page is unmounted and its `['agents','detail',…]` query is inactive.
2. The `session-created` account change invalidated with the default `refetchType: 'active'`, which skips inactive queries.
3. The web query client sets `refetchOnMount: false`, so returning to the agent page rendered the stale cached list indefinitely.

## Fix (`frontend/packages/ui/src/agents/models.ts`)

- `session-created` / `session-deleted` now refetch the agent detail, sessions, and child-sessions lists with `refetchType: 'all'`. Membership changes are rare; the per-event reasons (`session-event`, etc.) keep the active-only policy so a busy run does not refetch every list on each step.
- `useAgentDetail` sets `refetchOnMount: true` so any invalidation that landed while the page was away is honored when it mounts again (no effect on desktop's `staleTime: Infinity` unless invalidated).

## Also: "Continued from" on the successor row

The list chip used to say "Continued in …" on the predecessor, which has to pick one successor even though a session can be continued many times. Every successor has exactly one predecessor, so the chip is flipped: the successor row shows "Continued from “<title>”". It moves out of its own row into the right column under the timestamp (`detail.tsx`, `continuation.tsx`).

## Test

`src/__tests__/agent-account-change-invalidation.test.ts` seeds inactive queries on a web-configured QueryClient and asserts `session-created` refetches them while `session-event` does not. Verified the first case fails against the old active-only policy.

- `vitest --run` on the new file: 2 pass
- `tsc --noEmit` in `frontend/packages/ui`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHjnwU4r7hqXf16P5R554G

