### PR TITLE
Allow manual model IDs for Custom providers

### DIFF
--- a/frontend/packages/ui/src/__tests__/provider-model-select.test.tsx
+++ b/frontend/packages/ui/src/__tests__/provider-model-select.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import React from 'react'
+import {createRoot, type Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+;(globalThis as typeof globalThis & {React?: typeof React; IS_REACT_ACT_ENVIRONMENT?: boolean}).React = React
+;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+
+const modelState = vi.hoisted(() => ({
+  providerType: 'custom',
+  models: [] as Array<{id: string; name: string}>,
+  isError: false,
+}))
+
+vi.mock('../agents/models', () => ({
+  useModelProviders: () => ({
+    data: [{id: 'custom-provider', name: 'Local API', type: modelState.providerType}],
+    isLoading: false,
+  }),
+  useProviderModels: () => ({
+    data: modelState.models,
+    isError: modelState.isError,
+    isLoading: false,
+    isFetching: false,
+    error: modelState.isError ? new Error('Discovery failed') : null,
+    refetch: vi.fn(),
+  }),
+}))
+
+vi.mock('../components/popover', () => ({
+  Popover: ({children}: {children: React.ReactNode}) => <>{children}</>,
+  PopoverTrigger: ({children, ...props}: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+  PopoverContent: ({children}: {children: React.ReactNode}) => <div>{children}</div>,
+}))
+
+vi.mock('../components/input', () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}))
+vi.mock('../notice', () => ({Notice: ({children}: {children: React.ReactNode}) => <div>{children}</div>}))
+vi.mock('../text', () => ({SizableText: ({children}: {children: React.ReactNode}) => <span>{children}</span>}))
+vi.mock('../agents/provider-icons', () => ({ProviderIcon: () => null}))
+
+import {ProviderModelSelect} from '../agents/provider-model-select'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  modelState.providerType = 'custom'
+  modelState.models = []
+  modelState.isError = false
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+function typeModel(model: string) {
+  const input = container.querySelector('input')!
+  act(() => {
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!
+    setter.call(input, model)
+    input.dispatchEvent(new Event('input', {bubbles: true}))
+  })
+}
+
+describe('ProviderModelSelect custom model fallback', () => {
+  it.each([
+    ['an empty catalog', [], false],
+    ['failed discovery', [], true],
+    ['discovery returns no exact match', [{id: 'org/casesensitive-model', name: 'Different case'}], false],
+  ])('retains an exact-case custom model ID when %s', (_label, models, isError) => {
+    modelState.models = models
+    modelState.isError = isError
+    const onChange = vi.fn()
+    act(() => {
+      root.render(
+        <ProviderModelSelect
+          serverUrl="http://localhost:9999"
+          accountUid="account"
+          value={{provider: '', model: ''}}
+          onChange={onChange}
+        />,
+      )
+    })
+
+    typeModel('Org/CaseSensitive-Model')
+    const option = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.includes('Use “Org/CaseSensitive-Model”'),
+    )
+    expect(option).toBeDefined()
+
+    act(() => option!.click())
+    expect(onChange).toHaveBeenCalledWith({provider: 'Local API', model: 'Org/CaseSensitive-Model'})
+  })
+
+  it('does not duplicate an exact discovered custom model', () => {
+    modelState.models = [{id: 'Org/Exact-Model', name: 'Org/Exact-Model'}]
+    act(() => {
+      root.render(
+        <ProviderModelSelect
+          serverUrl="http://localhost:9999"
+          accountUid="account"
+          value={{provider: '', model: ''}}
+          onChange={vi.fn()}
+        />,
+      )
+    })
+
+    typeModel('Org/Exact-Model')
+    expect(container.textContent).not.toContain('Use “Org/Exact-Model”')
+  })
+
+  it('does not offer arbitrary model IDs for catalog-only providers', () => {
+    modelState.providerType = 'openai'
+    act(() => {
+      root.render(
+        <ProviderModelSelect
+          serverUrl="http://localhost:9999"
+          accountUid="account"
+          value={{provider: '', model: ''}}
+          onChange={vi.fn()}
+        />,
+      )
+    })
+
+    typeModel('not-in-catalog')
+    expect(container.textContent).not.toContain('Use “not-in-catalog”')
+  })
+})

