### PR TITLE
fix(cli): authorize both sides of document moves

### DIFF
--- a/frontend/apps/cli/src/commands/document.ts
+++ b/frontend/apps/cli/src/commands/document.ts
@@ -811,6 +811,27 @@ export function registerDocumentCommands(program: Command) {
         const key = await resolveSigningKey(_options.key, keyOptions(globalOpts))
         const signer = createSignerFromKey(key)
 
+        // Resolve both authorizations before publishing either side of the move. The daemon can
+        // accept a Ref blob before asynchronously rejecting it, so publishing first can otherwise
+        // leave a destination behind and let the CLI report success even though the source did not
+        // move.
+        const sourcePath = hmIdPathToEntityQueryPath(source.path)
+        const destPath = hmIdPathToEntityQueryPath(dest.path)
+        const sourceCapability = await resolveCapability(client, source.uid, key.accountId, sourcePath)
+        if (source.uid !== key.accountId && !sourceCapability) {
+          throw new Error(
+            `No WRITER or AGENT capability found for key ${key.accountId} on source account ${source.uid}. ` +
+              `Use "account capabilities hm://${source.uid}" to check available capabilities.`,
+          )
+        }
+        const destCapability = await resolveCapability(client, dest.uid, key.accountId, destPath)
+        if (dest.uid !== key.accountId && !destCapability) {
+          throw new Error(
+            `No WRITER or AGENT capability found for key ${key.accountId} on destination account ${dest.uid}. ` +
+              `Use "account capabilities hm://${dest.uid}" to check available capabilities.`,
+          )
+        }
+
         // A move acts on whatever lives at the source and keeps it that kind of thing at the
         // destination. Following redirects tells us which: a republish moves as a republish; a
         // plain document moves as a fork of its history; a path that has itself already moved is a
@@ -840,12 +861,13 @@ export function registerDocumentCommands(program: Command) {
           const destRepublishInput = await createRedirectRef(
             {
               space: dest.uid,
-              path: hmIdPathToEntityQueryPath(dest.path),
+              path: destPath,
               genesis,
               generation: Date.now(),
               targetSpace: original.uid,
               targetPath: hmIdPathToEntityQueryPath(original.path),
               republish: true,
+              capability: destCapability,
             },
             signer,
           )
@@ -856,10 +878,11 @@ export function registerDocumentCommands(program: Command) {
           const versionRefInput = await createVersionRef(
             {
               space: dest.uid,
-              path: hmIdPathToEntityQueryPath(dest.path),
+              path: destPath,
               genesis,
               version: followed.document.version,
               generation: Date.now(),
+              capability: destCapability,
             },
             signer,
           )
@@ -870,11 +893,12 @@ export function registerDocumentCommands(program: Command) {
         const redirectRefInput = await createRedirectRef(
           {
             space: source.uid,
-            path: hmIdPathToEntityQueryPath(source.path),
+            path: sourcePath,
             genesis,
             generation: Date.now(),
             targetSpace: dest.uid,
-            targetPath: hmIdPathToEntityQueryPath(dest.path),
+            targetPath: destPath,
+            capability: sourceCapability,
           },
           signer,
         )

--- a/frontend/apps/cli/src/test/cli-fixture.test.ts
+++ b/frontend/apps/cli/src/test/cli-fixture.test.ts
@@ -1614,6 +1614,32 @@ describe('CLI Full Integration Tests', () => {
       TEST_TIMEOUT,
     )
 
+    test(
+      'document move rejects an unauthorized source before publishing the destination (issue #901)',
+      async () => {
+        const destinationId = `hm://${writeAccount.accountId}/unauthorized-move-${Date.now()}`
+        const moveResult = await runCli(
+          ['document', 'move', FIXTURE_HIERARCHY_HM_ID, destinationId, '--key', TEST_KEY_NAME],
+          {server: ctx.webServerUrl},
+        )
+
+        expect(moveResult.exitCode).toBe(1)
+        expect(moveResult.stderr).toContain('No WRITER or AGENT capability')
+        expect(moveResult.stderr + moveResult.stdout).not.toContain('Document moved')
+
+        const sourceResult = await runCli(['document', 'get', FIXTURE_HIERARCHY_HM_ID, '--json'], {
+          server: ctx.webServerUrl,
+        })
+        expect(sourceResult.exitCode).toBe(0)
+
+        const destinationResult = await runCli(['document', 'get', destinationId, '--json'], {
+          server: ctx.webServerUrl,
+        })
+        expect(destinationResult.exitCode).toBe(1)
+      },
+      TEST_TIMEOUT,
+    )
+
     // --- Document Redirect Tests ---
 
     test(


### PR DESCRIPTION
## Why

`seed-cli document move` could publish both move refs without attaching delegated capabilities. Because the daemon can accept blobs before asynchronously rejecting unauthorized refs, the command could print `Document moved` even though a cross-account move was not authorized. In the worst ordering, the destination ref could be accepted while the source redirect was rejected, leaving a partial operation. This addresses #901.

## What changed

- Resolve authorization for both source and destination paths before publishing either side of a move.
- Fail immediately when the selected key owns neither account and has no WRITER/AGENT capability.
- Attach the destination capability to version or republish refs.
- Attach the source capability to the redirect ref.
- Add an integration regression proving an unauthorized foreign source is rejected, no success is printed, the source remains readable, and the destination does not materialize.

## Behavior

Before: cross-account move refs omitted capabilities and the CLI could report success for an unauthorized or partial move.

After: predictable missing authorization fails before the first publish; same-account moves retain their existing behavior, while delegated moves carry the capability CID used for each affected account/path.

## Validation

- `git diff --check` passed.
- Independent exact-diff review traced `resolveCapability`, `createVersionRef`, and `createRedirectRef` types and found no blocker across same-account, delegated source/destination, and republish flows.
- The pinned Node/pnpm/Bun toolchain was installed, but the monorepo's filtered pnpm install did not complete within repeated 300-second sandbox limits, so local `tsc` and the daemon integration fixture could not run here. CI is required for executable validation; this PR remains draft until it passes.

## Limits / follow-up

This prevents the known missing-capability failure before publication. It does not make the two-publish move atomic against process failure or a later indexing failure; a broader materialization/transaction design should be handled separately rather than hidden in this fix.

### Current validation (2026-09-10)

- Rebased conflict-free onto current upstream main `1d35e974b8276020133a5385d6f49ff776b58598`; exact branch head is `f4f740960782f6f20402b7e37f65004d46828b26` and matches `ion-lion/seed`.
- `git diff --check origin/main...HEAD` passes; the patch remains limited to the move command and its daemon-backed regression fixture.
- A fresh current-main code trace confirms the issue is still reachable: daemon ingestion intentionally stashes unauthorized refs for out-of-order P2P authorization, so the CLI must resolve both capabilities before publishing rather than treating blob acceptance as materialization.
- Exact-head GitHub Typecheck, Lint, shared/desktop/web unit tests, editor E2E, and aggregate check all pass. The generic `integration-tests` job was skipped. The daemon-backed CLI regression remains covered by the companion CI proposal in #1057 and is not claimed as executed on this head.

### Validation status (2026-09-06)

- Exact head `cec7024947f25eb0abcfe5248ef03ec08732c667`: required Typecheck, Lint, shared/desktop/web unit checks, editor E2E, and aggregate check passed.
- The workflow's `integration-tests` job was skipped (`if: inputs.run-integration-tests` on the direct PR run), and that job runs `tests/`, not `frontend/apps/cli/src/test/cli-fixture.test.ts`; therefore the added CLI daemon fixture did **not** run in CI.
- I attempted the exact Bun test locally. Test loading was repaired and the fixture reached daemon startup, but the constrained runner could not compile the required llama.cpp native library within its 300-second execution ceiling, so the daemon never became ready. This is an environment/setup failure before the test body, not a passing claim.
- `git diff --check` passes and the branch is clean.
