### PR TITLE
fix(agents): render agent images in chat from memory, not via ipfs://

### DIFF
--- a/agents/protocol/src/write-guides.ts
+++ b/agents/protocol/src/write-guides.ts
@@ -83,7 +83,9 @@ Write to \`ipfs://\` with exactly one source:
 {"address":"ipfs://","options":{"fromPath":"~/memory/site-assets/icon.png"}}
 \`\`\`
 
-The result includes the CID and \`ipfs://\` URL. Publishing is public, requires the agent's publish grant, and does not support \`dryRun\` or a signer.`,
+The result includes the CID and \`ipfs://\` URL. Publishing is public, requires the agent's publish grant, and does not support \`dryRun\` or a signer.
+
+The gateway serves the blob only once public Hypermedia content references it (a document image, a comment, a profile icon); an \`ipfs://\` URL on its own does not display anywhere yet. To show your user a file from memory in this chat, do not publish it — reference its memory path in markdown instead: \`![caption](~/memory/path/to/image.png)\`.`,
   },
   documents: {
     summary: 'Create, update, move, redirect, fork, delete, and publish Seed documents.',

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -6437,7 +6437,7 @@ export class Service {
       currentTime: new Date().toISOString(),
     })
     const memoryPrompt =
-      '\n\nYou have a private persistent memory filesystem shared across all of your sessions, addressed as ~/memory/ through your read and write verbs. Your user can also browse and edit these files. At the start of a task, check memory for relevant notes. Store durable learnings, preferences, and ongoing state as small, well-organized text files (for example ~/memory/notes/topic.md); update files by reading them and writing back the full revised content. `write` with {fromUrl} downloads web files (including binary media) into memory; `read ipfs://<cid>` fetches by CID; `write ipfs://` with {fromPath} publishes a memory file to IPFS and returns an ipfs:// URL you can reference from Hypermedia content. Files your user attaches to a chat message are session-private and are NOT in memory: their metadata appears on the message, and you can read one with `read attachment:<id>` or save it with `write ~/memory/<path>` and {fromAttachment}.'
+      '\n\nYou have a private persistent memory filesystem shared across all of your sessions, addressed as ~/memory/ through your read and write verbs. Your user can also browse and edit these files. At the start of a task, check memory for relevant notes. Store durable learnings, preferences, and ongoing state as small, well-organized text files (for example ~/memory/notes/topic.md); update files by reading them and writing back the full revised content. `write` with {fromUrl} downloads web files (including binary media) into memory; `read ipfs://<cid>` fetches by CID; `write ipfs://` with {fromPath} publishes a memory file to IPFS and returns an ipfs:// URL for use in Hypermedia content (the gateway serves such a blob only once a published document or comment references it, so an ipfs:// URL alone does not display in chat). To show your user an image or other file from memory in this conversation, reference its memory path in markdown: `![caption](~/memory/path/to/image.png)`; the chat renders it inline for the owner. Files your user attaches to a chat message are session-private and are NOT in memory: their metadata appears on the message, and you can read one with `read attachment:<id>` or save it with `write ~/memory/<path>` and {fromAttachment}.'
     const codeExecAvailable = (await this.#codeExec.availability()).available
     const callables = enabledCallableTools(definition, codeExecAvailable)
     const spaceIndex = stateDir
@@ -10703,7 +10703,9 @@ function readMemoryAddress(context: AgentServicePiToolContext, memoryPath: strin
       return {
         summary: `${file.path} is a binary file (${file.size} bytes${
           file.mimeType ? `, ${file.mimeType}` : ''
-        }); content not shown. Use write ipfs:// with {fromPath} to publish it for Hypermedia content.`,
+        }); content not shown. Show it in chat with ![caption](~/memory/${
+          file.path
+        }); use write ipfs:// with {fromPath} to publish it for Hypermedia content.`,
         ...meta,
       }
     }