--- a/frontend/packages/ui/src/agents/dialogs.tsx
+++ b/frontend/packages/ui/src/agents/dialogs.tsx
@@ -923,12 +923,16 @@ export function CreateAgentDialog({
     // auto-selected), so only a settled list may override the current selection.
     if (providers.isFetching) return
     const firstProvider = providers.data?.[0]?.name || ''
-    if (!providers.data?.some((provider) => provider.name === providerName)) setProviderName(firstProvider)
+    if (!providers.data?.some((provider) => provider.name === providerName)) {
+      setProviderName(firstProvider)
+      setModel('')
+    }
   }, [providerName, providers.data, providers.isFetching])
 
   useEffect(() => {
     const defaultModel = pickDefaultProviderModel(providerModels.data, selectedProviderType)?.id || ''
-    if (!providerModels.data?.some((providerModel) => providerModel.id === model)) setModel(defaultModel)
+    const modelIsDiscovered = providerModels.data?.some((providerModel) => providerModel.id === model)
+    if (!model || (selectedProviderType !== 'custom' && !modelIsDiscovered)) setModel(defaultModel)
   }, [model, providerModels.data, selectedProviderType])
 
   async function handleCreateAgent() {
@@ -1071,7 +1075,10 @@ export function CreateAgentDialog({
               addProviderDialog.open({
                 serverUrl: selectedServerUrl,
                 selectedAccountId: input.selectedAccountId,
-                onSaved: setProviderName,
+                onSaved: (nextProviderName) => {
+                  setProviderName(nextProviderName)
+                  setModel('')
+                },
               })
             }
           />

--- a/frontend/packages/ui/src/agents/header.tsx
+++ b/frontend/packages/ui/src/agents/header.tsx
@@ -559,14 +559,21 @@ export function SessionModelBadge({
 
   // Same switchable set as the agent header, seeded with the session's effective
   // pair and the agent default; entries are validated against live catalogs.
-  const providerNames = providers.data ? new Set(providers.data.map((provider) => provider.name)) : undefined
+  const providerTypes = providers.data
+    ? new Map(providers.data.map((provider) => [provider.name, provider.type]))
+    : undefined
   const samePair = (a: AgentModelRef, b: AgentModelRef) => a.provider === b.provider && a.model === b.model
   const options: AgentModelRef[] = [effective]
   for (const entry of [agentPair, ...(definition.enabledModels ?? [])]) {
     if (options.some((item) => samePair(item, entry))) continue
-    if (providerNames && !providerNames.has(entry.provider)) continue
+    if (providerTypes && !providerTypes.has(entry.provider)) continue
     const catalog = catalogs[entry.provider]
-    if (catalog?.length && !catalog.some((model) => model.id === entry.model)) continue
+    if (
+      providerTypes?.get(entry.provider) !== 'custom' &&
+      catalog?.length &&
+      !catalog.some((model) => model.id === entry.model)
+    )
+      continue
     options.push(entry)
   }
   const spansProviders = options.some((entry) => entry.provider !== effective.provider)

--- a/frontend/packages/ui/src/agents/provider-model-select.tsx
+++ b/frontend/packages/ui/src/agents/provider-model-select.tsx
@@ -48,7 +48,7 @@ export function ProviderModelSelect({
   const [query, setQuery] = useState('')
   const providers = useModelProviders(serverUrl, accountUid, agentId)
 
-  const trimmedQuery = query.trim().toLowerCase()
+  const trimmedQuery = query.trim()
   const valueProvider = providers.data?.find((provider) => provider.name === value.provider)
   const triggerLabel = value.model || 'Select a model'
 
@@ -161,7 +161,7 @@ function ProviderModelSection({
   accountUid: string | null | undefined
   agentId?: string
   provider: ModelProviderInfo
-  /** Lower-cased trimmed search text; empty shows the curated list. */
+  /** Trimmed search text; empty shows the curated list. */
   query: string
   value: AgentModelRef
   enabledModels?: AgentModelRef[]
@@ -171,19 +171,26 @@ function ProviderModelSection({
   const models = useProviderModels(serverUrl, accountUid, provider.name, agentId)
   const [showAll, setShowAll] = useState(false)
   const curated = useMemo(() => curateProviderModels(models.data, provider.type), [models.data, provider.type])
+  const normalizedQuery = query.toLowerCase()
+  const manualModel =
+    provider.type === 'custom' && query && !models.isLoading && !curated.all.some((model) => model.id === query)
+      ? query
+      : null
 
   const visibleModels = useMemo(() => {
-    if (query) {
+    if (normalizedQuery) {
       return curated.all.filter(
-        (model) => model.id.toLowerCase().includes(query) || model.name.toLowerCase().includes(query),
+        (model) =>
+          model.id.toLowerCase().includes(normalizedQuery) || model.name.toLowerCase().includes(normalizedQuery),
       )
     }
     return showAll ? curated.all : curated.recommended
-  }, [curated, query, showAll])
+  }, [curated, normalizedQuery, showAll])
 
-  // While searching, a provider with no matches drops out entirely instead of
-  // showing an empty header.
-  if (query && !visibleModels.length) return null
+  // While searching, a provider with no matches drops out entirely. Custom
+  // providers remain available so an exact, case-sensitive model ID can be
+  // selected even when discovery cannot return it.
+  if (query && !visibleModels.length && !manualModel) return null
 
   return (
     <div className="pb-1">
@@ -251,6 +258,16 @@ function ProviderModelSection({
           )
         })
       )}
+      {manualModel ? (
+        <button
+          type="button"
+          className="hover:bg-muted flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm"
+          onClick={() => onSelect({provider: provider.name, model: manualModel})}
+        >
+          <Plus className="size-4 shrink-0" />
+          <span className="min-w-0 truncate">Use “{manualModel}”</span>
+        </button>
+      ) : null}
       {!query && curated.hasMore && !models.isLoading && !models.isError ? (
         <button
           type="button"


### PR DESCRIPTION
## Summary
- allow OpenAI-compatible Custom providers to select a typed, case-sensitive model ID when discovery fails, is empty, or has no exact match
- keep catalog-only providers restricted to discovered models
- retain custom model IDs through creation and session model switching while clearing stale values on provider changes

## Scope
This removes the UI catalog dead end for arbitrary model IDs. It does not add support for provider-specific image-generation APIs such as Flux.2.

## Tests
- focused provider-model selector Vitest: 5/5 passed on rebased head
- Prettier check passed for all changed files
- `git diff --check` passed

Rebased onto current `main` on 2026-09-09. The earlier `use-media` import fix commit was dropped during the rebase because the same change already landed on `main` via 4ad8d8d0f.

Addresses #856.
