### PR TITLE
fix(frontend): repair agent test Typecheck failures

### DIFF
--- a/frontend/apps/desktop/src/__tests__/agent-session-rows.test.ts
+++ b/frontend/apps/desktop/src/__tests__/agent-session-rows.test.ts
@@ -285,8 +285,8 @@ describe('buildAgentSessionChatRows step timing', () => {
     expect(starts).toEqual([1_700_000_000_030, 1_700_000_000_030])
     // Without the runs the wait still reads as deliberation, as it always did.
     const withoutRuns = buildAgentSessionChatRows(events, CONTEXT)
-    const part =
-      withoutRuns[withoutRuns.length - 1]!.kind === 'message' ? withoutRuns.at(-1)!.message.parts?.[0] : undefined
+    const lastRow = withoutRuns.at(-1)
+    const part = lastRow?.kind === 'message' ? lastRow.message.parts?.[0] : undefined
     expect(part?.type === 'tool' ? part.stepStartedAt : 'wrong').toBe(1_700_000_000_001)
   })
 

--- a/frontend/apps/desktop/src/pages/agents/__tests__/run-work.test.tsx
+++ b/frontend/apps/desktop/src/pages/agents/__tests__/run-work.test.tsx
@@ -179,6 +179,7 @@ describe('journaled tool rows', () => {
     const parent = makeRun({id: 'root-1', status: 'running', kind: 'workflow', agentId: 'agent-1'} as never)
     render(
       <RunWorkHierarchy
+        serverUrl="http://localhost:3050"
         run={parent}
         childRuns={[]}
         journal={[
@@ -247,6 +248,7 @@ describe('integrated step rows', () => {
     const onOpenSession = vi.fn()
     render(
       <RunWorkHierarchy
+        serverUrl="http://localhost:3050"
         run={parent}
         childRuns={[child]}
         plan={plan}
@@ -292,6 +294,7 @@ describe('integrated step rows', () => {
     const onOpenSession = vi.fn()
     render(
       <RunWorkHierarchy
+        serverUrl="http://localhost:3050"
         run={parent}
         childRuns={[stamped]}
         plan={renamedPlan}
@@ -315,6 +318,7 @@ describe('integrated step rows', () => {
     const onOpenSession = vi.fn()
     render(
       <RunWorkHierarchy
+        serverUrl="http://localhost:3050"
         run={parent}
         childRuns={[child]}
         plan={plan}
@@ -360,6 +364,7 @@ describe('integrated step rows', () => {
     const onCancelRun = vi.fn()
     render(
       <RunWorkHierarchy
+        serverUrl="http://localhost:3050"
         run={parent}
         childRuns={[notion, coda]}
         plan={batchPlan}
@@ -415,6 +420,7 @@ describe('integrated step rows', () => {
     }
     render(
       <RunWorkHierarchy
+        serverUrl="http://localhost:3050"
         run={parent}
         childRuns={[]}
         plan={mixedPlan}
@@ -432,6 +438,7 @@ describe('integrated step rows', () => {
     const onOpenSession = vi.fn()
     render(
       <RunWorkHierarchy
+        serverUrl="http://localhost:3050"
         run={parent}
         childRuns={[child]}
         plan={plan}
@@ -455,6 +462,7 @@ describe('integrated step rows', () => {
     const onCancelRun = vi.fn()
     render(
       <RunWorkHierarchy
+        serverUrl="http://localhost:3050"
         run={parent}
         childRuns={[child]}
         plan={plan}

--- a/frontend/packages/ui/src/agents/dialogs.tsx
+++ b/frontend/packages/ui/src/agents/dialogs.tsx
@@ -636,8 +636,6 @@ export function EditAgentAccountDialog({
   const [label, setLabel] = useState(identity.label || identity.accountId || identity.name)
   const [iconFile, setIconFile] = useState<File | null>(null)
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
-  const profileId = identity.accountId ? hmId(identity.accountId) : undefined
-
   // Release the object URL when the dialog unmounts or the preview is replaced.
   useEffect(() => {
     return () => {

--- a/frontend/packages/ui/src/agents/memory.tsx
+++ b/frontend/packages/ui/src/agents/memory.tsx
@@ -37,7 +37,7 @@ import {
 } from 'lucide-react'
 import {useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react'
 import {Panel, PanelGroup, PanelResizeHandle} from 'react-resizable-panels'
-import {useMedia} from '@shm/ui/use-media'
+import {useMedia} from '../use-media'
 import {readAgentMemoryTabState, writeAgentMemoryTabState} from './memory-tab-state'
 
 /** Files above this size skip the inline preview fetch — pulling hundreds of MB stalls the UI. */


### PR DESCRIPTION
## Summary
- preserve the discriminated-union narrowing in the agent session row timing regression by storing the final row before reading `message`
- provide the required agent server URL in all `RunWorkHierarchy` test fixtures

## Why
Current `main` fails the frontend Typecheck job on these two test-only typing defects. The base failure is visible in [this Typecheck job](https://github.com/seed-hypermedia/seed/actions/runs/34162579625/job/101867243405), and an exact merge run for #1071 isolated the same diagnostics.

## Validation
- `git diff --check`
- Prettier check on both touched files
- Full desktop Typecheck was attempted locally but the constrained executor was killed at its memory limit; exact-head frontend CI is the deciding validation.
- Focused Vitest under the executor's Bun fallback could not initialize the repository's Zod module (`z.object` undefined), so it does not represent a test assertion failure.

## Follow-up exact-head CI repair

The first exact-head run exposed two additional current-main `@shm/ui` diagnostics after the original test-only errors were cleared. Commit `7c8d7e6d4` removes the now-unused `profileId` local and switches the package-internal `useMedia` import to its resolvable relative path. `git diff --check` passes; exact-head CI is the decisive Typecheck evidence in this constrained executor.
