### PR TITLE
Land on the unread chat when the panel opens; per-session state in the picker

### DIFF
--- a/agents/docs/persistence.md
+++ b/agents/docs/persistence.md
@@ -229,6 +229,10 @@ permanently wedge a session in `streaming` — the boot sweep requeues interrupt
 Deleting a session detaches rather than cascades: its runs keep their history with `session_id` nulled, and child
 sessions promote to top level (`parent_session_id` nulled).
 
+Latest message (`message_at`, `message_from`): the per-session half of the agent rollup above, written on every appended
+message from a person, a trigger or the agent in a top-level session; tool activity and child sessions never move it.
+Exposed as `SessionInfo.activity`, so a session list can mark which chats hold something unread.
+
 ### `runs`
 
 Every execution — an interactive turn, a trigger firing, an agent-started session, a delegated model child, a script

--- a/agents/protocol/src/index.ts
+++ b/agents/protocol/src/index.ts
@@ -1173,6 +1173,20 @@ export type SessionInfo = {
    * readable (and writable — writing here branches), but the foreground conversation moved on.
    */
   continuedTo?: SessionContinuationLink
+  /**
+   * The session's latest message from a person, a trigger, or the agent — tool activity excluded,
+   * like {@link AgentActivity}. Lets a session list show which chats hold something unread. Absent
+   * until the first message, and never set on delegated child sessions.
+   */
+  activity?: SessionActivity
+}
+
+/** Per-session counterpart of {@link AgentActivity}: only the message half. */
+export type SessionActivity = {
+  /** Time of the latest message. Tool activity excluded. */
+  messageAt: number
+  /** Who sent it. Triggers and the runtime count as `user`. */
+  messageFrom: 'user' | 'agent'
 }
 
 /** Why an agent carried a conversation into a fresh session. */