--- a/agents/src/verbs.test.ts
+++ b/agents/src/verbs.test.ts
@@ -10,6 +10,7 @@ import {executeCallVerb, executeReadVerb, executeWriteVerb, type AgentServicePiT
 import {encode as cborEncode} from '@/cbor'
 import {LAMBDA_RESULT_PREFIX} from '@/code-exec'
 import * as toolDocs from '@/tool-documents'
+import * as agentMemory from '@/agent-memory'
 import * as sqlite from '@/sqlite'
 import type {CodeExecutor} from '@/code-exec'
 
@@ -94,6 +95,24 @@ describe('read verb', () => {
 
     const root = await executeReadVerb(context, {address: '~/memory/'})
     expect(Array.isArray(root.entries)).toBe(true)
+  })
+
+  test('reading a binary memory file says how to show it in chat, not just how to publish it', async () => {
+    const context = makeContext()
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0])
+    agentMemory.writeMemoryFile(context.stateDir, 'ads/one.png', png)
+    const file = await executeReadVerb(context, {address: '~/memory/ads/one.png'})
+    expect(file.encoding).toBe('binary')
+    expect(file.mimeType).toBe('image/png')
+    // Bytes never reach the model; the summary points at the chat-rendered memory path first.
+    expect(file.data).toBeUndefined()
+    expect(String(file.summary)).toContain('Show it in chat with ![caption](~/memory/ads/one.png)')
+    expect(String(file.summary)).toContain('write ipfs://')
+
+    // The ipfs guide is honest about what an ipfs:// URL can and cannot do.
+    const guide = await executeReadVerb(context, {address: '~/tools/write/ipfs'})
+    expect(String(guide.markdown)).toContain('does not display anywhere yet')
+    expect(String(guide.markdown)).toContain('![caption](~/memory/path/to/image.png)')
   })
 
   test('~/tools lists verbs and callables; ~/tools/<name> returns the contract', async () => {

--- a/frontend/packages/ui/src/__tests__/agent-chat-bubble-images.test.tsx
+++ b/frontend/packages/ui/src/__tests__/agent-chat-bubble-images.test.tsx
@@ -1,5 +1,4 @@
 // @vitest-environment jsdom
-import React from 'react'
 import {createRoot, type Root} from 'react-dom/client'
 import {act} from 'react-dom/test-utils'
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query'

--- a/frontend/packages/ui/src/__tests__/agent-chat-bubble-images.test.tsx
+++ b/frontend/packages/ui/src/__tests__/agent-chat-bubble-images.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import React from 'react'
+import {createRoot, type Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {ChatMessageBubble} from '../agents/message-rendering'
+import {setAgentsPlatform} from '../agents/platform'
+;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+
+/**
+ * Exercises the whole chat path for an agent that answers "show me the image" with a memory
+ * path: the real bubble, the real Markdown renderer, the real react-query hook, down to the one
+ * signed API call — only the wire is faked.
+ */
+const sendAgentAction = vi.fn()
+vi.mock('../agents/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../agents/client')>()),
+  sendAgentAction: (...args: unknown[]) => sendAgentAction(...args),
+}))
+vi.mock('@shm/shared/models/entity', () => ({
+  useResource: () => ({data: null}),
+  useAccount: () => ({data: null}),
+}))
+vi.mock('../agents/navigation', () => ({
+  useOpenUrl: () => vi.fn(),
+  useClickNavigate: () => vi.fn(),
+  useNavigate: () => vi.fn(),
+  resolveHypermediaRoute: () => null,
+}))
+
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+
+describe('ChatMessageBubble with a memory image', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    sendAgentAction.mockReset()
+    setAgentsPlatform(
+      new Proxy(
+        {useGatewayUrl: () => 'https://gw.example', useAccountUid: () => 'owner-account'},
+        {get: (target, key) => (key in target ? target[key as keyof typeof target] : () => undefined)},
+      ) as never,
+    )
+    Object.assign(URL, {createObjectURL: () => 'blob:memory-image', revokeObjectURL: () => {}})
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  async function waitFor(check: () => boolean) {
+    for (let i = 0; i < 50 && !check(); i++) {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      })
+    }
+    expect(check()).toBe(true)
+  }
+
+  it('fetches the file for this agent over the signed API and renders it inline', async () => {
+    sendAgentAction.mockResolvedValue({
+      _: 'ReadAgentMemoryFileResponse',
+      file: {
+        path: 'ads/one.png',
+        size: PNG.byteLength,
+        updatedAt: 1,
+        mimeType: 'image/png',
+        encoding: 'binary',
+        data: PNG,
+      },
+    })
+    const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}})
+    act(() => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <ChatMessageBubble
+            message={{
+              role: 'assistant',
+              content: 'Here it is:\n\n![The ad](~/memory/ads/one.png)',
+              sessionId: 'sess-1',
+            }}
+            serverUrl="https://agents.example"
+            accountUid="owner-account"
+            agentId="agent-1"
+          />
+        </QueryClientProvider>,
+      )
+    })
+
+    await waitFor(() => container.querySelector('img')?.getAttribute('src') === 'blob:memory-image')
+    expect(container.querySelector('img')?.getAttribute('alt')).toBe('The ad')
+    expect(sendAgentAction).toHaveBeenCalledTimes(1)
+    expect(sendAgentAction.mock.calls[0]![0]).toEqual({
+      serverUrl: 'https://agents.example',
+      accountUid: 'owner-account',
+      action: {_: 'ReadAgentMemoryFile', agentId: 'agent-1', path: 'ads/one.png'},
+    })
+  })
+
+  it('never issues a request for a plain web image, and routes ipfs:// through the gateway', async () => {
+    const queryClient = new QueryClient()
+    act(() => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <ChatMessageBubble
+            message={{role: 'assistant', content: '![a](https://x.test/a.png) ![b](ipfs://bafyb)', sessionId: 'sess-1'}}
+            serverUrl="https://agents.example"
+            accountUid="owner-account"
+            agentId="agent-1"
+          />
+        </QueryClientProvider>,
+      )
+    })
+    const srcs = Array.from(container.querySelectorAll('img')).map((img) => img.getAttribute('src'))
+    expect(srcs).toEqual(['https://x.test/a.png', 'https://gw.example/ipfs/bafyb'])
+    expect(sendAgentAction).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/packages/ui/src/__tests__/agent-markdown-images.test.tsx
+++ b/frontend/packages/ui/src/__tests__/agent-markdown-images.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import React from 'react'
+import {createRoot, type Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {Markdown, MarkdownAssetContext, resolveMarkdownImageSource} from '../agents/markdown'
+;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+
+const memoryFile = vi.fn()
+vi.mock('../agents/models', () => ({
+  useAgentMemoryFile: (...args: unknown[]) => memoryFile(...args),
+  useSessionAttachmentDataUrls: () => ({}),
+}))
+vi.mock('@shm/shared/models/entity', () => ({useResource: () => ({data: null})}))
+vi.mock('../agents/platform', () => ({getAgentsPlatform: () => ({useGatewayUrl: () => GATEWAY})}))
+vi.mock('../agents/navigation', () => ({
+  useOpenUrl: () => vi.fn(),
+  resolveHypermediaRoute: () => null,
+}))
+
+const GATEWAY = 'https://gw.example'
+
+describe('resolveMarkdownImageSource', () => {
+  it('routes ipfs:// CIDs through the gateway, keeping any path suffix', () => {
+    expect(resolveMarkdownImageSource('ipfs://bafyabc', `${GATEWAY}/`)).toEqual({
+      kind: 'ipfs',
+      cid: 'bafyabc',
+      url: `${GATEWAY}/ipfs/bafyabc`,
+    })
+    expect(resolveMarkdownImageSource('ipfs://bafyabc/cover.png', GATEWAY)).toMatchObject({
+      url: `${GATEWAY}/ipfs/bafyabc/cover.png`,
+    })
+  })
+
+  it('reads memory paths as the agent writes them, including the sandbox mount', () => {
+    expect(resolveMarkdownImageSource('~/memory/ads/one.png', GATEWAY)).toEqual({kind: 'memory', path: 'ads/one.png'})
+    expect(resolveMarkdownImageSource('/workspace/ads/one.png', GATEWAY)).toEqual({kind: 'memory', path: 'ads/one.png'})
+  })
+
+  it('recognizes session attachments and leaves web URLs alone', () => {
+    expect(resolveMarkdownImageSource('attachment:abc123', GATEWAY)).toEqual({kind: 'attachment', id: 'abc123'})
+    expect(resolveMarkdownImageSource('https://x.test/a.png', GATEWAY)).toEqual({
+      kind: 'url',
+      url: 'https://x.test/a.png',
+    })
+  })
+})
+
+describe('Markdown images in a transcript', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    memoryFile.mockReset()
+    // jsdom lacks object URLs; the memory image only needs a stable string.
+    Object.assign(URL, {createObjectURL: () => 'blob:memory-image', revokeObjectURL: () => {}})
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  function render(markdown: string, scope?: React.ContextType<typeof MarkdownAssetContext>) {
+    act(() => {
+      root.render(
+        scope ? (
+          <MarkdownAssetContext.Provider value={scope}>
+            <Markdown>{markdown}</Markdown>
+          </MarkdownAssetContext.Provider>
+        ) : (
+          <Markdown>{markdown}</Markdown>
+        ),
+      )
+    })
+  }
+
+  it('renders an ipfs:// image through the gateway instead of dropping the src', () => {
+    render('![Square ad](ipfs://bafybeid4ik)')
+    const img = container.querySelector('img')
+    expect(img?.getAttribute('src')).toMatch(/\/ipfs\/bafybeid4ik$/)
+    expect(img?.getAttribute('alt')).toBe('Square ad')
+  })
+
+  it('shows a memory image by fetching the bytes for the scoped agent', () => {
+    memoryFile.mockReturnValue({
+      isLoading: false,
+      error: null,
+      data: {path: 'ads/one.png', mimeType: 'image/png', encoding: 'binary', data: new Uint8Array([1, 2, 3])},
+    })
+    render('![The ad](~/memory/ads/one.png)', {
+      serverUrl: 'https://agents.test',
+      accountUid: 'acct',
+      agentId: 'agent-1',
+    })
+    expect(memoryFile).toHaveBeenCalledWith('https://agents.test', 'acct', 'agent-1', 'ads/one.png')
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('blob:memory-image')
+  })
+
+  it('falls back to a labeled placeholder for a memory image outside any agent scope', () => {
+    render('![The ad](~/memory/ads/one.png)')
+    expect(memoryFile).not.toHaveBeenCalled()
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.textContent).toContain('The ad')
+  })
+})

