### PR TITLE
Unread activity dot for agents

### DIFF
--- a/agents/docs/persistence.md
+++ b/agents/docs/persistence.md
@@ -127,6 +127,12 @@ Current agent statuses:
 
 Most runtime work currently operates at the session level; agent status is not yet a rich run-state machine.
 
+Activity rollup (`activity_at`, `activity_kind`, `message_at`, `message_from`, `activity_session_id`): the latest
+transcript activity across the agent's sessions, written on every appended session event. Tool calls, spawns and
+results — and every event of a delegated child session — move only `activity_at`/`activity_kind`; a message from a
+person, a trigger or the agent in a top-level session also moves the `message_*` columns and `activity_session_id`. Exposed as `AgentInfo.activity` together with a `busy` flag derived
+from live runs, so unread indicators read the agents list and never enumerate sessions. NULL until the first event.
+
 ### `agent_collaborators`
 
 Stores pending invitations and accepted agent-level access grants, keyed by `(agent_id, account_id)`. The `account_id`

--- a/agents/docs/persistence.md
+++ b/agents/docs/persistence.md
@@ -128,10 +128,11 @@ Current agent statuses:
 Most runtime work currently operates at the session level; agent status is not yet a rich run-state machine.
 
 Activity rollup (`activity_at`, `activity_kind`, `message_at`, `message_from`, `activity_session_id`): the latest
-transcript activity across the agent's sessions, written on every appended session event. Tool calls, spawns and
-results — and every event of a delegated child session — move only `activity_at`/`activity_kind`; a message from a
-person, a trigger or the agent in a top-level session also moves the `message_*` columns and `activity_session_id`. Exposed as `AgentInfo.activity` together with a `busy` flag derived
-from live runs, so unread indicators read the agents list and never enumerate sessions. NULL until the first event.
+transcript activity across the agent's sessions, written on every appended session event. Tool calls, spawns and results
+— and every event of a delegated child session — move only `activity_at`/`activity_kind`; a message from a person, a
+trigger or the agent in a top-level session also moves the `message_*` columns and `activity_session_id`. Exposed as
+`AgentInfo.activity` together with a `busy` flag derived from live runs, so unread indicators read the agents list and
+never enumerate sessions. NULL until the first event.
 
 ### `agent_collaborators`
 

--- a/agents/docs/websocket-subscriptions.md
+++ b/agents/docs/websocket-subscriptions.md
@@ -56,7 +56,11 @@ type AgentWSEvent =
     }
   | {_: 'change'; key: `sessions/${string}`; value: SessionInfo}
   | {_: 'change'; key: `agents/${string}`; value: AgentInfo}
-  | {_: 'change'; key: `account/${string}`; value: {reason: string; agentId?: string; sessionId?: string; activity?: AgentActivity}}
+  | {
+      _: 'change'
+      key: `account/${string}`
+      value: {reason: string; agentId?: string; sessionId?: string; activity?: AgentActivity}
+    }
   | {_: 'change'; key: `runs/${string}`; value: RunInfo}
   | {_: 'append'; key: `runs/${string}`; runId: string; seq: number; entry: Record<string, unknown>; createdAt: number}
   | {
@@ -75,14 +79,14 @@ type AgentWSEvent =
 
 Account-wide notifications. The Agents list page uses this to refresh when agents/sessions/events change.
 
-Two reasons carry the agent's fresh **activity rollup** (`AgentActivity`: latest event time and kind, latest
-message time and sender, that message's session, and whether any run is live):
+Two reasons carry the agent's fresh **activity rollup** (`AgentActivity`: latest event time and kind, latest message
+time and sender, that message's session, and whether any run is live):
 
 - `session-event` — coalesced to about one per session per 1.5 s while a transcript grows.
 - `session-updated` — on a real session status transition, which is what flips `busy`.
 
-Clients write the rollup straight into their cached agent rows (list and detail), so an always-visible unread
-indicator costs no `ListAgents` or `ListSessions` refetch. A client that ignores the field behaves as before.
+Clients write the rollup straight into their cached agent rows (list and detail), so an always-visible unread indicator
+costs no `ListAgents` or `ListSessions` refetch. A client that ignores the field behaves as before.
 
 ### `agents/<agentId>`
 

--- a/agents/docs/websocket-subscriptions.md
+++ b/agents/docs/websocket-subscriptions.md
@@ -56,7 +56,7 @@ type AgentWSEvent =
     }
   | {_: 'change'; key: `sessions/${string}`; value: SessionInfo}
   | {_: 'change'; key: `agents/${string}`; value: AgentInfo}
