### PR TITLE
ci: run CLI fixture tests on relevant PRs

### DIFF
--- a/.github/workflows/test-cli-fixture.yml
+++ b/.github/workflows/test-cli-fixture.yml
@@ -48,7 +48,7 @@ jobs:
           go-version: '1.26.2'
 
       - name: Install native build dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential cmake
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake gnome-keyring libsecret-tools
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
@@ -94,7 +94,11 @@ jobs:
       # The package script boots one daemon and one web dev server for the whole
       # fixture suite, so the native stack is compiled once rather than per test.
       - name: Run CLI fixture tests
-        run: pnpm --filter @seed-hypermedia/cli test
+        run: |
+          dbus-run-session -- bash -c '
+            eval "$(printf %s ci-test-keyring | gnome-keyring-daemon --unlock)"
+            pnpm --filter @seed-hypermedia/cli test
+          '
         env:
           CGO_ENABLED: '1'
           GOFLAGS: '-tags=cpu'

--- a/.github/workflows/test-cli-fixture.yml
+++ b/.github/workflows/test-cli-fixture.yml
@@ -1,0 +1,102 @@
+name: CLI Fixture Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/test-cli-fixture.yml'
+      - 'backend/**'
+      - 'frontend/apps/cli/**'
+      - 'frontend/apps/web/**'
+      - 'frontend/packages/client/**'
+      - 'frontend/packages/shared/**'
+      - 'test-fixtures/**'
+      - 'pnpm-lock.yaml'
+
+concurrency:
+  group: cli-fixture-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cli-fixture-tests:
+    name: CLI daemon fixture tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.10'
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.2'
+
+      - name: Install native build dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Cache GGUF model
+        uses: actions/cache@v4
+        with:
+          path: backend/llm/backends/llamacpp/models/*.gguf
+          key: gguf-model-granite-v2
+          enableCrossOsArchive: true
+
+      - name: Download GGUF model
+        run: |
+          model=backend/llm/backends/llamacpp/models/granite-embedding-107m-multilingual-Q8_0.gguf
+          if [ ! -f "$model" ]; then
+            mkdir -p "$(dirname "$model")"
+            curl -fSL -o "$model" \
+              "https://huggingface.co/keisuke-miyako/granite-embedding-107m-multilingual-gguf-q8_0/resolve/main/granite-embedding-107m-multilingual-Q8_0.gguf?download=true"
+          fi
+
+      - name: Compute llama-go submodule SHA
+        id: llama-sha
+        run: echo "sha=$(git -C backend/util/llama-go rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache llama.cpp build
+        id: llama-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            backend/util/llama-go/libbinding.a
+            backend/util/llama-go/libllama.a
+            backend/util/llama-go/libggml*.a
+            backend/util/llama-go/libcommon.a
+            backend/util/llama-go/build
+          key: llama-cpu-linux-${{ runner.arch }}-${{ steps.llama-sha.outputs.sha }}
+
+      - name: Build llama.cpp (CPU-only)
+        if: steps.llama-cache.outputs.cache-hit != 'true'
+        run: |
+          cd backend/util/llama-go
+          CMAKE_ARGS="-DBUILD_SHARED_LIBS=OFF -DGGML_VULKAN=OFF -DGGML_METAL=OFF -DGGML_CUDA=OFF -DGGML_HIP=OFF -DGGML_SYCL=OFF -DGGML_BLAS=OFF" make libbinding.a
+
+      # The package script boots one daemon and one web dev server for the whole
+      # fixture suite, so the native stack is compiled once rather than per test.
+      - name: Run CLI fixture tests
+        run: pnpm --filter @seed-hypermedia/cli test
+        env:
+          CGO_ENABLED: '1'
+          GOFLAGS: '-tags=cpu'
+          LIBRARY_PATH: ${{ github.workspace }}/backend/util/llama-go
+          C_INCLUDE_PATH: ${{ github.workspace }}/backend/util/llama-go

--- a/frontend/apps/cli/src/test/cli-fixture.test.ts
+++ b/frontend/apps/cli/src/test/cli-fixture.test.ts
@@ -121,7 +121,7 @@ describe('CLI Full Integration Tests', () => {
 
         // Default output is markdown with frontmatter and block IDs
         expect(result.stdout).toMatch(/^---/)
-        expect(result.stdout).toContain('name: "Hierarchy Test"')
+        expect(result.stdout).toContain('name: Hierarchy Test')
 
         // Validate the markdown content matches the fixture document
         expect(result.stdout).toContain('Text before first heading')

--- a/frontend/apps/cli/src/test/cli-fixture.test.ts
+++ b/frontend/apps/cli/src/test/cli-fixture.test.ts
@@ -293,7 +293,7 @@ describe('CLI Full Integration Tests', () => {
         // Verify by reading back (default output is markdown with frontmatter).
         const getResult = await runCli(['document', 'get', writeAccountHmId], {server: ctx.webServerUrl})
         expect(getResult.exitCode).toBe(0)
-        expect(getResult.stdout).toContain(`name: "${newTitle}"`)
+        expect(getResult.stdout).toContain(`name: ${newTitle}`)
       },
       TEST_TIMEOUT,
     )
@@ -1221,7 +1221,7 @@ describe('CLI Full Integration Tests', () => {
           })
           expect(result.exitCode).toBe(0)
           // Should output markdown preview (no key needed for dry-run)
-          expect(result.stdout).toContain('name: "Dry Run Test"')
+          expect(result.stdout).toContain('name: Dry Run Test')
         } finally {
           rmSync(tmpDir, {recursive: true, force: true})
         }

--- a/frontend/apps/cli/src/test/setup.ts
+++ b/frontend/apps/cli/src/test/setup.ts
@@ -120,6 +120,9 @@ export async function startDaemon(config: TestConfig = {}): Promise<TestContext>
   const p2pPort = config.p2pPort || basePort + 2
 
   const dataDir = mkdtempSync(join(tmpdir(), 'seed-cli-test-'))
+  // Tests run in headless environments where an OS keyring service may not be
+  // available. Keep daemon credentials inside the already-ephemeral data dir.
+  const keystoreDir = join(dataDir, 'keystore')
 
   console.log(`[test] Starting daemon with testnet: ${testnetName}`)
   console.log(`[test] Data dir: ${dataDir}`)
@@ -137,7 +140,7 @@ export async function startDaemon(config: TestConfig = {}): Promise<TestContext>
     '/bin/sh',
     [
       '-c',
-      `cd "${daemonPath}" && "${goBinary}" run . -data-dir="${dataDir}" -http.port=${httpPort} -grpc.port=${grpcPort} -p2p.port=${p2pPort} -log-level=warn${
+      `cd "${daemonPath}" && "${goBinary}" run . -data-dir="${dataDir}" -keystore-dir="${keystoreDir}" -http.port=${httpPort} -grpc.port=${grpcPort} -p2p.port=${p2pPort} -log-level=warn${
         config.bootstrapPeers ? ` -p2p.bootstrap-peers="${config.bootstrapPeers}"` : ''
       }`,
     ],


### PR DESCRIPTION
## Why now

The authorization regression in #901 is covered by the daemon-backed CLI fixture added in #1055, but the generic frontend workflow does not run `@seed-hypermedia/cli` at all: its unit matrix contains web, shared, and desktop only. Without a dedicated job, changes to the CLI, daemon, or shared client/runtime code can merge without exercising the regression that distinguishes an accepted blob from a materialized authorized move.

## What changed

- Add a pull-request/manual workflow that runs the complete CLI daemon fixture when CLI, backend, web/client/shared runtime, fixture, lockfile, or workflow inputs change.
- Reuse the repository's CPU-only llama.cpp and GGUF cache strategy.
- Boot one daemon and one web process for the complete fixture suite rather than rebuilding the native stack per case.
- Give the headless daemon an ephemeral file keystore and run CLI signing cases inside an isolated DBus/gnome-keyring session.
- Match three stale assertions to the CLI's current valid plain-scalar YAML output.

## Why this approach

Adding the CLI package to the generic frontend unit matrix would make every frontend run provision the native daemon, embedding model, and Secret Service even for unrelated UI changes; that matrix is intentionally lightweight and does not install those dependencies. A separate path-filtered job preserves explicit coverage while containing its cost to changes that can affect the fixture. Running the package script once also lets the suite share its daemon and web process.

The file keystore is limited to the fixture daemon's already-ephemeral data directory. CLI key import still exercises the production Secret Service path through a temporary keyring session rather than weakening production key storage behavior.

## Validation

Exact head `6e42770a29c2bccdccdff690cdfc5ff795251aa9`, rebased without conflicts onto `main` at `1d35e974b8276020133a5385d6f49ff776b58598`:

- [CLI daemon fixture tests](https://github.com/seed-hypermedia/seed/actions/runs/34539034348/job/103077215602) passed.
- [Frontend workflow](https://github.com/seed-hypermedia/seed/actions/runs/34539034336) passed Typecheck, Lint, web/shared/desktop unit tests, editor E2E, and the aggregate check. Generic integration tests were skipped by workflow design.
- The rebased patch is byte-identical to the previously reviewed branch diff; no touched file changed upstream in the rebase range.
- `git diff --check` passed.

## Follow-up / removal condition

If the CLI fixture is split into a lightweight test target that no longer boots the native daemon, fold that target into the generic frontend matrix and retire this dedicated workflow. If CLI signing gains an explicit supported headless keystore, replace the temporary gnome-keyring session with that interface.

Closes the CI coverage gap for #1055; the product fix remains in that PR.
