### PR TITLE
Stop refetching GetAgent and ListSessions on every transcript event

### DIFF
--- a/agents/docs/websocket-subscriptions.md
+++ b/agents/docs/websocket-subscriptions.md
@@ -59,7 +59,7 @@ type AgentWSEvent =
   | {
       _: 'change'
       key: `account/${string}`
-      value: {reason: string; agentId?: string; sessionId?: string; activity?: AgentActivity}
+      value: {reason: string; agentId?: string; sessionId?: string; activity?: AgentActivity; session?: SessionInfo}
     }
   | {_: 'change'; key: `runs/${string}`; value: RunInfo}
   | {_: 'append'; key: `runs/${string}`; runId: string; seq: number; entry: Record<string, unknown>; createdAt: number}
@@ -85,8 +85,10 @@ time and sender, that message's session, and whether any run is live):
 - `session-event` — coalesced to about one per session per 1.5 s while a transcript grows.
 - `session-updated` — on a real session status transition, which is what flips `busy`.
 
-Clients write the rollup straight into their cached agent rows (list and detail), so an always-visible unread indicator
-costs no `ListAgents` or `ListSessions` refetch. A client that ignores the field behaves as before.
+Both also carry the session's fresh `SessionInfo` (`session`). Clients write the rollup into their cached agent rows and
+the snapshot into their cached session lists, so neither an always-visible unread indicator nor an open sidebar costs a
+`ListAgents`, `ListSessions`, `GetSession` or `GetAgent` refetch: the open transcript already streams on its own
+`sessions/<id>` subscription. A client that ignores the fields behaves as before.
 
 ### `agents/<agentId>`
 

--- a/agents/protocol/src/index.ts
+++ b/agents/protocol/src/index.ts
@@ -1624,6 +1624,11 @@ export type AgentWSEvent =
          * a client keeps its unread indicator current without refetching any list.
          */
         activity?: AgentActivity
+        /**
+         * Fresh snapshot of `sessionId`, on the same hints: its `updatedAt` and status moved, and a
+         * client that writes the snapshot into its session lists needs no ListSessions refetch.
+         */
+        session?: SessionInfo
       }
     }
   | {_: 'change'; key: `runs/${string}`; value: RunInfo}

