### PR TITLE
feat(agents-ui): fold tool bursts behind a "Thinking" line; timers on the server clock

### DIFF
--- a/frontend/apps/desktop/src/__tests__/agent-session-rows.test.ts
+++ b/frontend/apps/desktop/src/__tests__/agent-session-rows.test.ts
@@ -7,6 +7,7 @@ import {
   isOptimisticUserEcho,
   mergeConsecutiveToolMessageRows,
   retryableErrorRowKey,
+  sessionTurnStartedAt,
 } from '@shm/ui/agents/agent-session-rows'
 import {decodeAssistantSessionRef, encodeAssistantSessionRef} from '@shm/ui/agents/assistant-session-ref'
 
@@ -927,5 +928,40 @@ describe('continuation rows', () => {
       args: {title: 'Plan the offsite'},
       rawOutput: {successorSessionId: 'session-2'},
     })
+  })
+})
+
+describe('sessionTurnStartedAt', () => {
+  const run = (overrides: Partial<RunInfo>): RunInfo =>
+    ({id: 'run-1', status: 'running', createdAt: 1_000, ...overrides}) as RunInfo
+  const userRows = (createdAt: number) =>
+    buildAgentSessionChatRows([{...event(1, {type: 'message', role: 'user', content: 'go'}), createdAt}], CONTEXT)
+
+  it('anchors the timer on the live run the server reported', () => {
+    expect(sessionTurnStartedAt([], [run({startedAt: 5_000})])).toBe(5_000)
+    expect(sessionTurnStartedAt([], [run({createdAt: 4_000})])).toBe(4_000)
+  })
+
+  it('falls back to the last user message on the log', () => {
+    expect(sessionTurnStartedAt(userRows(3_000), [])).toBe(3_000)
+    expect(sessionTurnStartedAt(userRows(3_000), undefined)).toBe(3_000)
+  })
+
+  it('ignores finished runs, and a parked run older than the message that started this turn', () => {
+    expect(sessionTurnStartedAt(userRows(3_000), [run({status: 'succeeded', startedAt: 9_000})])).toBe(3_000)
+    expect(sessionTurnStartedAt(userRows(3_000), [run({status: 'waiting', startedAt: 1_000})])).toBe(3_000)
+    expect(sessionTurnStartedAt(userRows(3_000), [run({startedAt: 3_500})])).toBe(3_500)
+  })
+
+  it('does not mistake a runtime-authored prompt for the user starting a turn', () => {
+    const rows = buildAgentSessionChatRows(
+      [{...event(1, {type: 'message', role: 'user', content: 'continue', actor: 'system'}), createdAt: 3_000}],
+      CONTEXT,
+    )
+    expect(sessionTurnStartedAt(rows, [])).toBeUndefined()
+  })
+
+  it('knows nothing before the server has said anything', () => {
+    expect(sessionTurnStartedAt([], [])).toBeUndefined()
   })
 })

--- a/frontend/apps/desktop/src/__tests__/agent-session-rows.test.ts
+++ b/frontend/apps/desktop/src/__tests__/agent-session-rows.test.ts
@@ -245,6 +245,24 @@ describe('buildAgentSessionChatRows step timing', () => {
     ])
   })
 