--- a/agents/src/api-service.test.ts
+++ b/agents/src/api-service.test.ts
@@ -4563,6 +4563,15 @@ describe('api service', () => {
       const activity = listed.agents.find((agent) => agent.id === agentId)?.activity
       expect(activity).toMatchObject({kind: 'agent', messageFrom: 'agent', sessionId, busy: false})
       expect(activity!.messageAt).toBe(activity!.at)
+      // The session carries its own last message too, for session lists.
+      const listedSessions = await svc.message(
+        await apisvc.createSignedEnvelope(account, {action: {_: 'ListSessions', agentId}}),
+      )
+      if (listedSessions._ !== 'ListSessionsResponse') throw new Error('unexpected response')
+      expect(listedSessions.sessions.find((s) => s.id === sessionId)?.activity).toEqual({
+        messageAt: activity!.messageAt,
+        messageFrom: 'agent',
+      })
       // GetAgent reads the same columns.
       const detail = await svc.message(await apisvc.createSignedEnvelope(account, {action: {_: 'GetAgent', agentId}}))
       expect(detail).toMatchObject({_: 'GetAgentResponse', agent: {activity: {kind: 'agent', sessionId}}})

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -2789,7 +2789,7 @@ export class Service {
 
     const rows = stmt<SessionRow, (string | number)[]>(
       this.#db,
-      `SELECT id, account_id, agent_id, title, status, parent_session_id, run_id, plan_cbor, model_override_cbor, description,
+      `SELECT id, account_id, agent_id, title, status, parent_session_id, run_id, plan_cbor, model_override_cbor, description, message_at, message_from,
                 (SELECT COUNT(*) FROM sessions c WHERE c.parent_session_id = sessions.id) AS child_count,
                 created_at, updated_at
          FROM sessions WHERE ${conditions.join(' AND ')} ORDER BY updated_at DESC, id DESC LIMIT ?`,
@@ -4020,7 +4020,7 @@ export class Service {
     }
     const session = stmt<SessionRow, [string, string]>(
       this.#db,
-      `SELECT id, account_id, agent_id, title, status, parent_session_id, run_id, plan_cbor, model_override_cbor, description,
+      `SELECT id, account_id, agent_id, title, status, parent_session_id, run_id, plan_cbor, model_override_cbor, description, message_at, message_from,
                 0 AS child_count, created_at, updated_at
          FROM sessions WHERE account_id = ? AND id = ?`,
     ).get(accountId, sessionId)
@@ -4588,7 +4588,7 @@ export class Service {
     const messages = normalizeMessageContent(rawContent)
     const session = stmt<SessionRow, [string, string]>(
       this.#db,
-      `SELECT id, account_id, agent_id, title, status, parent_session_id, run_id, plan_cbor, model_override_cbor, description,
+      `SELECT id, account_id, agent_id, title, status, parent_session_id, run_id, plan_cbor, model_override_cbor, description, message_at, message_from,
                 (SELECT COUNT(*) FROM sessions c WHERE c.parent_session_id = sessions.id) AS child_count,
                 created_at, updated_at
          FROM sessions WHERE account_id = ? AND id = ?`,
@@ -7751,11 +7751,17 @@ export class Service {
     // messages are nothing a person is waiting to read — the parent gets the result as a tool
     // result. Only top-level conversations move the message columns.
     const kind = parent?.parent_session_id ? 'tool' : sessionEventActivityKind(event)
-    stmt(this.#db, `UPDATE sessions SET updated_at = ? WHERE id = ?`).run([now, sessionId])
     if (kind === 'tool') {
+      stmt(this.#db, `UPDATE sessions SET updated_at = ? WHERE id = ?`).run([now, sessionId])
       stmt(this.#db, `UPDATE agents SET activity_at = ?, activity_kind = 'tool' WHERE id = ?`).run([now, agentId])
       return
     }
+    stmt(this.#db, `UPDATE sessions SET updated_at = ?, message_at = ?, message_from = ? WHERE id = ?`).run([
+      now,
+      now,
+      kind,
+      sessionId,
+    ])
     stmt(
       this.#db,
       `UPDATE agents SET activity_at = ?, activity_kind = ?, message_at = ?, message_from = ?, activity_session_id = ?
@@ -7926,7 +7932,7 @@ export class Service {
     }
     const session = stmt<SessionRow, [string, string]>(
       this.#db,
-      `SELECT id, account_id, agent_id, title, status, parent_session_id, run_id, plan_cbor, model_override_cbor, description,
+      `SELECT id, account_id, agent_id, title, status, parent_session_id, run_id, plan_cbor, model_override_cbor, description, message_at, message_from,
                 (SELECT COUNT(*) FROM sessions c WHERE c.parent_session_id = sessions.id) AS child_count,
                 created_at, updated_at
          FROM sessions WHERE account_id = ? AND id = ?`,
@@ -8215,7 +8221,7 @@ export class Service {
   #getSessionInfo(accountId: string, sessionId: string): api.SessionInfo | null {
     const session = stmt<SessionRow, [string, string]>(
       this.#db,
-      `SELECT id, account_id, agent_id, title, status, parent_session_id, run_id, plan_cbor, model_override_cbor, description,
+      `SELECT id, account_id, agent_id, title, status, parent_session_id, run_id, plan_cbor, model_override_cbor, description, message_at, message_from,
                 (SELECT COUNT(*) FROM sessions c WHERE c.parent_session_id = sessions.id) AS child_count,
                 created_at, updated_at
          FROM sessions WHERE account_id = ? AND id = ?`,
@@ -9145,6 +9151,8 @@ type SessionRow = {
   child_count: number
   created_at: number
   updated_at: number
+  message_at?: number | null
+  message_from?: api.SessionActivity['messageFrom'] | null
 }
 
 type SessionEventRow = {
@@ -9672,6 +9680,9 @@ function sessionRowToInfo(
     ...(row.child_count > 0 ? {childSessionCount: row.child_count} : {}),
     ...(continuation.continuedFrom ? {continuedFrom: continuation.continuedFrom} : {}),
     ...(continuation.continuedTo ? {continuedTo: continuation.continuedTo} : {}),
+    ...(typeof row.message_at === 'number' && row.message_from
+      ? {activity: {messageAt: row.message_at, messageFrom: row.message_from}}
+      : {}),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     ...(triggerContext

--- a/agents/src/sqlite-schema.sql
+++ b/agents/src/sqlite-schema.sql
@@ -125,7 +125,11 @@ CREATE TABLE sessions (
     model_override_cbor BLOB,
     description TEXT,
     created_at INTEGER NOT NULL,
-    updated_at INTEGER NOT NULL
+    updated_at INTEGER NOT NULL,
+    -- Latest message from a person, a trigger or the agent (see SessionActivity in the protocol).
+    -- Tool activity never moves these; delegated child sessions never set them.
+    message_at INTEGER,
+    message_from TEXT
 ) WITHOUT ROWID;
 
 CREATE INDEX sessions_by_agent ON sessions (agent_id, updated_at DESC);

--- a/agents/src/sqlite.ts
+++ b/agents/src/sqlite.ts
@@ -14,6 +14,10 @@ export const BASELINE_SCHEMA_MIGRATION_VERSION = 0
 /** Prepend-only database migrations. */
 export const migrations: string[] = [
   // ======= IMPORTANT: Add new migrations below this line. =======
+  // Per-session latest message (see SessionActivity in the protocol), so a session list can show
+  // which chats hold something unread without the agent-level rollup.
+  `ALTER TABLE sessions ADD COLUMN message_at INTEGER;
+  ALTER TABLE sessions ADD COLUMN message_from TEXT;`,
   // Latest transcript activity rolled up per agent (see AgentActivity in the protocol): written on
   // every appended session event, read with the agent so unread indicators never list sessions.
   `ALTER TABLE agents ADD COLUMN activity_at INTEGER;

--- a/frontend/apps/desktop/src/__tests__/assistant-dialogs.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/assistant-dialogs.test.tsx
@@ -21,6 +21,8 @@ vi.mock('@shm/ui/agents/activity', () => ({
   markAgentSessionRead: () => {},
 }))
 vi.mock('@shm/ui/agents/models', () => ({
+  // The create-agent dialog checks the server before offering models; here it is never reached.
+  useAgentServerHealth: () => ({data: undefined, isLoading: false}),
   LOCAL_AGENT_SERVER_LABEL: 'Local Agents',
   isLocalAgentServer: () => false,
   describeAgentServer: (serverUrl: string) => new URL(serverUrl).host,

--- a/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/assistant-message-rendering.test.tsx
@@ -82,6 +82,8 @@ vi.mock('@shm/ui/agents/activity', () => ({
   markAgentSessionRead: () => {},
 }))
 vi.mock('@shm/ui/agents/models', () => ({
+  // The create-agent dialog checks the server before offering models; here it is never reached.
+  useAgentServerHealth: () => ({data: undefined, isLoading: false}),
   useSessionAttachmentDataUrls: () => ({}),
   // The delegate row resolves its live child through these; inert here — no child ever resolves.
   useSessionRuns: () => ({data: undefined}),

--- a/frontend/apps/desktop/src/__tests__/assistant-new-session-selection.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/assistant-new-session-selection.test.tsx
@@ -71,8 +71,12 @@ describe('sidebar new-chat selection after CreateSession', () => {
     queryClient.clear()
   })
 
-  it('without the seed, a stale list cannot place the new session, so it is not shown (the bug this guards)', () => {
+  it('without the seed, a stale list cannot name the new session’s agent, so the resolver holds it until its fetch does', () => {
     queryClient.setQueryData(listKey, [{serverUrl: SERVER, session: session('s-old', 100)}])
+    // Undetermined, not dropped: dropping here sent the panel to a draft while the lists loaded.
+    expect(resolveFromCaches('s-new').session).toEqual({serverUrl: SERVER, sessionId: 's-new'})
+    // Once its own fetch names another agent, it no longer belongs in this context.
+    queryClient.setQueryData(sessionKey('s-new'), {session: {...session('s-new', 200), agentId: 'someone-else'}})
     expect(resolveFromCaches('s-new').session).toBeNull()
   })
 

--- a/frontend/apps/desktop/src/__tests__/assistant-panel-context.test.tsx
+++ b/frontend/apps/desktop/src/__tests__/assistant-panel-context.test.tsx
@@ -44,6 +44,8 @@ vi.mock('@shm/ui/agents/activity', async (importOriginal) => ({
   },
 }))
 vi.mock('@shm/ui/agents/models', () => ({
+  // The create-agent dialog checks the server before offering models; here it is never reached.
+  useAgentServerHealth: () => ({data: undefined, isLoading: false}),
   LOCAL_AGENT_SERVER_LABEL: 'Local Agents',
   isLocalAgentServer: (serverUrl: string, localServerUrl?: string | null) =>
     !!localServerUrl && serverUrl === localServerUrl,
@@ -193,7 +195,17 @@ beforeEach(() => {
     {data: [{id: 'researcher', definition: {name: 'Researcher', model: 'gpt-5'}}]},
   ]
   mockState.sessionEntries = [
-    {serverUrl: REMOTE, session: {id: 's-r1', agentId: 'researcher', title: 'Web research', updatedAt: 400}},
+    {
+      serverUrl: REMOTE,
+      session: {
+        id: 's-r1',
+        agentId: 'researcher',
+        title: 'Web research',
+        updatedAt: 400,
+        status: 'idle',
+        activity: {messageAt: 100, messageFrom: 'agent'},
+      },
+    },
     {serverUrl: LOCAL, session: {id: 's-a1', agentId: 'assistant', title: 'Doc questions', updatedAt: 300}},
   ]
 })
@@ -259,6 +271,36 @@ describe('assistant sidebar agent context', () => {
     expect(document.body.textContent).toContain('Web research')
     expect(hasActiveSession()).toBe(true)
     expect(mockState.marked).toEqual([{serverUrl: REMOTE, sessionId: 's-r1', seenAt: 100}])
+  })
+
+  it('the session list marks each chat that holds something unread, from the session’s own last message', () => {
+    // The device has seen nothing since the baseline; both agents' chats carry a later reply.
+    mockState.sessionEntries = [
+      ...mockState.sessionEntries,
+      {
+        serverUrl: REMOTE,
+        session: {
+          id: 's-r2',
+          agentId: 'researcher',
+          title: 'Older thread',
+          updatedAt: 350,
+          status: 'streaming',
+          activity: {messageAt: 30, messageFrom: 'user'},
+        },
+      },
+    ]
+    act(() => {
+      root.render(<AssistantPanel initialSessionId={`${REMOTE} | s-r1`} />)
+    })
+    // On screen: s-r1. Open the chat list: s-r1 is the unread reply, s-r2 was read before the
+    // baseline but the agent is working in it now.
+    clickText('Web research')
+    const marks = Array.from(document.body.querySelectorAll('[data-testid="agent-activity-mark"]')).map((el) =>
+      el.getAttribute('data-tone'),
+    )
+    expect(marks).toContain('agent')
+    expect(marks).toContain('busy')
+    expect(document.body.textContent).toContain('Working')
   })
 
   it('opens straight onto the unread chat when there is one, marked read on arrival', () => {

--- a/frontend/packages/ui/src/__tests__/agent-activity.test.ts
+++ b/frontend/packages/ui/src/__tests__/agent-activity.test.ts
@@ -4,6 +4,7 @@ import {
   agentActivityReadKey,
   agentRowActivity,
   isAgentActivityUnread,
+  sessionRowActivity,
   latestSessionEventAt,
   summarizeAgentActivity,
   type AgentActivityReadState,
@@ -108,6 +109,29 @@ describe('agent activity indicator', () => {
     const idle = {...unreadBusy, busy: false}
     expect(agentRowActivity(idle, server, 'Researcher', read(80))).toBeNull()
     expect(agentRowActivity(undefined, server, 'Researcher', read(80))).toBeNull()
+  })
+
+  test('a session row shows its own unread state, then the agent working in it, then nothing', () => {
+    const base = {id: 's', account: 'z6MkOwner', agentId: 'a', createdAt: 0, updatedAt: 90} as const
+    const replied = {...base, status: 'idle' as const, activity: {messageAt: 80, messageFrom: 'agent' as const}}
+    expect(sessionRowActivity(replied, server, read(10))).toMatchObject({
+      tone: 'agent',
+      unread: true,
+      short: 'New reply',
+    })
+    expect(sessionRowActivity(replied, server, read(80))).toBeNull()
+    expect(sessionRowActivity(replied, server, read(10, {[agentActivityReadKey(server, 's')]: 80}))).toBeNull()
+    // Unread beats working; once read, a streaming session shows the agent at work, naming the
+    // tool when the agent's rollup points at this very session.
+    const working = {...replied, status: 'streaming' as const}
+    expect(sessionRowActivity(working, server, read(10))).toMatchObject({tone: 'agent', unread: true})
+    expect(sessionRowActivity(working, server, read(80))).toMatchObject({tone: 'busy', short: 'Working'})
+    const rollup = {at: 95, kind: 'tool', messageAt: 80, messageFrom: 'agent', sessionId: 's', busy: true} as const
+    expect(sessionRowActivity(working, server, read(80), rollup)).toMatchObject({tone: 'busy', short: 'Running a tool'})
+    // No message yet and idle: the plain status dot.
+    expect(sessionRowActivity({...base, status: 'idle'}, server, read(10))).toBeNull()
+    // Before the first-run baseline nothing is unread, but a working agent still shows.
+    expect(sessionRowActivity(working, server, undefined)).toMatchObject({tone: 'busy'})
   })
 
   test('the newest event time of a transcript is what a view marks as read', () => {

--- a/frontend/packages/ui/src/agents/activity.tsx
+++ b/frontend/packages/ui/src/agents/activity.tsx
@@ -1,4 +1,4 @@
-import type {AgentActivity, AgentInfo} from '@seed-hypermedia/agents-protocol'
+import type {AgentActivity, AgentInfo, SessionInfo} from '@seed-hypermedia/agents-protocol'
 import {getQueryClient} from '@shm/shared/models/query-client'
 import {useQuery} from '@tanstack/react-query'
 import {useEffect, useMemo} from 'react'
@@ -154,6 +154,43 @@ export function summarizeAgentActivity(
     sessionId: pick.activity.sessionId,
     label: pick.activity.kind === 'tool' ? `${agentName} is running a tool` : `${agentName} is working`,
   }
+}
+
+/**
+ * One session's own indicator, as a session list shows it: its unread tone when its latest message
+ * is unseen on this device, amber while the agent is streaming in it, otherwise nothing (the plain
+ * status dot). `agentActivity` — the agent's rollup — names the tool when the busy session is the
+ * one it points at.
+ */
+export function sessionRowActivity(
+  session: SessionInfo,
+  serverUrl: string,
+  read: AgentActivityReadState | undefined,
+  agentActivity?: AgentActivity,
+): AgentRowActivity | null {
+  const message = session.activity
+  if (message && read && read.allBefore !== undefined) {
+    const seen = Math.max(read.allBefore, read.sessions[agentActivityReadKey(serverUrl, session.id)] ?? 0)
+    if (message.messageAt > seen) {
+      const tone = message.messageFrom === 'agent' ? 'agent' : 'user'
+      return {
+        tone,
+        unread: true,
+        label: tone === 'agent' ? 'Unread reply' : 'Unread message',
+        short: tone === 'agent' ? 'New reply' : 'New message',
+      }
+    }
+  }
+  if (session.status === 'streaming') {
+    const tool = agentActivity?.sessionId === session.id && agentActivity.kind === 'tool' && agentActivity.busy
+    return {
+      tone: 'busy',
+      unread: false,
+      label: tool ? 'Running a tool' : 'Working',
+      short: tool ? 'Running a tool' : 'Working',
+    }
+  }
+  return null
 }
 
 /** The device's read marks, loaded once from the platform setting. */

--- a/frontend/packages/ui/src/agents/assistant-panel.tsx
+++ b/frontend/packages/ui/src/agents/assistant-panel.tsx
@@ -42,13 +42,15 @@ import {
 import {
   agentRowActivity,
   latestSessionEventAt,
+  sessionRowActivity,
   markAgentSessionRead,
   summarizeAgentActivity,
   useAgentActivityReadState,
   useMarkAgentSessionRead,
+  type AgentActivityReadState,
   type AgentRowActivity,
 } from './activity'
-import {AgentActivityMark, type AgentActivityTone} from './activity-dot'
+import {AgentActivityMark} from './activity-dot'
 import {CreateAgentDialog} from './dialogs'
 import {useSelectedAccountId} from './account'
 import {useNavigate} from './navigation'
@@ -100,6 +102,7 @@ import {
   type AssistantSessionRef,
 } from './assistant-session-ref'
 import {AgentServerError, type AgentInfo} from './client'
+import type {AgentActivity} from '@seed-hypermedia/agents-protocol'
 import {describeAgentError, errorMessage} from './errors'
 import {useAssistantWindowContextLines} from './assistant-window-context'
 import {AgentRichMessageComposer, SubSessionDrivenNotice, TERMINAL_RUN_STATUSES} from './rich-message-composer'
@@ -295,11 +298,6 @@ export function AssistantPanel({
     }
     return rows
   }, [agents, readState.data])
-  const activeRow = activeAgent ? rowActivities[`${activeAgent.serverUrl}${activeAgent.agent.id}`] : undefined
-  const activeUnreadTone = activeRow?.unread ? (activeRow.tone as 'agent' | 'user') : undefined
-  const activeUnreadSession = activeUnreadTone
-    ? {sessionId: activeAgent!.agent.activity!.sessionId, tone: activeUnreadTone}
-    : null
 
   // Opening the panel with something unread lands on it: the newest unread chat across agents,
   // marked read on arrival. Decided once per mount, as soon as the lists have settled, so a
@@ -307,7 +305,7 @@ export function AssistantPanel({
   // start a new chat keeps that intent instead.
   const jumpedToUnreadRef = useRef(false)
   useEffect(() => {
-    if (jumpedToUnreadRef.current || !agentsSettled || !readState.data) return
+    if (jumpedToUnreadRef.current || !agentsSettled || sessions.isLoading || !readState.data) return
     jumpedToUnreadRef.current = true
     if (newChatRequest) return
     const indicator = summarizeAgentActivity(agents, readState.data)
@@ -319,7 +317,7 @@ export function AssistantPanel({
     setChosenAgent({serverUrl: indicator.serverUrl, agentId: indicator.agentId})
     selectSession({serverUrl: indicator.serverUrl, sessionId: indicator.sessionId})
     markAgentSessionRead(indicator.serverUrl, indicator.sessionId, picked.agent.activity.messageAt)
-  }, [agentsSettled, readState.data, agents, newChatRequest, setChosenAgent, selectSession])
+  }, [agentsSettled, sessions.isLoading, readState.data, agents, newChatRequest, setChosenAgent, selectSession])
   const activeSession = selection.session
   const sessionEntry = activeSession
     ? sessions.entries.find(
@@ -403,7 +401,8 @@ export function AssistantPanel({
           selected={activeSession}
           selectedTitle={sessionTitle}
           isDraft={!activeSession}
-          unreadSession={activeUnreadSession}
+          readState={readState.data}
+          agentActivity={activeAgent?.agent.activity}
           onSelect={selectSession}
         />
         {activeSession ? (
@@ -702,7 +701,8 @@ function AssistantSessionPicker({
   selected,
   selectedTitle,
   isDraft,
-  unreadSession,
+  readState,
+  agentActivity,
   onSelect,
 }: {
   entries: AgentSessionListEntry[]
@@ -711,13 +711,28 @@ function AssistantSessionPicker({
   selected: AssistantSessionRef | null
   selectedTitle?: string
   isDraft: boolean
-  /** The active agent's session holding its unseen latest message, if any. */
-  unreadSession?: {sessionId: string; tone: AgentActivityTone} | null
+  /** This device's read marks, for each row's unread state. */
+  readState?: AgentActivityReadState
+  /** The active agent's rollup, which names the tool a busy session is running. */
+  agentActivity?: AgentActivity
   onSelect: (ref: AssistantSessionRef) => void
 }) {
   const [open, setOpen] = useState(false)
-  // Unread somewhere other than what is on screen: the trigger points at the list.
-  const unreadElsewhere = unreadSession && unreadSession.sessionId !== selected?.sessionId ? unreadSession : null
+  // Each row's own indicator — unread, or the agent working in it — and, for the closed trigger,
+  // the most pressing one among the chats not on screen.
+  const rows = useMemo(() => {
+    const byId: Record<string, AgentRowActivity> = {}
+    for (const entry of entries) {
+      const row = sessionRowActivity(entry.session, entry.serverUrl, readState, agentActivity)
+      if (row) byId[entry.session.id] = row
+    }
+    return byId
+  }, [entries, readState, agentActivity])
+  const elsewhere = entries
+    .filter((entry) => entry.session.id !== selected?.sessionId)
+    .map((entry) => rows[entry.session.id])
+    .filter((row): row is AgentRowActivity => !!row)
+  const triggerRow = elsewhere.find((row) => row.unread) ?? elsewhere[0] ?? null
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -729,7 +744,7 @@ function AssistantSessionPicker({
           <span className="min-w-0 flex-1 truncate text-left">
             {isDraft ? 'New chat' : selectedTitle || 'Untitled session'}
           </span>
-          {unreadElsewhere ? <AgentActivityMark tone={unreadElsewhere.tone} label="Unread chat" /> : null}
+          {triggerRow ? <AgentActivityMark tone={triggerRow.tone} label={triggerRow.label} /> : null}
           <ChevronDown className="size-3 shrink-0" />
         </button>
       </PopoverTrigger>
@@ -753,14 +768,24 @@ function AssistantSessionPicker({
                     setOpen(false)
                   }}
                 >
-                  <SessionStatusDot status={entry.session.status} className="size-2" />
+                  {rows[entry.session.id] ? (
+                    <AgentActivityMark
+                      tone={rows[entry.session.id]!.tone}
+                      label={rows[entry.session.id]!.label}
+                      className="size-2"
+                    />
+                  ) : (
+                    <SessionStatusDot status={entry.session.status} className="size-2" />
+                  )}
                   <span className="flex min-w-0 flex-1 flex-col">
                     <span className="flex items-center gap-1.5">
                       <span className="min-w-0 flex-1 truncate text-xs">
                         {entry.session.title || 'Untitled session'}
                       </span>
-                      {unreadSession?.sessionId === entry.session.id ? (
-                        <AgentActivityMark tone={unreadSession.tone} label="Unread" />
+                      {rows[entry.session.id] ? (
+                        <span className="text-muted-foreground shrink-0 text-[10px]">
+                          {rows[entry.session.id]!.short}
+                        </span>
                       ) : null}
                     </span>
                     {entry.session.description ? (

--- a/frontend/packages/ui/src/agents/assistant-selection.ts
+++ b/frontend/packages/ui/src/agents/assistant-selection.ts
@@ -125,10 +125,12 @@ export function resolveAssistantSelection(input: AssistantSelectionInput): Assis
   // moment later would flash the UI, and worse, the replacement would be written back as the
   // remembered selection. A refusal from the server settles it the other way.
   const chosenPending = !!input.chosenAgent && !chosen && !agentsSettled
+  // Undetermined whichever way the agent was chosen: a chosen agent says nothing about a stored
+  // session whose own agent is not yet known (session lists still loading, its fetch pending). The
+  // panel lands on a just-selected chat exactly this way — agent chosen, session named, lists not
+  // yet in — and dropping it here sent the user to a draft instead.
   const storedUndetermined =
-    !!input.storedSession &&
-    !input.storedSessionUnavailable &&
-    (chosenPending || (!input.chosenAgent && (!storedAgentId || !agentsSettled)))
+    !!input.storedSession && !input.storedSessionUnavailable && (chosenPending || !storedAgentId || !agentsSettled)
 
   if (input.storedSession && (storedBelongsToAgent || storedUndetermined)) {
     return {agent, agentSessions, session: input.storedSession}


### PR DESCRIPTION
## Summary

Two bugs found in manual testing of #1077.

**1. Opening the panel with something unread showed the agent's "new chat" draft, not the unread session.** The jump chose the right agent and marked the session read (so the dot cleared), but the selection resolver dropped a stored session whenever a chosen agent was set and the session's own agent was not yet known — exactly the state the jump produces while the session list is still loading — and the write-back effect then cleared the stored ref. The resolver now holds such a session until its agent is known (lists loaded, or its own fetch answered) and drops it only if that names another agent. The jump also waits for the session list. The resolver test that documented the old drop now asserts the hold.

**2. The session picker showed no per-session state.** Sessions now carry their own latest message on the server (`message_at`, `message_from`, exposed as `SessionInfo.activity`; tool activity and delegated child sessions never move them — same rule as the agent rollup). Each row in the picker shows:
- red / blue when that session's latest message is unseen on this device ("New reply" / "New message")
- pulsing amber while the agent is streaming in it ("Working", or "Running a tool" when the agent's rollup points at that session)
- the plain status dot otherwise

The closed picker trigger carries the most pressing state among the chats not on screen.

Also adds the `useAgentServerHealth` mock to three desktop panel suites that have been failing on main since the create-agent dialog started calling it — desktop unit test failures do not gate CI, so this went unnoticed.

Migration: two nullable columns on `sessions`, instant.

## Test plan

- [x] `agents`: full suite (487) — rollup test now also asserts `ListSessions` reports the session's own last message; prettier
- [x] `packages/ui`: activity suite incl. `sessionRowActivity` cases; invalidation, toggle, space-agents suites
- [x] `apps/desktop`: selection, new-session-selection (rewritten case), panel context incl. new per-session marks case, rendering, dialogs, agents list
- [x] `apps/web`: assistant host, agents page
- [x] ui / desktop / web typecheck
- [ ] Manual: with a red dot, open the panel → the unread session is on screen, not a draft; open the session dropdown → unread and working chats are marked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sKXifeuCKfkEK7ih1MxLt