--- a/agents/src/api-service.test.ts
+++ b/agents/src/api-service.test.ts
@@ -4558,10 +4558,13 @@ describe('api service', () => {
       // the settled reply.
       const hints = events.flatMap((event) =>
         event.type === 'account-change' && event.activity && event.agentId === agentId
-          ? [{reason: event.reason, ...event.activity}]
+          ? [{reason: event.reason, ...event.activity, snapshot: event.session}]
           : [],
       )
       expect(hints[0]).toMatchObject({reason: 'session-event', kind: 'user', messageFrom: 'user', sessionId})
+      // Every hint also carries the session itself, so a client can reorder its lists in place.
+      for (const hint of hints) expect(hint.snapshot).toMatchObject({id: sessionId, agentId})
+      expect(hints.at(-1)!.snapshot!.status).toBe('idle')
       expect(hints.some((hint) => hint.reason === 'session-updated' && hint.busy)).toBe(true)
       expect(hints.at(-1)).toMatchObject({reason: 'session-updated', kind: 'agent', messageFrom: 'agent', busy: false})
       // Tool activity moved the rollup's latest-event kind while the message columns stayed on

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -287,6 +287,8 @@ export type ServiceEvent =
       sessionId?: string
       /** Fresh activity rollup of `agentId`, on session-event and session-updated hints. */
       activity?: api.AgentActivity
+      /** Fresh snapshot of `sessionId`, on the same hints. */
+      session?: api.SessionInfo
     }
   | {type: 'run-change'; accountId: string; run: api.RunInfo}
   | {type: 'run-append'; accountId: string; rootRunId: string; entry: api.RunJournalEntryInfo}
@@ -7771,6 +7773,18 @@ export class Service {
   }
 
   /**
+   * The session's current snapshot, for live hints. Like {@link #agentActivity}, reachable from
+   * the trailing signal timer after the database has closed — then the hint goes without it.
+   */
+  #sessionSnapshot(accountId: string, sessionId: string): api.SessionInfo | undefined {
+    try {
+      return this.#getSessionInfo(accountId, sessionId) ?? undefined
+    } catch {
+      return undefined
+    }
+  }
+
+  /**
    * The agent's current activity rollup, for live hints. Looked up by id: the agent may be a
    * collaborator's. The coalesced list signal calls this from a trailing timer, which can outlive
    * the database (tests close it; a shutdown may too) — a hint without a rollup beats a crash.
@@ -7809,6 +7823,7 @@ export class Service {
         agentId,
         sessionId,
         activity: this.#agentActivity(agentId),
+        session: this.#sessionSnapshot(accountId, sessionId),
       })
       return
     }
@@ -7824,6 +7839,7 @@ export class Service {
           agentId,
           sessionId,
           activity: this.#agentActivity(agentId),
+          session: this.#sessionSnapshot(accountId, sessionId),
         })
       },
       SESSION_LIST_SIGNAL_WINDOW_MS - (now - last),
@@ -7858,6 +7874,7 @@ export class Service {
         agentId: session.agentId,
         sessionId,
         activity: this.#agentActivity(session.agentId),
+        session,
       })
     }
   }

--- a/agents/src/main.ts
+++ b/agents/src/main.ts
@@ -387,7 +387,13 @@ async function main(): Promise<void> {
         sendIfSubscribed(ws, event.accountId, `account/${event.accountId}`, {
           _: 'change',
           key: `account/${event.accountId}`,
-          value: {reason: event.reason, agentId: event.agentId, sessionId: event.sessionId, activity: event.activity},
+          value: {
+            reason: event.reason,
+            agentId: event.agentId,
+            sessionId: event.sessionId,
+            activity: event.activity,
+            session: event.session,
+          },
         })
         // Agent-scoped account changes also reach the open agent page. This covers memory writes
         // (which have no agent-change event), collaborator changes, and an owner deleting an agent
@@ -396,7 +402,13 @@ async function main(): Promise<void> {
           sendIfSubscribed(ws, event.accountId, `agents/${event.agentId}`, {
             _: 'change',
             key: `account/${event.accountId}`,
-            value: {reason: event.reason, agentId: event.agentId, sessionId: event.sessionId, activity: event.activity},
+            value: {
+              reason: event.reason,
+              agentId: event.agentId,
+              sessionId: event.sessionId,
+              activity: event.activity,
+              session: event.session,
+            },
           })
         }
       }

--- a/frontend/packages/ui/src/__tests__/agent-account-change-invalidation.test.ts
+++ b/frontend/packages/ui/src/__tests__/agent-account-change-invalidation.test.ts
@@ -1,4 +1,4 @@
-import {QueryClient} from '@tanstack/react-query'
+import {QueryClient, QueryObserver} from '@tanstack/react-query'
 import {registerQueryClient} from '@shm/shared/models/query-client'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 import {invalidateForAccountChange} from '../agents/models'
@@ -64,6 +64,57 @@ describe('invalidateForAccountChange', () => {
     await new Promise((resolve) => setTimeout(resolve, 20))
     expect(listFetch).toHaveBeenCalledTimes(1)
     expect(detailFetch).toHaveBeenCalledTimes(1)
+  })
+
+  test('a hint with a session snapshot reorders the lists in place and refetches nothing on screen', async () => {
+    const client = webQueryClient()
+    const older = {id: 's-old', account: accountUid, agentId, status: 'idle' as const, createdAt: 100, updatedAt: 100}
+    const session = {id: 's1', account: accountUid, agentId, status: 'idle' as const, createdAt: 200, updatedAt: 200}
+    const listFetch = vi.fn(async () => [
+      {serverUrl, session},
+      {serverUrl, session: older},
+    ])
+    const transcriptFetch = vi.fn(async () => ({_: 'GetSessionResponse', session, events: []}))
+    const detailFetch = vi.fn(async () => ({_: 'GetAgentResponse', agent: {id: agentId}, sessions: [session]}))
+    // On screen: an observer on each, the way a mounted sidebar, transcript and agent page hold them.
+    const observed = [
+      new QueryObserver(client, {queryKey: ['agents', 'sessions', serverUrl, accountUid], queryFn: listFetch}),
+      new QueryObserver(client, {
+        queryKey: ['agents', 'session', serverUrl, accountUid, 's1'],
+        queryFn: transcriptFetch,
+      }),
+      new QueryObserver(client, {queryKey: ['agents', 'detail', serverUrl, accountUid, agentId], queryFn: detailFetch}),
+    ]
+    const unsubscribe = observed.map((observer) => observer.subscribe(() => {}))
+    await vi.waitFor(() => {
+      expect(listFetch).toHaveBeenCalledTimes(1)
+      expect(transcriptFetch).toHaveBeenCalledTimes(1)
+      expect(detailFetch).toHaveBeenCalledTimes(1)
+    })
+
+    const fresh = {...session, status: 'streaming' as const, updatedAt: 300}
+    invalidateForAccountChange(serverUrl, accountUid, {
+      reason: 'session-event',
+      agentId,
+      sessionId: 's1',
+      session: fresh,
+    })
+
+    // Written straight into every cache that shows the session.
+    expect(client.getQueryData(['agents', 'sessions', serverUrl, accountUid])).toEqual([
+      {serverUrl, session: fresh},
+      {serverUrl, session: older},
+    ])
+    expect(client.getQueryData(['agents', 'session', serverUrl, accountUid, 's1'])).toMatchObject({session: fresh})
+    expect(client.getQueryData(['agents', 'detail', serverUrl, accountUid, agentId])).toMatchObject({sessions: [fresh]})
+    // And none of the mounted copies went back to the server — this was three refetches per hint.
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(listFetch).toHaveBeenCalledTimes(1)
+    expect(transcriptFetch).toHaveBeenCalledTimes(1)
+    expect(detailFetch).toHaveBeenCalledTimes(1)
+    // Still marked stale, so a remount would refetch.
+    expect(client.getQueryState(['agents', 'session', serverUrl, accountUid, 's1'])?.isInvalidated).toBe(true)
+    for (const stop of unsubscribe) stop()
   })
 
   test('per-event churn still only refetches active queries', async () => {

--- a/frontend/packages/ui/src/agents/assistant-panel.tsx
+++ b/frontend/packages/ui/src/agents/assistant-panel.tsx
@@ -3,7 +3,6 @@ import {
   addOptimisticSessionToCaches,
   describeAgentServer,
   removeOptimisticSessionFromLists,
-  useAgentDetail,
   useAgentLists,
   useAgentServerUrls,
   useAgentSession,
@@ -100,7 +99,7 @@ import {
   encodeAssistantSessionRef,
   type AssistantSessionRef,
 } from './assistant-session-ref'
-import {AgentServerError} from './client'
+import {AgentServerError, type AgentInfo} from './client'
 import {describeAgentError, errorMessage} from './errors'
 import {useAssistantWindowContextLines} from './assistant-window-context'
 import {AgentRichMessageComposer, SubSessionDrivenNotice, TERMINAL_RUN_STATUSES} from './rich-message-composer'
@@ -473,6 +472,8 @@ export function AssistantPanel({
           key={`${activeSession.serverUrl}${activeSession.sessionId}`}
           sessionRef={activeSession}
           accountUid={accountUid}
+          agentHint={activeAgent?.agent}
+          agentsSettled={agentsSettled}
           composerRef={composerRef}
           onOpenSession={(sessionId) => selectSession({serverUrl: activeSession.serverUrl, sessionId})}
         />
@@ -889,11 +890,19 @@ function AssistantDraftChat({
 function AssistantSessionChat({
   sessionRef,
   accountUid,
+  agentHint,
+  agentsSettled,
   composerRef,
   onOpenSession,
 }: {
   sessionRef: AssistantSessionRef
   accountUid: string | null | undefined
+  /**
+   * The panel's active agent, from the agent lists it already holds. Trusted for this session
+   * only once the session names it as its agent; until then the palette waits.
+   */
+  agentHint?: AgentInfo
+  agentsSettled: boolean
   composerRef: React.MutableRefObject<AgentsRichEditorSubmitHandle | null>
   /** Switches the panel to another session of this server (a continuation's successor or predecessor). */
   onOpenSession?: (sessionId: string) => void
