### PR TITLE
fix(desktop): push joined-site contacts after publish

### DIFF
--- a/frontend/apps/desktop/src/components/__tests__/desktop-intents.test.tsx
+++ b/frontend/apps/desktop/src/components/__tests__/desktop-intents.test.tsx
@@ -1,0 +1,108 @@
+import {hmId} from '@shm/shared/utils/entity-id-url'
+import {act} from 'react-dom/test-utils'
+import {createRoot, Root} from 'react-dom/client'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+const {createContactMock, publishMock, pushAfterActionMock, requestMock, setSubscriptionMock} = vi.hoisted(() => ({
+  createContactMock: vi.fn(),
+  publishMock: vi.fn(),
+  pushAfterActionMock: vi.fn(),
+  requestMock: vi.fn(),
+  setSubscriptionMock: vi.fn(),
+}))
+
+vi.mock('@/models/push-after-action', () => ({
+  usePushAfterAction: () => pushAfterActionMock,
+}))
+
+vi.mock('@/models/subscription', () => ({
+  useSetSubscription: () => ({isPending: false, mutate: setSubscriptionMock}),
+}))
+
+vi.mock('@/selected-account', () => ({
+  useSelectedAccountId: () => 'z6MkJoiningAccount',
+}))
+
+vi.mock('@seed-hypermedia/client', () => ({
+  createContact: createContactMock,
+  updateContact: vi.fn(),
+}))
+
+vi.mock('@shm/shared', () => ({
+  queryKeys: {
+    CONTACTS_ACCOUNT: 'contacts-account',
+    CONTACTS_SUBJECT: 'contacts-subject',
+  },
+  useUniversalClient: () => ({
+    getSigner: vi.fn(() => ({sign: vi.fn()})),
+    publish: publishMock,
+    request: requestMock,
+  }),
+}))
+
+vi.mock('@shm/shared/models/query-client', () => ({
+  invalidateQueries: vi.fn(),
+}))
+
+vi.mock('@shm/ui/toast', () => ({
+  toast: {error: vi.fn(), success: vi.fn()},
+}))
+
+vi.mock('../desktop-auth-dialog', () => ({
+  useDesktopAuthDialog: () => ({content: null, open: vi.fn()}),
+}))
+
+import {useJoinSiteIntent} from '../desktop-intents'
+
+function renderHook<T>(useHook: () => T) {
+  let result: T
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  function TestComponent() {
+    result = useHook()
+    return null
+  }
+
+  act(() => root.render(<TestComponent />))
+  return {container, root, result: () => result!}
+}
+
+function cleanupRendered(root: Root, container: HTMLDivElement) {
+  act(() => root.unmount())
+  container.remove()
+}
+
+describe('desktop Join site intent', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('pushes the joining account after publishing its site contact', async () => {
+    requestMock.mockResolvedValue([])
+    createContactMock.mockResolvedValue({blobs: [{cid: 'contact', data: new Uint8Array()}]})
+    publishMock.mockResolvedValue(undefined)
+
+    const {container, root, result} = renderHook(() => useJoinSiteIntent('z6MkJoinedSite', 'Joined Site'))
+    try {
+      act(() => result().join())
+
+      await vi.waitFor(() => {
+        expect(pushAfterActionMock).toHaveBeenCalledWith({
+          id: hmId('z6MkJoiningAccount'),
+          trigger: 'publish',
+        })
+      })
+      expect(publishMock).toHaveBeenCalledTimes(1)
+      expect(publishMock.mock.invocationCallOrder[0]).toBeLessThan(pushAfterActionMock.mock.invocationCallOrder[0]!)
+      expect(setSubscriptionMock).toHaveBeenCalledWith({
+        id: hmId('z6MkJoinedSite'),
+        subscribed: true,
+        recursive: true,
+      })
+    } finally {
+      cleanupRendered(root, container)
+    }
+  })
+})

--- a/frontend/apps/desktop/src/components/desktop-intents.tsx
+++ b/frontend/apps/desktop/src/components/desktop-intents.tsx
@@ -1,3 +1,4 @@
+import {usePushAfterAction} from '@/models/push-after-action'
 import {useSetSubscription} from '@/models/subscription'
 import {useSelectedAccountId} from '@/selected-account'
 import {createContact, updateContact} from '@seed-hypermedia/client'
@@ -98,6 +99,7 @@ export function useContactSubscribeIntent() {
 export function useJoinSiteIntent(siteUid: string, siteName?: string) {
   const {content, requireAccount} = useDesktopAccountIntent()
   const subscribeContact = useContactSubscribeIntent()
+  const pushAfterAction = usePushAfterAction()
   const setSubscription = useSetSubscription()
 
   const join = useCallback(() => {
@@ -106,6 +108,7 @@ export function useJoinSiteIntent(siteUid: string, siteName?: string) {
         if (accountUid === siteUid) return
         try {
           await subscribeContact({accountUid, subjectUid: siteUid, subscribe: 'site'})
+          pushAfterAction({id: hmId(accountUid), trigger: 'publish'})
           setSubscription.mutate({id: hmId(siteUid), subscribed: true, recursive: true})
           toast.success(`Joined ${siteName || 'space'}`)
         } catch (error) {
@@ -119,7 +122,7 @@ export function useJoinSiteIntent(siteUid: string, siteName?: string) {
         siteName,
       },
     )
-  }, [requireAccount, setSubscription, siteName, siteUid, subscribeContact])
+  }, [pushAfterAction, requireAccount, setSubscription, siteName, siteUid, subscribeContact])
 
   return {content, join, isPending: setSubscription.isPending}
 }


### PR DESCRIPTION
Fixes #973.

Desktop Join already publishes a signed Contact locally, but unlike document/comment publish flows it did not invoke the configured post-publish push. Push the joining account root after the Contact publish succeeds; account-root material includes authored Contact blobs, making the join available to the web gateway and other syncing clients while respecting the existing push-on-publish preference.

Adds a focused hook regression that fails on `main`, verifies the Contact publish happens first, and checks the existing site subscription still starts.

Validation:
- `vitest run src/components/__tests__/desktop-intents.test.tsx`
- focused Prettier check
- `git diff --check`
- desktop typecheck attempted, but the 256 MB executor exhausted its Node heap before reporting diagnostics