### PR TITLE
fix(editor): preserve rich paste with remote images

### DIFF
--- a/frontend/apps/desktop/src/app-web-importing.ts
+++ b/frontend/apps/desktop/src/app-web-importing.ts
@@ -4,15 +4,19 @@ import {DAEMON_FILE_UPLOAD_URL} from '@shm/shared/constants'
 import {htmlToBlocks} from '@shm/shared/html-to-blocks'
 import * as cheerio from 'cheerio'
 import {app, dialog} from 'electron'
+import {lookup} from 'dns/promises'
 import {readFile, writeFile} from 'fs/promises'
 import http from 'http'
 import https from 'https'
 import {nanoid} from 'nanoid'
+import {isIP} from 'net'
+import type {LookupFunction} from 'net'
 import {join} from 'path'
 import z from 'zod'
 import {getSigner, seedClient} from './app-client'
 import {userDataPath} from './app-paths'
 import {t} from './app-trpc'
+import {isPublicIPAddress, normalizeIPHostname} from './remote-file-security'
 import {PostsFile, ScrapeStatus, scrapeUrl} from './web-scraper'
 import {serializeImportFile} from './wxr-crypto'
 import {cancelWXRImport, getImportStatus, hasActiveImport, resumeWXRImport, startWXRImport} from './wxr-import'
@@ -48,45 +52,171 @@ export async function uploadLocalFile(filePath: string) {
   }
 }
 