@@ -916,8 +925,11 @@ function AssistantSessionChat({
   const messageSession = useMessageAgentSession(serverUrl, accountUid)
   const stopSession = useStopAgentSession(serverUrl, accountUid)
   const retrySession = useRetrySession(serverUrl, accountUid)
-  // The agent definition, for the composer's user tool palette — same source as the full page.
-  const agentDetail = useAgentDetail(serverUrl, accountUid, session.data?.session.agentId)
+  // The agent definition, for the composer's user tool palette and the access role. Read from the
+  // agent lists the panel holds rather than GetAgent: that call returns the agent with every one
+  // of its sessions, and this view has no use for those.
+  const agent = agentHint && agentHint.id === session.data?.session.agentId ? agentHint : undefined
+  const agentLoading = !agent && !agentsSettled
   const windowContextLines = useAssistantWindowContextLines()
   const windowContextLinesRef = useRef(windowContextLines)
   windowContextLinesRef.current = windowContextLines
@@ -926,8 +938,8 @@ function AssistantSessionChat({
 
   // Chatters (public chat) may send; only owners/writers may control runs, switch the model, or
   // run session tools.
-  const readOnly = !agentAccessCanChat(agentDetail.data?.agent.accessRole)
-  const canWrite = !!agentDetail.data && agentAccessCanWrite(agentDetail.data.agent.accessRole)
+  const readOnly = !agentAccessCanChat(agent?.accessRole)
+  const canWrite = !!agent && agentAccessCanWrite(agent.accessRole)
   const status = session.data?.session.status
   const isStreaming = status === 'streaming'
   const isBusy = messageSession.isPending || isStreaming
@@ -1198,8 +1210,8 @@ function AssistantSessionChat({
           serverUrl={serverUrl}
           accountId={accountUid ?? null}
           sessionId={sessionId}
-          agentTools={agentDetail.data?.agent.definition.tools}
-          agentToolsLoading={agentDetail.isLoading}
+          agentTools={agent?.definition.tools}
+          agentToolsLoading={agentLoading}
           focusOnMount={false}
           canInvokeTools={canWrite}
           composerHandleRef={composerRef}
@@ -1212,7 +1224,7 @@ function AssistantSessionChat({
           <div className="flex flex-none items-center justify-end gap-2 px-3 pb-2">
             <ContextUsageMeter tokens={contextTokens} contextWindow={session.data.contextWindow} size={16} />
             <SessionModelBadge
-              agent={agentDetail.data?.agent}
+              agent={agent}
               agentId={session.data.session.agentId}
               serverUrl={serverUrl}
               sessionId={sessionId}

--- a/frontend/packages/ui/src/agents/models.ts
+++ b/frontend/packages/ui/src/agents/models.ts
@@ -172,12 +172,15 @@ function applySessionToCaches(serverUrl: string, accountUid: string, session: Se
 export function invalidateForAccountChange(
   serverUrl: string,
   accountUid: string,
-  value: {reason?: string; agentId?: string; sessionId?: string; activity?: AgentActivity},
+  value: {reason?: string; agentId?: string; sessionId?: string; activity?: AgentActivity; session?: SessionInfo},
 ): void {
   const {reason, agentId, sessionId} = value
   // The hint carries the agent's fresh activity rollup: write it into the cached agent rows so
   // unread indicators move without refetching any list.
   if (agentId && value.activity) applyAgentActivityToCaches(serverUrl, accountUid, agentId, value.activity)
+  // And the session's fresh snapshot: written into every list and detail that shows it, which is
+  // what the ListSessions refetch below used to be for.
+  if (value.session) applySessionToCaches(serverUrl, accountUid, value.session)
   switch (reason) {
     case 'agent-memory-changed':
       invalidateQueries(agentId ? ['agents', 'memory', serverUrl, accountUid, agentId] : ['agents', 'memory'])
@@ -237,15 +240,25 @@ export function invalidateForAccountChange(
     case 'user-title-wins':
     case 'session-event':
     case 'children':
-    case 'budget-pause':
-      invalidateQueries(['agents', 'sessions', serverUrl, accountUid])
+    case 'budget-pause': {
+      // A snapshot on the hint has already been written into the lists; only a hint without one
+      // (an older server, or an emit that has no session to hand) still refetches the list.
+      if (!value.session) invalidateQueries(['agents', 'sessions', serverUrl, accountUid])
+      // The transcript and the agent page are marked stale so a remount refetches, but the mounted
+      // copies are left alone: an open transcript streams its own events over `sessions/<id>`, and
+      // an open agent page gets session snapshots over `agents/<id>`. Refetching them here was a
+      // GetSession of the whole transcript plus a GetAgent of every session, per hint, per viewer.
+      // Only a transcript event says nothing new about them; the other reasons may (a title, a
+      // child count, a parked run), so those keep refetching what is on screen.
+      const onScreen = reason === 'session-event' ? {refetchType: 'none' as const} : undefined
       if (sessionId) {
-        invalidateQueries(['agents', 'session', serverUrl, accountUid, sessionId])
+        invalidateQueries(['agents', 'session', serverUrl, accountUid, sessionId], onScreen)
         invalidateQueries(['agents', 'child-sessions', serverUrl, accountUid])
       }
-      if (agentId) invalidateQueries(['agents', 'detail', serverUrl, accountUid, agentId])
+      if (agentId) invalidateQueries(['agents', 'detail', serverUrl, accountUid, agentId], onScreen)
       if (reason === 'children' || reason === 'budget-pause') invalidateQueries(['agents', 'runs'])
       return
+    }
     default:
       // Unknown reason — likely a newer server. Refresh everything rather than miss it.
       invalidateQueries(['agents'])
@@ -3135,7 +3148,9 @@ export function useAgentWebSocketSubscription(
           return {...old, events: [...events, event.event]}
         },
       )
-      invalidateQueries(['agents', 'detail'])
+      // No agent-detail invalidation here: GetAgent returns the agent with every one of its
+      // sessions (two lookups per row on the server), and nothing in a transcript event changes
+      // the agent. The account hints refresh agent detail for the reasons that do.
     } else if (event._ === 'appendPartial') {
       // Run-keyed partials (workflow progress) are handled by the run-tree hook, not here.
       if (!event.key.startsWith('sessions/')) return


### PR DESCRIPTION
## Summary

Follow-up to #1077. Two pre-existing live-update paths turned every appended transcript event into heavy server calls for every viewer:

1. **Per-append GetAgent.** The per-session socket handler invalidated *every* cached agent detail on every append. `GetAgent` returns the agent with all of its sessions, two lookups per row — on prod the busiest agent has 511 sessions, so one call is ~1,000 SQLite statements, per message/tool call/tool result, per client with a transcript or agent page open.
2. **Three refetches per hint.** The coalesced account hint (≤1 per session per 1.5 s) refetched the sessions list, the open transcript in full (busiest prod session: 1,292 events), and the agent detail, for any client with the panel open. The transcript refetch duplicated the socket already streaming those events into the cache.

## Changes

- **Server:** the `session-event` / `session-updated` hints now carry the session's fresh `SessionInfo` next to the activity rollup (three cheap PK lookups; tolerant of a closed DB from the trailing timer). Protocol type extended; docs updated.
- **Client:** the snapshot is written into every list/detail that shows the session (`applySessionToCaches`), so the `ListSessions` refetch goes away. A `session-event` hint marks the transcript and agent detail stale with `refetchType: 'none'` — mounted copies are left alone (they stream on their own subscriptions), a remount still refetches. Other reasons (titles, child counts, parked runs) keep refetching what is on screen. A hint without a snapshot (older server) keeps the old behavior.
- **Client:** the per-append `['agents','detail']` invalidation is removed.
- **Sidebar:** the session view reads the agent's tools and access role from the agent lists the panel already holds instead of `GetAgent`.

## Before / after, per client watching a running session

| | before | after |
|---|---|---|
| per transcript event | 1 × GetAgent (~1,000 statements for the big agent) | 0 requests |
| per 1.5 s hint | ListSessions + GetSession (full transcript) + GetAgent | 0 requests |

The new client test (`agent-account-change-invalidation`) holds live observers on all three queries, feeds one hint, and asserts the caches are updated in place with zero refetches.

## Test plan

- [x] `agents`: api-service + main suites (142) — hint test now asserts the snapshot on every hint
- [x] `packages/ui`: invalidation suite incl. the new zero-refetch case; activity suite
- [x] `apps/desktop`: panel context / rendering / dialogs / new-session suites (66)
- [x] `apps/web`: assistant host suite
- [x] ui / desktop / web typecheck
- [ ] Manual: open a running session in the sidebar on dev and watch the server log — no `GetAgent` / `ListSessions` / `GetSession` per event

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sKXifeuCKfkEK7ih1MxLt