+  it('gives calls issued together the same start, so siblings do not read as milliseconds', () => {
+    const rows = buildAgentSessionChatRows(
+      [
+        event(1, {type: 'message', role: 'user', content: 'go'}),
+        event(2, {type: 'tool_call', id: 'call-1', name: 'read', input: {}}),
+        event(3, {type: 'tool_call', id: 'call-2', name: 'read', input: {}}),
+        event(4, {type: 'tool_result', toolCallId: 'call-1', name: 'read', output: {}}),
+        event(5, {type: 'tool_result', toolCallId: 'call-2', name: 'read', output: {}}),
+        event(6, {type: 'tool_call', id: 'call-3', name: 'read', input: {}}),
+      ],
+      CONTEXT,
+    )
+    const parts = rows.flatMap((row) => (row.kind === 'message' ? row.message.parts ?? [] : []))
+    expect(parts.map((part) => (part.type === 'tool' ? part.stepStartedAt : undefined))).toEqual([
+      1_700_000_000_001, 1_700_000_000_001, 1_700_000_000_005,
+    ])
+  })
+
   it('leaves the first event of a transcript with no step start', () => {
     const rows = buildAgentSessionChatRows(
       [event(1, {type: 'tool_call', id: 'call-1', name: 'search', input: {}})],

--- a/frontend/apps/desktop/src/__tests__/agent-session-rows.test.ts
+++ b/frontend/apps/desktop/src/__tests__/agent-session-rows.test.ts
@@ -227,6 +227,34 @@ describe('buildAgentSessionChatRows', () => {
   })
 })
 
+describe('buildAgentSessionChatRows step timing', () => {
+  it('stamps each call with the event before it, so a step counts the deliberation too', () => {
+    const rows = buildAgentSessionChatRows(
+      [
+        event(1, {type: 'message', role: 'user', content: 'go'}),
+        event(2, {type: 'tool_call', id: 'call-1', name: 'search', input: {}}),
+        event(3, {type: 'tool_result', toolCallId: 'call-1', name: 'search', output: {}}),
+        event(4, {type: 'tool_call', id: 'call-2', name: 'search', input: {}}),
+      ],
+      CONTEXT,
+    )
+    const parts = rows.flatMap((row) => (row.kind === 'message' ? row.message.parts ?? [] : []))
+    const calls = parts.filter((part) => part.type === 'tool')
+    expect(calls.map((part) => part.type === 'tool' && part.stepStartedAt)).toEqual([
+      1_700_000_000_001, 1_700_000_000_003,
+    ])
+  })
+
+  it('leaves the first event of a transcript with no step start', () => {
+    const rows = buildAgentSessionChatRows(
+      [event(1, {type: 'tool_call', id: 'call-1', name: 'search', input: {}})],
+      CONTEXT,
+    )
+    const part = rows[0]!.kind === 'message' ? rows[0]!.message.parts?.[0] : undefined
+    expect(part?.type === 'tool' ? part.stepStartedAt : 'wrong').toBeUndefined()
+  })
+})
+
 describe('retryableErrorRowKey', () => {
   const rows = (events: SessionEvent[]) => buildAgentSessionChatRows(events, CONTEXT)
 

--- a/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
@@ -298,7 +298,6 @@ describe('assistant message rendering', () => {
     // itself, so no "Read" verb in front of it.
     expect(container.textContent).not.toContain('Read')
     expect(container.textContent).toContain('Seed Notes')
-    expect(container.textContent).toContain('hm doc')
     expect(container.textContent).not.toContain('Project status and notes.')
 
     click(findButton(container, (element) => element.textContent === 'Seed Notes'))
@@ -334,7 +333,6 @@ describe('assistant message rendering', () => {
     // The linked path says what was read; no verb in front of it.
     expect(container.textContent).not.toContain('Read')
     expect(container.textContent).toContain('notes/competitors.md')
-    expect(container.textContent).toContain('memory')
     expect(container.textContent).not.toContain('Acme ships weekly.')
 
     click(findButton(container, (element) => element.textContent === 'notes/competitors.md'))
@@ -404,7 +402,6 @@ describe('assistant message rendering', () => {
     })
 
     expect(container.textContent).toContain('bun.sh/blog/bun-v1.2')
-    expect(container.textContent).toContain('web')
 
     click(findButton(container, (element) => element.textContent === 'bun.sh/blog/bun-v1.2'))
     expect(mockState.openUrl).toHaveBeenCalledWith('https://bun.sh/blog/bun-v1.2', false)
@@ -433,7 +430,6 @@ describe('assistant message rendering', () => {
     expect(container.textContent).toContain('Downloaded')
     expect(container.textContent).toContain('dl.txt')
     expect(container.textContent).toContain('from example.com/dl.txt')
-    expect(container.textContent).toContain('memory')
 
     cleanupRendered(root, container)
   })
@@ -941,9 +937,9 @@ describe('thinking group', () => {
     expect(container.textContent).toContain('Thinking (2:00)')
     expect(container.textContent).not.toContain('Found one.')
     expect(container.querySelector('[data-thinking-group="active"]')).toBeTruthy()
-    // The pending row is the one on screen; it says so itself, and the line sits under it.
-    expect(container.textContent).toContain('Running')
-    expect(container.textContent!.indexOf('Running')).toBeLessThan(container.textContent!.indexOf('Thinking ('))
+    // The pending row is the one on screen, its own step time ticking, and the line sits under it.
+    expect(container.querySelector('[aria-label="Time so far"]')?.textContent).toBe('1m 30s')
+    expect(container.textContent!.indexOf('1m 30s')).toBeLessThan(container.textContent!.indexOf('Thinking ('))
 
     act(() => {
       vi.advanceTimersByTime(3_000)
@@ -982,5 +978,67 @@ describe('thinking group', () => {
     expect(container.textContent).toContain('Found mine.')
     expect(container.textContent).toContain('Halfway there.')
     cleanupRendered(root, container)
+  })
+})
+
+describe('tool step time', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-09-07T10:00:00Z'))
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const t0 = Date.parse('2026-09-07T09:58:00Z')
+
+  it('shows the whole step on the row: the deliberation before the call plus the call itself', () => {
+    const {container, root} = renderToolPart({
+      type: 'tool',
+      id: 'call-1',
+      name: 'search',
+      args: {query: 'seed'},
+      result: 'Found 1.',
+      rawOutput: {summary: 'Found 1.'},
+      stepStartedAt: t0,
+      calledAt: t0 + 50_000,
+      completedAt: t0 + 65_000,
+    })
+    expect(container.querySelector('[aria-label="Time taken"]')?.textContent).toBe('1m 5s')
+    // The source chip that used to sit there is gone.
+    expect(container.textContent).not.toContain('search results')
+    cleanupRendered(root, container)
+  })
+
+  it('falls back to the call itself when the log has no step start', () => {
+    const {container, root} = renderToolPart({
+      type: 'tool',
+      id: 'call-1',
+      name: 'search',
+      args: {query: 'seed'},
+      result: 'Found 1.',
+      rawOutput: {summary: 'Found 1.'},
+      calledAt: t0,
+      completedAt: t0 + 400,
+    })
+    expect(container.querySelector('[aria-label="Time taken"]')?.textContent).toBe('0.4s')
+    cleanupRendered(root, container)
+  })
+
+  it('ticks while the call is out, and shows nothing without timing', () => {
+    const live = renderParts([
+      {type: 'tool', id: 'call-1', name: 'search', args: {query: 'seed'}, stepStartedAt: t0, calledAt: t0 + 30_000},
+    ])
+    expect(live.container.querySelector('[aria-label="Time so far"]')?.textContent).toBe('2m 0s')
+    act(() => {
+      vi.advanceTimersByTime(2_000)
+    })
+    expect(live.container.querySelector('[aria-label="Time so far"]')?.textContent).toBe('2m 2s')
+    expect(live.container.textContent).not.toContain('Running')
+    cleanupRendered(live.root, live.container)
+
+    const untimed = renderToolPart({type: 'tool', id: 'call-2', name: 'search', args: {}, result: 'ok', rawOutput: {}})
+    expect(untimed.container.querySelector('[aria-label="Time taken"]')).toBeNull()
+    cleanupRendered(untimed.root, untimed.container)
   })
 })

--- a/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
@@ -86,6 +86,7 @@ vi.mock('@shm/ui/agents/models', () => ({
 }))
 
 import {AgentErrorRow, ChatMessageBubble} from '@shm/ui/agents/message-rendering'
+import {recordServerClockSample, resetServerClocks} from '@shm/ui/agents/server-clock'
 
 /** Renders one assistant bubble carrying the given parts. */
 function renderParts(
@@ -898,6 +899,7 @@ describe('thinking group', () => {
   })
   afterEach(() => {
     vi.useRealTimers()
+    resetServerClocks()
   })
 
   const t0 = Date.parse('2026-09-07T09:58:00Z')
@@ -923,6 +925,8 @@ describe('thinking group', () => {
     expect(container.textContent).toContain('Found two.')
     expect(container.textContent).toContain('Found three.')
     expect(findThinkingToggle(container)?.getAttribute('aria-expanded')).toBe('true')
+    // The line stays at the bottom; opening grows the burst above it.
+    expect(container.textContent!.indexOf('Found three.')).toBeLessThan(container.textContent!.indexOf('Thought for'))
 
     click(findThinkingToggle(container))
     expect(container.textContent).not.toContain('Found one.')
@@ -937,8 +941,9 @@ describe('thinking group', () => {
     expect(container.textContent).toContain('Thinking (2:00)')
     expect(container.textContent).not.toContain('Found one.')
     expect(container.querySelector('[data-thinking-group="active"]')).toBeTruthy()
-    // The pending row is the one on screen; it says so itself.
+    // The pending row is the one on screen; it says so itself, and the line sits under it.
     expect(container.textContent).toContain('Running')
+    expect(container.textContent!.indexOf('Running')).toBeLessThan(container.textContent!.indexOf('Thinking ('))
 
     act(() => {
       vi.advanceTimersByTime(3_000)
@@ -947,6 +952,16 @@ describe('thinking group', () => {
 
     click(findThinkingToggle(container))
     expect(container.textContent).toContain('Found one.')
+    cleanupRendered(root, container)
+  })
+
+  it('counts on the server clock, so skew between the machines does not show in the timer', () => {
+    // The server runs five minutes ahead of this machine; the call was stamped two server-minutes ago.
+    const serverUrl = 'http://agents.test'
+    recordServerClockSample(serverUrl, Date.now() + 5 * 60_000, 'handshake')
+    const {container, root} = renderParts([search('one', 5 * 60_000, false)], {serverUrl})
+    // Locally the call would look like it is three minutes in the future (clamped to 0:00).
+    expect(container.textContent).toContain('Thinking (2:00)')
     cleanupRendered(root, container)
   })
 

--- a/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import {createRoot, Root} from 'react-dom/client'
 import {act} from 'react-dom/test-utils'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
-import type {ChatMessagePart} from '@shm/ui/agents/chat-parts'
+import type {ChatMessagePart, ChatToolPart} from '@shm/ui/agents/chat-parts'
 
 /**
  * Rendering coverage for assistant/agent chat bubbles.
@@ -58,6 +58,7 @@ vi.mock('@shm/shared/utils/entity-id-url', async () => {
 
 vi.mock('@shm/ui/agents/markdown', () => ({
   Markdown: ({children}: {children: React.ReactNode}) => React.createElement('div', null, children),
+  MarkdownAssetContext: React.createContext(null),
 }))
 
 vi.mock('@shm/shared/models/entity', () => ({
@@ -86,21 +87,40 @@ vi.mock('@shm/ui/agents/models', () => ({
 
 import {AgentErrorRow, ChatMessageBubble} from '@shm/ui/agents/message-rendering'
 
-/** Renders one assistant bubble carrying the given tool part. */
-function renderToolPart(part: ChatMessagePart, serverUrl?: string, agentId?: string) {
+/** Renders one assistant bubble carrying the given parts. */
+function renderParts(
+  parts: ChatMessagePart[],
+  options: {serverUrl?: string; agentId?: string; isLiveTail?: boolean} = {},
+) {
   const container = document.createElement('div')
   document.body.appendChild(container)
   const root = createRoot(container)
   act(() => {
     root.render(
       <ChatMessageBubble
-        message={{role: 'assistant', content: '', parts: [part]}}
-        serverUrl={serverUrl}
-        agentId={agentId}
+        message={{role: 'assistant', content: '', parts}}
+        serverUrl={options.serverUrl}
+        agentId={options.agentId}
+        isLiveTail={options.isLiveTail}
       />,
     )
   })
   return {container, root}
+}
+
+/** The "Thinking" / "Thought for" line that folds a burst of tool calls. */
+function findThinkingToggle(container: HTMLElement) {
+  return findButton(container, (element) => /^(Thinking|Thought for|Finished thinking)/.test(element.textContent ?? ''))
+}
+
+/**
+ * Renders one assistant bubble carrying the given tool part, opened: a settled tool call folds
+ * behind its "Thought" line, and these cases are about the row itself.
+ */
+function renderToolPart(part: ChatMessagePart, serverUrl?: string, agentId?: string) {
+  const rendered = renderParts([part], {serverUrl, agentId})
+  click(findThinkingToggle(rendered.container))
+  return rendered
 }
 
 /** Renders a bubble for an errored assistant message. */
@@ -867,6 +887,85 @@ describe('event info dialogs', () => {
     expect(document.body.textContent).toContain('Output')
     expect(document.body.textContent).not.toContain('Duration')
 
+    cleanupRendered(root, container)
+  })
+})
+
+describe('thinking group', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-09-07T10:00:00Z'))
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const t0 = Date.parse('2026-09-07T09:58:00Z')
+  const search = (id: string, offsetMs: number, done = true): ChatToolPart => ({
+    type: 'tool',
+    id,
+    name: 'search',
+    args: {query: id},
+    calledAt: t0 + offsetMs,
+    ...(done ? {result: `Found ${id}.`, rawOutput: {summary: `Found ${id}.`}, completedAt: t0 + offsetMs + 5_000} : {}),
+  })
+
+  it('folds a settled burst behind "Thought for", and the line opens and closes it', () => {
+    const {container, root} = renderParts([search('one', 0), search('two', 60_000), search('three', 115_000)])
+
+    expect(container.textContent).toContain('Thought for 2 minutes')
+    expect(container.textContent).toContain('3 tool calls')
+    expect(container.textContent).not.toContain('Found one.')
+    expect(container.textContent).not.toContain('Found three.')
+
+    click(findThinkingToggle(container))
+    expect(container.textContent).toContain('Found one.')
+    expect(container.textContent).toContain('Found two.')
+    expect(container.textContent).toContain('Found three.')
+    expect(findThinkingToggle(container)?.getAttribute('aria-expanded')).toBe('true')
+
+    click(findThinkingToggle(container))
+    expect(container.textContent).not.toContain('Found one.')
+    expect(findThinkingToggle(container)?.getAttribute('aria-expanded')).toBe('false')
+    cleanupRendered(root, container)
+  })
+
+  it('ticks "Thinking" over only the most recent call while a call is pending', () => {
+    const {container, root} = renderParts([search('one', 0), search('two', 30_000, false)])
+
+    // Timed from the first call: two minutes ago at the mocked clock.
+    expect(container.textContent).toContain('Thinking (2:00)')
+    expect(container.textContent).not.toContain('Found one.')
+    expect(container.querySelector('[data-thinking-group="active"]')).toBeTruthy()
+    // The pending row is the one on screen; it says so itself.
+    expect(container.textContent).toContain('Running')
+
+    act(() => {
+      vi.advanceTimersByTime(3_000)
+    })
+    expect(container.textContent).toContain('Thinking (2:03)')
+
+    click(findThinkingToggle(container))
+    expect(container.textContent).toContain('Found one.')
+    cleanupRendered(root, container)
+  })
+
+  it('stays live at the tail of a streaming session even between calls', () => {
+    const {container, root} = renderParts([search('one', 0)], {isLiveTail: true})
+    expect(container.textContent).toContain('Thinking (')
+    expect(container.textContent).toContain('Found one.')
+    cleanupRendered(root, container)
+  })
+
+  it('keeps user-run verbs and status updates out of the fold', () => {
+    const {container, root} = renderParts([
+      search('one', 0),
+      {...search('mine', 10_000), actor: 'user'},
+      {type: 'tool', id: 'st', name: 'status', args: {description: 'Halfway there.'}, result: 'ok', rawOutput: {}},
+    ])
+    expect(container.textContent).toContain('Thought for')
+    expect(container.textContent).toContain('Found mine.')
+    expect(container.textContent).toContain('Halfway there.')
     cleanupRendered(root, container)
   })
 })

--- a/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
@@ -930,12 +930,31 @@ describe('thinking group', () => {
     cleanupRendered(root, container)
   })
 
-  it('counts the deliberation before the first call, so the line never reads shorter than its rows', () => {
-    // The agent set out 22 seconds before it called; the call itself took 5.
-    const {container, root} = renderParts([{...search('one', 22_000), stepStartedAt: t0}])
-    expect(container.textContent).toContain('Thought for 27 seconds')
+  it('tells where the time went: deliberation as a divider before each batch, rows with their own run', () => {
+    // 22s of thinking, then two reads issued together (5s each); 60s more thinking, then one more.
+    const {container, root} = renderParts([
+      {...search('one', 22_000), stepStartedAt: t0},
+      {...search('two', 22_100), stepStartedAt: t0},
+      {...search('three', 87_100), stepStartedAt: t0 + 27_100},
+    ])
+    expect(container.textContent).toContain('Thought for 2 minutes')
     click(findThinkingToggle(container))
-    expect(container.querySelector('[aria-label="Time taken"]')?.textContent).toBe('27s')
+    const dividers = Array.from(container.querySelectorAll('[aria-label="Deliberation"]')).map((el) => el.textContent)
+    expect(dividers).toEqual(['thought for 22s', 'thought for 1m 0s'])
+    const runs = Array.from(container.querySelectorAll('[aria-label="Ran for"]')).map((el) => el.textContent)
+    expect(runs).toEqual(['5s', '5s', '5s'])
+    // The divider sits above the batch it led to.
+    const text = container.textContent!
+    expect(text.indexOf('thought for 22s')).toBeLessThan(text.indexOf('Found one.'))
+    expect(text.indexOf('Found two.')).toBeLessThan(text.indexOf('thought for 1m 0s'))
+    expect(text.indexOf('thought for 1m 0s')).toBeLessThan(text.indexOf('Found three.'))
+    cleanupRendered(root, container)
+  })
+
+  it('leaves out a divider for a pause too short to matter', () => {
+    const {container, root} = renderParts([{...search('one', 400), stepStartedAt: t0}])
+    click(findThinkingToggle(container))
+    expect(container.querySelector('[aria-label="Deliberation"]')).toBeNull()
     cleanupRendered(root, container)
   })
 
@@ -946,8 +965,8 @@ describe('thinking group', () => {
     expect(container.textContent).toContain('Thinking (2:00)')
     expect(container.textContent).not.toContain('Found one.')
     expect(container.querySelector('[data-thinking-group="active"]')).toBeTruthy()
-    // The pending row is the one on screen, its own step time ticking, and the line sits under it.
-    expect(container.querySelector('[aria-label="Time so far"]')?.textContent).toBe('1m 30s')
+    // The pending row is the one on screen, its own run time ticking, and the line sits under it.
+    expect(container.querySelector('[aria-label="Running for"]')?.textContent).toBe('1m 30s')
     expect(container.textContent!.indexOf('1m 30s')).toBeLessThan(container.textContent!.indexOf('Thinking ('))
 
     act(() => {
@@ -990,7 +1009,7 @@ describe('thinking group', () => {
   })
 })
 
-describe('tool step time', () => {
+describe('tool run time', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-09-07T10:00:00Z'))
@@ -1001,7 +1020,7 @@ describe('tool step time', () => {
 
   const t0 = Date.parse('2026-09-07T09:58:00Z')
 
-  it('shows the whole step on the row: the deliberation before the call plus the call itself', () => {
+  it("shows only the tool's own run on the row, from the executor's stamp when it left one", () => {
     const {container, root} = renderToolPart({
       type: 'tool',
       id: 'call-1',
@@ -1012,14 +1031,13 @@ describe('tool step time', () => {
       stepStartedAt: t0,
       calledAt: t0 + 50_000,
       completedAt: t0 + 65_000,
+      meta: {durationMs: 14_800},
     })
-    expect(container.querySelector('[aria-label="Time taken"]')?.textContent).toBe('1m 5s')
-    // The source chip that used to sit there is gone.
-    expect(container.textContent).not.toContain('search results')
+    expect(container.querySelector('[aria-label="Ran for"]')?.textContent).toBe('15s')
     cleanupRendered(root, container)
   })
 
-  it('falls back to the call itself when the log has no step start', () => {
+  it('falls back to the span between call and result', () => {
     const {container, root} = renderToolPart({
       type: 'tool',
       id: 'call-1',
@@ -1027,10 +1045,11 @@ describe('tool step time', () => {
       args: {query: 'seed'},
       result: 'Found 1.',
       rawOutput: {summary: 'Found 1.'},
-      calledAt: t0,
-      completedAt: t0 + 400,
+      stepStartedAt: t0,
+      calledAt: t0 + 20_000,
+      completedAt: t0 + 20_400,
     })
-    expect(container.querySelector('[aria-label="Time taken"]')?.textContent).toBe('0.4s')
+    expect(container.querySelector('[aria-label="Ran for"]')?.textContent).toBe('0.4s')
     cleanupRendered(root, container)
   })
 
@@ -1038,16 +1057,16 @@ describe('tool step time', () => {
     const live = renderParts([
       {type: 'tool', id: 'call-1', name: 'search', args: {query: 'seed'}, stepStartedAt: t0, calledAt: t0 + 30_000},
     ])
-    expect(live.container.querySelector('[aria-label="Time so far"]')?.textContent).toBe('2m 0s')
+    expect(live.container.querySelector('[aria-label="Running for"]')?.textContent).toBe('1m 30s')
     act(() => {
       vi.advanceTimersByTime(2_000)
     })
-    expect(live.container.querySelector('[aria-label="Time so far"]')?.textContent).toBe('2m 2s')
+    expect(live.container.querySelector('[aria-label="Running for"]')?.textContent).toBe('1m 32s')
     expect(live.container.textContent).not.toContain('Running')
     cleanupRendered(live.root, live.container)
 
     const untimed = renderToolPart({type: 'tool', id: 'call-2', name: 'search', args: {}, result: 'ok', rawOutput: {}})
-    expect(untimed.container.querySelector('[aria-label="Time taken"]')).toBeNull()
+    expect(untimed.container.querySelector('[aria-label="Ran for"]')).toBeNull()
     cleanupRendered(untimed.root, untimed.container)
   })
 })

--- a/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
@@ -930,6 +930,15 @@ describe('thinking group', () => {
     cleanupRendered(root, container)
   })
 
+  it('counts the deliberation before the first call, so the line never reads shorter than its rows', () => {
+    // The agent set out 22 seconds before it called; the call itself took 5.
+    const {container, root} = renderParts([{...search('one', 22_000), stepStartedAt: t0}])
+    expect(container.textContent).toContain('Thought for 27 seconds')
+    click(findThinkingToggle(container))
+    expect(container.querySelector('[aria-label="Time taken"]')?.textContent).toBe('27s')
+    cleanupRendered(root, container)
+  })
+
   it('ticks "Thinking" over only the most recent call while a call is pending', () => {
     const {container, root} = renderParts([search('one', 0), search('two', 30_000, false)])
 

--- a/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
@@ -912,7 +912,6 @@ describe('thinking group', () => {
     const {container, root} = renderParts([search('one', 0), search('two', 60_000), search('three', 115_000)])
 
     expect(container.textContent).toContain('Thought for 2 minutes')
-    expect(container.textContent).toContain('3 tool calls')
     expect(container.textContent).not.toContain('Found one.')
     expect(container.textContent).not.toContain('Found three.')
 

--- a/frontend/apps/desktop/src/pages/agents/__tests__/run-work.test.tsx
+++ b/frontend/apps/desktop/src/pages/agents/__tests__/run-work.test.tsx
@@ -209,9 +209,9 @@ describe('journaled tool rows', () => {
       />,
     )
 
-    // The workflow's own words lead, the source chip says where the work happened…
+    // The workflow's own words lead (no source chip beside them — the row's time takes that slot)…
     expect(container.textContent).toContain('Checking what we know about Acme')
-    expect(container.textContent).toContain('memory')
+    expect(container.textContent).not.toContain('memory')
     // …and the narration is itself the way into that memory file.
     const narration = Array.from(container.querySelectorAll('button')).find(
       (button) => button.textContent === 'Checking what we know about Acme',

--- a/frontend/apps/desktop/src/pages/agents/__tests__/run-work.test.tsx
+++ b/frontend/apps/desktop/src/pages/agents/__tests__/run-work.test.tsx
@@ -76,6 +76,7 @@ vi.mock('@shm/shared/utils/entity-id-url', async () => {
 
 vi.mock('@shm/ui/agents/markdown', () => ({
   Markdown: ({children}: {children: React.ReactNode}) => React.createElement('div', null, children),
+  MarkdownAssetContext: React.createContext(null),
 }))
 
 vi.mock('@shm/shared/models/entity', () => ({

--- a/frontend/packages/ui/src/__tests__/server-clock.test.ts
+++ b/frontend/packages/ui/src/__tests__/server-clock.test.ts
@@ -1,0 +1,51 @@
+import {afterEach, describe, expect, it} from 'vitest'
+import {recordServerClockSample, resetServerClocks, serverClockOffset, serverNow} from '../agents/server-clock'
+
+const SERVER = 'http://agents.test'
+
+describe('server clock', () => {
+  afterEach(() => {
+    resetServerClocks()
+  })
+
+  it('assumes no skew for a server it has not heard from', () => {
+    expect(serverClockOffset(SERVER)).toBe(0)
+    expect(serverClockOffset(undefined)).toBe(0)
+    expect(serverNow(SERVER, 1_000)).toBe(1_000)
+  })
+
+  it('takes the handshake stamp as the offset, ahead or behind', () => {
+    recordServerClockSample(SERVER, 10_000, 'handshake', 7_000)
+    expect(serverClockOffset(SERVER)).toBe(3_000)
+    expect(serverNow(SERVER, 8_000)).toBe(11_000)
+
+    recordServerClockSample(SERVER, 5_000, 'handshake', 7_000)
+    expect(serverClockOffset(SERVER)).toBe(-2_000)
+  })
+
+  it('lets an event stamp raise the offset but never lower it', () => {
+    recordServerClockSample(SERVER, 10_000, 'handshake', 7_000)
+    // Stamped before it arrived: a low sample says nothing new.
+    recordServerClockSample(SERVER, 9_500, 'event', 7_500)
+    expect(serverClockOffset(SERVER)).toBe(3_000)
+    // A sample that arrived faster than the handshake did is closer to the truth.
+    recordServerClockSample(SERVER, 10_600, 'event', 7_500)
+    expect(serverClockOffset(SERVER)).toBe(3_100)
+  })
+
+  it('learns from events alone before any handshake, and resets on the next handshake', () => {
+    recordServerClockSample(SERVER, 2_000, 'event', 1_000)
+    expect(serverClockOffset(SERVER)).toBe(1_000)
+    recordServerClockSample(SERVER, 1_000, 'handshake', 1_000)
+    expect(serverClockOffset(SERVER)).toBe(0)
+  })
+
+  it('keeps one offset per server and ignores a non-finite stamp', () => {
+    recordServerClockSample(SERVER, 10_000, 'handshake', 7_000)
+    recordServerClockSample('http://other.test', 1_000, 'handshake', 7_000)
+    expect(serverClockOffset(SERVER)).toBe(3_000)
+    expect(serverClockOffset('http://other.test')).toBe(-6_000)
+    recordServerClockSample(SERVER, Number.NaN, 'handshake', 7_000)
+    expect(serverClockOffset(SERVER)).toBe(3_000)
+  })
+})

--- a/frontend/packages/ui/src/agents/agent-run-status.tsx
+++ b/frontend/packages/ui/src/agents/agent-run-status.tsx
@@ -77,6 +77,22 @@ export function formatElapsed(ms: number): string {
   return `${minutes}:${seconds.toString().padStart(2, '0')}`
 }
 
+/** Formats a settled thinking span in words ("12 seconds", "3 minutes", "1 hour 5 minutes"). */
+export function formatThinkingDuration(ms: number): string {
+  const seconds = Math.round(ms / 1000)
+  if (seconds < 1) return 'less than a second'
+  if (seconds < 60) return plural(seconds, 'second')
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return plural(minutes, 'minute')
+  const hours = Math.floor(minutes / 60)
+  const rest = minutes % 60
+  return rest ? `${plural(hours, 'hour')} ${plural(rest, 'minute')}` : plural(hours, 'hour')
+}
+
+function plural(count: number, unit: string): string {
+  return `${count} ${unit}${count === 1 ? '' : 's'}`
+}
+
 /** Formats a token count compactly (e.g. 1234 → "1.2k"). */
 export function formatTokenCount(count: number): string {
   if (count >= 10_000) return `${Math.round(count / 1000)}k`

--- a/frontend/packages/ui/src/agents/agent-run-status.tsx
+++ b/frontend/packages/ui/src/agents/agent-run-status.tsx
@@ -1,7 +1,7 @@
 import {type AgentRunActivity, type AgentRunUsage} from './client'
 import {cn} from '@shm/ui/utils'
 import {Loader2} from 'lucide-react'
-import {useEffect, useState} from 'react'
+import {useServerNow} from './server-clock'
 
 /**
  * The one live "what is the agent doing right now" status UI, shared by the full
@@ -11,44 +11,35 @@ import {useEffect, useState} from 'react'
  */
 export function AgentRunStatusBar({
   startedAt,
+  serverUrl,
   activity,
   usage,
   className,
 }: {
-  startedAt: number | null
+  /**
+   * When the turn began, by the server's clock (see `sessionTurnStartedAt`). Undefined until the
+   * server has said — the timer waits rather than counting from a guess.
+   */
+  startedAt: number | undefined
+  /** The server whose clock the timer counts against. */
+  serverUrl?: string
   activity?: AgentRunActivity
   usage?: AgentRunUsage
   className?: string
 }) {
-  const [now, setNow] = useState(() => Date.now())
-  useEffect(() => {
-    if (startedAt === null) return
-    setNow(Date.now())
-    const interval = setInterval(() => setNow(Date.now()), 1000)
-    return () => clearInterval(interval)
-  }, [startedAt])
-  const elapsed = startedAt === null ? 0 : Math.max(0, now - startedAt)
+  const now = useServerNow(serverUrl, startedAt !== undefined)
+  const elapsed = startedAt === undefined ? undefined : Math.max(0, now - startedAt)
   return (
     <div className={cn('text-muted-foreground flex items-center gap-2 py-2 text-xs', className)} aria-live="polite">
       <Loader2 className="size-3.5 shrink-0 animate-spin" />
       <span className="font-medium">{activityLabel(activity)}</span>
       {activity?.detail ? <span className="max-w-64 min-w-0 truncate opacity-75">{activity.detail}</span> : null}
       <span className="ml-auto flex shrink-0 items-center gap-3 tabular-nums">
-        <span aria-label="Elapsed time">{formatElapsed(elapsed)}</span>
+        {elapsed !== undefined ? <span aria-label="Elapsed time">{formatElapsed(elapsed)}</span> : null}
         {usage && usage.total > 0 ? <span aria-label="Tokens used">{formatTokenCount(usage.total)} tokens</span> : null}
       </span>
     </div>
   )
-}
-
-/** Tracks when the current run began: set when `isBusy` turns on, cleared when it turns off. */
-export function useRunStartedAt(isBusy: boolean): number | null {
-  const [startedAt, setStartedAt] = useState<number | null>(null)
-  useEffect(() => {
-    if (isBusy) setStartedAt((prev) => prev ?? Date.now())
-    else setStartedAt(null)
-  }, [isBusy])
-  return startedAt
 }
 
 /** Human-readable label for the agent's current activity phase. */

--- a/frontend/packages/ui/src/agents/agent-run-status.tsx
+++ b/frontend/packages/ui/src/agents/agent-run-status.tsx
@@ -68,6 +68,16 @@ export function formatElapsed(ms: number): string {
   return `${minutes}:${seconds.toString().padStart(2, '0')}`
 }
 
+/** Formats a step's wall time compactly: "0.4s", "12s", "1m 5s", "1h 2m". */
+export function formatStepDuration(ms: number): string {
+  if (ms < 1000) return `${(ms / 1000).toFixed(1)}s`
+  const seconds = Math.round(ms / 1000)
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ${seconds % 60}s`
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`
+}
+
 /** Formats a settled thinking span in words ("12 seconds", "3 minutes", "1 hour 5 minutes"). */
 export function formatThinkingDuration(ms: number): string {
   const seconds = Math.round(ms / 1000)

--- a/frontend/packages/ui/src/agents/agent-session-rows.ts
+++ b/frontend/packages/ui/src/agents/agent-session-rows.ts
@@ -219,6 +219,31 @@ export function interleaveRunRecords(
 }
 
 /**
+ * When the turn now running on this session began, by the server's own stamps: the newest of the
+ * live run's start and the last user message on the log. Both survive a reload, unlike a clock
+ * started the moment this client noticed the session was busy — which snapped the elapsed timer
+ * back to zero on every refresh. The newer of the two wins so that a run parked from an earlier
+ * turn (a durable timer, say) cannot stretch the current turn's timer back to its own start.
+ */
+export function sessionTurnStartedAt(rows: AgentSessionChatRow[], runs: RunInfo[] | undefined): number | undefined {
+  let startedAt: number | undefined
+  const consider = (at: number | undefined) => {
+    if (at !== undefined && (startedAt === undefined || at > startedAt)) startedAt = at
+  }
+  for (const run of runs ?? []) {
+    if (!TERMINAL_RUN_STATUSES.has(run.status)) consider(run.startedAt ?? run.createdAt)
+  }
+  for (let index = rows.length - 1; index >= 0; index--) {
+    const row = rows[index]!
+    if (row.kind === 'message' && row.message.role === 'user' && row.message.actor !== 'system') {
+      consider(row.createdAt)
+      break
+    }
+  }
+  return startedAt
+}
+
+/**
  * Whether a row ends in a burst of thinking tool calls — the row whose "Thinking" line speaks for
  * the live run while it is the newest thing on the transcript, so the surfaces below it can stand
  * down their own status bar rather than tick twice.

--- a/frontend/packages/ui/src/agents/agent-session-rows.ts
+++ b/frontend/packages/ui/src/agents/agent-session-rows.ts
@@ -9,7 +9,7 @@ import {
 } from './client'
 import {type ChatBubbleMessage} from './chat-parts'
 import {isContinuationProjection, parseContinuationProjection, type ContinuationProjectionView} from './continuation'
-import {type ChatToolChild, type ChatToolPart} from './chat-parts'
+import {isThinkingToolPart, type ChatToolChild, type ChatToolPart} from './chat-parts'
 import {sessionEventActor} from '@seed-hypermedia/agents-protocol'
 import type {HMBlockNode} from '@seed-hypermedia/client/hm-types'
 
@@ -216,6 +216,18 @@ export function interleaveRunRecords(
     result.splice(index, 0, {key: `run-${run.id}`, kind: 'run-record', run, plan, createdAt: frozenAt})
   }
   return result
+}
+
+/**
+ * Whether a row ends in a burst of thinking tool calls — the row whose "Thinking" line speaks for
+ * the live run while it is the newest thing on the transcript, so the surfaces below it can stand
+ * down their own status bar rather than tick twice.
+ */
+export function chatRowEndsInThinkingGroup(row: AgentSessionChatRow): boolean {
+  if (row.kind !== 'message') return false
+  const parts = row.message.parts
+  const last = parts?.[parts.length - 1]
+  return !!last && isThinkingToolPart(last)
 }
 
 /** A message row that is nothing but tool parts, and so can fuse with a neighboring one. */

--- a/frontend/packages/ui/src/agents/agent-session-rows.ts
+++ b/frontend/packages/ui/src/agents/agent-session-rows.ts
@@ -456,12 +456,21 @@ export function buildAgentSessionChatRows(
   const rows: AgentSessionChatRow[] = []
   const toolRowsById = new Map<string, Extract<AgentSessionChatRow, {kind: 'message'}>>()
   let triggerCardAttached = false
-  // The stamp of the event before the one in hand: where the step that produced a tool call began.
+  // Where the step that produced a tool call began: the stamp of the event before it — except that
+  // calls the model issued together (one response, several tools: their call events land a few
+  // milliseconds apart with no result between) all began where the first of them did. Otherwise
+  // the deliberation lands on the first call alone and its siblings read as a few milliseconds.
   let previousEventAt: number | undefined
+  let previousEventType: string | undefined
+  let previousStepStartedAt: number | undefined
 
   for (const event of events) {
-    const stepStartedAt = previousEventAt
+    const eventType = (event.event as {type?: string}).type
+    const stepStartedAt =
+      eventType === 'tool_call' && previousEventType === 'tool_call' ? previousStepStartedAt : previousEventAt
     previousEventAt = event.createdAt
+    previousEventType = eventType
+    previousStepStartedAt = stepStartedAt
     const payload = event.event as {
       type?: string
       role?: string

--- a/frontend/packages/ui/src/agents/agent-session-rows.ts
+++ b/frontend/packages/ui/src/agents/agent-session-rows.ts
@@ -456,8 +456,12 @@ export function buildAgentSessionChatRows(
   const rows: AgentSessionChatRow[] = []
   const toolRowsById = new Map<string, Extract<AgentSessionChatRow, {kind: 'message'}>>()
   let triggerCardAttached = false
+  // The stamp of the event before the one in hand: where the step that produced a tool call began.
+  let previousEventAt: number | undefined
 
   for (const event of events) {
+    const stepStartedAt = previousEventAt
+    previousEventAt = event.createdAt
     const payload = event.event as {
       type?: string
       role?: string
@@ -550,6 +554,7 @@ export function buildAgentSessionChatRows(
         name: payload.name,
         args: isRecord(payload.input) ? payload.input : {input: payload.input},
         actor: sessionEventActor(event.event),
+        ...(stepStartedAt !== undefined ? {stepStartedAt} : {}),
         calledAt: event.createdAt,
         callSeq: event.seq,
         ...(event.truncated ? {callTruncated: true} : {}),

--- a/frontend/packages/ui/src/agents/assistant-panel.tsx
+++ b/frontend/packages/ui/src/agents/assistant-panel.tsx
@@ -27,6 +27,7 @@ import {
   mergeConsecutiveToolMessageRows,
   buildAgentSessionUrl,
   chatRowEndsInThinkingGroup,
+  sessionTurnStartedAt,
   chatRowHasPendingToolCall,
   frozenRunIds,
   retryableErrorRowKey,
@@ -77,7 +78,7 @@ import {
 } from './continuation'
 import {OpenAgentSessionContext} from './open-session-context'
 import {agentAccessCanChat, agentAccessCanWrite} from './access'
-import {AgentRunStatusBar, useRunStartedAt} from './agent-run-status'
+import {AgentRunStatusBar} from './agent-run-status'
 import {AgentErrorRow, AssistantMessageParts, ChatMessageBubble} from './message-rendering'
 import {useChatAutoScroll} from './chat-autoscroll'
 import {
@@ -829,7 +830,6 @@ function AssistantSessionChat({
   const status = session.data?.session.status
   const isStreaming = status === 'streaming'
   const isBusy = messageSession.isPending || isStreaming
-  const runStartedAt = useRunStartedAt(isStreaming)
   // A sub-session still being driven by its parent is not the user's to message — same rule and
   // wording as the full session page.
   const parentSessionId = session.data?.session.parentSessionId
@@ -880,6 +880,7 @@ function AssistantSessionChat({
   const lastRow = rows[rows.length - 1]
   const liveTailRowKey = isStreaming && !live.text ? lastRow?.key : undefined
   const thinkingLineShowing = !!lastRow && liveTailRowKey === lastRow.key && chatRowEndsInThinkingGroup(lastRow)
+  const runStartedAt = useMemo(() => sessionTurnStartedAt(rows, sessionRuns.data), [rows, sessionRuns.data])
 
   const doSendMessage = useCallback(
     (message: AgentSessionDraftMessage | AgentSessionDraftMessage[]) => {
@@ -1023,7 +1024,12 @@ function AssistantSessionChat({
             !(live.activity?.phase === 'tool' && rows.some(chatRowHasPendingToolCall)) ? (
               // Hidden while a thinking line or a pending tool row is showing its own live
               // status, to avoid two spinners.
-              <AgentRunStatusBar startedAt={runStartedAt} activity={live.activity} usage={live.usage} />
+              <AgentRunStatusBar
+                startedAt={runStartedAt}
+                serverUrl={serverUrl}
+                activity={live.activity}
+                usage={live.usage}
+              />
             ) : null}
             {autoScroll.showScrollButton ? (
               <div className="pointer-events-none sticky bottom-2 flex justify-center">

--- a/frontend/packages/ui/src/agents/assistant-panel.tsx
+++ b/frontend/packages/ui/src/agents/assistant-panel.tsx
@@ -26,6 +26,7 @@ import {
   interleaveRunRecords,
   mergeConsecutiveToolMessageRows,
   buildAgentSessionUrl,
+  chatRowEndsInThinkingGroup,
   chatRowHasPendingToolCall,
   frozenRunIds,
   retryableErrorRowKey,
@@ -874,6 +875,11 @@ function AssistantSessionChat({
   )
   // Which runs the scroll already owns, so the pinned slot does not tell the same story twice.
   const frozenRuns = useMemo(() => frozenRunIds(rows), [rows])
+  // The newest row of a streaming session, with nothing streaming below it, is the one a trailing
+  // "Thinking" line speaks for — and while it does, the status bar below would only tick twice.
+  const lastRow = rows[rows.length - 1]
+  const liveTailRowKey = isStreaming && !live.text ? lastRow?.key : undefined
+  const thinkingLineShowing = !!lastRow && liveTailRowKey === lastRow.key && chatRowEndsInThinkingGroup(lastRow)
 
   const doSendMessage = useCallback(
     (message: AgentSessionDraftMessage | AgentSessionDraftMessage[]) => {
@@ -964,6 +970,7 @@ function AssistantSessionChat({
                     key={row.key}
                     message={row.message}
                     liveActivity={chatRowHasPendingToolCall(row) ? live.activity : undefined}
+                    isLiveTail={row.key === liveTailRowKey}
                     serverUrl={serverUrl}
                     accountUid={accountUid}
                     agentId={session.data?.session.agentId}
@@ -1011,8 +1018,11 @@ function AssistantSessionChat({
             {live.text ? (
               <AssistantMessageParts parts={[{type: 'text', text: live.text}]} isStreaming={isStreaming} />
             ) : null}
-            {isStreaming && !(live.activity?.phase === 'tool' && rows.some(chatRowHasPendingToolCall)) ? (
-              // Hidden while a pending tool row is showing its own live status, to avoid two spinners.
+            {isStreaming &&
+            !thinkingLineShowing &&
+            !(live.activity?.phase === 'tool' && rows.some(chatRowHasPendingToolCall)) ? (
+              // Hidden while a thinking line or a pending tool row is showing its own live
+              // status, to avoid two spinners.
               <AgentRunStatusBar startedAt={runStartedAt} activity={live.activity} usage={live.usage} />
             ) : null}
             {autoScroll.showScrollButton ? (

--- a/frontend/packages/ui/src/agents/chat-parts.ts
+++ b/frontend/packages/ui/src/agents/chat-parts.ts
@@ -190,3 +190,54 @@ export function buildLegacyChatMessageParts(input: {
 
   return parts
 }
+
+/** A tool part still waiting on its result. */
+export function isPendingToolPart(part: ChatToolPart): boolean {
+  return part.result === undefined && part.rawOutput === undefined
+}
+
+/**
+ * Whether a part belongs in the collapsible "Thinking" line: ordinary tool activity by the agent
+ * (or the runtime on its behalf). Status updates, continuation handoffs, and verbs the user ran
+ * themselves are things the reader is meant to see, so they stay out and split a group.
+ */
+export function isThinkingToolPart(part: ChatMessagePart): part is ChatToolPart {
+  return part.type === 'tool' && part.name !== 'status' && part.name !== 'continue_session' && part.actor !== 'user'
+}
+
+/** One render unit of an assistant message: a burst of thinking tool calls, or a single part. */
+export type ChatMessageRenderItem =
+  | {kind: 'thinking'; parts: ChatToolPart[]}
+  | {kind: 'part'; part: ChatMessagePart; index: number}
+
+/** Folds consecutive thinking tool parts into one group, keeping every other part on its own. */
+export function groupThinkingParts(parts: ChatMessagePart[]): ChatMessageRenderItem[] {
+  const items: ChatMessageRenderItem[] = []
+  parts.forEach((part, index) => {
+    if (isThinkingToolPart(part)) {
+      const previous = items[items.length - 1]
+      if (previous?.kind === 'thinking') previous.parts.push(part)
+      else items.push({kind: 'thinking', parts: [part]})
+      return
+    }
+    items.push({kind: 'part', part, index})
+  })
+  return items
+}
+
+/**
+ * When a settled burst of thinking ended: the latest result on the log, or a call's own duration
+ * stamp when the result event is missing. Undefined on transcripts with no timing at all.
+ */
+export function thinkingGroupCompletedAt(parts: ChatToolPart[]): number | undefined {
+  let latest: number | undefined
+  for (const part of parts) {
+    const completedAt =
+      part.completedAt ??
+      (part.calledAt !== undefined && part.meta?.durationMs !== undefined
+        ? part.calledAt + part.meta.durationMs
+        : undefined)
+    if (completedAt !== undefined && (latest === undefined || completedAt > latest)) latest = completedAt
+  }
+  return latest
+}

--- a/frontend/packages/ui/src/agents/chat-parts.ts
+++ b/frontend/packages/ui/src/agents/chat-parts.ts
@@ -46,6 +46,12 @@ export type ChatToolPart = {
    * into the child's work for its whole life, not only once its result has come back.
    */
   child?: ChatToolChild
+  /**
+   * When the agent set out on this step: the stamp of the event just before the call on the log
+   * (the previous result, or the message that started the turn). The step's time is measured
+   * from here, so it counts the model's deliberation as well as the tool's own run.
+   */
+  stepStartedAt?: number
   /** Durable timestamp of the call event — when the tool was invoked. */
   calledAt?: number
   /** Sequence of the call event, so a truncated input can be fetched whole with GetSessionEvent. */
@@ -240,4 +246,22 @@ export function thinkingGroupCompletedAt(parts: ChatToolPart[]): number | undefi
     if (completedAt !== undefined && (latest === undefined || completedAt > latest)) latest = completedAt
   }
   return latest
+}
+
+/**
+ * How long a step took, from the moment the agent set out on it (`stepStartedAt`, falling back to
+ * the call itself) to its result — or to `now` while it is still running. Undefined on a
+ * transcript with no timing to go on.
+ */
+export function toolStepDurationMs(part: ChatToolPart, now?: number): number | undefined {
+  const startedAt = part.stepStartedAt ?? part.calledAt
+  if (startedAt === undefined) return undefined
+  const endedAt = isPendingToolPart(part)
+    ? now
+    : part.completedAt ??
+      (part.calledAt !== undefined && part.meta?.durationMs !== undefined
+        ? part.calledAt + part.meta.durationMs
+        : undefined)
+  if (endedAt === undefined) return undefined
+  return Math.max(0, endedAt - startedAt)
 }

--- a/frontend/packages/ui/src/agents/chat-parts.ts
+++ b/frontend/packages/ui/src/agents/chat-parts.ts
@@ -250,19 +250,27 @@ export function thinkingGroupCompletedAt(parts: ChatToolPart[]): number | undefi
 }
 
 /**
- * How long a step took, from the moment the agent set out on it (`stepStartedAt`, falling back to
- * the call itself) to its result — or to `now` while it is still running. Undefined on a
- * transcript with no timing to go on.
+ * How long the tool itself ran: the executor's own stamp when it left one, else the span between
+ * the call and its result — or up to `now` while the call is still out. Undefined on a transcript
+ * with no timing to go on.
  */
-export function toolStepDurationMs(part: ChatToolPart, now?: number): number | undefined {
-  const startedAt = part.stepStartedAt ?? part.calledAt
-  if (startedAt === undefined) return undefined
-  const endedAt = isPendingToolPart(part)
-    ? now
-    : part.completedAt ??
-      (part.calledAt !== undefined && part.meta?.durationMs !== undefined
-        ? part.calledAt + part.meta.durationMs
-        : undefined)
-  if (endedAt === undefined) return undefined
-  return Math.max(0, endedAt - startedAt)
+export function toolRunDurationMs(part: ChatToolPart, now?: number): number | undefined {
+  if (isPendingToolPart(part)) {
+    return part.calledAt !== undefined && now !== undefined ? Math.max(0, now - part.calledAt) : undefined
+  }
+  if (part.meta?.durationMs !== undefined) return part.meta.durationMs
+  if (part.calledAt !== undefined && part.completedAt !== undefined)
+    return Math.max(0, part.completedAt - part.calledAt)
+  return undefined
+}
+
+/**
+ * How long the model deliberated before this call: from the end of the step before it to the call
+ * itself. Calls issued together share one start, so only the first of them owns the deliberation;
+ * its siblings report none.
+ */
+export function toolDeliberationMs(part: ChatToolPart, previous?: ChatToolPart): number | undefined {
+  if (part.stepStartedAt === undefined || part.calledAt === undefined) return undefined
+  if (previous && previous.stepStartedAt === part.stepStartedAt) return undefined
+  return Math.max(0, part.calledAt - part.stepStartedAt)
 }

--- a/frontend/packages/ui/src/agents/chat-parts.ts
+++ b/frontend/packages/ui/src/agents/chat-parts.ts
@@ -48,8 +48,9 @@ export type ChatToolPart = {
   child?: ChatToolChild
   /**
    * When the agent set out on this step: the stamp of the event just before the call on the log
-   * (the previous result, or the message that started the turn). The step's time is measured
-   * from here, so it counts the model's deliberation as well as the tool's own run.
+   * (the previous result, or the message that started the turn). Calls issued together in one
+   * model response share the start of the first of them. The step's time is measured from here,
+   * so it counts the model's deliberation as well as the tool's own run.
    */
   stepStartedAt?: number
   /** Durable timestamp of the call event — when the tool was invoked. */

--- a/frontend/packages/ui/src/agents/message-rendering.tsx
+++ b/frontend/packages/ui/src/agents/message-rendering.tsx
@@ -416,10 +416,11 @@ function ThinkingGroup({
   // A call still waiting on its result keeps the line live; so does being the tail of a streaming
   // session, which covers the gap between one result and the next call.
   const active = isLiveTail || parts.some(isPendingToolPart)
-  // Timed on the server's clock, from the first call's stamp; a part with no stamp (a legacy
-  // transcript) is timed from when it appeared on screen.
+  // Timed on the server's clock from where the first step began — the event before its call, so
+  // the deliberation that led to it counts here exactly as it counts on the row. A part with no
+  // stamp at all (a legacy transcript) is timed from when it appeared on screen.
   const mountedAtRef = useRef(serverNow(serverUrl))
-  const startedAt = parts[0]?.calledAt ?? mountedAtRef.current
+  const startedAt = parts[0]?.stepStartedAt ?? parts[0]?.calledAt ?? mountedAtRef.current
   const now = useServerNow(serverUrl, active)
   const completedAt = active ? undefined : thinkingGroupCompletedAt(parts)
   const durationMs = active

--- a/frontend/packages/ui/src/agents/message-rendering.tsx
+++ b/frontend/packages/ui/src/agents/message-rendering.tsx
@@ -10,6 +10,7 @@ import {
   type ChatToolPart,
 } from './chat-parts'
 import {formatElapsed, formatThinkingDuration} from './agent-run-status'
+import {serverNow, useServerNow} from './server-clock'
 import {getSeedTool, type SeedToolMetadata} from '@seed-hypermedia/agents-protocol'
 import {
   detailLinkTarget,
@@ -65,7 +66,7 @@ import {
   Workflow,
   Wrench,
 } from 'lucide-react'
-import React, {Fragment, Suspense, useEffect, useMemo, useRef, useState} from 'react'
+import React, {Fragment, Suspense, useMemo, useRef, useState} from 'react'
 import {Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle} from '@shm/ui/components/dialog'
 import {Popover, PopoverContent, PopoverTrigger} from '@shm/ui/components/popover'
 import {Markdown} from './markdown'
@@ -384,18 +385,6 @@ export const AssistantMessageParts = React.memo(function AssistantMessageParts({
   })
 })
 
-/** Re-renders once a second while `active`, returning the current time. */
-function useNowTicker(active: boolean): number {
-  const [now, setNow] = useState(() => Date.now())
-  useEffect(() => {
-    if (!active) return
-    setNow(Date.now())
-    const interval = setInterval(() => setNow(Date.now()), 1000)
-    return () => clearInterval(interval)
-  }, [active])
-  return now
-}
-
 /**
  * A burst of tool calls, told as one line of thinking.
  *
@@ -426,10 +415,11 @@ function ThinkingGroup({
   // A call still waiting on its result keeps the line live; so does being the tail of a streaming
   // session, which covers the gap between one result and the next call.
   const active = isLiveTail || parts.some(isPendingToolPart)
-  // A part with no call stamp (a legacy transcript) is timed from when it appeared on screen.
-  const mountedAtRef = useRef(Date.now())
+  // Timed on the server's clock, from the first call's stamp; a part with no stamp (a legacy
+  // transcript) is timed from when it appeared on screen.
+  const mountedAtRef = useRef(serverNow(serverUrl))
   const startedAt = parts[0]?.calledAt ?? mountedAtRef.current
-  const now = useNowTicker(active)
+  const now = useServerNow(serverUrl, active)
   const completedAt = active ? undefined : thinkingGroupCompletedAt(parts)
   const durationMs = active
     ? Math.max(0, now - startedAt)
@@ -445,20 +435,10 @@ function ThinkingGroup({
   const visibleParts = expanded ? parts : active ? parts.slice(-1) : []
   const Chevron = expanded ? ChevronDown : ChevronRight
 
+  // The line sits under the calls it speaks for: live, it is the newest thing on the transcript,
+  // right where the eye already is; settled, opening it grows the burst upward and the line stays put.
   return (
     <div className="my-1.5 mr-6" data-thinking-group={active ? 'active' : 'done'}>
-      <button
-        type="button"
-        aria-expanded={expanded}
-        title={expanded ? 'Hide tool calls' : 'Show all tool calls'}
-        onClick={() => setExpanded((current) => !current)}
-        className="text-muted-foreground hover:text-foreground hover:bg-muted/60 flex w-full items-center gap-1.5 rounded-md px-1 py-1 text-left text-xs select-none"
-      >
-        {active ? <Loader2 className="size-3 shrink-0 animate-spin" /> : <Chevron className="size-3 shrink-0" />}
-        <span className="font-medium tabular-nums">{label}</span>
-        <span className="opacity-70">· {countLabel}</span>
-        {active ? <Chevron className="ml-auto size-3 shrink-0" /> : null}
-      </button>
       {visibleParts.length ? (
         <div>
           {visibleParts.map((part) => (
@@ -474,6 +454,18 @@ function ThinkingGroup({
           ))}
         </div>
       ) : null}
+      <button
+        type="button"
+        aria-expanded={expanded}
+        title={expanded ? 'Hide tool calls' : 'Show all tool calls'}
+        onClick={() => setExpanded((current) => !current)}
+        className="text-muted-foreground hover:text-foreground hover:bg-muted/60 flex w-full items-center gap-1.5 rounded-md px-1 py-1 text-left text-xs select-none"
+      >
+        {active ? <Loader2 className="size-3 shrink-0 animate-spin" /> : <Chevron className="size-3 shrink-0" />}
+        <span className="font-medium tabular-nums">{label}</span>
+        <span className="opacity-70">· {countLabel}</span>
+        {active ? <Chevron className="ml-auto size-3 shrink-0" /> : null}
+      </button>
     </div>
   )
 }
@@ -2277,7 +2269,7 @@ function DelegateRunView({
     <div className="flex min-w-0 flex-col gap-2">
       {/* A delegated child can be the thing waiting on you, so it gets the same answer affordance. */}
       <ParkedRunActions run={focus} serverUrl={serverUrl} accountUid={accountUid} />
-      <RunTimerProgress run={focus} journal={liveState.journal} wide />
+      <RunTimerProgress run={focus} journal={liveState.journal} serverUrl={serverUrl} wide />
       <RunWorkHierarchy
         run={focus}
         childRuns={children}

--- a/frontend/packages/ui/src/agents/message-rendering.tsx
+++ b/frontend/packages/ui/src/agents/message-rendering.tsx
@@ -5,11 +5,12 @@ import {
   groupThinkingParts,
   isPendingToolPart,
   thinkingGroupCompletedAt,
+  toolStepDurationMs,
   type ChatBubbleMessage,
   type ChatMessagePart,
   type ChatToolPart,
 } from './chat-parts'
-import {formatElapsed, formatThinkingDuration} from './agent-run-status'
+import {formatElapsed, formatStepDuration, formatThinkingDuration} from './agent-run-status'
 import {serverNow, useServerNow} from './server-clock'
 import {getSeedTool, type SeedToolMetadata} from '@seed-hypermedia/agents-protocol'
 import {
@@ -25,7 +26,6 @@ import {
   resolveToolRowSummary,
   shortUrlLabel,
   toolCallAddress,
-  toolRowSourceChip,
   type ToolLinkTarget,
   type ToolRowSummary,
 } from './tool-summary'
@@ -758,14 +758,6 @@ function ToolChip({children, tone}: {children: React.ReactNode; tone?: 'error'})
  * Mono so it reads as a label rather than as more sentence, and never a link: the subject beside
  * it is the thing you click.
  */
-function ToolSourceChip({children}: {children: React.ReactNode}) {
-  return (
-    <span className="text-muted-foreground shrink-0 font-mono text-[9px] tracking-wide whitespace-nowrap opacity-80">
-      {children}
-    </span>
-  )
-}
-
 /**
  * One result link in a tool row's trailing strip. Quiet text rather than a pill: a web search
  * returns many of these, and a row of bordered chips overflowed the line while saying nothing a
@@ -2392,7 +2384,10 @@ export function ToolCallLine({
   const summary = getToolSummary(item)
   const links = getToolLinks(item)
   const addressSummary = resolveToolRowSummary(item)
-  const sourceChip = addressSummary?.chip ?? toolRowSourceChip(item)
+  // The step's wall time, ticking on the server's clock while the call is out: from the moment
+  // the agent set out on it (its deliberation included) to the result.
+  const stepNow = useServerNow(serverUrl, isPending)
+  const stepDurationMs = toolStepDurationMs(item, stepNow)
   const colorClass = item.isError
     ? 'border-destructive/30 bg-destructive/5'
     : isTimerWorkflow
@@ -2495,12 +2490,22 @@ export function ToolCallLine({
               </div>
             </>
           )}
-          {/* One quiet marker of where this came from, then the row's state, then the raw payload. */}
+          {/* The step's time, then anything wrong with it, then the raw payload. */}
           <div className="ml-auto flex shrink-0 items-center gap-1.5">
-            {sourceChip ? <ToolSourceChip>{sourceChip}</ToolSourceChip> : null}
-            {isPending ? (
-              <ToolChip>{isTimerWorkflow ? 'Scheduled' : render?.pendingLabel || 'Running'}</ToolChip>
+            {stepDurationMs !== undefined ? (
+              <span
+                className="text-muted-foreground text-[10px] tabular-nums"
+                aria-label={isPending ? 'Time so far' : 'Time taken'}
+                title={
+                  item.stepStartedAt !== undefined
+                    ? "From the previous step to this result, the model's deliberation included"
+                    : 'From the call to its result'
+                }
+              >
+                {formatStepDuration(stepDurationMs)}
+              </span>
             ) : null}
+            {isPending && isTimerWorkflow ? <ToolChip>Scheduled</ToolChip> : null}
             {item.isError ? <ToolChip tone="error">Failed</ToolChip> : null}
             {getFirstToolValue(item.rawOutput, ['dryRun']) === true ? <ToolChip>Dry run</ToolChip> : null}
             <button

--- a/frontend/packages/ui/src/agents/message-rendering.tsx
+++ b/frontend/packages/ui/src/agents/message-rendering.tsx
@@ -5,7 +5,8 @@ import {
   groupThinkingParts,
   isPendingToolPart,
   thinkingGroupCompletedAt,
-  toolStepDurationMs,
+  toolDeliberationMs,
+  toolRunDurationMs,
   type ChatBubbleMessage,
   type ChatMessagePart,
   type ChatToolPart,
@@ -444,17 +445,26 @@ function ThinkingGroup({
     <div className="my-1.5 mr-6" data-thinking-group={active ? 'active' : 'done'}>
       {visibleParts.length ? (
         <div>
-          {visibleParts.map((part) => (
-            <ToolCallItem
-              key={part.id}
-              item={part}
-              liveActivity={liveActivity}
-              serverUrl={serverUrl}
-              accountUid={accountUid}
-              agentId={agentId}
-              sessionId={sessionId}
-            />
-          ))}
+          {visibleParts.map((part, index) => {
+            // Opened, the burst tells where the time went: a divider before each batch of calls
+            // carries the deliberation that led to it, and every row carries only its own run.
+            const deliberationMs = expanded ? toolDeliberationMs(part, parts[parts.indexOf(part) - 1]) : undefined
+            return (
+              <Fragment key={part.id}>
+                {deliberationMs !== undefined && deliberationMs >= 1000 ? (
+                  <DeliberationDivider durationMs={deliberationMs} first={index === 0} />
+                ) : null}
+                <ToolCallItem
+                  item={part}
+                  liveActivity={liveActivity}
+                  serverUrl={serverUrl}
+                  accountUid={accountUid}
+                  agentId={agentId}
+                  sessionId={sessionId}
+                />
+              </Fragment>
+            )
+          })}
         </div>
       ) : null}
       <button
@@ -469,6 +479,23 @@ function ThinkingGroup({
         <span className="opacity-70">· {countLabel}</span>
         {active ? <Chevron className="ml-auto size-3 shrink-0" /> : null}
       </button>
+    </div>
+  )
+}
+
+/** The model's deliberation before a batch of calls, as a thin line between the rows. */
+function DeliberationDivider({durationMs, first}: {durationMs: number; first: boolean}) {
+  return (
+    <div
+      className={cn(
+        'text-muted-foreground/80 flex items-center gap-2 px-1 text-[10px] select-none',
+        first ? 'mb-1' : 'my-1',
+      )}
+      aria-label="Deliberation"
+    >
+      <span className="bg-border h-px flex-1" />
+      <span className="tabular-nums">thought for {formatStepDuration(durationMs)}</span>
+      <span className="bg-border h-px flex-1" />
     </div>
   )
 }
@@ -2385,10 +2412,10 @@ export function ToolCallLine({
   const summary = getToolSummary(item)
   const links = getToolLinks(item)
   const addressSummary = resolveToolRowSummary(item)
-  // The step's wall time, ticking on the server's clock while the call is out: from the moment
-  // the agent set out on it (its deliberation included) to the result.
-  const stepNow = useServerNow(serverUrl, isPending)
-  const stepDurationMs = toolStepDurationMs(item, stepNow)
+  // How long the tool itself ran, ticking on the server's clock while the call is out. The
+  // model's deliberation before the call is told separately, between batches (see ThinkingGroup).
+  const runNow = useServerNow(serverUrl, isPending)
+  const runDurationMs = toolRunDurationMs(item, runNow)
   const colorClass = item.isError
     ? 'border-destructive/30 bg-destructive/5'
     : isTimerWorkflow
@@ -2491,19 +2518,15 @@ export function ToolCallLine({
               </div>
             </>
           )}
-          {/* The step's time, then anything wrong with it, then the raw payload. */}
+          {/* The tool's own run time, then anything wrong with it, then the raw payload. */}
           <div className="ml-auto flex shrink-0 items-center gap-1.5">
-            {stepDurationMs !== undefined ? (
+            {runDurationMs !== undefined ? (
               <span
                 className="text-muted-foreground text-[10px] tabular-nums"
-                aria-label={isPending ? 'Time so far' : 'Time taken'}
-                title={
-                  item.stepStartedAt !== undefined
-                    ? "From the previous step to this result, the model's deliberation included"
-                    : 'From the call to its result'
-                }
+                aria-label={isPending ? 'Running for' : 'Ran for'}
+                title="How long the tool ran"
               >
-                {formatStepDuration(stepDurationMs)}
+                {formatStepDuration(runDurationMs)}
               </span>
             ) : null}
             {isPending && isTimerWorkflow ? <ToolChip>Scheduled</ToolChip> : null}

--- a/frontend/packages/ui/src/agents/message-rendering.tsx
+++ b/frontend/packages/ui/src/agents/message-rendering.tsx
@@ -434,7 +434,6 @@ function ThinkingGroup({
     : durationMs !== undefined
       ? `Thought for ${formatThinkingDuration(durationMs)}`
       : 'Finished thinking'
-  const countLabel = `${parts.length} tool call${parts.length === 1 ? '' : 's'}`
   const visibleParts = expanded ? parts : active ? parts.slice(-1) : []
   // The burst opens above the line, so an open group points up at it.
   const Chevron = expanded ? ChevronUp : ChevronRight
@@ -472,12 +471,11 @@ function ThinkingGroup({
         aria-expanded={expanded}
         title={expanded ? 'Hide tool calls' : 'Show all tool calls'}
         onClick={() => setExpanded((current) => !current)}
-        className="text-muted-foreground hover:text-foreground hover:bg-muted/60 flex w-full items-center gap-1.5 rounded-md px-1 py-1 text-left text-xs select-none"
+        className="text-muted-foreground hover:text-foreground hover:bg-muted/60 my-2 flex w-full items-center justify-center gap-1.5 rounded-md px-2 py-1.5 text-xs select-none"
       >
-        {active ? <Loader2 className="size-3 shrink-0 animate-spin" /> : <Chevron className="size-3 shrink-0" />}
+        {active ? <Loader2 className="size-3 shrink-0 animate-spin" /> : null}
         <span className="font-medium tabular-nums">{label}</span>
-        <span className="opacity-70">· {countLabel}</span>
-        {active ? <Chevron className="ml-auto size-3 shrink-0" /> : null}
+        <Chevron className="size-3 shrink-0" />
       </button>
     </div>
   )

--- a/frontend/packages/ui/src/agents/message-rendering.tsx
+++ b/frontend/packages/ui/src/agents/message-rendering.tsx
@@ -52,6 +52,7 @@ import {
   Bot,
   ChevronDown,
   ChevronRight,
+  ChevronUp,
   Clock3,
   Compass,
   Info,
@@ -433,7 +434,8 @@ function ThinkingGroup({
       : 'Finished thinking'
   const countLabel = `${parts.length} tool call${parts.length === 1 ? '' : 's'}`
   const visibleParts = expanded ? parts : active ? parts.slice(-1) : []
-  const Chevron = expanded ? ChevronDown : ChevronRight
+  // The burst opens above the line, so an open group points up at it.
+  const Chevron = expanded ? ChevronUp : ChevronRight
 
   // The line sits under the calls it speaks for: live, it is the newest thing on the transcript,
   // right where the eye already is; settled, opening it grows the burst upward and the line stays put.

--- a/frontend/packages/ui/src/agents/message-rendering.tsx
+++ b/frontend/packages/ui/src/agents/message-rendering.tsx
@@ -2,10 +2,14 @@ import {type AgentRunActivity, type RunInfo, type SessionEventMeta} from './clie
 import {eventMetaRows, type EventTimes} from './event-meta'
 import {
   buildLegacyChatMessageParts,
+  groupThinkingParts,
+  isPendingToolPart,
+  thinkingGroupCompletedAt,
   type ChatBubbleMessage,
   type ChatMessagePart,
   type ChatToolPart,
 } from './chat-parts'
+import {formatElapsed, formatThinkingDuration} from './agent-run-status'
 import {getSeedTool, type SeedToolMetadata} from '@seed-hypermedia/agents-protocol'
 import {
   detailLinkTarget,
@@ -61,7 +65,7 @@ import {
   Workflow,
   Wrench,
 } from 'lucide-react'
-import React, {Fragment, Suspense, useMemo, useState} from 'react'
+import React, {Fragment, Suspense, useEffect, useMemo, useRef, useState} from 'react'
 import {Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle} from '@shm/ui/components/dialog'
 import {Popover, PopoverContent, PopoverTrigger} from '@shm/ui/components/popover'
 import {Markdown} from './markdown'
@@ -78,6 +82,7 @@ import {
 export const ChatMessageBubble = React.memo(function ChatMessageBubble({
   message,
   liveActivity,
+  isLiveTail = false,
   serverUrl,
   accountUid,
   agentId,
@@ -85,6 +90,12 @@ export const ChatMessageBubble = React.memo(function ChatMessageBubble({
   message: ChatBubbleMessage
   /** Live run activity, passed so a pending tool call row can show its in-flight progress. */
   liveActivity?: AgentRunActivity
+  /**
+   * This is the newest row of a session that is still streaming, with nothing streaming below it:
+   * a trailing burst of tool calls keeps ticking as "Thinking" even between calls, until the
+   * model's next message lands.
+   */
+  isLiveTail?: boolean
   /** Agent server URL, needed to resolve session attachment images for display. */
   serverUrl?: string
   /** Signing account for server-side record queries (delegate work views). */
@@ -139,6 +150,7 @@ export const ChatMessageBubble = React.memo(function ChatMessageBubble({
           <AssistantMessageParts
             parts={getAssistantMessageParts(message)}
             liveActivity={liveActivity}
+            isLiveTail={isLiveTail}
             serverUrl={serverUrl}
             accountUid={accountUid}
             agentId={agentId}
@@ -294,6 +306,7 @@ export const AssistantMessageParts = React.memo(function AssistantMessageParts({
   parts,
   isStreaming = false,
   liveActivity,
+  isLiveTail = false,
   rawMarkdownButton,
   serverUrl,
   accountUid,
@@ -303,6 +316,8 @@ export const AssistantMessageParts = React.memo(function AssistantMessageParts({
   parts: ChatMessagePart[]
   isStreaming?: boolean
   liveActivity?: AgentRunActivity
+  /** See ChatMessageBubble: keeps a trailing thinking group live between tool calls. */
+  isLiveTail?: boolean
   rawMarkdownButton?: React.ReactNode
   /** Agent server the parts' tool calls ran on, for tools that link to server-side records. */
   serverUrl?: string
@@ -316,8 +331,24 @@ export const AssistantMessageParts = React.memo(function AssistantMessageParts({
   const rawButtonIndex = rawMarkdownButton
     ? parts.reduce((lastTextIndex, part, index) => (part.type === 'text' ? index : lastTextIndex), -1)
     : -1
+  const items = useMemo(() => groupThinkingParts(parts), [parts])
 
-  return parts.map((part, index) => {
+  return items.map((item, itemIndex) => {
+    if (item.kind === 'thinking') {
+      return (
+        <ThinkingGroup
+          key={`thinking:${item.parts[0]!.id}`}
+          parts={item.parts}
+          isLiveTail={isLiveTail && itemIndex === items.length - 1}
+          liveActivity={liveActivity}
+          serverUrl={serverUrl}
+          accountUid={accountUid}
+          agentId={agentId}
+          sessionId={sessionId}
+        />
+      )
+    }
+    const {part, index} = item
     if (part.type === 'tool' && part.name === 'continue_session') {
       // The conversation moved on from here: a transition card, not a tool row.
       return <ContinuationTransitionRow key={`${part.id}:${index}`} item={part} serverUrl={serverUrl} />
@@ -352,6 +383,100 @@ export const AssistantMessageParts = React.memo(function AssistantMessageParts({
     )
   })
 })
+
+/** Re-renders once a second while `active`, returning the current time. */
+function useNowTicker(active: boolean): number {
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    if (!active) return
+    setNow(Date.now())
+    const interval = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(interval)
+  }, [active])
+  return now
+}
+
+/**
+ * A burst of tool calls, told as one line of thinking.
+ *
+ * While the agent is still at it the line ticks — "Thinking (0:42)" — over the most recent call,
+ * which is the only one worth watching. Once the burst is over it settles into "Thought for 2
+ * minutes" and folds every call away. The line is the toggle in both states: click to open the
+ * whole burst, click again to fold it back. A reader who opened it mid-run keeps it open when
+ * the run ends; nobody else sees the calls again unless they ask.
+ */
+function ThinkingGroup({
+  parts,
+  isLiveTail,
+  liveActivity,
+  serverUrl,
+  accountUid,
+  agentId,
+  sessionId,
+}: {
+  parts: ChatToolPart[]
+  isLiveTail: boolean
+  liveActivity?: AgentRunActivity
+  serverUrl?: string
+  accountUid?: string | null
+  agentId?: string
+  sessionId?: string
+}) {
+  const [expanded, setExpanded] = useState(false)
+  // A call still waiting on its result keeps the line live; so does being the tail of a streaming
+  // session, which covers the gap between one result and the next call.
+  const active = isLiveTail || parts.some(isPendingToolPart)
+  // A part with no call stamp (a legacy transcript) is timed from when it appeared on screen.
+  const mountedAtRef = useRef(Date.now())
+  const startedAt = parts[0]?.calledAt ?? mountedAtRef.current
+  const now = useNowTicker(active)
+  const completedAt = active ? undefined : thinkingGroupCompletedAt(parts)
+  const durationMs = active
+    ? Math.max(0, now - startedAt)
+    : completedAt !== undefined
+      ? Math.max(0, completedAt - startedAt)
+      : undefined
+  const label = active
+    ? `Thinking (${formatElapsed(durationMs ?? 0)})`
+    : durationMs !== undefined
+      ? `Thought for ${formatThinkingDuration(durationMs)}`
+      : 'Finished thinking'
+  const countLabel = `${parts.length} tool call${parts.length === 1 ? '' : 's'}`
+  const visibleParts = expanded ? parts : active ? parts.slice(-1) : []
+  const Chevron = expanded ? ChevronDown : ChevronRight
+
+  return (
+    <div className="my-1.5 mr-6" data-thinking-group={active ? 'active' : 'done'}>
+      <button
+        type="button"
+        aria-expanded={expanded}
+        title={expanded ? 'Hide tool calls' : 'Show all tool calls'}
+        onClick={() => setExpanded((current) => !current)}
+        className="text-muted-foreground hover:text-foreground hover:bg-muted/60 flex w-full items-center gap-1.5 rounded-md px-1 py-1 text-left text-xs select-none"
+      >
+        {active ? <Loader2 className="size-3 shrink-0 animate-spin" /> : <Chevron className="size-3 shrink-0" />}
+        <span className="font-medium tabular-nums">{label}</span>
+        <span className="opacity-70">· {countLabel}</span>
+        {active ? <Chevron className="ml-auto size-3 shrink-0" /> : null}
+      </button>
+      {visibleParts.length ? (
+        <div>
+          {visibleParts.map((part) => (
+            <ToolCallItem
+              key={part.id}
+              item={part}
+              liveActivity={liveActivity}
+              serverUrl={serverUrl}
+              accountUid={accountUid}
+              agentId={agentId}
+              sessionId={sessionId}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
 
 /**
  * A `status` call as the transcript shows it. The description is a status line the reader is

--- a/frontend/packages/ui/src/agents/models.ts
+++ b/frontend/packages/ui/src/agents/models.ts
@@ -36,6 +36,7 @@ import {
   type SigningIdentity,
   type SigningIdentityIcon,
 } from './client'
+import {recordServerClockSample} from './server-clock'
 import {isOptimisticUserEcho} from './agent-session-rows'
 import {moveAgentToServer, type MoveAgentOptions} from './move-agent'
 import {getAgentsPlatform} from './platform'
@@ -2934,6 +2935,16 @@ export type AgentSubscriptionKey = `account/${string}` | `agents/${string}` | `s
  * with backoff, tear down on unmount) is identical, only the event handling differs. `onEvent` is
  * held in a ref so a handler closing over render-scoped state never forces a reconnect.
  */
+/**
+ * Every message carries a server stamp of some kind; the clock module turns them into the offset
+ * every live timer counts against. See `server-clock.ts`.
+ */
+function recordServerClock(serverUrl: string, event: AgentWSEvent): void {
+  if (event._ === 'connected') recordServerClockSample(serverUrl, event.connectedAt, 'handshake')
+  else if (event._ === 'append' && 'event' in event) recordServerClockSample(serverUrl, event.event.createdAt, 'event')
+  else if (event._ === 'append') recordServerClockSample(serverUrl, event.createdAt, 'event')
+}
+
 function useSignedAgentSocket(
   serverUrl: string | undefined,
   accountUid: string | null | undefined,
@@ -2995,7 +3006,9 @@ function useSignedAgentSocket(
       ws.addEventListener('message', (message) => {
         void (async () => {
           try {
-            handlerRef.current(await parseMessage(message.data), log)
+            const event = await parseMessage(message.data)
+            if (serverUrl) recordServerClock(serverUrl, event)
+            handlerRef.current(event, log)
           } catch (error) {
             console.warn('[agents/ws] ignored malformed message', {
               serverUrl,

--- a/frontend/packages/ui/src/agents/run-card.tsx
+++ b/frontend/packages/ui/src/agents/run-card.tsx
@@ -13,6 +13,7 @@ import {
   useRunTreeView,
   type PlanSettle,
 } from './run-work'
+import {useServerNow} from './server-clock'
 import {formatElapsed, formatTokenCount} from './agent-run-status'
 import {DelayedSpinner} from './header'
 import {useCancelRun, useRun, useSessionRuns, type AgentRunTreeLiveState} from './models'
@@ -393,7 +394,7 @@ function RunCardBody({
       {/* The run has stopped and is asking; the answer belongs where the question is. */}
       {!readOnly ? <ParkedRunActions run={run} serverUrl={serverUrl} accountUid={accountUid} /> : null}
 
-      <RunTimerProgress run={run} journal={liveState.journal} wide />
+      <RunTimerProgress run={run} journal={liveState.journal} serverUrl={serverUrl} wide />
 
       {progress && !isTerminal ? (
         <div className="flex flex-col gap-1">
@@ -437,7 +438,7 @@ function RunCardBody({
               ? 'Paused'
               : RUN_STATUS_LABELS[run.status]}
         </span>
-        <RunElapsed run={run} />
+        <RunElapsed run={run} serverUrl={serverUrl} />
         {!compact && usageTotal > 0 ? (
           <span className="text-muted-foreground ml-auto text-[10px]">{formatTokenCount(usageTotal)} tokens</span>
         ) : null}
@@ -691,15 +692,9 @@ function RunCardShell({children, compact, column}: {children: React.ReactNode; c
 }
 
 /** Live elapsed timer for a run, frozen once it finishes. */
-function RunElapsed({run}: {run: RunInfo}) {
-  const [now, setNow] = useState(() => Date.now())
+function RunElapsed({run, serverUrl}: {run: RunInfo; serverUrl?: string}) {
   const isTerminal = isTerminalRun(run.status)
-  useEffect(() => {
-    if (isTerminal) return
-    setNow(Date.now())
-    const interval = setInterval(() => setNow(Date.now()), 1000)
-    return () => clearInterval(interval)
-  }, [isTerminal, run.id])
+  const now = useServerNow(serverUrl, !isTerminal)
   const startedAt = run.startedAt ?? run.createdAt
   const endedAt = isTerminal ? run.finishedAt ?? run.updatedAt : now
   return (

--- a/frontend/packages/ui/src/agents/run-work.tsx
+++ b/frontend/packages/ui/src/agents/run-work.tsx
@@ -7,6 +7,7 @@
  * injected via `renderToolPart` so this module stays import-cycle-free.
  */
 import {type RunInfo, type RunJournalEntryInfo, type RunPlan, type RunStatus} from './client'
+import {useServerNow} from './server-clock'
 import {useAgentRunTreeSubscription, useRunTree, type AgentRunTreeLiveState} from './models'
 import {SessionStatusDot} from './session-children'
 import {Popover, PopoverContent, PopoverTrigger} from '@shm/ui/components/popover'
@@ -31,14 +32,18 @@ function activeRunTimer(run: RunInfo, journal: RunJournalEntryInfo[]): RunTimer 
   return {startedAt: timer?.createdAt ?? run.updatedAt, wakeAt: run.wait.wakeAt}
 }
 
-function TimerProgress({run, timer, wide = false}: {run: RunInfo; timer: RunTimer; wide?: boolean}) {
-  const [now, setNow] = useState(() => Date.now())
-
-  React.useEffect(() => {
-    setNow(Date.now())
-    const interval = setInterval(() => setNow(Date.now()), 1_000)
-    return () => clearInterval(interval)
-  }, [timer.startedAt, timer.wakeAt])
+function TimerProgress({
+  run,
+  timer,
+  serverUrl,
+  wide = false,
+}: {
+  run: RunInfo
+  timer: RunTimer
+  serverUrl?: string
+  wide?: boolean
+}) {
+  const now = useServerNow(serverUrl, true)
 
   const duration = Math.max(1, timer.wakeAt - timer.startedAt)
   const remaining = Math.max(0, timer.wakeAt - now)
@@ -82,14 +87,17 @@ function TimerProgress({run, timer, wide = false}: {run: RunInfo; timer: RunTime
 export function RunTimerProgress({
   run,
   journal,
+  serverUrl,
   wide = false,
 }: {
   run: RunInfo
   journal: RunJournalEntryInfo[]
+  /** The server whose clock the countdown counts against. */
+  serverUrl?: string
   wide?: boolean
 }) {
   const timer = useMemo(() => activeRunTimer(run, journal), [journal, run])
-  return timer ? <TimerProgress run={run} timer={timer} wide={wide} /> : null
+  return timer ? <TimerProgress run={run} timer={timer} serverUrl={serverUrl} wide={wide} /> : null
 }
 
 /** A run's title. Mandatory at creation, so the display layer never invents a label. */

--- a/frontend/packages/ui/src/agents/run.tsx
+++ b/frontend/packages/ui/src/agents/run.tsx
@@ -1,4 +1,5 @@
 import {useSelectedAccountId} from './account'
+import {formatStepDuration} from './agent-run-status'
 import {formatTokenCount} from './agent-run-status'
 import {type ChatToolPart} from './chat-parts'
 import {describeAgentError} from './errors'
@@ -40,14 +41,6 @@ const ORIGIN_LABELS: Record<RunInfo['origin'], string> = {
   agent: 'started by an agent',
   workflow: 'started by a script',
   system: 'started by the system',
-}
-
-function formatDuration(ms: number): string {
-  const seconds = Math.round(ms / 1000)
-  if (seconds < 60) return `${seconds}s`
-  const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes}m ${seconds % 60}s`
-  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`
 }
 
 /**
@@ -102,7 +95,7 @@ function AgentRunPage({
         focus.kind === 'workflow' ? 'Script' : 'Agent run',
         ORIGIN_LABELS[focus.origin],
         formattedDateMedium(new Date(focus.createdAt)),
-        focus.startedAt && focus.finishedAt ? `ran ${formatDuration(focus.finishedAt - focus.startedAt)}` : null,
+        focus.startedAt && focus.finishedAt ? `ran ${formatStepDuration(focus.finishedAt - focus.startedAt)}` : null,
         (() => {
           const total = (focus.usage?.total ?? 0) + (focus.usage?.children?.total ?? 0)
           return total ? `${formatTokenCount(total)} tokens` : null

--- a/frontend/packages/ui/src/agents/server-clock.ts
+++ b/frontend/packages/ui/src/agents/server-clock.ts
@@ -1,0 +1,59 @@
+import {useEffect, useState} from 'react'
+
+/**
+ * The agents server's clock, as this client sees it.
+ *
+ * Every duration the UI ticks is anchored on a stamp the server wrote — a run's `startedAt`, a
+ * tool call's `calledAt` — so the "now" it counts up to has to be the server's now as well.
+ * Counting up to the local clock instead bakes the two machines' skew into every timer, and a
+ * timer started from the moment the client first noticed the work snaps back to zero on reload.
+ *
+ * The offset is learned from the socket handshake (the server stamps `connectedAt` as it accepts
+ * the connection, so that sample is authoritative and resets on every reconnect) and refined by
+ * each event that streams in: an event was stamped before it arrived, so its sample can only be
+ * low, and the largest one seen is the closest to the truth.
+ */
+const offsetByServer = new Map<string, number>()
+
+/** Records a server stamp received `localNow`: from the handshake, or from a streamed event. */
+export function recordServerClockSample(
+  serverUrl: string,
+  serverStamp: number,
+  source: 'handshake' | 'event',
+  localNow = Date.now(),
+): void {
+  if (!Number.isFinite(serverStamp)) return
+  const sample = serverStamp - localNow
+  const current = offsetByServer.get(serverUrl)
+  if (source === 'handshake' || current === undefined || sample > current) offsetByServer.set(serverUrl, sample)
+}
+
+/** Server time minus local time for a server, or zero before the server has been heard from. */
+export function serverClockOffset(serverUrl: string | undefined): number {
+  return serverUrl ? offsetByServer.get(serverUrl) ?? 0 : 0
+}
+
+/** The server's current time, as best this client can tell. */
+export function serverNow(serverUrl: string | undefined, localNow = Date.now()): number {
+  return localNow + serverClockOffset(serverUrl)
+}
+
+/** Forgets every learned offset (tests). */
+export function resetServerClocks(): void {
+  offsetByServer.clear()
+}
+
+/**
+ * The server's current time, re-read once a second while `active`. Inactive, it holds the value
+ * from its last tick — callers that have stopped counting use the server's end stamp instead.
+ */
+export function useServerNow(serverUrl: string | undefined, active: boolean): number {
+  const [now, setNow] = useState(() => serverNow(serverUrl))
+  useEffect(() => {
+    if (!active) return
+    setNow(serverNow(serverUrl))
+    const interval = setInterval(() => setNow(serverNow(serverUrl)), 1000)
+    return () => clearInterval(interval)
+  }, [active, serverUrl])
+  return now
+}

--- a/frontend/packages/ui/src/agents/session.tsx
+++ b/frontend/packages/ui/src/agents/session.tsx
@@ -35,6 +35,7 @@ import {
   interleaveRunRecords,
   mergeConsecutiveToolMessageRows,
   buildAgentSessionUrl,
+  chatRowEndsInThinkingGroup,
   chatRowHasPendingToolCall,
   frozenRunIds,
   getSharedEventIdFromHash,
@@ -251,6 +252,12 @@ function AgentSessionPage({
   // pending state until the retried run actually starts streaming, which is what removes the row.
   const retryableRowKey = canChat ? retryableErrorRowKey(chatRows, !!isAgentBusy) : undefined
   const runStartedAt = useRunStartedAt(isAgentBusy)
+  // The newest row of a streaming session, with nothing streaming below it, is the one a trailing
+  // "Thinking" line speaks for — and while it does, the status bar below would only tick twice.
+  const lastChatRow = chatRows[chatRows.length - 1]
+  const liveTailRowKey = isAgentStreaming && !partialAssistantText ? lastChatRow?.key : undefined
+  const thinkingLineShowing =
+    !!lastChatRow && liveTailRowKey === lastChatRow.key && chatRowEndsInThinkingGroup(lastChatRow)
   // Sub-session affordances: the parent is loaded only for its title/route, and the child's own run
   // to tell "still being driven by the parent" from "finished, yours to continue". That run is a
   // child in the parent's tree, so it is reachable by id (SessionInfo.runId), not by ListRuns.
@@ -559,6 +566,7 @@ function AgentSessionPage({
                       agentId={agentId}
                       accountUid={selectedAccountId}
                       liveActivity={chatRowHasPendingToolCall(row) ? liveState.activity : undefined}
+                      isLiveTail={row.key === liveTailRowKey}
                       onRetry={row.key === retryableRowKey ? handleRetrySession : undefined}
                       retryPending={retrySession.isPending}
                       onOpenSession={(childSessionId, childAgentId) =>
@@ -568,8 +576,11 @@ function AgentSessionPage({
                   </div>
                 ))}
                 {partialAssistantText ? <PartialAssistantRow text={partialAssistantText} /> : null}
-                {isAgentBusy && !(liveState.activity?.phase === 'tool' && chatRows.some(chatRowHasPendingToolCall)) ? (
-                  // Hidden while a pending tool row is showing its own live status, to avoid two spinners.
+                {isAgentBusy &&
+                !thinkingLineShowing &&
+                !(liveState.activity?.phase === 'tool' && chatRows.some(chatRowHasPendingToolCall)) ? (
+                  // Hidden while a thinking line or a pending tool row is showing its own live
+                  // status, to avoid two spinners.
                   <AgentRunStatusBar startedAt={runStartedAt} activity={liveState.activity} usage={liveState.usage} />
                 ) : null}
                 {autoScroll.showScrollButton ? (
@@ -718,6 +729,7 @@ const AgentSessionChatRow = React.memo(function AgentSessionChatRow({
   agentId,
   accountUid,
   liveActivity,
+  isLiveTail,
   onRetry,
   retryPending,
   onOpenSession,
@@ -727,6 +739,8 @@ const AgentSessionChatRow = React.memo(function AgentSessionChatRow({
   agentId?: string
   accountUid?: string | null
   liveActivity?: AgentRunActivity
+  /** See ChatMessageBubble: the newest row of a session still streaming. */
+  isLiveTail?: boolean
   /** Set only on a trailing error row, which is the only place a retry is offered. */
   onRetry?: () => void
   retryPending?: boolean
@@ -742,6 +756,7 @@ const AgentSessionChatRow = React.memo(function AgentSessionChatRow({
             <ChatMessageBubble
               message={row.message}
               liveActivity={liveActivity}
+              isLiveTail={isLiveTail}
               serverUrl={serverUrl}
               accountUid={accountUid}
               agentId={agentId}
@@ -760,6 +775,7 @@ const AgentSessionChatRow = React.memo(function AgentSessionChatRow({
       <ChatMessageBubble
         message={row.message}
         liveActivity={liveActivity}
+        isLiveTail={isLiveTail}
         serverUrl={serverUrl}
         accountUid={accountUid}
         agentId={agentId}

--- a/frontend/packages/ui/src/agents/session.tsx
+++ b/frontend/packages/ui/src/agents/session.tsx
@@ -1,6 +1,6 @@
 import {agentAccessCanChat, agentAccessCanWrite} from './access'
 import {type AgentRunActivity, type AgentSessionTriggerContext} from './client'
-import {AgentRunStatusBar, useRunStartedAt} from './agent-run-status'
+import {AgentRunStatusBar} from './agent-run-status'
 import {SessionSummaryBanner} from './session-children'
 import {
   ContextUsageMeter,
@@ -36,6 +36,7 @@ import {
   mergeConsecutiveToolMessageRows,
   buildAgentSessionUrl,
   chatRowEndsInThinkingGroup,
+  sessionTurnStartedAt,
   chatRowHasPendingToolCall,
   frozenRunIds,
   getSharedEventIdFromHash,
@@ -251,7 +252,7 @@ function AgentSessionPage({
   // Deliberately not gated on the mutation being in flight: the button stays put and shows its
   // pending state until the retried run actually starts streaming, which is what removes the row.
   const retryableRowKey = canChat ? retryableErrorRowKey(chatRows, !!isAgentBusy) : undefined
-  const runStartedAt = useRunStartedAt(isAgentBusy)
+  const runStartedAt = useMemo(() => sessionTurnStartedAt(chatRows, sessionRuns.data), [chatRows, sessionRuns.data])
   // The newest row of a streaming session, with nothing streaming below it, is the one a trailing
   // "Thinking" line speaks for — and while it does, the status bar below would only tick twice.
   const lastChatRow = chatRows[chatRows.length - 1]
@@ -581,7 +582,12 @@ function AgentSessionPage({
                 !(liveState.activity?.phase === 'tool' && chatRows.some(chatRowHasPendingToolCall)) ? (
                   // Hidden while a thinking line or a pending tool row is showing its own live
                   // status, to avoid two spinners.
-                  <AgentRunStatusBar startedAt={runStartedAt} activity={liveState.activity} usage={liveState.usage} />
+                  <AgentRunStatusBar
+                    startedAt={runStartedAt}
+                    serverUrl={serverUrl}
+                    activity={liveState.activity}
+                    usage={liveState.usage}
+                  />
                 ) : null}
                 {autoScroll.showScrollButton ? (
                   <div className="pointer-events-none sticky bottom-2 flex justify-center">


### PR DESCRIPTION
## Summary

- Consecutive agent tool calls in a session render as one centered **"Thinking (0:42)"** line while the agent works (only the most recent call shows above it), and settle into **"Thought for 2 minutes"** with the calls folded away. The line toggles the burst open and closed; opened, the calls grow upward and the chevron points up.
- Opened, the burst tells where the time went: each tool row shows only **how long the tool itself ran**, and a thin **"thought for 38s"** divider before each batch of calls carries the model's deliberation. Calls issued together in one model response share one divider. The bottom line keeps the total.
- The tool row's right-side source chip ("hm doc", "memory", "web") and "Running" chip made way for the run time. Failed, Dry run, and Scheduled stay.
- **Every live timer now counts on the server's clock.** A new `server-clock` module learns each server's offset from the socket handshake (`connectedAt`) and refines it from streamed event stamps. The run status bar anchors on server stamps (the live run's start, or the last user message) instead of a client-side "first noticed busy" clock, which is what made elapsed timers snap back to zero on refresh.
- Status updates, continuation handoffs, and verbs the user ran themselves stay out of the fold. The session page and assistant sidebar mark the trailing row of a streaming session as the live tail so the line keeps ticking between calls, and hide their own status bar while the line is showing.
- Also repairs the desktop rendering and run-work tests, whose markdown mock predated `MarkdownAssetContext`.

## Test plan

- [x] `assistant-message-rendering.test.tsx`: folded/open/close, live ticker over the latest call, live tail, exclusions, server-clock skew, deliberation dividers and per-row run time
- [x] `agent-session-rows.test.ts`: `stepStartedAt` stamping incl. parallel batches, `sessionTurnStartedAt`
- [x] `server-clock.test.ts`: handshake/event samples, per-server offsets
- [x] `pnpm typecheck` for `@shm/ui` and desktop; prettier clean
- [ ] Manual: open a session with a long tool burst, refresh mid-run, confirm timers hold

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sKXifeuCKfkEK7ih1MxLt