### PR TITLE
perf(agents): web_read page cache with in-flight coalescing

### DIFF
--- a/agents/src/perf.ts
+++ b/agents/src/perf.ts
@@ -38,6 +38,8 @@
  *   correlated with `run.dispatch_delay` / `provider.request_gap` / `provider.ttft` in the same
  *   snapshot.
  * - `run.retry.<code>`       — queue-level retries of failed runs, by error code.
+ * - `web_read.cache_hit` / `web_read.cache_miss` / `web_read.coalesced` — the web_read page
+ *   cache's effectiveness (see web-tools.ts).
  * - `exec.pool_hit` / `exec.pool_miss` / `exec.pool_overflow` — warm-pool acquisition outcomes.
  * - `exec.pool_reset_exhausted` / `exec.pool_reset_error` / `exec.pool_probe_failed` — why a
  *   pooled VM was disposed: its park reset ran out of pass budget (the guest's own verdict), the

--- a/agents/src/web-tools.test.ts
+++ b/agents/src/web-tools.test.ts
@@ -1,6 +1,7 @@
 import {afterEach, describe, expect, test} from 'bun:test'
 import {
   boundMarkdown,
+  clearWebReadCacheForTests,
   executeWebRead,
   executeWebSearch,
   extractReadableMarkdown,
@@ -11,6 +12,7 @@ import {
 const realFetch = globalThis.fetch
 afterEach(() => {
   globalThis.fetch = realFetch
+  clearWebReadCacheForTests()
 })
 
 type Route = (url: string, init?: RequestInit) => Response | Promise<Response>
@@ -189,6 +191,93 @@ describe('executeWebRead tiers', () => {
 
   test('rejects non-http(s) URLs', async () => {
     await expect(executeWebRead({}, {url: 'ftp://x'})).rejects.toThrow(/http/)
+  })
+
+  describe('read cache and coalescing', () => {
+    test('a repeat read is served from cache without fetching, fragment-insensitive', async () => {
+      let fetches = 0
+      mockFetch((url) => {
+        fetches += 1
+        if (url.startsWith('https://docs.test/page')) return htmlResponse(ARTICLE_HTML)
+        throw new Error(`unexpected fetch ${url}`)
+      })
+      const first = await executeWebRead({}, {url: 'https://docs.test/page#section-one'})
+      // The prod shape this exists for: the same page re-read under a different anchor.
+      const second = await executeWebRead({}, {url: 'https://docs.test/page#section-two'})
+      expect(fetches).toBe(1)
+      expect(second.markdown).toBe(first.markdown)
+      expect(String(second.summary)).toContain('(cached)')
+      // Each response still echoes the URL it was asked for.
+      expect(second.url).toBe('https://docs.test/page#section-two')
+      expect(String(first.summary)).not.toContain('(cached)')
+    })
+
+    test('concurrent identical reads share one fetch', async () => {
+      let fetches = 0
+      let release!: () => void
+      const gate = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      mockFetch(async (url) => {
+        fetches += 1
+        await gate
+        return htmlResponse(ARTICLE_HTML)
+      })
+      const a = executeWebRead({}, {url: 'https://docs.test/page'})
+      const b = executeWebRead({}, {url: 'https://docs.test/page#anchor'})
+      release()
+      const [ra, rb] = await Promise.all([a, b])
+      expect(fetches).toBe(1)
+      expect(rb.markdown).toBe(ra.markdown)
+    })
+
+    test('a coalesced failure rejects both callers and is not cached', async () => {
+      let fetches = 0
+      mockFetch(() => {
+        fetches += 1
+        return new Response('nope', {status: 500})
+      })
+      const settled = await Promise.allSettled([
+        executeWebRead({}, {url: 'https://dead.test/'}),
+        executeWebRead({}, {url: 'https://dead.test/'}),
+      ])
+      expect(settled.map((s) => s.status)).toEqual(['rejected', 'rejected'])
+      for (const s of settled) {
+        expect(String((s as PromiseRejectedResult).reason)).toMatch(/Could not extract/)
+      }
+      expect(fetches).toBe(1)
+      // The failure must not poison the cache: the next read tries again.
+      await expect(executeWebRead({}, {url: 'https://dead.test/'})).rejects.toThrow(/Could not extract/)
+      expect(fetches).toBe(2)
+    })
+
+    test('entries expire after the ttl and different queries do not share entries', async () => {
+      let fetches = 0
+      mockFetch((url) => {
+        fetches += 1
+        if (url.startsWith('https://docs.test/')) return htmlResponse(ARTICLE_HTML)
+        if (url.endsWith('/md')) return json({success: true, markdown: 'x'.repeat(300)})
+        throw new Error(`unexpected fetch ${url}`)
+      })
+      await executeWebRead({readCacheTtlMs: 30}, {url: 'https://docs.test/page'})
+      await new Promise((resolve) => setTimeout(resolve, 40))
+      await executeWebRead({readCacheTtlMs: 30}, {url: 'https://docs.test/page'})
+      expect(fetches).toBe(2)
+      // `query` steers crawl4ai's content filter, so it is part of the identity.
+      await executeWebRead({readCacheTtlMs: 60_000}, {url: 'https://docs.test/page', query: 'pricing'})
+      expect(fetches).toBe(3)
+    })
+
+    test('readCacheTtlMs: 0 disables caching entirely', async () => {
+      let fetches = 0
+      mockFetch(() => {
+        fetches += 1
+        return htmlResponse(ARTICLE_HTML)
+      })
+      await executeWebRead({readCacheTtlMs: 0}, {url: 'https://docs.test/page'})
+      await executeWebRead({readCacheTtlMs: 0}, {url: 'https://docs.test/page'})
+      expect(fetches).toBe(2)
+    })
   })
 
   // Regression: the fetch deadline must cover the BODY, not just the headers. A server that

--- a/agents/src/web-tools.ts
+++ b/agents/src/web-tools.ts
@@ -17,6 +17,8 @@ import {Readability} from '@mozilla/readability'
 import {parseHTML} from 'linkedom'
 import TurndownService from 'turndown'
 
+import {recordPerfCount} from '@/perf'
+
 /** Optional URLs/credentials for the self-hosted web backends. */
 export type WebToolsConfig = {
   /** Self-hosted SearXNG base URL, e.g. http://searxng:8080. Required for web_search. */
@@ -29,6 +31,8 @@ export type WebToolsConfig = {
   fetchTimeoutMs?: number
   /** Override for CRAWL_TIMEOUT_MS. */
   crawlTimeoutMs?: number
+  /** Override for READ_CACHE_TTL_MS (0 disables the web_read cache). */
+  readCacheTtlMs?: number
 }
 
 /** Keep markdown comfortably under the 256 KiB tool-result cap, leaving room for metadata. */
@@ -397,41 +401,39 @@ async function readRaw(url: string, timeoutMs: number): Promise<{body: string; f
   }
 }
 
-export async function executeWebRead(config: WebToolsConfig, raw: unknown): Promise<Record<string, unknown>> {
-  const input = isRecord(raw) ? raw : {}
-  const rawUrl = boundedString(input.url, 2048)
-  if (!rawUrl) throw new Error('A url is required')
-  let parsed: URL
-  try {
-    parsed = new URL(rawUrl)
-  } catch {
-    throw new Error(`Invalid url: ${rawUrl}`)
-  }
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:')
-    throw new Error('web_read only supports http(s) URLs')
-  const query = boundedString(input.query, 512)
+/**
+ * Extracted-page cache and in-flight coalescing for the tiered (non-raw) `web_read` path.
+ *
+ * Agents demonstrably re-read pages: a prod session fetched the same docs page three times — the
+ * last two as PARALLEL calls that differed only in their `#fragment` — burning ~63s on content the
+ * process had held 25 minutes earlier. The key strips the fragment (anchors never change the
+ * fetched document) and includes `query` (it steers crawl4ai's content filter). Failures are never
+ * cached; concurrent identical reads share one in-flight promise, including its rejection.
+ */
+const READ_CACHE_TTL_MS = 5 * 60_000
+const READ_CACHE_MAX_ENTRIES = 50
 
+type WebReadPage = {title: string; markdown: string; source: WebReadSource; finalUrl: string}
+const readCache = new Map<string, {page: WebReadPage; expiresAt: number}>()
+const readsInFlight = new Map<string, Promise<WebReadPage>>()
+
+/** Tests only — the cache is process-wide state. */
+export function clearWebReadCacheForTests(): void {
+  readCache.clear()
+  readsInFlight.clear()
+}
+
+function readCacheKey(parsed: URL, crawlQuery: string): string {
+  const noFragment = new URL(parsed.toString())
+  noFragment.hash = ''
+  return `${noFragment.toString()} ${crawlQuery}`
+}
+
+/** Runs the tier chain: MediaWiki -> static -> crawl4ai. Throws when no tier extracts content. */
+async function readTiered(config: WebToolsConfig, parsed: URL, rawUrl: string, query: string): Promise<WebReadPage> {
   const timeoutMs = config.fetchTimeoutMs ?? FETCH_TIMEOUT_MS
-
-  // Raw mode: return the response body verbatim (source code, JSON APIs, config files) with no extraction.
-  if (input.raw === true) {
-    const fetched = await readRaw(rawUrl, timeoutMs)
-    const {markdown, truncated} = boundMarkdown(fetched.body)
-    return {
-      summary: `Fetched ${fetched.finalUrl} via ${WEB_READ_SOURCE_LABEL.raw}${truncated ? ' (truncated)' : ''}.`,
-      url: rawUrl,
-      finalUrl: fetched.finalUrl,
-      title: hostnameOf(rawUrl),
-      source: 'raw' satisfies WebReadSource,
-      contentType: fetched.contentType,
-      truncated,
-      success: true,
-      markdown,
-    }
-  }
-
   const attempts: string[] = []
-  let result: {title: string; markdown: string; source: WebReadSource; finalUrl: string} | null = null
+  let result: WebReadPage | null = null
 
   // Tier 1: MediaWiki API (clean, no browser) when the URL looks like a wiki page.
   if (parseWikiTitle(parsed)) {
@@ -457,14 +459,86 @@ export async function executeWebRead(config: WebToolsConfig, raw: unknown): Prom
   if (!result) {
     throw new Error(`Could not extract readable content from ${rawUrl} (tried: ${attempts.join(', ') || 'none'}).`)
   }
+  return result
+}
 
-  const {markdown, truncated} = boundMarkdown(result.markdown)
+export async function executeWebRead(config: WebToolsConfig, raw: unknown): Promise<Record<string, unknown>> {
+  const input = isRecord(raw) ? raw : {}
+  const rawUrl = boundedString(input.url, 2048)
+  if (!rawUrl) throw new Error('A url is required')
+  let parsed: URL
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    throw new Error(`Invalid url: ${rawUrl}`)
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:')
+    throw new Error('web_read only supports http(s) URLs')
+  const query = boundedString(input.query, 512)
+
+  // Raw mode: return the response body verbatim (source code, JSON APIs, config files) with no
+  // extraction — and no caching: raw reads are often APIs whose freshness matters.
+  if (input.raw === true) {
+    const fetched = await readRaw(rawUrl, config.fetchTimeoutMs ?? FETCH_TIMEOUT_MS)
+    const {markdown, truncated} = boundMarkdown(fetched.body)
+    return {
+      summary: `Fetched ${fetched.finalUrl} via ${WEB_READ_SOURCE_LABEL.raw}${truncated ? ' (truncated)' : ''}.`,
+      url: rawUrl,
+      finalUrl: fetched.finalUrl,
+      title: hostnameOf(rawUrl),
+      source: 'raw' satisfies WebReadSource,
+      contentType: fetched.contentType,
+      truncated,
+      success: true,
+      markdown,
+    }
+  }
+
+  const ttlMs = config.readCacheTtlMs ?? READ_CACHE_TTL_MS
+  const key = readCacheKey(parsed, query)
+  let page: WebReadPage
+  let cached = false
+  const cachedEntry = ttlMs > 0 ? readCache.get(key) : undefined
+  if (cachedEntry && cachedEntry.expiresAt > Date.now()) {
+    page = cachedEntry.page
+    cached = true
+    recordPerfCount('web_read.cache_hit')
+  } else {
+    const inFlight = readsInFlight.get(key)
+    if (inFlight) {
+      recordPerfCount('web_read.coalesced')
+      page = await inFlight
+    } else {
+      recordPerfCount('web_read.cache_miss')
+      const pending = readTiered(config, parsed, rawUrl, query)
+      readsInFlight.set(key, pending)
+      try {
+        page = await pending
+      } finally {
+        readsInFlight.delete(key)
+      }
+      if (ttlMs > 0) {
+        // Refresh insertion order so eviction drops the least-recently written entry.
+        readCache.delete(key)
+        readCache.set(key, {page, expiresAt: Date.now() + ttlMs})
+        while (readCache.size > READ_CACHE_MAX_ENTRIES) {
+          const oldest = readCache.keys().next().value
+          if (oldest === undefined) break
+          readCache.delete(oldest)
+        }
+      }
+    }
+  }
+
+  const {markdown, truncated} = boundMarkdown(page.markdown)
   return {
-    summary: `Read ${result.title} via ${WEB_READ_SOURCE_LABEL[result.source]}${truncated ? ' (truncated)' : ''}.`,
+    summary: `Read ${page.title} via ${WEB_READ_SOURCE_LABEL[page.source]}${truncated ? ' (truncated)' : ''}${
+      cached ? ' (cached)' : ''
+    }.`,
     url: rawUrl,
-    finalUrl: result.finalUrl,
-    title: result.title,
-    source: result.source,
+    finalUrl: page.finalUrl,
+    title: page.title,
+    source: page.source,
     truncated,
     success: true,
     markdown,


### PR DESCRIPTION
## Why

The slow prod session fetched `documentation.datalab.to/api-reference/convert-result-check` three times — the last two as **parallel calls differing only in `#fragment`** — spending ~63s (they also hit the body-stall bug fixed in #1050) on a page the process had extracted 25 minutes earlier.

## What

- Non-raw `web_read` results cache for 5 min (50-entry cap), keyed by **fragment-stripped URL + crawl query** — the exact prod shape (two anchor variants of one page) collapses to one entry.
- **In-flight coalescing**: concurrent identical reads share one promise — the parallel-duplicate case costs one fetch even on a cold cache. A coalesced failure rejects all callers and is never cached.
- Raw mode never caches (API/source freshness); cache hits append `(cached)` to the summary; `web_read.cache_hit/cache_miss/coalesced` counters land in `/api/perf`; `readCacheTtlMs: 0` disables.

## Test plan

- 5 new tests: fragment-insensitive hit, concurrent coalescing, coalesced failure not cached, TTL expiry + query identity, TTL 0 disables. Full agents suite: 470 pass.
- `bun typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwyvKXowqRuZJVKuGbizvX