### PR TITLE
fix(ui): retain document title after publish

### DIFF
--- a/frontend/packages/shared/src/models/__tests__/document-machine.test.ts
+++ b/frontend/packages/shared/src/models/__tests__/document-machine.test.ts
@@ -5,6 +5,7 @@ import {
   deriveDocumentType,
   documentMachine,
   DocumentMachineInput,
+  getEffectiveDocumentMetadata,
   PushDocumentInput,
   retargetQueryBlockIncludesForPublish,
   WriteDraftOutput,
@@ -42,6 +43,17 @@ const mockDocument = {
   genesis: 'bafygenesis',
   visibility: 'PUBLIC',
 } as unknown as HMDocument
+
+describe('getEffectiveDocumentMetadata', () => {
+  it('keeps freshly published metadata while applying staged edits', () => {
+    expect(
+      getEffectiveDocumentMetadata({
+        document: {...mockDocument, metadata: {name: 'Published title', summary: 'Published summary'}},
+        metadata: {summary: 'Draft summary'},
+      }),
+    ).toEqual({name: 'Published title', summary: 'Draft summary'})
+  })
+})
 
 describe('document collection helpers', () => {
   function queryWithIncludes(includes: unknown): EditorBlock {

--- a/frontend/packages/shared/src/models/document-machine.ts
+++ b/frontend/packages/shared/src/models/document-machine.ts
@@ -322,7 +322,9 @@ function getMachineOwnedContentOverride(context: DocumentMachineContext): Editor
 }
 
 /** Returns the effective metadata derived from the published document and draft overlay. */
-export function getEffectiveDocumentMetadata(context: DocumentMachineContext): HMMetadata {
+export function getEffectiveDocumentMetadata(
+  context: Pick<DocumentMachineContext, 'document' | 'metadata'>,
+): HMMetadata {
   return {...(context.document?.metadata ?? {}), ...context.metadata}
 }
 

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -46,7 +46,11 @@ import type {
 import {findDraftForPath, isDraftPlaceholderPath, useDraftsForAccountSafe} from '@shm/shared/draft-breadcrumb-context'
 import {parseExploreQuery} from '@shm/shared/explore'
 import {useIsHomeDraftOverride} from '@shm/shared/home-draft-context'
-import type {DocumentMachineEvent, TransientResourceError} from '@shm/shared/models/document-machine'
+import {
+  getEffectiveDocumentMetadata,
+  type DocumentMachineEvent,
+  type TransientResourceError,
+} from '@shm/shared/models/document-machine'
 import {
   useAccount,
   useAccountsMetadata,
@@ -3077,10 +3081,10 @@ function EditableDocumentHeader({
   const send = useDocumentSend()
   const [summaryRequested, setSummaryRequested] = useState(false)
 
-  // Use machine context metadata if it has been changed, otherwise fall back to document metadata
-  const name = ctx.metadata?.name ?? docMetadata?.name ?? ''
-  const summary = ctx.metadata?.summary ?? docMetadata?.summary ?? ''
-  const metadata = {...(docMetadata || {}), ...ctx.metadata}
+  // Prefer the machine's freshly published document during the query-refetch gap, then apply draft edits.
+  const metadata = {...(docMetadata || {}), ...getEffectiveDocumentMetadata(ctx)}
+  const name = metadata.name ?? ''
+  const summary = metadata.summary ?? ''
 
   return (
     <DocumentHeader


### PR DESCRIPTION
## Summary
- make the editable header consume the document machine’s canonical effective metadata
- preserve the freshly published title/summary while the resource query refetches
- add focused regression coverage for published metadata plus a staged overlay

Fixes #558.

## Evidence
- current main clears `context.metadata` before storing the publish result in `context.document`, while the editable header only read the cleared overlay and potentially stale query data
- locked Prettier 3.1.1 check passes for all changed files
- `git diff --check` passes
- the constrained executor could not complete a targeted workspace dependency link; exact-head frontend CI is the decisive unit/typecheck evidence
## Exact-head CI

Run 34171842367 passed Lint, the new shared unit regression, all shared/desktop/web unit jobs, and editor E2E. Typecheck reached only the two pre-existing current-main diagnostics repaired by ready PR #1072; this branch introduced no additional diagnostic.
