### PR TITLE
fix(search): preserve matching document identity

### DIFF
--- a/backend/api/entities/v1alpha/entities.go
+++ b/backend/api/entities/v1alpha/entities.go
@@ -371,6 +371,14 @@ effective_comment_resources AS (
   )
   WHERE rn = 1
 ),
+document_resource_candidates AS (
+  SELECT DISTINCT f.rowid, refs.resource
+  FROM fts_data f
+  CROSS JOIN structural_blobs refs INDEXED BY structural_blobs_by_genesis_blob
+  WHERE f.type IN ('title', 'document')
+  AND refs.genesis_blob = COALESCE(f.genesis_blob, f.blob_id)
+  AND refs.type = 'Ref'
+),
 current_document_resources AS (
   SELECT rowid, resource, metadata, heads, is_deleted
   FROM (
@@ -385,11 +393,10 @@ current_document_resources AS (
         ORDER BY dg.last_alive_ref_time DESC, resources.id DESC
       ) AS rn
     FROM fts_data f
-    CROSS JOIN resources INDEXED BY resources_by_genesis_blob
-    JOIN document_generations dg
-      ON dg.resource = resources.id
+    JOIN document_resource_candidates candidates ON candidates.rowid = f.rowid
+    JOIN resources ON resources.id = candidates.resource
+    JOIN document_generations dg ON dg.resource = resources.id
     WHERE f.type IN ('title', 'document')
-    AND resources.genesis_blob = COALESCE(f.genesis_blob, f.blob_id)
     -- A genesis can back multiple document paths. Keep only generations that
     -- actually contain the change which produced this FTS row.
     AND rb64_and_count(dg.changes, rb64_create(f.blob_id)) > 0

--- a/backend/api/entities/v1alpha/entities.go
+++ b/backend/api/entities/v1alpha/entities.go
@@ -390,6 +390,9 @@ current_document_resources AS (
       ON dg.resource = resources.id
     WHERE f.type IN ('title', 'document')
     AND resources.genesis_blob = COALESCE(f.genesis_blob, f.blob_id)
+    -- A genesis can back multiple document paths. Keep only generations that
+    -- actually contain the change which produced this FTS row.
+    AND rb64_and_count(dg.changes, rb64_create(f.blob_id)) > 0
     AND dg.generation = (
       SELECT MAX(dg2.generation)
       FROM document_generations dg2

--- a/backend/daemon/daemon_e2e_test.go
+++ b/backend/daemon/daemon_e2e_test.go
@@ -4398,7 +4398,7 @@ func TestSearchEntitiesFilters(t *testing.T) {
 		require.NoError(t, err)
 		kp, err := alice.Storage.KeyStore().GetKey(ctx, "main")
 		require.NoError(t, err)
-		lateRef, err := blob.NewRef(kp, original.GenerationInfo.Generation, oldGenesis, kp.Principal(), path, oldHeads, time.Now(), blob.VisibilityPublic)
+		lateRef, err := blob.NewRef(kp, original.GenerationInfo.Generation, oldGenesis, kp.Principal(), path, oldHeads, time.Now().Round(blob.ClockPrecision), blob.VisibilityPublic)
 		require.NoError(t, err)
 		_, err = alice.RPC.Daemon.StoreBlobs(ctx, &daemon.StoreBlobsRequest{
 			Blobs: []*daemon.Blob{{Cid: lateRef.CID.String(), Data: lateRef.Data}},

--- a/backend/daemon/daemon_e2e_test.go
+++ b/backend/daemon/daemon_e2e_test.go
@@ -4355,6 +4355,72 @@ func TestSearchEntitiesFilters(t *testing.T) {
 		}
 	})
 
+	t.Run("LateOldGenerationRef", func(t *testing.T) {
+		const path = "/cars/generation-search"
+		original, err := createTestDocumentChange(ctx, t, alice, &apitest.DocumentChangeRequest{
+			Account:        aliceAccount,
+			Path:           path,
+			SigningKeyName: "main",
+			Changes: []*documents.DocumentChange{
+				{Op: &documents.DocumentChange_SetMetadata_{
+					SetMetadata: &documents.DocumentChange_SetMetadata{Key: "title", Value: "Obsolete generation title"},
+				}},
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = alice.RPC.DocumentsV3.CreateRef(ctx, &documents.CreateRefRequest{
+			Account:        aliceAccount,
+			Path:           path,
+			SigningKeyName: "main",
+			Target: &documents.RefTarget{
+				Target: &documents.RefTarget_Tombstone_{},
+			},
+		})
+		require.NoError(t, err)
+
+		republished, err := createTestDocumentChange(ctx, t, alice, &apitest.DocumentChangeRequest{
+			Account:        aliceAccount,
+			Path:           path,
+			SigningKeyName: "main",
+			Changes: []*documents.DocumentChange{
+				{Op: &documents.DocumentChange_SetMetadata_{
+					SetMetadata: &documents.DocumentChange_SetMetadata{Key: "title", Value: "Current generation quokka"},
+				}},
+			},
+		})
+		require.NoError(t, err)
+		require.NotEqual(t, original.Genesis, republished.Genesis)
+
+		oldGenesis, err := cid.Decode(original.Genesis)
+		require.NoError(t, err)
+		oldHeads, err := blob.Version(original.Version).Parse()
+		require.NoError(t, err)
+		kp, err := alice.Storage.KeyStore().GetKey(ctx, "main")
+		require.NoError(t, err)
+		lateRef, err := blob.NewRef(kp, original.GenerationInfo.Generation, oldGenesis, kp.Principal(), path, oldHeads, time.Now(), blob.VisibilityPublic)
+		require.NoError(t, err)
+		_, err = alice.RPC.Daemon.StoreBlobs(ctx, &daemon.StoreBlobsRequest{
+			Blobs: []*daemon.Blob{{Cid: lateRef.CID.String(), Data: lateRef.Data}},
+		})
+		require.NoError(t, err)
+
+		res, err := alice.RPC.Entities.SearchEntities(ctx, &entities.SearchEntitiesRequest{
+			Query:      "Current generation quokka",
+			SearchType: entities.SearchType_SEARCH_KEYWORD,
+		})
+		require.NoError(t, err)
+		wantID := "hm://" + aliceAccount + path
+		for _, entity := range res.Entities {
+			if entity.Type == "title" && strings.Contains(entity.Content, "Current generation quokka") {
+				require.Equal(t, wantID, entity.DocId)
+				require.Contains(t, entity.Id, wantID)
+				return
+			}
+		}
+		require.Fail(t, "missing current-generation search result")
+	})
+
 	t.Run("IriFilterSubtree", func(t *testing.T) {
 		// Search with iri_filter scoped to /cars/* — must only return honda and toyota.
 		res, err := alice.RPC.Entities.SearchEntities(ctx, &entities.SearchEntitiesRequest{

--- a/backend/daemon/daemon_e2e_test.go
+++ b/backend/daemon/daemon_e2e_test.go
@@ -4322,6 +4322,39 @@ func TestSearchEntitiesFilters(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	t.Run("DistinctDocumentIDs", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			query       string
+			includeBody bool
+			wantType    string
+		}{
+			{name: "title", query: "Why Honda", wantType: "title"},
+			{name: "body", query: "Honda reliability", includeBody: true, wantType: "document"},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				res, err := alice.RPC.Entities.SearchEntities(ctx, &entities.SearchEntitiesRequest{
+					Query:       test.query,
+					IncludeBody: test.includeBody,
+					SearchType:  entities.SearchType_SEARCH_KEYWORD,
+				})
+				require.NoError(t, err)
+
+				wantID := "hm://" + aliceAccount + "/cars/honda"
+				for _, entity := range res.Entities {
+					if entity.Type == test.wantType && strings.Contains(entity.Content, test.query) {
+						require.Equal(t, wantID, entity.DocId)
+						require.Contains(t, entity.Id, wantID)
+						return
+					}
+				}
+				require.Failf(t, "missing search result", "no %s result contained %q", test.wantType, test.query)
+			})
+		}
+	})
+
 	t.Run("IriFilterSubtree", func(t *testing.T) {
 		// Search with iri_filter scoped to /cars/* — must only return honda and toyota.
 		res, err := alice.RPC.Entities.SearchEntities(ctx, &entities.SearchEntitiesRequest{


### PR DESCRIPTION
## Summary
- constrain SearchEntities document-path resolution to generations that contain the matching FTS change
- retain current moved/republished-path selection among valid generations
- cover distinct title and body hits across multiple documents in one space

## Root cause
`current_document_resources` matched every live resource sharing a genesis, then selected the newest one. A genesis can back multiple document paths, so unrelated hits inherited the newest document ID. The generation already stores its reachable change set; intersecting it with the FTS row blob preserves the hit's document identity.

## Validation
- `gofmt` on both touched Go files
- `git diff --check`
- focused backend regression added; exact-head GitHub CI requested because the coordinator microVM's 128 MB `/tmp` cannot compile the backend test package without violating repository sandbox guidance

Closes #948