### PR TITLE
Fix republishing: publish a republished document and enable republish on web

### DIFF
--- a/backend/api/documents/v3alpha/documents.go
+++ b/backend/api/documents/v3alpha/documents.go
@@ -50,6 +50,7 @@ const (
 	maxPageAllocBuffer             = 400  // Arbitrary limit to prevent allocating too much memory when client requested huge page size.
 	maxQueryDocumentsPageSize      = 1000
 	maxQueryDocumentSorts          = 16
+	maxRedirectHops                = 16
 	publicOnlyListVisibilityFilter = `dg.visibility IS NOT 'Private'`
 	indexedAttributeString         = "s"
 	indexedAttributeBool           = "b"
@@ -1076,6 +1077,39 @@ type documentChangeParams struct {
 	allowPrivateCreationForTest bool
 }
 
+// loadDocumentForChange loads the document that a change should build on, following redirect Refs.
+//
+// A path holding a redirect Ref (a republished or moved document) has no change DAG of its own, so
+// editing it is a takeover: the Change must build on the redirect target's DAG, and the fresh-
+// generation Version Ref the client publishes at this path supersedes the redirect. This resolves
+// the redirect chain (bounded, matching the reader-side limit) and loads the target, so the change
+// shares the target's genesis and heads — otherwise PrepareChange would mint a brand-new genesis
+// that disagrees with the client-signed Ref, and the publish would fail.
+func (srv *Server) loadDocumentForChange(ctx context.Context, ns core.Principal, path string, heads []cid.Cid) (*docmodel.Document, error) {
+	for hop := 0; hop < maxRedirectHops; hop++ {
+		info, err := srv.loadDocumentInfo(ctx, ns, path)
+		if err != nil {
+			if status.Code(err) == codes.NotFound {
+				break // No document at this path; load a fresh one below.
+			}
+			return nil, err
+		}
+
+		if info.RedirectInfo == nil {
+			break // Not a redirect; edit this document.
+		}
+
+		redirectNS, err := core.DecodePrincipal(info.RedirectInfo.Account)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid redirect target account %q: %v", info.RedirectInfo.Account, err)
+		}
+
+		ns, path = redirectNS, info.RedirectInfo.Path
+	}
+
+	return srv.loadDocument(ctx, ns, path, heads, true)
+}
+
 // handleDocumentChangeRequest validates input, loads or creates the document, and applies the requested changes.
 func (srv *Server) handleDocumentChangeRequest(ctx context.Context, in documentChangeParams) (*docmodel.Document, error) {
 	ns, err := core.DecodePrincipal(in.Account)
@@ -1114,7 +1148,7 @@ func (srv *Server) handleDocumentChangeRequest(ctx context.Context, in documentC
 		return nil, err
 	}
 
-	doc, err := srv.loadDocument(ctx, ns, in.Path, heads, true)
+	doc, err := srv.loadDocumentForChange(ctx, ns, in.Path, heads)
 	if err != nil {
 		if status.Code(err) != codes.FailedPrecondition {
 			return nil, err

--- a/backend/api/documents/v3alpha/documents.go
+++ b/backend/api/documents/v3alpha/documents.go
@@ -50,7 +50,7 @@ const (
 	maxPageAllocBuffer             = 400  // Arbitrary limit to prevent allocating too much memory when client requested huge page size.
 	maxQueryDocumentsPageSize      = 1000
 	maxQueryDocumentSorts          = 16
-	maxRedirectHops                = 16
+	maxRedirectHops                = 5 // Matches MAX_REDIRECT_HOPS in frontend/packages/shared/src/redirects.ts.
 	publicOnlyListVisibilityFilter = `dg.visibility IS NOT 'Private'`
 	indexedAttributeString         = "s"
 	indexedAttributeBool           = "b"
@@ -1077,37 +1077,122 @@ type documentChangeParams struct {
 	allowPrivateCreationForTest bool
 }
 
-// loadDocumentForChange loads the document that a change should build on, following redirect Refs.
-//
-// A path holding a redirect Ref (a republished or moved document) has no change DAG of its own, so
-// editing it is a takeover: the Change must build on the redirect target's DAG, and the fresh-
-// generation Version Ref the client publishes at this path supersedes the redirect. This resolves
-// the redirect chain (bounded, matching the reader-side limit) and loads the target, so the change
-// shares the target's genesis and heads — otherwise PrepareChange would mint a brand-new genesis
-// that disagrees with the client-signed Ref, and the publish would fail.
-func (srv *Server) loadDocumentForChange(ctx context.Context, ns core.Principal, path string, heads []cid.Cid) (*docmodel.Document, error) {
-	for hop := 0; hop < maxRedirectHops; hop++ {
-		info, err := srv.loadDocumentInfo(ctx, ns, path)
-		if err != nil {
-			if status.Code(err) == codes.NotFound {
-				break // No document at this path; load a fresh one below.
-			}
-			return nil, err
-		}
-
-		if info.RedirectInfo == nil {
-			break // Not a redirect; edit this document.
-		}
-
-		redirectNS, err := core.DecodePrincipal(info.RedirectInfo.Account)
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "invalid redirect target account %q: %v", info.RedirectInfo.Account, err)
-		}
-
-		ns, path = redirectNS, info.RedirectInfo.Path
+// redirectDetails extracts the redirect target from the FailedPrecondition error the index reports
+// for a path holding a redirect Ref. It returns nil for every other error, including the tombstone
+// that carries no redirect.
+func redirectDetails(err error) *documents.RedirectErrorDetails {
+	st, ok := status.FromError(err)
+	if !ok {
+		return nil
 	}
 
-	return srv.loadDocument(ctx, ns, path, heads, true)
+	for _, d := range st.Details() {
+		if rd, ok := d.(*documents.RedirectErrorDetails); ok {
+			return rd
+		}
+	}
+
+	return nil
+}
+
+// loadDocumentForChange loads the document that a change must build on, following redirect Refs.
+//
+// A path holding a redirect Ref (a republished or moved document) has no change DAG of its own, so
+// editing it is a takeover: the Change has to build on the redirect target's DAG, and the fresh-
+// generation Version Ref published at this path then supersedes the redirect. Without this,
+// PrepareChange mints a brand-new genesis, the client signs its Ref against the target's genesis,
+// and indexing rejects the Ref with a genesis mismatch (crossLinkRefMaybe in blob/blob_ref.go).
+//
+// The returned document keeps the requested path as its identity, because that is where the Ref
+// belongs. Only the change history comes from the target. Redirects are resolved through
+// Index.ResolveLatest, which reports republish and move redirects through the same error, so both
+// kinds are taken over the same way, and which costs one indexed row read per hop.
+//
+// The chain is bounded by maxRedirectHops, the limit the readers use, so the daemon never accepts a
+// takeover that every client would then fail to resolve. (The 16 in the redirect_ancestors CTEs is a
+// SQL recursion depth, not a reader limit.) Cycles are refused outright: minting an empty document
+// instead would produce exactly the disagreeing genesis this resolution exists to prevent.
+func (srv *Server) loadDocumentForChange(ctx context.Context, identity blob.IRI, heads []cid.Cid) (*docmodel.Document, error) {
+	source := identity
+	visited := map[blob.IRI]struct{}{identity: {}}
+
+	// Generation of the redirect Ref being taken over, or -1 when this is an ordinary edit. The Ref
+	// this change produces has to outrank it, or the publish succeeds and the path keeps redirecting.
+	redirectGeneration := int64(-1)
+
+	for hop := 0; ; hop++ {
+		state, err := srv.idx.ResolveLatest(ctx, source)
+		if err == nil {
+			if source != identity && state.Visibility == blob.VisibilityPrivate {
+				// A redirect must not become a read primitive for a private document. The prepared
+				// change would carry the target's genesis and heads, which no read RPC on a
+				// public-only node discloses.
+				targetNS, targetPath, err := source.SpacePath()
+				if err != nil {
+					return nil, err
+				}
+
+				if err := srv.denyPrivateDocument(ctx, targetNS, targetPath); err != nil {
+					return nil, err
+				}
+			}
+
+			break // A readable document: build the change on it.
+		}
+
+		if status.Code(err) == codes.NotFound {
+			break // Nothing indexed here: the change starts a new document.
+		}
+
+		redirect := redirectDetails(err)
+		if redirect == nil {
+			// A tombstone, with no redirect to follow. There is no history to build on, so the
+			// change starts a new document at the requested path.
+			source = identity
+			break
+		}
+
+		if hop >= maxRedirectHops {
+			return nil, status.Errorf(codes.FailedPrecondition, "cannot edit %s: its redirect chain is longer than %d hops", identity, maxRedirectHops)
+		}
+
+		targetNS, err := core.DecodePrincipal(redirect.TargetAccount)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid redirect target account %q: %v", redirect.TargetAccount, err)
+		}
+
+		target, err := makeIRI(targetNS, redirect.TargetPath)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid redirect target %s%s: %v", redirect.TargetAccount, redirect.TargetPath, err)
+		}
+
+		if _, seen := visited[target]; seen {
+			return nil, status.Errorf(codes.FailedPrecondition, "cannot edit %s: its redirect chain is a cycle through %s", identity, target)
+		}
+		visited[target] = struct{}{}
+
+		// Only the first hop matters for the generation: that is the redirect Ref sitting at the
+		// path this change is written to.
+		if redirectGeneration < 0 {
+			redirectGeneration = state.Generation
+		}
+
+		source = target
+	}
+
+	doc, err := srv.loadDocumentFrom(ctx, identity, source, heads, true)
+	if err != nil {
+		return nil, err
+	}
+
+	if redirectGeneration >= 0 {
+		// Outrank the redirect this change takes over. Clients compute their own generation for the
+		// Ref they sign; a server-signed publish (Document.Ref) has no other source for it, and
+		// would otherwise inherit the target's generation, which says nothing about this path.
+		doc.Generation = maybe.New(redirectGeneration + 1)
+	}
+
+	return doc, nil
 }
 
 // handleDocumentChangeRequest validates input, loads or creates the document, and applies the requested changes.
@@ -1148,17 +1233,13 @@ func (srv *Server) handleDocumentChangeRequest(ctx context.Context, in documentC
 		return nil, err
 	}
 
-	doc, err := srv.loadDocumentForChange(ctx, ns, in.Path, heads)
+	// loadDocumentForChange decides on its own when a path has no usable history and the change
+	// starts a new document. Errors it does return are refusals — an unresolvable redirect chain, a
+	// private target — and must not be turned into a fresh document: minting one is exactly the
+	// broken publish this resolution exists to prevent.
+	doc, err := srv.loadDocumentForChange(ctx, iri, heads)
 	if err != nil {
-		if status.Code(err) != codes.FailedPrecondition {
-			return nil, err
-		}
-
-		clock := cclock.New()
-		doc, err = docmodel.New(iri, clock)
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 
 	if in.Visibility == documents.ResourceVisibility_RESOURCE_VISIBILITY_PRIVATE && doc.Visibility() != blob.VisibilityPrivate && !in.allowPrivateCreationForTest && !privateCreationEnabledForTests.Load() {
@@ -2190,8 +2271,11 @@ func documentInfoFromRow(lookup *blob.LookupCache, row *sqlite.Stmt) (*documents
 			return nil, 0, fmt.Errorf("failed to parse redirect target %v: %w", redirect.Value, err)
 		}
 		redirectInfo = &documents.RefTarget_Redirect{
-			Account:   space.String(),
-			Path:      path,
+			Account: space.String(),
+			Path:    path,
+			// Always a republish, because the query feeding this row keeps only generations with
+			// is_deleted = 0, and a move redirect is a tombstone. Move redirects never reach here
+			// at all; readers that need both kinds go through Index.ResolveLatest instead.
 			Republish: true,
 		}
 	}
@@ -2752,13 +2836,23 @@ func (srv *Server) loadDocument(ctx context.Context, account core.Principal, pat
 		return nil, err
 	}
 
+	return srv.loadDocumentFrom(ctx, iri, iri, heads, ensurePath)
+}
+
+// loadDocumentFrom replays the changes stored at source, but gives the result the identity of
+// identity: that is the address of every Ref derived from it, because Document.Ref reads the space
+// and the path from the document's own IRI.
+//
+// The two differ only for a redirect takeover, where the history lives at the redirect target while
+// the Ref belongs at the redirect path. Every other caller passes the same IRI twice.
+func (srv *Server) loadDocumentFrom(ctx context.Context, identity, source blob.IRI, heads []cid.Cid, ensurePath bool) (*docmodel.Document, error) {
 	clock := cclock.New()
-	doc, err := docmodel.New(iri, clock)
+	doc, err := docmodel.New(identity, clock)
 	if err != nil {
 		return nil, err
 	}
 
-	changes, check := srv.idx.IterChanges(ctx, iri, heads)
+	changes, check := srv.idx.IterChanges(ctx, source, heads)
 	for ch := range changes {
 		doc.SetVisibility(ch.Visibility)
 		if doc.Generation.IsSet() {
@@ -2782,7 +2876,7 @@ func (srv *Server) loadDocument(ctx context.Context, account core.Principal, pat
 
 	if len(doc.Heads()) == 0 {
 		if !ensurePath {
-			return nil, status.Errorf(codes.NotFound, "document not found: %s", iri)
+			return nil, status.Errorf(codes.NotFound, "document not found: %s", source)
 		}
 
 		doc.Generation = maybe.New(cclock.New().MustNow().UnixMilli())

--- a/backend/api/documents/v3alpha/documents_test.go
+++ b/backend/api/documents/v3alpha/documents_test.go
@@ -3112,6 +3112,354 @@ func TestPrepareChangeTakesOverRedirect(t *testing.T) {
 	require.Equal(t, targetGenesis.String(), got.Genesis, "the takeover keeps the target's genesis")
 }
 
+// publishRedirectTestDoc publishes a one-block document, so the redirect tests below read as tests
+// about redirects rather than about block plumbing.
+func publishRedirectTestDoc(ctx context.Context, t *testing.T, srv testServer, signingKey, space, path, text string) *documents.Document {
+	t.Helper()
+
+	doc, err := srv.PublishDocumentChangeForTest(ctx, &apitest.DocumentChangeRequest{
+		SigningKeyName: signingKey,
+		Account:        space,
+		Path:           path,
+		Changes: []*documents.DocumentChange{
+			{Op: &documents.DocumentChange_MoveBlock_{
+				MoveBlock: &documents.DocumentChange_MoveBlock{BlockId: "a", Parent: "", LeftSibling: ""},
+			}},
+			{Op: &documents.DocumentChange_ReplaceBlock{
+				ReplaceBlock: &documents.Block{Id: "a", Type: "paragraph", Text: text},
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	return doc
+}
+
+// createRedirectRef points path at a target with a redirect Ref. isRepublish picks the kind: a
+// republish keeps the path alive, a move writes a tombstone.
+func createRedirectRef(ctx context.Context, t *testing.T, srv testServer, signingKey, space, path, targetSpace, targetPath string, isRepublish bool) {
+	t.Helper()
+
+	_, err := srv.CreateRef(ctx, &documents.CreateRefRequest{
+		SigningKeyName: signingKey,
+		Account:        space,
+		Path:           path,
+		Target: &documents.RefTarget{
+			Target: &documents.RefTarget_Redirect_{
+				Redirect: &documents.RefTarget_Redirect{
+					Account:   targetSpace,
+					Path:      targetPath,
+					Republish: isRepublish,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+}
+
+// appendBlockChange builds the change every test below applies: one more paragraph at the end.
+func appendBlockChange(id, text, leftSibling string) []*documents.DocumentChange {
+	return []*documents.DocumentChange{
+		{Op: &documents.DocumentChange_MoveBlock_{
+			MoveBlock: &documents.DocumentChange_MoveBlock{BlockId: id, Parent: "", LeftSibling: leftSibling},
+		}},
+		{Op: &documents.DocumentChange_ReplaceBlock{
+			ReplaceBlock: &documents.Block{Id: id, Type: "paragraph", Text: text},
+		}},
+	}
+}
+
+// A server-signed publish at a republished path has to write its Ref to that path. The document is
+// loaded from the redirect target, but Document.Ref reads the space and the path from the document's
+// own IRI, so a document carrying the target's identity appends a head to the target instead of
+// taking over the redirect.
+func TestPublishDocumentChangeTakesOverRedirectAtItsOwnPath(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	alice := newTestDocsAPI(t, "alice")
+	space := alice.me.Account.PublicKey.String()
+
+	target := publishRedirectTestDoc(ctx, t, alice, "main", space, "/guide", "Block A")
+	createRedirectRef(ctx, t, alice, "main", space, "/mirror", space, "/guide", true)
+
+	edited, err := alice.PublishDocumentChangeForTest(ctx, &apitest.DocumentChangeRequest{
+		SigningKeyName: "main",
+		Account:        space,
+		Path:           "/mirror",
+		BaseVersion:    target.Version,
+		Changes:        appendBlockChange("b", "Block B", "a"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "/mirror", edited.Path, "the Ref must land on the redirect path, not on its target")
+	require.Equal(t, target.Genesis, edited.Genesis, "the takeover keeps the target's genesis")
+
+	got, err := alice.GetDocument(ctx, &documents.GetDocumentRequest{Account: space, Path: "/mirror"})
+	require.NoError(t, err)
+	require.Len(t, got.Content, 2, "the republished path must serve the edited document")
+
+	// crossLinkRefMaybe writes only to the Ref's own resource row, so the source keeps its heads.
+	source, err := alice.GetDocument(ctx, &documents.GetDocumentRequest{Account: space, Path: "/guide"})
+	require.NoError(t, err)
+	require.Equal(t, target.Version, source.Version, "the redirect target must not gain a new head")
+	require.Len(t, source.Content, 1, "the redirect target's content must not change")
+}
+
+// A move redirect is a tombstone Ref, which the listing queries filter out entirely. Editing a moved
+// path must take over just like a republish does.
+func TestPrepareChangeTakesOverMoveRedirect(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	alice := newTestDocsAPI(t, "alice")
+	space := alice.me.Account.PublicKey.String()
+
+	target := publishRedirectTestDoc(ctx, t, alice, "main", space, "/new-home", "Moved here")
+	targetGenesis, err := cid.Decode(target.Genesis)
+	require.NoError(t, err)
+
+	publishRedirectTestDoc(ctx, t, alice, "main", space, "/old-home", "Was here")
+	createRedirectRef(ctx, t, alice, "main", space, "/old-home", space, "/new-home", false)
+
+	// The move really is a tombstone: the query behind GetDocumentInfo cannot see it.
+	_, err = alice.GetDocumentInfo(ctx, &documents.GetDocumentInfoRequest{Account: space, Path: "/old-home"})
+	require.Error(t, err, "a moved path must be invisible to the listing queries")
+
+	prepared, err := alice.PrepareChange(ctx, &documents.PrepareChangeRequest{
+		Account:     space,
+		Path:        "/old-home",
+		BaseVersion: target.Version,
+		Changes:     appendBlockChange("b", "Block B", "a"),
+	})
+	require.NoError(t, err)
+
+	var unsigned blob.Change
+	require.NoError(t, cbornode.DecodeInto(prepared.UnsignedChange, &unsigned))
+	require.Equal(t, targetGenesis, unsigned.Genesis, "the change must build on the move target's genesis")
+	require.NotEmpty(t, unsigned.Deps, "the change must depend on the move target's heads")
+}
+
+func TestPrepareChangeRedirectChainLimits(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("follows a two-hop chain", func(t *testing.T) {
+		t.Parallel()
+
+		alice := newTestDocsAPI(t, "alice")
+		space := alice.me.Account.PublicKey.String()
+
+		target := publishRedirectTestDoc(ctx, t, alice, "main", space, "/c", "Block A")
+		targetGenesis, err := cid.Decode(target.Genesis)
+		require.NoError(t, err)
+
+		createRedirectRef(ctx, t, alice, "main", space, "/b", space, "/c", true)
+		createRedirectRef(ctx, t, alice, "main", space, "/a", space, "/b", true)
+
+		prepared, err := alice.PrepareChange(ctx, &documents.PrepareChangeRequest{
+			Account:     space,
+			Path:        "/a",
+			BaseVersion: target.Version,
+			Changes:     appendBlockChange("b", "Block B", "a"),
+		})
+		require.NoError(t, err)
+
+		var unsigned blob.Change
+		require.NoError(t, cbornode.DecodeInto(prepared.UnsignedChange, &unsigned))
+		require.Equal(t, targetGenesis, unsigned.Genesis, "the chain must resolve to the document at its end")
+	})
+
+	t.Run("refuses a cycle instead of minting an empty document", func(t *testing.T) {
+		t.Parallel()
+
+		alice := newTestDocsAPI(t, "alice")
+		space := alice.me.Account.PublicKey.String()
+
+		publishRedirectTestDoc(ctx, t, alice, "main", space, "/a", "Block A")
+		publishRedirectTestDoc(ctx, t, alice, "main", space, "/b", "Block B")
+		createRedirectRef(ctx, t, alice, "main", space, "/a", space, "/b", true)
+		createRedirectRef(ctx, t, alice, "main", space, "/b", space, "/a", true)
+
+		_, err := alice.PrepareChange(ctx, &documents.PrepareChangeRequest{
+			Account: space,
+			Path:    "/a",
+			Changes: appendBlockChange("c", "Block C", "a"),
+		})
+		require.Error(t, err, "a cycle must be an error, not a silent empty document")
+		require.Equal(t, codes.FailedPrecondition, status.Code(err))
+		require.Contains(t, status.Convert(err).Message(), "cycle")
+	})
+
+	t.Run("refuses a chain longer than the reader limit", func(t *testing.T) {
+		t.Parallel()
+
+		alice := newTestDocsAPI(t, "alice")
+		space := alice.me.Account.PublicKey.String()
+
+		// One hop more than a reader can follow, so the daemon must not accept a takeover that
+		// every client would then fail to resolve.
+		const hops = maxRedirectHops + 1
+		end := fmt.Sprintf("/h%d", hops)
+		target := publishRedirectTestDoc(ctx, t, alice, "main", space, end, "The end")
+
+		for i := hops - 1; i >= 0; i-- {
+			createRedirectRef(ctx, t, alice, "main", space, fmt.Sprintf("/h%d", i), space, fmt.Sprintf("/h%d", i+1), true)
+		}
+
+		_, err := alice.PrepareChange(ctx, &documents.PrepareChangeRequest{
+			Account:     space,
+			Path:        "/h0",
+			BaseVersion: target.Version,
+			Changes:     appendBlockChange("b", "Block B", "a"),
+		})
+		require.Error(t, err, "an over-long chain must be an error, not a silent empty document")
+		require.Equal(t, codes.FailedPrecondition, status.Code(err))
+		require.Contains(t, status.Convert(err).Message(), "longer than")
+	})
+}
+
+// A redirect is not an authorisation. Following one on the write path replays a private document on
+// a public-only node, where every read RPC denies it, and that leaked two things to an
+// unauthenticated caller: the target's existence, because "base_version is required" is only
+// reported when a document really is there; and its genesis and heads, to anyone who already knew
+// the version to ask with. The write path must refuse at the read instead, so neither depends on
+// what else the request happens to carry.
+func TestPrepareChangeRefusesPrivateRedirectTargetOnPublicOnlyNode(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	alice := newTestDocsAPIWithConfig(t, "alice", config.Base{PublicOnly: true})
+	space := alice.me.Account.PublicKey.String()
+
+	_, err := alice.PublishDocumentChangeForTest(ctx, &apitest.DocumentChangeRequest{
+		SigningKeyName: "main",
+		Account:        space,
+		Path:           "/private",
+		Visibility:     documents.ResourceVisibility_RESOURCE_VISIBILITY_PRIVATE,
+		Changes:        appendBlockChange("a", "Secret", ""),
+	})
+	require.NoError(t, err)
+
+	// The redirect Ref is written straight to the index, the way one would arrive from a peer.
+	// CreateRef reads its target, and on a public-only node that read already refuses.
+	privateState, err := alice.idx.ResolveLatest(ctx, blob.IRI("hm://"+space+"/private"))
+	require.NoError(t, err)
+	require.Equal(t, blob.VisibilityPrivate, privateState.Visibility)
+
+	privateDoc, err := alice.loadDocument(ctx, alice.me.Account.Principal(), "/private", nil, false)
+	require.NoError(t, err)
+	hydrated, err := privateDoc.Hydrate(ctx)
+	require.NoError(t, err)
+	genesis, err := cid.Decode(hydrated.Genesis)
+	require.NoError(t, err)
+
+	redirect, err := blob.NewRefRedirect(
+		alice.me.Account,
+		time.Now().UnixMilli(),
+		genesis,
+		alice.me.Account.Principal(),
+		"/bait",
+		blob.RedirectTarget{Space: alice.me.Account.Principal(), Path: "/private", Republish: true},
+		time.Now().Round(blob.ClockPrecision),
+	)
+	require.NoError(t, err)
+	require.NoError(t, alice.idx.Put(ctx, redirect))
+
+	// Knowing nothing: the refusal must not come from a downstream validation, which would still
+	// report that something is there.
+	_, err = alice.PrepareChange(ctx, &documents.PrepareChangeRequest{
+		Account: space,
+		Path:    "/bait",
+		Changes: appendBlockChange("b", "Block B", "a"),
+	})
+	require.Error(t, err, "a redirect must not read a private document on a public-only node")
+	require.Equal(t, codes.PermissionDenied, status.Code(err))
+
+	// Knowing the version: this is the request that used to come back with the private document's
+	// genesis and heads in the prepared change.
+	_, err = alice.PrepareChange(ctx, &documents.PrepareChangeRequest{
+		Account:     space,
+		Path:        "/bait",
+		BaseVersion: hydrated.Version,
+		Changes:     appendBlockChange("b", "Block B", "a"),
+	})
+	require.Error(t, err)
+	require.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+// The case from #1074: bob republishes alice's document into his own space and then edits it. The
+// generation the clients pick comes from the wall clock, not from the redirect Ref, so the takeover
+// has to win on that value too, and a second edit has to keep working afterwards.
+func TestPrepareChangeTakesOverCrossSpaceRepublish(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	alice := newTestDocsAPI(t, "alice")
+	bob := coretest.NewTester("bob")
+	require.NoError(t, alice.keys.StoreKey(ctx, "bob", bob.Account))
+
+	aliceSpace := alice.me.Account.PublicKey.String()
+	bobSpace := bob.Account.PublicKey.String()
+
+	target := publishRedirectTestDoc(ctx, t, alice, "main", aliceSpace, "/guide", "Alice's guide")
+	targetGenesis, err := cid.Decode(target.Genesis)
+	require.NoError(t, err)
+
+	createRedirectRef(ctx, t, alice, "bob", bobSpace, "/mirror", aliceSpace, "/guide", true)
+
+	prepared, err := alice.PrepareChange(ctx, &documents.PrepareChangeRequest{
+		Account:     bobSpace,
+		Path:        "/mirror",
+		BaseVersion: target.Version,
+		Changes:     appendBlockChange("b", "Bob's addition", "a"),
+	})
+	require.NoError(t, err)
+
+	var unsigned blob.Change
+	require.NoError(t, cbornode.DecodeInto(prepared.UnsignedChange, &unsigned))
+	require.Equal(t, targetGenesis, unsigned.Genesis, "the change must build on alice's genesis")
+
+	signed, err := signPreparedChangeBlob(prepared.UnsignedChange, bob.Account)
+	require.NoError(t, err)
+
+	// The generation a real client picks: a wall-clock value, not redirectRef.Generation + 1.
+	ref, err := blob.NewRef(
+		bob.Account,
+		time.Now().UnixMilli(),
+		targetGenesis,
+		bob.Account.Principal(),
+		"/mirror",
+		[]cid.Cid{signed.CID},
+		time.Now().Round(blob.ClockPrecision),
+		blob.VisibilityPublic,
+	)
+	require.NoError(t, err)
+	require.NoError(t, alice.idx.PutMany(ctx, []blocks.Block{signed, ref}))
+
+	got, err := alice.GetDocument(ctx, &documents.GetDocumentRequest{Account: bobSpace, Path: "/mirror"})
+	require.NoError(t, err)
+	require.Len(t, got.Content, 2, "bob's copy must serve the edited document, no longer a redirect")
+
+	// The redirect attribute is gone from the newest generation, so a second edit stays on the DAG.
+	prepared2, err := alice.PrepareChange(ctx, &documents.PrepareChangeRequest{
+		Account:     bobSpace,
+		Path:        "/mirror",
+		BaseVersion: got.Version,
+		Changes:     appendBlockChange("c", "And more", "b"),
+	})
+	require.NoError(t, err)
+
+	var unsigned2 blob.Change
+	require.NoError(t, cbornode.DecodeInto(prepared2.UnsignedChange, &unsigned2))
+	require.Equal(t, targetGenesis, unsigned2.Genesis, "the second edit must stay on the same DAG")
+
+	source, err := alice.GetDocument(ctx, &documents.GetDocumentRequest{Account: aliceSpace, Path: "/guide"})
+	require.NoError(t, err)
+	require.Equal(t, target.Version, source.Version, "alice's original must not change")
+	require.Len(t, source.Content, 1, "alice's original must not change")
+}
+
 func TestPrepareChangeBlockReordering(t *testing.T) {
 	t.Parallel()
 

--- a/backend/api/documents/v3alpha/documents_test.go
+++ b/backend/api/documents/v3alpha/documents_test.go
@@ -3010,6 +3010,108 @@ func TestPrepareChangeAndSubmit(t *testing.T) {
 	require.Contains(t, got.Version, signedChange.CID.String(), "version must reference the submitted change")
 }
 
+func TestPrepareChangeTakesOverRedirect(t *testing.T) {
+	t.Parallel()
+
+	alice := newTestDocsAPI(t, "alice")
+	ctx := context.Background()
+	space := alice.me.Account.PublicKey.String()
+
+	// A canonical document with blocks [a, b].
+	target, err := alice.PublishDocumentChangeForTest(ctx, &apitest.DocumentChangeRequest{
+		SigningKeyName: "main",
+		Account:        space,
+		Path:           "/guide",
+		Changes: []*documents.DocumentChange{
+			{Op: &documents.DocumentChange_MoveBlock_{
+				MoveBlock: &documents.DocumentChange_MoveBlock{BlockId: "a", Parent: "", LeftSibling: ""},
+			}},
+			{Op: &documents.DocumentChange_ReplaceBlock{
+				ReplaceBlock: &documents.Block{Id: "a", Type: "paragraph", Text: "Block A"},
+			}},
+			{Op: &documents.DocumentChange_MoveBlock_{
+				MoveBlock: &documents.DocumentChange_MoveBlock{BlockId: "b", Parent: "", LeftSibling: "a"},
+			}},
+			{Op: &documents.DocumentChange_ReplaceBlock{
+				ReplaceBlock: &documents.Block{Id: "b", Type: "paragraph", Text: "Block B"},
+			}},
+		},
+	})
+	require.NoError(t, err)
+	targetGenesis, err := cid.Decode(target.Genesis)
+	require.NoError(t, err)
+
+	// Republish it at /mirror: a redirect Ref with republish=true.
+	_, err = alice.CreateRef(ctx, &documents.CreateRefRequest{
+		SigningKeyName: "main",
+		Account:        space,
+		Path:           "/mirror",
+		Target: &documents.RefTarget{
+			Target: &documents.RefTarget_Redirect_{
+				Redirect: &documents.RefTarget_Redirect{
+					Account:   space,
+					Path:      "/guide",
+					Republish: true,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Editing the republished path is a takeover: PrepareChange must build on the redirect
+	// target's DAG rather than minting a fresh genesis that disagrees with the client-signed Ref.
+	prepared, err := alice.PrepareChange(ctx, &documents.PrepareChangeRequest{
+		Account:     space,
+		Path:        "/mirror",
+		BaseVersion: target.Version,
+		Changes: []*documents.DocumentChange{
+			{Op: &documents.DocumentChange_MoveBlock_{
+				MoveBlock: &documents.DocumentChange_MoveBlock{BlockId: "c", Parent: "", LeftSibling: "b"},
+			}},
+			{Op: &documents.DocumentChange_ReplaceBlock{
+				ReplaceBlock: &documents.Block{Id: "c", Type: "paragraph", Text: "Block C"},
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	var unsigned blob.Change
+	require.NoError(t, cbornode.DecodeInto(prepared.UnsignedChange, &unsigned))
+	require.Equal(t, targetGenesis, unsigned.Genesis, "the change must build on the redirect target's genesis, not a fresh one")
+	require.NotEmpty(t, unsigned.Deps, "the change must depend on the target's heads")
+
+	// Sign the change and submit a fresh-generation Ref at the redirect path, superseding the redirect.
+	kp := alice.me.Account
+	signedChange, err := signPreparedChangeBlob(prepared.UnsignedChange, kp)
+	require.NoError(t, err)
+
+	redirectInfo, err := alice.GetDocumentInfo(ctx, &documents.GetDocumentInfoRequest{Account: space, Path: "/mirror"})
+	require.NoError(t, err)
+
+	ref, err := blob.NewRef(
+		kp,
+		redirectInfo.GenerationInfo.Generation+1,
+		targetGenesis,
+		kp.Principal(),
+		"/mirror",
+		[]cid.Cid{signedChange.CID},
+		time.Now().Round(blob.ClockPrecision),
+		blob.VisibilityPublic,
+	)
+	require.NoError(t, err)
+	require.NoError(t, alice.idx.PutMany(ctx, []blocks.Block{signedChange, ref}))
+
+	// The republished path now serves the edited document, no longer a redirect.
+	got, err := alice.GetDocument(ctx, &documents.GetDocumentRequest{
+		Account: space,
+		Path:    "/mirror",
+	})
+	require.NoError(t, err)
+	require.Len(t, got.Content, 3, "must have 3 blocks after takeover")
+	require.Equal(t, "Block C", got.Content[2].Block.Text, "the new block must be present")
+	require.Equal(t, targetGenesis.String(), got.Genesis, "the takeover keeps the target's genesis")
+}
+
 func TestPrepareChangeBlockReordering(t *testing.T) {
 	t.Parallel()
 

--- a/backend/blob/index.go
+++ b/backend/blob/index.go
@@ -565,6 +565,12 @@ type DocumentState struct {
 // and tombstones with exactly the same errors: a caller that uses this to skip
 // a document load stays indistinguishable from one that doesn't. Returns
 // NotFound when the resource has no generations, matching loadDocument.
+//
+// On a redirect or a tombstone the error comes back with Generation and
+// Visibility still filled in, because the generation row is read before those
+// conditions are examined. A caller that follows a redirect needs the redirect's
+// own generation to supersede it, and has no cheaper way to read it. Heads are
+// left empty in that case: the resource is not readable.
 func (idx *Index) ResolveLatest(ctx context.Context, resource IRI) (DocumentState, error) {
 	conn, release, err := idx.db.ReadConn(ctx)
 	if err != nil {
@@ -574,7 +580,7 @@ func (idx *Index) ResolveLatest(ctx context.Context, resource IRI) (DocumentStat
 
 	dg, found, err := idx.resolveLatestGeneration(conn, resource)
 	if err != nil {
-		return DocumentState{}, err
+		return DocumentState{Generation: dg.Generation, Visibility: dg.Visibility}, err
 	}
 
 	if !found || len(dg.Heads) == 0 {

--- a/frontend/apps/web/app/web-feed-page.tsx
+++ b/frontend/apps/web/app/web-feed-page.tsx
@@ -46,6 +46,11 @@ export function WebFeedPage({docId}: {docId: UnpackedHypermediaId}) {
     (id: UnpackedHypermediaId, origin?: DocumentCardActionOrigin) => destinationDialog.open({id, mode: 'move', origin}),
     [destinationDialog],
   )
+  const onRepublishDocument = useCallback(
+    (id: UnpackedHypermediaId, origin?: DocumentCardActionOrigin) =>
+      destinationDialog.open({id, mode: 'republish', origin}),
+    [destinationDialog],
+  )
   const canWriteDocument = useCallback(
     (id: UnpackedHypermediaId) =>
       !!signingAccountId && (id.uid === signingAccountId || (canEdit && id.uid === docId.uid)),
@@ -61,6 +66,7 @@ export function WebFeedPage({docId}: {docId: UnpackedHypermediaId}) {
           myAccountIds={signingAccountId ? [signingAccountId] : []}
           canWriteDocument={canWriteDocument}
           onMoveDocument={signingAccountId ? onMoveDocument : undefined}
+          onRepublishDocument={signingAccountId ? onRepublishDocument : undefined}
           onDeleteDocument={onDeleteDocument}
         >
           <FeedPage docId={docId} extraMenuItems={menuItems} rightActions={<WebHeaderActions siteUid={docId.uid} />} />

--- a/frontend/apps/web/app/web-move-document-dialog.test.tsx
+++ b/frontend/apps/web/app/web-move-document-dialog.test.tsx
@@ -154,7 +154,7 @@ describe('WebDocumentDestinationDialog', () => {
     }))
     const request = vi.fn(async () => ({
       type: 'document',
-      document: {generationInfo: {genesis: 'genesis-cid', generation: 8n}},
+      document: {version: 'source-version', generationInfo: {genesis: 'genesis-cid', generation: 8n}},
     }))
     createRedirectRefMock.mockClear()
 

--- a/frontend/apps/web/app/web-move-document-dialog.test.tsx
+++ b/frontend/apps/web/app/web-move-document-dialog.test.tsx
@@ -73,7 +73,7 @@ describe('WebDocumentDestinationDialog', () => {
     sharedDestinationDialogMock.mockClear()
   })
 
-  it('uses the shared destination dialog with only move enabled on web', () => {
+  it('uses the shared destination dialog with move and republish enabled on web', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -102,7 +102,7 @@ describe('WebDocumentDestinationDialog', () => {
     expect(sharedDestinationDialogMock).toHaveBeenCalledWith(
       expect.objectContaining({
         input: {id, mode: 'move'},
-        enabledModes: ['move'],
+        enabledModes: ['move', 'republish'],
       }),
       {},
     )
@@ -138,6 +138,67 @@ describe('WebDocumentDestinationDialog', () => {
 
     const dialogProps = (sharedDestinationDialogMock.mock.calls as any[])[0][0]
     expect(dialogProps.writableDocuments[0].id).toBe(writableLocationId)
+  })
+
+  it('republish mode submits a republish redirect through the dialog', async () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    const from = makeId('source', ['doc'])
+    const to = makeId('site', ['parent', 'copy'])
+    const queryClient = new QueryClient()
+    const publish = vi.fn(async () => ({}))
+    const getSigner = vi.fn(() => ({
+      getPublicKey: async () => new Uint8Array([1]),
+      sign: async () => new Uint8Array([2]),
+    }))
+    const request = vi.fn(async () => ({
+      type: 'document',
+      document: {generationInfo: {genesis: 'genesis-cid', generation: 8n}},
+    }))
+    createRedirectRefMock.mockClear()
+
+    act(() => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <UniversalAppProvider
+            openRoute={vi.fn()}
+            openUrl={vi.fn()}
+            universalClient={{request, publish, getSigner} as any}
+          >
+            <WebDocumentDestinationDialog
+              input={{id: from, mode: 'republish'}}
+              onClose={vi.fn()}
+              signingAccountId="site"
+              capabilityId="cap-cid"
+              canMove
+            />
+          </UniversalAppProvider>
+        </QueryClientProvider>,
+      )
+    })
+
+    const dialogProps = (sharedDestinationDialogMock.mock.calls as any[])[0][0]
+    expect(dialogProps.enabledModes).toEqual(['move', 'republish'])
+
+    await act(async () => {
+      await dialogProps.onSubmit({from, to, mode: 'republish', signingAccountId: 'site'})
+    })
+
+    expect(createRedirectRefMock).toHaveBeenCalledWith(
+      {
+        space: 'site',
+        path: '/parent/copy',
+        genesis: 'genesis-cid',
+        generation: expect.any(Number),
+        targetSpace: 'source',
+        targetPath: '/doc',
+        republish: true,
+        capability: 'cap-cid',
+      },
+      expect.anything(),
+    )
+    expect(publish).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/frontend/apps/web/app/web-move-document-dialog.tsx
+++ b/frontend/apps/web/app/web-move-document-dialog.tsx
@@ -77,22 +77,30 @@ export function WebDocumentDestinationDialog({
   const writableDocuments = useWebWritableDestinations(input.id, signingAccountId, writableLocationId)
 
   async function onSubmit(submitInput: DocumentDestinationSubmitInput) {
-    if (submitInput.mode !== 'move') throw new Error('Republish is not available on web yet')
-    if (!canMove) throw new Error('You are not allowed to move this document')
-    if (submitInput.draft?.draftId) {
-      await moveWebDraft({
-        draftId: submitInput.draft.draftId,
+    if (submitInput.mode === 'move') {
+      if (!canMove) throw new Error('You are not allowed to move this document')
+      if (submitInput.draft?.draftId) {
+        await moveWebDraft({
+          draftId: submitInput.draft.draftId,
+          from: submitInput.from,
+          to: submitInput.to,
+          origin: submitInput.origin,
+        })
+        return
+      }
+      await moveWebDocuments(client, {
         from: submitInput.from,
         to: submitInput.to,
+        childDocuments,
         origin: submitInput.origin,
+        signingAccountId: submitInput.signingAccountId,
+        capabilityId,
       })
       return
     }
-    await moveWebDocuments(client, {
+    await republishWebDocument(client, {
       from: submitInput.from,
       to: submitInput.to,
-      childDocuments,
-      origin: submitInput.origin,
       signingAccountId: submitInput.signingAccountId,
       capabilityId,
     })
@@ -104,7 +112,7 @@ export function WebDocumentDestinationDialog({
       onClose={onClose || (() => {})}
       selectedAccountUid={signingAccountId}
       writableDocuments={writableDocuments}
-      enabledModes={['move']}
+      enabledModes={['move', 'republish']}
       onSubmit={onSubmit}
       onSuccess={({to}) => navigate({key: 'document', id: to})}
     />

--- a/frontend/apps/web/app/web-resource-page.tsx
+++ b/frontend/apps/web/app/web-resource-page.tsx
@@ -540,6 +540,11 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
     return (id: UnpackedHypermediaId, origin?: DocumentCardActionOrigin) =>
       destinationDialog.open({id, mode: 'move', origin})
   }, [destinationDialog, signingAccountId])
+  const onRepublishDocument = useMemo(() => {
+    if (!signingAccountId) return undefined
+    return (id: UnpackedHypermediaId, origin?: DocumentCardActionOrigin) =>
+      destinationDialog.open({id, mode: 'republish', origin})
+  }, [destinationDialog, signingAccountId])
   const canWriteDocument = useCallback(
     (id: UnpackedHypermediaId) =>
       !!signingAccountId && (id.uid === signingAccountId || (effectiveCanEdit && id.uid === docId.uid)),
@@ -675,6 +680,7 @@ export function WebResourcePage({docId, CommentEditor, ssrContentHTML}: WebResou
           myAccountIds={signingAccountId ? [signingAccountId] : []}
           canWriteDocument={canWriteDocument}
           onMoveDocument={onMoveDocument}
+          onRepublishDocument={onRepublishDocument}
           onDeleteDocument={onDeleteDocument}
           onRestoreDocumentVersion={effectiveCanEdit && signingAccountId ? onRestoreDocumentVersion : undefined}
         >


### PR DESCRIPTION
## Problem

Two related failures around republishing documents:

1. **Can't publish (edit) a republished document.** Republishing a document creates a redirect Ref (`republish=true`) at the destination. Editing that copy and clicking Publish failed with a 500 (`PublishBlobs`), and the console showed `document '…' has a redirect to … (republish = true)`.
2. **Republish wasn't available on the web.** The web destination dialog only exposed Move; choosing Republish was a no-op (`Republish is not available on web yet`).

## Root cause

- The publish path (`PrepareChange`) loaded the document from the **redirect path**, which has no change DAG of its own. It minted a brand-new genesis change, while the client signed a Version Ref against the redirect **target's** genesis — a mismatch that the daemon rejected. The CLI/agents already worked because they build the change client-side on the target's DAG.
- The web `WebDocumentDestinationDialog` was hardcoded to `enabledModes={['move']}` and threw for anything else, even though `republishWebDocument` already existed.

## Fix

- **Backend:** `PrepareChange` now follows the redirect chain (bounded) to the target document and builds the change on the target's DAG, so the client-signed fresh-generation Version Ref at the redirect path supersedes the redirect instead of conflicting with it (`loadDocumentForChange`).
- **Web:** enable `republish` in the destination dialog (wire `republishWebDocument`) and surface the Republish action from `web-resource-page` and `web-feed-page` via `onRepublishDocument`.

## Tests

- `TestPrepareChangeTakesOverRedirect` — verifies the prepared change uses the target's genesis/heads and that publishing a fresh-generation Ref at the redirect path yields the edited document (fails without the backend fix).
- `WebDocumentDestinationDialog` tests — republish mode submits a republish redirect; move+republish are now both enabled.

## Verification

- `go test ./backend/api/... ./backend/blob/...`
- `golangci-lint run --new-from-merge-base origin/main ./backend/api/documents/v3alpha/...`
- `pnpm --filter @shm/web test` (217 passed) and `pnpm --filter @shm/web typecheck`

Fixes #1074