### PR TITLE
perf(backend): index each block once per change; single-row fts move lookup

### DIFF
--- a/backend/blob/blob_change.go
+++ b/backend/blob/blob_change.go
@@ -401,6 +401,22 @@ func indexChange(ictx *indexingCtx, id int64, eb Encoded[*Change]) error {
 
 	extra := changeIndexedAttrs{Actor: uint64(author.ActorID())}
 	opIndex := -1
+
+	// Each block gets at most one fts row per change.
+	//
+	// The CRDT emits one MoveBlocks entry per recorded move, so a block dragged
+	// around during an editing session can appear thousands of times in a single
+	// change. Indexing every entry used to look up the block's previous content
+	// (a scan over every fts row the block already had) and insert yet another
+	// copy, which made the reindex quadratic in the number of moves. Moves are
+	// therefore only collected here and resolved after the loop, and only for
+	// blocks that the change doesn't also replace or delete: those ops write the
+	// block's final content for this version themselves, so a move row would be
+	// a stale duplicate at the same version.
+	ftsWritten := map[string]struct{}{}
+	movedSeen := map[string]struct{}{}
+	var movedBlocks []string
+
 	for op, err := range v.Ops() {
 		opIndex++
 		if err != nil {
@@ -500,28 +516,47 @@ func indexChange(ictx *indexingCtx, id int64, eb Encoded[*Change]) error {
 			if err := dbFTSInsertOrReplace(ictx.conn, blk.Text, "document", id, blk.ID(), sb.CID.String(), sb.Ts, sb.GenesisBlob.Hash().String()); err != nil {
 				return fmt.Errorf("failed to insert record in fts table: %w", err)
 			}
+			ftsWritten[blk.ID()] = struct{}{}
 		case OpMoveBlocks:
 			for _, blk := range op.Blocks {
-				content, _, err := dbFTSGetRawContent(ictx.conn, id, blk, sb.GenesisBlob.Hash().String())
-				if err != nil {
-					return fmt.Errorf("failed to get raw content for block %s: %w", blk, err)
-				}
-				if content == "" {
+				if _, seen := movedSeen[blk]; seen {
 					continue
-				} else if err := dbFTSInsertOrReplace(ictx.conn, content, "document", id, blk, sb.CID.String(), sb.Ts, sb.GenesisBlob.Hash().String()); err != nil {
-					return fmt.Errorf("failed to insert record in fts table: %w", err)
 				}
-
+				movedSeen[blk] = struct{}{}
+				movedBlocks = append(movedBlocks, blk)
 			}
 
 		case OpDeleteBlocks:
 			for _, blk := range op.Blocks {
+				if _, done := ftsWritten[blk]; done {
+					continue
+				}
 				if err := dbFTSInsertOrReplace(ictx.conn, "", "document", id, blk, sb.CID.String(), sb.Ts, sb.GenesisBlob.Hash().String()); err != nil {
 					return fmt.Errorf("failed to insert record in fts table: %w", err)
 				}
+				ftsWritten[blk] = struct{}{}
 			}
 
 		}
+	}
+
+	// Blocks that were only moved keep their latest indexed content, re-recorded
+	// under this change's version so search can point at it.
+	for _, blk := range movedBlocks {
+		if _, done := ftsWritten[blk]; done {
+			continue
+		}
+		content, _, err := dbFTSGetRawContent(ictx.conn, id, blk, sb.GenesisBlob.Hash().String())
+		if err != nil {
+			return fmt.Errorf("failed to get raw content for block %s: %w", blk, err)
+		}
+		if content == "" {
+			continue
+		}
+		if err := dbFTSInsertOrReplace(ictx.conn, content, "document", id, blk, sb.CID.String(), sb.Ts, sb.GenesisBlob.Hash().String()); err != nil {
+			return fmt.Errorf("failed to insert record in fts table: %w", err)
+		}
+		ftsWritten[blk] = struct{}{}
 	}
 
 	if extra.Title != "" || len(extra.Metadata) > 0 || len(extra.Attributes) > 0 {

--- a/backend/blob/blob_change.go
+++ b/backend/blob/blob_change.go
@@ -404,15 +404,18 @@ func indexChange(ictx *indexingCtx, id int64, eb Encoded[*Change]) error {
 
 	// Each block gets at most one fts row per change.
 	//
-	// The CRDT emits one MoveBlocks entry per recorded move, so a block dragged
-	// around during an editing session can appear thousands of times in a single
-	// change. Indexing every entry used to look up the block's previous content
-	// (a scan over every fts row the block already had) and insert yet another
-	// copy, which made the reindex quadratic in the number of moves. Moves are
-	// therefore only collected here and resolved after the loop, and only for
-	// blocks that the change doesn't also replace or delete: those ops write the
-	// block's final content for this version themselves, so a move row would be
-	// a stale duplicate at the same version.
+	// A change can list the same block in MoveBlocks ops many times over: the
+	// block tree's Commit yields a subtree once per historical position of its
+	// ancestors (older writers batched those repeats into a single op, and prod
+	// has one op moving the same block 1962 times), and frontend clients build
+	// MoveBlocks ops directly without going through docmodel. Indexing every
+	// entry used to look up the block's previous content (a scan over every fts
+	// row the block already had) and insert yet another copy, which made the
+	// reindex quadratic in the number of moves. Moves are therefore only
+	// collected here and resolved after the loop, and only for blocks that the
+	// change doesn't also replace or delete: those ops write the block's final
+	// content for this version themselves, so a move row would be a stale
+	// duplicate at the same version.
 	ftsWritten := map[string]struct{}{}
 	movedSeen := map[string]struct{}{}
 	var movedBlocks []string

--- a/backend/blob/index_sql.go
+++ b/backend/blob/index_sql.go
@@ -51,6 +51,12 @@ var qBlobLinksInsertOrIgnore = dqb.Str(`
 	VALUES (:blobLinksSource, :blobLinksType, :blobLinksTarget)
 `)
 
+// The raw-content lookups return only the most recently indexed non-empty row
+// for the block. fts_index is WITHOUT ROWID with the fts rowid as its primary
+// key, so within one genesis (or blob) the index is ordered by rowid and the
+// reverse scan stops at the first hit without a sort. Scanning the whole group
+// instead used to dominate reindexing: the group grows with every indexed move
+// of the block, and every move triggered one such scan.
 var qFTSGetRawContentByGenesis = dqb.Str(`
 	SELECT
 	fts.raw_content,
@@ -59,6 +65,9 @@ FROM fts_index ftsi
 JOIN fts ON fts.rowid = ftsi.rowid
 WHERE ftsi.block_id = :FTSBlockID
 AND ftsi.genesis_blob = :FTSGenesisBlob
+AND fts.raw_content != ''
+ORDER BY ftsi.rowid DESC
+LIMIT 1
 `)
 
 var qFTSGetRawContentByBlobID = dqb.Str(`
@@ -69,8 +78,14 @@ FROM fts_index ftsi
 JOIN fts ON fts.rowid = ftsi.rowid
 WHERE ftsi.block_id = :FTSBlockID
 AND ftsi.blob_id = :FTSBlobID
+AND fts.raw_content != ''
+ORDER BY ftsi.rowid DESC
+LIMIT 1
 `)
 
+// dbFTSGetRawContent returns the latest non-empty indexed content of a block
+// within the document identified by its genesis multihash (or, when that is
+// empty, within the given blob), along with the version it was indexed under.
 func dbFTSGetRawContent(conn *sqlite.Conn, FTSBlobID int64, FTSBlockID, FTSGenesisMultihash string) (string, string, error) {
 	before := func(stmt *sqlite.Stmt) {
 		stmt.SetText(":FTSBlockID", FTSBlockID)
@@ -99,10 +114,7 @@ func dbFTSGetRawContent(conn *sqlite.Conn, FTSBlobID int64, FTSBlockID, FTSGenes
 
 	var rawContent, ftsVersion string
 	var err error
-	onStep := func(i int, stmt *sqlite.Stmt) error {
-		if stmt.ColumnText(0) == "" {
-			return nil
-		}
+	onStep := func(_ int, stmt *sqlite.Stmt) error {
 		rawContent = stmt.ColumnText(0)
 		ftsVersion = stmt.ColumnText(1)
 		return nil

--- a/backend/blob/index_test.go
+++ b/backend/blob/index_test.go
@@ -53,6 +53,74 @@ func TestIndexIgnoresNonScalarDocumentAttributes(t *testing.T) {
 	require.Equal(t, 1, indexed, "only the scalar name attribute must be indexed")
 }
 
+// A block gets exactly one fts row per change, no matter how many times the
+// change moves it, and a move never records stale content for a block the same
+// change replaces. Before this, each move entry re-read and re-inserted the
+// block's content, which made a full reindex quadratic in the number of moves.
+func TestIndexChangeIndexesEachBlockOncePerChange(t *testing.T) {
+	alice := coretest.NewTester("alice").Account
+	db := storage.MakeTestDB(t)
+	idx, err := OpenIndex(t.Context(), db, zap.NewNop())
+	require.NoError(t, err)
+
+	clock := cclock.New()
+	first, err := NewChange(alice, cid.Undef, nil, 0, ChangeBody{
+		Ops: []OpMap{
+			NewOpMoveBlocks("", []string{"b1", "b2"}, nil),
+			NewOpReplaceBlock(Block{ID_Good: "b1", Type: "paragraph", Text: "hello"}),
+			NewOpReplaceBlock(Block{ID_Good: "b2", Type: "paragraph", Text: "world"}),
+		},
+	}, clock.MustNow())
+	require.NoError(t, err)
+
+	// b1 is dragged around 500 times and then rewritten; b2 is only moved.
+	moved := make([]string, 0, 501)
+	for range 500 {
+		moved = append(moved, "b1")
+	}
+	moved = append(moved, "b2")
+	second, err := NewChange(alice, first.CID, []cid.Cid{first.CID}, 1, ChangeBody{
+		Ops: []OpMap{
+			NewOpMoveBlocks("", moved, nil),
+			NewOpReplaceBlock(Block{ID_Good: "b1", Type: "paragraph", Text: "changed"}),
+		},
+	}, clock.MustNow())
+	require.NoError(t, err)
+
+	ref, err := NewRef(alice, 0, first.CID, alice.Principal(), "/moves", []cid.Cid{second.CID}, clock.MustNow(), VisibilityPublic)
+	require.NoError(t, err)
+	require.NoError(t, idx.PutMany(t.Context(), []blocks.Block{first, second, ref}))
+
+	const q = `
+		SELECT json_group_object(fi.block_id, fts.raw_content)
+		FROM fts_index fi
+		JOIN fts ON fts.rowid = fi.rowid
+		JOIN blobs b ON b.id = fi.blob_id
+		WHERE b.multihash = ? AND fi.type = 'document'
+	`
+	for _, tt := range []struct {
+		name   string
+		change Encoded[*Change]
+		want   map[string]string
+	}{
+		{"first", first, map[string]string{"b1": "hello", "b2": "world"}},
+		{"second", second, map[string]string{"b1": "changed", "b2": "world"}},
+	} {
+		rows, err := sqlitex.QueryOnePool[int](t.Context(), db, `
+			SELECT COUNT() FROM fts_index fi JOIN blobs b ON b.id = fi.blob_id
+			WHERE b.multihash = ? AND fi.type = 'document'
+		`, []byte(tt.change.CID.Hash()))
+		require.NoError(t, err)
+		require.Equal(t, len(tt.want), rows, "%s change: one fts row per block", tt.name)
+
+		raw, err := sqlitex.QueryOnePool[string](t.Context(), db, q, []byte(tt.change.CID.Hash()))
+		require.NoError(t, err)
+		var got map[string]string
+		require.NoError(t, json.Unmarshal([]byte(raw), &got))
+		require.Equal(t, tt.want, got, "%s change: indexed content", tt.name)
+	}
+}
+
 func TestIterChangesDoesNotLoadResolvedAttributes(t *testing.T) {
 	alice := coretest.NewTester("alice").Account
 	db := storage.MakeTestDB(t)


### PR DESCRIPTION
## Problem

A production CPU profile of the migration reindex (100 s window, 169.8 s CPU) spends **95 s of the reindex's 96.8 s in a single SELECT**: the raw-content lookup that the `OpMoveBlocks` branch of `indexChange` runs for every block entry of every move op. All fts inserts together take 0.7 s; everything else in indexing takes 1.75 s. The query plan is fine on both the system SQLite and the vendored 3.45.2; the cost is volume, and it is quadratic:

1. A change can list the same block in move ops many times. The block tree's `Commit` traversal yields a subtree once per historical position of its ancestors (no visited set in the BFS at `crdt_block_tree.go:370`, and old positions are never removed from the parent lists). Before 88d018f9f those repeats were batched into a single op, which is the shape in prod: one op moving the same block 1962 times. Frontend clients also build `MoveBlocks` ops directly without docmodel. The `Commit` duplicate yield will get its own PR; the indexer has to tolerate repeated ids regardless.
2. Each entry scanned every fts row the block already had for that document and then inserted one more duplicate (`INSERT OR REPLACE INTO fts` never replaces, and `fts_index` keys on a fresh rowid). The worst group in the April prod backup has 2044 rows for one 2-character block, 2029 of them from one change.
3. 98% of the lookups were wasted: across the backup, 53,538 of 62,608 lookups are for blocks the same change also replaces, and the `ReplaceBlock` op writes the final content itself. The move row was a stale duplicate at the same version.

Introduced by 03d873557 (2025-07-29, "account for moves in indexing search"). Every scheduled reindex since then has paid it, and it gets worse with every move-heavy edit, which is why the reindex from #1066's migration is so slow now.

## Why move rows exist at all

Only for search deep links. Before 03d873557 search could only link to a version that had fts rows, so a document whose latest version was just a move always showed "Previous Version". Indexing moves also makes a "previous version" link open the last snapshot where the block had that text, in the place it was moved to. fts writes are synchronous by design (search must work as soon as the app opens); only embeddings are async.

## Fix

- `indexChange` collects moved blocks (deduplicated) and resolves them after the ops loop, skipping any block the change replaces or deletes. Each block gets at most one fts row per change.
- `dbFTSGetRawContent` returns only the latest non-empty row: `AND fts.raw_content != '' ORDER BY ftsi.rowid DESC LIMIT 1`. `fts_index` is WITHOUT ROWID with the fts rowid as its primary key, so this is a reverse scan of the existing index with no sort (verified with `EXPLAIN QUERY PLAN` on the vendored 3.45.2 against the prod backup). Semantics are unchanged: the old `onStep` kept the last non-empty row in index order, which is the same row.

On the April prod backup this cuts the lookups from 62,608 to about 1,200.

## Test

`TestIndexChangeIndexesEachBlockOncePerChange`: a change that moves `b1` 500 times and also replaces it, and moves `b2` only. Asserts one fts row per block for the change, `b1` carries the new text (no stale row), `b2` keeps its previous text. Fails on `main` with 502 rows for 2 blocks.

`go test ./backend/blob/... ./backend/api/entities/... ./backend/api/documents/... ./backend/llm/...` and `golangci-lint run --new-from-rev main` pass.

## Not in scope

- The `Commit` duplicate-yield in docmodel (separate PR).
- A composite `fts_index (genesis_blob, block_id)` index would make the remaining lookups exact; unnecessary once the call count drops.
- Peers' `ReconcileBlobs` falling back to the legacy store during reindex adds another 15% of CPU in the same profile; separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MR849L65zgoPx52DGBngMD
