### PR TITLE
fix(ui): hide moved document redirects

### DIFF
--- a/frontend/packages/ui/src/__tests__/site-file-browser.test.tsx
+++ b/frontend/packages/ui/src/__tests__/site-file-browser.test.tsx
@@ -59,6 +59,25 @@ describe('SiteFileBrowser', () => {
     expect(container.textContent).not.toContain('Untitled Document')
   })
 
+  it('hides move redirects while keeping republished documents', () => {
+    const moved = makeDoc(['old-guide'], 'Moved guide')
+    moved.redirectInfo = {type: 'redirect', target: 'site/new-guide'}
+    const republished = makeDoc(['shared-guide'], 'Shared guide')
+    republished.redirectInfo = {type: 'redirect', target: 'other/guide', republish: true}
+    useDirectoryWithDraftsMock.mockReturnValue({
+      directory: [moved, republished],
+      drafts: [],
+      isLoading: false,
+    })
+
+    act(() => {
+      root.render(<SiteFileBrowser siteId={hmId('site')} activeDocumentId={null} onNavigate={vi.fn()} />)
+    })
+
+    expect(container.textContent).not.toContain('Moved guide')
+    expect(container.textContent).toContain('Shared guide')
+  })
+
   it('renders unpublished drafts in their parent directory', () => {
     useDirectoryWithDraftsMock.mockReturnValue({
       directory: [makeDoc(['guides'], 'Guides')],

--- a/frontend/packages/ui/src/site-file-browser.tsx
+++ b/frontend/packages/ui/src/site-file-browser.tsx
@@ -69,16 +69,18 @@ export function SiteFileBrowser({
         )
         .map((draft) => [draft.editId.id, draft]),
     )
-    const published = (directory ?? []).map((document) => {
-      const draft = draftEdits.get(document.id.id)
-      return draft
-        ? {
-            ...document,
-            metadata: {...document.metadata, ...draft.metadata},
-            isCollection: draft.isCollection ?? document.isCollection,
-          }
-        : document
-    })
+    const published = (directory ?? [])
+      .filter((document) => !document.redirectInfo || document.redirectInfo.republish)
+      .map((document) => {
+        const draft = draftEdits.get(document.id.id)
+        return draft
+          ? {
+              ...document,
+              metadata: {...document.metadata, ...draft.metadata},
+              isCollection: draft.isCollection ?? document.isCollection,
+            }
+          : document
+      })
     const unpublished = drafts.flatMap((draft) => {
       const {editId, locationId} = draft as HMListedDraftWithLocation
       if (!locationId || (editId && !isDraftPlaceholderPath(editId.path, draft.id))) return []


### PR DESCRIPTION
## Why now

Issue #972 reports that moving a document leaves its source redirect visible beside the destination in the site file browser. The document route already follows move redirects through `useResource`, but the directory response still reaches the shared browser as a normal row. Republish redirects are different: they intentionally expose target content at the source path and must remain visible.

## What changed

- hide only plain move redirects from the shared site file browser
- preserve republish redirects
- cover both boundaries with a focused component regression test

## Why this approach

Filtering the existing directory response avoids a resource request per row and keeps redirect semantics centralized at the browser boundary. Broadly hiding every redirect would break republished paths, so the predicate excludes only redirects without the republish flag.

## Validation

- focused component regression: `pnpm --filter @shm/ui exec vitest --run src/__tests__/site-file-browser.test.tsx` — 11 passed
- exact current-main source: `4b356bfb29a801a6ad310e16942e3f1dc72a66fd`
- deterministic web baseline: [run 34695901437](https://github.com/ion-lion/seed/actions/runs/34695901437) reproduced the stale row (`Moved guide = 2`) while retaining the republish path
- unchanged web assertion on PR head `b918b5a99b026253363fee9ed2adb5e4a7bb1905`: [run 34695902396](https://github.com/ion-lion/seed/actions/runs/34695902396) passed (`Moved guide = 1`, `Republished guide = 1`); summary SHA-256 `6179984eb80701feeabe2eaceabd7ab0440115c46c521c65491050167086b57b`, trace SHA-256 `239645805dad6a8abfcca1d52e77e4edbffdd9d42b9d04f4b810b7c0bd02e097`
- exact-main packaged Electron did not reproduce (`Moved guide = 1`, `Republished guide = 1`), bounding the live defect to web rather than claiming a desktop repair
- Prettier and `git diff --check` passed; PR CI is green at the exact head

## Follow-up / removal condition

No temporary compatibility layer is introduced. If the daemon directory API later suppresses plain move redirects while preserving republish redirects, this frontend filter can be removed after the same acceptance fixture passes without it.

Closes #972