-  | {_: 'change'; key: `account/${string}`; value: {reason: string; agentId?: string; sessionId?: string}}
+  | {_: 'change'; key: `account/${string}`; value: {reason: string; agentId?: string; sessionId?: string; activity?: AgentActivity}}
   | {_: 'change'; key: `runs/${string}`; value: RunInfo}
   | {_: 'append'; key: `runs/${string}`; runId: string; seq: number; entry: Record<string, unknown>; createdAt: number}
   | {
@@ -74,6 +74,15 @@ type AgentWSEvent =
 ### `account/<accountId>`
 
 Account-wide notifications. The Agents list page uses this to refresh when agents/sessions/events change.
+
+Two reasons carry the agent's fresh **activity rollup** (`AgentActivity`: latest event time and kind, latest
+message time and sender, that message's session, and whether any run is live):
+
+- `session-event` — coalesced to about one per session per 1.5 s while a transcript grows.
+- `session-updated` — on a real session status transition, which is what flips `busy`.
+
+Clients write the rollup straight into their cached agent rows (list and detail), so an always-visible unread
+indicator costs no `ListAgents` or `ListSessions` refetch. A client that ignores the field behaves as before.
 
 ### `agents/<agentId>`
 

--- a/agents/protocol/src/index.ts
+++ b/agents/protocol/src/index.ts
@@ -1059,6 +1059,43 @@ export type AgentInviteInfo = {
   updatedAt: number
 }
 
+/** What kind of transcript event an agent's latest activity was. */
+export type AgentActivityKind = 'user' | 'agent' | 'tool'
+
+/**
+ * The latest transcript activity across an agent's sessions, rolled up onto the agent so a client
+ * can show an unread indicator without enumerating sessions. Tool activity is tracked (it moves
+ * `at` and `kind`) but never counts as a message: `messageAt` and `messageFrom` only move for a
+ * message from a person, a trigger, or the agent. Absent until the agent's first message.
+ */
+export type AgentActivity = {
+  /** Time of the latest transcript event of any kind, tool activity included. */
+  at: number
+  /** What that latest event was. */
+  kind: AgentActivityKind
+  /** Time of the latest message from a person, a trigger, or the agent. Tool activity excluded. */
+  messageAt: number
+  /** Who sent that message. Triggers and the runtime count as `user`: something asked, the agent has yet to answer. */
+  messageFrom: 'user' | 'agent'
+  /** Session holding that message. */
+  sessionId: string
+  /** True while any of the agent's runs is live, whether or not a message has landed yet. */
+  busy: boolean
+}
+
+/**
+ * Classifies a transcript event for {@link AgentActivity}: tool calls, spawns, results and
+ * tool-role messages are `tool`; a message from the agent (or an error) is `agent`; any other
+ * message — a person, a trigger, the runtime — is `user`.
+ */
+export function sessionEventActivityKind(payload: SessionEventPayload): AgentActivityKind {
+  const value = payload as {type?: unknown; role?: unknown}
+  if (value.type === 'tool_call' || value.type === 'tool_spawn' || value.type === 'tool_result') return 'tool'
+  if (value.type === 'message' && value.role === 'tool') return 'tool'
+  if (value.type === 'error') return 'agent'
+  return sessionEventActor(payload) === 'agent' ? 'agent' : 'user'
+}
+
 /** Public metadata returned for an agent. */
 export type AgentInfo = {
   id: string
@@ -1068,6 +1105,8 @@ export type AgentInfo = {
   status: 'idle' | 'running' | 'stopped' | 'error'
   createdAt: number
   updatedAt: number
+  /** Latest transcript activity across the agent's sessions, for unread indicators. */
+  activity?: AgentActivity
   /** Permissions of the signed account that requested this value. */
   accessRole?: AgentAccessRole
   /** True when any signed account can read this agent by id (see `SetAgentPublicRead`). */
@@ -1573,7 +1612,20 @@ export type AgentWSEvent =
     }
   | {_: 'change'; key: `sessions/${string}`; value: SessionInfo}
   | {_: 'change'; key: `agents/${string}`; value: AgentInfo}
-  | {_: 'change'; key: `account/${string}`; value: {reason: string; agentId?: string; sessionId?: string}}
+  | {
+      _: 'change'
+      key: `account/${string}`
+      value: {
+        reason: string
+        agentId?: string
+        sessionId?: string
+        /**
+         * Fresh activity rollup of `agentId`, sent with session-event and session-updated hints so
+         * a client keeps its unread indicator current without refetching any list.
+         */
+        activity?: AgentActivity
+      }
+    }
   | {_: 'change'; key: `runs/${string}`; value: RunInfo}
   | {_: 'append'; key: `runs/${string}`; runId: string; seq: number; entry: Record<string, unknown>; createdAt: number}
   | {

--- a/agents/src/api-service.test.ts
+++ b/agents/src/api-service.test.ts
@@ -4468,6 +4468,112 @@ describe('api service', () => {
     }
   })
 
+  test('rolls transcript activity up onto the agent, tool activity excluded from the message columns', async () => {
+    const {db, dataDir, cleanup} = createTestState()
+    const originalFetch = globalThis.fetch
+    try {
+      const account = blobs.generateNobleKeyPair()
+      const events: apisvc.ServiceEvent[] = []
+      const svc = new apisvc.Service(db, dataDir, {onEvent: (event) => events.push(event)})
+      const sessionId = await seedAgentSession(svc, account, 'prompt', {tools: ['read']})
+      const listedBefore = await svc.message(await apisvc.createSignedEnvelope(account, {action: {_: 'ListAgents'}}))
+      if (listedBefore._ !== 'ListAgentsResponse') throw new Error('unexpected response')
+      const agentId = listedBefore.agents[0]!.id
+      // Nothing has been said yet: no rollup, so nothing can read as unread.
+      expect(listedBefore.agents[0]!.activity).toBeUndefined()
+
+      let openAICallCount = 0
+      globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+        const href = url instanceof Request ? url.url : String(url)
+        if (href.includes('/api/GetDomain')) return Response.json(serialize({registeredAccountUid: null}))
+        if (href.includes('/api/Resource')) {
+          return Response.json(
+            serialize({
+              type: 'document',
+              id: unpackHmId('hm://z6Mkdoc/docs/example'),
+              document: {
+                content: [{block: {id: 'block-1', type: 'Paragraph', text: 'Example'}, children: []}],
+                version: 'v1',
+                account: 'z6Mkdoc',
+                authors: [],
+                path: '/docs/example',
+                createTime: '',
+                updateTime: '',
+                metadata: {name: 'Example'},
+                genesis: 'genesis',
+                visibility: 'PUBLIC',
+              },
+            }),
+          )
+        }
+        openAICallCount += 1
+        if (openAICallCount === 1) {
+          return openAIStreamResponse([
+            {
+              id: 'chat-1',
+              choices: [
+                {
+                  delta: {
+                    tool_calls: [
+                      {
+                        index: 0,
+                        id: 'call-1',
+                        type: 'function',
+                        function: {name: 'read', arguments: JSON.stringify({address: 'hm://z6Mkdoc/docs/example'})},
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            {id: 'chat-1', choices: [{delta: {}, finish_reason: 'tool_calls'}], usage: openAIUsage()},
+          ])
+        }
+        return openAIStreamResponse([
+          {id: 'chat-2', choices: [{delta: {content: 'I read it.'}}]},
+          {id: 'chat-2', choices: [{delta: {}, finish_reason: 'stop'}], usage: openAIUsage()},
+        ])
+      }) as unknown as typeof fetch
+
+      await svc.message(
+        await apisvc.createSignedEnvelope(account, {
+          action: {_: 'MessageSession', sessionId, content: [{type: 'text', text: 'Read it'}]},
+        }),
+      )
+      expect(openAICallCount).toBe(2)
+
+      // The transcript ended on the agent's reply, so that is what the rollup says — and the run
+      // has settled, so the agent is no longer busy.
+      const listed = await svc.message(await apisvc.createSignedEnvelope(account, {action: {_: 'ListAgents'}}))
+      if (listed._ !== 'ListAgentsResponse') throw new Error('unexpected response')
+      const activity = listed.agents.find((agent) => agent.id === agentId)?.activity
+      expect(activity).toMatchObject({kind: 'agent', messageFrom: 'agent', sessionId, busy: false})
+      expect(activity!.messageAt).toBe(activity!.at)
+      // GetAgent reads the same columns.
+      const detail = await svc.message(await apisvc.createSignedEnvelope(account, {action: {_: 'GetAgent', agentId}}))
+      expect(detail).toMatchObject({_: 'GetAgentResponse', agent: {activity: {kind: 'agent', sessionId}}})
+
+      // The live hints carried the rollup at every step: the user's message first (the agent had
+      // not answered; the run may not even exist yet), then a busy agent on the status flip, then
+      // the settled reply.
+      const hints = events.flatMap((event) =>
+        event.type === 'account-change' && event.activity && event.agentId === agentId
+          ? [{reason: event.reason, ...event.activity}]
+          : [],
+      )
+      expect(hints[0]).toMatchObject({reason: 'session-event', kind: 'user', messageFrom: 'user', sessionId})
+      expect(hints.some((hint) => hint.reason === 'session-updated' && hint.busy)).toBe(true)
+      expect(hints.at(-1)).toMatchObject({reason: 'session-updated', kind: 'agent', messageFrom: 'agent', busy: false})
+      // Tool activity moved the rollup's latest-event kind while the message columns stayed on
+      // the user's message: no event-sequence gap read as a new message.
+      const toolHint = hints.find((hint) => hint.kind === 'tool')
+      if (toolHint) expect(toolHint.messageFrom).toBe('user')
+    } finally {
+      globalThis.fetch = originalFetch
+      cleanup()
+    }
+  })
+
   test('runs read tool calls and persists tool events', async () => {
     const {db, dataDir, cleanup} = createTestState()
     const originalFetch = globalThis.fetch

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -16,6 +16,7 @@ import {
   seedToolRegistry,
   seedVerbRegistry,
   toolContractMarkdown,
+  sessionEventActivityKind,
   toolSummaryLine,
   writeGuideRegistry,
   type JsonSchema,
@@ -278,7 +279,15 @@ export type ServiceEvent =
       usage?: api.AgentRunUsage
       activity?: api.AgentRunActivity
     }
-  | {type: 'account-change'; accountId: string; reason: string; agentId?: string; sessionId?: string}
+  | {
+      type: 'account-change'
+      accountId: string
+      reason: string
+      agentId?: string
+      sessionId?: string
+      /** Fresh activity rollup of `agentId`, on session-event and session-updated hints. */
+      activity?: api.AgentActivity
+    }
   | {type: 'run-change'; accountId: string; run: api.RunInfo}
   | {type: 'run-append'; accountId: string; rootRunId: string; entry: api.RunJournalEntryInfo}
   | {
@@ -1437,6 +1446,7 @@ export class Service {
     const rows = this.#db
       .query<AgentRow, [string, string, string]>(
         `SELECT a.id, a.account_id, a.definition_cbor, a.state_dir, a.status, a.public_read, a.public_chat, a.created_at, a.updated_at,
+                ${agentActivityColumns('a')},
                 CASE WHEN a.account_id = ? THEN 'owner' ELSE c.role END AS access_role
          FROM agents a
          LEFT JOIN agent_collaborators c ON c.agent_id = a.id AND c.account_id = ? AND c.status = 'accepted'
@@ -2707,7 +2717,8 @@ export class Service {
   #getAgent(accountId: string, agentId: string, viewerAccountId = accountId): api.GetAgentResponse {
     const agent = this.#db
       .query<AgentRow, [string, string]>(
-        `SELECT id, account_id, definition_cbor, state_dir, status, public_read, public_chat, created_at, updated_at
+        `SELECT agents.id, agents.account_id, agents.definition_cbor, agents.state_dir, agents.status, agents.public_read, agents.public_chat, agents.created_at, agents.updated_at,
+                ${agentActivityColumns('agents')}
          FROM agents WHERE account_id = ? AND id = ?`,
       )
       .get(accountId, agentId)
@@ -7726,11 +7737,57 @@ export class Service {
       now,
     ])
     const info = {id, sessionId, seq, event, createdAt: now}
+    this.#recordAgentActivity(agentId, sessionId, event, now)
     // Content stream: every event reaches the open session view immediately.
     this.#emit({type: 'session-event', accountId, agentId, event: info})
     // List-reorder signal: coalesced so a burst of events collapses to ~one ListSessions refetch.
     this.#signalSessionListChange(accountId, agentId, sessionId)
     return info
+  }
+
+  /**
+   * Rolls an appended event up onto the agent (see AgentActivity): every event moves the session's
+   * `updated_at` and the agent's latest-activity columns; only a message — never tool activity —
+   * moves the message columns that unread indicators read.
+   */
+  #recordAgentActivity(agentId: string, sessionId: string, event: api.SessionEventPayload, now: number): void {
+    const parent = this.#db
+      .query<{parent_session_id: string | null}, [string]>(`SELECT parent_session_id FROM sessions WHERE id = ?`)
+      .get(sessionId)
+    // A delegated child's transcript is the agent's internal work: it keeps the agent busy but its
+    // messages are nothing a person is waiting to read — the parent gets the result as a tool
+    // result. Only top-level conversations move the message columns.
+    const kind = parent?.parent_session_id ? 'tool' : sessionEventActivityKind(event)
+    this.#db.run(`UPDATE sessions SET updated_at = ? WHERE id = ?`, [now, sessionId])
+    if (kind === 'tool') {
+      this.#db.run(`UPDATE agents SET activity_at = ?, activity_kind = 'tool' WHERE id = ?`, [now, agentId])
+      return
+    }
+    this.#db.run(
+      `UPDATE agents SET activity_at = ?, activity_kind = ?, message_at = ?, message_from = ?, activity_session_id = ?
+       WHERE id = ?`,
+      [now, kind, now, kind, sessionId, agentId],
+    )
+  }
+
+  /**
+   * The agent's current activity rollup, for live hints. Looked up by id: the agent may be a
+   * collaborator's. The coalesced list signal calls this from a trailing timer, which can outlive
+   * the database (tests close it; a shutdown may too) — a hint without a rollup beats a crash.
+   */
+  #agentActivity(agentId: string): api.AgentActivity | undefined {
+    try {
+      const row = this.#db
+        .query<AgentRow, [string]>(
+          `SELECT agents.id, agents.account_id, agents.definition_cbor, agents.state_dir, agents.status, agents.created_at, agents.updated_at,
+                  ${agentActivityColumns('agents')}
+           FROM agents WHERE id = ?`,
+        )
+        .get(agentId)
+      return row ? agentRowActivity(row) : undefined
+    } catch {
+      return undefined
+    }
   }
 
   /**
@@ -7745,7 +7802,14 @@ export class Service {
     const last = this.#sessionListSignalAt.get(key) ?? 0
     if (now - last >= SESSION_LIST_SIGNAL_WINDOW_MS) {
       this.#sessionListSignalAt.set(key, now)
-      this.#emit({type: 'account-change', accountId, reason: 'session-event', agentId, sessionId})
+      this.#emit({
+        type: 'account-change',
+        accountId,
+        reason: 'session-event',
+        agentId,
+        sessionId,
+        activity: this.#agentActivity(agentId),
+      })
       return
     }
     if (this.#sessionListSignalTimer.has(key)) return
@@ -7753,7 +7817,14 @@ export class Service {
       () => {
         this.#sessionListSignalTimer.delete(key)
         this.#sessionListSignalAt.set(key, Date.now())
-        this.#emit({type: 'account-change', accountId, reason: 'session-event', agentId, sessionId})
+        this.#emit({
+          type: 'account-change',
+          accountId,
+          reason: 'session-event',
+          agentId,
+          sessionId,
+          activity: this.#agentActivity(agentId),
+        })
       },
       SESSION_LIST_SIGNAL_WINDOW_MS - (now - last),
     )
@@ -7762,6 +7833,11 @@ export class Service {
   }
 
   #updateSessionStatus(accountId: string, sessionId: string, status: api.SessionInfo['status'], now: number): void {
+    const previous = this.#db
+      .query<{status: api.SessionInfo['status']}, [string, string]>(
+        `SELECT status FROM sessions WHERE account_id = ? AND id = ?`,
+      )
+      .get(accountId, sessionId)?.status
     this.#db.run(`UPDATE sessions SET status = ?, updated_at = ? WHERE account_id = ? AND id = ?`, [
       status,
       now,
@@ -7769,7 +7845,21 @@ export class Service {
       sessionId,
     ])
     const session = this.#getSessionInfo(accountId, sessionId)
-    if (session) this.#emit({type: 'session-change', accountId, session})
+    if (!session) return
+    this.#emit({type: 'session-change', accountId, session})
+    // A run starting or settling is what flips the agent's `busy` flag; account subscribers hold
+    // no session subscription, so the change reaches them as an activity hint. Only on a real
+    // transition: the run bookkeeping re-derives the status more often than it changes.
+    if (previous !== undefined && previous !== status) {
+      this.#emit({
+        type: 'account-change',
+        accountId,
+        reason: 'session-updated',
+        agentId: session.agentId,
+        sessionId,
+        activity: this.#agentActivity(session.agentId),
+      })
+    }
   }
 
   #emit(event: ServiceEvent): void {
@@ -8107,7 +8197,8 @@ export class Service {
   #getAgentInfo(accountId: string, agentId: string): api.AgentInfo | null {
     const agent = this.#db
       .query<AgentRow, [string, string]>(
-        `SELECT id, account_id, definition_cbor, state_dir, status, public_read, public_chat, created_at, updated_at
+        `SELECT agents.id, agents.account_id, agents.definition_cbor, agents.state_dir, agents.status, agents.public_read, agents.public_chat, agents.created_at, agents.updated_at,
+                ${agentActivityColumns('agents')}
          FROM agents WHERE account_id = ? AND id = ?`,
       )
       .get(accountId, agentId)
@@ -9017,6 +9108,13 @@ type AgentRow = {
   created_at: number
   updated_at: number
   access_role?: api.AgentAccessRole
+  activity_at?: number | null
+  activity_kind?: api.AgentActivityKind | null
+  message_at?: number | null
+  message_from?: api.AgentActivity['messageFrom'] | null
+  activity_session_id?: string | null
+  /** 1 while any of the agent's runs is live; only selected where the activity rollup is read. */
+  busy?: number | null
 }
 
 type AgentTriggerRow = {
@@ -9430,6 +9528,7 @@ function publicReadOf(access: {ownerAccountId: string; viaPublic: boolean}): {pu
 }
 
 function agentRowToInfo(row: AgentRow, accessRole: api.AgentAccessRole = 'owner'): api.AgentInfo {
+  const activity = agentRowActivity(row)
   return {
     id: row.id,
     account: row.account_id,
@@ -9441,7 +9540,40 @@ function agentRowToInfo(row: AgentRow, accessRole: api.AgentAccessRole = 'owner'
     accessRole,
     publicRead: row.public_read === 1,
     publicChat: row.public_chat === 1,
+    ...(activity ? {activity} : {}),
   }
+}
+
+/**
+ * The agent's activity rollup from its row, or undefined until a message has landed. A tool event
+ * before any message leaves `message_at` unset, and a rollup without a message is not worth
+ * announcing: nothing could be unread yet.
+ */
+function agentRowActivity(row: AgentRow): api.AgentActivity | undefined {
+  if (
+    typeof row.activity_at !== 'number' ||
+    typeof row.message_at !== 'number' ||
+    !row.activity_kind ||
+    !row.message_from ||
+    !row.activity_session_id
+  ) {
+    return undefined
+  }
+  return {
+    at: row.activity_at,
+    kind: row.activity_kind,
+    messageAt: row.message_at,
+    messageFrom: row.message_from,
+    sessionId: row.activity_session_id,
+    busy: row.busy === 1,
+  }
+}
+
+/** Selects the activity columns plus a live-run flag for the agent row aliased `alias`. */
+function agentActivityColumns(alias: string): string {
+  return `${alias}.activity_at, ${alias}.activity_kind, ${alias}.message_at, ${alias}.message_from, ${alias}.activity_session_id,
+          (EXISTS (SELECT 1 FROM runs live_run WHERE live_run.agent_id = ${alias}.id
+                   AND live_run.status IN ('queued', 'claimed', 'running', 'waiting'))) AS busy`
 }
 
 /** How far back a run-completed chain is followed before it is called a loop. */

--- a/agents/src/main.ts
+++ b/agents/src/main.ts
@@ -387,7 +387,7 @@ async function main(): Promise<void> {
         sendIfSubscribed(ws, event.accountId, `account/${event.accountId}`, {
           _: 'change',
           key: `account/${event.accountId}`,
-          value: {reason: event.reason, agentId: event.agentId, sessionId: event.sessionId},
+          value: {reason: event.reason, agentId: event.agentId, sessionId: event.sessionId, activity: event.activity},
         })
         // Agent-scoped account changes also reach the open agent page. This covers memory writes
         // (which have no agent-change event), collaborator changes, and an owner deleting an agent
@@ -396,7 +396,7 @@ async function main(): Promise<void> {
           sendIfSubscribed(ws, event.accountId, `agents/${event.agentId}`, {
             _: 'change',
             key: `account/${event.accountId}`,
-            value: {reason: event.reason, agentId: event.agentId, sessionId: event.sessionId},
+            value: {reason: event.reason, agentId: event.agentId, sessionId: event.sessionId, activity: event.activity},
           })
         }
       }

--- a/agents/src/sqlite-schema.sql
+++ b/agents/src/sqlite-schema.sql
@@ -61,7 +61,14 @@ CREATE TABLE agents (
     public_read INTEGER NOT NULL DEFAULT 0,
     public_chat INTEGER NOT NULL DEFAULT 0,
     created_at INTEGER NOT NULL,
-    updated_at INTEGER NOT NULL
+    updated_at INTEGER NOT NULL,
+    -- Latest transcript activity across the agent's sessions (see AgentActivity in the protocol).
+    -- Written on every appended session event; NULL until the first one.
+    activity_at INTEGER,
+    activity_kind TEXT,
+    message_at INTEGER,
+    message_from TEXT,
+    activity_session_id TEXT
 ) WITHOUT ROWID;
 
 CREATE INDEX agents_by_account ON agents (account_id, updated_at DESC);

--- a/agents/src/sqlite.ts
+++ b/agents/src/sqlite.ts
@@ -13,6 +13,13 @@ export const BASELINE_SCHEMA_MIGRATION_VERSION = 0
 /** Prepend-only database migrations. */
 export const migrations: string[] = [
   // ======= IMPORTANT: Add new migrations below this line. =======
+  // Latest transcript activity rolled up per agent (see AgentActivity in the protocol): written on
+  // every appended session event, read with the agent so unread indicators never list sessions.
+  `ALTER TABLE agents ADD COLUMN activity_at INTEGER;
+  ALTER TABLE agents ADD COLUMN activity_kind TEXT;
+  ALTER TABLE agents ADD COLUMN message_at INTEGER;
+  ALTER TABLE agents ADD COLUMN message_from TEXT;
+  ALTER TABLE agents ADD COLUMN activity_session_id TEXT;`,
   // #getSessionTriggerContext filters trigger_firings by (account_id, session_id) with ORDER BY
   // created_at, but the only usable index was the (account_id, …) autoindex prefix — so each call
   // scanned every firing for the account and temp-b-tree-sorted (~9ms on prod). It runs once per

--- a/frontend/apps/desktop/src/__tests__/assistant-dialogs.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/assistant-dialogs.test.tsx
@@ -12,6 +12,14 @@ import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
  * identical prop types. This mounts the dialog in the root its call site actually uses.
  */
 
+// The transcript view marks itself read through react-query; nothing here provides a client.
+vi.mock('@shm/ui/agents/activity', () => ({
+  useMarkAgentSessionRead: () => {},
+  latestSessionEventAt: () => undefined,
+  useAgentActivityReadState: () => ({data: undefined}),
+  agentRowActivity: () => null,
+  markAgentSessionRead: () => {},
+}))
 vi.mock('@shm/ui/agents/models', () => ({
   LOCAL_AGENT_SERVER_LABEL: 'Local Agents',
   isLocalAgentServer: () => false,

--- a/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
@@ -73,6 +73,14 @@ vi.mock('@shm/ui/hm-icon', () => ({
 }))
 
 // models/agents creates the tRPC client at import time, which needs the electronTRPC preload global.
+// The transcript view marks itself read through react-query; nothing here provides a client.
+vi.mock('@shm/ui/agents/activity', () => ({
+  useMarkAgentSessionRead: () => {},
+  latestSessionEventAt: () => undefined,
+  useAgentActivityReadState: () => ({data: undefined}),
+  agentRowActivity: () => null,
+  markAgentSessionRead: () => {},
+}))
 vi.mock('@shm/ui/agents/models', () => ({
   useSessionAttachmentDataUrls: () => ({}),
   // The delegate row resolves its live child through these; inert here — no child ever resolves.

--- a/frontend/apps/desktop/src/__tests__/assistant-panel-context.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/assistant-panel-context.test.tsx
@@ -17,7 +17,9 @@ const REMOTE = 'https://agentic.seed.hyper.media'
 
 const mockState = vi.hoisted(() => ({
   serverUrls: [] as string[],
-  agentLists: [] as Array<{data: Array<{id: string; definition: {name: string; model: string}}>}>,
+  agentLists: [] as Array<{data: Array<{id: string; definition: {name: string; model: string}; activity?: unknown}>}>,
+  readState: undefined as undefined | {allBefore?: number; sessions: Record<string, number>},
+  marked: [] as Array<{serverUrl: string; sessionId: string; seenAt: number}>,
   sessionEntries: [] as Array<{serverUrl: string; session: Record<string, unknown>}>,
   spaceAgents: {
     agents: [] as Array<{serverUrl: string; agent: {id: string; definition: {name: string; model: string}}}>,
@@ -30,6 +32,17 @@ const mockState = vi.hoisted(() => ({
   createAgentDialogInput: null as null | {onCreated?: (created: {serverUrl: string; agentId: string}) => void},
 }))
 
+// The unread logic runs for real against a faked read state; the react-query-backed pieces (the
+// transcript's own mark, the stored state) are stubbed since nothing here provides a client.
+vi.mock('@shm/ui/agents/activity', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useMarkAgentSessionRead: () => {},
+  latestSessionEventAt: () => undefined,
+  useAgentActivityReadState: () => ({data: mockState.readState}),
+  markAgentSessionRead: (serverUrl: string, sessionId: string, seenAt: number) => {
+    mockState.marked.push({serverUrl, sessionId, seenAt})
+  },
+}))
 vi.mock('@shm/ui/agents/models', () => ({
   LOCAL_AGENT_SERVER_LABEL: 'Local Agents',
   isLocalAgentServer: (serverUrl: string, localServerUrl?: string | null) =>
@@ -171,6 +184,8 @@ beforeEach(() => {
   mockState.createAgentDialogMounts = 0
   mockState.createAgentDialogInput = null
   mockState.serverUrls = [LOCAL, REMOTE]
+  mockState.readState = {allBefore: 50, sessions: {}}
+  mockState.marked = []
   mockState.spaceAgents = {agents: [], sessions: [], isLoading: false}
   mockState.agentListsSettled = true
   mockState.agentLists = [
@@ -211,6 +226,75 @@ describe('assistant sidebar agent context', () => {
     })
     expect(document.body.textContent).toContain('Doc questions')
     expect(hasActiveSession()).toBe(true)
+  })
+
+  it('points at the agent and chat with an unread reply, and picking that agent opens the chat read', () => {
+    act(() => {
+      root.render(<AssistantPanel />)
+    })
+    expect(document.body.querySelector('[data-testid="agent-activity-mark"]')).toBeNull()
+    // A reply lands while the panel is open: nothing yanks the user, the pickers point at it.
+    mockState.agentLists[1] = {
+      data: [
+        {
+          id: 'researcher',
+          definition: {name: 'Researcher', model: 'gpt-5'},
+          activity: {at: 100, kind: 'agent', messageAt: 100, messageFrom: 'agent', sessionId: 's-r1', busy: false},
+        },
+      ],
+    }
+    act(() => {
+      root.render(<AssistantPanel />)
+    })
+    expect(document.body.textContent).toContain('Send a message to start chatting with Assistant')
+    // The closed picker already shows that something is unread somewhere.
+    expect(document.body.querySelector('[data-testid="agent-activity-mark"]')).not.toBeNull()
+
+    clickText('Assistant')
+    // The researcher's row names it, in place of the model line.
+    expect(document.body.textContent).toContain('New reply')
+
+    clickText('Researcher')
+    // Not a draft: the unread chat itself, and it is marked read as of that message.
+    expect(document.body.textContent).toContain('Web research')
+    expect(hasActiveSession()).toBe(true)
+    expect(mockState.marked).toEqual([{serverUrl: REMOTE, sessionId: 's-r1', seenAt: 100}])
+  })
+
+  it('opens straight onto the unread chat when there is one, marked read on arrival', () => {
+    mockState.agentLists[1] = {
+      data: [
+        {
+          id: 'researcher',
+          definition: {name: 'Researcher', model: 'gpt-5'},
+          activity: {at: 100, kind: 'user', messageAt: 100, messageFrom: 'user', sessionId: 's-r1', busy: false},
+        },
+      ],
+    }
+    act(() => {
+      root.render(<AssistantPanel />)
+    })
+    // Not the default agent's draft: the researcher's unread chat, already read.
+    expect(document.body.textContent).toContain('Web research')
+    expect(hasActiveSession()).toBe(true)
+    expect(mockState.marked).toEqual([{serverUrl: REMOTE, sessionId: 's-r1', seenAt: 100}])
+  })
+
+  it('a panel opened to start a new chat keeps that intent even with something unread', () => {
+    mockState.agentLists[1] = {
+      data: [
+        {
+          id: 'researcher',
+          definition: {name: 'Researcher', model: 'gpt-5'},
+          activity: {at: 100, kind: 'agent', messageAt: 100, messageFrom: 'agent', sessionId: 's-r1', busy: false},
+        },
+      ],
+    }
+    act(() => {
+      root.render(<AssistantPanel newChatRequest={1} />)
+    })
+    expect(hasActiveSession()).toBe(false)
+    expect(mockState.marked).toEqual([])
   })
 
   it('switches agent context from the top dropdown, grouped by server', () => {

--- a/frontend/apps/desktop/src/components/titlebar-common.tsx
+++ b/frontend/apps/desktop/src/components/titlebar-common.tsx
@@ -1,10 +1,14 @@
 import {domainResolver} from '@/grpc-client'
 import {roleCanWrite, useSelectedAccountCapability} from '@/models/access-control'
 import {DEFAULT_AGENT_SERVER_URL} from '@/agents-defaults'
+import {useSelectedAccountId as useSelectedAgentsAccountId} from '@shm/ui/agents/account'
+import {AgentActivityLiveUpdates, useAgentActivityIndicator} from '@shm/ui/agents/activity'
+import {AgentActivityDot} from '@shm/ui/agents/activity-dot'
 import {
   agentRouteServerUrl,
   isLocalAgentServer,
   LOCAL_AGENT_SERVER_LABEL,
+  useAgentServerUrls,
   useAgentSession,
   useLocalAgentServerUrl,
 } from '@shm/ui/agents/models'
@@ -496,13 +500,19 @@ function AssistantChatButton({
   assistantOpen,
   onToggleAssistant,
 }: Pick<TitleBarProps, 'assistantOpen' | 'onToggleAssistant'>) {
+  // The unread indicator: the agents lists, kept live by one account socket per server mounted
+  // here (the title bar outlives the panel), against this device's read marks.
+  const agentsAccountUid = useSelectedAgentsAccountId()
+  const agentServerUrls = useAgentServerUrls()
+  const activity = useAgentActivityIndicator(agentServerUrls.data, agentsAccountUid)
   if (!onToggleAssistant) return null
   const isActive = !!assistantOpen
+  const tooltip = activity?.label ?? (isActive ? 'Close Agents' : 'Open Agents')
   return (
-    <Tooltip content={isActive ? 'Close Agents' : 'Open Agents'} asChild>
+    <Tooltip content={tooltip} asChild>
       <Button
         className={cn(
-          'window-no-drag h-8 w-8 rounded-full border p-0',
+          'window-no-drag relative h-8 w-8 rounded-full border p-0',
           isActive
             ? 'border-black/15 bg-black/10 shadow-xs hover:border-black/20 hover:bg-black/15 dark:border-white/15 dark:bg-white/10 dark:hover:border-white/20 dark:hover:bg-white/15'
             : 'border-transparent',
@@ -512,6 +522,8 @@ function AssistantChatButton({
         onClick={onToggleAssistant}
       >
         <MessageCircle className="size-4" />
+        <AgentActivityDot indicator={activity} />
+        <AgentActivityLiveUpdates serverUrls={agentServerUrls.data} accountUid={agentsAccountUid} />
       </Button>
     </Tooltip>
   )

--- a/frontend/apps/web/app/__tests__/web-assistant-panel.test.tsx
+++ b/frontend/apps/web/app/__tests__/web-assistant-panel.test.tsx
@@ -24,7 +24,10 @@ vi.mock('@/auth', () => ({useLocalKeyPair: () => mockState.keyPair}))
 // The panel body is the lazy agents chunk; the host's job is where and whether it renders.
 vi.mock('@/client-lazy', () => ({
   clientLazy: () => () => <div data-testid="panel-content">PANEL</div>,
+  ClientOnly: ({children}: {children: React.ReactNode}) => <>{children}</>,
 }))
+// The header's activity tracker is the agents chunk too; the host's job is only to mount it.
+vi.mock('../web-assistant-activity', () => ({default: () => null}))
 
 import {useAssistantPanelToggle} from '@shm/ui/assistant-panel-toggle'
 import {AssistantPanelProvider, useAssistantAutoOpen, useAssistantPanel} from '../assistant-panel-state'

--- a/frontend/apps/web/app/web-assistant-activity.tsx
+++ b/frontend/apps/web/app/web-assistant-activity.tsx
@@ -1,0 +1,27 @@
+import {registerWebAgentsPlatform} from '@/web-agents-platform'
+import {useSelectedAccountId} from '@shm/ui/agents/account'
+import {AgentActivityLiveUpdates, useAgentActivityIndicator} from '@shm/ui/agents/activity'
+import type {AgentActivityIndicator} from '@shm/ui/agents/activity-dot'
+import {useAgentServerUrls} from '@shm/ui/agents/models'
+import {useEffect} from 'react'
+
+registerWebAgentsPlatform()
+
+/**
+ * Tracks recent agent activity for the site header's unread dot. Keeps one account socket per
+ * agents server open (so hints arrive with the panel closed) and reports the resolved indicator
+ * up to the assistant host, which hands it to the header through the toggle context.
+ */
+export default function WebAssistantActivity({
+  onChange,
+}: {
+  onChange: (indicator: AgentActivityIndicator | null) => void
+}) {
+  const accountUid = useSelectedAccountId()
+  const serverUrls = useAgentServerUrls()
+  const indicator = useAgentActivityIndicator(serverUrls.data, accountUid)
+  useEffect(() => {
+    onChange(indicator)
+  }, [indicator, onChange])
+  return <AgentActivityLiveUpdates serverUrls={serverUrls.data} accountUid={accountUid} />
+}

--- a/frontend/apps/web/app/web-assistant-host.tsx
+++ b/frontend/apps/web/app/web-assistant-host.tsx
@@ -1,16 +1,17 @@
 import {useAssistantPanel} from '@/assistant-panel-state'
 import {useLocalKeyPair} from '@/auth'
-import {clientLazy} from '@/client-lazy'
+import {clientLazy, ClientOnly} from '@/client-lazy'
 import {useSiteContextSnapshot} from '@/site-context-bridge'
 import {UniversalAppContext} from '@shm/shared'
 import {NavContextProvider} from '@shm/shared/utils/navigation'
+import type {AgentActivityIndicator} from '@shm/ui/agents/activity-dot'
 import {AssistantPanelToggleContext, type AssistantPanelToggle} from '@shm/ui/assistant-panel-toggle'
 import {Button} from '@shm/ui/button'
 import {Spinner} from '@shm/ui/spinner'
 import {useMedia} from '@shm/ui/use-media'
 import {cn} from '@shm/ui/utils'
 import {ArrowLeft} from 'lucide-react'
-import React, {Suspense, useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import React, {lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 
 // The panel body pulls in the agents models and the rich editor. Like the /hm/agents pages and the
 // commenting editor, it is a separate client-only chunk that only loads once the panel opens, so
@@ -18,6 +19,11 @@ import React, {Suspense, useCallback, useEffect, useMemo, useRef, useState} from
 const WebAssistantPanelContent = clientLazy<{showClose?: boolean}>(async () => ({
   default: (await import('./web-assistant-panel-content')).default,
 }))
+
+// The unread indicator needs the agents models (lists, sockets, read marks) — the same chunk the
+// panel body lives in. Loaded for a signed-in reader whether or not the panel is open, so the
+// header dot works with the panel closed; nothing of it enters the initial bundle.
+const WebAssistantActivity = lazy(() => import('./web-assistant-activity'))
 
 const WIDTH_STORAGE_KEY = 'seed.assistant.width'
 const DEFAULT_WIDTH_PX = 380
@@ -109,13 +115,23 @@ export function WebAssistantHost({children}: {children: React.ReactNode}) {
 
   // The site header's Agents button. Offered only to a signed-in reader, for the same reason the
   // panel itself is; the header additionally checks that the space names an agents server.
+  const [activity, setActivity] = useState<AgentActivityIndicator | null>(null)
   const headerToggle = useMemo<AssistantPanelToggle | null>(
-    () => (keyPair ? {isOpen: panel.isOpen, toggle: panel.toggle} : null),
-    [keyPair, panel.isOpen, panel.toggle],
+    () => (keyPair ? {isOpen: panel.isOpen, toggle: panel.toggle, activity} : null),
+    [keyPair, panel.isOpen, panel.toggle, activity],
   )
 
   return (
     <div className={cn('flex w-full flex-row items-stretch', dragging && 'cursor-col-resize select-none')}>
+      {keyPair ? (
+        <ClientOnly>
+          <SiteContextScope>
+            <Suspense fallback={null}>
+              <WebAssistantActivity onChange={setActivity} />
+            </Suspense>
+          </SiteContextScope>
+        </ClientOnly>
+      ) : null}
       <AssistantPanelToggleContext.Provider value={headerToggle}>
         <div className="min-w-0 flex-1">{children}</div>
       </AssistantPanelToggleContext.Provider>
@@ -181,6 +197,21 @@ function FullScreenPanel({onBack}: {onBack: () => void}) {
         <PanelBody />
       </div>
     </div>
+  )
+}
+
+/**
+ * The current page's contexts, re-provided above the outlet for what lives there. The activity
+ * tracker needs them to see the server the space in view advertises; before any page has
+ * published it runs without, on the configured servers alone.
+ */
+function SiteContextScope({children}: {children: React.ReactNode}) {
+  const site = useSiteContextSnapshot()
+  if (!site) return <>{children}</>
+  return (
+    <UniversalAppContext.Provider value={site.universal}>
+      <NavContextProvider value={site.navigation}>{children}</NavContextProvider>
+    </UniversalAppContext.Provider>
   )
 }
 

--- a/frontend/packages/ui/src/__tests__/agent-account-change-invalidation.test.ts
+++ b/frontend/packages/ui/src/__tests__/agent-account-change-invalidation.test.ts
@@ -45,6 +45,27 @@ describe('invalidateForAccountChange', () => {
     })
   })
 
+  test('an activity rollup on the hint lands in the cached agent rows without a refetch', async () => {
+    const client = webQueryClient()
+    const agent = {id: agentId, definition: {name: 'Researcher'}, status: 'idle'}
+    const other = {id: 'agent-2', definition: {name: 'Other'}, status: 'idle'}
+    const listFetch = vi.fn(async () => [agent, other])
+    await client.fetchQuery({queryKey: ['agents', 'list', serverUrl, accountUid], queryFn: listFetch})
+    const detailFetch = vi.fn(async () => ({_: 'GetAgentResponse', agent, sessions: []}))
+    await client.fetchQuery({queryKey: ['agents', 'detail', serverUrl, accountUid, agentId], queryFn: detailFetch})
+
+    const activity = {at: 5, kind: 'agent', messageAt: 5, messageFrom: 'agent', sessionId: 's1', busy: false} as const
+    invalidateForAccountChange(serverUrl, accountUid, {reason: 'session-event', agentId, sessionId: 's1', activity})
+
+    expect(client.getQueryData(['agents', 'list', serverUrl, accountUid])).toEqual([{...agent, activity}, other])
+    expect(client.getQueryData(['agents', 'detail', serverUrl, accountUid, agentId])).toMatchObject({
+      agent: {...agent, activity},
+    })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(listFetch).toHaveBeenCalledTimes(1)
+    expect(detailFetch).toHaveBeenCalledTimes(1)
+  })
+
   test('per-event churn still only refetches active queries', async () => {
     const client = webQueryClient()
     const detail = await seedInactiveQuery(client, ['agents', 'detail', serverUrl, accountUid, agentId])

--- a/frontend/packages/ui/src/__tests__/agent-activity.test.ts
+++ b/frontend/packages/ui/src/__tests__/agent-activity.test.ts
@@ -1,0 +1,117 @@
+import {describe, expect, test} from 'vitest'
+import type {AgentInfo} from '@seed-hypermedia/agents-protocol'
+import {
+  agentActivityReadKey,
+  agentRowActivity,
+  isAgentActivityUnread,
+  latestSessionEventAt,
+  summarizeAgentActivity,
+  type AgentActivityReadState,
+} from '../agents/activity'
+
+/**
+ * The unread indicator: what the server's per-agent activity rollup and this device's read marks
+ * resolve to. Tool activity never counts as unread; the newest unread message picks the color;
+ * a busy agent shows only when nothing is unread.
+ */
+
+const server = 'https://agents.example'
+
+function agent(id: string, activity?: AgentInfo['activity']): {serverUrl: string; agent: AgentInfo} {
+  return {
+    serverUrl: server,
+    agent: {
+      id,
+      account: 'z6MkOwner',
+      definition: {name: `Agent ${id}`} as AgentInfo['definition'],
+      stateDir: '',
+      status: 'idle',
+      createdAt: 0,
+      updatedAt: 0,
+      ...(activity ? {activity} : {}),
+    },
+  }
+}
+
+const read = (allBefore: number | undefined, sessions: Record<string, number> = {}): AgentActivityReadState => ({
+  ...(allBefore === undefined ? {} : {allBefore}),
+  sessions,
+})
+
+describe('agent activity indicator', () => {
+  test('nothing is unread before the first-run baseline exists, so a fresh device starts quiet', () => {
+    const entries = [
+      agent('a', {at: 50, kind: 'agent', messageAt: 50, messageFrom: 'agent', sessionId: 's', busy: false}),
+    ]
+    expect(summarizeAgentActivity(entries, undefined)).toBeNull()
+    expect(summarizeAgentActivity(entries, read(undefined))).toBeNull()
+  })
+
+  test('an unread agent reply is red, an unread human or trigger message is blue', () => {
+    const reply = agent('a', {at: 50, kind: 'agent', messageAt: 50, messageFrom: 'agent', sessionId: 's', busy: false})
+    expect(summarizeAgentActivity([reply], read(10))).toMatchObject({
+      tone: 'agent',
+      unread: true,
+      agentId: 'a',
+      sessionId: 's',
+      label: 'Agent a replied',
+    })
+    const asked = agent('b', {at: 50, kind: 'user', messageAt: 50, messageFrom: 'user', sessionId: 't', busy: true})
+    expect(summarizeAgentActivity([asked], read(10))).toMatchObject({tone: 'user', unread: true, agentId: 'b'})
+  })
+
+  test('the newest unread message across agents decides the color', () => {
+    const older = agent('a', {at: 50, kind: 'agent', messageAt: 50, messageFrom: 'agent', sessionId: 's', busy: false})
+    const newer = agent('b', {at: 80, kind: 'user', messageAt: 80, messageFrom: 'user', sessionId: 't', busy: false})
+    expect(summarizeAgentActivity([older, newer], read(10))).toMatchObject({tone: 'user', agentId: 'b'})
+  })
+
+  test('reading the session the rollup points at clears it; the baseline covers everything before it', () => {
+    const activity = {at: 50, kind: 'agent', messageAt: 50, messageFrom: 'agent', sessionId: 's', busy: false} as const
+    expect(isAgentActivityUnread(activity, server, read(10))).toBe(true)
+    expect(isAgentActivityUnread(activity, server, read(10, {[agentActivityReadKey(server, 's')]: 50}))).toBe(false)
+    expect(isAgentActivityUnread(activity, server, read(10, {[agentActivityReadKey(server, 'other')]: 99}))).toBe(true)
+    expect(isAgentActivityUnread(activity, server, read(50))).toBe(false)
+  })
+
+  test('tool activity after a read message does not reopen it, and a busy agent shows amber instead', () => {
+    // The agent is running a tool after the reply the user already saw: `at` moved, `messageAt` did not.
+    const working = agent('a', {at: 90, kind: 'tool', messageAt: 50, messageFrom: 'agent', sessionId: 's', busy: true})
+    const marks = read(10, {[agentActivityReadKey(server, 's')]: 50})
+    expect(summarizeAgentActivity([working], marks)).toMatchObject({
+      tone: 'busy',
+      unread: false,
+      label: 'Agent a is running a tool',
+    })
+    const thinking = agent('a', {at: 90, kind: 'user', messageAt: 50, messageFrom: 'user', sessionId: 's', busy: true})
+    expect(summarizeAgentActivity([thinking], marks)).toMatchObject({tone: 'busy', label: 'Agent a is working'})
+  })
+
+  test('an idle agent with everything read shows nothing', () => {
+    const quiet = agent('a', {at: 50, kind: 'agent', messageAt: 50, messageFrom: 'agent', sessionId: 's', busy: false})
+    expect(summarizeAgentActivity([quiet, agent('b')], read(60))).toBeNull()
+  })
+
+  test('a list row shows its agent’s own indicator: unread first, then working, then nothing', () => {
+    const unreadBusy = {at: 90, kind: 'tool', messageAt: 80, messageFrom: 'agent', sessionId: 's', busy: true} as const
+    expect(agentRowActivity(unreadBusy, server, 'Researcher', read(10))).toMatchObject({
+      tone: 'agent',
+      unread: true,
+      short: 'New reply',
+    })
+    expect(agentRowActivity(unreadBusy, server, 'Researcher', read(80))).toMatchObject({
+      tone: 'busy',
+      unread: false,
+      short: 'Running a tool',
+      label: 'Researcher is running a tool',
+    })
+    const idle = {...unreadBusy, busy: false}
+    expect(agentRowActivity(idle, server, 'Researcher', read(80))).toBeNull()
+    expect(agentRowActivity(undefined, server, 'Researcher', read(80))).toBeNull()
+  })
+
+  test('the newest event time of a transcript is what a view marks as read', () => {
+    expect(latestSessionEventAt(undefined)).toBeUndefined()
+    expect(latestSessionEventAt([{createdAt: 3}, {createdAt: 9}, {createdAt: 5}, {}])).toBe(9)
+  })
+})

--- a/frontend/packages/ui/src/__tests__/assistant-panel-toggle.test.tsx
+++ b/frontend/packages/ui/src/__tests__/assistant-panel-toggle.test.tsx
@@ -97,6 +97,27 @@ describe('agents panel entry points in the site header', () => {
     expect(container.textContent).not.toContain('Agents')
   })
 
+  it('shows the activity dot on both entry points, colored by tone, with the label for screen readers', () => {
+    mockState.envServerUrl = 'http://localhost:3051'
+    render({
+      isOpen: false,
+      toggle: vi.fn(),
+      activity: {
+        tone: 'agent',
+        unread: true,
+        serverUrl: 'http://localhost:3051',
+        agentId: 'a',
+        agentName: 'Researcher',
+        sessionId: 's',
+        label: 'Researcher replied',
+      },
+    })
+    const dots = container.querySelectorAll('[data-testid="agent-activity-dot"]')
+    expect(dots).toHaveLength(2)
+    expect(dots[0]!.getAttribute('data-tone')).toBe('agent')
+    expect(container.textContent).toContain('Researcher replied')
+  })
+
   it('toggles the panel, reflects its open state, and lets the mobile menu close itself', () => {
     mockState.envServerUrl = 'http://localhost:3051'
     const toggle = vi.fn()

--- a/frontend/packages/ui/src/agents/activity-dot.tsx
+++ b/frontend/packages/ui/src/agents/activity-dot.tsx
@@ -1,0 +1,81 @@
+import {cn} from '../utils'
+
+/** Which of the three indicator colors an agent activity summary resolves to. */
+export type AgentActivityTone = 'agent' | 'user' | 'busy'
+
+/**
+ * What the agents entry point should show about recent activity, or null for nothing. Computed
+ * by `summarizeAgentActivity` in ./activity; kept here, import-light, so the site header can
+ * render the dot without pulling the agents models into the initial bundle.
+ */
+export type AgentActivityIndicator = {
+  tone: AgentActivityTone
+  /** True for an unread message (agent or user tone); false while merely busy. */
+  unread: boolean
+  serverUrl: string
+  agentId: string
+  agentName: string
+  sessionId: string
+  /** One sentence for tooltips and screen readers, e.g. "Researcher replied". */
+  label: string
+}
+
+const TONE_CLASS: Record<AgentActivityTone, string> = {
+  agent: 'bg-red-500',
+  user: 'bg-blue-500',
+  busy: 'bg-amber-500 animate-pulse',
+}
+
+/**
+ * The small colored dot on an agents entry point: red for an unread agent reply, blue for an
+ * unread message from a person or a trigger, pulsing amber while an agent is working. Positioned
+ * like the notifications bell's dot; the parent must be `relative`.
+ */
+export function AgentActivityDot({
+  indicator,
+  className,
+}: {
+  indicator: AgentActivityIndicator | null | undefined
+  className?: string
+}) {
+  if (!indicator) return null
+  return (
+    <>
+      <span
+        aria-hidden="true"
+        data-testid="agent-activity-dot"
+        data-tone={indicator.tone}
+        className={cn('absolute top-1 right-1 size-2 rounded-full', TONE_CLASS[indicator.tone], className)}
+      />
+      <span className="sr-only">{indicator.label}</span>
+    </>
+  )
+}
+
+/**
+ * The same colored dot inline, for a list row that has something unread (or an agent that is
+ * working): sits in the flow next to a name rather than on a button's corner.
+ */
+export function AgentActivityMark({
+  tone,
+  label,
+  className,
+}: {
+  tone: AgentActivityTone | null | undefined
+  /** Screen-reader text; the tooltip, if any, is the caller's. */
+  label?: string
+  className?: string
+}) {
+  if (!tone) return null
+  return (
+    <>
+      <span
+        aria-hidden="true"
+        data-testid="agent-activity-mark"
+        data-tone={tone}
+        className={cn('inline-block size-2 shrink-0 rounded-full', TONE_CLASS[tone], className)}
+      />
+      {label ? <span className="sr-only">{label}</span> : null}
+    </>
+  )
+}

--- a/frontend/packages/ui/src/agents/activity.tsx
+++ b/frontend/packages/ui/src/agents/activity.tsx
@@ -1,0 +1,304 @@
+import type {AgentActivity, AgentInfo} from '@seed-hypermedia/agents-protocol'
+import {getQueryClient} from '@shm/shared/models/query-client'
+import {useQuery} from '@tanstack/react-query'
+import {useEffect, useMemo} from 'react'
+import type {AgentActivityIndicator, AgentActivityTone} from './activity-dot'
+import {useAgentLists, useAgentWebSocketSubscription} from './models'
+import {getAgentsPlatform} from './platform'
+
+/**
+ * Unread indicator for the agents entry points (desktop title bar, web site header).
+ *
+ * The server rolls the latest transcript activity up onto each agent (`AgentInfo.activity`), so
+ * "is anything unread" needs only the agents list this client already fetches — never a session
+ * enumeration. What has been read is this device's business alone: a map of the latest transcript
+ * time seen per session, marked while a transcript is actually on screen, plus a baseline set the
+ * first time the feature runs so a fresh browser does not light up for weeks of history.
+ */
+
+/** Platform setting key holding {@link AgentActivityReadState}. */
+export const AGENT_ACTIVITY_READ_KEY = 'agents.activity-read'
+/** Sessions remembered per device; the oldest marks are dropped past this. */
+const READ_STATE_MAX_SESSIONS = 300
+const READ_STATE_QUERY_KEY = ['agents', 'activity-read'] as const
+
+export type AgentActivityReadState = {
+  /**
+   * Messages at or before this instant count as read everywhere. Set once, from the newest message
+   * across the agents known at the time, so the indicator starts quiet on a new device. Undefined
+   * until the agent lists have settled once.
+   */
+  allBefore?: number
+  /** Latest transcript time seen per `serverUrl|sessionId`. */
+  sessions: Record<string, number>
+}
+
+export function agentActivityReadKey(serverUrl: string, sessionId: string): string {
+  return `${serverUrl}|${sessionId}`
+}
+
+function isReadState(value: unknown): value is AgentActivityReadState {
+  if (!value || typeof value !== 'object') return false
+  const state = value as {allBefore?: unknown; sessions?: unknown}
+  if (state.allBefore !== undefined && typeof state.allBefore !== 'number') return false
+  return !!state.sessions && typeof state.sessions === 'object'
+}
+
+/** Whether an agent's rollup is unread on this device. Without a baseline nothing is unread yet. */
+export function isAgentActivityUnread(
+  activity: AgentActivity,
+  serverUrl: string,
+  read: AgentActivityReadState | undefined,
+): boolean {
+  if (!read || read.allBefore === undefined) return false
+  const seen = Math.max(read.allBefore, read.sessions[agentActivityReadKey(serverUrl, activity.sessionId)] ?? 0)
+  return activity.messageAt > seen
+}
+
+export type AgentActivityEntry = {serverUrl: string; agent: AgentInfo}
+
+/**
+ * The unread tone of one agent on this device — red for the agent's own reply, blue for a message
+ * from a person or a trigger — or null when its latest message has been seen. Lists use this to
+ * point at the agent (and, through `activity.sessionId`, the session) that keeps the dot lit.
+ */
+export function agentUnreadTone(
+  activity: AgentActivity | undefined,
+  serverUrl: string,
+  read: AgentActivityReadState | undefined,
+): 'agent' | 'user' | null {
+  if (!activity || !isAgentActivityUnread(activity, serverUrl, read)) return null
+  return activity.messageFrom === 'agent' ? 'agent' : 'user'
+}
+
+/** Tooltip-ready sentence for an unread tone. */
+export function agentUnreadLabel(tone: 'agent' | 'user', agentName: string): string {
+  return tone === 'agent' ? `${agentName} replied` : `New message for ${agentName}`
+}
+
+/** One agent's own indicator, as a list row shows it: unread first, else amber while it works. */
+export type AgentRowActivity = {tone: AgentActivityTone; unread: boolean; label: string; short: string}
+
+/**
+ * The indicator for one agent on this device: its unread tone (red reply, blue message) when its
+ * latest message is unseen, amber while any of its runs is live, otherwise nothing. The same rule
+ * the title-bar dot applies across agents, applied to a single row.
+ */
+export function agentRowActivity(
+  activity: AgentActivity | undefined,
+  serverUrl: string,
+  agentName: string,
+  read: AgentActivityReadState | undefined,
+): AgentRowActivity | null {
+  const unreadTone = agentUnreadTone(activity, serverUrl, read)
+  if (unreadTone) {
+    return {
+      tone: unreadTone,
+      unread: true,
+      label: agentUnreadLabel(unreadTone, agentName),
+      short: unreadTone === 'agent' ? 'New reply' : 'New message',
+    }
+  }
+  if (activity?.busy) {
+    const tool = activity.kind === 'tool'
+    return {
+      tone: 'busy',
+      unread: false,
+      label: tool ? `${agentName} is running a tool` : `${agentName} is working`,
+      short: tool ? 'Running a tool' : 'Working',
+    }
+  }
+  return null
+}
+
+/**
+ * Resolves the agents' rollups and this device's read marks into one indicator: the newest unread
+ * message wins (red for the agent's reply, blue for a person's or a trigger's); otherwise a busy
+ * agent shows amber; otherwise nothing.
+ */
+export function summarizeAgentActivity(
+  entries: AgentActivityEntry[],
+  read: AgentActivityReadState | undefined,
+): AgentActivityIndicator | null {
+  let unread: (AgentActivityEntry & {activity: AgentActivity}) | null = null
+  let busy: (AgentActivityEntry & {activity: AgentActivity}) | null = null
+  for (const entry of entries) {
+    const activity = entry.agent.activity
+    if (!activity) continue
+    if (isAgentActivityUnread(activity, entry.serverUrl, read)) {
+      if (!unread || activity.messageAt > unread.activity.messageAt) unread = {...entry, activity}
+    }
+    if (activity.busy && (!busy || activity.at > busy.activity.at)) busy = {...entry, activity}
+  }
+  const pick = unread ?? busy
+  if (!pick) return null
+  const agentName = pick.agent.definition.name
+  if (unread) {
+    const tone = unread.activity.messageFrom === 'agent' ? 'agent' : 'user'
+    return {
+      tone,
+      unread: true,
+      serverUrl: unread.serverUrl,
+      agentId: unread.agent.id,
+      agentName,
+      sessionId: unread.activity.sessionId,
+      label: agentUnreadLabel(tone, agentName),
+    }
+  }
+  return {
+    tone: 'busy',
+    unread: false,
+    serverUrl: pick.serverUrl,
+    agentId: pick.agent.id,
+    agentName,
+    sessionId: pick.activity.sessionId,
+    label: pick.activity.kind === 'tool' ? `${agentName} is running a tool` : `${agentName} is working`,
+  }
+}
+
+/** The device's read marks, loaded once from the platform setting. */
+export function useAgentActivityReadState() {
+  return useQuery({
+    queryKey: READ_STATE_QUERY_KEY,
+    queryFn: async (): Promise<AgentActivityReadState> => {
+      const stored = await getAgentsPlatform().getSetting(AGENT_ACTIVITY_READ_KEY)
+      return isReadState(stored) ? stored : {sessions: {}}
+    },
+    staleTime: Infinity,
+    retry: false,
+    useErrorBoundary: false,
+  })
+}
+
+/** Writes the read marks to the cache (so indicators update at once) and to the device setting. */
+function writeReadState(next: AgentActivityReadState): void {
+  const keys = Object.keys(next.sessions)
+  const sessions =
+    keys.length > READ_STATE_MAX_SESSIONS
+      ? Object.fromEntries(
+          keys
+            .sort((a, b) => next.sessions[b]! - next.sessions[a]!)
+            .slice(0, READ_STATE_MAX_SESSIONS)
+            .map((key) => [key, next.sessions[key]!]),
+        )
+      : next.sessions
+  const state = {...next, sessions}
+  getQueryClient().setQueryData(READ_STATE_QUERY_KEY, state)
+  void getAgentsPlatform()
+    .setSetting(AGENT_ACTIVITY_READ_KEY, state)
+    .catch(() => {
+      // A full or unavailable store loses nothing but a future dot; the cache is already current.
+    })
+}
+
+/**
+ * Marks a session read up to `seenAt` right now — for the moment a user picks an agent whose
+ * unread session the panel is about to show, so the indicators clear without waiting on the
+ * transcript to load. The transcript view then keeps the mark current as events arrive.
+ */
+export function markAgentSessionRead(serverUrl: string, sessionId: string, seenAt: number): void {
+  const current = getQueryClient().getQueryData<AgentActivityReadState>(READ_STATE_QUERY_KEY) ?? {sessions: {}}
+  const key = agentActivityReadKey(serverUrl, sessionId)
+  if ((current.sessions[key] ?? 0) >= seenAt) return
+  writeReadState({...current, sessions: {...current.sessions, [key]: seenAt}})
+}
+
+/**
+ * Records that this device has seen a session's transcript up to `latestEventAt` — the newest
+ * event time the view has rendered, in the server's clock, which is what the rollup's
+ * `messageAt` is measured in. Only while the document is visible: a transcript left open in a
+ * background tab has not been read.
+ */
+export function useMarkAgentSessionRead(
+  serverUrl: string | undefined,
+  sessionId: string | undefined,
+  latestEventAt: number | undefined,
+): void {
+  const read = useAgentActivityReadState()
+  const stored = read.data
+  useEffect(() => {
+    if (!serverUrl || !sessionId || !latestEventAt || !stored) return
+    const key = agentActivityReadKey(serverUrl, sessionId)
+    const mark = () => {
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return
+      const current = getQueryClient().getQueryData<AgentActivityReadState>(READ_STATE_QUERY_KEY) ?? stored
+      if ((current.sessions[key] ?? 0) >= latestEventAt) return
+      writeReadState({...current, sessions: {...current.sessions, [key]: latestEventAt}})
+    }
+    mark()
+    if (typeof document === 'undefined') return
+    document.addEventListener('visibilitychange', mark)
+    return () => document.removeEventListener('visibilitychange', mark)
+  }, [serverUrl, sessionId, latestEventAt, stored])
+}
+
+/** The newest event time in a transcript, for {@link useMarkAgentSessionRead}. */
+export function latestSessionEventAt(events: {createdAt?: number}[] | undefined): number | undefined {
+  let latest: number | undefined
+  for (const event of events ?? []) {
+    if (typeof event.createdAt === 'number' && (latest === undefined || event.createdAt > latest))
+      latest = event.createdAt
+  }
+  return latest
+}
+
+/**
+ * The indicator for the given servers' agents, kept current by the agent lists (which the account
+ * sockets update in place from the server's activity hints) and this device's read marks.
+ */
+export function useAgentActivityIndicator(
+  serverUrls: string[] | undefined,
+  accountUid: string | null | undefined,
+): AgentActivityIndicator | null {
+  const lists = useAgentLists(serverUrls, accountUid)
+  const read = useAgentActivityReadState()
+  const settled = lists.length > 0 && lists.every((query) => query.isSuccess || query.isError)
+  // Cheap enough to rebuild per render (a handful of agents); useQueries hands back a fresh array
+  // anyway, so memoizing on it would buy nothing.
+  const entries = (serverUrls ?? []).flatMap((serverUrl, index) =>
+    (lists[index]?.data ?? []).map((agent): AgentActivityEntry => ({serverUrl, agent})),
+  )
+
+  // First run on this device: everything that already happened is read. The baseline is the newest
+  // message known right now, in the server's clock, rather than this device's clock.
+  const stored = read.data
+  const newestMessageAt = Math.max(0, ...entries.map((entry) => entry.agent.activity?.messageAt ?? 0))
+  useEffect(() => {
+    if (!stored || stored.allBefore !== undefined || !settled) return
+    writeReadState({...stored, allBefore: newestMessageAt})
+  }, [stored, settled, newestMessageAt])
+
+  // Referentially stable while nothing changed: consumers report it upward through effects and
+  // context, and a fresh object per render would make those fire every render.
+  const indicator = summarizeAgentActivity(entries, read.data)
+  const signature = JSON.stringify(indicator)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useMemo(() => indicator, [signature])
+}
+
+/** Keeps one account-wide socket per server open, so activity hints arrive with the panel closed. */
+export function AgentActivityLiveUpdates({
+  serverUrls,
+  accountUid,
+}: {
+  serverUrls: string[] | undefined
+  accountUid: string | null | undefined
+}) {
+  if (!accountUid) return null
+  return (
+    <>
+      {(serverUrls ?? []).map((serverUrl) => (
+        <AgentAccountLiveUpdates key={serverUrl} serverUrl={serverUrl} accountUid={accountUid} />
+      ))}
+    </>
+  )
+}
+
+/**
+ * Account-wide live updates for one server: session changes (titles, statuses, activity) reach
+ * every list the moment they happen, instead of waiting on a background poll.
+ */
+export function AgentAccountLiveUpdates({serverUrl, accountUid}: {serverUrl: string; accountUid: string}) {
+  useAgentWebSocketSubscription(serverUrl, accountUid, `account/${accountUid}`)
+  return null
+}

--- a/frontend/packages/ui/src/agents/agent-row.tsx
+++ b/frontend/packages/ui/src/agents/agent-row.tsx
@@ -1,3 +1,6 @@
+import type {AgentActivity} from '@seed-hypermedia/agents-protocol'
+import {agentRowActivity, useAgentActivityReadState} from './activity'
+import {AgentActivityMark} from './activity-dot'
 import {useNavigate} from './navigation'
 import {SizableText} from '@shm/ui/text'
 import {Tooltip} from '@shm/ui/tooltip'
@@ -24,15 +27,20 @@ export function AgentListRow({
   status,
   serverUrl,
   accessRole,
+  activity,
 }: {
   agentId: string
   name: string
   status: string
   serverUrl: string
   accessRole?: 'owner' | 'reader' | 'writer' | 'chatter'
+  /** The agent's latest-activity rollup, for the unread mark beside its name. */
+  activity?: AgentActivity
 }) {
   const navigate = useNavigate()
   const statusIndicator = getAgentStatusIndicator(status)
+  const readState = useAgentActivityReadState()
+  const row = agentRowActivity(activity, serverUrl, name, readState.data)
   return (
     <div
       className="border-border hover:bg-muted/60 flex cursor-pointer items-center justify-between gap-4 rounded-lg border p-3 transition-colors"
@@ -42,6 +50,13 @@ export function AgentListRow({
         <SizableText weight="bold" className="min-w-0 truncate">
           {name}
         </SizableText>
+        {row ? (
+          <Tooltip content={row.label} asChild>
+            <span className="inline-flex">
+              <AgentActivityMark tone={row.tone} label={row.label} />
+            </span>
+          </Tooltip>
+        ) : null}
         {accessRole && accessRole !== 'owner' ? (
           <span className="bg-muted text-muted-foreground flex-none rounded-full px-2 py-0.5 text-[10px] font-medium tracking-wide uppercase">
             {accessRole}

--- a/frontend/packages/ui/src/agents/assistant-panel.tsx
+++ b/frontend/packages/ui/src/agents/assistant-panel.tsx
@@ -40,6 +40,16 @@ import {
   type AssistantAgentKey,
   type AssistantAgentOption,
 } from './assistant-selection'
+import {
+  agentRowActivity,
+  latestSessionEventAt,
+  markAgentSessionRead,
+  summarizeAgentActivity,
+  useAgentActivityReadState,
+  useMarkAgentSessionRead,
+  type AgentRowActivity,
+} from './activity'
+import {AgentActivityMark, type AgentActivityTone} from './activity-dot'
 import {CreateAgentDialog} from './dialogs'
 import {useSelectedAccountId} from './account'
 import {useNavigate} from './navigation'
@@ -270,6 +280,47 @@ export function AssistantPanel({
   }, [newChatRequest, startDraft])
 
   const activeAgent = selection.agent
+  // Which agents still have an unseen latest message on this device, so the pickers can point at
+  // them: the title-bar dot only goes out once every one of these has been looked at.
+  const readState = useAgentActivityReadState()
+  const rowActivities = useMemo(() => {
+    const rows: Record<string, AgentRowActivity> = {}
+    for (const option of agents) {
+      const row = agentRowActivity(
+        option.agent.activity,
+        option.serverUrl,
+        option.agent.definition.name,
+        readState.data,
+      )
+      if (row) rows[`${option.serverUrl}${option.agent.id}`] = row
+    }
+    return rows
+  }, [agents, readState.data])
+  const activeRow = activeAgent ? rowActivities[`${activeAgent.serverUrl}${activeAgent.agent.id}`] : undefined
+  const activeUnreadTone = activeRow?.unread ? (activeRow.tone as 'agent' | 'user') : undefined
+  const activeUnreadSession = activeUnreadTone
+    ? {sessionId: activeAgent!.agent.activity!.sessionId, tone: activeUnreadTone}
+    : null
+
+  // Opening the panel with something unread lands on it: the newest unread chat across agents,
+  // marked read on arrival. Decided once per mount, as soon as the lists have settled, so a
+  // message that lands later never yanks the user out of what they are doing. A panel opened to
+  // start a new chat keeps that intent instead.
+  const jumpedToUnreadRef = useRef(false)
+  useEffect(() => {
+    if (jumpedToUnreadRef.current || !agentsSettled || !readState.data) return
+    jumpedToUnreadRef.current = true
+    if (newChatRequest) return
+    const indicator = summarizeAgentActivity(agents, readState.data)
+    if (!indicator?.unread) return
+    const picked = agents.find(
+      (option) => option.serverUrl === indicator.serverUrl && option.agent.id === indicator.agentId,
+    )
+    if (!picked?.agent.activity) return
+    setChosenAgent({serverUrl: indicator.serverUrl, agentId: indicator.agentId})
+    selectSession({serverUrl: indicator.serverUrl, sessionId: indicator.sessionId})
+    markAgentSessionRead(indicator.serverUrl, indicator.sessionId, picked.agent.activity.messageAt)
+  }, [agentsSettled, readState.data, agents, newChatRequest, setChosenAgent, selectSession])
   const activeSession = selection.session
   const sessionEntry = activeSession
     ? sessions.entries.find(
@@ -297,22 +348,30 @@ export function AssistantPanel({
 
   return (
     <div className="flex h-full flex-col">
-      {/* Account-wide live updates per server: session changes (titles, statuses) reach the
-          sidebar the moment they happen, instead of waiting on the 5s background poll. */}
-      {accountUid
-        ? (serverUrls.data || []).map((serverUrl) => (
-            <AgentAccountLiveUpdates key={serverUrl} serverUrl={serverUrl} accountUid={accountUid} />
-          ))
-        : null}
+      {/* Account-wide live updates are mounted by the shell (desktop title bar, web assistant host)
+          so they also run while this panel is closed, feeding the unread indicator. */}
       {deleteDialog.content}
       {createAgentDialog.content}
       <div className="border-border window-drag flex h-10 items-center justify-between gap-1 border-b px-2 py-2">
         <AssistantAgentPicker
           agents={agents}
           activeAgent={activeAgent}
+          rowActivities={rowActivities}
           localServerUrl={localServerUrl.data ?? null}
           advertisedServerUrl={serverUrls.advertisedServerUrl}
-          onSelect={(key) => setChosenAgent(key)}
+          onSelect={(key) => {
+            setChosenAgent(key)
+            // Picking an agent that has something unread lands on that chat, read: the whole point
+            // of the dot was to get here, and leaving it lit on the way in would be a nag.
+            const picked = agents.find(
+              (option) => option.serverUrl === key.serverUrl && option.agent.id === key.agentId,
+            )
+            const activity = picked?.agent.activity
+            if (activity && rowActivities[`${key.serverUrl}${key.agentId}`]?.unread) {
+              selectSession({serverUrl: key.serverUrl, sessionId: activity.sessionId})
+              markAgentSessionRead(key.serverUrl, activity.sessionId, activity.messageAt)
+            }
+          }}
           onCreateAgent={openCreateAgent}
           onOpenAgentsPage={() => navigate({key: 'agents'})}
           onOpenAgentPage={
@@ -345,6 +404,7 @@ export function AssistantPanel({
           selected={activeSession}
           selectedTitle={sessionTitle}
           isDraft={!activeSession}
+          unreadSession={activeUnreadSession}
           onSelect={selectSession}
         />
         {activeSession ? (
@@ -480,19 +540,10 @@ export function AssistantPanel({
  * and jumping to the full Agents page — live here so the sidebar is self-sufficient: on a fresh
  * install with zero agents, this dropdown is where you fix that.
  */
-/**
- * Renders nothing; holds one account-wide WebSocket subscription open for a server so every
- * session change (agent-set titles, status flips) invalidates the sidebar queries immediately.
- * A component rather than a hook because the server list is dynamic and hooks cannot loop.
- */
-function AgentAccountLiveUpdates({serverUrl, accountUid}: {serverUrl: string; accountUid: string}) {
-  useAgentWebSocketSubscription(serverUrl, accountUid, `account/${accountUid}`)
-  return null
-}
-
 function AssistantAgentPicker({
   agents,
   activeAgent,
+  rowActivities,
   localServerUrl,
   advertisedServerUrl,
   onSelect,
@@ -502,6 +553,8 @@ function AssistantAgentPicker({
 }: {
   agents: AssistantAgentOption[]
   activeAgent: AssistantAgentOption | null
+  /** Each agent's own indicator (unread, or working), keyed `${serverUrl}${agentId}`. */
+  rowActivities: Record<string, AgentRowActivity>
   localServerUrl: string | null
   /** Server the site on screen advertises; its group is labeled so the user knows why it is here. */
   advertisedServerUrl?: string | null
@@ -512,6 +565,9 @@ function AssistantAgentPicker({
   onOpenAgentPage?: () => void
 }) {
   const [open, setOpen] = useState(false)
+  // The closed trigger carries what the rows would show: anything unread first, else a working agent.
+  const triggerTone =
+    Object.values(rowActivities).find((row) => row.unread)?.tone ?? Object.values(rowActivities)[0]?.tone ?? null
 
   const groups = useMemo(() => {
     const byServer = new Map<string, AssistantAgentOption[]>()
@@ -533,7 +589,16 @@ function AssistantAgentPicker({
             type="button"
             className="no-window-drag hover:bg-muted flex max-w-full min-w-0 items-center gap-2 rounded px-1.5 py-1"
           >
-            <Bot className="text-muted-foreground size-4 shrink-0" />
+            <span className="relative inline-flex shrink-0">
+              <Bot className="text-muted-foreground size-4 shrink-0" />
+              {triggerTone ? (
+                <AgentActivityMark
+                  tone={triggerTone}
+                  className="absolute -top-1 -right-1"
+                  label={triggerTone === 'busy' ? 'An agent is working' : 'Unread messages'}
+                />
+              ) : null}
+            </span>
             <SizableText size="sm" className="min-w-0 truncate font-medium">
               {activeAgent?.agent.definition.name || 'Agents'}
             </SizableText>
@@ -559,6 +624,7 @@ function AssistantAgentPicker({
                 {group.options.map((option) => {
                   const isActive =
                     option.serverUrl === activeAgent?.serverUrl && option.agent.id === activeAgent.agent.id
+                  const row = rowActivities[`${option.serverUrl}${option.agent.id}`]
                   return (
                     <button
                       key={`${option.serverUrl}${option.agent.id}`}
@@ -571,9 +637,14 @@ function AssistantAgentPicker({
                         setOpen(false)
                       }}
                     >
-                      <span className="w-full truncate text-xs font-medium">{option.agent.definition.name}</span>
+                      <span className="flex w-full items-center gap-1.5">
+                        <span className="min-w-0 flex-1 truncate text-xs font-medium">
+                          {option.agent.definition.name}
+                        </span>
+                        <AgentActivityMark tone={row?.tone} label={row?.label} />
+                      </span>
                       <span className="text-muted-foreground w-full truncate text-[10px]">
-                        {option.agent.definition.model}
+                        {row?.short ?? option.agent.definition.model}
                       </span>
                     </button>
                   )
@@ -630,6 +701,7 @@ function AssistantSessionPicker({
   selected,
   selectedTitle,
   isDraft,
+  unreadSession,
   onSelect,
 }: {
   entries: AgentSessionListEntry[]
@@ -638,9 +710,13 @@ function AssistantSessionPicker({
   selected: AssistantSessionRef | null
   selectedTitle?: string
   isDraft: boolean
+  /** The active agent's session holding its unseen latest message, if any. */
+  unreadSession?: {sessionId: string; tone: AgentActivityTone} | null
   onSelect: (ref: AssistantSessionRef) => void
 }) {
   const [open, setOpen] = useState(false)
+  // Unread somewhere other than what is on screen: the trigger points at the list.
+  const unreadElsewhere = unreadSession && unreadSession.sessionId !== selected?.sessionId ? unreadSession : null
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -652,6 +728,7 @@ function AssistantSessionPicker({
           <span className="min-w-0 flex-1 truncate text-left">
             {isDraft ? 'New chat' : selectedTitle || 'Untitled session'}
           </span>
+          {unreadElsewhere ? <AgentActivityMark tone={unreadElsewhere.tone} label="Unread chat" /> : null}
           <ChevronDown className="size-3 shrink-0" />
         </button>
       </PopoverTrigger>
@@ -677,7 +754,14 @@ function AssistantSessionPicker({
                 >
                   <SessionStatusDot status={entry.session.status} className="size-2" />
                   <span className="flex min-w-0 flex-1 flex-col">
-                    <span className="truncate text-xs">{entry.session.title || 'Untitled session'}</span>
+                    <span className="flex items-center gap-1.5">
+                      <span className="min-w-0 flex-1 truncate text-xs">
+                        {entry.session.title || 'Untitled session'}
+                      </span>
+                      {unreadSession?.sessionId === entry.session.id ? (
+                        <AgentActivityMark tone={unreadSession.tone} label="Unread" />
+                      ) : null}
+                    </span>
                     {entry.session.description ? (
                       <span className="text-muted-foreground line-clamp-3 text-xs">{entry.session.description}</span>
                     ) : null}
@@ -827,6 +911,8 @@ function AssistantSessionChat({
     session.data ? `sessions/${sessionId}` : undefined,
     lastSeq ?? 0,
   )
+  // This transcript is on screen: whatever it shows is read on this device.
+  useMarkAgentSessionRead(serverUrl, sessionId, latestSessionEventAt(session.data?.events))
   const messageSession = useMessageAgentSession(serverUrl, accountUid)
   const stopSession = useStopAgentSession(serverUrl, accountUid)
   const retrySession = useRetrySession(serverUrl, accountUid)

--- a/frontend/packages/ui/src/agents/list.tsx
+++ b/frontend/packages/ui/src/agents/list.tsx
@@ -228,6 +228,7 @@ function AgentsListContent({selectedAccountId}: {selectedAccountId: string}) {
                   status={agent.status}
                   serverUrl={serverUrl}
                   accessRole={agent.accessRole}
+                  activity={agent.activity}
                 />
               ))}
             </div>
@@ -274,6 +275,7 @@ function AgentsListContent({selectedAccountId}: {selectedAccountId: string}) {
                 status={agent.status}
                 serverUrl={agent.serverUrl}
                 accessRole={agent.accessRole}
+                activity={agent.activity}
               />
             ))}
           </div>

--- a/frontend/packages/ui/src/agents/models.ts
+++ b/frontend/packages/ui/src/agents/models.ts
@@ -41,7 +41,7 @@ import {isOptimisticUserEcho} from './agent-session-rows'
 import {moveAgentToServer, type MoveAgentOptions} from './move-agent'
 import {getAgentsPlatform} from './platform'
 import {parseSpaceAgentIds} from './space-agents'
-import {getToolReferencedUrls} from '@seed-hypermedia/agents-protocol'
+import {getToolReferencedUrls, type AgentActivity} from '@seed-hypermedia/agents-protocol'
 import * as cbor from '@shm/shared/cbor'
 import {getQueryClient, invalidateQueries} from '@shm/shared/models/query-client'
 import type {HMMetadata} from '@seed-hypermedia/client/hm-types'
@@ -108,6 +108,23 @@ function applyAgentToCaches(serverUrl: string, accountUid: string, agent: AgentI
   )
 }
 
+/** Writes an agent's fresh activity rollup into the cached agent list and detail. */
+export function applyAgentActivityToCaches(
+  serverUrl: string,
+  accountUid: string,
+  agentId: string,
+  activity: AgentActivity,
+): void {
+  const client = getQueryClient()
+  client.setQueriesData({queryKey: ['agents', 'list', serverUrl, accountUid]}, (old: any) =>
+    Array.isArray(old) ? old.map((entry: AgentInfo) => (entry.id === agentId ? {...entry, activity} : entry)) : old,
+  )
+  client.setQueriesData({queryKey: ['agents', 'detail', serverUrl, accountUid, agentId]}, (old: any) => {
+    if (!old || old._ !== 'GetAgentResponse' || !old.agent) return old
+    return {...old, agent: {...old.agent, activity}}
+  })
+}
+
 /**
  * Writes a fresh session snapshot into every cache that renders it: the session page, the
  * cross-server sidebar list (upserting a session the cache has not seen yet), and the owning
@@ -155,9 +172,12 @@ function applySessionToCaches(serverUrl: string, accountUid: string, session: Se
 export function invalidateForAccountChange(
   serverUrl: string,
   accountUid: string,
-  value: {reason?: string; agentId?: string; sessionId?: string},
+  value: {reason?: string; agentId?: string; sessionId?: string; activity?: AgentActivity},
 ): void {
   const {reason, agentId, sessionId} = value
+  // The hint carries the agent's fresh activity rollup: write it into the cached agent rows so
+  // unread indicators move without refetching any list.
+  if (agentId && value.activity) applyAgentActivityToCaches(serverUrl, accountUid, agentId, value.activity)
   switch (reason) {
     case 'agent-memory-changed':
       invalidateQueries(agentId ? ['agents', 'memory', serverUrl, accountUid, agentId] : ['agents', 'memory'])

--- a/frontend/packages/ui/src/agents/session.tsx
+++ b/frontend/packages/ui/src/agents/session.tsx
@@ -9,6 +9,7 @@ import {
   sessionContextTokens,
   useFollowContinuation,
 } from './continuation'
+import {latestSessionEventAt, useMarkAgentSessionRead} from './activity'
 import {useChatAutoScroll} from './chat-autoscroll'
 import {describeAgentError} from './errors'
 import {AgentErrorRow, AssistantMessageParts, ChatMessageBubble} from './message-rendering'
@@ -192,6 +193,8 @@ function AgentSessionPage({
     className: 'w-[min(44rem,calc(100vw-2rem))] max-h-[85vh]',
   })
   const lastSeq = session.data?.events.filter((event) => event.seq !== Number.MAX_SAFE_INTEGER).at(-1)?.seq
+  // This transcript is on screen: whatever it shows is read on this device.
+  useMarkAgentSessionRead(serverUrl, sessionId, latestSessionEventAt(session.data?.events))
   // The subscription waits for the initial GetSession: subscribing with no afterSeq makes the
   // server replay the whole transcript over the socket on top of the fetch.
   const liveState = useAgentWebSocketSubscription(

--- a/frontend/packages/ui/src/assistant-panel-toggle.tsx
+++ b/frontend/packages/ui/src/assistant-panel-toggle.tsx
@@ -3,6 +3,7 @@ import {SEED_AGENT_SERVER_URL} from '@shm/shared/constants'
 import {useResource} from '@shm/shared/models/entity'
 import {MessageCircle} from 'lucide-react'
 import {createContext, useContext} from 'react'
+import {AgentActivityDot, type AgentActivityIndicator} from './agents/activity-dot'
 import {parseSpaceAgentIds} from './agents/space-agents'
 import {Button} from './button'
 import {SmallListItem} from './list-item'
@@ -13,6 +14,8 @@ import {cn} from './utils'
 export type AssistantPanelToggle = {
   isOpen: boolean
   toggle: () => void
+  /** Recent activity to show on the entry points, when the host tracks it. */
+  activity?: AgentActivityIndicator | null
 }
 
 /**
@@ -64,16 +67,20 @@ export function AssistantPanelHeaderButton({siteUid}: {siteUid: string}) {
   const hasAgentServer = useHasAgentServer(siteUid)
   if (!toggle || !hasAgentServer) return null
   return (
-    <Tooltip content={toggle.isOpen ? 'Close Agents' : 'Open Agents'}>
+    <Tooltip content={toggle.activity?.label ?? (toggle.isOpen ? 'Close Agents' : 'Open Agents')}>
       <Button
         variant="ghost"
         size="icon"
         aria-label="Agents"
         aria-pressed={toggle.isOpen}
-        className={cn('h-8 rounded-full border-1 border-transparent p-0', toggle.isOpen && 'dark:bg-muted bg-black/5')}
+        className={cn(
+          'relative h-8 rounded-full border-1 border-transparent p-0',
+          toggle.isOpen && 'dark:bg-muted bg-black/5',
+        )}
         onClick={toggle.toggle}
       >
         <MessageCircle className="size-4" />
+        <AgentActivityDot indicator={toggle.activity} />
       </Button>
     </Tooltip>
   )
@@ -92,7 +99,12 @@ export function AssistantPanelMenuItem({siteUid, onClick}: {siteUid: string; onC
       bold
       active={toggle.isOpen}
       title={toggle.isOpen ? 'Close Agents' : 'Agents'}
-      icon={<MessageCircle className="size-4" />}
+      icon={
+        <span className="relative inline-flex">
+          <MessageCircle className="size-4" />
+          <AgentActivityDot indicator={toggle.activity} className="-top-1 -right-1" />
+        </span>
+      }
       onClick={() => {
         toggle.toggle()
         onClick?.()


### PR DESCRIPTION
## Summary

A small dot on the Agents button (desktop title bar, web site header, mobile menu) whenever there is unread agent activity, colored by what it is:

- **red** — an unread reply from an agent
- **blue** — an unread message from a person or a trigger (covers sessions started elsewhere)
- **pulsing amber** — an agent is working and nothing is unread

Tool calls move the "working" state but never count as unread. Delegated child sessions count as work, never as a message.

The dot goes out only once the latest message of **every** agent has been seen, and the panel points the way: the agent picker rows and the Agents page rows carry each agent's own indicator (unread, or amber while it works, with "New reply" / "New message" / "Working" text), and the session picker marks the chat holding the unread message. Opening the panel with something unread lands on the newest unread chat; picking a marked agent opens its unread chat. Both mark it read on arrival. A panel opened via "new chat" keeps that intent.

## How it works

**Server** — the latest transcript activity is rolled up per agent (not per session) in five new columns on `agents`, written on every appended session event, exposed as `AgentInfo.activity` with a `busy` flag derived from live runs. A viewer's indicator therefore reads only the agents they can see and never enumerates sessions (100 agents × 100 sessions = 100 small objects). The coalesced `session-event` hint and a new `session-updated` hint (on real status transitions) carry the rollup; clients write it straight into their cached agent rows, so an always-visible dot adds **no** `ListAgents`/`ListSessions` refetch. Old clients ignore the field; new clients treat a missing one as nothing unread. Migration runs on next server start.

**Client** — read state is per device: newest transcript time seen per session, marked while a transcript is on screen and the document is visible, plus a first-run baseline so a fresh device starts quiet. The account-wide socket that fed the panel moves to the shell (title bar on desktop, assistant host on web) so hints arrive with the panel closed. On web the tracker is a lazy chunk under the page's contexts, feeding the existing header toggle context so the header stays import-light.

Docs: `agents/docs/websocket-subscriptions.md` and `agents/docs/persistence.md`.

## Test plan

- [x] `agents`: full suite (481) incl. new rollup test (user → tool → agent events, busy flag, hint sequence)
- [x] `packages/ui`: activity summary/read-mark/row-indicator tests, hint-to-cache application, header dot rendering
- [x] `apps/desktop`: panel context suite incl. open-jump, new-chat exception, pick-to-open with read mark; panel/dialog/rendering suites; agents list
- [x] `apps/web`: assistant host, Agents page content, platform
- [x] ui / desktop / web typecheck
- [ ] Manual: `./dev up`, message an agent from another device or a trigger, watch the dot on desktop and web; open the panel and confirm it lands on the unread chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sKXifeuCKfkEK7ih1MxLt
