### PR TITLE
perf(backend): maintain comment activity by genesis, index feed ordering

### DIFF
--- a/backend/api/activity/v1alpha/activity.go
+++ b/backend/api/activity/v1alpha/activity.go
@@ -105,6 +105,52 @@ func (srv *Server) RegisterServer(rpc grpc.ServiceRegistrar) {
 	activity.RegisterSubscriptionsServer(rpc, srv)
 }
 
+// buildMainEventsQuery assembles the feed's main blob-events query. filtersStr
+// is the caller's already-rendered filter prefix (each term ending in " AND ",
+// possibly empty); orderByObserved selects the observed-time cursor column
+// instead of the claimed-time one.
+//
+// No DISTINCT: every join here is many-to-one on a primary key (blobs.id is
+// structural_blobs' own primary key, and public_keys.id and resources.id are
+// the other two), so one structural_blobs row can only ever produce one output
+// row. The DISTINCT that used to be here removed nothing — verified on a
+// production database, 37912 rows either way — while costing a temp b-tree
+// over every row that survived the WHERE: ~100ms of the query's 175ms.
+//
+// The remaining cost was the ORDER BY. Neither cursor column had an index that
+// could serve the ordering, so SQLite materialized all ~40k surviving rows,
+// each carrying the whole extra_attrs JSONB, and then discarded all but the
+// page. structural_blobs_by_ts (schema.sql) fixes that for the claimed-time
+// order; the observed-time order sorts by structural_blobs.id, which is the
+// table's own primary key. Both now terminate at the LIMIT.
+//
+// It's a function rather than inline SQL so TestFeedQueriesUseIndexedOrdering
+// can assert the plan of the exact statement this runs.
+func buildMainEventsQuery(filtersStr string, orderByObserved bool) string {
+	var (
+		selectStr            = "SELECT " + storage.BlobsID + ", " + storage.StructuralBlobsType + ", " + storage.PublicKeysPrincipal + ", " + storage.ResourcesIRI + ", " + storage.StructuralBlobsTs + ", " + storage.BlobsInsertTime + ", " + storage.BlobsMultihash + ", " + storage.BlobsCodec + ", " + "structural_blobs.extra_attrs->>'tsid' AS tsid" + ", " + "structural_blobs.extra_attrs" + ", " + storage.StructuralBlobsGenesisBlob
+		tableStr             = "FROM " + storage.T_StructuralBlobs
+		joinIDStr            = "JOIN " + storage.Blobs.String() + " ON " + storage.BlobsID.String() + "=" + storage.StructuralBlobsID.String()
+		joinpkStr            = "JOIN " + storage.PublicKeys.String() + " ON " + storage.StructuralBlobsAuthor.String() + "=" + storage.PublicKeysID.String()
+		leftjoinResourcesStr = "LEFT JOIN " + storage.Resources.String() + " ON " + storage.StructuralBlobsResource.String() + "=" + storage.ResourcesID.String()
+
+		mainCursorColumn = storage.StructuralBlobsTs.String()
+	)
+	if orderByObserved {
+		mainCursorColumn = storage.StructuralBlobsID.String()
+	}
+	pageTokenStr := mainCursorColumn + " <= :idx AND " + storage.StructuralBlobsType.String() + " != 'Change' AND " + storage.BlobsSize.String() + ">0 ORDER BY " + mainCursorColumn + " desc limit :page_size"
+
+	return strings.TrimSpace(fmt.Sprintf(`
+		%s
+		%s
+		%s
+		%s
+		%s
+		WHERE %s %s;
+	`, selectStr, tableStr, joinIDStr, joinpkStr, leftjoinResourcesStr, filtersStr, pageTokenStr))
+}
+
 // ListEvents list all the events seen locally.
 func (srv *Server) ListEvents(ctx context.Context, req *activity.ListEventsRequest) (*activity.ListEventsResponse, error) {
 	var cursorValue int64 = math.MaxInt64
@@ -247,33 +293,13 @@ func (srv *Server) ListEvents(ctx context.Context, req *activity.ListEventsReque
 		filtersStr += " AND "
 		mainEventsArgs = append(mainEventsArgs, string(irisJSON))
 	}
-	var (
-		selectStr            = "SELECT distinct " + storage.BlobsID + ", " + storage.StructuralBlobsType + ", " + storage.PublicKeysPrincipal + ", " + storage.ResourcesIRI + ", " + storage.StructuralBlobsTs + ", " + storage.BlobsInsertTime + ", " + storage.BlobsMultihash + ", " + storage.BlobsCodec + ", " + "structural_blobs.extra_attrs->>'tsid' AS tsid" + ", " + "structural_blobs.extra_attrs" + ", " + storage.StructuralBlobsGenesisBlob
-		tableStr             = "FROM " + storage.T_StructuralBlobs
-		joinIDStr            = "JOIN " + storage.Blobs.String() + " ON " + storage.BlobsID.String() + "=" + storage.StructuralBlobsID.String()
-		joinpkStr            = "JOIN " + storage.PublicKeys.String() + " ON " + storage.StructuralBlobsAuthor.String() + "=" + storage.PublicKeysID.String()
-		leftjoinResourcesStr = "LEFT JOIN " + storage.Resources.String() + " ON " + storage.StructuralBlobsResource.String() + "=" + storage.ResourcesID.String()
-
-		mainCursorColumn = storage.StructuralBlobsTs.String()
-	)
-	if orderByObserved {
-		mainCursorColumn = storage.StructuralBlobsID.String()
-	}
-	pageTokenStr := mainCursorColumn + " <= :idx AND " + storage.StructuralBlobsType.String() + " != 'Change' AND " + storage.BlobsSize.String() + ">0 ORDER BY " + mainCursorColumn + " desc limit :page_size"
 	if req.PageSize <= 0 {
 		req.PageSize = 30
 	}
 	// Append the page-token binds after :iris_json (which, when present, appears first in the SQL)
 	// and after PageSize has been defaulted, so :idx and :page_size bind to the correct values.
 	mainEventsArgs = append(mainEventsArgs, cursorValue, req.PageSize)
-	var getEventsStr = strings.TrimSpace(fmt.Sprintf(`
-		%s
-		%s
-		%s
-		%s
-		%s
-		WHERE %s %s;
-	`, selectStr, tableStr, joinIDStr, joinpkStr, leftjoinResourcesStr, filtersStr, pageTokenStr))
+	var getEventsStr = buildMainEventsQuery(filtersStr, orderByObserved)
 	var refIDs, resources, genesisBlobIDs []string
 	// Count rows returned by the main DB fetch (pre-filter). Used to decide whether to
 	// emit a next-page token even if the deleted/dedup filters shorten the visible page.

--- a/backend/api/activity/v1alpha/feed_plan_test.go
+++ b/backend/api/activity/v1alpha/feed_plan_test.go
@@ -1,0 +1,93 @@
+package activity
+
+import (
+	"strings"
+	"testing"
+
+	"seed/backend/storage"
+	"seed/backend/util/sqlite"
+	"seed/backend/util/sqlite/sqlitex"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFeedQueriesUseIndexedOrdering guards the ordering index the activity feed
+// depends on.
+//
+// Both feed queries page with ORDER BY <cursor> DESC LIMIT :page_size. If no
+// index can serve that ordering, SQLite has to build the *entire* result set in
+// a temp b-tree before it can apply the LIMIT — for the main query that meant
+// ~40k rows, each carrying the whole extra_attrs JSONB, to return 30. Measured
+// on a 6.2 GB production database, that cost 175ms for the main query and 250ms
+// for the mentions query, and it was ~10% of the daemon's total CPU.
+//
+// The plan assertions below are the cheap, stable way to catch a regression:
+// adding a predicate that defeats structural_blobs_by_ts (say, wrapping ts in a
+// function, or reintroducing a DISTINCT over the pre-LIMIT row set) silently
+// restores the old cost, and no functional test would notice.
+func TestFeedQueriesUseIndexedOrdering(t *testing.T) {
+	t.Parallel()
+
+	db := storage.MakeTestDB(t)
+	conn, release, err := db.ReadConn(t.Context())
+	require.NoError(t, err)
+	defer release()
+
+	plan := func(t *testing.T, query string) string {
+		t.Helper()
+		var sb strings.Builder
+		// Trim: sqlite rejects anything after the statement's ";", and the
+		// mentions constants carry a trailing newline.
+		require.NoError(t, sqlitex.ExecTransient(conn, "EXPLAIN QUERY PLAN "+strings.TrimSpace(query), func(stmt *sqlite.Stmt) error {
+			sb.WriteString(stmt.ColumnText(3))
+			sb.WriteString("\n")
+			return nil
+		}))
+		return sb.String()
+	}
+
+	// The mentions query is assembled the same way ListEvents does it: the
+	// claimed-time order swaps the cursor column via this same Replace.
+	claimedOrder := func(core string) string {
+		return strings.Replace(core, "structural_blobs.id <= :idx", "structural_blobs.ts <= :idx", 1) + limitMentionsByClaimed
+	}
+
+	for _, tt := range []struct {
+		name  string
+		query string
+		// drivenBy is the table the plan must start from, and it is the whole
+		// point. Driving the mentions query from resource_links without a
+		// selective filter meant scanning every link row in the database.
+		drivenBy string
+		// maySort is set for the one shape where an ORDER BY b-tree is the
+		// right plan rather than a regression: see the comment below.
+		maySort bool
+	}{
+		{name: "main/claimed", query: buildMainEventsQuery("", false), drivenBy: "structural_blobs"},
+		{name: "main/observed", query: buildMainEventsQuery("", true), drivenBy: "structural_blobs"},
+		{name: "mentions/claimed", query: claimedOrder(listMentionsCoreNoTargets), drivenBy: "structural_blobs"},
+		{name: "mentions/observed", query: listMentionsCoreNoTargets + limitMentionsByObserved, drivenBy: "structural_blobs"},
+
+		// The filtered variant is the exception. Its target IN(...) predicate is
+		// selective, so seeking resource_links_by_target and sorting what comes
+		// back beats walking structural_blobs in ts order and discarding almost
+		// every row. The set it sorts is bounded by one document's inbound
+		// links: at most 832 on a 6.2 GB production database, 9.6 on average,
+		// which measured 4.5ms for the busiest target. What must not happen is
+		// this shape falling back to driving from structural_blobs.
+		{name: "mentions/claimed/filtered", query: claimedOrder(listMentionsCore), drivenBy: "resource_links", maySort: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := plan(t, tt.query)
+
+			if !tt.maySort {
+				require.NotContains(t, got, "USE TEMP B-TREE FOR ORDER BY",
+					"query must page through an index, not sort every candidate row first\nplan:\n%s", got)
+			}
+
+			first, _, _ := strings.Cut(got, "\n")
+			require.Contains(t, first, tt.drivenBy,
+				"query must be driven by %s so the LIMIT stays bounded\nplan:\n%s", tt.drivenBy, got)
+		})
+	}
+}

--- a/backend/api/documents/v3alpha/comment_stats_test.go
+++ b/backend/api/documents/v3alpha/comment_stats_test.go
@@ -240,6 +240,32 @@ func TestCommentStatsMatchLegacyAggregation(t *testing.T) {
 	require.Equal(t, want, rows(qMaintainedCommentStats),
 		"maintained comment stats diverged from the aggregation they replaced")
 
+	// The space total counts each live comment once, wherever in the space it was
+	// written -- six here: four on the moved document (two at /a, one at /b, one at
+	// /c) and two surviving on /stable. Unlike the per-document counts it does not
+	// follow redirects, because a comment belongs to exactly one space.
+	assertSpaceTotal := func(when string) {
+		t.Helper()
+
+		acc, err := alice.GetAccount(ctx, &pb.GetAccountRequest{Id: space})
+		require.NoError(t, err)
+		require.Equal(t, int32(6), acc.ActivitySummary.GetCommentCount(),
+			"space comment total is wrong %s", when)
+
+		spaceRows := func(query string) []string {
+			t.Helper()
+			conn, release, err := alice.db.ReadConn(ctx)
+			require.NoError(t, err)
+			defer release()
+			return readSpaceStatRows(t, conn, query)
+		}
+
+		require.Equal(t, spaceRows(qSpaceLiveCommentCount), spaceRows(qSpaceCommentStats),
+			"stored space stats diverged from a direct count over comment_live %s", when)
+	}
+
+	assertSpaceTotal("after incremental indexing")
+
 	// The migration that introduced these tables ships no backfill: it creates them
 	// empty and schedules a reindex, on the premise that replaying the blobs refills
 	// them. Check that premise here rather than discovering it on someone's daemon.
@@ -247,6 +273,44 @@ func TestCommentStatsMatchLegacyAggregation(t *testing.T) {
 
 	require.Equal(t, want, rows(qMaintainedCommentStats),
 		"a reindex must rebuild comment stats, since that is how the migration fills them")
+
+	assertSpaceTotal("after a reindex")
+}
+
+// The two halves of the space-total check: what is stored, and what it should be.
+// Same column shape, so they can be compared row for row.
+const qSpaceCommentStats = `
+	SELECT id, comment_count, last_comment_time, COALESCE(last_comment, 0)
+	FROM spaces ORDER BY id;
+`
+
+const qSpaceLiveCommentCount = `
+	SELECT s.id,
+	       (SELECT COUNT(*) FROM comment_live l JOIN resources r ON r.id = l.resource
+	         WHERE r.iri = 'hm://' || s.id
+	         OR (r.iri >= 'hm://' || s.id || '/' AND r.iri < 'hm://' || s.id || '0')),
+	       COALESCE((SELECT MAX(l.ts) FROM comment_live l JOIN resources r ON r.id = l.resource
+	         WHERE r.iri = 'hm://' || s.id
+	         OR (r.iri >= 'hm://' || s.id || '/' AND r.iri < 'hm://' || s.id || '0')), 0),
+	       COALESCE((SELECT l.blob_id FROM comment_live l JOIN resources r ON r.id = l.resource
+	         WHERE r.iri = 'hm://' || s.id
+	         OR (r.iri >= 'hm://' || s.id || '/' AND r.iri < 'hm://' || s.id || '0')
+	         ORDER BY l.ts DESC, l.blob_id DESC LIMIT 1), 0)
+	FROM spaces s ORDER BY s.id;
+`
+
+// readSpaceStatRows is readCommentStatRows' counterpart for the spaces table,
+// whose key is a text id rather than an integer resource.
+func readSpaceStatRows(t *testing.T, conn *sqlite.Conn, query string) []string {
+	t.Helper()
+
+	var out []string
+	require.NoError(t, sqlitex.ExecTransient(conn, strings.TrimSpace(query), func(stmt *sqlite.Stmt) error {
+		out = append(out, fmt.Sprintf("space=%s count=%d last_time=%d last_blob=%d",
+			stmt.ColumnText(0), stmt.ColumnInt64(1), stmt.ColumnInt64(2), stmt.ColumnInt64(3)))
+		return nil
+	}))
+	return out
 }
 
 // readCommentStatRows returns "resource=N count=N last_time=N last_blob=N" per row,

--- a/backend/api/documents/v3alpha/comment_stats_test.go
+++ b/backend/api/documents/v3alpha/comment_stats_test.go
@@ -15,108 +15,57 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// qLegacyCommentAggAll is the query the listings used to run inline, on every
-// request, to derive comment activity from the raw Comment blobs. It is kept here
-// as the oracle for resource_comment_stats: the maintained table must agree with
-// it exactly, or the listings changed meaning.
-//
-// Verbatim from the deleted qListDocsCommentAggScoped with the whole-database
-// scope substituted, so the comparison is against what shipped, not a
-// paraphrase of it.
-const qLegacyCommentAggAll = `
-	WITH RECURSIVE
-	targets AS (
-		SELECT id FROM resources tr WHERE (tr.iri GLOB 'hm://*')
-	),
-	redirected AS MATERIALIZED (
-		SELECT
-			dg.resource AS resource,
-			da.value AS redirect_iri
-		FROM document_generations dg
-		JOIN document_attributes da ON da.resource = dg.resource AND da.kind = 's'
-		JOIN document_attribute_keys dak ON dak.id = da.key AND dak.key = '$db.redirect'
-		WHERE da.value IS NOT NULL
-		AND dg.generation = (SELECT MAX(g.generation) FROM document_generations g WHERE g.resource = dg.resource)
-	),
-	chains(source, target_iri, depth) AS (
-		SELECT rd.resource, rd.redirect_iri, 0 FROM redirected rd
-		UNION ALL
-		SELECT c.source, rd.redirect_iri, c.depth + 1
-		FROM chains c
-		JOIN resources tr ON tr.iri = c.target_iri
-		JOIN redirected rd ON rd.resource = tr.id
-		WHERE c.depth < 16 AND rd.redirect_iri != c.target_iri
-	),
-	credits AS (
-		SELECT DISTINCT c.source, tr.id AS target
-		FROM chains c
-		JOIN resources tr ON tr.iri = c.target_iri
-		WHERE tr.id != c.source
-		AND (tr.iri GLOB 'hm://*')
-	),
-	sources AS (
-		SELECT id FROM targets
-		UNION
-		SELECT source FROM credits
-	),
-	cand_tsids AS (
-		SELECT DISTINCT sb.extra_attrs->>'tsid' AS tsid
-		FROM structural_blobs sb
-		WHERE sb.type = 'Comment'
-		AND sb.resource IN (SELECT id FROM sources)
-	),
-	deduped AS (
-		SELECT
-			sb.resource AS resource,
-			sb.id AS id,
-			sb.ts AS ts,
-			ROW_NUMBER() OVER (PARTITION BY sb.extra_attrs->>'tsid' ORDER BY sb.ts DESC, sb.id DESC) AS rn,
-			sb.extra_attrs->>'deleted' AS deleted
-		FROM cand_tsids ct
-		JOIN structural_blobs sb ON sb.extra_attrs->>'tsid' = ct.tsid
-		WHERE sb.type = 'Comment'
-	),
-	live AS (
-		SELECT resource, id, ts FROM deduped WHERE rn = 1 AND deleted IS NULL
-	),
-	credited AS (
-		SELECT l.resource AS resource, l.id, l.ts FROM live l
-		WHERE l.resource IN (SELECT id FROM targets)
-		UNION ALL
-		SELECT cr.target, l.id, l.ts FROM live l JOIN credits cr ON cr.source = l.resource
-	),
-	totals AS (
-		SELECT resource, COUNT(*) AS comment_count FROM credited GROUP BY resource
-	),
-	latest AS (
-		SELECT resource, MAX(ts) AS last_comment_time, id AS last_comment FROM credited GROUP BY resource
-	)
-	SELECT t.resource, t.comment_count, l.last_comment_time, l.last_comment
-	FROM totals t
-	JOIN latest l ON l.resource = t.resource
-	ORDER BY t.resource;
+// qDocumentCommentStats is what the listings read.
+const qDocumentCommentStats = `
+	SELECT genesis, comment_count, last_comment_time, COALESCE(last_comment, 0)
+	FROM document_comment_stats ORDER BY genesis;
 `
 
-const qMaintainedCommentStats = `
-	SELECT resource, comment_count, last_comment_time, last_comment
-	FROM resource_comment_stats
-	ORDER BY resource;
+// qDocumentLiveCommentCount is what it should be: comment_live aggregated by the
+// document each comment belongs to. Zero-count rows are excluded because
+// updateDocumentCommentStats prunes them.
+const qDocumentLiveCommentCount = `
+	SELECT genesis, COUNT(*), MAX(ts),
+	       (SELECT l2.blob_id FROM comment_live l2 WHERE l2.genesis = l.genesis
+	         ORDER BY l2.ts DESC, l2.blob_id DESC LIMIT 1)
+	FROM comment_live l GROUP BY genesis ORDER BY genesis;
 `
 
-// TestCommentStatsMatchLegacyAggregation pins the maintained comment tables to the
-// query they replaced.
+const qSpaceCommentStats = `
+	SELECT id, comment_count, last_comment_time, COALESCE(last_comment, 0)
+	FROM spaces ORDER BY id;
+`
+
+const qSpaceLiveCommentCount = `
+	SELECT s.id,
+	       (SELECT COUNT(*) FROM comment_live l JOIN resources r ON r.id = l.resource
+	         WHERE r.iri = 'hm://' || s.id
+	         OR (r.iri >= 'hm://' || s.id || '/' AND r.iri < 'hm://' || s.id || '0')),
+	       COALESCE((SELECT MAX(l.ts) FROM comment_live l JOIN resources r ON r.id = l.resource
+	         WHERE r.iri = 'hm://' || s.id
+	         OR (r.iri >= 'hm://' || s.id || '/' AND r.iri < 'hm://' || s.id || '0')), 0),
+	       COALESCE((SELECT l.blob_id FROM comment_live l JOIN resources r ON r.id = l.resource
+	         WHERE r.iri = 'hm://' || s.id
+	         OR (r.iri >= 'hm://' || s.id || '/' AND r.iri < 'hm://' || s.id || '0')
+	         ORDER BY l.ts DESC, l.blob_id DESC LIMIT 1), 0)
+	FROM spaces s ORDER BY s.id;
+`
+
+// TestCommentActivityFollowsTheDocument pins what a comment count means.
 //
-// The listings used to derive comment activity per request, walking the redirect
-// graph and de-duplicating comment versions in SQL every time. That is now settled
-// at index time (backend/blob/comment_stats.go), which is only safe if the two
-// agree on every case the old query handled: comments inherited across a move,
-// multi-hop redirect chains, edits that supersede an earlier version, and deletions
-// that remove one.
+// A comment belongs to a document, and a document is its genesis. Two consequences
+// have to hold at once, and they used to be in tension because the old rule keyed
+// on the redirect graph instead:
 //
-// The scenario below exercises all four, and the assertion is a full row-by-row
-// comparison rather than a spot check on one document, so a resource the
-// maintenance path forgot to recompute shows up as a difference.
-func TestCommentStatsMatchLegacyAggregation(t *testing.T) {
+//   - a document that moves keeps its comments, at every path in the chain, because
+//     moving republishes the same genesis;
+//   - a redirect between two *unrelated* documents transfers nothing, because their
+//     genesises differ.
+//
+// The second one is the change. On a 6.2 GB production database the old rule was
+// crediting 293 comments written against /tech-talks onto /tech, which is a
+// different document that /tech-talks merely redirects to.
+func TestCommentActivityFollowsTheDocument(t *testing.T) {
 	t.Parallel()
 
 	alice := newTestDocsAPI(t, "alice")
@@ -150,8 +99,23 @@ func TestCommentStatsMatchLegacyAggregation(t *testing.T) {
 		return cmt
 	}
 
-	// move republishes doc at `to` and leaves a redirect at `from`, which is what
-	// makes `to` inherit the comments written against `from`.
+	// redirect points `from` at `to` without republishing anything, which is how a
+	// redirect to an unrelated document looks.
+	redirect := func(from, to string) {
+		t.Helper()
+		_, err := alice.CreateRef(ctx, &pb.CreateRefRequest{
+			Account:        space,
+			Path:           from,
+			SigningKeyName: "main",
+			Target: &pb.RefTarget{Target: &pb.RefTarget_Redirect_{
+				Redirect: &pb.RefTarget_Redirect{Account: space, Path: to},
+			}},
+		})
+		require.NoError(t, err)
+	}
+
+	// move republishes the same document at `to` first, so both paths carry the
+	// same genesis, and then redirects the old path at it.
 	move := func(doc *pb.Document, from, to string) {
 		t.Helper()
 		_, err := alice.CreateRef(ctx, &pb.CreateRefRequest{
@@ -163,19 +127,10 @@ func TestCommentStatsMatchLegacyAggregation(t *testing.T) {
 			}},
 		})
 		require.NoError(t, err)
-
-		_, err = alice.CreateRef(ctx, &pb.CreateRefRequest{
-			Account:        space,
-			Path:           from,
-			SigningKeyName: "main",
-			Target: &pb.RefTarget{Target: &pb.RefTarget_Redirect_{
-				Redirect: &pb.RefTarget_Redirect{Account: space, Path: to},
-			}},
-		})
-		require.NoError(t, err)
+		redirect(from, to)
 	}
 
-	// A document that moves twice, so its comments have to travel a two-hop chain.
+	// A document that moves twice. Its comments must survive both hops.
 	moved := publish("/a")
 	comment(moved, "/a", "written at /a")
 	comment(moved, "/a", "also at /a")
@@ -191,139 +146,103 @@ func TestCommentStatsMatchLegacyAggregation(t *testing.T) {
 	comment(stable, "/stable", "untouched")
 
 	edited.Content = []*pb.BlockNode{{Block: &pb.Block{Id: "b1", Type: "paragraph", Text: "second version"}}}
-	_, err := alice.UpdateComment(ctx, &pb.UpdateCommentRequest{
-		Comment:        edited,
-		SigningKeyName: "main",
-	})
+	_, err := alice.UpdateComment(ctx, &pb.UpdateCommentRequest{Comment: edited, SigningKeyName: "main"})
 	require.NoError(t, err)
 
-	_, err = alice.DeleteComment(ctx, &pb.DeleteCommentRequest{
-		Id:             deleted.Id,
-		SigningKeyName: "main",
-	})
+	_, err = alice.DeleteComment(ctx, &pb.DeleteCommentRequest{Id: deleted.Id, SigningKeyName: "main"})
 	require.NoError(t, err)
 
-	// A document with no comments at all, which must appear in neither result.
+	// The case this change is about: /orphan has a comment and redirects at
+	// /unrelated, which is a different document. /unrelated must not inherit it.
+	orphan := publish("/orphan")
+	comment(orphan, "/orphan", "belongs to /orphan only")
+	publish("/unrelated")
+	redirect("/orphan", "/unrelated")
+
 	publish("/quiet")
 
-	// Pin the numbers, not just the agreement: two identically broken sides would
-	// satisfy the comparison below on their own.
-	list, err := alice.ListDirectory(ctx, &pb.ListDirectoryRequest{Account: space, Recursive: true})
-	require.NoError(t, err)
-
-	counts := map[string]int32{}
-	for _, doc := range list.Documents {
-		counts[doc.Path] = doc.ActivitySummary.GetCommentCount()
+	counts := func() map[string]int32 {
+		t.Helper()
+		list, err := alice.ListDirectory(ctx, &pb.ListDirectoryRequest{Account: space, Recursive: true})
+		require.NoError(t, err)
+		out := map[string]int32{}
+		for _, doc := range list.Documents {
+			out[doc.Path] = doc.ActivitySummary.GetCommentCount()
+		}
+		return out
 	}
 
-	// /c is where the twice-moved document now lives, so it carries all four of its
-	// comments: two written at /a, one at /b, one at /c.
-	require.Equal(t, int32(4), counts["/c"], "the moved document must keep the comments written against its old paths")
-	// Three comments, one edited (an edit replaces a version, it doesn't add one)
+	got := counts()
+	// Four comments: two written at /a, one at /b, one at /c. Same document
+	// throughout, so they all land on the path it lives at now.
+	require.Equal(t, int32(4), got["/c"], "a moved document must keep the comments written against its old paths")
+	// Three comments, one edited (an edit replaces a version, it does not add one)
 	// and one deleted.
-	require.Equal(t, int32(2), counts["/stable"], "an edit must not add a comment and a deletion must remove one")
-	require.Equal(t, int32(0), counts["/quiet"])
+	require.Equal(t, int32(2), got["/stable"], "an edit must not add a comment and a deletion must remove one")
+	// The whole point: a redirect is not a move, and these are different documents.
+	require.Equal(t, int32(0), got["/unrelated"], "a redirect to an unrelated document must not transfer its comments")
+	require.Equal(t, int32(0), got["/quiet"])
 
-	// Read on a connection that is released before the reindex below asks for the
-	// writer.
 	rows := func(query string) []string {
 		t.Helper()
 		conn, release, err := alice.db.ReadConn(ctx)
 		require.NoError(t, err)
 		defer release()
-		return readCommentStatRows(t, conn, query)
+		return readStatRows(t, conn, query)
 	}
 
-	want := rows(qLegacyCommentAggAll)
+	// ListComments has to agree with the counts, or the two disagree about what a
+	// document's comments are -- which is the complaint in #779.
+	listed, err := alice.ListComments(ctx, &pb.ListCommentsRequest{TargetAccount: space, TargetPath: "/c", PageSize: 100})
+	require.NoError(t, err)
+	require.Len(t, listed.Comments, 4, "ListComments must return what the count reports")
 
-	require.NotEmpty(t, want, "scenario produced no comment activity, so the comparison would be vacuous")
-	require.Equal(t, want, rows(qMaintainedCommentStats),
-		"maintained comment stats diverged from the aggregation they replaced")
+	orphaned, err := alice.ListComments(ctx, &pb.ListCommentsRequest{TargetAccount: space, TargetPath: "/unrelated", PageSize: 100})
+	require.NoError(t, err)
+	require.Empty(t, orphaned.Comments, "ListComments must not show another document's comments either")
 
-	// The space total counts each live comment once, wherever in the space it was
-	// written -- six here: four on the moved document (two at /a, one at /b, one at
-	// /c) and two surviving on /stable. Unlike the per-document counts it does not
-	// follow redirects, because a comment belongs to exactly one space.
-	assertSpaceTotal := func(when string) {
+	// Querying by a path the document moved away from still works, because that
+	// path's own latest generation carries the same genesis. Notification links
+	// record the historical path, so they depend on this.
+	byOldPath, err := alice.ListComments(ctx, &pb.ListCommentsRequest{TargetAccount: space, TargetPath: "/a", PageSize: 100})
+	require.NoError(t, err)
+	require.Len(t, byOldPath.Comments, 4, "a moved document's comments must stay reachable by its old path")
+
+	assertConsistent := func(when string) {
 		t.Helper()
 
+		require.Equal(t, rows(qDocumentLiveCommentCount), rows(qDocumentCommentStats),
+			"stored document stats diverged from comment_live %s", when)
+		require.Equal(t, rows(qSpaceLiveCommentCount), rows(qSpaceCommentStats),
+			"stored space stats diverged from comment_live %s", when)
+
+		// Space totals count each live comment once, by location: four on the moved
+		// document, two surviving on /stable, one on /orphan.
 		acc, err := alice.GetAccount(ctx, &pb.GetAccountRequest{Id: space})
 		require.NoError(t, err)
-		require.Equal(t, int32(6), acc.ActivitySummary.GetCommentCount(),
-			"space comment total is wrong %s", when)
-
-		spaceRows := func(query string) []string {
-			t.Helper()
-			conn, release, err := alice.db.ReadConn(ctx)
-			require.NoError(t, err)
-			defer release()
-			return readSpaceStatRows(t, conn, query)
-		}
-
-		require.Equal(t, spaceRows(qSpaceLiveCommentCount), spaceRows(qSpaceCommentStats),
-			"stored space stats diverged from a direct count over comment_live %s", when)
+		require.Equal(t, int32(7), acc.ActivitySummary.GetCommentCount(), "space comment total is wrong %s", when)
 	}
 
-	assertSpaceTotal("after incremental indexing")
+	assertConsistent("after incremental indexing")
 
 	// The migration that introduced these tables ships no backfill: it creates them
 	// empty and schedules a reindex, on the premise that replaying the blobs refills
 	// them. Check that premise here rather than discovering it on someone's daemon.
 	require.NoError(t, alice.idx.Reindex(ctx))
 
-	require.Equal(t, want, rows(qMaintainedCommentStats),
-		"a reindex must rebuild comment stats, since that is how the migration fills them")
-
-	assertSpaceTotal("after a reindex")
+	require.Equal(t, got, counts(), "a reindex must reproduce the same counts")
+	assertConsistent("after a reindex")
 }
 
-// The two halves of the space-total check: what is stored, and what it should be.
-// Same column shape, so they can be compared row for row.
-const qSpaceCommentStats = `
-	SELECT id, comment_count, last_comment_time, COALESCE(last_comment, 0)
-	FROM spaces ORDER BY id;
-`
-
-const qSpaceLiveCommentCount = `
-	SELECT s.id,
-	       (SELECT COUNT(*) FROM comment_live l JOIN resources r ON r.id = l.resource
-	         WHERE r.iri = 'hm://' || s.id
-	         OR (r.iri >= 'hm://' || s.id || '/' AND r.iri < 'hm://' || s.id || '0')),
-	       COALESCE((SELECT MAX(l.ts) FROM comment_live l JOIN resources r ON r.id = l.resource
-	         WHERE r.iri = 'hm://' || s.id
-	         OR (r.iri >= 'hm://' || s.id || '/' AND r.iri < 'hm://' || s.id || '0')), 0),
-	       COALESCE((SELECT l.blob_id FROM comment_live l JOIN resources r ON r.id = l.resource
-	         WHERE r.iri = 'hm://' || s.id
-	         OR (r.iri >= 'hm://' || s.id || '/' AND r.iri < 'hm://' || s.id || '0')
-	         ORDER BY l.ts DESC, l.blob_id DESC LIMIT 1), 0)
-	FROM spaces s ORDER BY s.id;
-`
-
-// readSpaceStatRows is readCommentStatRows' counterpart for the spaces table,
-// whose key is a text id rather than an integer resource.
-func readSpaceStatRows(t *testing.T, conn *sqlite.Conn, query string) []string {
+// readStatRows formats a four-column stats row as text, so a mismatch names the
+// key and the column instead of dumping structs.
+func readStatRows(t *testing.T, conn *sqlite.Conn, query string) []string {
 	t.Helper()
 
 	var out []string
 	require.NoError(t, sqlitex.ExecTransient(conn, strings.TrimSpace(query), func(stmt *sqlite.Stmt) error {
-		out = append(out, fmt.Sprintf("space=%s count=%d last_time=%d last_blob=%d",
+		out = append(out, fmt.Sprintf("key=%s count=%d last_time=%d last_blob=%d",
 			stmt.ColumnText(0), stmt.ColumnInt64(1), stmt.ColumnInt64(2), stmt.ColumnInt64(3)))
-		return nil
-	}))
-	return out
-}
-
-// readCommentStatRows returns "resource=N count=N last_time=N last_blob=N" per row,
-// so a mismatch names the resource and the column instead of dumping structs.
-func readCommentStatRows(t *testing.T, conn *sqlite.Conn, query string) []string {
-	t.Helper()
-
-	var out []string
-	// Trim: sqlite rejects anything after the statement's ";", including the
-	// newline the raw-string constants above end with.
-	require.NoError(t, sqlitex.ExecTransient(conn, strings.TrimSpace(query), func(stmt *sqlite.Stmt) error {
-		out = append(out, fmt.Sprintf("resource=%d count=%d last_time=%d last_blob=%d",
-			stmt.ColumnInt64(0), stmt.ColumnInt64(1), stmt.ColumnInt64(2), stmt.ColumnInt64(3)))
 		return nil
 	}))
 	return out

--- a/backend/api/documents/v3alpha/comment_stats_test.go
+++ b/backend/api/documents/v3alpha/comment_stats_test.go
@@ -1,0 +1,266 @@
+package documents
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"seed/backend/api/apitest"
+	"seed/backend/util/sqlite"
+	"seed/backend/util/sqlite/sqlitex"
+
+	pb "seed/backend/genproto/documents/v3alpha"
+
+	"github.com/stretchr/testify/require"
+)
+
+// qLegacyCommentAggAll is the query the listings used to run inline, on every
+// request, to derive comment activity from the raw Comment blobs. It is kept here
+// as the oracle for resource_comment_stats: the maintained table must agree with
+// it exactly, or the listings changed meaning.
+//
+// Verbatim from the deleted qListDocsCommentAggScoped with the whole-database
+// scope substituted, so the comparison is against what shipped, not a
+// paraphrase of it.
+const qLegacyCommentAggAll = `
+	WITH RECURSIVE
+	targets AS (
+		SELECT id FROM resources tr WHERE (tr.iri GLOB 'hm://*')
+	),
+	redirected AS MATERIALIZED (
+		SELECT
+			dg.resource AS resource,
+			da.value AS redirect_iri
+		FROM document_generations dg
+		JOIN document_attributes da ON da.resource = dg.resource AND da.kind = 's'
+		JOIN document_attribute_keys dak ON dak.id = da.key AND dak.key = '$db.redirect'
+		WHERE da.value IS NOT NULL
+		AND dg.generation = (SELECT MAX(g.generation) FROM document_generations g WHERE g.resource = dg.resource)
+	),
+	chains(source, target_iri, depth) AS (
+		SELECT rd.resource, rd.redirect_iri, 0 FROM redirected rd
+		UNION ALL
+		SELECT c.source, rd.redirect_iri, c.depth + 1
+		FROM chains c
+		JOIN resources tr ON tr.iri = c.target_iri
+		JOIN redirected rd ON rd.resource = tr.id
+		WHERE c.depth < 16 AND rd.redirect_iri != c.target_iri
+	),
+	credits AS (
+		SELECT DISTINCT c.source, tr.id AS target
+		FROM chains c
+		JOIN resources tr ON tr.iri = c.target_iri
+		WHERE tr.id != c.source
+		AND (tr.iri GLOB 'hm://*')
+	),
+	sources AS (
+		SELECT id FROM targets
+		UNION
+		SELECT source FROM credits
+	),
+	cand_tsids AS (
+		SELECT DISTINCT sb.extra_attrs->>'tsid' AS tsid
+		FROM structural_blobs sb
+		WHERE sb.type = 'Comment'
+		AND sb.resource IN (SELECT id FROM sources)
+	),
+	deduped AS (
+		SELECT
+			sb.resource AS resource,
+			sb.id AS id,
+			sb.ts AS ts,
+			ROW_NUMBER() OVER (PARTITION BY sb.extra_attrs->>'tsid' ORDER BY sb.ts DESC, sb.id DESC) AS rn,
+			sb.extra_attrs->>'deleted' AS deleted
+		FROM cand_tsids ct
+		JOIN structural_blobs sb ON sb.extra_attrs->>'tsid' = ct.tsid
+		WHERE sb.type = 'Comment'
+	),
+	live AS (
+		SELECT resource, id, ts FROM deduped WHERE rn = 1 AND deleted IS NULL
+	),
+	credited AS (
+		SELECT l.resource AS resource, l.id, l.ts FROM live l
+		WHERE l.resource IN (SELECT id FROM targets)
+		UNION ALL
+		SELECT cr.target, l.id, l.ts FROM live l JOIN credits cr ON cr.source = l.resource
+	),
+	totals AS (
+		SELECT resource, COUNT(*) AS comment_count FROM credited GROUP BY resource
+	),
+	latest AS (
+		SELECT resource, MAX(ts) AS last_comment_time, id AS last_comment FROM credited GROUP BY resource
+	)
+	SELECT t.resource, t.comment_count, l.last_comment_time, l.last_comment
+	FROM totals t
+	JOIN latest l ON l.resource = t.resource
+	ORDER BY t.resource;
+`
+
+const qMaintainedCommentStats = `
+	SELECT resource, comment_count, last_comment_time, last_comment
+	FROM resource_comment_stats
+	ORDER BY resource;
+`
+
+// TestCommentStatsMatchLegacyAggregation pins the maintained comment tables to the
+// query they replaced.
+//
+// The listings used to derive comment activity per request, walking the redirect
+// graph and de-duplicating comment versions in SQL every time. That is now settled
+// at index time (backend/blob/comment_stats.go), which is only safe if the two
+// agree on every case the old query handled: comments inherited across a move,
+// multi-hop redirect chains, edits that supersede an earlier version, and deletions
+// that remove one.
+//
+// The scenario below exercises all four, and the assertion is a full row-by-row
+// comparison rather than a spot check on one document, so a resource the
+// maintenance path forgot to recompute shows up as a difference.
+func TestCommentStatsMatchLegacyAggregation(t *testing.T) {
+	t.Parallel()
+
+	alice := newTestDocsAPI(t, "alice")
+	ctx := context.Background()
+	space := alice.me.Account.PublicKey.String()
+
+	publish := func(path string) *pb.Document {
+		t.Helper()
+		doc, err := alice.PublishDocumentChangeForTest(ctx, &apitest.DocumentChangeRequest{
+			SigningKeyName: "main",
+			Account:        space,
+			Path:           path,
+			Changes: []*pb.DocumentChange{
+				{Op: &pb.DocumentChange_SetMetadata_{SetMetadata: &pb.DocumentChange_SetMetadata{Key: "title", Value: "doc " + path}}},
+			},
+		})
+		require.NoError(t, err)
+		return doc
+	}
+
+	comment := func(doc *pb.Document, path, text string) *pb.Comment {
+		t.Helper()
+		cmt, err := alice.CreateComment(ctx, &pb.CreateCommentRequest{
+			SigningKeyName: "main",
+			TargetAccount:  space,
+			TargetPath:     path,
+			TargetVersion:  doc.Version,
+			Content:        []*pb.BlockNode{{Block: &pb.Block{Id: "b1", Type: "paragraph", Text: text}}},
+		})
+		require.NoError(t, err)
+		return cmt
+	}
+
+	// move republishes doc at `to` and leaves a redirect at `from`, which is what
+	// makes `to` inherit the comments written against `from`.
+	move := func(doc *pb.Document, from, to string) {
+		t.Helper()
+		_, err := alice.CreateRef(ctx, &pb.CreateRefRequest{
+			Account:        space,
+			Path:           to,
+			SigningKeyName: "main",
+			Target: &pb.RefTarget{Target: &pb.RefTarget_Version_{
+				Version: &pb.RefTarget_Version{Genesis: doc.Genesis, Version: doc.Version},
+			}},
+		})
+		require.NoError(t, err)
+
+		_, err = alice.CreateRef(ctx, &pb.CreateRefRequest{
+			Account:        space,
+			Path:           from,
+			SigningKeyName: "main",
+			Target: &pb.RefTarget{Target: &pb.RefTarget_Redirect_{
+				Redirect: &pb.RefTarget_Redirect{Account: space, Path: to},
+			}},
+		})
+		require.NoError(t, err)
+	}
+
+	// A document that moves twice, so its comments have to travel a two-hop chain.
+	moved := publish("/a")
+	comment(moved, "/a", "written at /a")
+	comment(moved, "/a", "also at /a")
+	move(moved, "/a", "/b")
+	comment(moved, "/b", "written at /b")
+	move(moved, "/b", "/c")
+	comment(moved, "/c", "written at /c")
+
+	// A document that stays put, with an edited and a deleted comment.
+	stable := publish("/stable")
+	edited := comment(stable, "/stable", "first version")
+	deleted := comment(stable, "/stable", "will be deleted")
+	comment(stable, "/stable", "untouched")
+
+	edited.Content = []*pb.BlockNode{{Block: &pb.Block{Id: "b1", Type: "paragraph", Text: "second version"}}}
+	_, err := alice.UpdateComment(ctx, &pb.UpdateCommentRequest{
+		Comment:        edited,
+		SigningKeyName: "main",
+	})
+	require.NoError(t, err)
+
+	_, err = alice.DeleteComment(ctx, &pb.DeleteCommentRequest{
+		Id:             deleted.Id,
+		SigningKeyName: "main",
+	})
+	require.NoError(t, err)
+
+	// A document with no comments at all, which must appear in neither result.
+	publish("/quiet")
+
+	// Pin the numbers, not just the agreement: two identically broken sides would
+	// satisfy the comparison below on their own.
+	list, err := alice.ListDirectory(ctx, &pb.ListDirectoryRequest{Account: space, Recursive: true})
+	require.NoError(t, err)
+
+	counts := map[string]int32{}
+	for _, doc := range list.Documents {
+		counts[doc.Path] = doc.ActivitySummary.GetCommentCount()
+	}
+
+	// /c is where the twice-moved document now lives, so it carries all four of its
+	// comments: two written at /a, one at /b, one at /c.
+	require.Equal(t, int32(4), counts["/c"], "the moved document must keep the comments written against its old paths")
+	// Three comments, one edited (an edit replaces a version, it doesn't add one)
+	// and one deleted.
+	require.Equal(t, int32(2), counts["/stable"], "an edit must not add a comment and a deletion must remove one")
+	require.Equal(t, int32(0), counts["/quiet"])
+
+	// Read on a connection that is released before the reindex below asks for the
+	// writer.
+	rows := func(query string) []string {
+		t.Helper()
+		conn, release, err := alice.db.ReadConn(ctx)
+		require.NoError(t, err)
+		defer release()
+		return readCommentStatRows(t, conn, query)
+	}
+
+	want := rows(qLegacyCommentAggAll)
+
+	require.NotEmpty(t, want, "scenario produced no comment activity, so the comparison would be vacuous")
+	require.Equal(t, want, rows(qMaintainedCommentStats),
+		"maintained comment stats diverged from the aggregation they replaced")
+
+	// The migration that introduced these tables ships no backfill: it creates them
+	// empty and schedules a reindex, on the premise that replaying the blobs refills
+	// them. Check that premise here rather than discovering it on someone's daemon.
+	require.NoError(t, alice.idx.Reindex(ctx))
+
+	require.Equal(t, want, rows(qMaintainedCommentStats),
+		"a reindex must rebuild comment stats, since that is how the migration fills them")
+}
+
+// readCommentStatRows returns "resource=N count=N last_time=N last_blob=N" per row,
+// so a mismatch names the resource and the column instead of dumping structs.
+func readCommentStatRows(t *testing.T, conn *sqlite.Conn, query string) []string {
+	t.Helper()
+
+	var out []string
+	// Trim: sqlite rejects anything after the statement's ";", including the
+	// newline the raw-string constants above end with.
+	require.NoError(t, sqlitex.ExecTransient(conn, strings.TrimSpace(query), func(stmt *sqlite.Stmt) error {
+		out = append(out, fmt.Sprintf("resource=%d count=%d last_time=%d last_blob=%d",
+			stmt.ColumnInt64(0), stmt.ColumnInt64(1), stmt.ColumnInt64(2), stmt.ColumnInt64(3)))
+		return nil
+	}))
+	return out
+}

--- a/backend/api/documents/v3alpha/comments.go
+++ b/backend/api/documents/v3alpha/comments.go
@@ -287,80 +287,56 @@ func (srv *Server) commentDBMapper() sqlitex.MapperFunc[indexedComment] {
 	}
 }
 
-// redirectAncestorsCTE collects every resource whose latest generation transitively
-// redirects to :iri (plus :iri's own resource). Seeded from :iri so the recursion
-// only walks the redirect chain relevant to the requested document, not every
-// Comment in the database. The seed is included unconditionally — even when :iri's
-// own latest generation is itself a redirect — so that comments authored against a
-// moved-away path remain reachable when queried by that path (e.g. notification
-// links that record the historical path).
-const redirectAncestorsCTE = `
-	WITH RECURSIVE
-	latest_document_generations AS (
-		SELECT
-			dg.resource AS resource,
-			da.value AS redirect_iri
-		FROM document_generations dg
-		JOIN document_attributes da ON da.resource = dg.resource AND da.kind = 's'
-		JOIN document_attribute_keys dak ON dak.id = da.key AND dak.key = '$db.redirect'
+// targetGenesisCTE resolves :iri to the genesis of the document that currently
+// lives there -- its identity rather than its location.
+//
+// This replaces a recursive walk that collected every path transitively redirecting
+// to :iri. That walk had no way to tell a move from a redirect between two
+// unrelated documents, so it merged their comments: on a 6.2 GB production database
+// it credited 293 comments written against /tech-talks onto /tech, which has a
+// different genesis. Matching on genesis keeps a moved document's comments (the
+// genesis doesn't change when the path does) and drops the ones that never belonged.
+//
+// Querying by a path the document has moved away from still works, because that
+// path's own latest generation carries the same genesis.
+const targetGenesisCTE = `
+	WITH target_genesis AS (
+		SELECT dg.genesis AS genesis
+		FROM resources r
+		JOIN document_generations dg ON dg.resource = r.id
+		WHERE r.iri = :iri
 		GROUP BY dg.resource
 		HAVING dg.generation = MAX(dg.generation)
-	),
-	redirect_ancestors(resource, iri, depth) AS (
-		SELECT id, iri, 0
-		FROM resources
-		WHERE iri = :iri
-
-		UNION ALL
-
-		SELECT r.id, r.iri, ra.depth + 1
-		FROM redirect_ancestors ra
-		JOIN latest_document_generations dg ON dg.redirect_iri = ra.iri
-		JOIN resources r ON r.id = dg.resource
-		WHERE r.iri != ra.iri
-		AND ra.depth < 16
 	)
 `
 
-var qIterComments = dqb.Str(redirectAncestorsCTE + `
+// The live-version dedup that used to be a ROW_NUMBER() window here is already
+// settled in comment_live, so this just reads it.
+var qIterComments = dqb.Str(targetGenesisCTE + `
 	SELECT
 		sb.id,
-        b.codec,
+		b.codec,
 		b.multihash,
 		b.data,
 		sb.extra_attrs->>'tsid' AS tsid
-	FROM (
-		SELECT
-        	sb.*,
-         	ROW_NUMBER() OVER (PARTITION BY sb.extra_attrs->>'tsid' ORDER BY sb.ts DESC) rn
-        FROM structural_blobs sb
-		WHERE sb.type = 'Comment'
-		AND sb.resource IN (SELECT resource FROM redirect_ancestors)
-	) sb
-	JOIN blobs b ON b.id = sb.id
-	WHERE sb.rn = 1
-	AND sb.extra_attrs->>'deleted' IS NULL
+	FROM comment_live l
+	JOIN structural_blobs sb ON sb.id = l.blob_id
+	JOIN blobs b ON b.id = l.blob_id
+	WHERE l.genesis IN (SELECT genesis FROM target_genesis)
 	ORDER BY sb.ts
 `)
 
-var qIterCommentsPublicOnly = dqb.Str(redirectAncestorsCTE + `
+var qIterCommentsPublicOnly = dqb.Str(targetGenesisCTE + `
 	SELECT
 		sb.id,
-        b.codec,
+		b.codec,
 		b.multihash,
 		b.data,
 		sb.extra_attrs->>'tsid' AS tsid
-	FROM (
-		SELECT
-        	sb.*,
-         	ROW_NUMBER() OVER (PARTITION BY sb.extra_attrs->>'tsid' ORDER BY sb.ts DESC) rn
-        FROM structural_blobs sb
-		WHERE sb.type = 'Comment'
-		AND sb.resource IN (SELECT resource FROM redirect_ancestors)
-	) sb
-	JOIN blobs b ON b.id = sb.id
-	WHERE sb.rn = 1
-	AND sb.extra_attrs->>'deleted' IS NULL
+	FROM comment_live l
+	JOIN structural_blobs sb ON sb.id = l.blob_id
+	JOIN blobs b ON b.id = l.blob_id
+	WHERE l.genesis IN (SELECT genesis FROM target_genesis)
 	AND sb.extra_attrs->>'visibility' IS NOT 'Private'
 	ORDER BY sb.ts
 `)

--- a/backend/api/documents/v3alpha/documents.go
+++ b/backend/api/documents/v3alpha/documents.go
@@ -14,6 +14,7 @@ import (
 	"seed/backend/core"
 	documents "seed/backend/genproto/documents/v3alpha"
 	"seed/backend/hmnet"
+	"seed/backend/storage"
 	"seed/backend/util/apiutil"
 	"seed/backend/util/attrkey"
 	"seed/backend/util/cclock"
@@ -189,7 +190,7 @@ func (srv *Server) QueryDocuments(ctx context.Context, in *documents.QueryDocume
 	}
 
 	args := colx.Slice[any]{}
-	qb := baseListDocumentsQuery(commentAggAll)
+	qb := baseDocumentsQuery()
 	qb.Where("r.iri GLOB 'hm://*'")
 	whereFilters, havingFilter := splitDocumentLocationFilters(in.GetFilter())
 	for _, locationFilter := range whereFilters {
@@ -1193,13 +1194,7 @@ func (srv *Server) ListDirectory(ctx context.Context, in *documents.ListDirector
 			return nil, err
 		}
 
-		qb := baseListDocumentsQuery(commentAggSubtree)
-
-		// The comment aggregation is scoped to the same subtree as the row filter below.
-		// It's a LEFT JOIN, so it precedes the WHERE clause and binds first. The scope
-		// appears twice inside it (targets, then credits), so it binds twice.
-		args.Append(baseIRI, baseIRI+"/", baseIRI+"0")
-		args.Append(baseIRI, baseIRI+"/", baseIRI+"0")
+		qb := baseDocumentsQuery()
 
 		if publicOnly, err := srv.isPublicOnlyFor(ctx, ns, in.DirectoryPath); err != nil {
 			return nil, err
@@ -1429,24 +1424,23 @@ func (srv *Server) ListAccounts(ctx context.Context, in *documents.ListAccountsR
 // using a single query.
 //
 // ListAccounts used to call [getDocumentInfo] once per account. That is a full
-// single-document query — recursive redirect walk, comment aggregation and the
-// children_count subquery — re-run N times on one connection. Measured against a real
+// single-document query — at the time, a recursive redirect walk and a comment
+// aggregation as well as the children_count subquery — re-run N times on one
+// connection. Measured against a real
 // database it cost 513ms for 321 accounts (mean 1.6ms, p95 4.5ms, slowest 8.8ms) on top
 // of a 10ms main query, and it grows linearly with the account count: ~1.6s at 1000
 // accounts and ~4.8s at 3000, which is where the desktop app starts reporting the call
 // as hung.
 //
-// Home documents are exactly the root document of each space, which is the scope
-// [commentAggRoots] already covers, so the listing aggregation can serve them directly.
-// It takes no bound parameters, so the only bindings here are the IRIs and the page
-// size. This also makes the home document info consistent with what ListRootDocuments
-// reports for the same documents, since both now derive it the same way.
+// One query over the whole set fixes that, and it also makes the home document info
+// consistent with what ListRootDocuments reports for the same documents, since both
+// derive it the same way.
 func getRootDocumentInfos(conn *sqlite.Conn, lookup *blob.LookupCache, iris []blob.IRI) (out map[blob.IRI]*documents.DocumentInfo, err error) {
 	if len(iris) == 0 {
 		return nil, nil
 	}
 
-	qb := baseListDocumentsQuery(commentAggRoots)
+	qb := baseDocumentsQuery()
 	qb.Where("r.iri IN (" + strings.TrimSuffix(strings.Repeat("?,", len(iris)), ",") + ")")
 
 	args := make([]any, 0, len(iris)+1)
@@ -1844,9 +1838,7 @@ func (srv *Server) ListRootDocuments(ctx context.Context, in *documents.ListRoot
 		args  colx.Slice[any]
 	)
 	{
-		// The comment aggregation is scoped to root documents, matching the row filter
-		// below. The scope takes no parameters, so binding order is unaffected.
-		qb := baseListDocumentsQuery(commentAggRoots).OrderBy("activity_time DESC")
+		qb := baseDocumentsQuery().OrderBy("activity_time DESC")
 
 		qb.Where("r.iri GLOB 'hm://*'")
 		qb.Where("r.iri NOT GLOB 'hm://*/*'")
@@ -1928,11 +1920,7 @@ func (srv *Server) ListDocuments(ctx context.Context, in *documents.ListDocument
 		args  colx.Slice[any]
 	)
 	{
-		// Resolve the account scope up front: the comment aggregation is scoped to the
-		// same resources the row filter selects, and being a LEFT JOIN it binds first.
-		// The scope appears twice inside it (targets, then credits), so it binds twice.
 		var (
-			commentAgg = commentAggAll
 			accountIRI blob.IRI
 			publicOnly bool
 		)
@@ -1951,13 +1939,9 @@ func (srv *Server) ListDocuments(ctx context.Context, in *documents.ListDocument
 			if err != nil {
 				return nil, err
 			}
-
-			commentAgg = commentAggSubtree
-			args.Append(accountIRI, accountIRI+"/", accountIRI+"0")
-			args.Append(accountIRI, accountIRI+"/", accountIRI+"0")
 		}
 
-		qb := baseListDocumentsQuery(commentAgg).OrderBy("activity_time DESC")
+		qb := baseDocumentsQuery().OrderBy("activity_time DESC")
 
 		if in.Account == "" {
 			qb.Where("r.iri GLOB 'hm://*'")
@@ -2019,10 +2003,9 @@ func (srv *Server) ListDocuments(ctx context.Context, in *documents.ListDocument
 }
 
 func getDocumentInfo(conn *sqlite.Conn, lookup *blob.LookupCache, iri blob.IRI) (info *documents.DocumentInfo, err error) {
-	q := wrapDocumentsQuery(baseSingleDocumentQuery().Where("r.iri = ?"), "")
-	// The IRI is bound twice: as the comment aggregation seed, and as the row filter.
+	q := wrapDocumentsQuery(baseDocumentsQuery().Where("r.iri = ?"), "")
 	// 0 is the page size parameter.
-	rows, discard, check := sqlitex.Query(conn, q, iri, iri, 0).All()
+	rows, discard, check := sqlitex.Query(conn, q, iri, 0).All()
 	defer discard(&err)
 
 	for row := range rows {
@@ -2037,232 +2020,7 @@ func getDocumentInfo(conn *sqlite.Conn, lookup *blob.LookupCache, iri blob.IRI) 
 	return nil, status.Errorf(codes.NotFound, "document with IRI %s is not found", iri)
 }
 
-// qSingleDocCommentAgg is the single-document counterpart of qListDocsCommentAggScoped.
-// Instead of aggregating comment activity for every document, it walks the redirect
-// chain backwards from one IRI (bound as the subquery's parameter, same as the outer
-// r.iri filter), exactly like ListComments' redirectAncestorsCTE, and only touches
-// that document's comments. Point lookups like GetDocumentInfo (which gets called in
-// loops by BatchGetDocumentInfo and for accounts' home documents) must use this
-// instead of paying for the global aggregation.
-const qSingleDocCommentAgg = `(
-	WITH RECURSIVE
-	redirect_ancestors(resource, iri, depth) AS (
-		SELECT r.id, r.iri, 0 FROM resources r WHERE r.iri = ?
-
-		UNION ALL
-
-		SELECT dg.resource, res.iri, ra.depth + 1
-		FROM redirect_ancestors ra
-		JOIN document_attributes da ON da.kind = 's' AND da.value = ra.iri
-		JOIN document_attribute_keys dak ON dak.id = da.key AND dak.key = '$db.redirect'
-		JOIN document_generations dg ON dg.resource = da.resource
-		JOIN resources res ON res.id = dg.resource
-		WHERE dg.generation = (SELECT MAX(g.generation) FROM document_generations g WHERE g.resource = dg.resource)
-		AND res.iri != ra.iri
-		AND ra.depth < 16
-	),
-	deduped AS (
-		SELECT
-			sb.id AS id,
-			sb.ts AS ts,
-			ROW_NUMBER() OVER (PARTITION BY sb.extra_attrs->>'tsid' ORDER BY sb.ts DESC, sb.id DESC) AS rn,
-			sb.extra_attrs->>'deleted' AS deleted
-		FROM structural_blobs sb
-		WHERE sb.type = 'Comment'
-		AND sb.resource IN (SELECT resource FROM redirect_ancestors)
-	),
-	live AS (
-		SELECT id, ts FROM deduped WHERE rn = 1 AND deleted IS NULL
-	),
-	totals AS (
-		SELECT COUNT(*) AS comment_count FROM live
-	),
-	latest AS (
-		SELECT MAX(ts) AS last_comment_time, id AS last_comment FROM live
-	)
-	SELECT
-		(SELECT resource FROM redirect_ancestors WHERE depth = 0) AS resource,
-		t.comment_count,
-		l.last_comment_time,
-		l.last_comment
-	FROM totals t, latest l
-) agg`
-
-// Prebuilt comment aggregations, one per listing scope. Each scope predicate must select
-// exactly the resources its listing can return, expressed over the `tr` alias of
-// `resources`, and must bind the same values as the outer query's `r.iri` filter (see the
-// binding order note on [baseListDocumentsQuery]).
-//
-// A parameterised scope appears *twice* in the generated SQL, so its callers must bind its
-// arguments twice — see [qListDocsCommentAggScoped].
-//
-// These are built once rather than per request: the scopes are fixed, and assembling a
-// couple of kilobytes of SQL on every call would be pure waste on a hot path.
-var (
-	// commentAggSubtree covers one document and everything below it. The subtree is
-	// expressed as an explicit range rather than GLOB because a parameterized GLOB
-	// inside an OR never seeks the resources.iri index (the prefix optimization doesn't
-	// apply to it there), while the equivalent range becomes a MULTI-INDEX OR of two
-	// seeks. Callers bind (iri, iri+"/", iri+"0") — '0' is '/'+1, so the range is
-	// exactly the iri+"/*" prefix, same trick as children_count below.
-	commentAggSubtree = qListDocsCommentAggScoped(`tr.iri = ? OR (tr.iri >= ? AND tr.iri < ?)`)
-
-	// commentAggRoots covers the root document of every space.
-	commentAggRoots = qListDocsCommentAggScoped(`tr.iri GLOB 'hm://*' AND tr.iri NOT GLOB 'hm://*/*'`)
-
-	// commentAggAll covers every document in the database. It's the widest scope, and it's
-	// also the hottest: the desktop app lists documents with no account filter on load.
-	commentAggAll = qListDocsCommentAggScoped(`tr.iri GLOB 'hm://*'`)
-)
-
-// qListDocsCommentAggScoped computes each listed document's comment activity (count,
-// latest comment) directly from the indexed Comment blobs, deduplicating edits by TSID
-// and dropping deleted comments, and credits every comment both to the resource it
-// targets and to all transitive redirect targets of that resource.
-//
-// It exists because comment blobs record the document path as it was when the comment was
-// written: after a document moves, its comments stay attached to the old path's resource,
-// and the incrementally-maintained document_generations.comment_count of the new path's
-// resource knows nothing about them. Deriving the stats from the blobs at query time keeps
-// listings consistent with what ListComments actually returns for the document (which
-// walks the same redirect relation backwards via redirectAncestorsCTE), no matter in which
-// order the blobs arrived.
-//
-// It is scoped because the original unscoped form derived its stats from *every* Comment
-// blob in the database. Such a subquery can't be flattened (CTEs + aggregates) and the
-// outer r.iri filter can't be pushed into it, so SQLite materialized a whole-database
-// aggregate before emitting a single row — on every request. That cost is linear in total
-// comment count and independent of the directory being listed, which is what saturated the
-// production gateway's CPU. Seeding from `targets` instead keeps the work proportional to
-// the listing: the comment scan seeks structural_blobs_by_resource rather than scanning
-// structural_blobs_by_type, and this applies to listings the same trick
-// [qSingleDocCommentAgg] already applies to point lookups.
-//
-// Semantics are preserved exactly, and the subtle part is the TSID dedup. A comment edit
-// can land on a *different* resource than the original once a document has moved, so
-// restricting the ROW_NUMBER() partitions to in-scope blobs could let an edit win a
-// partition it loses globally, and inflate a count. So the scope picks candidate *TSIDs*
-// (cand_tsids), and the window then runs over every blob carrying one of them — including
-// blobs outside the scope. Winner-per-TSID is therefore identical to the unscoped query;
-// losers outside the scope simply credit nothing. Comment blobs always carry a TSID
-// (blob_comment.go sets it unconditionally), so the partition key is never NULL.
-//
-// `deduped` fetches those blobs by JOINing cand_tsids rather than with an IN subquery:
-// an equality join term proves the partial structural_blobs_by_tsid index's IS NOT NULL
-// predicate, so each candidate TSID is a seek, whereas `tsid IN (SELECT …)` cannot prove
-// it and degraded to scanning every Comment blob in the database via
-// structural_blobs_by_type on each call.
-//
-// The scope must be written in terms of the `tr` alias of `resources` (e.g.
-// `tr.iri GLOB 'hm://*'`), because it is applied in two places, and callers with a
-// parameterised scope must therefore bind its arguments TWICE: once for `targets`, then
-// once for `credits`, in that order. The duplication is deliberate. `credits` already
-// joins `resources tr`, and testing membership there via `tr.id IN (SELECT id FROM
-// targets)` was quadratic: `chains` is a recursive CTE consumed as a co-routine, so SQLite
-// re-evaluated the IN list per row instead of materializing it once (~2k chain rows × ~7k
-// target rows ≈ 15M scans ≈ 2.5s on a real database, and MATERIALIZED hints on `targets`,
-// `redirected` or `chains` did not fix THAT problem). Applying the predicate directly to
-// `tr.iri` makes it a filter on a row already in hand: same rows, ~0.07s instead of ~2.5s.
-//
-// The parenthetical above used to read "did not help", full stop. It is scoped to the
-// IN-list pathology, and reading it more broadly steered the 2026-08-11 outage response
-// away from the actual fix: `redirected` is also referenced from the recursive term of
-// `chains`, where it was re-derived once per visited row at ~5.5s per listing call. It now
-// carries a MATERIALIZED hint for that separate reason (see the comment on it below). That
-// win was invisible when the note was written, because the 2.5s IN-list scan dominated.
-func qListDocsCommentAggScoped(scope string) string {
-	return `(
-	WITH RECURSIVE
-	targets AS (
-		SELECT id FROM resources tr WHERE (` + scope + `)
-	),
-	redirected AS MATERIALIZED (
-		-- MATERIALIZED is load-bearing. This CTE is referenced from the recursive
-		-- term of ` + "`chains`" + ` below, and without the hint SQLite re-derives it for
-		-- every row the recursion visits, paying the correlated MAX(generation)
-		-- subquery each time: ~2.2k rows x ~2.5ms = 5.5s of CPU per listing call,
-		-- which saturated production on 2026-08-11. Materialized it's ~40ms.
-		SELECT
-			dg.resource AS resource,
-			da.value AS redirect_iri
-		FROM document_generations dg
-		JOIN document_attributes da ON da.resource = dg.resource AND da.kind = 's'
-		JOIN document_attribute_keys dak ON dak.id = da.key AND dak.key = '$db.redirect'
-		WHERE da.value IS NOT NULL
-		AND dg.generation = (SELECT MAX(g.generation) FROM document_generations g WHERE g.resource = dg.resource)
-	),
-	chains(source, target_iri, depth) AS (
-		SELECT rd.resource, rd.redirect_iri, 0 FROM redirected rd
-		UNION ALL
-		SELECT c.source, rd.redirect_iri, c.depth + 1
-		FROM chains c
-		JOIN resources tr ON tr.iri = c.target_iri
-		JOIN redirected rd ON rd.resource = tr.id
-		WHERE c.depth < 16 AND rd.redirect_iri != c.target_iri
-	),
-	credits AS (
-		SELECT DISTINCT c.source, tr.id AS target
-		FROM chains c
-		JOIN resources tr ON tr.iri = c.target_iri
-		WHERE tr.id != c.source
-		AND (` + scope + `)
-	),
-	sources AS (
-		SELECT id FROM targets
-		UNION
-		SELECT source FROM credits
-	),
-	cand_tsids AS (
-		SELECT DISTINCT sb.extra_attrs->>'tsid' AS tsid
-		FROM structural_blobs sb
-		WHERE sb.type = 'Comment'
-		AND sb.resource IN (SELECT id FROM sources)
-	),
-	deduped AS (
-		SELECT
-			sb.resource AS resource,
-			sb.id AS id,
-			sb.ts AS ts,
-			ROW_NUMBER() OVER (PARTITION BY sb.extra_attrs->>'tsid' ORDER BY sb.ts DESC, sb.id DESC) AS rn,
-			sb.extra_attrs->>'deleted' AS deleted
-		FROM cand_tsids ct
-		JOIN structural_blobs sb ON sb.extra_attrs->>'tsid' = ct.tsid
-		WHERE sb.type = 'Comment'
-	),
-	live AS (
-		SELECT resource, id, ts FROM deduped WHERE rn = 1 AND deleted IS NULL
-	),
-	credited AS (
-		SELECT l.resource AS resource, l.id, l.ts FROM live l
-		WHERE l.resource IN (SELECT id FROM targets)
-		UNION ALL
-		SELECT cr.target, l.id, l.ts FROM live l JOIN credits cr ON cr.source = l.resource
-	),
-	totals AS (
-		SELECT resource, COUNT(*) AS comment_count FROM credited GROUP BY resource
-	),
-	latest AS (
-		SELECT resource, MAX(ts) AS last_comment_time, id AS last_comment FROM credited GROUP BY resource
-	)
-	SELECT t.resource AS resource, t.comment_count, l.last_comment_time, l.last_comment
-	FROM totals t
-	JOIN latest l ON l.resource = t.resource
-) agg`
-}
-
-// baseListDocumentsQuery builds a listing query using one of the prebuilt scoped comment
-// aggregations above. Callers must bind the scope's parameters (if any) *before* any other
-// parameter, because the aggregation is a LEFT JOIN and so precedes the WHERE clause in the
-// generated SQL.
-func baseListDocumentsQuery(commentAgg string) *dqb.SelectQuery {
-	return baseDocumentsQuery(commentAgg)
-}
-
-func baseSingleDocumentQuery() *dqb.SelectQuery {
-	return baseDocumentsQuery(qSingleDocCommentAgg)
-}
-
-func baseDocumentsQuery(commentAggJoin string) *dqb.SelectQuery {
+func baseDocumentsQuery() *dqb.SelectQuery {
 	// Page size must be the last binding parameter.
 	return dqb.
 		Select(
@@ -2291,7 +2049,14 @@ func baseDocumentsQuery(commentAggJoin string) *dqb.SelectQuery {
 		From(
 			"resources r CROSS JOIN document_generations dg",
 		).
-		LeftJoin(commentAggJoin, "agg.resource = dg.resource").
+		// Comment activity is maintained by the indexer (backend/blob/comment_stats.go),
+		// so this is a seek on the joined table's primary key. It used to be an inline
+		// aggregation that re-derived every listed document's comment stats from the raw
+		// Comment blobs on every request — 53ms of a 60ms ListDirectory call on a 6.2 GB
+		// production database, and proportional to the comments in scope rather than to
+		// the page size. The maintained table gives byte-identical results, verified
+		// across every resource in that database.
+		LeftJoin(storage.T_ResourceCommentStats+" agg", "agg.resource = dg.resource").
 		Where("r.id = dg.resource").
 		GroupBy("dg.resource").
 		Having("dg.generation = MAX(dg.generation)", "dg.is_deleted = 0").

--- a/backend/api/documents/v3alpha/documents.go
+++ b/backend/api/documents/v3alpha/documents.go
@@ -2054,9 +2054,12 @@ func baseDocumentsQuery() *dqb.SelectQuery {
 		// aggregation that re-derived every listed document's comment stats from the raw
 		// Comment blobs on every request — 53ms of a 60ms ListDirectory call on a 6.2 GB
 		// production database, and proportional to the comments in scope rather than to
-		// the page size. The maintained table gives byte-identical results, verified
-		// across every resource in that database.
-		LeftJoin(storage.T_ResourceCommentStats+" agg", "agg.resource = dg.resource").
+		// the page size.
+		//
+		// Joined on genesis, not resource: a comment belongs to a document, and a
+		// document's identity is its genesis. That's why a moved document keeps its
+		// comments without anyone walking a redirect chain here.
+		LeftJoin(storage.T_DocumentCommentStats+" agg", "agg.genesis = dg.genesis").
 		Where("r.id = dg.resource").
 		GroupBy("dg.resource").
 		Having("dg.generation = MAX(dg.generation)", "dg.is_deleted = 0").

--- a/backend/blob/blob_comment.go
+++ b/backend/blob/blob_comment.go
@@ -7,7 +7,6 @@ import (
 	"seed/backend/core"
 	"seed/backend/ipfs"
 	"seed/backend/util/dqb"
-	"seed/backend/util/maybe"
 	"seed/backend/util/sqlite"
 	"seed/backend/util/sqlite/sqlitex"
 	"time"
@@ -336,14 +335,17 @@ func indexComment(ictx *indexingCtx, id int64, eb Encoded[*Comment]) error {
 		panic("BUG: missing resource for comment target")
 	}
 
-	// Settle this comment's live version and the affected documents' activity.
+	spaceID := v.Space().String()
+
+	// Settle this comment's live version, the affected documents' activity, and
+	// the space total.
 	//
 	// Deliberately ahead of the document-generation bookkeeping below, and
 	// independent of it: that bookkeeping gives up when the comment's target
 	// changes aren't indexed yet (it can't tell which generation to credit), and
-	// nothing ever comes back to it, which is why it under-counts. These two
-	// tables are keyed by resource, so they don't need a generation and can be
-	// settled the moment the blob lands.
+	// nothing ever comes back to it, which is why it under-counts. None of these
+	// three need a generation -- they're keyed by resource or by space -- so they
+	// can be settled the moment the blob lands.
 	if err := updateCommentLive(ictx.conn, eb.TSID()); err != nil {
 		return err
 	}
@@ -352,9 +354,11 @@ func indexComment(ictx *indexingCtx, id int64, eb Encoded[*Comment]) error {
 		return err
 	}
 
-	spaceID := v.Space().String()
+	if err := updateSpaceCommentStats(ictx.conn, spaceID); err != nil {
+		return err
+	}
 
-	// Update space comment stats.
+	// Update document generation comment stats.
 	{
 		changeIDs := make([]int64, len(v.Version))
 		for i, v := range v.Version {
@@ -415,27 +419,6 @@ func indexComment(ictx *indexingCtx, id int64, eb Encoded[*Comment]) error {
 			}
 		}
 
-		var sm spaceCommentStats
-		if err := sm.load(ictx.conn, spaceID); err != nil {
-			return err
-		}
-
-		if !isTombstone {
-			if commentTime := v.Ts.UnixMilli(); commentTime > sm.LastCommentTime {
-				sm.LastCommentTime = commentTime
-				sm.LastComment = id
-			}
-		}
-
-		sm.CommentCount += delta
-		if sm.CommentCount < 0 {
-			sm.CommentCount = 0
-		}
-
-		if err := sm.save(ictx.conn); err != nil {
-			return err
-		}
-
 		if ictx.mustTrackUnreads {
 			if err := ensureUnread(ictx.conn, iri); err != nil {
 				return err
@@ -493,64 +476,4 @@ var qCommentTSIDPriorVersions = dqb.Str(`
 	WHERE type = 'Comment'
 	  AND extra_attrs->>'tsid' = ?1
 	  AND id != ?2;
-`)
-
-type spaceCommentStats struct {
-	shouldUpdate bool
-
-	ID              string
-	LastComment     int64
-	LastCommentTime int64
-	CommentCount    int64
-}
-
-func (sm *spaceCommentStats) load(conn *sqlite.Conn, spaceID string) (err error) {
-	sm.ID = spaceID
-
-	rows, discard, check := sqlitex.Query(conn, qLoadSpaceCommentStats(), spaceID).All()
-	defer discard(&err)
-	for row := range rows {
-		sm.shouldUpdate = true
-		row.Scan(&sm.LastComment, &sm.LastCommentTime, &sm.CommentCount)
-		break
-	}
-	if err := check(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-var qLoadSpaceCommentStats = dqb.Str(`
-	SELECT
-		last_comment,
-		last_comment_time,
-		comment_count
-	FROM spaces
-	WHERE id = :id;
-`)
-
-func (sm *spaceCommentStats) save(conn *sqlite.Conn) error {
-	var q string
-	if sm.shouldUpdate {
-		q = qUpdateSpaceCommentStats()
-	} else {
-		q = qInsertSpaceCommentStats()
-	}
-
-	return sqlitex.Exec(conn, q, nil, sm.ID, maybe.Any(sm.LastComment), sm.LastCommentTime, sm.CommentCount)
-}
-
-var qInsertSpaceCommentStats = dqb.Str(`
-	INSERT INTO spaces (id, last_comment, last_comment_time, comment_count)
-	VALUES (?1, ?2, ?3, ?4);
-`)
-
-var qUpdateSpaceCommentStats = dqb.Str(`
-	UPDATE spaces
-	SET
-		last_comment = ?2,
-		last_comment_time = ?3,
-		comment_count = ?4
-	WHERE id = ?1;
 `)

--- a/backend/blob/blob_comment.go
+++ b/backend/blob/blob_comment.go
@@ -337,20 +337,88 @@ func indexComment(ictx *indexingCtx, id int64, eb Encoded[*Comment]) error {
 
 	spaceID := v.Space().String()
 
-	// Settle this comment's live version, the affected documents' activity, and
-	// the space total.
+	// Resolve the document this comment belongs to.
 	//
-	// Deliberately ahead of the document-generation bookkeeping below, and
-	// independent of it: that bookkeeping gives up when the comment's target
-	// changes aren't indexed yet (it can't tell which generation to credit), and
-	// nothing ever comes back to it, which is why it under-counts. None of these
-	// three need a generation -- they're keyed by resource or by space -- so they
-	// can be settled the moment the blob lands.
-	if err := updateCommentLive(ictx.conn, eb.TSID()); err != nil {
+	// The document is identified by the genesis of its changes, which is what makes
+	// comment activity survive a move: the path can change, the genesis can't.
+	//
+	// That needs the target's changes indexed, and when they aren't there are two
+	// different situations, which is why this doesn't simply give up on both:
+	//
+	//   - We have the change but haven't indexed it yet. That's routine -- blobs
+	//     sync out of order, and a reindex replays them in blob-id order. Stash the
+	//     comment so it retries when the change is indexed (see reindexStashedBlobs).
+	//     Skipping instead loses the comment permanently: on a 6.2 GB production
+	//     database, reindexing without this attributed only 6602 of 12659 comments,
+	//     even though every one of their targets was present by the end.
+	//
+	//   - We don't have the change at all (BlobsSize < 0 means we know the hash and
+	//     nothing else). Stashing on a blob that may never arrive would hide the
+	//     comment indefinitely, so index it and leave it out of the counts, which
+	//     is what the old code did for both cases.
+	var (
+		changeIDs      = make([]int64, len(v.Version))
+		genesisBlobID  int64
+		pendingChanges []cid.Cid
+	)
+	for i, ver := range v.Version {
+		changeID, ok := ictx.blobs[ver]
+		if !ok {
+			return fmt.Errorf("BUG: missing change for version %v when indexing comment target", ver)
+		}
+
+		var cm changeMetadata
+		if err := cm.load(ictx.conn, changeID.BlobsID); err != nil {
+			return err
+		}
+
+		if cm.ID == 0 {
+			if changeID.BlobsSize < 0 {
+				return nil
+			}
+			pendingChanges = append(pendingChanges, ver)
+			continue
+		}
+
+		changeIDs[i] = cm.ID
+		genesisBlobID = cm.Genesis()
+	}
+
+	if pendingChanges != nil {
+		return stashError{
+			Reason: stashReasonFailedPrecondition,
+			Metadata: stashMetadata{
+				MissingBlobs: pendingChanges,
+			},
+		}
+	}
+
+	// A comment that pins no target version means "the document at this path", so
+	// its identity is whatever genesis that path currently resolves to.
+	var genesis string
+	if genesisBlobID != 0 {
+		genesis, err = lookupBlobCID(ictx.conn, genesisBlobID)
+	} else {
+		genesis, err = lookupResourceGenesis(ictx.conn, resourceID)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to resolve target genesis for comment %s: %w", c, err)
+	}
+
+	// No generation at that path yet, so there is no document to attribute this to.
+	// The same repair applies as for unindexed target changes above.
+	if genesis == "" {
+		return nil
+	}
+
+	// Settle this comment's live version, its document's activity, and the space
+	// total. None of these need a document generation, so they're settled the
+	// moment the blob lands rather than waiting for a Ref.
+	if err := updateCommentLive(ictx.conn, eb.TSID(), genesis); err != nil {
 		return err
 	}
 
-	if err := updateResourceCommentStats(ictx.conn, resourceID); err != nil {
+	if err := updateDocumentCommentStats(ictx.conn, genesis); err != nil {
 		return err
 	}
 
@@ -360,28 +428,6 @@ func indexComment(ictx *indexingCtx, id int64, eb Encoded[*Comment]) error {
 
 	// Update document generation comment stats.
 	{
-		changeIDs := make([]int64, len(v.Version))
-		for i, v := range v.Version {
-			changeID, ok := ictx.blobs[v]
-			if !ok {
-				return fmt.Errorf("BUG: missing change for version %v when indexing comment target", v)
-			}
-
-			var cm changeMetadata
-			if err := cm.load(ictx.conn, changeID.BlobsID); err != nil {
-				return err
-			}
-
-			// If some of the comment target changes are not indexed yet, we skip updating any stats,
-			// because we don't know what document generation to update.
-			// We'll get to that later, if we ever receive a Ref that would incorporate those changes.
-			if cm.ID == 0 {
-				return nil
-			}
-
-			changeIDs[i] = cm.ID
-		}
-
 		// commentCountDelta computes how this blob changes the count of distinct,
 		// non-deleted comment TSIDs for the target. Edits with the same TSID don't
 		// change the count; tombstones decrement only when a previously-live version

--- a/backend/blob/blob_comment.go
+++ b/backend/blob/blob_comment.go
@@ -330,6 +330,28 @@ func indexComment(ictx *indexingCtx, id int64, eb Encoded[*Comment]) error {
 		return err
 	}
 
+	// SaveBlob above ensures the target resource, so it's in the map from here on.
+	resourceID, ok := ictx.resources[iri]
+	if !ok {
+		panic("BUG: missing resource for comment target")
+	}
+
+	// Settle this comment's live version and the affected documents' activity.
+	//
+	// Deliberately ahead of the document-generation bookkeeping below, and
+	// independent of it: that bookkeeping gives up when the comment's target
+	// changes aren't indexed yet (it can't tell which generation to credit), and
+	// nothing ever comes back to it, which is why it under-counts. These two
+	// tables are keyed by resource, so they don't need a generation and can be
+	// settled the moment the blob lands.
+	if err := updateCommentLive(ictx.conn, eb.TSID()); err != nil {
+		return err
+	}
+
+	if err := updateResourceCommentStats(ictx.conn, resourceID); err != nil {
+		return err
+	}
+
 	spaceID := v.Space().String()
 
 	// Update space comment stats.
@@ -354,11 +376,6 @@ func indexComment(ictx *indexingCtx, id int64, eb Encoded[*Comment]) error {
 			}
 
 			changeIDs[i] = cm.ID
-		}
-
-		resourceID, ok := ictx.resources[iri]
-		if !ok {
-			panic("BUG: missing resource for comment target")
 		}
 
 		// commentCountDelta computes how this blob changes the count of distinct,

--- a/backend/blob/blob_ref.go
+++ b/backend/blob/blob_ref.go
@@ -498,15 +498,6 @@ func crossLinkRefMaybe(ictx *indexingCtx, v *Ref) error {
 		return err
 	}
 
-	// A redirect moves comment activity: everything this document redirects to now
-	// inherits the comments written against this path. dg.save has just written the
-	// $db.redirect attribute the walk follows, so this has to come after it.
-	if v.Redirect != nil {
-		if err := updateResourceCommentStats(conn, resourceID); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/backend/blob/blob_ref.go
+++ b/backend/blob/blob_ref.go
@@ -498,6 +498,15 @@ func crossLinkRefMaybe(ictx *indexingCtx, v *Ref) error {
 		return err
 	}
 
+	// A redirect moves comment activity: everything this document redirects to now
+	// inherits the comments written against this path. dg.save has just written the
+	// $db.redirect attribute the walk follows, so this has to come after it.
+	if v.Redirect != nil {
+		if err := updateResourceCommentStats(conn, resourceID); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/backend/blob/comment_stats.go
+++ b/backend/blob/comment_stats.go
@@ -6,11 +6,12 @@ import (
 	"seed/backend/util/dqb"
 	"seed/backend/util/sqlite"
 	"seed/backend/util/sqlite/sqlitex"
+
+	"github.com/ipfs/go-cid"
 )
 
-// Comment activity is maintained here, in two tables, instead of being derived
-// on every read (see the schema comments on comment_live and
-// resource_comment_stats).
+// Comment activity is maintained here, in two tables, instead of being derived on
+// every read (see the schema comments on comment_live and document_comment_stats).
 //
 // Two facts have to be settled to answer "how many comments does this document
 // have, and what's the latest one":
@@ -18,40 +19,42 @@ import (
 //  1. Which blob is the live version of each comment. Comments are edited and
 //     deleted by publishing further blobs that share a TSID, so the live version
 //     is the newest one, and it counts only if it isn't a tombstone. That's
-//     comment_live, and it's settled per TSID as blobs arrive.
+//     comment_live, settled per TSID as blobs arrive.
 //
-//  2. Which comments belong to a resource. A comment records the document path
-//     as it was when it was written, so after a document moves its comments stay
-//     attached to the old path's resource. A resource's comments are therefore
-//     those of its whole redirect-ancestor chain. That's resource_comment_stats.
+//  2. Which document a comment belongs to. That's the genesis of the document its
+//     target version belongs to -- an identity, not a location. A document keeps
+//     its genesis when it moves, so its comments follow it without anyone walking
+//     a redirect chain; and a redirect between two unrelated documents can't merge
+//     their comments, because their genesises differ.
 //
-// Both walks below are seeks from a single resource, never scans of the redirect
-// graph: document_attributes is keyed (resource, key) for the forward direction
-// and indexed (key, kind, value) for the backward one.
-
-// redirectKeyPredicate matches the internal attribute that records a document's
-// redirect target. Written by indexRef when a Ref carries a redirect.
-const redirectKeyPredicate = `dak.key = '$db.redirect'`
+// Both are recomputed from scratch rather than adjusted by deltas. That makes them
+// insensitive to arrival order, which matters because blobs sync out of order and a
+// reindex replays them in blob-id order rather than causal order.
 
 // updateCommentLive settles which blob is the live version of tsid, considering
 // every blob that shares it.
 //
-// Called after a Comment blob is saved, and correct regardless of arrival order:
-// it re-derives the winner from scratch rather than adjusting a counter, so a
-// tombstone arriving before the comment it deletes, or an edit arriving before
-// the version it supersedes, both land on the same answer as any other order.
-// That is the bug this replaces — document_generations.comment_count was
-// maintained by deltas and drifted low on real data.
-func updateCommentLive(conn *sqlite.Conn, tsid TSID) error {
+// Correct regardless of arrival order: it re-derives the winner from scratch, so a
+// tombstone arriving before the comment it deletes, or an edit arriving before the
+// version it supersedes, both land on the same answer as any other order.
+//
+// genesis is the target document's genesis, resolved by the caller. Every version
+// of one comment targets the same document, so it's the same for every blob sharing
+// the TSID, and it's safe to stamp the caller's value onto whichever blob wins.
+func updateCommentLive(conn *sqlite.Conn, tsid TSID, genesis string) error {
 	if tsid == "" {
 		return fmt.Errorf("BUG: updateCommentLive called with empty TSID")
+	}
+
+	if genesis == "" {
+		return fmt.Errorf("BUG: updateCommentLive called with empty genesis for tsid %s", tsid)
 	}
 
 	if err := sqlitex.Exec(conn, qDeleteCommentLive(), nil, string(tsid)); err != nil {
 		return fmt.Errorf("failed to clear live comment for tsid %s: %w", tsid, err)
 	}
 
-	if err := sqlitex.Exec(conn, qInsertCommentLive(), nil, string(tsid)); err != nil {
+	if err := sqlitex.Exec(conn, qInsertCommentLive(), nil, string(tsid), genesis); err != nil {
 		return fmt.Errorf("failed to record live comment for tsid %s: %w", tsid, err)
 	}
 
@@ -59,15 +62,19 @@ func updateCommentLive(conn *sqlite.Conn, tsid TSID) error {
 }
 
 var qDeleteCommentLive = dqb.Str(`
-	DELETE FROM comment_live WHERE tsid = :tsid;
+	DELETE FROM comment_live WHERE tsid = ?1;
 `)
 
 // The winner is the highest (ts, id) among the blobs sharing the TSID, and it's
 // inserted only when it's live: a tombstone winning the TSID leaves no row, which
 // is how deleted comments drop out of every count.
+//
+// Numbered parameters, not named: SQLite assigns named parameters their indices in
+// order of first appearance in the text, so ?1/?2 keeps the binding order tied to
+// the Go call rather than to where each name happens to sit in the query.
 var qInsertCommentLive = dqb.Str(`
-	INSERT INTO comment_live (tsid, blob_id, resource, ts)
-	SELECT tsid, id, resource, ts
+	INSERT INTO comment_live (tsid, blob_id, genesis, resource, ts)
+	SELECT tsid, id, ?2, resource, ts
 	FROM (
 		SELECT
 			sb.extra_attrs->>'tsid' AS tsid,
@@ -76,50 +83,75 @@ var qInsertCommentLive = dqb.Str(`
 			sb.ts AS ts,
 			sb.extra_attrs->>'deleted' AS deleted
 		FROM structural_blobs sb
-		WHERE sb.type = 'Comment'
-		AND sb.extra_attrs->>'tsid' = :tsid
+		WHERE sb.extra_attrs->>'tsid' IS NOT NULL
+		AND sb.extra_attrs->>'tsid' = ?1
+		AND sb.type = 'Comment'
 		ORDER BY sb.ts DESC, sb.id DESC
 		LIMIT 1
 	)
 	WHERE deleted IS NULL AND resource IS NOT NULL;
 `)
 
-// updateResourceCommentStats recomputes comment activity for resource and for
-// every resource it transitively redirects to.
+// updateDocumentCommentStats recomputes one document's comment activity.
 //
-// The redirect targets are included because they inherit the comments: when a
-// document moves from A to B, B's listing must show the comments written against
-// A. So a change at A — a new comment, or a new redirect — moves the numbers for
-// the whole forward chain, and each of those is then recomputed from its own
-// ancestor chain.
+// No walk of any kind: the document is the genesis, and comment_live is indexed by
+// it. This replaces a pair of recursive redirect walks that used to run here, and
+// that had to be reasoned about carefully because they could reach only part of a
+// chain when blobs were replayed out of order.
 //
-// Recomputing rather than adjusting is deliberate, and cheap: both directions are
-// index seeks bounded by the redirect depth limit, and the aggregate reads
-// comment_live by resource.
-func updateResourceCommentStats(conn *sqlite.Conn, resource int64) error {
-	if err := sqlitex.Exec(conn, qDeleteResourceCommentStats(), nil, resource); err != nil {
-		return fmt.Errorf("failed to clear comment stats for resource %d: %w", resource, err)
+// Being a full recompute per genesis, it's also self-correcting: the last comment
+// indexed for a document lands on the right answer no matter what order the rest
+// arrived in, so no end-of-reindex rebuild pass is needed.
+func updateDocumentCommentStats(conn *sqlite.Conn, genesis string) error {
+	if genesis == "" {
+		return fmt.Errorf("BUG: updateDocumentCommentStats called with empty genesis")
 	}
 
-	if err := sqlitex.Exec(conn, qInsertResourceCommentStats(), nil, resource); err != nil {
-		return fmt.Errorf("failed to recompute comment stats for resource %d: %w", resource, err)
+	if err := sqlitex.Exec(conn, qUpsertDocumentCommentStats(), nil, genesis); err != nil {
+		return fmt.Errorf("failed to recompute comment stats for genesis %s: %w", genesis, err)
+	}
+
+	if err := sqlitex.Exec(conn, qPruneDocumentCommentStats(), nil, genesis); err != nil {
+		return fmt.Errorf("failed to prune comment stats for genesis %s: %w", genesis, err)
 	}
 
 	return nil
 }
 
+var qUpsertDocumentCommentStats = dqb.Str(`
+	WITH live AS (
+		SELECT blob_id, ts FROM comment_live WHERE genesis = :genesis
+	)
+	INSERT INTO document_comment_stats (genesis, last_comment, last_comment_time, comment_count)
+	SELECT
+		:genesis,
+		(SELECT blob_id FROM live ORDER BY ts DESC, blob_id DESC LIMIT 1),
+		COALESCE((SELECT MAX(ts) FROM live), 0),
+		(SELECT COUNT(*) FROM live)
+	ON CONFLICT (genesis) DO UPDATE SET
+		last_comment = excluded.last_comment,
+		last_comment_time = excluded.last_comment_time,
+		comment_count = excluded.comment_count;
+`)
+
+// Deleting the last comment of a document leaves a zero row, which would report
+// the same as no row but keep the table growing. Drop it instead.
+var qPruneDocumentCommentStats = dqb.Str(`
+	DELETE FROM document_comment_stats WHERE genesis = :genesis AND comment_count = 0;
+`)
+
 // updateSpaceCommentStats recomputes one space's comment activity.
 //
-// A comment belongs to exactly one space -- the space of the document it targets
-// -- so this needs no redirect walk at all. That is what makes space totals
-// independent of how comments are credited across redirects.
+// Space totals are attributed by location, not identity: a comment counts for the
+// space of the path it was written against. So this reads comment_live by resource
+// while the document counts above read it by genesis, and the two are independent.
 //
-// It recomputes rather than adjusting a delta, for the same reason as
-// updateResourceCommentStats and with the same evidence: on a 6.2 GB production
-// database the delta-maintained totals had drifted to 5062 against 11964 real
-// live comments. The arithmetic was only half of it -- indexComment also gave up
-// entirely when a comment's target changes weren't indexed yet, and nothing ever
-// came back to repair the skipped update.
+// It recomputes rather than adjusting a delta, for the same reason as everything
+// else here and with the same evidence: on a 6.2 GB production database the
+// delta-maintained totals had drifted to 5062 against 11964 real live comments. The
+// arithmetic was only half of it -- indexComment also gave up entirely when a
+// comment's target changes weren't indexed yet, and nothing ever came back to
+// repair the skipped update.
 //
 // last_change_time is deliberately absent from the upsert: that column belongs to
 // touchSpaceStats (blob_ref.go) and has to survive this write.
@@ -135,21 +167,17 @@ func updateSpaceCommentStats(conn *sqlite.Conn, spaceID string) error {
 	return nil
 }
 
-// qSpaceLiveCommentsCTE selects the live comments of one space: its home document
-// plus everything below it. A range rather than a GLOB, so it seeks the
-// resources.iri index ('0' being the character after '/') -- the same trick the
-// document listings use.
-const qSpaceLiveCommentsCTE = `
-	live AS (
+// The scope is the space's own home document plus everything below it, expressed as
+// a range rather than a GLOB so it seeks the resources.iri index ('0' being the
+// character after '/') -- the same trick the document listings use.
+var qUpsertSpaceCommentStats = dqb.Str(`
+	WITH live AS (
 		SELECT l.blob_id, l.ts
 		FROM comment_live l
 		JOIN resources r ON r.id = l.resource
 		WHERE r.iri = 'hm://' || :space
 		OR (r.iri >= 'hm://' || :space || '/' AND r.iri < 'hm://' || :space || '0')
-	)`
-
-var qUpsertSpaceCommentStats = dqb.Str(`
-	WITH` + qSpaceLiveCommentsCTE + `
+	)
 	INSERT INTO spaces (id, last_comment, last_comment_time, comment_count)
 	SELECT
 		:space,
@@ -162,140 +190,48 @@ var qUpsertSpaceCommentStats = dqb.Str(`
 		comment_count = excluded.comment_count;
 `)
 
-// rebuildResourceCommentStats recomputes the whole table in one pass.
+// lookupResourceGenesis returns the genesis of the document currently at a
+// resource, or "" if it has no generation yet.
 //
-// The incremental path above keeps each resource current as blobs arrive, but it
-// can only be as right as the database is at the moment it runs, and a reindex
-// replays history in blob-id order rather than causal order. A redirect Ref can
-// be replayed before the redirect that precedes it in the chain, so the walk from
-// a resource reaches only part of its chain and stops there; nothing revisits it.
-// Measured on a 6.2 GB production database, that left 163 resources — all of them
-// pure redirect targets two or more hops down a chain — with no row at all.
-//
-// So the reindex doesn't rely on the incremental path: it rebuilds from the final
-// state, where every chain is complete. This mirrors deriveAllDocFields, which
-// does the same for the derived document fields and for the same reason.
-//
-// It runs the walk in the cheap direction. Seeding from the resources that
-// actually hold comments and pushing forward touches ~1.5k rows on that database
-// and takes ~13ms; seeding from every resource and walking backwards is the same
-// answer for 3.7s.
-//
-// Space totals need no equivalent pass, and adding one would be dead code.
-// updateSpaceCommentStats recomputes a whole space from comment_live rather than
-// walking anything, so the last comment indexed for a space lands on the right
-// answer no matter what order the rest arrived in. Verified rather than assumed:
-// a full reindex of that same production database leaves all 324 spaces correct
-// with no rebuild pass at all.
-func rebuildResourceCommentStats(conn *sqlite.Conn) error {
-	if err := sqlitex.Exec(conn, qClearResourceCommentStats(), nil); err != nil {
-		return fmt.Errorf("failed to clear comment stats: %w", err)
+// Used for comments that pin no target version: they mean "the document at this
+// path", so their identity is whatever genesis that path currently resolves to.
+func lookupResourceGenesis(conn *sqlite.Conn, resource int64) (out string, err error) {
+	rows, discard, check := sqlitex.Query(conn, qResourceGenesis(), resource).All()
+	defer discard(&err)
+	for row := range rows {
+		out = row.ColumnText(0)
+		break
 	}
 
-	if err := sqlitex.Exec(conn, qRebuildResourceCommentStats(), nil); err != nil {
-		return fmt.Errorf("failed to rebuild comment stats: %w", err)
-	}
-
-	// Space totals need the same treatment, and for a simpler reason than the
-	// per-resource ones: a space's row is written whenever any of its comments is
-	// indexed, so during a replay it settles on whatever subset had arrived by
-	// then. Only rows already in `spaces` are updated -- a space with no row has
-	// no comments to count, and inserting one here would invent a space that
-	// nothing else has registered.
-
-	return nil
+	return out, check()
 }
 
-var qClearResourceCommentStats = dqb.Str(`DELETE FROM resource_comment_stats;`)
-
-var qRebuildResourceCommentStats = dqb.Str(`
-	INSERT INTO resource_comment_stats (resource, comment_count, last_comment_time, last_comment)
-	WITH RECURSIVE spread(target, source, iri, depth) AS (
-		SELECT l.resource, l.resource, r.iri, 0
-		FROM (SELECT DISTINCT resource FROM comment_live) l
-		JOIN resources r ON r.id = l.resource
-
-		UNION ALL
-
-		SELECT r.id, s.source, r.iri, s.depth + 1
-		FROM spread s
-		JOIN resources r ON r.iri = (
-			SELECT da.value
-			FROM document_attributes da
-			JOIN document_attribute_keys dak ON dak.id = da.key AND ` + redirectKeyPredicate + `
-			WHERE da.resource = s.target AND da.kind = 's'
-		)
-		WHERE s.depth < 16 AND r.iri != s.iri
-	)
-	SELECT sp.target, COUNT(*), MAX(l.ts), l.blob_id
-	FROM (SELECT DISTINCT target, source FROM spread) sp
-	JOIN comment_live l ON l.resource = sp.source
-	GROUP BY sp.target;
+var qResourceGenesis = dqb.Str(`
+	SELECT dg.genesis
+	FROM document_generations dg
+	WHERE dg.resource = ?1
+	GROUP BY dg.resource
+	HAVING dg.generation = MAX(dg.generation);
 `)
 
-// qAffectedResourcesCTE walks forward from :resource along redirect edges,
-// yielding the resource itself plus everything it redirects to.
-//
-// The redirect target is fetched with a correlated subquery rather than a join,
-// which is what gets the seek: document_attributes is keyed (resource, key), and
-// only in this shape does the planner use that key. Written as a join, it drives
-// from document_attributes instead and range-scans every redirect attribute in the
-// database on each hop.
-//
-// The depth cap and the `r.iri != a.iri` guard match the ones the listing queries
-// used, and keep a redirect cycle from looping forever.
-const qAffectedResourcesCTE = `
-	affected(resource, iri, depth) AS (
-		SELECT r.id, r.iri, 0 FROM resources r WHERE r.id = :resource
+// lookupBlobCID returns the CID string of a blob id. Used to turn the genesis blob
+// id that changeMetadata carries into the form document_generations.genesis stores,
+// so the listings can join on it directly.
+func lookupBlobCID(conn *sqlite.Conn, id int64) (out string, err error) {
+	rows, discard, check := sqlitex.Query(conn, qLookupCID(), id).All()
+	defer discard(&err)
+	for row := range rows {
+		out = cid.NewCidV1(uint64(row.ColumnInt64(0)), row.ColumnBytes(1)).String() //nolint:gosec
+		break
+	}
 
-		UNION ALL
+	if err := check(); err != nil {
+		return "", err
+	}
 
-		SELECT r.id, r.iri, a.depth + 1
-		FROM affected a
-		JOIN resources r ON r.iri = (
-			SELECT da.value
-			FROM document_attributes da
-			JOIN document_attribute_keys dak ON dak.id = da.key AND ` + redirectKeyPredicate + `
-			WHERE da.resource = a.resource AND da.kind = 's'
-		)
-		WHERE a.depth < 16 AND r.iri != a.iri
-	)`
+	if out == "" {
+		return "", fmt.Errorf("no CID found for blob %d", id)
+	}
 
-var qDeleteResourceCommentStats = dqb.Str(`
-	WITH RECURSIVE` + qAffectedResourcesCTE + `
-	DELETE FROM resource_comment_stats WHERE resource IN (SELECT resource FROM affected);
-`)
-
-// The inner walk goes the other way: for each affected resource, collect every
-// resource that transitively redirects *into* it, because those hold the comments
-// it inherits. Many resources can redirect into one IRI, so this one has to be a
-// join, and the CROSS JOIN is what makes it a seek: it pins the walk as the driver
-// so document_attributes_by_key (key, kind, value) is probed on all three columns.
-// Left to itself the planner drives from document_attributes and only constrains
-// (key, kind), which scans every redirect attribute in the database per hop.
-//
-// DISTINCT before the join: two redirect paths can reach the same ancestor, and
-// counting it twice would inflate the total.
-//
-// last_comment rides along with MAX(ts) as a bare column, so it's the blob of the
-// row that won the MAX — the same thing the query this replaces returned.
-var qInsertResourceCommentStats = dqb.Str(`
-	WITH RECURSIVE` + qAffectedResourcesCTE + `,
-	ancestors(root, resource, iri, depth) AS (
-		SELECT a.resource, a.resource, a.iri, 0 FROM affected a
-
-		UNION ALL
-
-		SELECT n.root, r.id, r.iri, n.depth + 1
-		FROM ancestors n
-		CROSS JOIN document_attributes da ON da.kind = 's' AND da.value = n.iri
-		JOIN document_attribute_keys dak ON dak.id = da.key AND ` + redirectKeyPredicate + `
-		JOIN resources r ON r.id = da.resource
-		WHERE n.depth < 16 AND r.iri != n.iri
-	)
-	INSERT INTO resource_comment_stats (resource, comment_count, last_comment_time, last_comment)
-	SELECT n.root, COUNT(*), MAX(l.ts), l.blob_id
-	FROM (SELECT DISTINCT root, resource FROM ancestors) n
-	JOIN comment_live l ON l.resource = n.resource
-	GROUP BY n.root;
-`)
+	return out, nil
+}

--- a/backend/blob/comment_stats.go
+++ b/backend/blob/comment_stats.go
@@ -1,0 +1,233 @@
+package blob
+
+import (
+	"fmt"
+
+	"seed/backend/util/dqb"
+	"seed/backend/util/sqlite"
+	"seed/backend/util/sqlite/sqlitex"
+)
+
+// Comment activity is maintained here, in two tables, instead of being derived
+// on every read (see the schema comments on comment_live and
+// resource_comment_stats).
+//
+// Two facts have to be settled to answer "how many comments does this document
+// have, and what's the latest one":
+//
+//  1. Which blob is the live version of each comment. Comments are edited and
+//     deleted by publishing further blobs that share a TSID, so the live version
+//     is the newest one, and it counts only if it isn't a tombstone. That's
+//     comment_live, and it's settled per TSID as blobs arrive.
+//
+//  2. Which comments belong to a resource. A comment records the document path
+//     as it was when it was written, so after a document moves its comments stay
+//     attached to the old path's resource. A resource's comments are therefore
+//     those of its whole redirect-ancestor chain. That's resource_comment_stats.
+//
+// Both walks below are seeks from a single resource, never scans of the redirect
+// graph: document_attributes is keyed (resource, key) for the forward direction
+// and indexed (key, kind, value) for the backward one.
+
+// redirectKeyPredicate matches the internal attribute that records a document's
+// redirect target. Written by indexRef when a Ref carries a redirect.
+const redirectKeyPredicate = `dak.key = '$db.redirect'`
+
+// updateCommentLive settles which blob is the live version of tsid, considering
+// every blob that shares it.
+//
+// Called after a Comment blob is saved, and correct regardless of arrival order:
+// it re-derives the winner from scratch rather than adjusting a counter, so a
+// tombstone arriving before the comment it deletes, or an edit arriving before
+// the version it supersedes, both land on the same answer as any other order.
+// That is the bug this replaces — document_generations.comment_count was
+// maintained by deltas and drifted low on real data.
+func updateCommentLive(conn *sqlite.Conn, tsid TSID) error {
+	if tsid == "" {
+		return fmt.Errorf("BUG: updateCommentLive called with empty TSID")
+	}
+
+	if err := sqlitex.Exec(conn, qDeleteCommentLive(), nil, string(tsid)); err != nil {
+		return fmt.Errorf("failed to clear live comment for tsid %s: %w", tsid, err)
+	}
+
+	if err := sqlitex.Exec(conn, qInsertCommentLive(), nil, string(tsid)); err != nil {
+		return fmt.Errorf("failed to record live comment for tsid %s: %w", tsid, err)
+	}
+
+	return nil
+}
+
+var qDeleteCommentLive = dqb.Str(`
+	DELETE FROM comment_live WHERE tsid = :tsid;
+`)
+
+// The winner is the highest (ts, id) among the blobs sharing the TSID, and it's
+// inserted only when it's live: a tombstone winning the TSID leaves no row, which
+// is how deleted comments drop out of every count.
+var qInsertCommentLive = dqb.Str(`
+	INSERT INTO comment_live (tsid, blob_id, resource, ts)
+	SELECT tsid, id, resource, ts
+	FROM (
+		SELECT
+			sb.extra_attrs->>'tsid' AS tsid,
+			sb.id AS id,
+			sb.resource AS resource,
+			sb.ts AS ts,
+			sb.extra_attrs->>'deleted' AS deleted
+		FROM structural_blobs sb
+		WHERE sb.type = 'Comment'
+		AND sb.extra_attrs->>'tsid' = :tsid
+		ORDER BY sb.ts DESC, sb.id DESC
+		LIMIT 1
+	)
+	WHERE deleted IS NULL AND resource IS NOT NULL;
+`)
+
+// updateResourceCommentStats recomputes comment activity for resource and for
+// every resource it transitively redirects to.
+//
+// The redirect targets are included because they inherit the comments: when a
+// document moves from A to B, B's listing must show the comments written against
+// A. So a change at A — a new comment, or a new redirect — moves the numbers for
+// the whole forward chain, and each of those is then recomputed from its own
+// ancestor chain.
+//
+// Recomputing rather than adjusting is deliberate, and cheap: both directions are
+// index seeks bounded by the redirect depth limit, and the aggregate reads
+// comment_live by resource.
+func updateResourceCommentStats(conn *sqlite.Conn, resource int64) error {
+	if err := sqlitex.Exec(conn, qDeleteResourceCommentStats(), nil, resource); err != nil {
+		return fmt.Errorf("failed to clear comment stats for resource %d: %w", resource, err)
+	}
+
+	if err := sqlitex.Exec(conn, qInsertResourceCommentStats(), nil, resource); err != nil {
+		return fmt.Errorf("failed to recompute comment stats for resource %d: %w", resource, err)
+	}
+
+	return nil
+}
+
+// rebuildResourceCommentStats recomputes the whole table in one pass.
+//
+// The incremental path above keeps each resource current as blobs arrive, but it
+// can only be as right as the database is at the moment it runs, and a reindex
+// replays history in blob-id order rather than causal order. A redirect Ref can
+// be replayed before the redirect that precedes it in the chain, so the walk from
+// a resource reaches only part of its chain and stops there; nothing revisits it.
+// Measured on a 6.2 GB production database, that left 163 resources — all of them
+// pure redirect targets two or more hops down a chain — with no row at all.
+//
+// So the reindex doesn't rely on the incremental path: it rebuilds from the final
+// state, where every chain is complete. This mirrors deriveAllDocFields, which
+// does the same for the derived document fields and for the same reason.
+//
+// It runs the walk in the cheap direction. Seeding from the resources that
+// actually hold comments and pushing forward touches ~1.5k rows on that database
+// and takes ~13ms; seeding from every resource and walking backwards is the same
+// answer for 3.7s.
+func rebuildResourceCommentStats(conn *sqlite.Conn) error {
+	if err := sqlitex.Exec(conn, qClearResourceCommentStats(), nil); err != nil {
+		return fmt.Errorf("failed to clear comment stats: %w", err)
+	}
+
+	if err := sqlitex.Exec(conn, qRebuildResourceCommentStats(), nil); err != nil {
+		return fmt.Errorf("failed to rebuild comment stats: %w", err)
+	}
+
+	return nil
+}
+
+var qClearResourceCommentStats = dqb.Str(`DELETE FROM resource_comment_stats;`)
+
+var qRebuildResourceCommentStats = dqb.Str(`
+	INSERT INTO resource_comment_stats (resource, comment_count, last_comment_time, last_comment)
+	WITH RECURSIVE spread(target, source, iri, depth) AS (
+		SELECT l.resource, l.resource, r.iri, 0
+		FROM (SELECT DISTINCT resource FROM comment_live) l
+		JOIN resources r ON r.id = l.resource
+
+		UNION ALL
+
+		SELECT r.id, s.source, r.iri, s.depth + 1
+		FROM spread s
+		JOIN resources r ON r.iri = (
+			SELECT da.value
+			FROM document_attributes da
+			JOIN document_attribute_keys dak ON dak.id = da.key AND ` + redirectKeyPredicate + `
+			WHERE da.resource = s.target AND da.kind = 's'
+		)
+		WHERE s.depth < 16 AND r.iri != s.iri
+	)
+	SELECT sp.target, COUNT(*), MAX(l.ts), l.blob_id
+	FROM (SELECT DISTINCT target, source FROM spread) sp
+	JOIN comment_live l ON l.resource = sp.source
+	GROUP BY sp.target;
+`)
+
+// qAffectedResourcesCTE walks forward from :resource along redirect edges,
+// yielding the resource itself plus everything it redirects to.
+//
+// The redirect target is fetched with a correlated subquery rather than a join,
+// which is what gets the seek: document_attributes is keyed (resource, key), and
+// only in this shape does the planner use that key. Written as a join, it drives
+// from document_attributes instead and range-scans every redirect attribute in the
+// database on each hop.
+//
+// The depth cap and the `r.iri != a.iri` guard match the ones the listing queries
+// used, and keep a redirect cycle from looping forever.
+const qAffectedResourcesCTE = `
+	affected(resource, iri, depth) AS (
+		SELECT r.id, r.iri, 0 FROM resources r WHERE r.id = :resource
+
+		UNION ALL
+
+		SELECT r.id, r.iri, a.depth + 1
+		FROM affected a
+		JOIN resources r ON r.iri = (
+			SELECT da.value
+			FROM document_attributes da
+			JOIN document_attribute_keys dak ON dak.id = da.key AND ` + redirectKeyPredicate + `
+			WHERE da.resource = a.resource AND da.kind = 's'
+		)
+		WHERE a.depth < 16 AND r.iri != a.iri
+	)`
+
+var qDeleteResourceCommentStats = dqb.Str(`
+	WITH RECURSIVE` + qAffectedResourcesCTE + `
+	DELETE FROM resource_comment_stats WHERE resource IN (SELECT resource FROM affected);
+`)
+
+// The inner walk goes the other way: for each affected resource, collect every
+// resource that transitively redirects *into* it, because those hold the comments
+// it inherits. Many resources can redirect into one IRI, so this one has to be a
+// join, and the CROSS JOIN is what makes it a seek: it pins the walk as the driver
+// so document_attributes_by_key (key, kind, value) is probed on all three columns.
+// Left to itself the planner drives from document_attributes and only constrains
+// (key, kind), which scans every redirect attribute in the database per hop.
+//
+// DISTINCT before the join: two redirect paths can reach the same ancestor, and
+// counting it twice would inflate the total.
+//
+// last_comment rides along with MAX(ts) as a bare column, so it's the blob of the
+// row that won the MAX — the same thing the query this replaces returned.
+var qInsertResourceCommentStats = dqb.Str(`
+	WITH RECURSIVE` + qAffectedResourcesCTE + `,
+	ancestors(root, resource, iri, depth) AS (
+		SELECT a.resource, a.resource, a.iri, 0 FROM affected a
+
+		UNION ALL
+
+		SELECT n.root, r.id, r.iri, n.depth + 1
+		FROM ancestors n
+		CROSS JOIN document_attributes da ON da.kind = 's' AND da.value = n.iri
+		JOIN document_attribute_keys dak ON dak.id = da.key AND ` + redirectKeyPredicate + `
+		JOIN resources r ON r.id = da.resource
+		WHERE n.depth < 16 AND r.iri != n.iri
+	)
+	INSERT INTO resource_comment_stats (resource, comment_count, last_comment_time, last_comment)
+	SELECT n.root, COUNT(*), MAX(l.ts), l.blob_id
+	FROM (SELECT DISTINCT root, resource FROM ancestors) n
+	JOIN comment_live l ON l.resource = n.resource
+	GROUP BY n.root;
+`)

--- a/backend/blob/comment_stats.go
+++ b/backend/blob/comment_stats.go
@@ -108,6 +108,60 @@ func updateResourceCommentStats(conn *sqlite.Conn, resource int64) error {
 	return nil
 }
 
+// updateSpaceCommentStats recomputes one space's comment activity.
+//
+// A comment belongs to exactly one space -- the space of the document it targets
+// -- so this needs no redirect walk at all. That is what makes space totals
+// independent of how comments are credited across redirects.
+//
+// It recomputes rather than adjusting a delta, for the same reason as
+// updateResourceCommentStats and with the same evidence: on a 6.2 GB production
+// database the delta-maintained totals had drifted to 5062 against 11964 real
+// live comments. The arithmetic was only half of it -- indexComment also gave up
+// entirely when a comment's target changes weren't indexed yet, and nothing ever
+// came back to repair the skipped update.
+//
+// last_change_time is deliberately absent from the upsert: that column belongs to
+// touchSpaceStats (blob_ref.go) and has to survive this write.
+func updateSpaceCommentStats(conn *sqlite.Conn, spaceID string) error {
+	if spaceID == "" {
+		return fmt.Errorf("BUG: updateSpaceCommentStats called with empty space")
+	}
+
+	if err := sqlitex.Exec(conn, qUpsertSpaceCommentStats(), nil, spaceID); err != nil {
+		return fmt.Errorf("failed to recompute comment stats for space %s: %w", spaceID, err)
+	}
+
+	return nil
+}
+
+// qSpaceLiveCommentsCTE selects the live comments of one space: its home document
+// plus everything below it. A range rather than a GLOB, so it seeks the
+// resources.iri index ('0' being the character after '/') -- the same trick the
+// document listings use.
+const qSpaceLiveCommentsCTE = `
+	live AS (
+		SELECT l.blob_id, l.ts
+		FROM comment_live l
+		JOIN resources r ON r.id = l.resource
+		WHERE r.iri = 'hm://' || :space
+		OR (r.iri >= 'hm://' || :space || '/' AND r.iri < 'hm://' || :space || '0')
+	)`
+
+var qUpsertSpaceCommentStats = dqb.Str(`
+	WITH` + qSpaceLiveCommentsCTE + `
+	INSERT INTO spaces (id, last_comment, last_comment_time, comment_count)
+	SELECT
+		:space,
+		(SELECT blob_id FROM live ORDER BY ts DESC, blob_id DESC LIMIT 1),
+		COALESCE((SELECT MAX(ts) FROM live), 0),
+		(SELECT COUNT(*) FROM live)
+	ON CONFLICT (id) DO UPDATE SET
+		last_comment = excluded.last_comment,
+		last_comment_time = excluded.last_comment_time,
+		comment_count = excluded.comment_count;
+`)
+
 // rebuildResourceCommentStats recomputes the whole table in one pass.
 //
 // The incremental path above keeps each resource current as blobs arrive, but it
@@ -126,6 +180,13 @@ func updateResourceCommentStats(conn *sqlite.Conn, resource int64) error {
 // actually hold comments and pushing forward touches ~1.5k rows on that database
 // and takes ~13ms; seeding from every resource and walking backwards is the same
 // answer for 3.7s.
+//
+// Space totals need no equivalent pass, and adding one would be dead code.
+// updateSpaceCommentStats recomputes a whole space from comment_live rather than
+// walking anything, so the last comment indexed for a space lands on the right
+// answer no matter what order the rest arrived in. Verified rather than assumed:
+// a full reindex of that same production database leaves all 324 spaces correct
+// with no rebuild pass at all.
 func rebuildResourceCommentStats(conn *sqlite.Conn) error {
 	if err := sqlitex.Exec(conn, qClearResourceCommentStats(), nil); err != nil {
 		return fmt.Errorf("failed to clear comment stats: %w", err)
@@ -134,6 +195,13 @@ func rebuildResourceCommentStats(conn *sqlite.Conn) error {
 	if err := sqlitex.Exec(conn, qRebuildResourceCommentStats(), nil); err != nil {
 		return fmt.Errorf("failed to rebuild comment stats: %w", err)
 	}
+
+	// Space totals need the same treatment, and for a simpler reason than the
+	// per-resource ones: a space's row is written whenever any of its comments is
+	// indexed, so during a replay it settles on whatever subset had arrived by
+	// then. Only rows already in `spaces` are updated -- a space with no row has
+	// no comments to count, and inserting one here would invent a space that
+	// nothing else has registered.
 
 	return nil
 }

--- a/backend/blob/comment_stats_test.go
+++ b/backend/blob/comment_stats_test.go
@@ -1,0 +1,66 @@
+package blob
+
+import (
+	"strings"
+	"testing"
+
+	"seed/backend/storage"
+	"seed/backend/util/sqlite"
+	"seed/backend/util/sqlite/sqlitex"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCommentStatsWalksSeek guards the shape of the two redirect walks in
+// updateResourceCommentStats.
+//
+// Both run on the write path, once per indexed comment and once per redirect, so
+// they have to cost about as much as the chain is long — not as much as the
+// database is big. Both get there only because of a specific formulation, and
+// both silently fall back to scanning every redirect attribute in the database if
+// that formulation is disturbed:
+//
+//   - forward: the target is read through a correlated subquery, which is the only
+//     shape where the planner uses document_attributes' (resource, key) key;
+//   - backward: a CROSS JOIN pins the walk as the driver, so the three-column
+//     document_attributes_by_key index is probed on value as well as (key, kind).
+//
+// Written as ordinary joins both plans still return the right answer, so only the
+// plan catches the regression.
+func TestCommentStatsWalksSeek(t *testing.T) {
+	t.Parallel()
+
+	db := storage.MakeTestDB(t)
+	conn, release, err := db.ReadConn(t.Context())
+	require.NoError(t, err)
+	defer release()
+
+	for _, tt := range []struct {
+		name  string
+		query string
+	}{
+		{"delete", qDeleteResourceCommentStats()},
+		{"insert", qInsertResourceCommentStats()},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var sb strings.Builder
+			require.NoError(t, sqlitex.ExecTransient(conn, "EXPLAIN QUERY PLAN "+strings.TrimSpace(tt.query), func(stmt *sqlite.Stmt) error {
+				sb.WriteString(stmt.ColumnText(3))
+				sb.WriteString("\n")
+				return nil
+			}, 0))
+			plan := sb.String()
+
+			require.Contains(t, plan, "SEARCH da USING PRIMARY KEY (resource=? AND key=?)",
+				"the forward redirect walk must seek document_attributes by resource\nplan:\n%s", plan)
+
+			if tt.name == "insert" {
+				require.Contains(t, plan, "document_attributes_by_key (key=? AND kind=? AND value=?)",
+					"the backward redirect walk must seek on the redirect target's IRI, not scan every redirect\nplan:\n%s", plan)
+			}
+
+			require.NotContains(t, plan, "SCAN document_attributes",
+				"a full document_attributes scan puts the whole database on the write path\nplan:\n%s", plan)
+		})
+	}
+}

--- a/backend/blob/comment_stats_test.go
+++ b/backend/blob/comment_stats_test.go
@@ -11,23 +11,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestCommentStatsWalksSeek guards the shape of the two redirect walks in
-// updateResourceCommentStats.
+// TestCommentStatsQueriesSeek guards the shape of the maintenance queries.
 //
-// Both run on the write path, once per indexed comment and once per redirect, so
-// they have to cost about as much as the chain is long — not as much as the
-// database is big. Both get there only because of a specific formulation, and
-// both silently fall back to scanning every redirect attribute in the database if
-// that formulation is disturbed:
-//
-//   - forward: the target is read through a correlated subquery, which is the only
-//     shape where the planner uses document_attributes' (resource, key) key;
-//   - backward: a CROSS JOIN pins the walk as the driver, so the three-column
-//     document_attributes_by_key index is probed on value as well as (key, kind).
-//
-// Written as ordinary joins both plans still return the right answer, so only the
-// plan catches the regression.
-func TestCommentStatsWalksSeek(t *testing.T) {
+// They run on the write path, once per indexed comment, so each has to cost about
+// as much as one document's comments -- not as much as the database is big. Each
+// gets there through an index that the query text has to keep provable: keying
+// comment activity by genesis is only cheap because comment_live_by_genesis can be
+// seeked, and a change that hides the genesis behind an expression or a join would
+// still return the right answer, just slowly. Only the plan catches that.
+func TestCommentStatsQueriesSeek(t *testing.T) {
 	t.Parallel()
 
 	db := storage.MakeTestDB(t)
@@ -35,32 +27,34 @@ func TestCommentStatsWalksSeek(t *testing.T) {
 	require.NoError(t, err)
 	defer release()
 
-	for _, tt := range []struct {
-		name  string
-		query string
-	}{
-		{"delete", qDeleteResourceCommentStats()},
-		{"insert", qInsertResourceCommentStats()},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			var sb strings.Builder
-			require.NoError(t, sqlitex.ExecTransient(conn, "EXPLAIN QUERY PLAN "+strings.TrimSpace(tt.query), func(stmt *sqlite.Stmt) error {
-				sb.WriteString(stmt.ColumnText(3))
-				sb.WriteString("\n")
-				return nil
-			}, 0))
-			plan := sb.String()
-
-			require.Contains(t, plan, "SEARCH da USING PRIMARY KEY (resource=? AND key=?)",
-				"the forward redirect walk must seek document_attributes by resource\nplan:\n%s", plan)
-
-			if tt.name == "insert" {
-				require.Contains(t, plan, "document_attributes_by_key (key=? AND kind=? AND value=?)",
-					"the backward redirect walk must seek on the redirect target's IRI, not scan every redirect\nplan:\n%s", plan)
-			}
-
-			require.NotContains(t, plan, "SCAN document_attributes",
-				"a full document_attributes scan puts the whole database on the write path\nplan:\n%s", plan)
-		})
+	plan := func(t *testing.T, query string, args ...any) string {
+		t.Helper()
+		var sb strings.Builder
+		require.NoError(t, sqlitex.ExecTransient(conn, "EXPLAIN QUERY PLAN "+strings.TrimSpace(query), func(stmt *sqlite.Stmt) error {
+			sb.WriteString(stmt.ColumnText(3))
+			sb.WriteString("\n")
+			return nil
+		}, args...))
+		return sb.String()
 	}
+
+	t.Run("document stats seek comment_live by genesis", func(t *testing.T) {
+		got := plan(t, qUpsertDocumentCommentStats(), "")
+		require.Contains(t, got, "comment_live_by_genesis",
+			"recomputing a document's comments must seek by genesis\nplan:\n%s", got)
+		require.NotContains(t, got, "SCAN comment_live",
+			"a full comment_live scan puts every comment in the database on the write path\nplan:\n%s", got)
+	})
+
+	t.Run("space stats seek resources by iri", func(t *testing.T) {
+		got := plan(t, qUpsertSpaceCommentStats(), "")
+		require.NotContains(t, got, "SCAN resources",
+			"the space scope must seek the resources.iri index, not scan it\nplan:\n%s", got)
+	})
+
+	t.Run("live comment lookup seeks by tsid", func(t *testing.T) {
+		got := plan(t, qInsertCommentLive(), "", "")
+		require.Contains(t, got, "structural_blobs_by_tsid",
+			"settling a TSID's live version must seek the tsid index\nplan:\n%s", got)
+	})
 }

--- a/backend/blob/reindex.go
+++ b/backend/blob/reindex.go
@@ -22,13 +22,13 @@ var derivedTables = []string{
 	storage.T_StructuralBlobs,
 	storage.T_DocumentAttributes,
 	storage.T_DocumentAttributeKeys,
-	// Comment activity is derived from Comment blobs and the redirect chains, so
-	// it's rebuilt by the blob loop below. Both have an FK to resources with
-	// ON DELETE CASCADE, but reindex deletes in list order, so list them before
-	// resources rather than relying on the cascade (same reasoning as the RBSR
-	// tables at the end of this list).
+	// Comment activity is derived from Comment blobs, so it's rebuilt by the blob
+	// loop below. comment_live has an FK to resources with ON DELETE CASCADE, but
+	// reindex deletes in list order, so list it before resources rather than
+	// relying on the cascade (same reasoning as the RBSR tables at the end of
+	// this list).
 	storage.T_CommentLive,
-	storage.T_ResourceCommentStats,
+	storage.T_DocumentCommentStats,
 	storage.T_Resources,
 	storage.T_Spaces,
 	storage.T_DocumentGenerations,
@@ -234,15 +234,6 @@ func (idx *Index) reindex(conn *sqlite.Conn) (err error) {
 			return err
 		}
 		coverDur = time.Since(coverStart)
-
-		// Same reason as the pass above: the loop replays blobs in id order, not
-		// causal order, so a redirect can be indexed before the chain it extends
-		// and the incremental walk then only reaches part of it. Rebuilding from
-		// the final state settles every chain at once. Cheap — ~13ms on a 6.2 GB
-		// production database.
-		if err := rebuildResourceCommentStats(conn); err != nil {
-			return err
-		}
 
 		return dbSetReindexTime(conn, time.Now().UTC().String())
 	}); err != nil {

--- a/backend/blob/reindex.go
+++ b/backend/blob/reindex.go
@@ -22,6 +22,13 @@ var derivedTables = []string{
 	storage.T_StructuralBlobs,
 	storage.T_DocumentAttributes,
 	storage.T_DocumentAttributeKeys,
+	// Comment activity is derived from Comment blobs and the redirect chains, so
+	// it's rebuilt by the blob loop below. Both have an FK to resources with
+	// ON DELETE CASCADE, but reindex deletes in list order, so list them before
+	// resources rather than relying on the cascade (same reasoning as the RBSR
+	// tables at the end of this list).
+	storage.T_CommentLive,
+	storage.T_ResourceCommentStats,
 	storage.T_Resources,
 	storage.T_Spaces,
 	storage.T_DocumentGenerations,
@@ -227,6 +234,15 @@ func (idx *Index) reindex(conn *sqlite.Conn) (err error) {
 			return err
 		}
 		coverDur = time.Since(coverStart)
+
+		// Same reason as the pass above: the loop replays blobs in id order, not
+		// causal order, so a redirect can be indexed before the chain it extends
+		// and the incremental walk then only reaches part of it. Rebuilding from
+		// the final state settles every chain at once. Cheap — ~13ms on a 6.2 GB
+		// production database.
+		if err := rebuildResourceCommentStats(conn); err != nil {
+			return err
+		}
 
 		return dbSetReindexTime(conn, time.Now().UTC().String())
 	}); err != nil {

--- a/backend/storage/schema.gen.go
+++ b/backend/storage/schema.gen.go
@@ -98,6 +98,7 @@ const (
 const (
 	CommentLive         sqlitegen.Table  = "comment_live"
 	CommentLiveBlobID   sqlitegen.Column = "comment_live.blob_id"
+	CommentLiveGenesis  sqlitegen.Column = "comment_live.genesis"
 	CommentLiveResource sqlitegen.Column = "comment_live.resource"
 	CommentLiveTs       sqlitegen.Column = "comment_live.ts"
 	CommentLiveTsid     sqlitegen.Column = "comment_live.tsid"
@@ -107,6 +108,7 @@ const (
 const (
 	T_CommentLive         = "comment_live"
 	C_CommentLiveBlobID   = "comment_live.blob_id"
+	C_CommentLiveGenesis  = "comment_live.genesis"
 	C_CommentLiveResource = "comment_live.resource"
 	C_CommentLiveTs       = "comment_live.ts"
 	C_CommentLiveTsid     = "comment_live.tsid"
@@ -150,6 +152,24 @@ const (
 	C_DocumentAttributesResource  = "document_attributes.resource"
 	C_DocumentAttributesTimestamp = "document_attributes.timestamp"
 	C_DocumentAttributesValue     = "document_attributes.value"
+)
+
+// Table document_comment_stats.
+const (
+	DocumentCommentStats                sqlitegen.Table  = "document_comment_stats"
+	DocumentCommentStatsCommentCount    sqlitegen.Column = "document_comment_stats.comment_count"
+	DocumentCommentStatsGenesis         sqlitegen.Column = "document_comment_stats.genesis"
+	DocumentCommentStatsLastComment     sqlitegen.Column = "document_comment_stats.last_comment"
+	DocumentCommentStatsLastCommentTime sqlitegen.Column = "document_comment_stats.last_comment_time"
+)
+
+// Table document_comment_stats. Plain strings.
+const (
+	T_DocumentCommentStats                = "document_comment_stats"
+	C_DocumentCommentStatsCommentCount    = "document_comment_stats.comment_count"
+	C_DocumentCommentStatsGenesis         = "document_comment_stats.genesis"
+	C_DocumentCommentStatsLastComment     = "document_comment_stats.last_comment"
+	C_DocumentCommentStatsLastCommentTime = "document_comment_stats.last_comment_time"
 )
 
 // Table document_generations.
@@ -554,24 +574,6 @@ const (
 	C_RbsrScopeMaterialized = "rbsr_scope.materialized"
 )
 
-// Table resource_comment_stats.
-const (
-	ResourceCommentStats                sqlitegen.Table  = "resource_comment_stats"
-	ResourceCommentStatsCommentCount    sqlitegen.Column = "resource_comment_stats.comment_count"
-	ResourceCommentStatsLastComment     sqlitegen.Column = "resource_comment_stats.last_comment"
-	ResourceCommentStatsLastCommentTime sqlitegen.Column = "resource_comment_stats.last_comment_time"
-	ResourceCommentStatsResource        sqlitegen.Column = "resource_comment_stats.resource"
-)
-
-// Table resource_comment_stats. Plain strings.
-const (
-	T_ResourceCommentStats                = "resource_comment_stats"
-	C_ResourceCommentStatsCommentCount    = "resource_comment_stats.comment_count"
-	C_ResourceCommentStatsLastComment     = "resource_comment_stats.last_comment"
-	C_ResourceCommentStatsLastCommentTime = "resource_comment_stats.last_comment_time"
-	C_ResourceCommentStatsResource        = "resource_comment_stats.resource"
-)
-
 // Table resource_links.
 const (
 	ResourceLinks           sqlitegen.Table  = "resource_links"
@@ -767,6 +769,7 @@ var Schema = sqlitegen.Schema{
 		BlobsMultihash:                          {Table: Blobs, SQLType: "BLOB"},
 		BlobsSize:                               {Table: Blobs, SQLType: "INTEGER"},
 		CommentLiveBlobID:                       {Table: CommentLive, SQLType: "INTEGER"},
+		CommentLiveGenesis:                      {Table: CommentLive, SQLType: "TEXT"},
 		CommentLiveResource:                     {Table: CommentLive, SQLType: "INTEGER"},
 		CommentLiveTs:                           {Table: CommentLive, SQLType: "INTEGER"},
 		CommentLiveTsid:                         {Table: CommentLive, SQLType: "TEXT"},
@@ -780,6 +783,10 @@ var Schema = sqlitegen.Schema{
 		DocumentAttributesResource:              {Table: DocumentAttributes, SQLType: "INTEGER"},
 		DocumentAttributesTimestamp:             {Table: DocumentAttributes, SQLType: "INTEGER"},
 		DocumentAttributesValue:                 {Table: DocumentAttributes, SQLType: ""},
+		DocumentCommentStatsCommentCount:        {Table: DocumentCommentStats, SQLType: "INTEGER"},
+		DocumentCommentStatsGenesis:             {Table: DocumentCommentStats, SQLType: "TEXT"},
+		DocumentCommentStatsLastComment:         {Table: DocumentCommentStats, SQLType: "INTEGER"},
+		DocumentCommentStatsLastCommentTime:     {Table: DocumentCommentStats, SQLType: "INTEGER"},
 		DocumentGenerationsAuthors:              {Table: DocumentGenerations, SQLType: "JSON"},
 		DocumentGenerationsChangeCount:          {Table: DocumentGenerations, SQLType: "INTEGER"},
 		DocumentGenerationsChanges:              {Table: DocumentGenerations, SQLType: "BLOB"},
@@ -871,10 +878,6 @@ var Schema = sqlitegen.Schema{
 		RbsrScopeKind:                           {Table: RbsrScope, SQLType: "INTEGER"},
 		RbsrScopeLastAccess:                     {Table: RbsrScope, SQLType: "INTEGER"},
 		RbsrScopeMaterialized:                   {Table: RbsrScope, SQLType: "INTEGER"},
-		ResourceCommentStatsCommentCount:        {Table: ResourceCommentStats, SQLType: "INTEGER"},
-		ResourceCommentStatsLastComment:         {Table: ResourceCommentStats, SQLType: "INTEGER"},
-		ResourceCommentStatsLastCommentTime:     {Table: ResourceCommentStats, SQLType: "INTEGER"},
-		ResourceCommentStatsResource:            {Table: ResourceCommentStats, SQLType: "INTEGER"},
 		ResourceLinksExtraAttrs:                 {Table: ResourceLinks, SQLType: "JSONB"},
 		ResourceLinksID:                         {Table: ResourceLinks, SQLType: "INTEGER"},
 		ResourceLinksIsPinned:                   {Table: ResourceLinks, SQLType: "INTEGER"},

--- a/backend/storage/schema.gen.go
+++ b/backend/storage/schema.gen.go
@@ -94,6 +94,24 @@ const (
 	C_BlobsSize       = "blobs.size"
 )
 
+// Table comment_live.
+const (
+	CommentLive         sqlitegen.Table  = "comment_live"
+	CommentLiveBlobID   sqlitegen.Column = "comment_live.blob_id"
+	CommentLiveResource sqlitegen.Column = "comment_live.resource"
+	CommentLiveTs       sqlitegen.Column = "comment_live.ts"
+	CommentLiveTsid     sqlitegen.Column = "comment_live.tsid"
+)
+
+// Table comment_live. Plain strings.
+const (
+	T_CommentLive         = "comment_live"
+	C_CommentLiveBlobID   = "comment_live.blob_id"
+	C_CommentLiveResource = "comment_live.resource"
+	C_CommentLiveTs       = "comment_live.ts"
+	C_CommentLiveTsid     = "comment_live.tsid"
+)
+
 // Table document_attribute_keys.
 const (
 	DocumentAttributeKeys          sqlitegen.Table  = "document_attribute_keys"
@@ -536,6 +554,24 @@ const (
 	C_RbsrScopeMaterialized = "rbsr_scope.materialized"
 )
 
+// Table resource_comment_stats.
+const (
+	ResourceCommentStats                sqlitegen.Table  = "resource_comment_stats"
+	ResourceCommentStatsCommentCount    sqlitegen.Column = "resource_comment_stats.comment_count"
+	ResourceCommentStatsLastComment     sqlitegen.Column = "resource_comment_stats.last_comment"
+	ResourceCommentStatsLastCommentTime sqlitegen.Column = "resource_comment_stats.last_comment_time"
+	ResourceCommentStatsResource        sqlitegen.Column = "resource_comment_stats.resource"
+)
+
+// Table resource_comment_stats. Plain strings.
+const (
+	T_ResourceCommentStats                = "resource_comment_stats"
+	C_ResourceCommentStatsCommentCount    = "resource_comment_stats.comment_count"
+	C_ResourceCommentStatsLastComment     = "resource_comment_stats.last_comment"
+	C_ResourceCommentStatsLastCommentTime = "resource_comment_stats.last_comment_time"
+	C_ResourceCommentStatsResource        = "resource_comment_stats.resource"
+)
+
 // Table resource_links.
 const (
 	ResourceLinks           sqlitegen.Table  = "resource_links"
@@ -730,6 +766,10 @@ var Schema = sqlitegen.Schema{
 		BlobsInsertTime:                         {Table: Blobs, SQLType: "INTEGER"},
 		BlobsMultihash:                          {Table: Blobs, SQLType: "BLOB"},
 		BlobsSize:                               {Table: Blobs, SQLType: "INTEGER"},
+		CommentLiveBlobID:                       {Table: CommentLive, SQLType: "INTEGER"},
+		CommentLiveResource:                     {Table: CommentLive, SQLType: "INTEGER"},
+		CommentLiveTs:                           {Table: CommentLive, SQLType: "INTEGER"},
+		CommentLiveTsid:                         {Table: CommentLive, SQLType: "TEXT"},
 		DocumentAttributeKeysID:                 {Table: DocumentAttributeKeys, SQLType: "INTEGER"},
 		DocumentAttributeKeysKey:                {Table: DocumentAttributeKeys, SQLType: "TEXT"},
 		DocumentAttributeKeysSearchKey:          {Table: DocumentAttributeKeys, SQLType: "TEXT"},
@@ -831,6 +871,10 @@ var Schema = sqlitegen.Schema{
 		RbsrScopeKind:                           {Table: RbsrScope, SQLType: "INTEGER"},
 		RbsrScopeLastAccess:                     {Table: RbsrScope, SQLType: "INTEGER"},
 		RbsrScopeMaterialized:                   {Table: RbsrScope, SQLType: "INTEGER"},
+		ResourceCommentStatsCommentCount:        {Table: ResourceCommentStats, SQLType: "INTEGER"},
+		ResourceCommentStatsLastComment:         {Table: ResourceCommentStats, SQLType: "INTEGER"},
+		ResourceCommentStatsLastCommentTime:     {Table: ResourceCommentStats, SQLType: "INTEGER"},
+		ResourceCommentStatsResource:            {Table: ResourceCommentStats, SQLType: "INTEGER"},
 		ResourceLinksExtraAttrs:                 {Table: ResourceLinks, SQLType: "JSONB"},
 		ResourceLinksID:                         {Table: ResourceLinks, SQLType: "INTEGER"},
 		ResourceLinksIsPinned:                   {Table: ResourceLinks, SQLType: "INTEGER"},

--- a/backend/storage/schema.sql
+++ b/backend/storage/schema.sql
@@ -258,42 +258,46 @@ CREATE TABLE comment_live (
     tsid TEXT PRIMARY KEY,
     -- The winning blob. Also the value listings report as `last_comment`.
     blob_id INTEGER REFERENCES blobs (id) ON UPDATE CASCADE ON DELETE CASCADE NOT NULL,
-    -- The resource the winning blob targets. Comments record the document path as
-    -- it was when they were written, so this is not necessarily where the document
-    -- lives now -- resource_comment_stats resolves that.
+    -- Genesis CID of the document this comment targets, resolved from the comment's
+    -- target version when it's indexed. This is the document's *identity*, so it
+    -- survives the document moving, and two documents that merely redirect at each
+    -- other never share it.
+    genesis TEXT NOT NULL,
+    -- The resource the comment targeted: its *location* when it was written. Used
+    -- only to attribute the comment to a space, never to a document.
     resource INTEGER REFERENCES resources (id) ON UPDATE CASCADE ON DELETE CASCADE NOT NULL,
     ts INTEGER NOT NULL
 ) WITHOUT ROWID;
 
+CREATE INDEX comment_live_by_genesis ON comment_live (genesis, ts);
 CREATE INDEX comment_live_by_resource ON comment_live (resource, ts);
 CREATE INDEX comment_live_by_blob ON comment_live (blob_id);
 
--- Redirect-aware comment activity per resource: what the document listings read.
+-- Comment activity per document, keyed by genesis: what the listings read.
 --
--- A document that moved leaves its comments attached to the old path's resource, so
--- a resource's comments are those of its whole redirect-ancestor chain, not just its
--- own. Listings JOIN this table by resource and are done; the chain walk happens
--- here, at index time, in updateResourceCommentStats.
+-- Keyed by genesis and not by resource, because a comment belongs to a *document*,
+-- and a document's identity is its genesis, not the path it currently sits at.
+-- That makes a moved document keep its comments for free -- the genesis doesn't
+-- change when the path does -- and it stops a redirect between two unrelated
+-- documents from merging their counts. Measured on a 6.2 GB production database,
+-- 6 of 1766 redirect edges pointed at a different genesis, and one of them was
+-- crediting 293 comments from /tech-talks onto /tech.
 --
--- This is deliberately keyed by resource rather than by (resource, generation) like
--- document_generations.comment_count. That column only ever counted comments against
--- generations satisfying containsAllChanges, and skipped comments whose target
--- changes hadn't been indexed yet; measured on a 6.2 GB production database it was
--- too low for 1141 of the 1489 resources that have comments, 5062 counted against
--- 11964 real ones. Comment activity belongs to the resource.
-CREATE TABLE resource_comment_stats (
-    resource INTEGER PRIMARY KEY REFERENCES resources (id) ON UPDATE CASCADE ON DELETE CASCADE,
+-- It also replaces document_generations.comment_count, which counted only against
+-- generations satisfying containsAllChanges and skipped comments whose target
+-- changes weren't indexed yet: too low for 1141 of the 1489 resources that had
+-- comments, 5062 counted against 11964 real ones.
+CREATE TABLE document_comment_stats (
+    genesis TEXT PRIMARY KEY,
     comment_count INTEGER NOT NULL,
-    -- Blob id of the most recent credited comment, i.e. the one whose ts equals
+    -- Blob id of the most recent comment, i.e. the one whose ts equals
     -- last_comment_time.
     last_comment INTEGER REFERENCES blobs (id) ON UPDATE CASCADE ON DELETE CASCADE,
     last_comment_time INTEGER NOT NULL
--- WITHOUT ROWID so the primary key is a real index over `resource`, which is also
--- the foreign key every read of this table seeks by.
 ) WITHOUT ROWID;
 
 -- Index to fullfill the rule of having an index on all foreign keys.
-CREATE INDEX resource_comment_stats_by_last_comment ON resource_comment_stats (last_comment) WHERE last_comment IS NOT NULL;
+CREATE INDEX document_comment_stats_by_last_comment ON document_comment_stats (last_comment) WHERE last_comment IS NOT NULL;
 
 -- Stores content-addressable links between blobs.
 -- Links are typed (rel) and directed.

--- a/backend/storage/schema.sql
+++ b/backend/storage/schema.sql
@@ -107,6 +107,15 @@ CREATE INDEX structural_blobs_by_genesis_blob ON structural_blobs (genesis_blob)
 CREATE INDEX structural_blobs_by_author ON structural_blobs (author);
 CREATE INDEX structural_blobs_by_type ON structural_blobs (type, ts, resource, author);
 
+-- Feed ordering index. The activity feed sorts by claimed time (`ts DESC`) with a
+-- LIMIT, and no other index can serve that: structural_blobs_by_type leads with
+-- `type`, so a `type != 'Change'` filter can't range-scan it, and the planner had
+-- to materialize every surviving row into a temp b-tree before applying the LIMIT.
+-- Measured on a 6.2 GB production database: the main ListEvents query went from
+-- 175ms to 0.05ms, and listMentionsCore (which this index also lets drive from
+-- structural_blobs instead of scanning all of resource_links) from 250ms to 0.06ms.
+CREATE INDEX structural_blobs_by_ts ON structural_blobs (ts, id);
+
 -- Index for tsid.
 CREATE INDEX structural_blobs_by_tsid ON structural_blobs (extra_attrs->>'tsid', author) WHERE extra_attrs->>'tsid' IS NOT NULL;
 
@@ -233,6 +242,58 @@ CREATE TABLE document_attributes (
 ) WITHOUT ROWID;
 
 CREATE INDEX document_attributes_by_key ON document_attributes (key, kind, value);
+
+-- The live version of each comment thread-scoped ID.
+--
+-- A comment can be edited or deleted, and each version is a separate blob sharing
+-- one TSID. The live version is the highest (ts, id) among them, and it counts only
+-- if it isn't a tombstone -- deleted comments have no row here at all.
+--
+-- Deriving this at query time is what it replaces: the listing queries used to run a
+-- ROW_NUMBER() window over every comment blob in the requested scope on every
+-- request, which was 37ms of a 60ms ListDirectory call on a 6.2 GB production
+-- database. Which blob wins a TSID is a fact about the data, not about the request,
+-- so it's settled once, when the blob is indexed (see updateCommentLive).
+CREATE TABLE comment_live (
+    tsid TEXT PRIMARY KEY,
+    -- The winning blob. Also the value listings report as `last_comment`.
+    blob_id INTEGER REFERENCES blobs (id) ON UPDATE CASCADE ON DELETE CASCADE NOT NULL,
+    -- The resource the winning blob targets. Comments record the document path as
+    -- it was when they were written, so this is not necessarily where the document
+    -- lives now -- resource_comment_stats resolves that.
+    resource INTEGER REFERENCES resources (id) ON UPDATE CASCADE ON DELETE CASCADE NOT NULL,
+    ts INTEGER NOT NULL
+) WITHOUT ROWID;
+
+CREATE INDEX comment_live_by_resource ON comment_live (resource, ts);
+CREATE INDEX comment_live_by_blob ON comment_live (blob_id);
+
+-- Redirect-aware comment activity per resource: what the document listings read.
+--
+-- A document that moved leaves its comments attached to the old path's resource, so
+-- a resource's comments are those of its whole redirect-ancestor chain, not just its
+-- own. Listings JOIN this table by resource and are done; the chain walk happens
+-- here, at index time, in updateResourceCommentStats.
+--
+-- This is deliberately keyed by resource rather than by (resource, generation) like
+-- document_generations.comment_count. That column only ever counted comments against
+-- generations satisfying containsAllChanges, and skipped comments whose target
+-- changes hadn't been indexed yet; measured on a 6.2 GB production database it was
+-- too low for 1141 of the 1489 resources that have comments, 5062 counted against
+-- 11964 real ones. Comment activity belongs to the resource.
+CREATE TABLE resource_comment_stats (
+    resource INTEGER PRIMARY KEY REFERENCES resources (id) ON UPDATE CASCADE ON DELETE CASCADE,
+    comment_count INTEGER NOT NULL,
+    -- Blob id of the most recent credited comment, i.e. the one whose ts equals
+    -- last_comment_time.
+    last_comment INTEGER REFERENCES blobs (id) ON UPDATE CASCADE ON DELETE CASCADE,
+    last_comment_time INTEGER NOT NULL
+-- WITHOUT ROWID so the primary key is a real index over `resource`, which is also
+-- the foreign key every read of this table seeks by.
+) WITHOUT ROWID;
+
+-- Index to fullfill the rule of having an index on all foreign keys.
+CREATE INDEX resource_comment_stats_by_last_comment ON resource_comment_stats (last_comment) WHERE last_comment IS NOT NULL;
 
 -- Stores content-addressable links between blobs.
 -- Links are typed (rel) and directed.

--- a/backend/storage/storage_migrations.go
+++ b/backend/storage/storage_migrations.go
@@ -63,37 +63,41 @@ type migration struct {
 //
 // In case of even the most minor doubts, consult with the team before adding a new migration, and submit the code to review if needed.
 var migrations = []migration{
-	// Materialize redirect-aware comment activity so the document listings can read
-	// it instead of deriving it per request. ListDirectory used to spend 53ms of a
-	// 60ms call re-deciding which blob is the live version of every comment in the
-	// listed scope, and GetAccount paid the same for its home document. Measured on
-	// a 6.2 GB production database: ListDirectory 60ms -> 0.9ms, getDocumentInfo
+	// Materialize comment activity so the document listings can read it instead of
+	// deriving it per request. ListDirectory used to spend 53ms of a 60ms call
+	// re-deciding which blob is the live version of every comment in the listed
+	// scope, and GetAccount paid the same for its home document. Measured on a
+	// 6.2 GB production database: ListDirectory 52ms -> 2.3ms, getDocumentInfo
 	// 3.0ms -> 0.11ms.
 	//
-	// Reindex rather than backfill: both tables are derived from Comment blobs and
-	// the redirect chains, and indexComment now maintains them, so replaying the
-	// blobs is both the simplest and the most trustworthy way to fill them. It also
-	// repairs document_generations.comment_count, which the same reindex recomputes.
+	// Keyed by genesis, so comment activity follows a document's identity rather
+	// than its current path. See the schema comments on document_comment_stats.
+	//
+	// Reindex rather than backfill: both tables are derived from Comment blobs, and
+	// indexComment maintains them, so replaying the blobs is both the simplest and
+	// the most trustworthy way to fill them.
 	{Version: "2026-09-07.100001", Run: func(_ *Store, conn *sqlite.Conn) error {
 		if err := sqlitex.ExecScript(conn, sqlfmt(`
 			CREATE TABLE IF NOT EXISTS comment_live (
 			    tsid TEXT PRIMARY KEY,
 			    blob_id INTEGER REFERENCES blobs (id) ON UPDATE CASCADE ON DELETE CASCADE NOT NULL,
+			    genesis TEXT NOT NULL,
 			    resource INTEGER REFERENCES resources (id) ON UPDATE CASCADE ON DELETE CASCADE NOT NULL,
 			    ts INTEGER NOT NULL
 			) WITHOUT ROWID;
 
+			CREATE INDEX IF NOT EXISTS comment_live_by_genesis ON comment_live (genesis, ts);
 			CREATE INDEX IF NOT EXISTS comment_live_by_resource ON comment_live (resource, ts);
 			CREATE INDEX IF NOT EXISTS comment_live_by_blob ON comment_live (blob_id);
 
-			CREATE TABLE IF NOT EXISTS resource_comment_stats (
-			    resource INTEGER PRIMARY KEY REFERENCES resources (id) ON UPDATE CASCADE ON DELETE CASCADE,
+			CREATE TABLE IF NOT EXISTS document_comment_stats (
+			    genesis TEXT PRIMARY KEY,
 			    comment_count INTEGER NOT NULL,
 			    last_comment INTEGER REFERENCES blobs (id) ON UPDATE CASCADE ON DELETE CASCADE,
 			    last_comment_time INTEGER NOT NULL
 			) WITHOUT ROWID;
 
-			CREATE INDEX IF NOT EXISTS resource_comment_stats_by_last_comment ON resource_comment_stats (last_comment) WHERE last_comment IS NOT NULL;
+			CREATE INDEX IF NOT EXISTS document_comment_stats_by_last_comment ON document_comment_stats (last_comment) WHERE last_comment IS NOT NULL;
 		`)); err != nil {
 			return err
 		}

--- a/backend/storage/storage_migrations.go
+++ b/backend/storage/storage_migrations.go
@@ -63,6 +63,59 @@ type migration struct {
 //
 // In case of even the most minor doubts, consult with the team before adding a new migration, and submit the code to review if needed.
 var migrations = []migration{
+	// Materialize redirect-aware comment activity so the document listings can read
+	// it instead of deriving it per request. ListDirectory used to spend 53ms of a
+	// 60ms call re-deciding which blob is the live version of every comment in the
+	// listed scope, and GetAccount paid the same for its home document. Measured on
+	// a 6.2 GB production database: ListDirectory 60ms -> 0.9ms, getDocumentInfo
+	// 3.0ms -> 0.11ms.
+	//
+	// Reindex rather than backfill: both tables are derived from Comment blobs and
+	// the redirect chains, and indexComment now maintains them, so replaying the
+	// blobs is both the simplest and the most trustworthy way to fill them. It also
+	// repairs document_generations.comment_count, which the same reindex recomputes.
+	{Version: "2026-09-07.100001", Run: func(_ *Store, conn *sqlite.Conn) error {
+		if err := sqlitex.ExecScript(conn, sqlfmt(`
+			CREATE TABLE IF NOT EXISTS comment_live (
+			    tsid TEXT PRIMARY KEY,
+			    blob_id INTEGER REFERENCES blobs (id) ON UPDATE CASCADE ON DELETE CASCADE NOT NULL,
+			    resource INTEGER REFERENCES resources (id) ON UPDATE CASCADE ON DELETE CASCADE NOT NULL,
+			    ts INTEGER NOT NULL
+			) WITHOUT ROWID;
+
+			CREATE INDEX IF NOT EXISTS comment_live_by_resource ON comment_live (resource, ts);
+			CREATE INDEX IF NOT EXISTS comment_live_by_blob ON comment_live (blob_id);
+
+			CREATE TABLE IF NOT EXISTS resource_comment_stats (
+			    resource INTEGER PRIMARY KEY REFERENCES resources (id) ON UPDATE CASCADE ON DELETE CASCADE,
+			    comment_count INTEGER NOT NULL,
+			    last_comment INTEGER REFERENCES blobs (id) ON UPDATE CASCADE ON DELETE CASCADE,
+			    last_comment_time INTEGER NOT NULL
+			) WITHOUT ROWID;
+
+			CREATE INDEX IF NOT EXISTS resource_comment_stats_by_last_comment ON resource_comment_stats (last_comment) WHERE last_comment IS NOT NULL;
+		`)); err != nil {
+			return err
+		}
+
+		return scheduleReindex(conn)
+	}},
+
+	// Feed ordering index. Both activity-feed queries sort by claimed time with a
+	// LIMIT, and nothing could serve that ordering: structural_blobs_by_type leads
+	// with `type`, so the feed's `type != 'Change'` filter can't range-scan it. The
+	// planner materialized every surviving row — 40k of them, carrying the whole
+	// extra_attrs JSONB — into a temp b-tree and then threw away all but 30.
+	// Measured on a 6.2 GB production database: main feed query 175ms -> 0.05ms,
+	// listMentionsCore 250ms -> 0.06ms (the index also flips its driving table from
+	// a full resource_links scan to structural_blobs). No reindex needed: an index
+	// is derived from rows that are already correct.
+	{Version: "2026-09-07.100000", Run: func(_ *Store, conn *sqlite.Conn) error {
+		return sqlitex.ExecScript(conn, sqlfmt(`
+			CREATE INDEX IF NOT EXISTS structural_blobs_by_ts ON structural_blobs (ts, id);
+		`))
+	}},
+
 	// Stale-mark every maintained RBSR scope so it re-materializes lazily on
 	// its next serve: earlier builds could leave permanent holes in rbsr_item
 	// (Capability/Contact blobs missing from the advertised set — the oracle's


### PR DESCRIPTION
## Why

A 100s CPU profile of the production gateway shows `sqlite3_step` using **148 of 193 CPU-seconds — 77% of everything the daemon does**. Three read endpoints account for most of it, and all three recompute, on every request, data that doesn't change between requests:

| Method | CPU | Share |
|---|---|---|
| `Documents.ListDirectory` | 67.4s | 35% |
| `ActivityFeed.ListEvents` | 19.3s | 10% |
| `Documents.GetAccount` | 18.5s | 9.6% |

## What this does

**1. Comment activity is maintained, not derived** (`backend/blob/comment_stats.go`). Two tables settle at index time what the listings used to recompute per request: `comment_live` (which blob is the live version of each comment TSID) and `document_comment_stats`. The listings read them with one indexed point lookup.

**2. One index for the feed**, `structural_blobs_by_ts (ts, id)`. Neither feed query could page through an index, so SQLite materialised ~40k rows — each carrying the whole `extra_attrs` JSONB — into temp b-trees to return 30. The main query's `SELECT DISTINCT` is also dropped: every join is many-to-one on a primary key, so it removed nothing (37912 rows either way).

**3. Space comment totals are recomputed, not accumulated.** `spaces.comment_count` had drifted to **5062 against 11964 real** — delta arithmetic plus an early return that silently skipped updates. Now exact.

**4. Comment activity is keyed by genesis, not by redirects** — from Alex's review.

## Results

Measured on a 6.2 GB copy of production, with the daemon's own vendored SQLite:

| Query | Before | After |
|---|---|---|
| `ListDirectory`, busiest space | 52ms | **2.3ms** |
| `ListEvents` main query | 175ms | **~0.05ms** |
| `ListEvents` mentions query | 250ms | **~0.06ms** |
| `getDocumentInfo` | 3.0ms | **0.11ms** |

Reindex on that database also got *faster*, 1m50s → 1m39s, because the redirect walks are gone.

## The genesis change, and why it matters

A comment belongs to a document, and a document's identity is its genesis — not the path it currently sits at. That makes both of the things reviewers wanted true at once, where the old redirect-graph rule could only manage one:

- a document that **moves** keeps its comments at every path in the chain, because moving republishes the same genesis;
- a redirect between two **unrelated** documents transfers nothing, because their genesises differ.

The second was already wrong in production. Nothing in any of the four redirect walks checked document identity — `RedirectTarget` is `{Space, Path, Republish}`, a location. On the production copy:

| | |
|---|---|
| Redirect edges | 1766 |
| Same genesis (real moves) | 1759 |
| **Different genesis** | **6** |
| …of those, carrying comments | 2 |

`/tech-talks` redirects at `/tech` with a different genesis, and was pushing **293 comments** onto a document they were never written against. After this change `/tech` reports 1 and `/tech-talks` keeps its 293.

`ListComments` changes in lockstep — otherwise the count and the list disagree about what a document's comments are, which is the complaint in #779. Querying by a path the document moved away from still works, because that path's own latest generation carries the same genesis.

## Worth a reviewer's attention

**One behaviour change.** A comment whose target changes we *hold but haven't indexed yet* is now stashed and retried, instead of being indexed with no attribution. Without it, reindexing attributed only **6602 of 12659** comments — a comment replayed before its target was skipped and nothing revisited it. With it, all **11964** are attributed and space totals agree exactly.

A comment whose target changes we **don't hold at all** (`BlobsSize < 0`) is still indexed and left out of the counts, so nothing gets hidden waiting for a blob that may never arrive.

**It deletes more than it adds.** Both recursive redirect walks are gone, along with the end-of-reindex rebuild they required and the recursive CTE in `ListComments`.

## Tests

- `TestCommentActivityFollowsTheDocument` — pins both halves: a twice-moved document keeps all four of its comments, and a redirect to an unrelated document transfers none. Also checks `ListComments` agrees with the counts, that old paths still resolve, and that a reindex reproduces the same numbers.
- `TestCommentStatsQueriesSeek` / `TestFeedQueriesUseIndexedOrdering` — plan guards. These failure modes are silent: the wrong plan still returns the right answer, just slowly. One of these already caught a full-table scan I'd written by accident.
- Pre-existing `TestCommentCount_*`, `TestListComments_AfterDocumentMove` and `TestRedirect` pass unchanged.

## Verify

```
go test ./backend/...
```

For the production numbers: point a daemon at a copy of a real database, let it migrate and reindex, then compare `document_comment_stats` against `comment_live` grouped by genesis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
