### PR TITLE
Mitigate Agent Chat partial-state growth

### DIFF
--- a/frontend/packages/ui/src/__tests__/agent-session-partials.test.ts
+++ b/frontend/packages/ui/src/__tests__/agent-session-partials.test.ts
@@ -1,0 +1,30 @@
+import {describe, expect, test} from 'vitest'
+import {applyAgentSessionPartial} from '../agents/models'
+
+describe('applyAgentSessionPartial', () => {
+  test('an account-wide subscription does not retain partial state for observed sessions', () => {
+    const current = {}
+
+    const next = applyAgentSessionPartial(current, 'account/z6MkViewer', 'sessions/background-session', {
+      textDelta: 'streamed output',
+      usage: {input: 10, output: 4, total: 14},
+    })
+
+    expect(next).toBe(current)
+    expect(next).toEqual({})
+  })
+
+  test('a direct session subscription only accumulates its own partials', () => {
+    const first = applyAgentSessionPartial({}, 'sessions/selected', 'sessions/selected', {textDelta: 'hello'})
+    const unrelated = applyAgentSessionPartial(first, 'sessions/selected', 'sessions/background', {
+      textDelta: 'ignored',
+    })
+    const done = applyAgentSessionPartial(unrelated, 'sessions/selected', 'sessions/selected', {
+      done: true,
+      usage: {input: 12, output: 5, total: 17},
+    })
+
+    expect(unrelated).toBe(first)
+    expect(done).toEqual({selected: {text: 'hello', usage: {input: 12, output: 5, total: 17}}})
+  })
+})

--- a/frontend/packages/ui/src/__tests__/agent-session-partials.test.ts
+++ b/frontend/packages/ui/src/__tests__/agent-session-partials.test.ts
@@ -7,7 +7,7 @@ describe('applyAgentSessionPartial', () => {
 
     const next = applyAgentSessionPartial(current, 'account/z6MkViewer', 'sessions/background-session', {
       textDelta: 'streamed output',
-      usage: {input: 10, output: 4, total: 14},
+      usage: {input: 10, output: 4, cacheRead: 0, cacheWrite: 0, total: 14},
     })
 
     expect(next).toBe(current)
@@ -21,10 +21,15 @@ describe('applyAgentSessionPartial', () => {
     })
     const done = applyAgentSessionPartial(unrelated, 'sessions/selected', 'sessions/selected', {
       done: true,
-      usage: {input: 12, output: 5, total: 17},
+      usage: {input: 12, output: 5, cacheRead: 0, cacheWrite: 0, total: 17},
     })
 
     expect(unrelated).toBe(first)
-    expect(done).toEqual({selected: {text: 'hello', usage: {input: 12, output: 5, total: 17}}})
+    expect(done).toEqual({
+      selected: {
+        text: 'hello',
+        usage: {input: 12, output: 5, cacheRead: 0, cacheWrite: 0, total: 17},
+      },
+    })
   })
 })

--- a/frontend/packages/ui/src/agents/models.ts
+++ b/frontend/packages/ui/src/agents/models.ts
@@ -3028,6 +3028,31 @@ function useSignedAgentSocket(
   }, [serverUrl, accountUid, key])
 }
 
+/**
+ * Applies one streamed assistant-state patch only to the directly subscribed session.
+ *
+ * Account subscriptions also receive every session partial, but their callers only need durable
+ * cache invalidations. Ignoring those partials prevents an account socket from retaining live state
+ * for every session it observes and from duplicating the selected session's streaming work.
+ */
+export function applyAgentSessionPartial(
+  current: Record<string, AgentSessionLiveState>,
+  subscribedKey: AgentSubscriptionKey | undefined,
+  eventKey: string,
+  patch: {textDelta?: string; done?: boolean; usage?: AgentRunUsage; activity?: AgentRunActivity},
+): Record<string, AgentSessionLiveState> {
+  if (!subscribedKey?.startsWith('sessions/') || eventKey !== subscribedKey) return current
+  const sessionId = eventKey.slice('sessions/'.length)
+  const existing = current[sessionId] ?? EMPTY_SESSION_LIVE_STATE
+  const next: AgentSessionLiveState = {
+    ...existing,
+    ...(patch.usage ? {usage: patch.usage} : {}),
+    ...(patch.activity ? {activity: patch.activity} : {}),
+  }
+  if (!patch.done) next.text = existing.text + (patch.textDelta || '')
+  return {...current, [sessionId]: next}
+}
+
 /** Subscribes to signed agent-server WebSocket updates and refreshes cached data. */
 export function useAgentWebSocketSubscription(
   serverUrl: string | undefined,
@@ -3104,8 +3129,9 @@ export function useAgentWebSocketSubscription(
       )
       invalidateQueries(['agents', 'detail'])
     } else if (event._ === 'appendPartial') {
-      // Run-keyed partials (workflow progress) are handled by the run-tree hook, not here.
-      if (!event.key.startsWith('sessions/')) return
+      // Account subscriptions also receive every session partial, but their callers only need
+      // durable cache invalidations. Ignore those updates before logging or scheduling React state.
+      if (!key?.startsWith('sessions/') || event.key !== key) return
       const patch = event.patch as {
         textDelta?: string
         done?: boolean
@@ -3123,24 +3149,19 @@ export function useAgentWebSocketSubscription(
         totalTokens: patch.usage?.total,
       })
       setPartials((current) => {
-        const existing = current[sessionId] ?? EMPTY_SESSION_LIVE_STATE
-        // Usage and activity updates always apply, even on the `done` patch.
-        const next: AgentSessionLiveState = {
-          ...existing,
-          ...(patch.usage ? {usage: patch.usage} : {}),
-          ...(patch.activity ? {activity: patch.activity} : {}),
-        }
+        const next = applyAgentSessionPartial(current, key, event.key, patch)
+        if (next === current) return current
+        const totalLength = next[sessionId]?.text.length ?? 0
         if (patch.done) {
           log('partial marked done; keeping visible until durable append', {
             sessionId,
             partialId: event.partialId,
-            totalLength: existing.text.length,
+            totalLength,
           })
-          return {...current, [sessionId]: next}
+        } else {
+          log('partial state updated', {sessionId, partialId: event.partialId, totalLength})
         }
-        next.text = existing.text + (patch.textDelta || '')
-        log('partial state updated', {sessionId, partialId: event.partialId, totalLength: next.text.length})
-        return {...current, [sessionId]: next}
+        return next
       })
     } else if (event._ === 'error') {
       log('server error event', {message: event.message})


### PR DESCRIPTION
## Summary
- ignore session streaming partials received by account-wide Agent Chat subscriptions
- avoid retaining one live-state object per observed session and duplicating the selected session’s streaming work
- preserve direct-session text, usage, and completion behavior with focused regression coverage

## Why
Issue #997 reports an eventual Agent Chat crash during sustained use. Current account subscriptions receive every session partial, even though their callers discard the returned live state. The hook nevertheless retained partial state for every observed session for its full mounted lifetime and duplicated work for the selected session.

This is a narrow, low-risk mitigation for a concrete unbounded growth path. It is not claimed as a definitive root-cause fix because the issue currently has no reproducible steps or crash telemetry.

## Validation
- `pnpm exec vitest --run src/__tests__/agent-session-partials.test.ts` — 2/2 passed
- focused Prettier check passed
- `git diff --check` passed
- `pnpm typecheck` was attempted twice but this constrained executor exhausted its Node/V8 memory budget (exit 134 at default heap, exit 137 at 768 MB) before reporting any TypeScript diagnostic; CI remains authoritative

Relates to #997.