-function downloadFile(fileUrl: string): Promise<Blob> {
+const MAX_REMOTE_FILE_BYTES = 20 * 1024 * 1024
+const MAX_REMOTE_REDIRECTS = 5
+const REMOTE_FILE_TIMEOUT_MS = 15_000
+const MAX_CONCURRENT_REMOTE_DOWNLOADS = 4
+
+let activeRemoteDownloads = 0
+const remoteDownloadWaiters: Array<() => void> = []
+
+async function acquireRemoteDownloadSlot(): Promise<void> {
+  if (activeRemoteDownloads < MAX_CONCURRENT_REMOTE_DOWNLOADS) {
+    activeRemoteDownloads += 1
+    return
+  }
+  await new Promise<void>((resolve) => remoteDownloadWaiters.push(resolve))
+}
+
+function releaseRemoteDownloadSlot(): void {
+  const next = remoteDownloadWaiters.shift()
+  if (next) next()
+  else activeRemoteDownloads -= 1
+}
+
+async function withRemoteDownloadSlot<T>(operation: () => Promise<T>): Promise<T> {
+  await acquireRemoteDownloadSlot()
+  try {
+    return await operation()
+  } finally {
+    releaseRemoteDownloadSlot()
+  }
+}
+
+function remainingTime(deadline: number): number {
+  const remaining = deadline - Date.now()
+  if (remaining <= 0) throw new Error('Remote file download timed out')
+  return remaining
+}
+
+function withDeadline<T>(operation: Promise<T>, deadline: number): Promise<T> {
   return new Promise((resolve, reject) => {
-    const protocol = new URL(fileUrl).protocol === 'https:' ? https : http
-    protocol
-      .get(fileUrl, (response) => {
-        if (response.statusCode === 200) {
-          const chunks: Buffer[] = []
-          response.on('data', (chunk) => chunks.push(chunk))
-          response.on('end', () => {
-            const blob = new Blob(chunks, {
-              type: response.headers['content-type'],
-            })
-            resolve(blob)
-          })
-        } else if (
-          // Many image hosts 30x to a different URL before serving the data.
-          // Without following these the import surfaces as a generic
-          // "Couldn't fetch the image" error in the editor.
-          response.statusCode === 301 ||
-          response.statusCode === 302 ||
-          response.statusCode === 303 ||
-          response.statusCode === 307 ||
-          response.statusCode === 308
-        ) {
-          const location = response.headers.location
-          if (location) {
-            const next = new URL(location, fileUrl).toString()
-            downloadFile(next).then(resolve).catch(reject)
-          } else {
-            reject(new Error(`Redirect without location header`))
-          }
-        } else {
-          reject(new Error(`Failed to download file: ${response.statusCode}`))
-        }
-      })
-      .on('error', (err) => {
-        reject(err)
-      })
+    const timer = setTimeout(() => reject(new Error('Remote file download timed out')), remainingTime(deadline))
+    operation.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (error) => {
+        clearTimeout(timer)
+        reject(error)
+      },
+    )
   })
+}
+
+async function publicAddressFor(hostname: string, deadline: number) {
+  const normalizedHostname = normalizeIPHostname(hostname)
+  if (isIP(normalizedHostname)) {
+    if (!isPublicIPAddress(normalizedHostname)) throw new Error('Remote file URL resolves to a non-global network')
+    return {address: normalizedHostname, family: isIP(normalizedHostname) as 4 | 6}
+  }
+
+  const addresses = await withDeadline(lookup(normalizedHostname, {all: true, verbatim: true}), deadline)
+  if (addresses.length === 0 || addresses.some(({address}) => !isPublicIPAddress(address))) {
+    throw new Error('Remote file URL resolves to a non-global network')
+  }
+  return addresses[0] as {address: string; family: 4 | 6}
+}
+
+async function downloadFileWithRedirects(fileUrl: string, redirects: number, deadline: number): Promise<Blob> {
+  const parsed = new URL(fileUrl)
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error('Remote file URL must use HTTP or HTTPS')
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error('Remote file URL must not contain credentials')
+  }
+  if (redirects > MAX_REMOTE_REDIRECTS) {
+    throw new Error('Too many remote file redirects')
+  }
+
+  const {address, family} = await publicAddressFor(parsed.hostname, deadline)
+  const protocol = parsed.protocol === 'https:' ? https : http
+  const pinnedLookup: LookupFunction = ((
+    _hostname: string,
+    options: {all?: boolean},
+    callback: (...args: any[]) => void,
+  ) => {
+    if (options.all) callback(null, [{address, family}])
+    else callback(null, address, family)
+  }) as LookupFunction
+
+  const timeout = remainingTime(deadline)
+  return new Promise((resolve, reject) => {
+    let settled = false
+    let deadlineTimer: NodeJS.Timeout | undefined
+    const finishError = (error: Error) => {
+      if (settled) return
+      settled = true
+      if (deadlineTimer) clearTimeout(deadlineTimer)
+      reject(error)
+    }
+    const request = protocol.get(
+      parsed,
+      {
+        lookup: pinnedLookup,
+        family,
+      },
+      (response) => {
+        if (response.statusCode === 200) {
+          const declaredSize = Number(response.headers['content-length'] || 0)
+          if (declaredSize > MAX_REMOTE_FILE_BYTES) {
+            response.destroy()
+            finishError(new Error('Remote file exceeds the 20 MB limit'))
+            return
+          }
+
+          const chunks: Buffer[] = []
+          let size = 0
+          response.on('data', (chunk: Buffer) => {
+            size += chunk.length
+            if (size > MAX_REMOTE_FILE_BYTES) {
+              response.destroy()
+              finishError(new Error('Remote file exceeds the 20 MB limit'))
+              return
+            }
+            chunks.push(chunk)
+          })
+          response.on('end', () => {
+            if (settled) return
+            settled = true
+            if (deadlineTimer) clearTimeout(deadlineTimer)
+            resolve(new Blob(chunks, {type: response.headers['content-type']}))
+          })
+          response.on('error', finishError)
+          return
+        }
+
+        if ([301, 302, 303, 307, 308].includes(response.statusCode || 0)) {
+          const location = response.headers.location
+          response.destroy()
+          if (!location) {
+            finishError(new Error('Redirect without location header'))
+            return
+          }
+          downloadFileWithRedirects(new URL(location, parsed).toString(), redirects + 1, deadline)
+            .then((blob) => {
+              if (settled) return
+              settled = true
+              if (deadlineTimer) clearTimeout(deadlineTimer)
+              resolve(blob)
+            })
+            .catch(finishError)
+          return
+        }
+
+        response.destroy()
+        finishError(new Error(`Failed to download file: ${response.statusCode}`))
+      },
+    )
+    deadlineTimer = setTimeout(() => request.destroy(new Error('Remote file download timed out')), timeout)
+    request.on('error', finishError)
+  })
+}
+
+async function downloadFile(fileUrl: string): Promise<Blob> {
+  return withRemoteDownloadSlot(() => downloadFileWithRedirects(fileUrl, 0, Date.now() + REMOTE_FILE_TIMEOUT_MS))
 }
 
 export function extractMetaTags(html: string) {

--- a/frontend/apps/desktop/src/remote-file-security.test.ts
+++ b/frontend/apps/desktop/src/remote-file-security.test.ts
@@ -1,0 +1,49 @@
+import {describe, expect, it} from 'vitest'
+import {isPublicIPAddress, normalizeIPHostname} from './remote-file-security'
+
+describe('remote file address policy', () => {
+  it.each([
+    '0.0.0.0',
+    '10.0.0.1',
+    '100.64.0.1',
+    '127.0.0.1',
+    '169.254.169.254',
+    '172.16.0.1',
+    '192.0.0.1',
+    '192.0.2.1',
+    '192.168.0.1',
+    '198.18.0.1',
+    '198.51.100.1',
+    '203.0.113.1',
+    '224.0.0.1',
+    '255.255.255.255',
+    '::',
+    '::1',
+    '::127.0.0.1',
+    '::ffff:127.0.0.1',
+    '64:ff9b::7f00:1',
+    '100::1',
+    '100:0:0:1::1',
+    '2001:db8::1',
+    '2002::1',
+    '3fff::1',
+    '4000::1',
+    '5f00::1',
+    'fc00::1',
+    'fe80::1',
+    'ff00::1',
+  ])('rejects non-global address %s', (address) => {
+    expect(isPublicIPAddress(address)).toBe(false)
+  })
+
+  it.each(['1.1.1.1', '8.8.8.8', '2606:4700:4700::1111', '2001:4860:4860::8888'])(
+    'allows global unicast address %s',
+    (address) => {
+      expect(isPublicIPAddress(address)).toBe(true)
+    },
+  )
+
+  it('removes URL brackets from IPv6 literals', () => {
+    expect(normalizeIPHostname('[2001:4860:4860::8888]')).toBe('2001:4860:4860::8888')
+  })
+})

--- a/frontend/apps/desktop/src/remote-file-security.ts
+++ b/frontend/apps/desktop/src/remote-file-security.ts
@@ -1,0 +1,61 @@
+import {BlockList, isIP} from 'net'
+
+const blockedIPv4Addresses = new BlockList()
+const blockedIPv6Addresses = new BlockList()
+const allowedIPv6Addresses = new BlockList()
+allowedIPv6Addresses.addSubnet('2000::', 3, 'ipv6')
+
+for (const [address, prefix] of [
+  ['0.0.0.0', 8],
+  ['10.0.0.0', 8],
+  ['100.64.0.0', 10],
+  ['127.0.0.0', 8],
+  ['169.254.0.0', 16],
+  ['172.16.0.0', 12],
+  ['192.0.0.0', 24],
+  ['192.0.2.0', 24],
+  ['192.88.99.0', 24],
+  ['192.168.0.0', 16],
+  ['198.18.0.0', 15],
+  ['198.51.100.0', 24],
+  ['203.0.113.0', 24],
+  ['224.0.0.0', 4],
+  ['240.0.0.0', 4],
+] as const) {
+  blockedIPv4Addresses.addSubnet(address, prefix, 'ipv4')
+}
+
+for (const [address, prefix] of [
+  ['::', 128],
+  ['::1', 128],
+  ['::', 96],
+  ['::ffff:0:0', 96],
+  ['64:ff9b::', 96],
+  ['64:ff9b:1::', 48],
+  ['100::', 64],
+  ['100:0:0:1::', 64],
+  ['2001::', 23],
+  ['2001:db8::', 32],
+  ['2002::', 16],
+  ['3fff::', 20],
+  ['5f00::', 16],
+  ['fc00::', 7],
+  ['fe80::', 10],
+  ['ff00::', 8],
+] as const) {
+  blockedIPv6Addresses.addSubnet(address, prefix, 'ipv6')
+}
+
+export function normalizeIPHostname(hostname: string): string {
+  return hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname
+}
+
+export function isPublicIPAddress(address: string): boolean {
+  const normalized = normalizeIPHostname(address)
+  const family = isIP(normalized)
+  if (family === 4) return !blockedIPv4Addresses.check(normalized, 'ipv4')
+  if (family === 6) {
+    return allowedIPv6Addresses.check(normalized, 'ipv6') && !blockedIPv6Addresses.check(normalized, 'ipv6')
+  }
+  return false
+}

--- a/frontend/packages/editor/src/blocknote/core/BlockNoteEditor.ts
+++ b/frontend/packages/editor/src/blocknote/core/BlockNoteEditor.ts
@@ -36,7 +36,7 @@ import {insertBlocks} from './api/blockManipulation/commands/insertBlocks'
 import {unnestBlock as unnestBlockCommand} from './api/blockManipulation/commands/nestBlock'
 import {newRemoveBlocks} from './api/blockManipulation/commands/removeBlocks'
 import {newReplaceBlocks} from './api/blockManipulation/commands/replaceBlocks'
-import {updateBlock} from './api/blockManipulation/commands/updateBlock'
+import {updateBlock, UpdateBlockOptions} from './api/blockManipulation/commands/updateBlock'
 import {BlockHoverActionsProsemirrorPlugin} from './extensions/BlockHoverActions/BlockHoverActionsPlugin'
 import {FormattingToolbarProsemirrorPlugin} from './extensions/FormattingToolbar/FormattingToolbarPlugin'
 import {FullBlockSelectionProsemirrorPlugin} from './extensions/FullBlockSelection/FullBlockSelectionPlugin'
@@ -718,9 +718,15 @@ export class BlockNoteEditor<BSchema extends BlockSchema = HMBlockSchema> {
    * not be found.
    * @param blockToUpdate The block that should be updated.
    * @param update A partial block which defines how the existing block should be changed.
+   * @param options `addToHistory: false` keeps an editor-initiated update out of the undo stack.
    */
-  public updateBlock(blockToUpdate: BlockIdentifier, update: PartialBlock<BSchema>, keepSelection?: boolean) {
-    return updateBlock(this, blockToUpdate, update, keepSelection)
+  public updateBlock(
+    blockToUpdate: BlockIdentifier,
+    update: PartialBlock<BSchema>,
+    keepSelection?: boolean,
+    options?: UpdateBlockOptions,
+  ) {
+    return updateBlock(this, blockToUpdate, update, keepSelection, options)
   }
 
   // /**

--- a/frontend/packages/editor/src/blocknote/core/api/blockManipulation/commands/updateBlock.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/blockManipulation/commands/updateBlock.ts
@@ -197,11 +197,22 @@ function updateChildren<BSchema extends BlockSchema>(
   }
 }
 
+/** Options for {@link updateBlock}. */
+export type UpdateBlockOptions = {
+  /**
+   * `false` keeps the update out of the undo history: undo skips over it and reverts the user's
+   * previous action instead. Use it for updates the editor makes on its own (importing a pasted
+   * remote image to IPFS, for instance), so Cmd-Z still undoes the paste that created the block.
+   */
+  addToHistory?: boolean
+}
+
 export function updateBlock<BSchema extends BlockSchema>(
   editor: BlockNoteEditor<BSchema>,
   blockToUpdate: BlockIdentifier,
   update: PartialBlock<BSchema>,
   keepSelection?: boolean,
+  options?: UpdateBlockOptions,
 ): Block<BSchema> {
   const ttEditor = editor._tiptapEditor
 
@@ -215,6 +226,7 @@ export function updateBlock<BSchema extends BlockSchema>(
   // @ts-ignore
   ttEditor.commands.command(({state, dispatch}) => {
     updateBlockCommand(posInfo.posBeforeNode, update, keepSelection)({state, dispatch})
+    if (options?.addToHistory === false) state.tr.setMeta('addToHistory', false)
     return true
   })
 

--- a/frontend/packages/editor/src/document-editor-history.test.tsx
+++ b/frontend/packages/editor/src/document-editor-history.test.tsx
@@ -35,3 +35,36 @@ it('keeps the editor and undo/redo history while publication review pauses an ed
   act(() => root.unmount())
   original._tiptapEditor.destroy()
 })
+
+it('undoes a paste in one step after the editor imported the pasted remote image on its own', () => {
+  let editor: ReturnType<typeof useBlockNote>
+  function Harness({blocks}: {blocks: DocumentContentProps['blocks']}) {
+    const initialContent = useDocumentEditorInitialContent(blocks, true)
+    editor = useBlockNote({blockSchema: hmBlockSchema, initialContent}, [initialContent])
+    return null
+  }
+  const blocks = [{id: 'text', type: 'paragraph', content: [{type: 'text', text: 'Before', styles: {}}]}] as any
+  const root = createRoot(document.createElement('div'))
+  act(() => root.render(<Harness blocks={blocks} />))
+  const original = editor!
+  // A rich HTML paste lands as an image block that still points at the remote source.
+  act(() =>
+    original.insertBlocks(
+      [{id: 'pasted', type: 'image', props: {url: 'https://example.com/pasted.png'}} as any],
+      'text',
+      'after',
+    ),
+  )
+  expect(original.getBlock('pasted')?.props.url).toBe('https://example.com/pasted.png')
+  // The block then imports that file to IPFS by itself, outside the undo history.
+  act(() => original.updateBlock('pasted', {props: {url: 'ipfs://imported'}}, undefined, {addToHistory: false}))
+  expect(original.getBlock('pasted')?.props.url).toBe('ipfs://imported')
+  // One Cmd-Z removes the paste; it does not merely revert the import (which would re-import).
+  act(() => original._tiptapEditor.commands.undo())
+  expect(original.getBlock('pasted')).toBeUndefined()
+  expect(original._tiptapEditor.state.doc.textContent).toBe('Before')
+  act(() => original._tiptapEditor.commands.redo())
+  expect(original.getBlock('pasted')).toBeDefined()
+  original._tiptapEditor.destroy()
+  act(() => root.unmount())
+})

--- a/frontend/packages/editor/src/handle-local-media-paste-plugin.test.ts
+++ b/frontend/packages/editor/src/handle-local-media-paste-plugin.test.ts
@@ -34,6 +34,41 @@ describe('local media paste helpers', () => {
     vi.unstubAllGlobals()
   })
 
+  it('still claims direct clipboard images and inserts their uploaded node', async () => {
+    const file = new File(['image'], 'paste.png', {type: 'image/png'})
+    const handleFileAttachment = vi.fn().mockResolvedValue({url: 'ipfs://cid'})
+    const create = vi.fn((props: Record<string, any>) => ({type: 'image', props}))
+    const insert = vi.fn(() => 'transaction')
+    const dispatch = vi.fn()
+    const plugin = handleLocalMediaPastePlugin({handleFileAttachment})
+    const view = {
+      dom: {closest: vi.fn(() => null)},
+      dispatch,
+      state: {
+        schema: {nodes: {image: {create}}},
+        tr: {insert},
+        selection: {
+          $anchor: {
+            parent: {type: {name: 'paragraph'}, nodeSize: 3},
+            end: () => 1,
+          },
+        },
+      },
+    }
+    const event = {
+      clipboardData: {
+        getData: vi.fn(() => ''),
+        items: [{type: 'image/png', getAsFile: vi.fn(() => file)}],
+        files: [],
+      },
+    }
+
+    expect(plugin.props.handlePaste?.(view as never, event as never, undefined as never)).toBe(true)
+    await vi.waitFor(() => expect(dispatch).toHaveBeenCalledWith('transaction'))
+    expect(handleFileAttachment).toHaveBeenCalledWith(file)
+    expect(create).toHaveBeenCalledWith({name: 'paste.png', url: 'ipfs://cid', displaySrc: ''})
+  })
+
   it('maps desktop/web document upload results to IPFS node props', () => {
     const file = new File(['image'], 'paste.png', {type: 'image/png'})
 

--- a/frontend/packages/editor/src/handle-local-media-paste-plugin.test.ts
+++ b/frontend/packages/editor/src/handle-local-media-paste-plugin.test.ts
@@ -1,49 +1,40 @@
-import {describe, expect, it, vi, afterEach} from 'vitest'
+import {describe, expect, it, vi} from 'vitest'
 import {
   createNodePropsFromAttachmentResult,
-  extractPastedImageSources,
-  imageSourceToFile,
+  handleLocalMediaPastePlugin,
 } from './handle-local-media-paste-plugin'
 
 describe('local media paste helpers', () => {
-  afterEach(() => {
-    vi.unstubAllGlobals()
-  })
-
-  it('extracts pasted HTML image sources', () => {
-    const html = `
-      <p>before</p>
-      <img src="data:image/png;base64,abc" alt="pasted screenshot">
-      <img src="https://example.com/image.webp">
-    `
-
-    expect(extractPastedImageSources(html)).toEqual(['data:image/png;base64,abc', 'https://example.com/image.webp'])
-  })
-
-  it('skips Seed image block HTML that the schema parser handles', () => {
-    const html = `
-      <div data-content-type="image">
-        <img src="ipfs://already-a-block">
-      </div>
-      <p><img src="https://example.com/external.png"></p>
-    `
-
-    expect(extractPastedImageSources(html)).toEqual(['https://example.com/external.png'])
-  })
-
-  it('converts pasted HTML image sources to Files', async () => {
-    const blob = new Blob(['jpeg data'], {type: 'image/jpeg'})
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      blob: async () => blob,
-    }))
+  it('leaves rich HTML images to the editor parser without renderer fetch', () => {
+    const plugin = handleLocalMediaPastePlugin({})
+    const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
+    const getAsFile = vi.fn(() => null)
+    const event = {
+      clipboardData: {
+        getData: vi.fn((type: string) =>
+          type === 'text/html' ? '<p>before</p><img src="https://example.com/image.jpg"><p>after</p>' : '',
+        ),
+        items: [{type: 'text/html', getAsFile}],
+        files: [],
+      },
+    }
+    const view = {
+      state: {
+        selection: {
+          $anchor: {
+            parent: {type: {name: 'paragraph'}, nodeSize: 3},
+            end: () => 1,
+          },
+        },
+      },
+    }
 
-    const file = await imageSourceToFile('https://example.com/image.jpg', () => 123)
+    expect(plugin.props.handlePaste?.(view as never, event as never, undefined as never)).toBe(false)
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(getAsFile).toHaveBeenCalledOnce()
 
-    expect(fetchMock).toHaveBeenCalledWith('https://example.com/image.jpg')
-    expect(file.name).toBe('pasted-image-123.jpg')
-    expect(file.type).toBe('image/jpeg')
+    vi.unstubAllGlobals()
   })
 
   it('maps desktop/web document upload results to IPFS node props', () => {

--- a/frontend/packages/editor/src/handle-local-media-paste-plugin.test.ts
+++ b/frontend/packages/editor/src/handle-local-media-paste-plugin.test.ts
@@ -7,13 +7,14 @@ describe('local media paste helpers', () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
     const getAsFile = vi.fn(() => null)
+    const imageFile = new File(['image'], 'paste.png', {type: 'image/png'})
     const event = {
       clipboardData: {
         getData: vi.fn((type: string) =>
           type === 'text/html' ? '<p>before</p><img src="https://example.com/image.jpg"><p>after</p>' : '',
         ),
         items: [{type: 'text/html', getAsFile}],
-        files: [],
+        files: [imageFile],
       },
     }
     const view = {
@@ -29,7 +30,7 @@ describe('local media paste helpers', () => {
 
     expect(plugin.props.handlePaste?.(view as never, event as never, undefined as never)).toBe(false)
     expect(fetchMock).not.toHaveBeenCalled()
-    expect(getAsFile).toHaveBeenCalledOnce()
+    expect(getAsFile).not.toHaveBeenCalled()
 
     vi.unstubAllGlobals()
   })
@@ -67,6 +68,43 @@ describe('local media paste helpers', () => {
     await vi.waitFor(() => expect(dispatch).toHaveBeenCalledWith('transaction'))
     expect(handleFileAttachment).toHaveBeenCalledWith(file)
     expect(create).toHaveBeenCalledWith({name: 'paste.png', url: 'ipfs://cid', displaySrc: ''})
+  })
+
+  it.each([
+    {type: 'video/mp4', name: 'clip.mp4', nodeType: 'video'},
+    {type: 'application/pdf', name: 'notes.pdf', nodeType: 'file'},
+  ])('claims a mixed HTML + $nodeType clipboard attachment', async ({type, name, nodeType}) => {
+    const file = new File(['attachment'], name, {type})
+    const handleFileAttachment = vi.fn().mockResolvedValue({url: 'ipfs://cid'})
+    const create = vi.fn((props: Record<string, any>) => ({type: nodeType, props}))
+    const insert = vi.fn(() => 'transaction')
+    const dispatch = vi.fn()
+    const plugin = handleLocalMediaPastePlugin({handleFileAttachment})
+    const view = {
+      dom: {closest: vi.fn(() => null)},
+      dispatch,
+      state: {
+        schema: {nodes: {[nodeType]: {create}}},
+        tr: {insert},
+        selection: {
+          $anchor: {
+            parent: {type: {name: 'paragraph'}, nodeSize: 3},
+            end: () => 1,
+          },
+        },
+      },
+    }
+    const event = {
+      clipboardData: {
+        getData: vi.fn((flavor: string) => (flavor === 'text/html' ? '<p>attachment</p>' : '')),
+        items: [{type, getAsFile: vi.fn(() => file)}],
+        files: [file],
+      },
+    }
+
+    expect(plugin.props.handlePaste?.(view as never, event as never, undefined as never)).toBe(true)
+    await vi.waitFor(() => expect(dispatch).toHaveBeenCalledWith('transaction'))
+    expect(handleFileAttachment).toHaveBeenCalledWith(file)
   })
 
   it('maps desktop/web document upload results to IPFS node props', () => {

--- a/frontend/packages/editor/src/handle-local-media-paste-plugin.test.ts
+++ b/frontend/packages/editor/src/handle-local-media-paste-plugin.test.ts
@@ -1,8 +1,5 @@
 import {describe, expect, it, vi} from 'vitest'
-import {
-  createNodePropsFromAttachmentResult,
-  handleLocalMediaPastePlugin,
-} from './handle-local-media-paste-plugin'
+import {createNodePropsFromAttachmentResult, handleLocalMediaPastePlugin} from './handle-local-media-paste-plugin'
 
 describe('local media paste helpers', () => {
   it('leaves rich HTML images to the editor parser without renderer fetch', () => {

--- a/frontend/packages/editor/src/handle-local-media-paste-plugin.ts
+++ b/frontend/packages/editor/src/handle-local-media-paste-plugin.ts
@@ -28,7 +28,7 @@ export const LocalMediaPastePlugin = Extension.create({
   },
 })
 
-const handleLocalMediaPastePlugin = (blockNoteEditor: any) =>
+export const handleLocalMediaPastePlugin = (blockNoteEditor: any) =>
   new Plugin({
     key: new PluginKey('pm-local-media-paste'),
     props: {
@@ -69,14 +69,6 @@ const handleLocalMediaPastePlugin = (blockNoteEditor: any) =>
           }
         }
 
-        const html = event.clipboardData?.getData('text/html') || ''
-        const htmlImageSources = extractPastedImageSources(html)
-        const firstHtmlImageSource = htmlImageSources[0]
-        if (firstHtmlImageSource) {
-          processImageSource(firstHtmlImageSource, view, insertPos, blockNoteEditor)
-          return true
-        }
-
         // Check for video and other file types
         for (const item of items) {
           if (item.type.startsWith('video/')) {
@@ -109,65 +101,6 @@ const handleLocalMediaPastePlugin = (blockNoteEditor: any) =>
       },
     },
   })
-
-/** Extract image URLs from pasted HTML, skipping Seed image blocks that the schema parser handles. */
-export function extractPastedImageSources(html: string): string[] {
-  if (!html) return []
-
-  const tempEl = document.createElement('div')
-  tempEl.innerHTML = html
-
-  return (
-    Array.from(tempEl.querySelectorAll('img[src]'))
-      // Skip images inside Seed image blocks and images inside tables.
-      .filter((imgEl) => !imgEl.closest('[data-content-type="image"]') && !imgEl.closest('table'))
-      .map((imgEl) => imgEl.getAttribute('src') || '')
-      .filter(Boolean)
-  )
-}
-
-/** Convert an image URL from pasted HTML into a File that can use the normal media insertion path. */
-export async function imageSourceToFile(src: string, now: () => number = Date.now): Promise<File> {
-  const response = await fetch(src)
-  if (!response.ok) {
-    throw new Error(`Image fetch failed with status ${response.status}`)
-  }
-  const blob = await response.blob()
-  const type = blob.type || 'image/png'
-  return new File([blob], `pasted-image-${now()}.${extensionForImageType(type)}`, {
-    type,
-  })
-}
-
-function extensionForImageType(type: string): string {
-  switch (type) {
-    case 'image/jpeg':
-    case 'image/jpg':
-      return 'jpg'
-    case 'image/gif':
-      return 'gif'
-    case 'image/webp':
-      return 'webp'
-    case 'image/svg+xml':
-      return 'svg'
-    case 'image/bmp':
-      return 'bmp'
-    case 'image/avif':
-      return 'avif'
-    default:
-      return 'png'
-  }
-}
-
-function processImageSource(src: string, view: any, insertPos: number, blockNoteEditor: any) {
-  imageSourceToFile(src)
-    .then((file) => {
-      processMedia(file, view, insertPos, blockNoteEditor, 'image')
-    })
-    .catch((error) => {
-      console.error('Error processing pasted HTML image:', error)
-    })
-}
 
 function processMedia(file: File, view: any, insertPos: number, blockNoteEditor: any, mediaType: LocalMediaType) {
   // Check if we're in a comment editor in the web app

--- a/frontend/packages/editor/src/handle-local-media-paste-plugin.ts
+++ b/frontend/packages/editor/src/handle-local-media-paste-plugin.ts
@@ -42,6 +42,18 @@ export const handleLocalMediaPastePlugin = (blockNoteEditor: any) =>
         const items = Array.from(event.clipboardData?.items || [])
         const files = Array.from(event.clipboardData?.files || [])
 
+        // Browsers may expose both rich HTML and an image File for one copy.
+        // Let the schema preserve the complete HTML instead of replacing it with
+        // the first image flavor and dropping adjacent text or additional images.
+        // Other file types have no equivalent rich-HTML representation, so they
+        // must continue through the attachment handlers below.
+        if (
+          rawHtml &&
+          (items.some((item) => item.type.startsWith('image/')) || files.some((file) => file.type.startsWith('image/')))
+        ) {
+          return false
+        }
+
         if (items.length === 0 && files.length === 0) {
           return false
         }

--- a/frontend/packages/editor/src/image.test.tsx
+++ b/frontend/packages/editor/src/image.test.tsx
@@ -156,7 +156,9 @@ describe('pasted remote image import', () => {
       root.render(<ImageDisplay editor={makeEditor(390, importWebFile)} block={makeBlock()} assign={assign} />)
     })
 
-    await vi.waitFor(() => expect(assign).toHaveBeenCalledWith({props: {url: 'ipfs://image-cid'}}))
+    await vi.waitFor(() =>
+      expect(assign).toHaveBeenCalledWith({props: {url: 'ipfs://image-cid'}}, {addToHistory: false}),
+    )
     expect(importWebFile).toHaveBeenCalledWith('https://example.com/tall-mobile-screenshot.png')
   })
 
@@ -172,9 +174,7 @@ describe('pasted remote image import', () => {
 
     await vi.waitFor(() => expect(consoleError).toHaveBeenCalledWith('Could not fetch image from URL:', error))
     expect(assign).not.toHaveBeenCalled()
-    expect(container.querySelector('img')?.getAttribute('src')).toBe(
-      'resolved:https://example.com/tall-mobile-screenshot.png',
-    )
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('https://example.com/tall-mobile-screenshot.png')
 
     consoleError.mockRestore()
   })

--- a/frontend/packages/editor/src/image.test.tsx
+++ b/frontend/packages/editor/src/image.test.tsx
@@ -44,12 +44,12 @@ vi.mock('./media-container', () => ({
   ),
 }))
 
-import {ImageDisplay} from './image'
+import {ImageBlock, ImageDisplay} from './image'
 
-function makeEditor(editorWidth = 390) {
+function makeEditor(editorWidth = 390, importWebFile?: any) {
   return {
     domElement: {firstElementChild: {clientWidth: editorWidth}},
-    importWebFile: undefined,
+    importWebFile,
     isEditable: true,
     renderType: 'editor',
     setTextCursorPosition: vi.fn(),
@@ -144,5 +144,52 @@ describe('ImageDisplay responsive sizing', () => {
         width: '76.92%',
       },
     })
+  })
+})
+
+describe('pasted remote image import', () => {
+  it('imports a remote image through the configured native boundary', async () => {
+    const importWebFile = vi.fn().mockResolvedValue({cid: 'image-cid', type: 'image/jpeg', size: 12})
+    const assign = vi.fn()
+
+    await act(async () => {
+      root.render(<ImageDisplay editor={makeEditor(390, importWebFile)} block={makeBlock()} assign={assign} />)
+    })
+
+    await vi.waitFor(() => expect(assign).toHaveBeenCalledWith({props: {url: 'ipfs://image-cid'}}))
+    expect(importWebFile).toHaveBeenCalledWith('https://example.com/tall-mobile-screenshot.png')
+  })
+
+  it('keeps the original remote image when native import fails', async () => {
+    const error = new Error('network failure')
+    const importWebFile = vi.fn().mockRejectedValue(error)
+    const assign = vi.fn()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await act(async () => {
+      root.render(<ImageDisplay editor={makeEditor(390, importWebFile)} block={makeBlock()} assign={assign} />)
+    })
+
+    await vi.waitFor(() => expect(consoleError).toHaveBeenCalledWith('Could not fetch image from URL:', error))
+    expect(assign).not.toHaveBeenCalled()
+    expect(container.querySelector('img')?.getAttribute('src')).toBe(
+      'resolved:https://example.com/tall-mobile-screenshot.png',
+    )
+
+    consoleError.mockRestore()
+  })
+
+  it('parses external image attributes into an image block', () => {
+    const wrapper = document.createElement('div')
+    wrapper.innerHTML = '<p>before</p><img src="https://example.com/image.jpg" alt="alt text"><p>after</p>'
+    const image = wrapper.querySelector('img')!
+    const rule = ImageBlock.parseHTML[0]
+
+    expect(rule.getAttrs?.(image)).toMatchObject({
+      url: 'https://example.com/image.jpg',
+      src: 'https://example.com/image.jpg',
+      alt: 'alt text',
+    })
+    expect(wrapper.textContent).toBe('beforeafter')
   })
 })

--- a/frontend/packages/editor/src/image.tsx
+++ b/frontend/packages/editor/src/image.tsx
@@ -212,6 +212,10 @@ export const ImageDisplay = ({editor, block, assign}: DisplayComponentProps) => 
     }
     // @ts-ignore
     if (url && isValidUrl(url) && editor.importWebFile) {
+      // The import finishes a paste on the editor's behalf: keep it out of the undo history so
+      // Cmd-Z undoes the paste that created the block rather than reverting the URL swap (which
+      // would only trigger this effect again).
+      const silently = {addToHistory: false}
       timeoutPromise(editor.importWebFile(url), 5000, {
         reason: 'Error fetching the image.',
       })
@@ -221,19 +225,22 @@ export const ImageDisplay = ({editor, block, assign}: DisplayComponentProps) => 
             if (!imageData.type.includes('image')) {
               return
             }
-            assign({props: {url: `ipfs://${imageData.cid}`}} as MediaType)
+            assign({props: {url: `ipfs://${imageData.cid}`}} as MediaType, silently)
           }
           // Web result
           else if ('displaySrc' in imageData && 'fileBinary' in imageData) {
             if (!imageData.type.includes('image')) {
               return
             }
-            assign({
-              props: {
-                fileBinary: imageData.fileBinary,
-                displaySrc: imageData.displaySrc,
-              },
-            } as MediaType)
+            assign(
+              {
+                props: {
+                  fileBinary: imageData.fileBinary,
+                  displaySrc: imageData.displaySrc,
+                },
+              } as MediaType,
+              silently,
+            )
           }
         })
         .catch((e) => {

--- a/frontend/packages/editor/src/media-render.tsx
+++ b/frontend/packages/editor/src/media-render.tsx
@@ -98,10 +98,10 @@ export const MediaRender: React.FC<RenderProps> = ({
   useEffect(() => {
     if (!uploading && hasSrc && editor.importWebFile && block.props.src) {
       // @ts-ignore
+      // These updates are the editor finishing a paste, not a user action: keep them out of the
+      // undo history so Cmd-Z undoes the paste itself instead of reverting the import.
       if (block.props.src.startsWith('ipfs')) {
-        editor.updateBlock(block, {
-          props: {url: block.props.src, src: ''},
-        })
+        editor.updateBlock(block, {props: {url: block.props.src, src: ''}}, undefined, {addToHistory: false})
         return
       }
       setUploading(true)
@@ -112,25 +112,29 @@ export const MediaRender: React.FC<RenderProps> = ({
           setUploading(false)
           // Desktop result
           if ('cid' in imageData) {
-            editor.updateBlock(block, {
-              props: {
-                url: `ipfs://${imageData.cid}`,
-                size: imageData.size.toString(),
-                src: '',
-              },
-            })
+            editor.updateBlock(
+              block,
+              {props: {url: `ipfs://${imageData.cid}`, size: imageData.size.toString(), src: ''}},
+              undefined,
+              {addToHistory: false},
+            )
           }
           // Web result
           else if ('displaySrc' in imageData && 'fileBinary' in imageData) {
-            editor.updateBlock(block, {
-              props: {
-                displaySrc: imageData.displaySrc,
-                // @ts-expect-error - schema defines fileBinary as string but it's actually Uint8Array
-                fileBinary: imageData.fileBinary,
-                size: imageData.size?.toString() || '',
-                src: '',
+            editor.updateBlock(
+              block,
+              {
+                props: {
+                  displaySrc: imageData.displaySrc,
+                  // @ts-expect-error - schema defines fileBinary as string but it's actually Uint8Array
+                  fileBinary: imageData.fileBinary,
+                  size: imageData.size?.toString() || '',
+                  src: '',
+                },
               },
-            })
+              undefined,
+              {addToHistory: false},
+            )
           }
         })
         .catch((e: any) => {
@@ -140,11 +144,11 @@ export const MediaRender: React.FC<RenderProps> = ({
     }
   }, [hasSrc, block, uploading, editor, editor.importWebFile])
 
-  const assignMedia = (props: MediaType) => {
+  const assignMedia = (props: MediaType, options?: {addToHistory?: boolean}) => {
     beginEditIfNeeded()
     // we used to spread the current block.props into the new props, but now we just overwrite the whole thing because it was causing bugs
     // @ts-expect-error
-    editor.updateBlock(block.id, props)
+    editor.updateBlock(block.id, props, undefined, options)
   }
 
   if (hasSrc || uploading) {


### PR DESCRIPTION
## Summary
- stop the local-media plugin from consuming rich HTML just because it contains an image
- let the editor schema paste the complete HTML, preserving adjacent text and every image
- keep direct clipboard image/file handling unchanged
- avoid renderer-side remote image fetches; desktop image blocks use the existing main-process `importWebFile` path and failed imports remain non-fatal

Fixes #735.

## Root cause
The plugin extracted the first `img[src]`, returned `true` immediately, and fetched that URL in the renderer. A CORS failure then only logged an error, after the whole paste had already been consumed.

## Validation
- rich HTML with a remote image is not claimed and renderer `fetch` is never called
- direct clipboard image files still use the attachment handler and insert an image node
- external image attributes remain accepted by the image schema
- native import success rewrites the image to `ipfs://`; rejection leaves the original remote image intact
- exact-head frontend CI is the test authority for the current head

## Security boundary
This adds no IPC endpoint or renderer capability: desktop document editors already receive the callable `importWebFile` procedure, and image blocks already invoke it for external URLs. Rich-HTML paste now reaches that existing path after an explicit user paste instead of auto-fetching the same URL in the renderer. The generic importer's pre-existing URL/redirect/size policy remains a separate hardening concern and is called out rather than obscured here.

## Scope
Existing direct clipboard-file paste and web/comment attachment handling remain in place.