### PR TITLE
fix: discard empty failed discovery scopes

### DIFF
--- a/backend/hmnet/syncing/discovery.go
+++ b/backend/hmnet/syncing/discovery.go
@@ -115,6 +115,23 @@ func (s *Service) DiscoverObjectWithProgress(ctx context.Context, entityID blob.
 		return "", fmt.Errorf("remote content discovery is disabled")
 	}
 
+	indexKey := DiscoveryKey{
+		IRI:       entityID,
+		Recursive: recursive,
+		DepthOne:  depthOne,
+		BlobTypes: BlobTypesString(blobTypes),
+	}
+	defer func() {
+		if resultVersion != "" {
+			return
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		if err := deleteEmptyScope(cleanupCtx, s.db, indexKey); err != nil {
+			s.log.Debug("RBSREmptyScopeCleanupFailed", zap.String("iri", string(entityID)), zap.Error(err))
+		}
+	}()
+
 	discoverStart := time.Now()
 	// This is the single entry point for every sync session — scheduler tasks,
 	// gRPC DiscoverEntity, and direct subscription calls all funnel here — so

--- a/backend/hmnet/syncing/rbsr_index.go
+++ b/backend/hmnet/syncing/rbsr_index.go
@@ -317,6 +317,47 @@ const qMaterializeReplace = `
 	JOIN blobs b INDEXED BY blobs_metadata ON b.id = rb.id
 	WHERE b.size >= 0;`
 
+var qEmptyScopeExists = dqb.Str(`
+	SELECT 1 FROM rbsr_scope s
+	WHERE s.iri = :iri
+	AND s.kind = :kind
+	AND NOT EXISTS (SELECT 1 FROM rbsr_item WHERE scope = s.id);`)
+
+var qDeleteEmptyScope = dqb.Str(`
+	DELETE FROM rbsr_scope
+	WHERE iri = :iri
+	AND kind = :kind
+	AND NOT EXISTS (SELECT 1 FROM rbsr_item WHERE scope = rbsr_scope.id);`)
+
+// deleteEmptyScope removes a maintained scope that discovered no blobs. It is
+// called after a discovery wave, so the scope remains available to incremental
+// maintenance while blocks are arriving but nonexistent arbitrary paths do not
+// become durable registry rows.
+func deleteEmptyScope(ctx context.Context, db *sqlitex.Pool, dkey DiscoveryKey) error {
+	kind, err := scopeKindFor(dkey)
+	if err != nil {
+		if errors.Is(err, errScopeNotRepresentable) {
+			return nil
+		}
+		return err
+	}
+
+	args := []any{string(dkey.IRI), int64(kind)}
+	var empty bool
+	if err := db.WithSave(ctx, func(conn *sqlite.Conn) error {
+		return sqlitex.Exec(conn, qEmptyScopeExists(), func(*sqlite.Stmt) error {
+			empty = true
+			return nil
+		}, args...)
+	}); err != nil || !empty {
+		return err
+	}
+
+	return db.WithTx(ctx, func(conn *sqlite.Conn) error {
+		return sqlitex.Exec(conn, qDeleteEmptyScope(), nil, args...)
+	})
+}
+
 var qMaterializeClear = dqb.Str(`DELETE FROM rbsr_item WHERE scope = :scope;`)
 
 var qMarkMaterialized = dqb.Str(`

--- a/backend/hmnet/syncing/rbsr_index_test.go
+++ b/backend/hmnet/syncing/rbsr_index_test.go
@@ -57,6 +57,54 @@ func TestRbsrIndex_BuildMatchesLoadRBSRStore(t *testing.T) {
 	require.Equal(t, fingerprintOf(t, want), fingerprintOf(t, got), "fingerprints must match")
 }
 
+func TestDeleteEmptyScope(t *testing.T) {
+	t.Parallel()
+	db, base := oracleFixture(t)
+	ctx := t.Context()
+	dkey := DiscoveryKey{IRI: blob.IRI(base + "/missing")}
+
+	require.NoError(t, loadAndSealIndexedScope(ctx, db, dkey))
+	require.Equal(t, 1, countScopeRows(t, db, dkey))
+
+	require.NoError(t, deleteEmptyScope(ctx, db, dkey))
+	require.Zero(t, countScopeRows(t, db, dkey), "an empty failed discovery scope must not persist")
+}
+
+func TestDeleteEmptyScopeRetainsPopulatedScope(t *testing.T) {
+	t.Parallel()
+	db, base := oracleFixture(t)
+	ctx := t.Context()
+	dkey := DiscoveryKey{IRI: blob.IRI(base), Recursive: true}
+
+	require.NoError(t, loadAndSealIndexedScope(ctx, db, dkey))
+	require.NotEmpty(t, itemSetForScope(t, db, scopeIDFor(t, db, dkey)))
+
+	require.NoError(t, deleteEmptyScope(ctx, db, dkey))
+	require.Equal(t, 1, countScopeRows(t, db, dkey), "a populated scope must remain maintained")
+}
+
+func loadAndSealIndexedScope(ctx context.Context, db *sqlitex.Pool, dkey DiscoveryKey) error {
+	store := newAuthorizedTreeStore()
+	if _, err := loadIndexedScopes(ctx, db, colx.HashSet[DiscoveryKey]{dkey: {}}, store); err != nil {
+		return err
+	}
+	return store.Seal()
+}
+
+func countScopeRows(t *testing.T, db *sqlitex.Pool, dkey DiscoveryKey) int {
+	t.Helper()
+	kind, err := scopeKindFor(dkey)
+	require.NoError(t, err)
+	var count int
+	require.NoError(t, db.WithSave(t.Context(), func(conn *sqlite.Conn) error {
+		return sqlitex.Exec(conn, `SELECT COUNT(*) FROM rbsr_scope WHERE iri = ? AND kind = ?`, func(stmt *sqlite.Stmt) error {
+			count = stmt.ColumnInt(0)
+			return nil
+		}, string(dkey.IRI), int64(kind))
+	}))
+	return count
+}
+
 func itemSetForScope(t *testing.T, db *sqlitex.Pool, scopeID int64) map[int64]struct{} {
 	t.Helper()
 	out := map[int64]struct{}{}


### PR DESCRIPTION
## Summary

- remove a maintained RBSR scope after a discovery wave returns no resource and the scope still contains no blobs
- keep populated scopes intact and make cleanup safe after caller cancellation with a bounded detached context
- avoid acquiring the SQLite writer on the successful/populated path by probing emptiness on a read connection first

Closes #957.

## Why

`DiscoverEntity` accepts arbitrary valid paths. The client-side maintained-index load materializes each path as an `rbsr_scope` row even when it resolves to an empty blob set. With eviction disabled, direct callers can grow the table without bound.

Cleanup runs only after the wave has finished and only when its result version is empty. The conditional delete rechecks that no `rbsr_item` exists in the writer transaction, so a scope populated concurrently is retained. Future attempts for a genuinely absent resource can recreate the cheap scope transiently.

## Validation

- `gofmt` clean
- `git diff --check` clean
- focused tests added for deleting an empty scope and retaining a populated scope
- local `go test ./backend/hmnet/syncing -run 'TestDeleteEmptyScope|TestRbsrIndex' -count=1` could not complete because this executor exposes a fixed 128 MB `/tmp`; compilation exhausted it. GitHub `test-go` and `lint-go` are authoritative.
