### PR TITLE
test(daemon): repair private document fixtures

### DIFF
--- a/backend/daemon/daemon_e2e_test.go
+++ b/backend/daemon/daemon_e2e_test.go
@@ -94,13 +94,20 @@ func createTestDocumentChange(ctx context.Context, t *testing.T, app *App, in *a
 		return nil, err
 	}
 
+	prepareVisibility := in.Visibility
+	if existing == nil && in.Visibility == documents.ResourceVisibility_RESOURCE_VISIBILITY_PRIVATE {
+		// Private creation is intentionally disabled in the public RPC. Prepare the
+		// content as public, then store the test fixture with a private Ref below.
+		prepareVisibility = documents.ResourceVisibility_RESOURCE_VISIBILITY_PUBLIC
+	}
+
 	prepared, err := app.RPC.DocumentsV3.PrepareChange(ctx, &documents.PrepareChangeRequest{
 		Account:     in.Account,
 		Path:        in.Path,
 		BaseVersion: in.BaseVersion,
 		Changes:     in.Changes,
 		Capability:  in.Capability,
-		Visibility:  in.Visibility,
+		Visibility:  prepareVisibility,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- keep private document creation disabled on the public `PrepareChange` RPC
- have daemon tests prepare new private fixture content as public, then store the signed change behind the private Ref they already construct
- restore the six private/public-only daemon tests that currently fail during fixture setup

## Why
Document visibility lives on the Ref, not the content change. The daemon fixture helper already signs the prepared change and constructs/stores its own Ref, but it requested PRIVATE while preparing a brand-new document and therefore hit the intentional production guard before it could create that private Ref.

## Validation
Exact-head Test Go and Lint Go CI are the test authority; the constrained executor currently has no Go binary. The prior failure set is:
- `TestPrivateDocumentAccessControl`
- `TestPrivateDocumentUpdatePreservesVisibility`
- `TestPrivateDocumentExplicitPublicUpdateBecomesPublic`
- `TestPrivateDocumentsSync`
- `TestPublicOnlyGetPrivateDocument`
- `TestPublicOnlyAuthenticatedPrivateBlobBlockstoreMethods`