--- a/frontend/packages/ui/src/agents/markdown.tsx
+++ b/frontend/packages/ui/src/agents/markdown.tsx
@@ -3,7 +3,9 @@ import {getAgentsPlatform} from './platform'
 import {DEFAULT_GATEWAY_URL} from '@shm/shared/constants'
 import {useResource} from '@shm/shared/models/entity'
 import {hmId, routeToUrl} from '@shm/shared/utils/entity-id-url'
+import {ImageOff, Loader2} from 'lucide-react'
 import React from 'react'
+import {useAgentMemoryFile, useSessionAttachmentDataUrls} from './models'
 import ReactMarkdown, {defaultUrlTransform, type Components, type ExtraProps} from 'react-markdown'
 // The bare `remark-gfm` specifier is ambiguous in the renderer bundle: the
 // vite alias pulls @shm/editor in by source, so the dep optimizer resolves
@@ -39,6 +41,149 @@ const useGatewayUrlHook: () => string | undefined = () => {
   return (getAgentsPlatform().useGatewayUrl ?? (() => undefined))()
 }
 
+/**
+ * Where a transcript's inline assets resolve from: the agent whose private memory holds them and
+ * the session whose attachments they came from. Provided per message bubble; absent outside a
+ * transcript, where memory and attachment images render as labeled placeholders instead.
+ */
+export type MarkdownAssetScope = {
+  serverUrl?: string
+  accountUid?: string | null
+  agentId?: string
+  sessionId?: string
+}
+
+export const MarkdownAssetContext = React.createContext<MarkdownAssetScope | null>(null)
+
+export type MarkdownImageSource =
+  | {kind: 'url'; url: string}
+  /** An IPFS CID, served through the HM gateway. */
+  | {kind: 'ipfs'; cid: string; url: string}
+  /** A file in the agent's private memory, fetched over the signed agents API. */
+  | {kind: 'memory'; path: string}
+  /** A session-private attachment the user dropped into the chat. */
+  | {kind: 'attachment'; id: string}
+
+/**
+ * Classifies an image reference the way the agent addresses things: `ipfs://<cid>` (the
+ * `write ipfs://` result), `~/memory/<path>` or the sandbox mount `/workspace/<path>` (memory
+ * files), and `attachment:<id>` (chat attachments). Anything else is a plain URL.
+ */
+export function resolveMarkdownImageSource(src: string, gatewayUrl: string): MarkdownImageSource {
+  const ipfs = src.match(/^ipfs:\/\/([^/?#]+)(\/[^?#]*)?/)
+  if (ipfs) {
+    const cid = ipfs[1]!
+    return {kind: 'ipfs', cid, url: `${gatewayUrl.replace(/\/$/, '')}/ipfs/${cid}${ipfs[2] ?? ''}`}
+  }
+  const memory = src.match(/^(?:~\/memory|\/workspace)\/(.+)$/)
+  if (memory) return {kind: 'memory', path: memory[1]!.replace(/^\/+/, '')}
+  const attachment = src.match(/^attachment:(?:\/\/)?(.+)$/)
+  if (attachment) return {kind: 'attachment', id: attachment[1]!}
+  return {kind: 'url', url: src}
+}
+
+/** URL schemes react-markdown's sanitizer would drop but the transcript knows how to render. */
+const TRANSCRIPT_URL_PREFIXES = ['hm://', 'ipfs://', 'attachment:']
+
+function transcriptUrlTransform(value: string): string {
+  return TRANSCRIPT_URL_PREFIXES.some((prefix) => value.startsWith(prefix)) ? value : defaultUrlTransform(value)
+}
+
+function ImagePlaceholder({label, detail}: {label: string; detail?: string}) {
+  return (
+    <span
+      className="bg-background/50 text-muted-foreground border-border my-1 inline-flex max-w-full items-center gap-1.5 rounded border px-2 py-1 text-xs"
+      title={detail}
+    >
+      <ImageOff className="size-3.5 flex-none" />
+      <span className="min-w-0 truncate">{label}</span>
+    </span>
+  )
+}
+
+/** Renders a resolved image URL, degrading to a labeled placeholder if it fails to load. */
+function InlineImage({src, alt, detail}: {src: string; alt?: string; detail: string}) {
+  const [failed, setFailed] = React.useState(false)
+  React.useEffect(() => setFailed(false), [src])
+  if (failed) return <ImagePlaceholder label={alt || detail} detail={`Could not load ${detail}`} />
+  return (
+    <img
+      src={src}
+      alt={alt ?? ''}
+      title={alt || undefined}
+      loading="lazy"
+      className="my-2 max-h-[480px] max-w-full rounded-md object-contain"
+      onError={() => setFailed(true)}
+    />
+  )
+}
+
+/** Turns fetched bytes into an object URL for the lifetime of the element. */
+function useObjectUrl(data: Uint8Array | undefined, mimeType: string | undefined): string | null {
+  const objectUrl = React.useMemo(() => {
+    if (!data || !data.byteLength) return null
+    return URL.createObjectURL(new Blob([new Uint8Array(data)], mimeType ? {type: mimeType} : undefined))
+  }, [data, mimeType])
+  React.useEffect(() => {
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl)
+    }
+  }, [objectUrl])
+  return objectUrl
+}
+
+function MemoryImage({path, alt, scope}: {path: string; alt?: string; scope: MarkdownAssetScope}) {
+  const file = useAgentMemoryFile(scope.serverUrl, scope.accountUid, scope.agentId, path)
+  const objectUrl = useObjectUrl(file.data?.data, file.data?.mimeType)
+  const label = alt || path
+  if (file.isLoading) {
+    return (
+      <span className="text-muted-foreground my-1 inline-flex items-center gap-1.5 text-xs">
+        <Loader2 className="size-3.5 animate-spin" />
+        {label}
+      </span>
+    )
+  }
+  if (file.error) {
+    return <ImagePlaceholder label={label} detail={`~/memory/${path}: ${(file.error as Error).message}`} />
+  }
+  if (!objectUrl || !file.data?.mimeType?.startsWith('image/')) {
+    return <ImagePlaceholder label={label} detail={`~/memory/${path} is not an image`} />
+  }
+  return <InlineImage src={objectUrl} alt={alt} detail={`~/memory/${path}`} />
+}
+
+function AttachmentImage({id, alt, scope}: {id: string; alt?: string; scope: MarkdownAssetScope}) {
+  const ids = React.useMemo(() => [id], [id])
+  const srcById = useSessionAttachmentDataUrls(scope.serverUrl, scope.accountUid, scope.sessionId, ids)
+  const src = srcById[id]
+  if (!src) return <ImagePlaceholder label={alt || `attachment:${id}`} detail={`attachment:${id}`} />
+  return <InlineImage src={src} alt={alt} detail={`attachment:${id}`} />
+}
+
+/**
+ * Images in agent messages. The agent points at its own artifacts by memory path, attachment id,
+ * or `ipfs://` CID — none of which a browser can fetch directly — so each is resolved here:
+ * memory and attachment bytes come over the signed agents API (only the owner can see them),
+ * and CIDs go through the HM gateway, which serves a blob once public Hypermedia content
+ * references it.
+ */
+function MarkdownImage({src, alt}: React.ComponentProps<'img'> & ExtraProps) {
+  const gatewayUrl = useGatewayUrlHook() || DEFAULT_GATEWAY_URL
+  const scope = React.useContext(MarkdownAssetContext)
+  const source = React.useMemo(() => (src ? resolveMarkdownImageSource(src, gatewayUrl) : null), [src, gatewayUrl])
+  if (!source) return null
+  if (source.kind === 'memory') {
+    if (!scope?.agentId) return <ImagePlaceholder label={alt || source.path} detail={`~/memory/${source.path}`} />
+    return <MemoryImage path={source.path} alt={alt} scope={scope} />
+  }
+  if (source.kind === 'attachment') {
+    if (!scope?.sessionId) return <ImagePlaceholder label={alt || `attachment:${source.id}`} />
+    return <AttachmentImage id={source.id} alt={alt} scope={scope} />
+  }
+  return <InlineImage src={source.url} alt={alt} detail={src!} />
+}
+
 function MarkdownLink({href, children}: React.ComponentProps<'a'> & ExtraProps) {
   const openUrl = useOpenUrl()
   const gatewayUrl = useGatewayUrlHook() || DEFAULT_GATEWAY_URL
@@ -50,6 +195,10 @@ function MarkdownLink({href, children}: React.ComponentProps<'a'> & ExtraProps) 
   const siteHome = useResource(resolvedLink ? hmId(resolvedLink.id.uid) : null)
   const siteUrl = siteHome.data?.type === 'document' ? siteHome.data.document.metadata?.siteUrl : null
   const renderedHref = React.useMemo(() => {
+    if (href?.startsWith('ipfs://')) {
+      const source = resolveMarkdownImageSource(href, gatewayUrl)
+      return source.kind === 'ipfs' ? source.url : href
+    }
     if (!href || !resolvedLink) return href
     return (
       routeToUrl(resolvedLink.route, {
@@ -91,6 +240,7 @@ export function Markdown({children, enableGfm = true}: {children: string; enable
     ol: ({children}) => <ol className="mb-2 list-decimal pl-4 last:mb-0">{children}</ol>,
     li: ({children}) => <li className="mb-0.5">{children}</li>,
     a: MarkdownLink,
+    img: MarkdownImage,
     blockquote: ({children}) => (
       <blockquote className="border-muted-foreground/30 my-2 border-l-2 pl-3 italic">{children}</blockquote>
     ),
@@ -119,7 +269,7 @@ export function Markdown({children, enableGfm = true}: {children: string; enable
     <ReactMarkdown
       remarkPlugins={enableGfm ? [remarkGfm, remarkStripHtmlComments] : [remarkStripHtmlComments]}
       components={components}
-      urlTransform={(value) => (value.startsWith('hm://') ? value : defaultUrlTransform(value))}
+      urlTransform={transcriptUrlTransform}
     >
       {children}
     </ReactMarkdown>

--- a/frontend/packages/ui/src/agents/message-rendering.tsx
+++ b/frontend/packages/ui/src/agents/message-rendering.tsx
@@ -26,6 +26,7 @@ import {
 } from './tool-summary'
 import {useOpenUrl} from './navigation'
 import {useOpenAgentSession} from './open-session-context'
+import {MarkdownAssetContext, type MarkdownAssetScope} from './markdown'
 import {useFullAgentSessionEvent, useRun, useRunTree, useSessionAttachmentDataUrls, useSessionRuns} from './models'
 import {Notice} from '@shm/ui/notice'
 import {descendantsOf, isTerminalRun, RunTimerProgress, RunWorkHierarchy, useRunTreeView} from './run-work'
@@ -98,99 +99,113 @@ export const ChatMessageBubble = React.memo(function ChatMessageBubble({
   const isUser = !isSystem && message.role === 'user'
   const rawMarkdown = message.rawMarkdown ?? message.content
   const resolvedBlocks = useAttachmentResolvedBlocks(serverUrl, message)
+  const selectedAccountId = useSelectedAccountId()
+  // Inline images in the markdown (`![…](~/memory/…)`, `attachment:<id>`) resolve against this
+  // agent and session; see MarkdownImage.
+  const assetScope = useMemo<MarkdownAssetScope>(
+    () => ({serverUrl, accountUid: accountUid ?? selectedAccountId, agentId, sessionId: message.sessionId}),
+    [serverUrl, accountUid, selectedAccountId, agentId, message.sessionId],
+  )
 
   return (
-    <div className="group/message my-1.5" data-message-kind={isSystem ? 'system' : isUser ? 'user' : 'assistant'}>
-      {isSystem ? (
-        <SystemMessageRow
-          content={message.content || ''}
-          rawMarkdownButton={rawMarkdown ? <RawMarkdownButton onClick={() => setShowRawMarkdown(true)} /> : null}
-        />
-      ) : isUser ? (
-        <div className="flex items-start gap-1">
-          <div className="ml-6 min-w-0 flex-1 rounded-lg border border-sky-200 bg-sky-100 px-3 py-2 text-[13px] break-words text-slate-950 dark:border-sky-800 dark:bg-sky-950/60 dark:text-sky-50 [&_.ProseMirror]:!text-[13px] [&_.hm-prose]:!text-[13px]">
-            {resolvedBlocks?.length ? (
-              <div className="text-foreground rounded-md bg-transparent px-1 py-0.5 [&_.ProseMirror]:!bg-transparent [&_.bn-container]:!bg-transparent [&_.bn-editor]:!bg-transparent [&_.hm-prose]:!font-sans [&_.hm-prose]:!text-base">
-                <Suspense fallback={<Markdown>{message.content || ''}</Markdown>}>
-                  <RichMessageBlocks blocks={resolvedBlocks} />
-                </Suspense>
-              </div>
-            ) : (
-              <Markdown>{message.content || ''}</Markdown>
-            )}
-            {message.contextLines?.length ? <MessageContextInfo lines={message.contextLines} /> : null}
-            {message.meta?.continuedFrom ? (
-              <ContinuedMessageChip continuedFrom={message.meta.continuedFrom} serverUrl={serverUrl} />
-            ) : null}
-          </div>
-          {rawMarkdown ? <RawMarkdownButton onClick={() => setShowRawMarkdown(true)} /> : null}
-          <UserMessageOrigin meta={message.meta} />
-        </div>
-      ) : (
-        <AssistantMessageParts
-          parts={getAssistantMessageParts(message)}
-          liveActivity={liveActivity}
-          serverUrl={serverUrl}
-          accountUid={accountUid}
-          agentId={agentId}
-          sessionId={message.sessionId}
-          rawMarkdownButton={rawMarkdown ? <RawMarkdownButton onClick={() => setShowRawMarkdown(true)} /> : null}
-        />
-      )}
-      {message.errorMessage ? <AgentErrorRow message={message.errorMessage} className="mt-1" /> : null}
-      {rawMarkdown ? (
-        <Dialog open={showRawMarkdown} onOpenChange={setShowRawMarkdown}>
-          {/* `w-full` is restated because passing a max-w overrides DialogContent's own; without a
-              width the dialog shrink-to-fits its longest line and spills past a phone viewport. */}
-          <DialogContent className="w-full max-w-2xl">
-            <DialogHeader>
-              <DialogTitle>Message details</DialogTitle>
-              <DialogDescription>This is the exact markdown text represented by this message.</DialogDescription>
-            </DialogHeader>
-            {message.shareUrl ? (
-              <div className="flex flex-col gap-2">
-                <div className="text-muted-foreground text-xs">Share URL</div>
-                <div className="flex gap-2">
-                  <code className="bg-muted min-w-0 flex-1 overflow-auto rounded-md p-2 text-xs whitespace-nowrap">
-                    {message.shareUrl}
-                  </code>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => void navigator.clipboard?.writeText(message.shareUrl!)}
-                  >
-                    Copy
-                  </Button>
+    <MarkdownAssetContext.Provider value={assetScope}>
+      <div className="group/message my-1.5" data-message-kind={isSystem ? 'system' : isUser ? 'user' : 'assistant'}>
+        {isSystem ? (
+          <SystemMessageRow
+            content={message.content || ''}
+            rawMarkdownButton={rawMarkdown ? <RawMarkdownButton onClick={() => setShowRawMarkdown(true)} /> : null}
+          />
+        ) : isUser ? (
+          <div className="flex items-start gap-1">
+            <div className="ml-6 min-w-0 flex-1 rounded-lg border border-sky-200 bg-sky-100 px-3 py-2 text-[13px] break-words text-slate-950 dark:border-sky-800 dark:bg-sky-950/60 dark:text-sky-50 [&_.ProseMirror]:!text-[13px] [&_.hm-prose]:!text-[13px]">
+              {resolvedBlocks?.length ? (
+                <div className="text-foreground rounded-md bg-transparent px-1 py-0.5 [&_.ProseMirror]:!bg-transparent [&_.bn-container]:!bg-transparent [&_.bn-editor]:!bg-transparent [&_.hm-prose]:!font-sans [&_.hm-prose]:!text-base">
+                  <Suspense fallback={<Markdown>{message.content || ''}</Markdown>}>
+                    <RichMessageBlocks blocks={resolvedBlocks} />
+                  </Suspense>
                 </div>
-              </div>
-            ) : null}
-            <div className="flex flex-wrap gap-2 text-xs">
-              {message.sessionId ? (
-                <span className="bg-muted rounded px-2 py-1">Session: {message.sessionId}</span>
-              ) : null}
-              {message.eventId ? <span className="bg-muted rounded px-2 py-1">Message: {message.eventId}</span> : null}
-              {typeof message.seq === 'number' ? (
-                <span className="bg-muted rounded px-2 py-1">Seq: {message.seq}</span>
+              ) : (
+                <Markdown>{message.content || ''}</Markdown>
+              )}
+              {message.contextLines?.length ? <MessageContextInfo lines={message.contextLines} /> : null}
+              {message.meta?.continuedFrom ? (
+                <ContinuedMessageChip continuedFrom={message.meta.continuedFrom} serverUrl={serverUrl} />
               ) : null}
             </div>
-            <EventMetaSection meta={message.meta} times={message.createdAt ? {sentAt: message.createdAt} : undefined} />
-            <pre className="bg-muted max-h-[50vh] overflow-auto rounded-md p-3 text-xs whitespace-pre-wrap">
-              {rawMarkdown}
-            </pre>
-            {message.contextLines?.length ? (
-              <div className="flex flex-col gap-2">
-                <div className="text-muted-foreground text-xs">
-                  Context shared with the agent (attached to this message, hidden from the chat)
+            {rawMarkdown ? <RawMarkdownButton onClick={() => setShowRawMarkdown(true)} /> : null}
+            <UserMessageOrigin meta={message.meta} />
+          </div>
+        ) : (
+          <AssistantMessageParts
+            parts={getAssistantMessageParts(message)}
+            liveActivity={liveActivity}
+            serverUrl={serverUrl}
+            accountUid={accountUid}
+            agentId={agentId}
+            sessionId={message.sessionId}
+            rawMarkdownButton={rawMarkdown ? <RawMarkdownButton onClick={() => setShowRawMarkdown(true)} /> : null}
+          />
+        )}
+        {message.errorMessage ? <AgentErrorRow message={message.errorMessage} className="mt-1" /> : null}
+        {rawMarkdown ? (
+          <Dialog open={showRawMarkdown} onOpenChange={setShowRawMarkdown}>
+            {/* `w-full` is restated because passing a max-w overrides DialogContent's own; without a
+              width the dialog shrink-to-fits its longest line and spills past a phone viewport. */}
+            <DialogContent className="w-full max-w-2xl">
+              <DialogHeader>
+                <DialogTitle>Message details</DialogTitle>
+                <DialogDescription>This is the exact markdown text represented by this message.</DialogDescription>
+              </DialogHeader>
+              {message.shareUrl ? (
+                <div className="flex flex-col gap-2">
+                  <div className="text-muted-foreground text-xs">Share URL</div>
+                  <div className="flex gap-2">
+                    <code className="bg-muted min-w-0 flex-1 overflow-auto rounded-md p-2 text-xs whitespace-nowrap">
+                      {message.shareUrl}
+                    </code>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => void navigator.clipboard?.writeText(message.shareUrl!)}
+                    >
+                      Copy
+                    </Button>
+                  </div>
                 </div>
-                <pre className="bg-muted max-h-[30vh] overflow-auto rounded-md p-3 text-xs whitespace-pre-wrap">
-                  {message.contextLines.join('\n')}
-                </pre>
+              ) : null}
+              <div className="flex flex-wrap gap-2 text-xs">
+                {message.sessionId ? (
+                  <span className="bg-muted rounded px-2 py-1">Session: {message.sessionId}</span>
+                ) : null}
+                {message.eventId ? (
+                  <span className="bg-muted rounded px-2 py-1">Message: {message.eventId}</span>
+                ) : null}
+                {typeof message.seq === 'number' ? (
+                  <span className="bg-muted rounded px-2 py-1">Seq: {message.seq}</span>
+                ) : null}
               </div>
-            ) : null}
-          </DialogContent>
-        </Dialog>
-      ) : null}
-    </div>
+              <EventMetaSection
+                meta={message.meta}
+                times={message.createdAt ? {sentAt: message.createdAt} : undefined}
+              />
+              <pre className="bg-muted max-h-[50vh] overflow-auto rounded-md p-3 text-xs whitespace-pre-wrap">
+                {rawMarkdown}
+              </pre>
+              {message.contextLines?.length ? (
+                <div className="flex flex-col gap-2">
+                  <div className="text-muted-foreground text-xs">
+                    Context shared with the agent (attached to this message, hidden from the chat)
+                  </div>
+                  <pre className="bg-muted max-h-[30vh] overflow-auto rounded-md p-3 text-xs whitespace-pre-wrap">
+                    {message.contextLines.join('\n')}
+                  </pre>
+                </div>
+              ) : null}
+            </DialogContent>
+          </Dialog>
+        ) : null}
+      </div>
+    </MarkdownAssetContext.Provider>
   )
 })
 


### PR DESCRIPTION
## Problem

An agent asked to "show me the images" published two PNGs with `write ipfs://` and answered with `![…](ipfs://<cid>)`. The chat showed nothing (prod session `d0254245…`). Two independent failures:

- **The chat renderer dropped the URL.** react-markdown's default sanitizer strips the `ipfs:` scheme, so the `<img>` had an empty src.
- **The gateway refuses the blob anyway.** The daemon only serves blobs in its public view, and a UnixFS blob only becomes public when a public Change/Comment/Profile links to it. A standalone `write ipfs://` upload is stored but answers `blob … is not public` until published content references it.

Root cause of the agent's choice: nothing told it that a memory file could be shown in chat. The system prompt, the binary-file read summary ("content not shown. Use write ipfs://…"), and the write/ipfs guide all pointed at IPFS, and the renderer could not have shown a memory path anyway.

## Fix

- **Transcript images resolve the way the agent addresses things.** `~/memory/<path>` and the sandbox mount `/workspace/<path>` fetch the bytes over the signed agents API (owner only). `attachment:<id>` uses the session attachment. `ipfs://<cid>` goes through the HM gateway, for images and links. Failures degrade to a labeled placeholder instead of a broken image. The message bubble provides the agent/session scope through a React context; outside a transcript such images render as placeholders.
- **Agent guidance corrected.** The system prompt, the binary-file read summary, and the write/ipfs guide now say: to show a file in chat, reference its memory path in markdown; an ipfs:// URL alone does not display until public content references it.

## Validation

- Verbs test: reading a binary memory file through the real read verb yields the new guidance and no bytes; the ipfs guide states the caveat.
- UI test through the real `ChatMessageBubble` with a real react-query client and only the wire faked: a `![…](~/memory/…)` answer issues exactly one signed `ReadAgentMemoryFile` for that agent and path and renders the bytes; plain and ipfs images make no request.
- Resolver/placeholder unit tests. UI suite (416) and verbs suite (44) pass; UI and agents typechecks clean.
- Not covered: pixels in a real browser, and a real model following the new guidance. Cheapest post-deploy check: ask the same agent to show the images again.

## Not in this PR

- The desktop memory tab's "Publish to IPFS" hands out URLs with the same not-public caveat.
- The mobile app's markdown renderer does not get this resolution.
- Whether the daemon should serve orphan UnixFS blobs is a policy question; left as is.
- The matching correction to `hypermedia/agent-security.md` lives on `feat/onyx` (1d9f7ea35), since that folder is not on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Msk4TkhjQ1C5BCUs4i5pR5
