### PR TITLE
fix(ui): wait for document handoff before block scroll

### DIFF
--- a/frontend/packages/ui/src/__tests__/use-block-scroll.test.tsx
+++ b/frontend/packages/ui/src/__tests__/use-block-scroll.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import {act} from 'react-dom/test-utils'
 import {createRoot, type Root} from 'react-dom/client'
-import {afterEach, beforeEach, describe, expect, it} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {useBlockScroll} from '../use-block-scroll'
 ;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -47,6 +47,47 @@ describe('useBlockScroll', () => {
     act(() => root.unmount())
     host.remove()
     scrollContainer.remove()
+  })
+
+  it('waits for the two-frame editor handoff before scrolling on initial load', () => {
+    vi.useFakeTimers()
+    const originalRequestAnimationFrame = window.requestAnimationFrame
+    const originalCancelAnimationFrame = window.cancelAnimationFrame
+    const originalWindowScrollTo = window.scrollTo
+    const animationFrames: FrameRequestCallback[] = []
+    const windowScrollCalls: ScrollToOptions[] = []
+    window.requestAnimationFrame = (callback) => {
+      animationFrames.push(callback)
+      return animationFrames.length
+    }
+    window.cancelAnimationFrame = () => {}
+    window.scrollTo = ((options: ScrollToOptions) => windowScrollCalls.push(options)) as typeof window.scrollTo
+    Object.defineProperty(scrollContainer, 'scrollHeight', {value: 800, configurable: true})
+
+    function Harness() {
+      useBlockScroll('block-1')
+      return null
+    }
+
+    try {
+      act(() => root.render(<Harness />))
+      act(() => animationFrames.shift()?.(0))
+      act(() => vi.advanceTimersByTime(0))
+      expect(scrollCalls).toEqual([])
+      expect(windowScrollCalls).toEqual([])
+
+      Object.defineProperty(scrollContainer, 'scrollHeight', {value: 5000, configurable: true})
+      act(() => animationFrames.shift()?.(16))
+      act(() => vi.advanceTimersByTime(0))
+
+      expect(scrollCalls).toEqual([{top: 1284, behavior: 'smooth'}])
+      expect(windowScrollCalls).toEqual([])
+    } finally {
+      window.requestAnimationFrame = originalRequestAnimationFrame
+      window.cancelAnimationFrame = originalCancelAnimationFrame
+      window.scrollTo = originalWindowScrollTo
+      vi.useRealTimers()
+    }
   })
 
   it('leaves only a small margin above the target block', () => {

--- a/frontend/packages/ui/src/use-block-scroll.ts
+++ b/frontend/packages/ui/src/use-block-scroll.ts
@@ -115,14 +115,19 @@ export function useBlockScroll(blockRef: string | null | undefined, options: Blo
       timeoutId = setTimeout(retry, retryDelay)
     }
 
-    // Wait for next frame to allow scroll containers to be created
-    let rafId = requestAnimationFrame(() => {
-      timeoutId = setTimeout(retry, 0)
+    // The SSR placeholder remains for two frames while editor node views mount.
+    // Wait for that handoff before treating the target's position as final.
+    let secondRafId = 0
+    const rafId = requestAnimationFrame(() => {
+      secondRafId = requestAnimationFrame(() => {
+        timeoutId = setTimeout(retry, 0)
+      })
     })
 
     let timeoutId: ReturnType<typeof setTimeout>
     return () => {
       cancelAnimationFrame(rafId)
+      if (secondRafId) cancelAnimationFrame(secondRafId)
       clearTimeout(timeoutId)
     }
   }, [blockRef, behavior, block])


### PR DESCRIPTION
## Summary
- wait through the existing two-frame SSR-to-editor handoff before resolving a route block fragment
- keep the existing missing-target retry behavior after the live editor layout is ready
- add a deterministic regression covering the premature window-scroll fallback

Fixes #953.

## Validation
- `vitest --run src/__tests__/use-block-scroll.test.tsx` (3 passed)
- regression test fails against `origin/main` by observing the first-frame window scroll
- Prettier check passed for both changed files
- `git diff --check` passed
- `@shm/ui` typecheck was attempted twice but exceeded this sandbox's memory limit (Node OOM at 256 MB; process killed at larger heap limits); CI remains authoritative for typecheck
