### PR TITLE
feat(agents): version the wire protocol, serve pre-#1078 clients again, and gate breaking changes in CI

### DIFF
--- a/.github/workflows/test-agents.yml
+++ b/.github/workflows/test-agents.yml
@@ -20,9 +20,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        task: [test, check, build]
+        task: [test, check, build, protocol]
     steps:
       - uses: actions/checkout@v4
+      - name: Fetch base branch for the protocol compatibility diff
+        if: matrix.task == 'protocol' && github.base_ref != ''
+        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.10"
@@ -43,6 +46,10 @@ jobs:
             bun test
           elif [ "${{ matrix.task }}" = "check" ]; then
             bun run check
+          elif [ "${{ matrix.task }}" = "protocol" ]; then
+            # Fails on a wire-surface change that would break a released client unless
+            # AGENTS_PROTOCOL_VERSION was bumped and documented; see agents/protocol/PROTOCOL.md.
+            PROTOCOL_BASE_REF="origin/${{ github.base_ref || 'main' }}" bun run protocol:check
           else
             bun run test:build
           fi

--- a/.github/workflows/test-agents.yml
+++ b/.github/workflows/test-agents.yml
@@ -24,8 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Fetch base branch for the protocol compatibility diff
-        if: matrix.task == 'protocol' && github.base_ref != ''
-        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+        if: matrix.task == 'protocol'
+        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref || 'main' }}"
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.10"
@@ -49,6 +49,7 @@ jobs:
           elif [ "${{ matrix.task }}" = "protocol" ]; then
             # Fails on a wire-surface change that would break a released client unless
             # AGENTS_PROTOCOL_VERSION was bumped and documented; see agents/protocol/PROTOCOL.md.
+            # The PR checkout is the test-merge commit, so the base tip is the right comparison.
             PROTOCOL_BASE_REF="origin/${{ github.base_ref || 'main' }}" bun run protocol:check
           else
             bun run test:build

--- a/agents/bun.lock
+++ b/agents/bun.lock
@@ -33,6 +33,7 @@
         "prettier": "3.1.1",
         "prettier-plugin-tailwindcss": "0.6.14",
         "superjson": "2.2.1",
+        "typescript": "5.8.3",
       },
     },
   },

--- a/agents/docs/signed-api.md
+++ b/agents/docs/signed-api.md
@@ -18,7 +18,17 @@ Equivalent prefixed endpoint:
 POST /agents/api/message
 ```
 
-Responses are DAG-CBOR encoded `AgentResponse` values.
+Responses are DAG-CBOR encoded `AgentResponse` values. Every response carries the server's protocol version in the
+`X-Agents-Protocol` header (also in `/api/version` as `protocol` and `minClientProtocol`).
+
+## Protocol versioning
+
+Clients and servers are deployed independently, so the wire surface is versioned by a single integer,
+`AGENTS_PROTOCOL_VERSION` in `agents/protocol/src/version.ts`. A client declares the version it speaks in
+`envelope.protocol`; the server answers in that version's shape (shims in `agents/src/protocol-compat.ts`) or, below
+`MIN_CLIENT_PROTOCOL`, refuses with HTTP 426 and `{_: 'Error', code: 'protocol_too_old'}`. `bun run protocol:check` in
+CI fails any change to the surface that would break a released client without a version bump. The rules, the table of
+what counts as breaking, and the per-version changelog are in `agents/protocol/PROTOCOL.md`.
 
 ## Signed envelope
 
@@ -28,6 +38,7 @@ type SignedActionEnvelope = {
   signer: blobs.Principal
   sig: blobs.Signature
   account: blobs.Principal
+  protocol?: number // AGENTS_PROTOCOL_VERSION of the client; absent = 1
   action: AgentAction
 }
 

--- a/agents/package.json
+++ b/agents/package.json
@@ -11,6 +11,9 @@
     "test:docker": "bun scripts/smoke-docker.ts",
     "test:trigger": "bun scripts/smoke-trigger.ts",
     "typecheck": "bun tsgo --noEmit",
+    "protocol:snapshot": "bun scripts/protocol-surface.ts write",
+    "protocol:check": "bun scripts/protocol-surface.ts check",
+    "protocol:diff": "bun scripts/protocol-surface.ts diff",
     "format:check": "prettier --check .",
     "format:write": "prettier --write .",
     "check": "conc 'bun typecheck' 'bun format:write'"
@@ -48,6 +51,7 @@
     "concurrently": "^9.2.1",
     "prettier": "3.1.1",
     "prettier-plugin-tailwindcss": "0.6.14",
-    "superjson": "2.2.1"
+    "superjson": "2.2.1",
+    "typescript": "5.8.3"
   }
 }

--- a/agents/protocol/PROTOCOL.md
+++ b/agents/protocol/PROTOCOL.md
@@ -19,12 +19,15 @@ surface changes in a way an older client could be hurt by.
   (`protocol`, `minClientProtocol`).
 - Envelopes and responses that carry no version are protocol 1 (everything before this file).
 
-Two more constants bound what each side still tolerates:
+One more constant bounds what a server still tolerates:
 
 - `MIN_CLIENT_PROTOCOL`: the oldest client a server still answers. Below it the server refuses with HTTP 426 and
-  `{_: 'Error', code: 'protocol_too_old'}`. The client shows "This app is out of date" instead of misreading a response.
-- `MIN_SERVER_PROTOCOL`: the oldest server a client still trusts. Below it the client throws
-  `AgentProtocolError('server_too_old')` after the request instead of using the response.
+  `{_: 'Error', code: 'protocol_too_old'}` (over the websocket, an `error` frame with the same `code`). The client shows
+  "This app is out of date" instead of misreading a response, and keeps its remembered session for after the update.
+
+Only that direction is enforced. Hosted servers redeploy before any client can update, and the desktop bundles its own
+server, so "new client, old server" only happens to a self-hosted server that fell behind; it is expected to be
+upgraded. The client reads the server's version for display and diagnostics but does not refuse it.
 
 ## What counts as breaking
 
@@ -32,19 +35,23 @@ Judged from the point of view of a client built from `main` before your change. 
 every PR touching `agents/`) classifies the difference between the committed `surface.json` on the base branch and the
 types in your working tree:
 
-| Change                                                     | Client reads it (responses) | Client writes it (actions, envelope) |
-| ---------------------------------------------------------- | --------------------------- | ------------------------------------ |
-| New action / response type                                 | compatible                  | compatible                           |
-| New field                                                  | compatible                  | compatible only if optional          |
-| Field removed                                              | breaking                    | breaking                             |
-| Field type changed (including a widened or narrowed union) | breaking                    | breaking                             |
-| Required field became optional                             | breaking                    | compatible                           |
-| Optional field became required                             | compatible                  | breaking                             |
-| Named type changed in any other way                        | breaking                    | breaking                             |
+| Change                                                         | Client reads it (responses) | Client writes it (actions, envelope) |
+| -------------------------------------------------------------- | --------------------------- | ------------------------------------ |
+| New action / response type                                     | compatible                  | compatible                           |
+| New field (also inside one member of a discriminated union)    | compatible                  | compatible only if optional          |
+| Field removed                                                  | breaking                    | breaking                             |
+| Field type changed                                             | breaking                    | breaking                             |
+| Required field became optional                                 | breaking                    | compatible                           |
+| Optional field became required                                 | compatible                  | breaking                             |
+| Member added to a discriminated union (`_`/`type`/`kind`)      | breaking                    | compatible                           |
+| Member removed from a discriminated union                      | breaking                    | breaking                             |
+| Any other change to a named type (e.g. a string-literal union) | breaking                    | breaking                             |
 
-The classifier is conservative on purpose. Adding a member to a union that a client reads is "breaking" because a client
-with an exhaustive switch over it does not know the new member. If you judge such a change harmless, bump the version
-anyway and say so in the entry below; the cost is one line, and the entry is where the next person learns what changed.
+Discriminated unions of objects are compared member by member with the field rules above; every other union is compared
+as a whole. The classifier is conservative on purpose: adding a member to a union that a client reads is "breaking"
+because a client with an exhaustive switch over it does not know the new member. If you judge such a change harmless,
+bump the version anyway and say so in the entry below; the cost is one line, and the entry is where the next person
+learns what changed.
 
 ## What to do when the check fails
 
@@ -75,5 +82,7 @@ with `MIN_CLIENT_PROTOCOL <= 1`.
 - `GetAgentResponse` lost `sessions` and gained `sessionCount`; sessions come from the paginated
   `ListSessions {agentId, includeChildren: false}`.
 - `SignedActionEnvelope` gained the optional `protocol` field; `ErrorResponse` gained the optional `code`.
-- Older clients: `protocol-compat.ts` fills `GetAgentResponse.sessions` with the newest page of top-level sessions for
-  protocol 1 clients. Remove the shim and the deprecated field when `MIN_CLIENT_PROTOCOL` reaches 2.
+- Older clients: `protocol-compat.ts` fills `GetAgentResponse.sessions` (the `GetAgentResponseV1` shape declared there)
+  with the newest 50 top-level sessions, as the viewer may see them, for protocol 1 clients. Protocol 1 answered every
+  session unbounded; those clients filtered children themselves, so nothing is lost below 50, but on a busier agent
+  their agent page shows a capped list and count. Remove the shim and the V1 type when `MIN_CLIENT_PROTOCOL` reaches 2.

--- a/agents/protocol/PROTOCOL.md
+++ b/agents/protocol/PROTOCOL.md
@@ -1,0 +1,79 @@
+# Agents protocol versioning
+
+The client (desktop, web, mobile) and the agents server share the TypeScript types in `agents/protocol/src`, but they
+are not deployed together. A desktop release stays in use for weeks; the hosted servers (`agents-stable`, `agents-dev`)
+redeploy on every push. The types prove that both sides agree at one commit. Across commits, the rules below are the
+contract.
+
+The incident that made this necessary: PR #1078 removed `sessions` from `GetAgentResponse`. The change typechecked,
+shipped to the server within the hour, and every desktop still on 2026.9.4 crashed at its root component on
+`undefined.filter` as soon as it looked at a site that publishes agents.
+
+## The number
+
+`AGENTS_PROTOCOL_VERSION` in `src/version.ts` is a single integer. It is not semver: it goes up by one whenever the wire
+surface changes in a way an older client could be hurt by.
+
+- Clients send it as `SignedActionEnvelope.protocol`, signed with the rest of the envelope.
+- Servers answer with theirs in the `X-Agents-Protocol` response header and in `/api/version` and `/api/health`
+  (`protocol`, `minClientProtocol`).
+- Envelopes and responses that carry no version are protocol 1 (everything before this file).
+
+Two more constants bound what each side still tolerates:
+
+- `MIN_CLIENT_PROTOCOL`: the oldest client a server still answers. Below it the server refuses with HTTP 426 and
+  `{_: 'Error', code: 'protocol_too_old'}`. The client shows "This app is out of date" instead of misreading a response.
+- `MIN_SERVER_PROTOCOL`: the oldest server a client still trusts. Below it the client throws
+  `AgentProtocolError('server_too_old')` after the request instead of using the response.
+
+## What counts as breaking
+
+Judged from the point of view of a client built from `main` before your change. `bun run protocol:check` (run in CI on
+every PR touching `agents/`) classifies the difference between the committed `surface.json` on the base branch and the
+types in your working tree:
+
+| Change                                                     | Client reads it (responses) | Client writes it (actions, envelope) |
+| ---------------------------------------------------------- | --------------------------- | ------------------------------------ |
+| New action / response type                                 | compatible                  | compatible                           |
+| New field                                                  | compatible                  | compatible only if optional          |
+| Field removed                                              | breaking                    | breaking                             |
+| Field type changed (including a widened or narrowed union) | breaking                    | breaking                             |
+| Required field became optional                             | breaking                    | compatible                           |
+| Optional field became required                             | compatible                  | breaking                             |
+| Named type changed in any other way                        | breaking                    | breaking                             |
+
+The classifier is conservative on purpose. Adding a member to a union that a client reads is "breaking" because a client
+with an exhaustive switch over it does not know the new member. If you judge such a change harmless, bump the version
+anyway and say so in the entry below; the cost is one line, and the entry is where the next person learns what changed.
+
+## What to do when the check fails
+
+1. **Prefer an additive change.** Add a new field or a new action and leave the old one in place. Most breaking changes
+   can be rephrased this way, and then no version bump is needed.
+2. **Otherwise bump `AGENTS_PROTOCOL_VERSION`** by one and add a `## Protocol <n>` entry at the bottom of this file
+   describing the change.
+3. **Keep answering older clients.** Add a shim in `agents/src/protocol-compat.ts` that rewrites your new response into
+   the old shape for `clientProtocol < n` (and, if an action changed, accepts the old form). The shim stays until the
+   old clients are gone.
+4. **Or retire them.** If the old shape genuinely cannot be served any more, raise `MIN_CLIENT_PROTOCOL` to `n` and
+   delete the shims below it. Old clients then get a clean "update the app" error. Do this only when a desktop release
+   carrying protocol `n` has been out long enough for auto-update to have reached people.
+5. `bun run protocol:snapshot` to regenerate `surface.json`, and commit it with the change. The snapshot diff in the PR
+   is the review artifact.
+
+## Changelog
+
+## Protocol 1
+
+Everything before versioning existed: envelopes without `protocol`, responses without the header. Served by every server
+with `MIN_CLIENT_PROTOCOL <= 1`.
+
+## Protocol 2
+
+2026-09-09, PR #1078 (and the compat layer that followed it).
+
+- `GetAgentResponse` lost `sessions` and gained `sessionCount`; sessions come from the paginated
+  `ListSessions {agentId, includeChildren: false}`.
+- `SignedActionEnvelope` gained the optional `protocol` field; `ErrorResponse` gained the optional `code`.
+- Older clients: `protocol-compat.ts` fills `GetAgentResponse.sessions` with the newest page of top-level sessions for
+  protocol 1 clients. Remove the shim and the deprecated field when `MIN_CLIENT_PROTOCOL` reaches 2.

--- a/agents/protocol/src/index.ts
+++ b/agents/protocol/src/index.ts
@@ -2,8 +2,10 @@ export * from './tool-registry'
 import type {JsonSchema} from './tool-registry'
 export * from './reasoning'
 export * from './model-capabilities'
+export * from './version'
 
 import type {ReasoningLevel} from './reasoning'
+import type {ProtocolErrorCode} from './version'
 
 /** Shared options for Seed assistant/agent system prompt construction. */
 export type SeedAssistantPromptOptions = {
@@ -151,6 +153,12 @@ export type SignedActionEnvelope = {
    * (or need not) fetch it from the network. Must hash to {@link capability}.
    */
   capabilityBlob?: Uint8Array
+  /**
+   * The protocol version the client speaks ({@link AGENTS_PROTOCOL_VERSION} at build time). Signed
+   * with the rest of the envelope. Absent from clients built before protocol 2, which servers read
+   * as protocol 1; see `agents/protocol/PROTOCOL.md`.
+   */
+  protocol?: number
   action: AgentAction
 }
 
@@ -1961,6 +1969,12 @@ export type GetAgentResponse = {
    * sessions themselves come from `ListSessions {agentId, includeChildren: false}`.
    */
   sessionCount: number
+  /**
+   * @deprecated Protocol 1 answered every session of the agent here. Servers still fill it (newest
+   * page only) for clients that declare no protocol; protocol 2 clients never receive it. Removed
+   * when `MIN_CLIENT_PROTOCOL` reaches 2.
+   */
+  sessions?: SessionInfo[]
 }
 
 /** Successful response for `ListAgentTriggers`. */
@@ -2329,6 +2343,8 @@ export type StopSessionResponse = {
 export type ErrorResponse = {
   _: 'Error'
   message: string
+  /** Machine-readable cause for errors a client is expected to act on, e.g. `protocol_too_old`. */
+  code?: ProtocolErrorCode
 }
 
 /** Response values for the Agents API. */

--- a/agents/protocol/src/index.ts
+++ b/agents/protocol/src/index.ts
@@ -1670,7 +1670,7 @@ export type AgentWSEvent =
         usage?: AgentRunUsage
       }
     }
-  | {_: 'error'; message: string}
+  | {_: 'error'; message: string; code?: ProtocolErrorCode}
 
 /** Redacted provider metadata returned after provider writes. */
 export type RedactedModelProvider = {
@@ -1969,12 +1969,6 @@ export type GetAgentResponse = {
    * sessions themselves come from `ListSessions {agentId, includeChildren: false}`.
    */
   sessionCount: number
-  /**
-   * @deprecated Protocol 1 answered every session of the agent here. Servers still fill it (newest
-   * page only) for clients that declare no protocol; protocol 2 clients never receive it. Removed
-   * when `MIN_CLIENT_PROTOCOL` reaches 2.
-   */
-  sessions?: SessionInfo[]
 }
 
 /** Successful response for `ListAgentTriggers`. */

--- a/agents/protocol/src/version.ts
+++ b/agents/protocol/src/version.ts
@@ -1,0 +1,56 @@
+/**
+ * Agents protocol versioning.
+ *
+ * Clients and servers are built from the same repository but are not deployed together: a desktop
+ * release stays in use for weeks, while the hosted agents servers redeploy on every push to main.
+ * The shared TypeScript types therefore only prove that client and server agree *at one commit*.
+ * Across commits, this number is the contract.
+ *
+ * Rules (enforced in part by `agents/scripts/protocol-surface.ts`, see `agents/protocol/PROTOCOL.md`):
+ *
+ * - Additive changes (a new action, a new response, a new field on a response, a new *optional*
+ *   field on an action) do not bump the version.
+ * - Any other change to what a client sends or a server answers is breaking and bumps
+ *   {@link AGENTS_PROTOCOL_VERSION}, with an entry in `PROTOCOL.md`. The server keeps answering
+ *   older clients (down to {@link MIN_CLIENT_PROTOCOL}) in the shape they expect — see the compat
+ *   layer in `agents/src/protocol-compat.ts` — until the old shape is retired by raising
+ *   {@link MIN_CLIENT_PROTOCOL}, at which point those clients get a clear "update the app" error
+ *   instead of a response they misread.
+ *
+ * A client sends the version it speaks as {@link SignedActionEnvelope.protocol}; a server answers
+ * with its own in the {@link AGENTS_PROTOCOL_HEADER} response header and in `/api/version`.
+ * Clients and servers from before this file existed send and advertise nothing, which both sides
+ * read as protocol 1.
+ */
+
+/** The protocol version this code speaks (client and server alike). */
+export const AGENTS_PROTOCOL_VERSION = 2
+
+/**
+ * The oldest client protocol a server built from this code still answers. A client below it is
+ * refused with a `protocol_too_old` error (HTTP 426) rather than served a shape it may crash on.
+ */
+export const MIN_CLIENT_PROTOCOL = 1
+
+/**
+ * The oldest server protocol a client built from this code still accepts. A server below it (a
+ * self-hosted server left behind) is reported as too old rather than trusted to answer correctly.
+ */
+export const MIN_SERVER_PROTOCOL = 1
+
+/** Response header carrying the server's {@link AGENTS_PROTOCOL_VERSION}. */
+export const AGENTS_PROTOCOL_HEADER = 'X-Agents-Protocol'
+
+/** The version implied by an envelope or response that carries none. */
+export const IMPLICIT_PROTOCOL_VERSION = 1
+
+/** Error codes a server answers with when the protocol versions cannot be reconciled. */
+export type ProtocolErrorCode = 'protocol_too_old'
+
+/**
+ * The protocol version a client declared, or the implicit version 1 when it declared none or
+ * declared nonsense (a client that sends garbage is not a client this code was built with).
+ */
+export function declaredProtocolVersion(value: unknown): number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 1 ? value : IMPLICIT_PROTOCOL_VERSION
+}

--- a/agents/protocol/src/version.ts
+++ b/agents/protocol/src/version.ts
@@ -21,6 +21,11 @@
  * with its own in the {@link AGENTS_PROTOCOL_HEADER} response header and in `/api/version`.
  * Clients and servers from before this file existed send and advertise nothing, which both sides
  * read as protocol 1.
+ *
+ * Only the "old client, new server" direction is enforced: hosted servers redeploy before any
+ * client can update, and the desktop bundles its own server. A self-hosted server that falls behind
+ * a client is expected to be upgraded; the client reads the server's version for display and
+ * diagnostics but does not refuse it.
  */
 
 /** The protocol version this code speaks (client and server alike). */
@@ -31,12 +36,6 @@ export const AGENTS_PROTOCOL_VERSION = 2
  * refused with a `protocol_too_old` error (HTTP 426) rather than served a shape it may crash on.
  */
 export const MIN_CLIENT_PROTOCOL = 1
-
-/**
- * The oldest server protocol a client built from this code still accepts. A server below it (a
- * self-hosted server left behind) is reported as too old rather than trusted to answer correctly.
- */
-export const MIN_SERVER_PROTOCOL = 1
 
 /** Response header carrying the server's {@link AGENTS_PROTOCOL_VERSION}. */
 export const AGENTS_PROTOCOL_HEADER = 'X-Agents-Protocol'

--- a/agents/protocol/surface.json
+++ b/agents/protocol/surface.json
@@ -1,7 +1,7 @@
 {
+  "format": 1,
   "protocol": 2,
   "minClientProtocol": 1,
-  "minServerProtocol": 1,
   "envelope": {
     "fields": {
       "account": "Uint8Array<ArrayBufferLike>",
@@ -249,11 +249,6 @@
         "path?": "string"
       }
     },
-    "ListAgents": {
-      "fields": {
-        "_": "\"ListAgents\""
-      }
-    },
     "ListAgentTools": {
       "fields": {
         "_": "\"ListAgentTools\"",
@@ -264,6 +259,11 @@
       "fields": {
         "_": "\"ListAgentTriggers\"",
         "agentId": "string"
+      }
+    },
+    "ListAgents": {
+      "fields": {
+        "_": "\"ListAgents\""
       }
     },
     "ListMcpServers": {
@@ -641,8 +641,7 @@
       "fields": {
         "_": "\"GetAgentResponse\"",
         "agent": "AgentInfo",
-        "sessionCount": "number",
-        "sessions?": "SessionInfo[]"
+        "sessionCount": "number"
       }
     },
     "GetAgentTriggerResponse": {
@@ -739,12 +738,6 @@
         "truncated?": "boolean"
       }
     },
-    "ListAgentsResponse": {
-      "fields": {
-        "_": "\"ListAgentsResponse\"",
-        "agents": "AgentInfo[]"
-      }
-    },
     "ListAgentToolsResponse": {
       "fields": {
         "_": "\"ListAgentToolsResponse\"",
@@ -756,6 +749,12 @@
       "fields": {
         "_": "\"ListAgentTriggersResponse\"",
         "triggers": "AgentTriggerInfo[]"
+      }
+    },
+    "ListAgentsResponse": {
+      "fields": {
+        "_": "\"ListAgentsResponse\"",
+        "agents": "AgentInfo[]"
       }
     },
     "ListMcpServersResponse": {
@@ -1067,7 +1066,30 @@
       }
     },
     "AgentScheduleTrigger": {
-      "alias": "{daysOfWeek: number[]; kind: \"weekly\"; timeOfDay: string; timezone: string} | {every: number; kind: \"interval\"; unit: \"hours\" | \"minutes\"} | {kind: \"once\"; runAt: number; timezone?: string}"
+      "variants": {
+        "interval": {
+          "fields": {
+            "every": "number",
+            "kind": "\"interval\"",
+            "unit": "\"hours\" | \"minutes\""
+          }
+        },
+        "once": {
+          "fields": {
+            "kind": "\"once\"",
+            "runAt": "number",
+            "timezone?": "string"
+          }
+        },
+        "weekly": {
+          "fields": {
+            "daysOfWeek": "number[]",
+            "kind": "\"weekly\"",
+            "timeOfDay": "string",
+            "timezone": "string"
+          }
+        }
+      }
     },
     "AgentSessionTriggerContext": {
       "fields": {
@@ -1162,10 +1184,67 @@
       }
     },
     "AgentTriggerSource": {
-      "alias": "{agentId?: string; status?: \"canceled\" | \"failed\" | \"succeeded\"; titleMatch?: string; type: \"run-completed\"} | {author?: string; resource: string; type: \"document-comment\"} | {eventTypes?: string[]; resourcePrefix: string; type: \"site-update\"} | {mentionedAccounts: string[]; resourcePrefix?: string; type: \"user-mention\"} | {schedule: AgentScheduleTrigger; type: \"schedule\"} | {type: \"webhook\"}"
+      "variants": {
+        "document-comment": {
+          "fields": {
+            "author?": "string",
+            "resource": "string",
+            "type": "\"document-comment\""
+          }
+        },
+        "run-completed": {
+          "fields": {
+            "agentId?": "string",
+            "status?": "\"canceled\" | \"failed\" | \"succeeded\"",
+            "titleMatch?": "string",
+            "type": "\"run-completed\""
+          }
+        },
+        "schedule": {
+          "fields": {
+            "schedule": "AgentScheduleTrigger",
+            "type": "\"schedule\""
+          }
+        },
+        "site-update": {
+          "fields": {
+            "eventTypes?": "string[]",
+            "resourcePrefix": "string",
+            "type": "\"site-update\""
+          }
+        },
+        "user-mention": {
+          "fields": {
+            "mentionedAccounts": "string[]",
+            "resourcePrefix?": "string",
+            "type": "\"user-mention\""
+          }
+        },
+        "webhook": {
+          "fields": {
+            "type": "\"webhook\""
+          }
+        }
+      }
     },
     "FileUploadTarget": {
-      "alias": "{agentId: string; kind: \"memory\"; path: string} | {kind: \"session-attachment\"; mimeType?: string; name: string; sessionId: string}"
+      "variants": {
+        "memory": {
+          "fields": {
+            "agentId": "string",
+            "kind": "\"memory\"",
+            "path": "string"
+          }
+        },
+        "session-attachment": {
+          "fields": {
+            "kind": "\"session-attachment\"",
+            "mimeType?": "string",
+            "name": "string",
+            "sessionId": "string"
+          }
+        }
+      }
     },
     "JsonSchema": {
       "fields": {
@@ -1173,12 +1252,12 @@
         "description?": "string",
         "enum?": "string[]",
         "items?": "JsonSchema",
-        "maximum?": "number",
         "maxItems?": "number",
         "maxLength?": "number",
-        "minimum?": "number",
+        "maximum?": "number",
         "minItems?": "number",
         "minLength?": "number",
+        "minimum?": "number",
         "properties?": "Record<string, JsonSchema>",
         "required?": "string[]",
         "type?": "\"array\" | \"boolean\" | \"integer\" | \"null\" | \"number\" | \"object\" | \"string\" | JsonSchemaTypeName[]"
@@ -1214,7 +1293,28 @@
       }
     },
     "MessageSessionContentPart": {
-      "alias": "{blocks?: AgentPromptBlock[]; clientMessageId?: string; text: string; type: \"text\"} | {id: string; type: \"attachment\"} | {lines: string[]; type: \"context\"}"
+      "variants": {
+        "attachment": {
+          "fields": {
+            "id": "string",
+            "type": "\"attachment\""
+          }
+        },
+        "context": {
+          "fields": {
+            "lines": "string[]",
+            "type": "\"context\""
+          }
+        },
+        "text": {
+          "fields": {
+            "blocks?": "AgentPromptBlock[]",
+            "clientMessageId?": "string",
+            "text": "string",
+            "type": "\"text\""
+          }
+        }
+      }
     },
     "ModelProviderConfig": {
       "fields": {
@@ -1459,7 +1559,40 @@
       }
     },
     "TriggerContinuation": {
-      "alias": "{includeAgentSystemPrompt?: boolean; kind: \"newThread\"; systemPrompt?: string; tools?: string[]} | {input?: unknown; kind: \"script\"; onFailure?: TriggerFailurePolicy; script: string} | {input?: unknown; kind: \"tool\"; onFailure?: TriggerFailurePolicy; tool: string} | {kind: \"wake\"; payload?: unknown; runId?: string; signal: string}"
+      "variants": {
+        "newThread": {
+          "fields": {
+            "includeAgentSystemPrompt?": "boolean",
+            "kind": "\"newThread\"",
+            "systemPrompt?": "string",
+            "tools?": "string[]"
+          }
+        },
+        "script": {
+          "fields": {
+            "input?": "unknown",
+            "kind": "\"script\"",
+            "onFailure?": "TriggerFailurePolicy",
+            "script": "string"
+          }
+        },
+        "tool": {
+          "fields": {
+            "input?": "unknown",
+            "kind": "\"tool\"",
+            "onFailure?": "TriggerFailurePolicy",
+            "tool": "string"
+          }
+        },
+        "wake": {
+          "fields": {
+            "kind": "\"wake\"",
+            "payload?": "unknown",
+            "runId?": "string",
+            "signal": "string"
+          }
+        }
+      }
     },
     "TriggerFailurePolicy": {
       "alias": "\"none\" | \"thread\""
@@ -1477,7 +1610,19 @@
       }
     },
     "UnmetObligation": {
-      "alias": "{kind: \"plan\"; steps: string[]} | {kind: \"typed-result\"}"
+      "variants": {
+        "plan": {
+          "fields": {
+            "kind": "\"plan\"",
+            "steps": "string[]"
+          }
+        },
+        "typed-result": {
+          "fields": {
+            "kind": "\"typed-result\""
+          }
+        }
+      }
     }
   }
 }

--- a/agents/protocol/surface.json
+++ b/agents/protocol/surface.json
@@ -1,0 +1,1483 @@
+{
+  "protocol": 2,
+  "minClientProtocol": 1,
+  "minServerProtocol": 1,
+  "envelope": {
+    "fields": {
+      "account": "Uint8Array<ArrayBufferLike>",
+      "action": "AgentAction",
+      "capability?": "string",
+      "capabilityBlob?": "Uint8Array<ArrayBufferLike>",
+      "protocol?": "number",
+      "sig": "Uint8Array<ArrayBufferLike>",
+      "signer": "Uint8Array<ArrayBufferLike>",
+      "type": "\"AgentsAction\""
+    }
+  },
+  "actions": {
+    "AbortFileUpload": {
+      "fields": {
+        "_": "\"AbortFileUpload\"",
+        "uploadId": "string"
+      }
+    },
+    "AcceptAgentInvite": {
+      "fields": {
+        "_": "\"AcceptAgentInvite\"",
+        "agentId": "string"
+      }
+    },
+    "AppendFileUploadChunk": {
+      "fields": {
+        "_": "\"AppendFileUploadChunk\"",
+        "content": "Uint8Array<ArrayBufferLike>",
+        "offset": "number",
+        "uploadId": "string"
+      }
+    },
+    "BeginFileUpload": {
+      "fields": {
+        "_": "\"BeginFileUpload\"",
+        "size": "number",
+        "target": "FileUploadTarget"
+      }
+    },
+    "CancelProviderOAuth": {
+      "fields": {
+        "_": "\"CancelProviderOAuth\"",
+        "loginId": "string"
+      }
+    },
+    "CancelRun": {
+      "fields": {
+        "_": "\"CancelRun\"",
+        "runId": "string"
+      }
+    },
+    "CommitFileUpload": {
+      "fields": {
+        "_": "\"CommitFileUpload\"",
+        "uploadId": "string"
+      }
+    },
+    "CreateAgent": {
+      "fields": {
+        "_": "\"CreateAgent\"",
+        "clientRequestId?": "string",
+        "definition": "AgentDefinition"
+      }
+    },
+    "CreateAgentTrigger": {
+      "fields": {
+        "_": "\"CreateAgentTrigger\"",
+        "agentId": "string",
+        "clientRequestId?": "string",
+        "trigger": "AgentTriggerInput"
+      }
+    },
+    "CreateSession": {
+      "fields": {
+        "_": "\"CreateSession\"",
+        "agentId": "string",
+        "clientRequestId?": "string",
+        "title?": "string"
+      }
+    },
+    "CreateSigningIdentity": {
+      "fields": {
+        "_": "\"CreateSigningIdentity\"",
+        "clientRequestId?": "string",
+        "label?": "string"
+      }
+    },
+    "DeclineAgentInvite": {
+      "fields": {
+        "_": "\"DeclineAgentInvite\"",
+        "agentId": "string"
+      }
+    },
+    "DeleteAgent": {
+      "fields": {
+        "_": "\"DeleteAgent\"",
+        "agentId": "string"
+      }
+    },
+    "DeleteAgentMemoryFile": {
+      "fields": {
+        "_": "\"DeleteAgentMemoryFile\"",
+        "agentId": "string",
+        "path": "string"
+      }
+    },
+    "DeleteAgentTool": {
+      "fields": {
+        "_": "\"DeleteAgentTool\"",
+        "agentId": "string",
+        "name": "string"
+      }
+    },
+    "DeleteAgentTrigger": {
+      "fields": {
+        "_": "\"DeleteAgentTrigger\"",
+        "triggerId": "string"
+      }
+    },
+    "DeleteMcpServer": {
+      "fields": {
+        "_": "\"DeleteMcpServer\"",
+        "name": "string"
+      }
+    },
+    "DeleteModelProvider": {
+      "fields": {
+        "_": "\"DeleteModelProvider\"",
+        "name": "string"
+      }
+    },
+    "DeleteSession": {
+      "fields": {
+        "_": "\"DeleteSession\"",
+        "sessionId": "string"
+      }
+    },
+    "DeleteSigningIdentity": {
+      "fields": {
+        "_": "\"DeleteSigningIdentity\"",
+        "name": "string"
+      }
+    },
+    "DownloadAgentMemoryFile": {
+      "fields": {
+        "_": "\"DownloadAgentMemoryFile\"",
+        "agentId": "string",
+        "path?": "string",
+        "url": "string"
+      }
+    },
+    "GetAgent": {
+      "fields": {
+        "_": "\"GetAgent\"",
+        "agentId": "string"
+      }
+    },
+    "GetAgentTrigger": {
+      "fields": {
+        "_": "\"GetAgentTrigger\"",
+        "triggerId": "string"
+      }
+    },
+    "GetProviderOAuthStatus": {
+      "fields": {
+        "_": "\"GetProviderOAuthStatus\"",
+        "loginId": "string"
+      }
+    },
+    "GetRun": {
+      "fields": {
+        "_": "\"GetRun\"",
+        "runId": "string"
+      }
+    },
+    "GetRunJournal": {
+      "fields": {
+        "_": "\"GetRunJournal\"",
+        "afterSeq?": "number",
+        "runId": "string"
+      }
+    },
+    "GetSession": {
+      "fields": {
+        "_": "\"GetSession\"",
+        "afterSeq?": "number",
+        "beforeSeq?": "number",
+        "limit?": "number",
+        "sessionId": "string"
+      }
+    },
+    "GetSessionEvent": {
+      "fields": {
+        "_": "\"GetSessionEvent\"",
+        "seq": "number",
+        "sessionId": "string"
+      }
+    },
+    "ImportSigningIdentity": {
+      "fields": {
+        "_": "\"ImportSigningIdentity\"",
+        "clientRequestId?": "string",
+        "label?": "string",
+        "seed": "Uint8Array<ArrayBufferLike>"
+      }
+    },
+    "InviteAgentCollaborator": {
+      "fields": {
+        "_": "\"InviteAgentCollaborator\"",
+        "accountId": "string",
+        "agentId": "string",
+        "role": "AgentCollaboratorRole"
+      }
+    },
+    "InvokeSessionTool": {
+      "fields": {
+        "_": "\"InvokeSessionTool\"",
+        "input": "unknown",
+        "sessionId": "string",
+        "verb": "\"call\" | \"read\" | \"write\""
+      }
+    },
+    "ListAgentCollaborators": {
+      "fields": {
+        "_": "\"ListAgentCollaborators\"",
+        "agentId": "string"
+      }
+    },
+    "ListAgentInvites": {
+      "fields": {
+        "_": "\"ListAgentInvites\""
+      }
+    },
+    "ListAgentMemory": {
+      "fields": {
+        "_": "\"ListAgentMemory\"",
+        "agentId": "string"
+      }
+    },
+    "ListAgentMemoryDir": {
+      "fields": {
+        "_": "\"ListAgentMemoryDir\"",
+        "agentId": "string",
+        "path?": "string"
+      }
+    },
+    "ListAgents": {
+      "fields": {
+        "_": "\"ListAgents\""
+      }
+    },
+    "ListAgentTools": {
+      "fields": {
+        "_": "\"ListAgentTools\"",
+        "agentId": "string"
+      }
+    },
+    "ListAgentTriggers": {
+      "fields": {
+        "_": "\"ListAgentTriggers\"",
+        "agentId": "string"
+      }
+    },
+    "ListMcpServers": {
+      "fields": {
+        "_": "\"ListMcpServers\""
+      }
+    },
+    "ListModelProviders": {
+      "fields": {
+        "_": "\"ListModelProviders\"",
+        "agentId?": "string"
+      }
+    },
+    "ListProviderModels": {
+      "fields": {
+        "_": "\"ListProviderModels\"",
+        "agentId?": "string",
+        "provider": "string"
+      }
+    },
+    "ListRuns": {
+      "fields": {
+        "_": "\"ListRuns\"",
+        "agentId?": "string",
+        "limit?": "number",
+        "rootRunId?": "string",
+        "sessionId?": "string",
+        "status?": "RunStatus"
+      }
+    },
+    "ListSessions": {
+      "fields": {
+        "_": "\"ListSessions\"",
+        "agentId?": "string",
+        "cursor?": "SessionListCursor",
+        "includeChildren?": "boolean",
+        "limit?": "number",
+        "parentSessionId?": "string"
+      }
+    },
+    "ListSigningIdentities": {
+      "fields": {
+        "_": "\"ListSigningIdentities\"",
+        "agentId?": "string"
+      }
+    },
+    "MessageSession": {
+      "fields": {
+        "_": "\"MessageSession\"",
+        "clientMessageId?": "string",
+        "content": "MessageSessionContentPart[]",
+        "sessionId": "string"
+      }
+    },
+    "ReadAgentMemoryFile": {
+      "fields": {
+        "_": "\"ReadAgentMemoryFile\"",
+        "agentId": "string",
+        "path": "string"
+      }
+    },
+    "ReadSessionAttachment": {
+      "fields": {
+        "_": "\"ReadSessionAttachment\"",
+        "attachmentId": "string",
+        "sessionId": "string"
+      }
+    },
+    "RefreshMcpServer": {
+      "fields": {
+        "_": "\"RefreshMcpServer\"",
+        "name": "string"
+      }
+    },
+    "RegisterSigner": {
+      "fields": {
+        "_": "\"RegisterSigner\"",
+        "capability": "Uint8Array<ArrayBufferLike>"
+      }
+    },
+    "RemoveAgentCollaborator": {
+      "fields": {
+        "_": "\"RemoveAgentCollaborator\"",
+        "accountId": "string",
+        "agentId": "string"
+      }
+    },
+    "RetrySession": {
+      "fields": {
+        "_": "\"RetrySession\"",
+        "sessionId": "string"
+      }
+    },
+    "SaveAgentTool": {
+      "fields": {
+        "_": "\"SaveAgentTool\"",
+        "agentId": "string",
+        "previousName?": "string",
+        "tool": "AgentToolInput"
+      }
+    },
+    "SetAgentPublicChat": {
+      "fields": {
+        "_": "\"SetAgentPublicChat\"",
+        "agentId": "string",
+        "publicChat": "boolean"
+      }
+    },
+    "SetAgentPublicRead": {
+      "fields": {
+        "_": "\"SetAgentPublicRead\"",
+        "agentId": "string",
+        "publicRead": "boolean"
+      }
+    },
+    "SetMcpServer": {
+      "fields": {
+        "_": "\"SetMcpServer\"",
+        "config": "McpServerConfig",
+        "name": "string"
+      }
+    },
+    "SetModelProvider": {
+      "fields": {
+        "_": "\"SetModelProvider\"",
+        "name": "string",
+        "provider": "ModelProviderConfig"
+      }
+    },
+    "SetSecret": {
+      "fields": {
+        "_": "\"SetSecret\"",
+        "metadata?": "Record<string, unknown>",
+        "name": "string",
+        "value": "Uint8Array<ArrayBufferLike>"
+      }
+    },
+    "SignalRun": {
+      "fields": {
+        "_": "\"SignalRun\"",
+        "payload?": "unknown",
+        "runId": "string",
+        "signal": "string"
+      }
+    },
+    "StartProviderOAuth": {
+      "fields": {
+        "_": "\"StartProviderOAuth\"",
+        "providerType": "string"
+      }
+    },
+    "StopSession": {
+      "fields": {
+        "_": "\"StopSession\"",
+        "sessionId": "string"
+      }
+    },
+    "SubmitProviderOAuthCode": {
+      "fields": {
+        "_": "\"SubmitProviderOAuthCode\"",
+        "code": "string",
+        "loginId": "string"
+      }
+    },
+    "Subscribe": {
+      "fields": {
+        "_": "\"Subscribe\"",
+        "afterSeq?": "number",
+        "key": "`account/${string}` | `agents/${string}` | `runs/${string}` | `sessions/${string}`"
+      }
+    },
+    "UpdateAgent": {
+      "fields": {
+        "_": "\"UpdateAgent\"",
+        "agentId": "string",
+        "definition": "AgentDefinition"
+      }
+    },
+    "UpdateAgentTrigger": {
+      "fields": {
+        "_": "\"UpdateAgentTrigger\"",
+        "patch": "AgentTriggerPatch",
+        "triggerId": "string"
+      }
+    },
+    "UpdateSession": {
+      "fields": {
+        "_": "\"UpdateSession\"",
+        "modelOverride?": "SessionModelOverride | null",
+        "sessionId": "string",
+        "title?": "string"
+      }
+    },
+    "UpdateSigningIdentity": {
+      "fields": {
+        "_": "\"UpdateSigningIdentity\"",
+        "icon?": "SigningIdentityIcon",
+        "label": "string",
+        "name": "string"
+      }
+    },
+    "UploadAgentMemoryFileToIpfs": {
+      "fields": {
+        "_": "\"UploadAgentMemoryFileToIpfs\"",
+        "agentId": "string",
+        "path": "string"
+      }
+    },
+    "UploadSessionAttachment": {
+      "fields": {
+        "_": "\"UploadSessionAttachment\"",
+        "content": "Uint8Array<ArrayBufferLike>",
+        "mimeType?": "string",
+        "name": "string",
+        "sessionId": "string"
+      }
+    },
+    "WriteAgentMemoryFile": {
+      "fields": {
+        "_": "\"WriteAgentMemoryFile\"",
+        "agentId": "string",
+        "content": "Uint8Array<ArrayBufferLike> | string",
+        "path": "string"
+      }
+    }
+  },
+  "responses": {
+    "AbortFileUploadResponse": {
+      "fields": {
+        "_": "\"AbortFileUploadResponse\"",
+        "uploadId": "string"
+      }
+    },
+    "AcceptAgentInviteResponse": {
+      "fields": {
+        "_": "\"AcceptAgentInviteResponse\"",
+        "agent": "AgentInfo"
+      }
+    },
+    "AppendFileUploadChunkResponse": {
+      "fields": {
+        "_": "\"AppendFileUploadChunkResponse\"",
+        "received": "number",
+        "uploadId": "string"
+      }
+    },
+    "BeginFileUploadResponse": {
+      "fields": {
+        "_": "\"BeginFileUploadResponse\"",
+        "maxChunkBytes": "number",
+        "uploadId": "string"
+      }
+    },
+    "CancelProviderOAuthResponse": {
+      "fields": {
+        "_": "\"CancelProviderOAuthResponse\"",
+        "loginId": "string"
+      }
+    },
+    "CancelRunResponse": {
+      "fields": {
+        "_": "\"CancelRunResponse\"",
+        "canceled": "boolean",
+        "runId": "string"
+      }
+    },
+    "CommitFileUploadResponse": {
+      "fields": {
+        "_": "\"CommitFileUploadResponse\"",
+        "attachment?": "SessionAttachmentInfo",
+        "entry?": "AgentMemoryEntry"
+      }
+    },
+    "CreateAgentResponse": {
+      "fields": {
+        "_": "\"CreateAgentResponse\"",
+        "agentId": "string"
+      }
+    },
+    "CreateAgentTriggerResponse": {
+      "fields": {
+        "_": "\"CreateAgentTriggerResponse\"",
+        "trigger": "AgentTriggerInfo",
+        "webhookSecret?": "string"
+      }
+    },
+    "CreateSessionResponse": {
+      "fields": {
+        "_": "\"CreateSessionResponse\"",
+        "sessionId": "string"
+      }
+    },
+    "CreateSigningIdentityResponse": {
+      "fields": {
+        "_": "\"CreateSigningIdentityResponse\"",
+        "identity": "SigningIdentity"
+      }
+    },
+    "DeclineAgentInviteResponse": {
+      "fields": {
+        "_": "\"DeclineAgentInviteResponse\"",
+        "agentId": "string"
+      }
+    },
+    "DeleteAgentMemoryFileResponse": {
+      "fields": {
+        "_": "\"DeleteAgentMemoryFileResponse\"",
+        "agentId": "string",
+        "deleted": "boolean",
+        "path": "string"
+      }
+    },
+    "DeleteAgentResponse": {
+      "fields": {
+        "_": "\"DeleteAgentResponse\"",
+        "agentId": "string"
+      }
+    },
+    "DeleteAgentToolResponse": {
+      "fields": {
+        "_": "\"DeleteAgentToolResponse\"",
+        "agentId": "string",
+        "deleted": "boolean",
+        "name": "string"
+      }
+    },
+    "DeleteAgentTriggerResponse": {
+      "fields": {
+        "_": "\"DeleteAgentTriggerResponse\"",
+        "triggerId": "string"
+      }
+    },
+    "DeleteMcpServerResponse": {
+      "fields": {
+        "_": "\"DeleteMcpServerResponse\"",
+        "name": "string"
+      }
+    },
+    "DeleteModelProviderResponse": {
+      "fields": {
+        "_": "\"DeleteModelProviderResponse\"",
+        "name": "string"
+      }
+    },
+    "DeleteSessionResponse": {
+      "fields": {
+        "_": "\"DeleteSessionResponse\"",
+        "agentId": "string",
+        "sessionId": "string"
+      }
+    },
+    "DeleteSigningIdentityResponse": {
+      "fields": {
+        "_": "\"DeleteSigningIdentityResponse\"",
+        "name": "string"
+      }
+    },
+    "DownloadAgentMemoryFileResponse": {
+      "fields": {
+        "_": "\"DownloadAgentMemoryFileResponse\"",
+        "agentId": "string",
+        "contentType?": "string",
+        "entry": "AgentMemoryEntry",
+        "finalUrl": "string"
+      }
+    },
+    "Error": {
+      "fields": {
+        "_": "\"Error\"",
+        "code?": "\"protocol_too_old\"",
+        "message": "string"
+      }
+    },
+    "GetAgentResponse": {
+      "fields": {
+        "_": "\"GetAgentResponse\"",
+        "agent": "AgentInfo",
+        "sessionCount": "number",
+        "sessions?": "SessionInfo[]"
+      }
+    },
+    "GetAgentTriggerResponse": {
+      "fields": {
+        "_": "\"GetAgentTriggerResponse\"",
+        "firings": "TriggerFiringInfo[]",
+        "sessions": "SessionInfo[]",
+        "trigger": "AgentTriggerInfo",
+        "webhookSecret?": "string"
+      }
+    },
+    "GetRunJournalResponse": {
+      "fields": {
+        "_": "\"GetRunJournalResponse\"",
+        "entries": "RunJournalEntryInfo[]",
+        "runId": "string"
+      }
+    },
+    "GetRunResponse": {
+      "fields": {
+        "_": "\"GetRunResponse\"",
+        "run": "RunInfo"
+      }
+    },
+    "GetSessionEventResponse": {
+      "fields": {
+        "_": "\"GetSessionEventResponse\"",
+        "event": "SessionEvent"
+      }
+    },
+    "GetSessionResponse": {
+      "fields": {
+        "_": "\"GetSessionResponse\"",
+        "contextWindow?": "number",
+        "events": "SessionEvent[]",
+        "hasMoreBefore?": "boolean",
+        "session": "SessionInfo",
+        "systemPromptMarkdown": "string",
+        "triggerContext?": "AgentSessionTriggerContext"
+      }
+    },
+    "ImportSigningIdentityResponse": {
+      "fields": {
+        "_": "\"ImportSigningIdentityResponse\"",
+        "identity": "SigningIdentity"
+      }
+    },
+    "InviteAgentCollaboratorResponse": {
+      "fields": {
+        "_": "\"InviteAgentCollaboratorResponse\"",
+        "collaborator": "AgentCollaboratorInfo"
+      }
+    },
+    "InvokeSessionToolResponse": {
+      "fields": {
+        "_": "\"InvokeSessionToolResponse\"",
+        "error?": "string",
+        "output?": "unknown",
+        "resultEventId": "string",
+        "sessionId": "string"
+      }
+    },
+    "ListAgentCollaboratorsResponse": {
+      "fields": {
+        "_": "\"ListAgentCollaboratorsResponse\"",
+        "agentId": "string",
+        "collaborators": "AgentCollaboratorInfo[]",
+        "publicChat": "boolean",
+        "publicRead": "boolean"
+      }
+    },
+    "ListAgentInvitesResponse": {
+      "fields": {
+        "_": "\"ListAgentInvitesResponse\"",
+        "invites": "AgentInviteInfo[]"
+      }
+    },
+    "ListAgentMemoryDirResponse": {
+      "fields": {
+        "_": "\"ListAgentMemoryDirResponse\"",
+        "agentId": "string",
+        "entries": "AgentMemoryEntry[]",
+        "path": "string",
+        "totalBytes": "number",
+        "totals?": "{bytes: number; files: number; truncated: boolean}"
+      }
+    },
+    "ListAgentMemoryResponse": {
+      "fields": {
+        "_": "\"ListAgentMemoryResponse\"",
+        "agentId": "string",
+        "entries": "AgentMemoryEntry[]",
+        "totalBytes": "number",
+        "truncated?": "boolean"
+      }
+    },
+    "ListAgentsResponse": {
+      "fields": {
+        "_": "\"ListAgentsResponse\"",
+        "agents": "AgentInfo[]"
+      }
+    },
+    "ListAgentToolsResponse": {
+      "fields": {
+        "_": "\"ListAgentToolsResponse\"",
+        "agentId": "string",
+        "tools": "AgentToolInfo[]"
+      }
+    },
+    "ListAgentTriggersResponse": {
+      "fields": {
+        "_": "\"ListAgentTriggersResponse\"",
+        "triggers": "AgentTriggerInfo[]"
+      }
+    },
+    "ListMcpServersResponse": {
+      "fields": {
+        "_": "\"ListMcpServersResponse\"",
+        "servers": "RedactedMcpServer[]"
+      }
+    },
+    "ListModelProvidersResponse": {
+      "fields": {
+        "_": "\"ListModelProvidersResponse\"",
+        "providers": "RedactedModelProvider[]"
+      }
+    },
+    "ListProviderModelsResponse": {
+      "fields": {
+        "_": "\"ListProviderModelsResponse\"",
+        "models": "ProviderModelInfo[]"
+      }
+    },
+    "ListRunsResponse": {
+      "fields": {
+        "_": "\"ListRunsResponse\"",
+        "runs": "RunInfo[]"
+      }
+    },
+    "ListSessionsResponse": {
+      "fields": {
+        "_": "\"ListSessionsResponse\"",
+        "agents": "AgentInfo[]",
+        "nextCursor?": "SessionListCursor",
+        "sessions": "SessionInfo[]"
+      }
+    },
+    "ListSigningIdentitiesResponse": {
+      "fields": {
+        "_": "\"ListSigningIdentitiesResponse\"",
+        "identities": "SigningIdentity[]"
+      }
+    },
+    "MessageSessionResponse": {
+      "fields": {
+        "_": "\"MessageSessionResponse\"",
+        "assistantEventId": "string",
+        "continuedToSessionId?": "string",
+        "sessionId": "string"
+      }
+    },
+    "ProviderOAuthStatusResponse": {
+      "fields": {
+        "_": "\"ProviderOAuthStatusResponse\"",
+        "error?": "string",
+        "loginId": "string",
+        "secretName?": "string",
+        "status": "\"completed\" | \"failed\" | \"pending\""
+      }
+    },
+    "ReadAgentMemoryFileResponse": {
+      "fields": {
+        "_": "\"ReadAgentMemoryFileResponse\"",
+        "agentId": "string",
+        "file": "AgentMemoryFile"
+      }
+    },
+    "ReadSessionAttachmentResponse": {
+      "fields": {
+        "_": "\"ReadSessionAttachmentResponse\"",
+        "attachment": "SessionAttachmentInfo",
+        "data": "Uint8Array<ArrayBufferLike>"
+      }
+    },
+    "RegisterSignerResponse": {
+      "fields": {
+        "_": "\"RegisterSignerResponse\"",
+        "accountId": "string",
+        "signerId": "string"
+      }
+    },
+    "RemoveAgentCollaboratorResponse": {
+      "fields": {
+        "_": "\"RemoveAgentCollaboratorResponse\"",
+        "accountId": "string",
+        "agentId": "string"
+      }
+    },
+    "RetrySessionResponse": {
+      "fields": {
+        "_": "\"RetrySessionResponse\"",
+        "assistantEventId": "string",
+        "sessionId": "string"
+      }
+    },
+    "SaveAgentToolResponse": {
+      "fields": {
+        "_": "\"SaveAgentToolResponse\"",
+        "agentId": "string",
+        "tool": "AgentToolInfo"
+      }
+    },
+    "SetAgentPublicChatResponse": {
+      "fields": {
+        "_": "\"SetAgentPublicChatResponse\"",
+        "agent": "AgentInfo"
+      }
+    },
+    "SetAgentPublicReadResponse": {
+      "fields": {
+        "_": "\"SetAgentPublicReadResponse\"",
+        "agent": "AgentInfo"
+      }
+    },
+    "SetMcpServerResponse": {
+      "fields": {
+        "_": "\"SetMcpServerResponse\"",
+        "server": "RedactedMcpServer"
+      }
+    },
+    "SetModelProviderResponse": {
+      "fields": {
+        "_": "\"SetModelProviderResponse\"",
+        "provider": "RedactedModelProvider"
+      }
+    },
+    "SetSecretResponse": {
+      "fields": {
+        "_": "\"SetSecretResponse\"",
+        "secret": "RedactedSecret"
+      }
+    },
+    "SignalRunResponse": {
+      "fields": {
+        "_": "\"SignalRunResponse\"",
+        "delivered": "boolean",
+        "runId": "string"
+      }
+    },
+    "StartProviderOAuthResponse": {
+      "fields": {
+        "_": "\"StartProviderOAuthResponse\"",
+        "authUrl": "string",
+        "expiresAt": "number",
+        "loginId": "string"
+      }
+    },
+    "StopSessionResponse": {
+      "fields": {
+        "_": "\"StopSessionResponse\"",
+        "sessionId": "string",
+        "stopped": "boolean"
+      }
+    },
+    "SubmitProviderOAuthCodeResponse": {
+      "fields": {
+        "_": "\"SubmitProviderOAuthCodeResponse\""
+      }
+    },
+    "UpdateAgentTriggerResponse": {
+      "fields": {
+        "_": "\"UpdateAgentTriggerResponse\"",
+        "trigger": "AgentTriggerInfo"
+      }
+    },
+    "UpdateSessionResponse": {
+      "fields": {
+        "_": "\"UpdateSessionResponse\"",
+        "session": "SessionInfo"
+      }
+    },
+    "UpdateSigningIdentityResponse": {
+      "fields": {
+        "_": "\"UpdateSigningIdentityResponse\"",
+        "identity": "SigningIdentity"
+      }
+    },
+    "UploadAgentMemoryFileToIpfsResponse": {
+      "fields": {
+        "_": "\"UploadAgentMemoryFileToIpfsResponse\"",
+        "agentId": "string",
+        "cid": "string",
+        "mimeType?": "string",
+        "path": "string",
+        "size": "number",
+        "url": "string"
+      }
+    },
+    "UploadSessionAttachmentResponse": {
+      "fields": {
+        "_": "\"UploadSessionAttachmentResponse\"",
+        "attachment": "SessionAttachmentInfo"
+      }
+    },
+    "WriteAgentMemoryFileResponse": {
+      "fields": {
+        "_": "\"WriteAgentMemoryFileResponse\"",
+        "agentId": "string",
+        "entry": "AgentMemoryEntry"
+      }
+    }
+  },
+  "types": {
+    "AgentAccessRole": {
+      "alias": "\"chatter\" | \"owner\" | \"reader\" | \"writer\""
+    },
+    "AgentActivity": {
+      "fields": {
+        "at": "number",
+        "busy": "boolean",
+        "kind": "AgentActivityKind",
+        "messageAt": "number",
+        "messageFrom": "\"agent\" | \"user\"",
+        "sessionId": "string"
+      }
+    },
+    "AgentActivityKind": {
+      "alias": "\"agent\" | \"tool\" | \"user\""
+    },
+    "AgentCollaboratorInfo": {
+      "fields": {
+        "accountId": "string",
+        "createdAt": "number",
+        "role": "AgentAccessRole",
+        "status": "\"accepted\" | \"pending\"",
+        "updatedAt": "number"
+      }
+    },
+    "AgentCollaboratorRole": {
+      "alias": "\"reader\" | \"writer\""
+    },
+    "AgentDefinition": {
+      "fields": {
+        "enabledModels?": "AgentModelRef[]",
+        "mcpServers?": "string[]",
+        "metadata?": "Record<string, unknown>",
+        "model": "string",
+        "modelProvider": "string",
+        "name": "string",
+        "reasoningLevel?": "ReasoningLevel",
+        "signingKey?": "string",
+        "signingKeys?": "string[]",
+        "systemPrompt": "AgentPromptBlock[] | string",
+        "tools?": "string[]"
+      }
+    },
+    "AgentInfo": {
+      "fields": {
+        "accessRole?": "AgentAccessRole",
+        "account": "string",
+        "activity?": "AgentActivity",
+        "createdAt": "number",
+        "definition": "AgentDefinition",
+        "id": "string",
+        "publicChat?": "boolean",
+        "publicRead?": "boolean",
+        "stateDir": "string",
+        "status": "\"error\" | \"idle\" | \"running\" | \"stopped\"",
+        "updatedAt": "number"
+      }
+    },
+    "AgentInviteInfo": {
+      "fields": {
+        "agentId": "string",
+        "agentName": "string",
+        "createdAt": "number",
+        "ownerAccountId": "string",
+        "role": "AgentCollaboratorRole",
+        "updatedAt": "number"
+      }
+    },
+    "AgentMemoryEntry": {
+      "fields": {
+        "entryCount?": "number",
+        "mimeType?": "string",
+        "path": "string",
+        "size": "number",
+        "type": "\"dir\" | \"file\"",
+        "updatedAt": "number"
+      }
+    },
+    "AgentMemoryFile": {
+      "fields": {
+        "content?": "string",
+        "data?": "Uint8Array<ArrayBufferLike>",
+        "encoding": "\"binary\" | \"utf8\"",
+        "mimeType?": "string",
+        "path": "string",
+        "size": "number",
+        "updatedAt": "number"
+      }
+    },
+    "AgentModelRef": {
+      "fields": {
+        "model": "string",
+        "provider": "string"
+      }
+    },
+    "AgentPromptBlock": {
+      "fields": {
+        "block": "{[key: string]: unknown; id: string; type: string}",
+        "children?": "AgentPromptBlock[]"
+      }
+    },
+    "AgentRunUsage": {
+      "fields": {
+        "cacheRead": "number",
+        "cacheWrite": "number",
+        "input": "number",
+        "output": "number",
+        "total": "number"
+      }
+    },
+    "AgentScheduleTrigger": {
+      "alias": "{daysOfWeek: number[]; kind: \"weekly\"; timeOfDay: string; timezone: string} | {every: number; kind: \"interval\"; unit: \"hours\" | \"minutes\"} | {kind: \"once\"; runAt: number; timezone?: string}"
+    },
+    "AgentSessionTriggerContext": {
+      "fields": {
+        "activity": "Record<string, unknown>",
+        "activityKey": "string",
+        "activitySummary": "string",
+        "error?": "string",
+        "firedAt": "number",
+        "firingId": "string",
+        "prompt": "string",
+        "promptBlocks?": "AgentPromptBlock[]",
+        "source": "AgentTriggerSource",
+        "status": "string",
+        "triggerId": "string",
+        "triggerName": "string"
+      }
+    },
+    "AgentSessionTriggerSummary": {
+      "fields": {
+        "activityKey": "string",
+        "activitySummary": "string",
+        "firedAt": "number",
+        "firingId": "string",
+        "source": "AgentTriggerSource",
+        "triggerId": "string",
+        "triggerName": "string"
+      }
+    },
+    "AgentToolInfo": {
+      "fields": {
+        "cid": "string",
+        "createdAt": "number",
+        "description": "string",
+        "enabled": "boolean",
+        "granted": "boolean",
+        "input": "Record<string, unknown>",
+        "kind": "\"builtin\" | \"lambda\" | \"mcp\"",
+        "name": "string",
+        "output?": "Record<string, unknown>",
+        "remoteName?": "string",
+        "runtime?": "\"python\" | \"typescript\"",
+        "server?": "string",
+        "source?": "string",
+        "summary": "string",
+        "updatedAt": "number"
+      }
+    },
+    "AgentToolInput": {
+      "fields": {
+        "description": "string",
+        "input": "Record<string, unknown>",
+        "name": "string",
+        "output?": "Record<string, unknown>",
+        "runtime": "\"python\" | \"typescript\"",
+        "source": "string",
+        "summary?": "string"
+      }
+    },
+    "AgentTriggerInfo": {
+      "fields": {
+        "account": "string",
+        "agentId": "string",
+        "continuation?": "TriggerContinuation",
+        "createdAt": "number",
+        "enabled": "boolean",
+        "id": "string",
+        "lastCheckedAt?": "number",
+        "lastError?": "string",
+        "lastFiredAt?": "number",
+        "name": "string",
+        "prompt": "AgentPromptBlock[] | string",
+        "source": "AgentTriggerSource",
+        "updatedAt": "number"
+      }
+    },
+    "AgentTriggerInput": {
+      "fields": {
+        "continuation?": "TriggerContinuation",
+        "enabled?": "boolean",
+        "name": "string",
+        "prompt?": "AgentPromptBlock[] | string",
+        "source": "AgentTriggerSource"
+      }
+    },
+    "AgentTriggerPatch": {
+      "fields": {
+        "continuation?": "TriggerContinuation",
+        "enabled?": "boolean",
+        "name?": "string",
+        "prompt?": "AgentPromptBlock[] | string",
+        "source?": "AgentTriggerSource"
+      }
+    },
+    "AgentTriggerSource": {
+      "alias": "{agentId?: string; status?: \"canceled\" | \"failed\" | \"succeeded\"; titleMatch?: string; type: \"run-completed\"} | {author?: string; resource: string; type: \"document-comment\"} | {eventTypes?: string[]; resourcePrefix: string; type: \"site-update\"} | {mentionedAccounts: string[]; resourcePrefix?: string; type: \"user-mention\"} | {schedule: AgentScheduleTrigger; type: \"schedule\"} | {type: \"webhook\"}"
+    },
+    "FileUploadTarget": {
+      "alias": "{agentId: string; kind: \"memory\"; path: string} | {kind: \"session-attachment\"; mimeType?: string; name: string; sessionId: string}"
+    },
+    "JsonSchema": {
+      "fields": {
+        "additionalProperties?": "JsonSchema | false | true",
+        "description?": "string",
+        "enum?": "string[]",
+        "items?": "JsonSchema",
+        "maximum?": "number",
+        "maxItems?": "number",
+        "maxLength?": "number",
+        "minimum?": "number",
+        "minItems?": "number",
+        "minLength?": "number",
+        "properties?": "Record<string, JsonSchema>",
+        "required?": "string[]",
+        "type?": "\"array\" | \"boolean\" | \"integer\" | \"null\" | \"number\" | \"object\" | \"string\" | JsonSchemaTypeName[]"
+      }
+    },
+    "JsonSchemaTypeName": {
+      "alias": "\"array\" | \"boolean\" | \"integer\" | \"null\" | \"number\" | \"object\" | \"string\""
+    },
+    "McpServerConfig": {
+      "fields": {
+        "headers?": "Record<string, string>",
+        "secretRefs?": "Record<string, string>",
+        "transport?": "McpServerTransport",
+        "url": "string"
+      }
+    },
+    "McpServerStatus": {
+      "fields": {
+        "checkedAt?": "number",
+        "error?": "string",
+        "state": "\"error\" | \"ok\" | \"unknown\""
+      }
+    },
+    "McpServerTransport": {
+      "alias": "\"http\" | \"sse\""
+    },
+    "McpToolInfo": {
+      "fields": {
+        "description?": "string",
+        "inputSchema?": "JsonSchema",
+        "name": "string",
+        "toolName": "string"
+      }
+    },
+    "MessageSessionContentPart": {
+      "alias": "{blocks?: AgentPromptBlock[]; clientMessageId?: string; text: string; type: \"text\"} | {id: string; type: \"attachment\"} | {lines: string[]; type: \"context\"}"
+    },
+    "ModelProviderConfig": {
+      "fields": {
+        "authMode?": "\"api-key\" | \"subscription\"",
+        "baseUrl?": "string",
+        "modelDefaults?": "Record<string, unknown>",
+        "secretRefs?": "Record<string, string>",
+        "type": "string"
+      }
+    },
+    "ProviderModelInfo": {
+      "fields": {
+        "id": "string",
+        "name": "string"
+      }
+    },
+    "ReasoningLevel": {
+      "alias": "\"high\" | \"low\" | \"max\" | \"medium\" | \"minimal\" | \"xhigh\""
+    },
+    "RedactedMcpServer": {
+      "fields": {
+        "createdAt": "number",
+        "hasSecrets": "boolean",
+        "headerNames": "string[]",
+        "id": "string",
+        "name": "string",
+        "secretHeaderNames": "string[]",
+        "status": "McpServerStatus",
+        "tools": "McpToolInfo[]",
+        "transport": "McpServerTransport",
+        "updatedAt": "number",
+        "url": "string"
+      }
+    },
+    "RedactedModelProvider": {
+      "fields": {
+        "authMode?": "\"api-key\" | \"subscription\"",
+        "authStatus?": "\"needs-login\" | \"ok\"",
+        "createdAt": "number",
+        "hasSecrets": "boolean",
+        "id": "string",
+        "name": "string",
+        "type": "string",
+        "updatedAt": "number"
+      }
+    },
+    "RedactedSecret": {
+      "fields": {
+        "createdAt": "number",
+        "hasValue": "true",
+        "id": "string",
+        "metadata?": "Record<string, unknown>",
+        "name": "string",
+        "updatedAt": "number"
+      }
+    },
+    "RunInfo": {
+      "fields": {
+        "account": "string",
+        "agentId?": "string",
+        "childRunCount?": "number",
+        "continuedFromRunId?": "string",
+        "createdAt": "number",
+        "depth": "number",
+        "error?": "{callSeq?: number; code: string; detail?: unknown; message: string; stack?: string; tool?: string}",
+        "finishedAt?": "number",
+        "id": "string",
+        "kind": "\"agent\" | \"workflow\"",
+        "origin": "\"agent\" | \"system\" | \"trigger\" | \"user\" | \"workflow\"",
+        "parentRunId?": "string",
+        "parentToolCallId?": "string",
+        "plan?": "RunPlan",
+        "planStepId?": "string",
+        "rootRunId": "string",
+        "sessionId?": "string",
+        "sourceText?": "string",
+        "startedAt?": "number",
+        "status": "RunStatus",
+        "stepLabel?": "string",
+        "title": "string",
+        "unmetObligations?": "UnmetObligation[]",
+        "updatedAt": "number",
+        "usage?": "RunUsageInfo",
+        "wait?": "RunWaitInfo"
+      }
+    },
+    "RunJournalEntryInfo": {
+      "fields": {
+        "createdAt": "number",
+        "entry": "Record<string, unknown>",
+        "runId": "string",
+        "seq": "number"
+      }
+    },
+    "RunPlan": {
+      "fields": {
+        "ownerRunId?": "string",
+        "settledAt?": "number",
+        "steps": "RunPlanStep[]",
+        "title?": "string"
+      }
+    },
+    "RunPlanStep": {
+      "fields": {
+        "id": "string",
+        "label": "string",
+        "resolvedBy?": "\"runtime\"",
+        "status": "\"done\" | \"failed\" | \"pending\" | \"running\" | \"skipped\""
+      }
+    },
+    "RunStatus": {
+      "alias": "\"canceled\" | \"claimed\" | \"failed\" | \"queued\" | \"running\" | \"succeeded\" | \"waiting\""
+    },
+    "RunUsageInfo": {
+      "fields": {
+        "cacheRead": "number",
+        "cacheWrite": "number",
+        "children?": "{cacheRead: number; cacheWrite: number; input: number; output: number; runs: number; total: number}",
+        "input": "number",
+        "output": "number",
+        "total": "number"
+      }
+    },
+    "RunWaitInfo": {
+      "fields": {
+        "answerWith?": "string",
+        "label?": "string",
+        "pendingChildren?": "number",
+        "reason": "\"budget-pause\" | \"children\" | \"event\" | \"timer\"",
+        "wakeAt?": "number"
+      }
+    },
+    "SessionActivity": {
+      "fields": {
+        "messageAt": "number",
+        "messageFrom": "\"agent\" | \"user\""
+      }
+    },
+    "SessionActor": {
+      "alias": "\"agent\" | \"system\" | \"trigger\" | \"user\""
+    },
+    "SessionAttachmentInfo": {
+      "fields": {
+        "createdAt": "number",
+        "id": "string",
+        "mimeType?": "string",
+        "name": "string",
+        "sessionId": "string",
+        "size": "number"
+      }
+    },
+    "SessionContinuationLink": {
+      "fields": {
+        "continuationId": "string",
+        "createdAt": "number",
+        "reason": "SessionContinuationReason",
+        "sessionId": "string",
+        "title?": "string"
+      }
+    },
+    "SessionContinuationReason": {
+      "alias": "\"context_pressure\" | \"other\" | \"phase_change\" | \"refocus\" | \"topic_change\" | \"user_request\""
+    },
+    "SessionEvent": {
+      "fields": {
+        "createdAt": "number",
+        "event": "SessionEventPayload",
+        "id": "string",
+        "seq": "number",
+        "sessionId": "string",
+        "truncated?": "boolean"
+      }
+    },
+    "SessionEventMeta": {
+      "fields": {
+        "accountId?": "string",
+        "continuedFrom?": "{eventId: string; seq: number; sessionId: string}",
+        "durationMs?": "number",
+        "model?": "string",
+        "provider?": "string",
+        "reasoningLevel?": "\"default\" | \"high\" | \"low\" | \"max\" | \"medium\" | \"minimal\" | \"off\" | \"xhigh\"",
+        "signerId?": "string",
+        "turn?": "{index?: number; ttftMs?: number; turnMs?: number}",
+        "usage?": "AgentRunUsage"
+      }
+    },
+    "SessionEventPayload": {
+      "alias": "Record<string, unknown> | {actor?: SessionActor; attachments?: SessionAttachmentInfo[]; blocks?: AgentPromptBlock[]; clientMessageId?: string; content: string; contextLines?: string[]; meta?: SessionEventMeta; rawMarkdown?: string; role: \"assistant\" | \"tool\" | \"user\"; toolCallId?: string; type: \"message\"} | {actor?: SessionActor; error?: string; meta?: SessionEventMeta; name: string; output?: unknown; toolCallId: string; type: \"tool_result\"} | {actor?: SessionActor; id: string; input: unknown; meta?: SessionEventMeta; name: string; type: \"tool_call\"} | {actor?: SessionActor; message: string; type: \"error\"} | {actor?: SessionActor; name: string; runId: string; sessionId?: string; title: string; toolCallId: string; type: \"tool_spawn\"}"
+    },
+    "SessionInfo": {
+      "fields": {
+        "account": "string",
+        "activity?": "SessionActivity",
+        "agentId": "string",
+        "childSessionCount?": "number",
+        "continuedFrom?": "SessionContinuationLink",
+        "continuedTo?": "SessionContinuationLink",
+        "createdAt": "number",
+        "description?": "string",
+        "id": "string",
+        "modelOverride?": "SessionModelOverride",
+        "parentSessionId?": "string",
+        "plan?": "RunPlan",
+        "runId?": "string",
+        "startedByTrigger?": "AgentSessionTriggerSummary",
+        "status": "\"error\" | \"idle\" | \"stopped\" | \"streaming\"",
+        "title?": "string",
+        "updatedAt": "number"
+      }
+    },
+    "SessionListCursor": {
+      "fields": {
+        "idBefore": "string",
+        "updatedBefore": "number"
+      }
+    },
+    "SessionModelOverride": {
+      "fields": {
+        "model": "string",
+        "provider": "string",
+        "reasoningLevel?": "ReasoningLevel"
+      }
+    },
+    "SigningIdentity": {
+      "fields": {
+        "accountId?": "string",
+        "createdAt": "number",
+        "dev?": "boolean",
+        "icon?": "string",
+        "id": "string",
+        "label?": "string",
+        "name": "string",
+        "serverUrl?": "string",
+        "updatedAt": "number"
+      }
+    },
+    "SigningIdentityIcon": {
+      "fields": {
+        "data": "Uint8Array<ArrayBufferLike>",
+        "fileName?": "string",
+        "mimeType?": "string"
+      }
+    },
+    "TriggerContinuation": {
+      "alias": "{includeAgentSystemPrompt?: boolean; kind: \"newThread\"; systemPrompt?: string; tools?: string[]} | {input?: unknown; kind: \"script\"; onFailure?: TriggerFailurePolicy; script: string} | {input?: unknown; kind: \"tool\"; onFailure?: TriggerFailurePolicy; tool: string} | {kind: \"wake\"; payload?: unknown; runId?: string; signal: string}"
+    },
+    "TriggerFailurePolicy": {
+      "alias": "\"none\" | \"thread\""
+    },
+    "TriggerFiringInfo": {
+      "fields": {
+        "activityKey": "string",
+        "activitySummary": "string",
+        "createdAt": "number",
+        "error?": "string",
+        "id": "string",
+        "runId?": "string",
+        "sessionId?": "string",
+        "status": "string"
+      }
+    },
+    "UnmetObligation": {
+      "alias": "{kind: \"plan\"; steps: string[]} | {kind: \"typed-result\"}"
+    }
+  }
+}

--- a/agents/scripts/protocol-surface.ts
+++ b/agents/scripts/protocol-surface.ts
@@ -46,6 +46,10 @@ function serialize(surface: ProtocolSurface): string {
 }
 
 const mode = process.argv[2] ?? 'check'
+if (mode !== 'write' && mode !== 'check' && mode !== 'diff') {
+  console.error(`unknown mode ${mode}; use write, check, or diff`)
+  process.exit(2)
+}
 const current = extractSurface()
 
 if (mode === 'write') {
@@ -58,26 +62,23 @@ const ref = baseRef()
 const base = baseSurface(ref)
 const changelog = readFileSync(changelogPath, 'utf8')
 
+const baseComparable = base !== null && base.format === current.format
+if (base && !baseComparable) {
+  console.log(`${surfaceRepoPath} at ${ref} was written in snapshot format ${base.format} (now ${current.format})`)
+}
+
 if (mode === 'diff') {
-  if (!base) {
-    console.log(`no ${surfaceRepoPath} at ${ref}; nothing to compare`)
+  if (!baseComparable) {
+    console.log(`nothing to compare against ${ref}`)
     process.exit(0)
   }
   const verdict = judgeSurfaceChange(base, current, changelog)
   for (const change of verdict.changes) {
-    console.log(
-      `${change.severity === 'breaking' ? 'BREAKING' : 'ok      '} ${change.path}: ${change.detail} [${
-        change.direction
-      }]`,
-    )
+    const tag = change.severity === 'breaking' ? 'BREAKING' : 'ok      '
+    console.log(`${tag} ${change.path}: ${change.detail} [${change.direction}]`)
   }
   if (verdict.changes.length === 0) console.log('no protocol changes')
   process.exit(0)
-}
-
-if (mode !== 'check') {
-  console.error(`unknown mode ${mode}; use write, check, or diff`)
-  process.exit(2)
 }
 
 const problems: string[] = []
@@ -93,20 +94,15 @@ if (committed !== null && committed !== serialize(current)) {
   )
 }
 
-if (base) {
+if (baseComparable) {
   const verdict = judgeSurfaceChange(base, current, changelog)
   problems.push(...verdict.problems)
   const compatible = verdict.changes.filter((change) => change.severity === 'compatible')
   if (compatible.length > 0) {
-    console.log(
-      `${compatible.length} compatible protocol change${compatible.length === 1 ? '' : 's'} against ${ref.slice(
-        0,
-        12,
-      )}`,
-    )
+    console.log(`${compatible.length} compatible protocol change${compatible.length === 1 ? '' : 's'} against ${ref}`)
   }
 } else {
-  console.log(`no ${surfaceRepoPath} at ${ref.slice(0, 12)}; skipping the compatibility diff`)
+  console.log(`skipping the compatibility diff against ${ref}`)
 }
 
 if (problems.length > 0) {

--- a/agents/scripts/protocol-surface.ts
+++ b/agents/scripts/protocol-surface.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env bun
+/**
+ * Protocol surface snapshot and compatibility gate.
+ *
+ *   bun scripts/protocol-surface.ts write   # regenerate agents/protocol/surface.json from the types
+ *   bun scripts/protocol-surface.ts check   # CI: snapshot is current, and no unversioned breaking change
+ *   bun scripts/protocol-surface.ts diff    # print the classified changes against the base, exit 0
+ *
+ * `check` compares the working tree against the snapshot committed on the base branch:
+ * `$PROTOCOL_BASE_REF` when set, else the merge-base with `origin/main` (falling back to `main`).
+ * On a fresh clone in CI fetch the base first (`git fetch origin main`). See
+ * `agents/protocol/PROTOCOL.md` for what counts as breaking and what to do about it.
+ */
+import {spawnSync} from 'node:child_process'
+import {readFileSync, writeFileSync} from 'node:fs'
+import path from 'node:path'
+import {extractSurface, judgeSurfaceChange, type ProtocolSurface} from '../src/protocol-surface'
+
+const agentsDir = path.resolve(import.meta.dir, '..')
+const surfacePath = path.join(agentsDir, 'protocol', 'surface.json')
+const changelogPath = path.join(agentsDir, 'protocol', 'PROTOCOL.md')
+const surfaceRepoPath = 'agents/protocol/surface.json'
+
+function git(args: string[]): string | null {
+  const result = spawnSync('git', args, {cwd: agentsDir, encoding: 'utf8'})
+  return result.status === 0 ? result.stdout : null
+}
+
+function baseRef(): string {
+  const configured = process.env.PROTOCOL_BASE_REF
+  if (configured) return configured
+  for (const candidate of ['origin/main', 'main']) {
+    const merged = git(['merge-base', 'HEAD', candidate])
+    if (merged) return merged.trim()
+  }
+  throw new Error('cannot find a base to compare with: set PROTOCOL_BASE_REF or fetch origin/main')
+}
+
+function baseSurface(ref: string): ProtocolSurface | null {
+  const text = git(['show', `${ref}:${surfaceRepoPath}`])
+  return text ? (JSON.parse(text) as ProtocolSurface) : null
+}
+
+function serialize(surface: ProtocolSurface): string {
+  return `${JSON.stringify(surface, null, 2)}\n`
+}
+
+const mode = process.argv[2] ?? 'check'
+const current = extractSurface()
+
+if (mode === 'write') {
+  writeFileSync(surfacePath, serialize(current))
+  console.log(`wrote ${path.relative(process.cwd(), surfacePath)} (protocol ${current.protocol})`)
+  process.exit(0)
+}
+
+const ref = baseRef()
+const base = baseSurface(ref)
+const changelog = readFileSync(changelogPath, 'utf8')
+
+if (mode === 'diff') {
+  if (!base) {
+    console.log(`no ${surfaceRepoPath} at ${ref}; nothing to compare`)
+    process.exit(0)
+  }
+  const verdict = judgeSurfaceChange(base, current, changelog)
+  for (const change of verdict.changes) {
+    console.log(
+      `${change.severity === 'breaking' ? 'BREAKING' : 'ok      '} ${change.path}: ${change.detail} [${
+        change.direction
+      }]`,
+    )
+  }
+  if (verdict.changes.length === 0) console.log('no protocol changes')
+  process.exit(0)
+}
+
+if (mode !== 'check') {
+  console.error(`unknown mode ${mode}; use write, check, or diff`)
+  process.exit(2)
+}
+
+const problems: string[] = []
+let committed: string | null = null
+try {
+  committed = readFileSync(surfacePath, 'utf8')
+} catch {
+  problems.push(`${surfaceRepoPath} is missing`)
+}
+if (committed !== null && committed !== serialize(current)) {
+  problems.push(
+    `${surfaceRepoPath} is out of date with the protocol types: run \`bun run protocol:snapshot\` and commit it`,
+  )
+}
+
+if (base) {
+  const verdict = judgeSurfaceChange(base, current, changelog)
+  problems.push(...verdict.problems)
+  const compatible = verdict.changes.filter((change) => change.severity === 'compatible')
+  if (compatible.length > 0) {
+    console.log(
+      `${compatible.length} compatible protocol change${compatible.length === 1 ? '' : 's'} against ${ref.slice(
+        0,
+        12,
+      )}`,
+    )
+  }
+} else {
+  console.log(`no ${surfaceRepoPath} at ${ref.slice(0, 12)}; skipping the compatibility diff`)
+}
+
+if (problems.length > 0) {
+  console.error('\nProtocol check failed:\n')
+  for (const problem of problems) console.error(`* ${problem}\n`)
+  console.error('See agents/protocol/PROTOCOL.md for the rules.')
+  process.exit(1)
+}
+console.log(`protocol ${current.protocol} surface is current and compatible`)

--- a/agents/src/api-service.test.ts
+++ b/agents/src/api-service.test.ts
@@ -21,7 +21,7 @@ import {
   type AgentDefinition,
 } from '@seed-hypermedia/agents-protocol'
 import {createAPIRoutes} from '@/main'
-import {ProtocolTooOldError, assertClientProtocolSupported, clientProtocolOf} from '@/protocol-compat'
+import {clientProtocolOf, clientProtocolProblem, type GetAgentResponseV1} from '@/protocol-compat'
 import {startTestMcpServer} from '@/mcp-test-server'
 
 /**
@@ -11369,10 +11369,10 @@ describe('protocol version negotiation', () => {
       const {agentId, sessionId} = await createAgentWithSession(svc, owner)
       const envelope = await apisvc.createSignedEnvelope(owner, {action: {_: 'GetAgent', agentId}, protocol: null})
       expect('protocol' in envelope).toBe(false)
-      const read = await svc.message(envelope)
+      const read = (await svc.message(envelope)) as GetAgentResponseV1
       if (read._ !== 'GetAgentResponse') throw new Error('unexpected response')
       expect(read.sessionCount).toBe(1)
-      expect(read.sessions?.map((session) => session.id)).toEqual([sessionId])
+      expect(read.sessions.map((session) => session.id)).toEqual([sessionId])
     } finally {
       sqlite.closeDatabase(db)
       cleanup()
@@ -11384,19 +11384,15 @@ describe('protocol version negotiation', () => {
     try {
       const owner = blobs.generateNobleKeyPair()
       const svc = new apisvc.Service(db, dataDir)
-      // Cannot happen today (MIN_CLIENT_PROTOCOL is 1), so the check is exercised directly.
-      expect(() => assertClientProtocolSupported(MIN_CLIENT_PROTOCOL - 1)).toThrow(ProtocolTooOldError)
-      expect(() => assertClientProtocolSupported(MIN_CLIENT_PROTOCOL)).not.toThrow()
-      try {
-        assertClientProtocolSupported(0)
-      } catch (error) {
-        expect(error).toBeInstanceOf(ProtocolTooOldError)
-        if (error instanceof ProtocolTooOldError) {
-          expect(error.status).toBe(426)
-          expect(error.code).toBe('protocol_too_old')
-          expect(error.message).toContain('Update Seed')
-        }
-      }
+      // Cannot happen today (MIN_CLIENT_PROTOCOL is 1), so the judgement is exercised directly.
+      expect(clientProtocolProblem(MIN_CLIENT_PROTOCOL)).toBeNull()
+      expect(clientProtocolProblem(MIN_CLIENT_PROTOCOL - 1)).toMatchObject({
+        status: 426,
+        code: 'protocol_too_old',
+        message: expect.stringContaining('Update Seed'),
+      })
+      // A malformed envelope is left to verification, which answers 401 as before.
+      expect(clientProtocolOf(null)).toBe(1)
       // A nonsense declaration is treated as the implicit version 1, never as "unsupported".
       const garbage = await apisvc.createSignedEnvelope(owner, {action: {_: 'ListAgents'}, protocol: -7})
       expect(clientProtocolOf(garbage)).toBe(1)
@@ -11438,6 +11434,17 @@ describe('protocol version negotiation', () => {
         protocol: AGENTS_PROTOCOL_VERSION,
         minClientProtocol: MIN_CLIENT_PROTOCOL,
       })
+      expect(version.headers.get(AGENTS_PROTOCOL_HEADER)).toBe(String(AGENTS_PROTOCOL_VERSION))
+
+      // A body that is not an envelope still gets the 401 verification always gave it.
+      const garbage = await message(
+        new Request('http://agents.test/api/message', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/cbor'},
+          body: cbor.encode(null) as BodyInit,
+        }),
+      )
+      expect(garbage.status).toBe(401)
     } finally {
       sqlite.closeDatabase(db)
       cleanup()

--- a/agents/src/api-service.test.ts
+++ b/agents/src/api-service.test.ts
@@ -12,7 +12,16 @@ import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import {z} from 'zod'
-import {modelReasoningSupport, sessionEventActor, type AgentDefinition} from '@seed-hypermedia/agents-protocol'
+import {
+  AGENTS_PROTOCOL_HEADER,
+  AGENTS_PROTOCOL_VERSION,
+  MIN_CLIENT_PROTOCOL,
+  modelReasoningSupport,
+  sessionEventActor,
+  type AgentDefinition,
+} from '@seed-hypermedia/agents-protocol'
+import {createAPIRoutes} from '@/main'
+import {ProtocolTooOldError, assertClientProtocolSupported, clientProtocolOf} from '@/protocol-compat'
 import {startTestMcpServer} from '@/mcp-test-server'
 
 /**
@@ -11312,5 +11321,126 @@ describe('narrowDefinitionTools', () => {
     ).toEqual(['publish'])
     // Names that are not lambdas of this agent never ride along.
     expect(apisvc.narrowDefinitionTools(parentBase, ['made_up_tool'], ['check_broken_links'])).toEqual([])
+  })
+})
+
+describe('protocol version negotiation', () => {
+  async function createAgentWithSession(svc: apisvc.Service, owner: blobs.Signer) {
+    await setDefaultProvider(svc, owner)
+    const created = await svc.message(
+      await apisvc.createSignedEnvelope(owner, {
+        action: {
+          _: 'CreateAgent',
+          definition: {name: 'Versioned', systemPrompt: 'Be stable.', modelProvider: 'openai', model: 'gpt'},
+        },
+      }),
+    )
+    if (created._ !== 'CreateAgentResponse') throw new Error('unexpected response')
+    const session = await svc.message(
+      await apisvc.createSignedEnvelope(owner, {action: {_: 'CreateSession', agentId: created.agentId}}),
+    )
+    if (session._ !== 'CreateSessionResponse') throw new Error('unexpected response')
+    return {agentId: created.agentId, sessionId: session.sessionId}
+  }
+
+  test('a client declaring the current protocol gets GetAgent without sessions', async () => {
+    const {db, dataDir, cleanup} = createTestState()
+    try {
+      const owner = blobs.generateNobleKeyPair()
+      const svc = new apisvc.Service(db, dataDir)
+      const {agentId} = await createAgentWithSession(svc, owner)
+      const read = await svc.message(await apisvc.createSignedEnvelope(owner, {action: {_: 'GetAgent', agentId}}))
+      if (read._ !== 'GetAgentResponse') throw new Error('unexpected response')
+      expect(read.sessionCount).toBe(1)
+      expect('sessions' in read).toBe(false)
+    } finally {
+      sqlite.closeDatabase(db)
+      cleanup()
+    }
+  })
+
+  test('a client declaring no protocol (pre-2 desktop) still gets the sessions it reads unguarded', async () => {
+    // The #1078 regression: a 2026.9.4 desktop read `response.sessions.filter(...)` and crashed
+    // its window when the field went missing. Such clients send no `protocol` at all.
+    const {db, dataDir, cleanup} = createTestState()
+    try {
+      const owner = blobs.generateNobleKeyPair()
+      const svc = new apisvc.Service(db, dataDir)
+      const {agentId, sessionId} = await createAgentWithSession(svc, owner)
+      const envelope = await apisvc.createSignedEnvelope(owner, {action: {_: 'GetAgent', agentId}, protocol: null})
+      expect('protocol' in envelope).toBe(false)
+      const read = await svc.message(envelope)
+      if (read._ !== 'GetAgentResponse') throw new Error('unexpected response')
+      expect(read.sessionCount).toBe(1)
+      expect(read.sessions?.map((session) => session.id)).toEqual([sessionId])
+    } finally {
+      sqlite.closeDatabase(db)
+      cleanup()
+    }
+  })
+
+  test('a client below the minimum protocol is refused with a typed 426 before anything else', async () => {
+    const {db, dataDir, cleanup} = createTestState()
+    try {
+      const owner = blobs.generateNobleKeyPair()
+      const svc = new apisvc.Service(db, dataDir)
+      // Cannot happen today (MIN_CLIENT_PROTOCOL is 1), so the check is exercised directly.
+      expect(() => assertClientProtocolSupported(MIN_CLIENT_PROTOCOL - 1)).toThrow(ProtocolTooOldError)
+      expect(() => assertClientProtocolSupported(MIN_CLIENT_PROTOCOL)).not.toThrow()
+      try {
+        assertClientProtocolSupported(0)
+      } catch (error) {
+        expect(error).toBeInstanceOf(ProtocolTooOldError)
+        if (error instanceof ProtocolTooOldError) {
+          expect(error.status).toBe(426)
+          expect(error.code).toBe('protocol_too_old')
+          expect(error.message).toContain('Update Seed')
+        }
+      }
+      // A nonsense declaration is treated as the implicit version 1, never as "unsupported".
+      const garbage = await apisvc.createSignedEnvelope(owner, {action: {_: 'ListAgents'}, protocol: -7})
+      expect(clientProtocolOf(garbage)).toBe(1)
+      const list = await svc.message(garbage)
+      expect(list._).toBe('ListAgentsResponse')
+      // A future client is admitted: the server answers in its own protocol.
+      const future = await apisvc.createSignedEnvelope(owner, {
+        action: {_: 'ListAgents'},
+        protocol: AGENTS_PROTOCOL_VERSION + 5,
+      })
+      expect((await svc.message(future))._).toBe('ListAgentsResponse')
+    } finally {
+      sqlite.closeDatabase(db)
+      cleanup()
+    }
+  })
+
+  test('the HTTP layer sends the protocol header and the error code', async () => {
+    const {db, dataDir, cleanup} = createTestState()
+    try {
+      const owner = blobs.generateNobleKeyPair()
+      const svc = new apisvc.Service(db, dataDir)
+      const routes = createAPIRoutes(svc)
+      const message = (routes['/api/message'] as {POST: (req: Request) => Promise<Response>}).POST
+      const envelope = await apisvc.createSignedEnvelope(owner, {action: {_: 'ListAgents'}})
+      const ok = await message(
+        new Request('http://agents.test/api/message', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/cbor'},
+          body: cbor.encode(envelope) as BodyInit,
+        }),
+      )
+      expect(ok.status).toBe(200)
+      expect(ok.headers.get(AGENTS_PROTOCOL_HEADER)).toBe(String(AGENTS_PROTOCOL_VERSION))
+      expect(ok.headers.get('Access-Control-Expose-Headers')).toContain(AGENTS_PROTOCOL_HEADER)
+
+      const version = (routes['/api/version'] as {GET: () => Response}).GET()
+      expect(await version.json()).toMatchObject({
+        protocol: AGENTS_PROTOCOL_VERSION,
+        minClientProtocol: MIN_CLIENT_PROTOCOL,
+      })
+    } finally {
+      sqlite.closeDatabase(db)
+      cleanup()
+    }
   })
 })

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -42,12 +42,7 @@ import {
 } from '@/code-exec'
 import * as scheduleTriggers from '@/schedule-triggers'
 import * as auth from '@/auth'
-import {
-  ProtocolTooOldError,
-  assertClientProtocolSupported,
-  clientProtocolOf,
-  downgradeResponse,
-} from '@/protocol-compat'
+import {clientProtocolOf, clientProtocolProblem, downgradeResponse} from '@/protocol-compat'
 import * as cbor from '@/cbor'
 import * as mcp from '@/mcp'
 import * as runs from '@/runs'
@@ -1034,24 +1029,23 @@ export class Service {
    * declared protocol version (see `protocol-compat.ts`).
    */
   async message(envelope: api.SignedActionEnvelope): Promise<api.AgentResponse> {
+    // Judged before the signature: the answer does not depend on who signed, and a refused client
+    // should learn why without the server doing any more work for it.
     const clientProtocol = clientProtocolOf(envelope)
     this.#assertClientProtocol(clientProtocol)
     const verified = await this.#verifyEnvelope(envelope)
     const response = await this.#dispatch(envelope, verified)
     return downgradeResponse(response, clientProtocol, {
+      // Viewer-scoped like `ListSessions {agentId}`: a superset of who passes GetAgent's reader check.
       listAgentSessions: (agentId) =>
-        this.#listSessions(verified.accountId, agentId, DEFAULT_SESSION_PAGE_SIZE, undefined, undefined, false)
+        this.#listSessionPage(verified.accountId, agentId, DEFAULT_SESSION_PAGE_SIZE, undefined, undefined, false)
           .sessions,
     })
   }
 
   #assertClientProtocol(clientProtocol: number): void {
-    try {
-      assertClientProtocolSupported(clientProtocol)
-    } catch (error) {
-      if (error instanceof ProtocolTooOldError) throw new APIError(error.status, error.message, error.code)
-      throw error
-    }
+    const problem = clientProtocolProblem(clientProtocol)
+    if (problem) throw new APIError(problem.status, problem.message, problem.code)
   }
 
   async #dispatch(envelope: api.SignedActionEnvelope, verified: auth.VerifiedEnvelope): Promise<api.AgentResponse> {
@@ -2778,6 +2772,21 @@ export class Service {
     parentSessionId?: string,
     includeChildren?: boolean,
   ): api.ListSessionsResponse {
+    const page = this.#listSessionPage(accountId, agentId, limit, cursor, parentSessionId, includeChildren)
+    const referencedAgentIds = new Set(page.sessions.map((session) => session.agentId))
+    const agents = this.#listAgents(accountId).agents.filter((agent) => referencedAgentIds.has(agent.id))
+    return {_: 'ListSessionsResponse', agents, ...page}
+  }
+
+  /** One page of {@link #listSessions} without the agent lookup, for callers that only need rows. */
+  #listSessionPage(
+    accountId: string,
+    agentId?: string,
+    limit?: number,
+    cursor?: api.SessionListCursor,
+    parentSessionId?: string,
+    includeChildren?: boolean,
+  ): Pick<api.ListSessionsResponse, 'sessions' | 'nextCursor'> {
     const pageSize = boundedInteger(limit, DEFAULT_SESSION_PAGE_SIZE, 1, MAX_SESSION_PAGE_SIZE)
     // Account-wide listings only cover agents the account owns or collaborates on. A listing scoped to
     // one agent additionally admits public-read agents, which #actionAccountId already authorized.
@@ -2836,14 +2845,9 @@ export class Service {
         this.#sessionContinuationLinks(session.account_id, session.id),
       ),
     )
-    const referencedAgentIds = new Set(sessions.map((session) => session.agentId))
-    const agents = this.#listAgents(accountId).agents.filter((agent) => referencedAgentIds.has(agent.id))
     const last = page[page.length - 1]
-
     return {
-      _: 'ListSessionsResponse',
       sessions,
-      agents,
       ...(hasMore && last ? {nextCursor: {updatedBefore: last.updated_at, idBefore: last.id}} : {}),
     }
   }

--- a/agents/src/api-service.ts
+++ b/agents/src/api-service.ts
@@ -1,6 +1,7 @@
 import type {Database} from 'bun:sqlite'
 import type * as api from '@/api'
 import {
+  AGENTS_PROTOCOL_VERSION,
   callableToolRegistry,
   getSeedTool,
   sessionEventActor,
@@ -41,6 +42,12 @@ import {
 } from '@/code-exec'
 import * as scheduleTriggers from '@/schedule-triggers'
 import * as auth from '@/auth'
+import {
+  ProtocolTooOldError,
+  assertClientProtocolSupported,
+  clientProtocolOf,
+  downgradeResponse,
+} from '@/protocol-compat'
 import * as cbor from '@/cbor'
 import * as mcp from '@/mcp'
 import * as runs from '@/runs'
@@ -310,10 +317,13 @@ export type ServiceEvent =
 export class APIError extends Error {
   /** HTTP status code for the error response. */
   readonly status: number
+  /** Machine-readable cause, sent as `ErrorResponse.code` when set. */
+  readonly code?: api.ErrorResponse['code']
 
-  constructor(status: number, message: string) {
+  constructor(status: number, message: string, code?: api.ErrorResponse['code']) {
     super(message)
     this.status = status
+    if (code) this.code = code
   }
 }
 
@@ -1019,10 +1029,32 @@ export class Service {
     }
   }
 
-  /** Verifies and dispatches a signed action envelope. */
+  /**
+   * Verifies and dispatches a signed action envelope, answering in the shape of the client's
+   * declared protocol version (see `protocol-compat.ts`).
+   */
   async message(envelope: api.SignedActionEnvelope): Promise<api.AgentResponse> {
+    const clientProtocol = clientProtocolOf(envelope)
+    this.#assertClientProtocol(clientProtocol)
     const verified = await this.#verifyEnvelope(envelope)
+    const response = await this.#dispatch(envelope, verified)
+    return downgradeResponse(response, clientProtocol, {
+      listAgentSessions: (agentId) =>
+        this.#listSessions(verified.accountId, agentId, DEFAULT_SESSION_PAGE_SIZE, undefined, undefined, false)
+          .sessions,
+    })
+  }
 
+  #assertClientProtocol(clientProtocol: number): void {
+    try {
+      assertClientProtocolSupported(clientProtocol)
+    } catch (error) {
+      if (error instanceof ProtocolTooOldError) throw new APIError(error.status, error.message, error.code)
+      throw error
+    }
+  }
+
+  async #dispatch(envelope: api.SignedActionEnvelope, verified: auth.VerifiedEnvelope): Promise<api.AgentResponse> {
     const accountId = this.#actionAccountId(verified.accountId, envelope.action)
 
     switch (envelope.action._) {
@@ -8154,6 +8186,7 @@ export class Service {
     /** Snapshot + durable journal replay for `runs/<rootRunId>` subscriptions. */
     runsReplay?: {runs: api.RunInfo[]; entries: api.RunJournalEntryInfo[]}
   }> {
+    this.#assertClientProtocol(clientProtocolOf(envelope))
     const verified = await this.#verifyEnvelope(envelope)
     if (envelope.action._ !== 'Subscribe') throw new APIError(400, 'Expected Subscribe action')
     const key = envelope.action.key
@@ -15793,8 +15826,14 @@ export async function createSignedEnvelope(
     capabilityBlob?: Uint8Array
     action: api.UnsignedAgentAction
     ts?: number
+    /**
+     * Protocol version to declare; defaults to this build's. `null` declares none, as clients from
+     * before protocol 2 do (servers read that as protocol 1).
+     */
+    protocol?: number | null
   },
 ): Promise<api.SignedActionEnvelope> {
+  const protocol = input.protocol === undefined ? AGENTS_PROTOCOL_VERSION : input.protocol
   const envelope: api.SignedActionEnvelope = {
     type: 'AgentsAction',
     signer: signer.principal,
@@ -15802,6 +15841,7 @@ export async function createSignedEnvelope(
     account: input.account ?? signer.principal,
     ...(input.capability !== undefined ? {capability: input.capability} : {}),
     ...(input.capabilityBlob !== undefined ? {capabilityBlob: input.capabilityBlob} : {}),
+    ...(protocol !== null ? {protocol} : {}),
     action: {...input.action, ts: input.ts ?? Date.now()} as api.AgentAction,
   }
   return (await blobs.sign(signer, envelope as unknown as blobs.Blob)) as unknown as api.SignedActionEnvelope

--- a/agents/src/build-info.ts
+++ b/agents/src/build-info.ts
@@ -8,11 +8,17 @@
  * `/api/version` and inside `/api/health`.
  *
  * `commit`/`branch`/`date` mirror the daemon `/debug/version` and web `/hm/api/version`
- * shape; `version` (the image tag) is an agents-specific addition.
+ * shape; `version` (the image tag) and the protocol fields are agents-specific additions.
  */
+import {AGENTS_PROTOCOL_VERSION, MIN_CLIENT_PROTOCOL} from '@seed-hypermedia/agents-protocol'
+
 export type BuildInfo = {
   /** Image tag / release version, e.g. `2026.6.10` or `dev`. */
   version: string
+  /** Agents wire protocol this build speaks (`AGENTS_PROTOCOL_VERSION`); see agents/protocol/PROTOCOL.md. */
+  protocol: number
+  /** Oldest client protocol this build still answers (`MIN_CLIENT_PROTOCOL`). */
+  minClientProtocol: number
   /** Full git commit SHA the image was built from. */
   commit: string
   /** Git ref the image was built from. */
@@ -24,6 +30,8 @@ export type BuildInfo = {
 export function getBuildInfo(): BuildInfo {
   return {
     version: process.env.SEED_AGENTS_VERSION || 'dev',
+    protocol: AGENTS_PROTOCOL_VERSION,
+    minClientProtocol: MIN_CLIENT_PROTOCOL,
     commit: process.env.SEED_AGENTS_COMMIT || 'unknown',
     branch: process.env.SEED_AGENTS_BRANCH || 'unknown',
     date: process.env.SEED_AGENTS_DATE || 'unknown',

--- a/agents/src/cbor.ts
+++ b/agents/src/cbor.ts
@@ -11,18 +11,27 @@ export function decode<T = unknown>(data: Uint8Array): T {
   return sharedCBOR.decode<T>(data)
 }
 
+/**
+ * CORS headers plus the server's protocol version, for every route a browser client reads.
+ * Browsers hide response headers from cross-origin scripts unless exposed, hence the second line
+ * (see `agents/protocol/PROTOCOL.md`).
+ */
+export function corsHeaders(methods = 'POST, OPTIONS'): Record<string, string> {
+  return {
+    'Access-Control-Allow-Headers': 'Content-Type, Accept',
+    'Access-Control-Allow-Methods': methods,
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Expose-Headers': AGENTS_PROTOCOL_HEADER,
+    [AGENTS_PROTOCOL_HEADER]: String(AGENTS_PROTOCOL_VERSION),
+  }
+}
+
 /** Creates an `application/cbor` response body. */
 export function response(value: unknown, init?: ResponseInit): Response {
   return new Response(encode(value) as BodyInit, {
     ...init,
     headers: {
-      'Access-Control-Allow-Headers': 'Content-Type, Accept',
-      'Access-Control-Allow-Methods': 'POST, OPTIONS',
-      'Access-Control-Allow-Origin': '*',
-      // Browsers hide response headers from cross-origin scripts unless exposed; the client reads
-      // this one to tell a server it is too new for (see `agents/protocol/PROTOCOL.md`).
-      'Access-Control-Expose-Headers': AGENTS_PROTOCOL_HEADER,
-      [AGENTS_PROTOCOL_HEADER]: String(AGENTS_PROTOCOL_VERSION),
+      ...corsHeaders(),
       'Content-Type': 'application/cbor',
       ...(init?.headers ?? {}),
     },

--- a/agents/src/cbor.ts
+++ b/agents/src/cbor.ts
@@ -1,4 +1,5 @@
 import * as sharedCBOR from '@shm/shared/cbor'
+import {AGENTS_PROTOCOL_HEADER, AGENTS_PROTOCOL_VERSION} from '@seed-hypermedia/agents-protocol'
 
 /** Encodes a value as canonical DAG-CBOR bytes. */
 export function encode<T = unknown>(value: T): Uint8Array {
@@ -18,6 +19,10 @@ export function response(value: unknown, init?: ResponseInit): Response {
       'Access-Control-Allow-Headers': 'Content-Type, Accept',
       'Access-Control-Allow-Methods': 'POST, OPTIONS',
       'Access-Control-Allow-Origin': '*',
+      // Browsers hide response headers from cross-origin scripts unless exposed; the client reads
+      // this one to tell a server it is too new for (see `agents/protocol/PROTOCOL.md`).
+      'Access-Control-Expose-Headers': AGENTS_PROTOCOL_HEADER,
+      [AGENTS_PROTOCOL_HEADER]: String(AGENTS_PROTOCOL_VERSION),
       'Content-Type': 'application/cbor',
       ...(init?.headers ?? {}),
     },

--- a/agents/src/main.ts
+++ b/agents/src/main.ts
@@ -1,5 +1,4 @@
 import type * as api from '@/api'
-import {AGENTS_PROTOCOL_HEADER, AGENTS_PROTOCOL_VERSION, MIN_CLIENT_PROTOCOL} from '@seed-hypermedia/agents-protocol'
 import {ActivityMonitor} from '@/activity-monitor'
 import * as apisvc from '@/api-service'
 import {getBuildInfo} from '@/build-info'
@@ -119,8 +118,8 @@ export function createAPIRoutes(svc: apisvc.Service): Bun.Serve.Routes<undefined
         status: 'ok',
         uptime: process.uptime(),
         version: buildInfo.version,
-        protocol: AGENTS_PROTOCOL_VERSION,
-        minClientProtocol: MIN_CLIENT_PROTOCOL,
+        protocol: buildInfo.protocol,
+        minClientProtocol: buildInfo.minClientProtocol,
         hmServerUrl: svc.hmServerUrl,
         ipfsServerUrl: svc.ipfsServerUrl,
         webTools: svc.webToolCapabilities(),
@@ -135,11 +134,7 @@ export function createAPIRoutes(svc: apisvc.Service): Bun.Serve.Routes<undefined
       {headers: corsHeaders()},
     )
   }
-  const version = () =>
-    Response.json(
-      {...buildInfo, protocol: AGENTS_PROTOCOL_VERSION, minClientProtocol: MIN_CLIENT_PROTOCOL},
-      {headers: corsHeaders()},
-    )
+  const version = () => Response.json(buildInfo, {headers: corsHeaders()})
   // Aggregate latency stats (metric names and millisecond percentiles only — no ids, no content),
   // so "is this server slow, and where" is one curl away. Same exposure class as /api/health.
   const perf = () => Response.json(perfSnapshot(), {headers: corsHeaders()})
@@ -278,13 +273,7 @@ function sendIfSubscribed(
 }
 
 function corsHeaders(): HeadersInit {
-  return {
-    'Access-Control-Allow-Headers': 'Content-Type, Accept',
-    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Expose-Headers': AGENTS_PROTOCOL_HEADER,
-    [AGENTS_PROTOCOL_HEADER]: String(AGENTS_PROTOCOL_VERSION),
-  }
+  return cbor.corsHeaders('GET, POST, OPTIONS')
 }
 
 async function main(): Promise<void> {
@@ -541,7 +530,11 @@ async function main(): Promise<void> {
               }
             }
           } catch (error) {
-            sendWS(ws, {_: 'error', message: error instanceof Error ? error.message : 'Invalid subscription'})
+            sendWS(ws, {
+              _: 'error',
+              message: error instanceof Error ? error.message : 'Invalid subscription',
+              ...(error instanceof apisvc.APIError && error.code ? {code: error.code} : {}),
+            })
           }
         })()
       },

--- a/agents/src/main.ts
+++ b/agents/src/main.ts
@@ -1,4 +1,5 @@
 import type * as api from '@/api'
+import {AGENTS_PROTOCOL_HEADER, AGENTS_PROTOCOL_VERSION, MIN_CLIENT_PROTOCOL} from '@seed-hypermedia/agents-protocol'
 import {ActivityMonitor} from '@/activity-monitor'
 import * as apisvc from '@/api-service'
 import {getBuildInfo} from '@/build-info'
@@ -52,7 +53,10 @@ export function createAPIRoutes(svc: apisvc.Service): Bun.Serve.Routes<undefined
       return cbor.response(await svc.message(envelope))
     } catch (error) {
       if (error instanceof apisvc.APIError) {
-        return cbor.response({_: 'Error', message: error.message} satisfies api.ErrorResponse, {status: error.status})
+        return cbor.response(
+          {_: 'Error', message: error.message, ...(error.code ? {code: error.code} : {})} satisfies api.ErrorResponse,
+          {status: error.status},
+        )
       }
       // A thrown non-API error must still come back as a CORS-bearing CBOR error: Bun's bare 500
       // carries no Access-Control-Allow-Origin, which browsers report only as "Failed to fetch".
@@ -115,6 +119,8 @@ export function createAPIRoutes(svc: apisvc.Service): Bun.Serve.Routes<undefined
         status: 'ok',
         uptime: process.uptime(),
         version: buildInfo.version,
+        protocol: AGENTS_PROTOCOL_VERSION,
+        minClientProtocol: MIN_CLIENT_PROTOCOL,
         hmServerUrl: svc.hmServerUrl,
         ipfsServerUrl: svc.ipfsServerUrl,
         webTools: svc.webToolCapabilities(),
@@ -129,7 +135,11 @@ export function createAPIRoutes(svc: apisvc.Service): Bun.Serve.Routes<undefined
       {headers: corsHeaders()},
     )
   }
-  const version = () => Response.json(buildInfo, {headers: corsHeaders()})
+  const version = () =>
+    Response.json(
+      {...buildInfo, protocol: AGENTS_PROTOCOL_VERSION, minClientProtocol: MIN_CLIENT_PROTOCOL},
+      {headers: corsHeaders()},
+    )
   // Aggregate latency stats (metric names and millisecond percentiles only — no ids, no content),
   // so "is this server slow, and where" is one curl away. Same exposure class as /api/health.
   const perf = () => Response.json(perfSnapshot(), {headers: corsHeaders()})
@@ -272,6 +282,8 @@ function corsHeaders(): HeadersInit {
     'Access-Control-Allow-Headers': 'Content-Type, Accept',
     'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
     'Access-Control-Allow-Origin': '*',
+    'Access-Control-Expose-Headers': AGENTS_PROTOCOL_HEADER,
+    [AGENTS_PROTOCOL_HEADER]: String(AGENTS_PROTOCOL_VERSION),
   }
 }
 

--- a/agents/src/protocol-compat.ts
+++ b/agents/src/protocol-compat.ts
@@ -4,63 +4,71 @@
  * Every signed envelope names the protocol its client speaks (`envelope.protocol`; absent means 1).
  * The dispatcher refuses clients older than `MIN_CLIENT_PROTOCOL` with a `protocol_too_old` error,
  * and hands every successful response through {@link downgradeResponse}, which rewrites it into
- * the shape the client's protocol expects. The shims live here and nowhere else, so retiring a
- * protocol version (raising `MIN_CLIENT_PROTOCOL`) is deleting one block from this file.
+ * the shape the client's protocol expects. The shims and the legacy shapes they produce live here
+ * and nowhere else, so retiring a protocol version (raising `MIN_CLIENT_PROTOCOL`) is deleting one
+ * block from this file.
  *
  * See `agents/protocol/PROTOCOL.md` for the rules and the per-version changelog.
  */
 import type * as api from '@/api'
 import {AGENTS_PROTOCOL_VERSION, MIN_CLIENT_PROTOCOL, declaredProtocolVersion} from '@seed-hypermedia/agents-protocol'
 
-/** Error thrown for a client this server no longer answers. Carries the wire code for the client. */
-export class ProtocolTooOldError extends Error {
-  readonly status = 426
-  readonly code = 'protocol_too_old' as const
-  constructor(readonly clientProtocol: number) {
-    super(
-      `This app speaks agents protocol ${clientProtocol}, but this server only answers protocol ${MIN_CLIENT_PROTOCOL} and newer. Update Seed to continue.`,
-    )
-    this.name = 'ProtocolTooOldError'
-  }
-}
+/** The wire error for a client this server no longer answers; the dispatcher throws it as an APIError. */
+export type ProtocolProblem = {status: 426; code: 'protocol_too_old'; message: string}
 
-/** The protocol version an envelope's client speaks. */
-export function clientProtocolOf(envelope: Pick<api.SignedActionEnvelope, 'protocol'>): number {
-  return declaredProtocolVersion(envelope.protocol)
+/** The protocol version an envelope's client speaks. Tolerates a malformed envelope (verification rejects it next). */
+export function clientProtocolOf(envelope: unknown): number {
+  const declared = envelope && typeof envelope === 'object' ? (envelope as {protocol?: unknown}).protocol : undefined
+  return declaredProtocolVersion(declared)
 }
 
 /**
- * Rejects clients below `MIN_CLIENT_PROTOCOL`. Newer clients are always admitted: a bump of the
- * version obliges the *client* to keep talking to servers down to its `MIN_SERVER_PROTOCOL`, and
- * an action this server does not know falls through to the dispatcher's own "unknown action".
+ * The refusal for a client below `MIN_CLIENT_PROTOCOL`, or null when it is served. Newer clients
+ * are always admitted: a bump of the version obliges the *client* to keep talking to older servers,
+ * and an action this server does not know falls through to the dispatcher's own "unknown action".
  */
-export function assertClientProtocolSupported(clientProtocol: number): void {
-  if (clientProtocol < MIN_CLIENT_PROTOCOL) throw new ProtocolTooOldError(clientProtocol)
+export function clientProtocolProblem(clientProtocol: number): ProtocolProblem | null {
+  if (clientProtocol >= MIN_CLIENT_PROTOCOL) return null
+  return {
+    status: 426,
+    code: 'protocol_too_old',
+    message: `This app speaks agents protocol ${clientProtocol}, but this server only answers protocol ${MIN_CLIENT_PROTOCOL} and newer. Update Seed to continue.`,
+  }
 }
 
 /** What the shims need from the service to rebuild an older shape. */
 export type DowngradeContext = {
-  /** Newest top-level sessions of an agent, as the protocol 1 `GetAgent` answered them. */
+  /** Newest top-level sessions of an agent as the viewer may see them, for the protocol 1 `GetAgent`. */
   listAgentSessions(agentId: string): api.SessionInfo[]
 }
 
 /**
+ * Protocol 1 `GetAgentResponse`: it carried the agent's sessions. Declared here rather than on the
+ * shared type so that no protocol 2 client can be written against a field it is never sent.
+ */
+export type GetAgentResponseV1 = api.GetAgentResponse & {sessions: api.SessionInfo[]}
+
+/**
  * Rewrites a response built for {@link AGENTS_PROTOCOL_VERSION} into the shape `clientProtocol`
- * expects. Applied in descending order so a client two versions behind gets each step.
+ * expects. Each shim rewrites from its version to the one below and passes the result on, so a
+ * client several versions behind gets every step; add new shims at the top, newest first.
  */
 export function downgradeResponse(
   response: api.AgentResponse,
   clientProtocol: number,
   context: DowngradeContext,
 ): api.AgentResponse {
-  if (clientProtocol >= AGENTS_PROTOCOL_VERSION) return response
+  let out = response
 
-  // Protocol 1 → 2: GetAgent stopped carrying the agent's sessions (#1078). A protocol 1 client
-  // reads `sessions` unguarded and crashes its whole window on `undefined` — so the newest page is
-  // filled in for it, which is what its sidebar and agent page showed anyway.
-  if (clientProtocol < 2 && response._ === 'GetAgentResponse') {
-    return {...response, sessions: context.listAgentSessions(response.agent.id)}
+  // 2 → 1: GetAgent stopped carrying the agent's sessions (#1078). A protocol 1 client reads
+  // `sessions` unguarded and crashes its whole window on `undefined`. It gets the newest page of
+  // top-level sessions: those clients filter children themselves and their sidebar showed the
+  // newest few; the agent page shows a capped list rather than nothing. `sessionCount` is free, so
+  // an agent with no sessions costs no extra query.
+  if (clientProtocol < 2 && out._ === 'GetAgentResponse') {
+    const sessions = out.sessionCount > 0 ? context.listAgentSessions(out.agent.id) : []
+    out = {...out, sessions} as GetAgentResponseV1
   }
 
-  return response
+  return out
 }

--- a/agents/src/protocol-compat.ts
+++ b/agents/src/protocol-compat.ts
@@ -1,0 +1,66 @@
+/**
+ * Protocol version negotiation and per-version response shaping.
+ *
+ * Every signed envelope names the protocol its client speaks (`envelope.protocol`; absent means 1).
+ * The dispatcher refuses clients older than `MIN_CLIENT_PROTOCOL` with a `protocol_too_old` error,
+ * and hands every successful response through {@link downgradeResponse}, which rewrites it into
+ * the shape the client's protocol expects. The shims live here and nowhere else, so retiring a
+ * protocol version (raising `MIN_CLIENT_PROTOCOL`) is deleting one block from this file.
+ *
+ * See `agents/protocol/PROTOCOL.md` for the rules and the per-version changelog.
+ */
+import type * as api from '@/api'
+import {AGENTS_PROTOCOL_VERSION, MIN_CLIENT_PROTOCOL, declaredProtocolVersion} from '@seed-hypermedia/agents-protocol'
+
+/** Error thrown for a client this server no longer answers. Carries the wire code for the client. */
+export class ProtocolTooOldError extends Error {
+  readonly status = 426
+  readonly code = 'protocol_too_old' as const
+  constructor(readonly clientProtocol: number) {
+    super(
+      `This app speaks agents protocol ${clientProtocol}, but this server only answers protocol ${MIN_CLIENT_PROTOCOL} and newer. Update Seed to continue.`,
+    )
+    this.name = 'ProtocolTooOldError'
+  }
+}
+
+/** The protocol version an envelope's client speaks. */
+export function clientProtocolOf(envelope: Pick<api.SignedActionEnvelope, 'protocol'>): number {
+  return declaredProtocolVersion(envelope.protocol)
+}
+
+/**
+ * Rejects clients below `MIN_CLIENT_PROTOCOL`. Newer clients are always admitted: a bump of the
+ * version obliges the *client* to keep talking to servers down to its `MIN_SERVER_PROTOCOL`, and
+ * an action this server does not know falls through to the dispatcher's own "unknown action".
+ */
+export function assertClientProtocolSupported(clientProtocol: number): void {
+  if (clientProtocol < MIN_CLIENT_PROTOCOL) throw new ProtocolTooOldError(clientProtocol)
+}
+
+/** What the shims need from the service to rebuild an older shape. */
+export type DowngradeContext = {
+  /** Newest top-level sessions of an agent, as the protocol 1 `GetAgent` answered them. */
+  listAgentSessions(agentId: string): api.SessionInfo[]
+}
+
+/**
+ * Rewrites a response built for {@link AGENTS_PROTOCOL_VERSION} into the shape `clientProtocol`
+ * expects. Applied in descending order so a client two versions behind gets each step.
+ */
+export function downgradeResponse(
+  response: api.AgentResponse,
+  clientProtocol: number,
+  context: DowngradeContext,
+): api.AgentResponse {
+  if (clientProtocol >= AGENTS_PROTOCOL_VERSION) return response
+
+  // Protocol 1 → 2: GetAgent stopped carrying the agent's sessions (#1078). A protocol 1 client
+  // reads `sessions` unguarded and crashes its whole window on `undefined` — so the newest page is
+  // filled in for it, which is what its sidebar and agent page showed anyway.
+  if (clientProtocol < 2 && response._ === 'GetAgentResponse') {
+    return {...response, sessions: context.listAgentSessions(response.agent.id)}
+  }
+
+  return response
+}

--- a/agents/src/protocol-surface.test.ts
+++ b/agents/src/protocol-surface.test.ts
@@ -1,8 +1,14 @@
 import {describe, expect, test} from 'bun:test'
 import {readFileSync} from 'node:fs'
 import path from 'node:path'
-import {AGENTS_PROTOCOL_VERSION, MIN_CLIENT_PROTOCOL, MIN_SERVER_PROTOCOL} from '@seed-hypermedia/agents-protocol'
-import {diffSurfaces, extractSurface, judgeSurfaceChange, type ProtocolSurface} from './protocol-surface'
+import {AGENTS_PROTOCOL_VERSION, MIN_CLIENT_PROTOCOL} from '@seed-hypermedia/agents-protocol'
+import {
+  SURFACE_FORMAT,
+  diffSurfaces,
+  extractSurface,
+  judgeSurfaceChange,
+  type ProtocolSurface,
+} from './protocol-surface'
 
 const surfacePath = path.resolve(import.meta.dir, '../protocol/surface.json')
 const changelogPath = path.resolve(import.meta.dir, '../protocol/PROTOCOL.md')
@@ -10,10 +16,6 @@ const changelogPath = path.resolve(import.meta.dir, '../protocol/PROTOCOL.md')
 // One extraction for the whole file: it type-checks the protocol package.
 const current = extractSurface()
 const committed = JSON.parse(readFileSync(surfacePath, 'utf8')) as ProtocolSurface
-
-function clone(surface: ProtocolSurface): ProtocolSurface {
-  return structuredClone(surface)
-}
 
 function breaking(base: ProtocolSurface, next: ProtocolSurface) {
   return diffSurfaces(base, next)
@@ -27,16 +29,17 @@ describe('protocol surface snapshot', () => {
   })
 
   test('records the version constants', () => {
+    expect(current.format).toBe(SURFACE_FORMAT)
     expect(current.protocol).toBe(AGENTS_PROTOCOL_VERSION)
     expect(current.minClientProtocol).toBe(MIN_CLIENT_PROTOCOL)
-    expect(current.minServerProtocol).toBe(MIN_SERVER_PROTOCOL)
   })
 
   test('lists every action and response by its discriminant, and the envelope', () => {
     expect(current.actions.GetAgent?.fields).toEqual({_: '"GetAgent"', agentId: 'string'})
-    expect(current.responses.GetAgentResponse?.fields).toMatchObject({
+    expect(current.responses.GetAgentResponse?.fields).toEqual({
+      _: '"GetAgentResponse"',
+      agent: 'AgentInfo',
       sessionCount: 'number',
-      'sessions?': 'SessionInfo[]',
     })
     expect(current.envelope.fields).toMatchObject({'protocol?': 'number', action: 'AgentAction'})
     // The action union is the `actions` group; it must not be duplicated as an opaque type.
@@ -50,19 +53,40 @@ describe('protocol surface snapshot', () => {
     expect(current.types.SessionInfo?.fields?.['modelOverride?']).toBe('SessionModelOverride')
     expect(current.types.SessionModelOverride).toBeDefined()
   })
+
+  test('splits discriminated unions into members, and leaves literal unions whole', () => {
+    expect(current.types.AgentTriggerSource?.variants?.schedule?.fields).toMatchObject({type: '"schedule"'})
+    expect(current.types.RunStatus?.alias).toContain('"queued"')
+    expect(current.types.RunStatus?.variants).toBeUndefined()
+  })
 })
 
 describe('protocol compatibility rules', () => {
   test('the #1078 change is caught: a response field removed is breaking for readers', () => {
-    const base = clone(current)
+    const base = structuredClone(current)
     base.responses.GetAgentResponse!.fields = {_: '"GetAgentResponse"', agent: 'AgentInfo', sessions: 'SessionInfo[]'}
-    const next = clone(current)
-    delete next.responses.GetAgentResponse!.fields!['sessions?']
-    expect(breaking(base, next)).toEqual(['responses.GetAgentResponse.sessions [reads]'])
+    expect(breaking(base, current)).toEqual(['responses.GetAgentResponse.sessions [reads]'])
+  })
+
+  test('a change inside one member of a discriminated union is judged by the field rules', () => {
+    const next = structuredClone(current)
+    next.types.AgentTriggerSource!.variants!.schedule!.fields!['timezone?'] = 'string'
+    expect(breaking(current, next)).toEqual([])
+
+    const removed = structuredClone(current)
+    delete removed.types.AgentTriggerSource!.variants!.schedule
+    const added = structuredClone(current)
+    added.types.AgentTriggerSource!.variants!.pigeon = {fields: {type: '"pigeon"', loft: 'string'}}
+    // The source is written (CreateAgentTrigger) and read (AgentTriggerInfo).
+    expect(breaking(current, removed)).toEqual([
+      'types.AgentTriggerSource.<schedule> [reads]',
+      'types.AgentTriggerSource.<schedule> [writes]',
+    ])
+    expect(breaking(current, added)).toEqual(['types.AgentTriggerSource.<pigeon> [reads]'])
   })
 
   test('additive changes are compatible', () => {
-    const next = clone(current)
+    const next = structuredClone(current)
     next.responses.GetAgentResponse!.fields!['starred?'] = 'boolean'
     next.responses.GetAgentResponse!.fields!.owner = 'string'
     next.actions.GetAgent!.fields!['includeArchived?'] = 'boolean'
@@ -74,13 +98,13 @@ describe('protocol compatibility rules', () => {
   })
 
   test('a required field added to an action is breaking for writers', () => {
-    const next = clone(current)
+    const next = structuredClone(current)
     next.actions.GetAgent!.fields!.reason = 'string'
     expect(breaking(current, next)).toEqual(['actions.GetAgent.reason [writes]'])
   })
 
   test('optionality flips are judged by direction', () => {
-    const next = clone(current)
+    const next = structuredClone(current)
     // Readers lose a guarantee.
     delete next.responses.GetAgentResponse!.fields!.sessionCount
     next.responses.GetAgentResponse!.fields!['sessionCount?'] = 'number'
@@ -92,7 +116,7 @@ describe('protocol compatibility rules', () => {
       'actions.ListSessions.limit [writes]',
     ])
 
-    const relaxed = clone(current)
+    const relaxed = structuredClone(current)
     delete relaxed.actions.ListSessions!.fields!.agentId
     delete relaxed.actions.GetAgent!.fields!.agentId
     relaxed.actions.GetAgent!.fields!['agentId?'] = 'string'
@@ -100,7 +124,7 @@ describe('protocol compatibility rules', () => {
   })
 
   test('a change inside a nested type is attributed to the type, in every direction it travels', () => {
-    const next = clone(current)
+    const next = structuredClone(current)
     // AgentDefinition is sent (CreateAgent) and received (AgentInfo).
     delete next.types.AgentDefinition!.fields!.model
     expect(breaking(current, next)).toEqual([
@@ -108,22 +132,22 @@ describe('protocol compatibility rules', () => {
       'types.AgentDefinition.model [writes]',
     ])
 
-    const widened = clone(current)
+    const widened = structuredClone(current)
     widened.types.RunStatus = {alias: `${current.types.RunStatus!.alias} | "paused"`}
     expect(breaking(current, widened)).toContain('types.RunStatus [reads]')
   })
 
   test('removing an action or response is breaking', () => {
-    const next = clone(current)
+    const next = structuredClone(current)
     delete next.actions.GetAgent
     delete next.responses.GetAgentResponse
     expect(breaking(current, next)).toEqual(['responses.GetAgentResponse [reads]', 'actions.GetAgent [writes]'])
   })
 
   test('types no longer reachable from the wire are not compared', () => {
-    const base = clone(current)
+    const base = structuredClone(current)
     base.types.Orphan = {fields: {x: 'string'}}
-    const next = clone(current)
+    const next = structuredClone(current)
     expect(breaking(base, next)).toEqual([])
   })
 })
@@ -136,7 +160,7 @@ describe('protocol version judgement', () => {
   })
 
   test('a breaking change without a bump fails, naming the change', () => {
-    const next = clone(current)
+    const next = structuredClone(current)
     delete next.responses.GetAgentResponse!.fields!.sessionCount
     const verdict = judgeSurfaceChange(current, next, changelog)
     expect(verdict.ok).toBe(false)
@@ -145,7 +169,7 @@ describe('protocol version judgement', () => {
   })
 
   test('a bump needs a changelog entry, and then passes', () => {
-    const next = clone(current)
+    const next = structuredClone(current)
     delete next.responses.GetAgentResponse!.fields!.sessionCount
     next.protocol = current.protocol + 1
     const missing = judgeSurfaceChange(current, next, changelog)
@@ -160,12 +184,15 @@ describe('protocol version judgement', () => {
   })
 
   test('the version never goes down and the minimums never exceed it', () => {
-    const down = clone(current)
+    const down = structuredClone(current)
     down.protocol = current.protocol - 1
     expect(judgeSurfaceChange(current, down, changelog).ok).toBe(false)
-    const minTooHigh = clone(current)
+    const minTooHigh = structuredClone(current)
     minTooHigh.minClientProtocol = current.protocol + 1
     expect(judgeSurfaceChange(current, minTooHigh, changelog).ok).toBe(false)
+    const minDown = structuredClone(current)
+    minDown.minClientProtocol = current.minClientProtocol - 1
+    expect(judgeSurfaceChange(current, minDown, changelog).ok).toBe(false)
   })
 
   test('the committed changelog has an entry for the current version', () => {

--- a/agents/src/protocol-surface.test.ts
+++ b/agents/src/protocol-surface.test.ts
@@ -1,0 +1,174 @@
+import {describe, expect, test} from 'bun:test'
+import {readFileSync} from 'node:fs'
+import path from 'node:path'
+import {AGENTS_PROTOCOL_VERSION, MIN_CLIENT_PROTOCOL, MIN_SERVER_PROTOCOL} from '@seed-hypermedia/agents-protocol'
+import {diffSurfaces, extractSurface, judgeSurfaceChange, type ProtocolSurface} from './protocol-surface'
+
+const surfacePath = path.resolve(import.meta.dir, '../protocol/surface.json')
+const changelogPath = path.resolve(import.meta.dir, '../protocol/PROTOCOL.md')
+
+// One extraction for the whole file: it type-checks the protocol package.
+const current = extractSurface()
+const committed = JSON.parse(readFileSync(surfacePath, 'utf8')) as ProtocolSurface
+
+function clone(surface: ProtocolSurface): ProtocolSurface {
+  return structuredClone(surface)
+}
+
+function breaking(base: ProtocolSurface, next: ProtocolSurface) {
+  return diffSurfaces(base, next)
+    .filter((change) => change.severity === 'breaking')
+    .map((change) => `${change.path} [${change.direction}]`)
+}
+
+describe('protocol surface snapshot', () => {
+  test('surface.json matches the protocol types (run `bun run protocol:snapshot` when it does not)', () => {
+    expect(committed).toEqual(current)
+  })
+
+  test('records the version constants', () => {
+    expect(current.protocol).toBe(AGENTS_PROTOCOL_VERSION)
+    expect(current.minClientProtocol).toBe(MIN_CLIENT_PROTOCOL)
+    expect(current.minServerProtocol).toBe(MIN_SERVER_PROTOCOL)
+  })
+
+  test('lists every action and response by its discriminant, and the envelope', () => {
+    expect(current.actions.GetAgent?.fields).toEqual({_: '"GetAgent"', agentId: 'string'})
+    expect(current.responses.GetAgentResponse?.fields).toMatchObject({
+      sessionCount: 'number',
+      'sessions?': 'SessionInfo[]',
+    })
+    expect(current.envelope.fields).toMatchObject({'protocol?': 'number', action: 'AgentAction'})
+    // The action union is the `actions` group; it must not be duplicated as an opaque type.
+    expect(current.types.AgentAction).toBeUndefined()
+    expect(current.types.UnsignedAgentAction).toBeUndefined()
+  })
+
+  test('names nested protocol types once, by alias, and keeps the alias through optional fields', () => {
+    expect(current.responses.GetAgentResponse?.fields?.agent).toBe('AgentInfo')
+    expect(current.types.AgentInfo?.fields?.definition).toBe('AgentDefinition')
+    expect(current.types.SessionInfo?.fields?.['modelOverride?']).toBe('SessionModelOverride')
+    expect(current.types.SessionModelOverride).toBeDefined()
+  })
+})
+
+describe('protocol compatibility rules', () => {
+  test('the #1078 change is caught: a response field removed is breaking for readers', () => {
+    const base = clone(current)
+    base.responses.GetAgentResponse!.fields = {_: '"GetAgentResponse"', agent: 'AgentInfo', sessions: 'SessionInfo[]'}
+    const next = clone(current)
+    delete next.responses.GetAgentResponse!.fields!['sessions?']
+    expect(breaking(base, next)).toEqual(['responses.GetAgentResponse.sessions [reads]'])
+  })
+
+  test('additive changes are compatible', () => {
+    const next = clone(current)
+    next.responses.GetAgentResponse!.fields!['starred?'] = 'boolean'
+    next.responses.GetAgentResponse!.fields!.owner = 'string'
+    next.actions.GetAgent!.fields!['includeArchived?'] = 'boolean'
+    next.actions.ArchiveAgent = {fields: {_: '"ArchiveAgent"', agentId: 'string', ts: 'number'}}
+    next.responses.ArchiveAgentResponse = {fields: {_: '"ArchiveAgentResponse"'}}
+    next.types.AgentDefinition!.fields!['color?'] = 'string'
+    expect(breaking(current, next)).toEqual([])
+    expect(diffSurfaces(current, next).length).toBeGreaterThan(0)
+  })
+
+  test('a required field added to an action is breaking for writers', () => {
+    const next = clone(current)
+    next.actions.GetAgent!.fields!.reason = 'string'
+    expect(breaking(current, next)).toEqual(['actions.GetAgent.reason [writes]'])
+  })
+
+  test('optionality flips are judged by direction', () => {
+    const next = clone(current)
+    // Readers lose a guarantee.
+    delete next.responses.GetAgentResponse!.fields!.sessionCount
+    next.responses.GetAgentResponse!.fields!['sessionCount?'] = 'number'
+    // Writers gain an obligation.
+    delete next.actions.ListSessions!.fields!['limit?']
+    next.actions.ListSessions!.fields!.limit = 'number'
+    expect(breaking(current, next)).toEqual([
+      'responses.GetAgentResponse.sessionCount [reads]',
+      'actions.ListSessions.limit [writes]',
+    ])
+
+    const relaxed = clone(current)
+    delete relaxed.actions.ListSessions!.fields!.agentId
+    delete relaxed.actions.GetAgent!.fields!.agentId
+    relaxed.actions.GetAgent!.fields!['agentId?'] = 'string'
+    expect(breaking(current, relaxed)).toEqual([])
+  })
+
+  test('a change inside a nested type is attributed to the type, in every direction it travels', () => {
+    const next = clone(current)
+    // AgentDefinition is sent (CreateAgent) and received (AgentInfo).
+    delete next.types.AgentDefinition!.fields!.model
+    expect(breaking(current, next)).toEqual([
+      'types.AgentDefinition.model [reads]',
+      'types.AgentDefinition.model [writes]',
+    ])
+
+    const widened = clone(current)
+    widened.types.RunStatus = {alias: `${current.types.RunStatus!.alias} | "paused"`}
+    expect(breaking(current, widened)).toContain('types.RunStatus [reads]')
+  })
+
+  test('removing an action or response is breaking', () => {
+    const next = clone(current)
+    delete next.actions.GetAgent
+    delete next.responses.GetAgentResponse
+    expect(breaking(current, next)).toEqual(['responses.GetAgentResponse [reads]', 'actions.GetAgent [writes]'])
+  })
+
+  test('types no longer reachable from the wire are not compared', () => {
+    const base = clone(current)
+    base.types.Orphan = {fields: {x: 'string'}}
+    const next = clone(current)
+    expect(breaking(base, next)).toEqual([])
+  })
+})
+
+describe('protocol version judgement', () => {
+  const changelog = readFileSync(changelogPath, 'utf8')
+
+  test('no change passes', () => {
+    expect(judgeSurfaceChange(current, current, changelog)).toMatchObject({ok: true, problems: []})
+  })
+
+  test('a breaking change without a bump fails, naming the change', () => {
+    const next = clone(current)
+    delete next.responses.GetAgentResponse!.fields!.sessionCount
+    const verdict = judgeSurfaceChange(current, next, changelog)
+    expect(verdict.ok).toBe(false)
+    expect(verdict.problems.join('\n')).toContain('responses.GetAgentResponse.sessionCount')
+    expect(verdict.problems.join('\n')).toContain('AGENTS_PROTOCOL_VERSION')
+  })
+
+  test('a bump needs a changelog entry, and then passes', () => {
+    const next = clone(current)
+    delete next.responses.GetAgentResponse!.fields!.sessionCount
+    next.protocol = current.protocol + 1
+    const missing = judgeSurfaceChange(current, next, changelog)
+    expect(missing.ok).toBe(false)
+    expect(missing.problems.join('\n')).toContain(`## Protocol ${next.protocol}`)
+    const noted = judgeSurfaceChange(
+      current,
+      next,
+      `${changelog}\n## Protocol ${next.protocol}\n\nDropped sessionCount.\n`,
+    )
+    expect(noted).toMatchObject({ok: true})
+  })
+
+  test('the version never goes down and the minimums never exceed it', () => {
+    const down = clone(current)
+    down.protocol = current.protocol - 1
+    expect(judgeSurfaceChange(current, down, changelog).ok).toBe(false)
+    const minTooHigh = clone(current)
+    minTooHigh.minClientProtocol = current.protocol + 1
+    expect(judgeSurfaceChange(current, minTooHigh, changelog).ok).toBe(false)
+  })
+
+  test('the committed changelog has an entry for the current version', () => {
+    expect(changelog).toMatch(new RegExp(`^## Protocol ${AGENTS_PROTOCOL_VERSION}\\b`, 'm'))
+  })
+})

--- a/agents/src/protocol-surface.ts
+++ b/agents/src/protocol-surface.ts
@@ -1,0 +1,458 @@
+/**
+ * The agents protocol's wire surface as data, and the compatibility rules over it.
+ *
+ * {@link extractSurface} walks the protocol package with the TypeScript compiler and writes down
+ * every action a client can send, every response a server can answer, the envelope around them,
+ * and every named type they reach — each as a flat map of field name → rendered type. It is what
+ * `agents/protocol/surface.json` holds, and what CI diffs against the base branch.
+ *
+ * {@link diffSurfaces} then classifies each difference from the point of view of a client built
+ * from the base: what it *reads* (responses and the types they reach) must still be there in the
+ * shape it expects, and what it *writes* (actions, the envelope, and the types they reach) must
+ * still be accepted. Anything else is breaking and needs a protocol version bump — see
+ * `agents/protocol/PROTOCOL.md`. The rules are deliberately conservative: a changed type string
+ * counts as breaking even when the change might be benign, because a human deciding "this is
+ * fine, bump and note it" is cheap and a crashed release is not.
+ */
+import ts from 'typescript'
+import path from 'node:path'
+
+/**
+ * A named type on the wire: an object (field name → rendered type, the name suffixed `?` when the
+ * field is optional, so a PR diff of the snapshot reads like the type itself), or anything else
+ * (its rendered form).
+ */
+export type SurfaceShape = {fields?: Record<string, string>; alias?: string}
+
+/** One field of an object type, parsed back out of {@link SurfaceShape.fields}. */
+export type SurfaceField = {type: string; optional: boolean}
+
+/** Parses a shape's fields into name → field. */
+export function surfaceFields(shape: SurfaceShape): Map<string, SurfaceField> {
+  const fields = new Map<string, SurfaceField>()
+  for (const [key, type] of Object.entries(shape.fields ?? {})) {
+    const optional = key.endsWith('?')
+    fields.set(optional ? key.slice(0, -1) : key, {type, optional})
+  }
+  return fields
+}
+
+/**
+ * Aliases rendered by name and never recorded under `types`: their members are the `actions` and
+ * `responses` groups themselves, and expanding them again would report every action change twice
+ * (once correctly classified under `actions`, once as an opaque string change here).
+ */
+const GROUP_ALIASES = new Set(['UnsignedAgentAction', 'AgentAction', 'AgentResponse'])
+
+export type ProtocolSurface = {
+  protocol: number
+  minClientProtocol: number
+  minServerProtocol: number
+  /** The signed envelope a client sends, keyed `SignedActionEnvelope`. */
+  envelope: SurfaceShape
+  /** Every `UnsignedAgentAction` member, keyed by its `_` discriminant. */
+  actions: Record<string, SurfaceShape>
+  /** Every `AgentResponse` member, keyed by its `_` discriminant. */
+  responses: Record<string, SurfaceShape>
+  /** Every named type the above reach, keyed by alias name. */
+  types: Record<string, SurfaceShape>
+}
+
+export type SurfaceChange = {
+  /** `breaking` needs a protocol bump; `compatible` does not. */
+  severity: 'breaking' | 'compatible'
+  /** Which side a client from the base would be hurt on. */
+  direction: 'reads' | 'writes'
+  /** `responses.GetAgentResponse.sessions`, `types.SessionInfo`, ... */
+  path: string
+  detail: string
+}
+
+const DEFAULT_ENTRY = path.resolve(import.meta.dir, '../protocol/src/index.ts')
+
+/** Reads the protocol package's wire surface. Slow (a full type-check of the package): call once. */
+export function extractSurface(entryFile: string = DEFAULT_ENTRY): ProtocolSurface {
+  const program = ts.createProgram([entryFile], {
+    strict: true,
+    noEmit: true,
+    skipLibCheck: true,
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+  })
+  const diagnostics = ts.getPreEmitDiagnostics(program).filter((d) => d.category === ts.DiagnosticCategory.Error)
+  if (diagnostics.length > 0) {
+    const first = diagnostics[0]!
+    throw new Error(`protocol does not type-check: ${ts.flattenDiagnosticMessageText(first.messageText, '\n')}`)
+  }
+  const checker = program.getTypeChecker()
+  const source = program.getSourceFile(entryFile)
+  if (!source) throw new Error(`cannot load ${entryFile}`)
+  const moduleSymbol = checker.getSymbolAtLocation(source)
+  if (!moduleSymbol) throw new Error('protocol entry has no module symbol')
+  const exports = new Map(checker.getExportsOfModule(moduleSymbol).map((symbol) => [symbol.name, symbol]))
+  const protocolDir = path.dirname(entryFile)
+
+  const exportedType = (name: string): ts.Type => {
+    const symbol = exports.get(name)
+    if (!symbol) throw new Error(`protocol does not export ${name}`)
+    const resolved = symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol
+    return checker.getDeclaredTypeOfSymbol(resolved)
+  }
+  const exportedConstant = (name: string): number => {
+    const symbol = exports.get(name)
+    if (!symbol) throw new Error(`protocol does not export ${name}`)
+    const resolved = symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol
+    const type = checker.getTypeOfSymbol(resolved)
+    if (!type.isNumberLiteral()) throw new Error(`${name} must be a number literal`)
+    return type.value
+  }
+
+  const types: Record<string, SurfaceShape> = {}
+  const inProgress = new Set<string>()
+
+  /** Whether a symbol is declared inside the protocol package (as opposed to the TS lib). */
+  const isProtocolSymbol = (symbol: ts.Symbol | undefined): boolean =>
+    !!symbol?.declarations?.some((decl) => decl.getSourceFile().fileName.startsWith(protocolDir))
+
+  const shapeOf = (type: ts.Type): SurfaceShape => {
+    if (type.isUnion() && !(type.flags & ts.TypeFlags.Boolean)) return {alias: render(type, true)}
+    if (type.flags & ts.TypeFlags.Object || type.isIntersection()) {
+      const fields = fieldsOf(type)
+      if (fields) return {fields}
+    }
+    return {alias: render(type, true)}
+  }
+
+  const fieldsOf = (type: ts.Type): Record<string, string> | undefined => {
+    if (checker.isArrayType(type) || checker.isTupleType(type)) return undefined
+    if (type.getCallSignatures().length > 0) return undefined
+    const props = checker.getPropertiesOfType(type)
+    const indexInfos = checker.getIndexInfosOfType(type)
+    if (props.length === 0 && indexInfos.length === 0) return undefined
+    const fields: Record<string, string> = {}
+    for (const info of indexInfos) {
+      fields[`[key: ${render(info.keyType)}]`] = render(info.type)
+    }
+    for (const prop of props.sort((a, b) => a.name.localeCompare(b.name))) {
+      const optional = (prop.flags & ts.SymbolFlags.Optional) !== 0
+      fields[optional ? `${prop.name}?` : prop.name] = render(declaredType(prop))
+    }
+    return fields
+  }
+
+  /**
+   * The type a property was written with. Read from its declaration rather than the checker's
+   * widened property type, which for `status?: SessionStatus` would be the alias's members plus
+   * `undefined` — losing the alias name that lets a change inside it show up in one place.
+   */
+  const declaredType = (prop: ts.Symbol): ts.Type => {
+    const decl = prop.valueDeclaration ?? prop.declarations?.[0]
+    if (decl && (ts.isPropertySignature(decl) || ts.isPropertyDeclaration(decl)) && decl.type) {
+      return checker.getTypeFromTypeNode(decl.type)
+    }
+    return checker.getTypeOfSymbol(prop)
+  }
+
+  /**
+   * Renders a type for the snapshot. Named protocol aliases are recorded under `types` and
+   * referenced by name, so a change inside them shows up once, where it happened; everything
+   * else is rendered structurally.
+   */
+  const render = (type: ts.Type, expandAlias = false): string => {
+    const alias = type.aliasSymbol
+    if (alias && !expandAlias) {
+      if (GROUP_ALIASES.has(alias.name)) return alias.name
+      if (isProtocolSymbol(alias)) {
+        record(alias.name, type)
+        return alias.name
+      }
+      // A lib alias such as `Record<string, X>` or `Partial<X>`: keep the name, render the args.
+      const args = type.aliasTypeArguments ?? []
+      return args.length ? `${alias.name}<${args.map((arg) => render(arg)).join(', ')}>` : alias.name
+    }
+    if (type.flags & ts.TypeFlags.Boolean) return 'boolean'
+    if (type.isUnion()) return uniqueSorted(type.types.map((member) => render(member))).join(' | ')
+    if (type.isIntersection()) {
+      const fields = fieldsOf(type)
+      return fields ? renderFields(fields) : type.types.map((member) => render(member)).join(' & ')
+    }
+    if (checker.isTupleType(type)) {
+      const elements = checker.getTypeArguments(type as ts.TypeReference)
+      return `[${elements.map((element) => render(element)).join(', ')}]`
+    }
+    if (checker.isArrayType(type)) {
+      const [element] = checker.getTypeArguments(type as ts.TypeReference)
+      return `${element ? renderAtom(element) : 'unknown'}[]`
+    }
+    if (type.flags & ts.TypeFlags.Object) {
+      if (type.getCallSignatures().length > 0) return 'function'
+      const symbol = type.getSymbol()
+      if (symbol && isProtocolSymbol(symbol) && symbol.name !== '__type' && symbol.name !== '__object') {
+        record(symbol.name, type)
+        return symbol.name
+      }
+      if (symbol && !isProtocolSymbol(symbol) && symbol.name !== '__type' && symbol.name !== '__object') {
+        // A lib object such as `Uint8Array` or `Date`: its name is its contract.
+        const args = checker.getTypeArguments(type as ts.TypeReference)
+        return args.length ? `${symbol.name}<${args.map((arg) => render(arg)).join(', ')}>` : symbol.name
+      }
+      const fields = fieldsOf(type)
+      return fields ? renderFields(fields) : '{}'
+    }
+    return checker.typeToString(type, undefined, ts.TypeFormatFlags.NoTruncation)
+  }
+
+  const renderAtom = (type: ts.Type): string => {
+    const rendered = render(type)
+    return rendered.includes(' | ') || rendered.includes(' & ') ? `(${rendered})` : rendered
+  }
+
+  const renderFields = (fields: Record<string, string>): string =>
+    `{${Object.entries(fields)
+      .map(([name, type]) => `${name}: ${type}`)
+      .join('; ')}}`
+
+  const record = (name: string, type: ts.Type): void => {
+    if (name in types || inProgress.has(name)) return
+    inProgress.add(name)
+    types[name] = shapeOf(type)
+    inProgress.delete(name)
+  }
+
+  const discriminatedMembers = (type: ts.Type, of: string): Record<string, SurfaceShape> => {
+    const members = type.isUnion() ? type.types : [type]
+    const out: Record<string, SurfaceShape> = {}
+    for (const member of members) {
+      const tag = checker.getPropertyOfType(member, '_')
+      const tagType = tag && checker.getTypeOfSymbol(tag)
+      const name = tagType?.isStringLiteral() ? tagType.value : member.aliasSymbol?.name ?? member.symbol?.name
+      if (!name) throw new Error(`a member of ${of} has neither a \`_\` tag nor a name`)
+      if (name in out) throw new Error(`${of} names ${name} twice`)
+      const fields = fieldsOf(member)
+      if (!fields) throw new Error(`${of} member ${name} is not an object type`)
+      out[name] = {fields}
+    }
+    return sortKeys(out)
+  }
+
+  const actions = discriminatedMembers(exportedType('UnsignedAgentAction'), 'UnsignedAgentAction')
+  const responses = discriminatedMembers(exportedType('AgentResponse'), 'AgentResponse')
+  const envelope = shapeOf(exportedType('SignedActionEnvelope'))
+
+  return {
+    protocol: exportedConstant('AGENTS_PROTOCOL_VERSION'),
+    minClientProtocol: exportedConstant('MIN_CLIENT_PROTOCOL'),
+    minServerProtocol: exportedConstant('MIN_SERVER_PROTOCOL'),
+    envelope,
+    actions,
+    responses,
+    types: sortKeys(types),
+  }
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values)].sort()
+}
+
+function sortKeys<T>(record: Record<string, T>): Record<string, T> {
+  return Object.fromEntries(Object.entries(record).sort(([a], [b]) => a.localeCompare(b)))
+}
+
+/** Names of `types` entries reachable from a set of shapes, following rendered type strings. */
+export function reachableTypes(roots: SurfaceShape[], types: Record<string, SurfaceShape>): Set<string> {
+  const names = Object.keys(types)
+  const seen = new Set<string>()
+  const queue = [...roots]
+  const mentioned = (shape: SurfaceShape): string[] => {
+    const text = shape.alias ?? Object.values(shape.fields ?? {}).join(' ')
+    return names.filter((name) => new RegExp(`(?<![\\w.])${name}(?![\\w])`).test(text))
+  }
+  while (queue.length) {
+    for (const name of mentioned(queue.pop()!)) {
+      if (seen.has(name)) continue
+      seen.add(name)
+      queue.push(types[name]!)
+    }
+  }
+  return seen
+}
+
+/**
+ * Classifies the differences between two surfaces from the point of view of a client built from
+ * `base` talking to a server built from `current` — and, for what the client writes, of a server
+ * built from `base` receiving a client built from `current` is *not* the concern: servers redeploy
+ * first, so the question is always "does the old client survive the new server".
+ */
+export function diffSurfaces(base: ProtocolSurface, current: ProtocolSurface): SurfaceChange[] {
+  const changes: SurfaceChange[] = []
+  const readTypes = reachableTypes(Object.values(base.responses), base.types)
+  const writeTypes = reachableTypes([base.envelope, ...Object.values(base.actions)], base.types)
+
+  const compareShape = (
+    pathPrefix: string,
+    before: SurfaceShape,
+    after: SurfaceShape,
+    direction: 'reads' | 'writes',
+  ) => {
+    if (before.alias !== undefined || after.alias !== undefined) {
+      if (before.alias !== after.alias || !!before.fields !== !!after.fields) {
+        changes.push({
+          severity: 'breaking',
+          direction,
+          path: pathPrefix,
+          detail: `type changed from \`${before.alias ?? '{…}'}\` to \`${after.alias ?? '{…}'}\``,
+        })
+      }
+      return
+    }
+    const beforeFields = surfaceFields(before)
+    const afterFields = surfaceFields(after)
+    for (const [name, field] of beforeFields) {
+      const next = afterFields.get(name)
+      const fieldPath = `${pathPrefix}.${name}`
+      if (!next) {
+        changes.push({
+          severity: 'breaking',
+          direction,
+          path: fieldPath,
+          detail:
+            direction === 'reads'
+              ? 'field removed; old clients still read it'
+              : 'field removed; old clients still send it',
+        })
+        continue
+      }
+      if (next.type !== field.type) {
+        changes.push({
+          severity: 'breaking',
+          direction,
+          path: fieldPath,
+          detail: `type changed from \`${field.type}\` to \`${next.type}\``,
+        })
+      }
+      if (field.optional !== next.optional) {
+        // Reads: a field an old client relies on may now be missing. Writes: a server may now
+        // refuse an old client that omits it.
+        const breaking = direction === 'reads' ? !field.optional && next.optional : field.optional && !next.optional
+        changes.push({
+          severity: breaking ? 'breaking' : 'compatible',
+          direction,
+          path: fieldPath,
+          detail: next.optional ? 'became optional' : 'became required',
+        })
+      }
+    }
+    for (const [name, field] of afterFields) {
+      if (beforeFields.has(name)) continue
+      const breaking = direction === 'writes' && !field.optional
+      changes.push({
+        severity: breaking ? 'breaking' : 'compatible',
+        direction,
+        path: `${pathPrefix}.${name}`,
+        detail: breaking ? 'required field added; old clients do not send it' : 'field added',
+      })
+    }
+  }
+
+  const compareGroup = (
+    group: 'actions' | 'responses',
+    direction: 'reads' | 'writes',
+    before: Record<string, SurfaceShape>,
+    after: Record<string, SurfaceShape>,
+  ) => {
+    for (const [name, shape] of Object.entries(before)) {
+      const next = after[name]
+      if (!next) {
+        changes.push({
+          severity: 'breaking',
+          direction,
+          path: `${group}.${name}`,
+          detail: `${group.slice(0, -1)} removed`,
+        })
+        continue
+      }
+      compareShape(`${group}.${name}`, shape, next, direction)
+    }
+    for (const name of Object.keys(after)) {
+      if (!(name in before)) {
+        changes.push({
+          severity: 'compatible',
+          direction,
+          path: `${group}.${name}`,
+          detail: `${group.slice(0, -1)} added`,
+        })
+      }
+    }
+  }
+
+  compareGroup('responses', 'reads', base.responses, current.responses)
+  compareGroup('actions', 'writes', base.actions, current.actions)
+  compareShape('envelope', base.envelope, current.envelope, 'writes')
+
+  for (const [name, shape] of Object.entries(base.types)) {
+    const directions: Array<'reads' | 'writes'> = []
+    if (readTypes.has(name)) directions.push('reads')
+    if (writeTypes.has(name)) directions.push('writes')
+    if (directions.length === 0) continue
+    const next = current.types[name]
+    for (const direction of directions) {
+      if (!next) {
+        changes.push({severity: 'breaking', direction, path: `types.${name}`, detail: 'type no longer on the wire'})
+        continue
+      }
+      compareShape(`types.${name}`, shape, next, direction)
+    }
+  }
+
+  return dedupe(changes)
+}
+
+function dedupe(changes: SurfaceChange[]): SurfaceChange[] {
+  const seen = new Set<string>()
+  return changes.filter((change) => {
+    const key = `${change.severity}|${change.direction}|${change.path}|${change.detail}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+export type SurfaceVerdict = {ok: boolean; problems: string[]; changes: SurfaceChange[]}
+
+/**
+ * Applies the versioning rules to a diff: breaking changes need `protocol` to have gone up, a
+ * bump needs a `## Protocol <n>` entry in the changelog, and the version never goes down.
+ */
+export function judgeSurfaceChange(base: ProtocolSurface, current: ProtocolSurface, changelog: string): SurfaceVerdict {
+  const changes = diffSurfaces(base, current)
+  const breaking = changes.filter((change) => change.severity === 'breaking')
+  const problems: string[] = []
+  if (current.protocol < base.protocol) {
+    problems.push(`AGENTS_PROTOCOL_VERSION went down from ${base.protocol} to ${current.protocol}`)
+  }
+  if (current.minClientProtocol > current.protocol || current.minServerProtocol > current.protocol) {
+    problems.push('MIN_CLIENT_PROTOCOL and MIN_SERVER_PROTOCOL cannot exceed AGENTS_PROTOCOL_VERSION')
+  }
+  if (current.minClientProtocol < base.minClientProtocol) {
+    problems.push(`MIN_CLIENT_PROTOCOL went down from ${base.minClientProtocol} to ${current.minClientProtocol}`)
+  }
+  if (breaking.length > 0 && current.protocol <= base.protocol) {
+    problems.push(
+      `${breaking.length} breaking protocol change${
+        breaking.length === 1 ? '' : 's'
+      } without bumping AGENTS_PROTOCOL_VERSION (still ${current.protocol}):\n` +
+        breaking.map((change) => `  - ${change.path}: ${change.detail} [${change.direction}]`).join('\n'),
+    )
+  }
+  if (current.protocol > base.protocol) {
+    for (let version = base.protocol + 1; version <= current.protocol; version++) {
+      if (!new RegExp(`^## Protocol ${version}\\b`, 'm').test(changelog)) {
+        problems.push(
+          `PROTOCOL.md has no "## Protocol ${version}" entry describing the change and how older clients are served`,
+        )
+      }
+    }
+  }
+  return {ok: problems.length === 0, problems, changes}
+}

--- a/agents/src/protocol-surface.ts
+++ b/agents/src/protocol-surface.ts
@@ -10,19 +10,20 @@
  * from the base: what it *reads* (responses and the types they reach) must still be there in the
  * shape it expects, and what it *writes* (actions, the envelope, and the types they reach) must
  * still be accepted. Anything else is breaking and needs a protocol version bump — see
- * `agents/protocol/PROTOCOL.md`. The rules are deliberately conservative: a changed type string
- * counts as breaking even when the change might be benign, because a human deciding "this is
- * fine, bump and note it" is cheap and a crashed release is not.
+ * `agents/protocol/PROTOCOL.md`. The rules are deliberately conservative: a changed type counts as
+ * breaking even when the change might be benign, because a human deciding "this is fine, bump and
+ * note it" is cheap and a crashed release is not.
  */
 import ts from 'typescript'
 import path from 'node:path'
 
 /**
- * A named type on the wire: an object (field name → rendered type, the name suffixed `?` when the
- * field is optional, so a PR diff of the snapshot reads like the type itself), or anything else
- * (its rendered form).
+ * A type on the wire, in one of three forms: an object (`fields`: name → rendered type, the name
+ * suffixed `?` when optional, so a snapshot diff reads like the type itself); a discriminated
+ * union of objects (`variants`: discriminant value → object shape); or anything else (`alias`:
+ * its rendered form).
  */
-export type SurfaceShape = {fields?: Record<string, string>; alias?: string}
+export type SurfaceShape = {fields?: Record<string, string>; variants?: Record<string, SurfaceShape>; alias?: string}
 
 /** One field of an object type, parsed back out of {@link SurfaceShape.fields}. */
 export type SurfaceField = {type: string; optional: boolean}
@@ -38,17 +39,18 @@ export function surfaceFields(shape: SurfaceShape): Map<string, SurfaceField> {
 }
 
 /**
- * Aliases rendered by name and never recorded under `types`: their members are the `actions` and
- * `responses` groups themselves, and expanding them again would report every action change twice
- * (once correctly classified under `actions`, once as an opaque string change here).
+ * Version of the snapshot layout itself. Bumped when the extractor changes what it writes (a new
+ * shape form, a different rendering), so that such a change is never mistaken for a protocol
+ * change: the check skips the compatibility diff when the base was written in another format.
  */
-const GROUP_ALIASES = new Set(['UnsignedAgentAction', 'AgentAction', 'AgentResponse'])
+export const SURFACE_FORMAT = 1
 
+/** The whole wire surface at one commit: what `agents/protocol/surface.json` holds. */
 export type ProtocolSurface = {
+  format: number
   protocol: number
   minClientProtocol: number
-  minServerProtocol: number
-  /** The signed envelope a client sends, keyed `SignedActionEnvelope`. */
+  /** The signed envelope a client sends. */
   envelope: SurfaceShape
   /** Every `UnsignedAgentAction` member, keyed by its `_` discriminant. */
   actions: Record<string, SurfaceShape>
@@ -58,17 +60,37 @@ export type ProtocolSurface = {
   types: Record<string, SurfaceShape>
 }
 
+/** One classified difference between two surfaces. */
 export type SurfaceChange = {
   /** `breaking` needs a protocol bump; `compatible` does not. */
   severity: 'breaking' | 'compatible'
   /** Which side a client from the base would be hurt on. */
   direction: 'reads' | 'writes'
-  /** `responses.GetAgentResponse.sessions`, `types.SessionInfo`, ... */
+  /** `responses.GetAgentResponse.sessions`, `types.SessionInfo`, `types.AgentTriggerSource.<schedule>.at`, ... */
   path: string
   detail: string
 }
 
+/**
+ * Aliases rendered by name and never recorded under `types`: their members are the `actions` and
+ * `responses` groups themselves, and expanding them again would report every action change twice
+ * (once correctly classified under `actions`, once as an opaque string change here).
+ */
+const GROUP_ALIASES = new Set(['UnsignedAgentAction', 'AgentAction', 'AgentResponse'])
+
+/** Keys a discriminated union may be keyed by, in order of preference. */
+const DISCRIMINANTS = ['_', 'type', 'kind']
+
 const DEFAULT_ENTRY = path.resolve(import.meta.dir, '../protocol/src/index.ts')
+
+/** Plain code-point order: `localeCompare` depends on the ICU build and would make snapshots drift. */
+function byCodePoint(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0
+}
+
+function sortKeys<T>(record: Record<string, T>): Record<string, T> {
+  return Object.fromEntries(Object.entries(record).sort(([a], [b]) => byCodePoint(a, b)))
+}
 
 /** Reads the protocol package's wire surface. Slow (a full type-check of the package): call once. */
 export function extractSurface(entryFile: string = DEFAULT_ENTRY): ProtocolSurface {
@@ -93,17 +115,14 @@ export function extractSurface(entryFile: string = DEFAULT_ENTRY): ProtocolSurfa
   const exports = new Map(checker.getExportsOfModule(moduleSymbol).map((symbol) => [symbol.name, symbol]))
   const protocolDir = path.dirname(entryFile)
 
-  const exportedType = (name: string): ts.Type => {
+  const exportedSymbol = (name: string): ts.Symbol => {
     const symbol = exports.get(name)
     if (!symbol) throw new Error(`protocol does not export ${name}`)
-    const resolved = symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol
-    return checker.getDeclaredTypeOfSymbol(resolved)
+    return symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol
   }
+  const exportedType = (name: string): ts.Type => checker.getDeclaredTypeOfSymbol(exportedSymbol(name))
   const exportedConstant = (name: string): number => {
-    const symbol = exports.get(name)
-    if (!symbol) throw new Error(`protocol does not export ${name}`)
-    const resolved = symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol
-    const type = checker.getTypeOfSymbol(resolved)
+    const type = checker.getTypeOfSymbol(exportedSymbol(name))
     if (!type.isNumberLiteral()) throw new Error(`${name} must be a number literal`)
     return type.value
   }
@@ -115,13 +134,45 @@ export function extractSurface(entryFile: string = DEFAULT_ENTRY): ProtocolSurfa
   const isProtocolSymbol = (symbol: ts.Symbol | undefined): boolean =>
     !!symbol?.declarations?.some((decl) => decl.getSourceFile().fileName.startsWith(protocolDir))
 
+  /** A checker-made synthetic symbol name (`__type`, `__object`), as opposed to something the author wrote. */
+  const isSynthetic = (symbol: ts.Symbol): boolean => symbol.name.startsWith('__')
+
   const shapeOf = (type: ts.Type): SurfaceShape => {
-    if (type.isUnion() && !(type.flags & ts.TypeFlags.Boolean)) return {alias: render(type, true)}
+    if (type.isUnion() && !(type.flags & ts.TypeFlags.Boolean)) {
+      const variants = variantsOf(type)
+      return variants ? {variants} : {alias: render(type, true)}
+    }
     if (type.flags & ts.TypeFlags.Object || type.isIntersection()) {
       const fields = fieldsOf(type)
       if (fields) return {fields}
     }
     return {alias: render(type, true)}
+  }
+
+  /**
+   * A union of objects keyed by a shared discriminant becomes one shape per member, so that an
+   * optional field added to one member reads as what it is (additive) rather than as an opaque
+   * change to the whole union.
+   */
+  const variantsOf = (type: ts.UnionType): Record<string, SurfaceShape> | undefined => {
+    const members = type.types
+    if (members.length < 2 || !members.every((member) => member.flags & ts.TypeFlags.Object)) return undefined
+    for (const key of DISCRIMINANTS) {
+      const variants: Record<string, SurfaceShape> = {}
+      let ok = true
+      for (const member of members) {
+        const tag = checker.getPropertyOfType(member, key)
+        const tagType = tag && declaredType(tag)
+        const fields = tagType?.isStringLiteral() && !(tagType.value in variants) ? fieldsOf(member) : undefined
+        if (!fields) {
+          ok = false
+          break
+        }
+        variants[(tagType as ts.StringLiteralType).value] = {fields}
+      }
+      if (ok) return sortKeys(variants)
+    }
+    return undefined
   }
 
   const fieldsOf = (type: ts.Type): Record<string, string> | undefined => {
@@ -134,7 +185,8 @@ export function extractSurface(entryFile: string = DEFAULT_ENTRY): ProtocolSurfa
     for (const info of indexInfos) {
       fields[`[key: ${render(info.keyType)}]`] = render(info.type)
     }
-    for (const prop of props.sort((a, b) => a.name.localeCompare(b.name))) {
+    // Copied before sorting: the checker hands out its own cached member array.
+    for (const prop of [...props].sort((a, b) => byCodePoint(a.name, b.name))) {
       const optional = (prop.flags & ts.SymbolFlags.Optional) !== 0
       fields[optional ? `${prop.name}?` : prop.name] = render(declaredType(prop))
     }
@@ -154,6 +206,10 @@ export function extractSurface(entryFile: string = DEFAULT_ENTRY): ProtocolSurfa
     return checker.getTypeOfSymbol(prop)
   }
 
+  /** `Name` or `Name<arg, arg>`. */
+  const named = (name: string, args: readonly ts.Type[]): string =>
+    args.length ? `${name}<${args.map((arg) => render(arg)).join(', ')}>` : name
+
   /**
    * Renders a type for the snapshot. Named protocol aliases are recorded under `types` and
    * referenced by name, so a change inside them shows up once, where it happened; everything
@@ -168,11 +224,10 @@ export function extractSurface(entryFile: string = DEFAULT_ENTRY): ProtocolSurfa
         return alias.name
       }
       // A lib alias such as `Record<string, X>` or `Partial<X>`: keep the name, render the args.
-      const args = type.aliasTypeArguments ?? []
-      return args.length ? `${alias.name}<${args.map((arg) => render(arg)).join(', ')}>` : alias.name
+      return named(alias.name, type.aliasTypeArguments ?? [])
     }
     if (type.flags & ts.TypeFlags.Boolean) return 'boolean'
-    if (type.isUnion()) return uniqueSorted(type.types.map((member) => render(member))).join(' | ')
+    if (type.isUnion()) return [...new Set(type.types.map((member) => render(member)))].sort(byCodePoint).join(' | ')
     if (type.isIntersection()) {
       const fields = fieldsOf(type)
       return fields ? renderFields(fields) : type.types.map((member) => render(member)).join(' & ')
@@ -188,14 +243,13 @@ export function extractSurface(entryFile: string = DEFAULT_ENTRY): ProtocolSurfa
     if (type.flags & ts.TypeFlags.Object) {
       if (type.getCallSignatures().length > 0) return 'function'
       const symbol = type.getSymbol()
-      if (symbol && isProtocolSymbol(symbol) && symbol.name !== '__type' && symbol.name !== '__object') {
-        record(symbol.name, type)
-        return symbol.name
-      }
-      if (symbol && !isProtocolSymbol(symbol) && symbol.name !== '__type' && symbol.name !== '__object') {
+      if (symbol && !isSynthetic(symbol)) {
+        if (isProtocolSymbol(symbol)) {
+          record(symbol.name, type)
+          return symbol.name
+        }
         // A lib object such as `Uint8Array` or `Date`: its name is its contract.
-        const args = checker.getTypeArguments(type as ts.TypeReference)
-        return args.length ? `${symbol.name}<${args.map((arg) => render(arg)).join(', ')}>` : symbol.name
+        return named(symbol.name, checker.getTypeArguments(type as ts.TypeReference))
       }
       const fields = fieldsOf(type)
       return fields ? renderFields(fields) : '{}'
@@ -241,9 +295,9 @@ export function extractSurface(entryFile: string = DEFAULT_ENTRY): ProtocolSurfa
   const envelope = shapeOf(exportedType('SignedActionEnvelope'))
 
   return {
+    format: SURFACE_FORMAT,
     protocol: exportedConstant('AGENTS_PROTOCOL_VERSION'),
     minClientProtocol: exportedConstant('MIN_CLIENT_PROTOCOL'),
-    minServerProtocol: exportedConstant('MIN_SERVER_PROTOCOL'),
     envelope,
     actions,
     responses,
@@ -251,26 +305,23 @@ export function extractSurface(entryFile: string = DEFAULT_ENTRY): ProtocolSurfa
   }
 }
 
-function uniqueSorted(values: string[]): string[] {
-  return [...new Set(values)].sort()
+/** Every identifier-looking token in a shape's rendered types, recursively. */
+function mentionedNames(shape: SurfaceShape, into: Set<string>): Set<string> {
+  const texts = shape.alias !== undefined ? [shape.alias] : Object.values(shape.fields ?? {})
+  for (const text of texts) {
+    for (const token of text.match(/(?<![\w.])[A-Za-z_$][\w$]*(?![\w])/g) ?? []) into.add(token)
+  }
+  for (const variant of Object.values(shape.variants ?? {})) mentionedNames(variant, into)
+  return into
 }
 
-function sortKeys<T>(record: Record<string, T>): Record<string, T> {
-  return Object.fromEntries(Object.entries(record).sort(([a], [b]) => a.localeCompare(b)))
-}
-
-/** Names of `types` entries reachable from a set of shapes, following rendered type strings. */
+/** Names of `types` entries reachable from a set of shapes, following rendered type references. */
 export function reachableTypes(roots: SurfaceShape[], types: Record<string, SurfaceShape>): Set<string> {
-  const names = Object.keys(types)
   const seen = new Set<string>()
   const queue = [...roots]
-  const mentioned = (shape: SurfaceShape): string[] => {
-    const text = shape.alias ?? Object.values(shape.fields ?? {}).join(' ')
-    return names.filter((name) => new RegExp(`(?<![\\w.])${name}(?![\\w])`).test(text))
-  }
   while (queue.length) {
-    for (const name of mentioned(queue.pop()!)) {
-      if (seen.has(name)) continue
+    for (const name of mentionedNames(queue.pop()!, new Set())) {
+      if (seen.has(name) || !(name in types)) continue
       seen.add(name)
       queue.push(types[name]!)
     }
@@ -278,31 +329,49 @@ export function reachableTypes(roots: SurfaceShape[], types: Record<string, Surf
   return seen
 }
 
+type Direction = 'reads' | 'writes'
+
 /**
  * Classifies the differences between two surfaces from the point of view of a client built from
- * `base` talking to a server built from `current` — and, for what the client writes, of a server
- * built from `base` receiving a client built from `current` is *not* the concern: servers redeploy
- * first, so the question is always "does the old client survive the new server".
+ * `base` talking to a server built from `current`. The other direction (a new client against an
+ * old server) is not judged: servers deploy first, so the question is always "does the old client
+ * survive the new server". A type reached both by what the client reads and by what it writes is
+ * reported once per direction.
  */
 export function diffSurfaces(base: ProtocolSurface, current: ProtocolSurface): SurfaceChange[] {
   const changes: SurfaceChange[] = []
   const readTypes = reachableTypes(Object.values(base.responses), base.types)
   const writeTypes = reachableTypes([base.envelope, ...Object.values(base.actions)], base.types)
+  const push = (severity: SurfaceChange['severity'], direction: Direction, path: string, detail: string) =>
+    changes.push({severity, direction, path, detail})
 
-  const compareShape = (
-    pathPrefix: string,
-    before: SurfaceShape,
-    after: SurfaceShape,
-    direction: 'reads' | 'writes',
-  ) => {
-    if (before.alias !== undefined || after.alias !== undefined) {
-      if (before.alias !== after.alias || !!before.fields !== !!after.fields) {
-        changes.push({
-          severity: 'breaking',
-          direction,
-          path: pathPrefix,
-          detail: `type changed from \`${before.alias ?? '{…}'}\` to \`${after.alias ?? '{…}'}\``,
-        })
+  const compareShape = (pathPrefix: string, before: SurfaceShape, after: SurfaceShape, direction: Direction): void => {
+    const form = (shape: SurfaceShape) => (shape.fields ? 'fields' : shape.variants ? 'variants' : 'alias')
+    if (form(before) !== form(after)) {
+      push('breaking', direction, pathPrefix, `type changed form (${form(before)} → ${form(after)})`)
+      return
+    }
+    if (before.alias !== undefined) {
+      if (before.alias !== after.alias) {
+        push('breaking', direction, pathPrefix, `type changed from \`${before.alias}\` to \`${after.alias}\``)
+      }
+      return
+    }
+    if (before.variants) {
+      const afterVariants = after.variants ?? {}
+      for (const [tag, shape] of Object.entries(before.variants)) {
+        const next = afterVariants[tag]
+        if (!next) push('breaking', direction, `${pathPrefix}.<${tag}>`, 'union member removed')
+        else compareShape(`${pathPrefix}.<${tag}>`, shape, next, direction)
+      }
+      for (const tag of Object.keys(afterVariants)) {
+        if (tag in before.variants) continue
+        // A reader with an exhaustive switch does not know the new member; a writer never sends it.
+        if (direction === 'reads') {
+          push('breaking', direction, `${pathPrefix}.<${tag}>`, 'union member added; old clients do not know it')
+        } else {
+          push('compatible', direction, `${pathPrefix}.<${tag}>`, 'union member added')
+        }
       }
       return
     }
@@ -312,77 +381,49 @@ export function diffSurfaces(base: ProtocolSurface, current: ProtocolSurface): S
       const next = afterFields.get(name)
       const fieldPath = `${pathPrefix}.${name}`
       if (!next) {
-        changes.push({
-          severity: 'breaking',
-          direction,
-          path: fieldPath,
-          detail:
-            direction === 'reads'
-              ? 'field removed; old clients still read it'
-              : 'field removed; old clients still send it',
-        })
+        const who = direction === 'reads' ? 'old clients still read it' : 'old clients still send it'
+        push('breaking', direction, fieldPath, `field removed; ${who}`)
         continue
       }
       if (next.type !== field.type) {
-        changes.push({
-          severity: 'breaking',
-          direction,
-          path: fieldPath,
-          detail: `type changed from \`${field.type}\` to \`${next.type}\``,
-        })
+        push('breaking', direction, fieldPath, `type changed from \`${field.type}\` to \`${next.type}\``)
       }
       if (field.optional !== next.optional) {
         // Reads: a field an old client relies on may now be missing. Writes: a server may now
         // refuse an old client that omits it.
         const breaking = direction === 'reads' ? !field.optional && next.optional : field.optional && !next.optional
-        changes.push({
-          severity: breaking ? 'breaking' : 'compatible',
+        push(
+          breaking ? 'breaking' : 'compatible',
           direction,
-          path: fieldPath,
-          detail: next.optional ? 'became optional' : 'became required',
-        })
+          fieldPath,
+          next.optional ? 'became optional' : 'became required',
+        )
       }
     }
     for (const [name, field] of afterFields) {
       if (beforeFields.has(name)) continue
-      const breaking = direction === 'writes' && !field.optional
-      changes.push({
-        severity: breaking ? 'breaking' : 'compatible',
-        direction,
-        path: `${pathPrefix}.${name}`,
-        detail: breaking ? 'required field added; old clients do not send it' : 'field added',
-      })
+      if (direction === 'writes' && !field.optional) {
+        push('breaking', direction, `${pathPrefix}.${name}`, 'required field added; old clients do not send it')
+      } else {
+        push('compatible', direction, `${pathPrefix}.${name}`, 'field added')
+      }
     }
   }
 
   const compareGroup = (
     group: 'actions' | 'responses',
-    direction: 'reads' | 'writes',
+    direction: Direction,
     before: Record<string, SurfaceShape>,
     after: Record<string, SurfaceShape>,
   ) => {
+    const kind = group.slice(0, -1)
     for (const [name, shape] of Object.entries(before)) {
       const next = after[name]
-      if (!next) {
-        changes.push({
-          severity: 'breaking',
-          direction,
-          path: `${group}.${name}`,
-          detail: `${group.slice(0, -1)} removed`,
-        })
-        continue
-      }
-      compareShape(`${group}.${name}`, shape, next, direction)
+      if (!next) push('breaking', direction, `${group}.${name}`, `${kind} removed`)
+      else compareShape(`${group}.${name}`, shape, next, direction)
     }
     for (const name of Object.keys(after)) {
-      if (!(name in before)) {
-        changes.push({
-          severity: 'compatible',
-          direction,
-          path: `${group}.${name}`,
-          detail: `${group.slice(0, -1)} added`,
-        })
-      }
+      if (!(name in before)) push('compatible', direction, `${group}.${name}`, `${kind} added`)
     }
   }
 
@@ -391,33 +432,20 @@ export function diffSurfaces(base: ProtocolSurface, current: ProtocolSurface): S
   compareShape('envelope', base.envelope, current.envelope, 'writes')
 
   for (const [name, shape] of Object.entries(base.types)) {
-    const directions: Array<'reads' | 'writes'> = []
+    const directions: Direction[] = []
     if (readTypes.has(name)) directions.push('reads')
     if (writeTypes.has(name)) directions.push('writes')
-    if (directions.length === 0) continue
     const next = current.types[name]
     for (const direction of directions) {
-      if (!next) {
-        changes.push({severity: 'breaking', direction, path: `types.${name}`, detail: 'type no longer on the wire'})
-        continue
-      }
-      compareShape(`types.${name}`, shape, next, direction)
+      if (!next) push('breaking', direction, `types.${name}`, 'type no longer on the wire')
+      else compareShape(`types.${name}`, shape, next, direction)
     }
   }
 
-  return dedupe(changes)
+  return changes
 }
 
-function dedupe(changes: SurfaceChange[]): SurfaceChange[] {
-  const seen = new Set<string>()
-  return changes.filter((change) => {
-    const key = `${change.severity}|${change.direction}|${change.path}|${change.detail}`
-    if (seen.has(key)) return false
-    seen.add(key)
-    return true
-  })
-}
-
+/** The outcome of {@link judgeSurfaceChange}: the classified changes and why the check fails, if it does. */
 export type SurfaceVerdict = {ok: boolean; problems: string[]; changes: SurfaceChange[]}
 
 /**
@@ -431,8 +459,8 @@ export function judgeSurfaceChange(base: ProtocolSurface, current: ProtocolSurfa
   if (current.protocol < base.protocol) {
     problems.push(`AGENTS_PROTOCOL_VERSION went down from ${base.protocol} to ${current.protocol}`)
   }
-  if (current.minClientProtocol > current.protocol || current.minServerProtocol > current.protocol) {
-    problems.push('MIN_CLIENT_PROTOCOL and MIN_SERVER_PROTOCOL cannot exceed AGENTS_PROTOCOL_VERSION')
+  if (current.minClientProtocol > current.protocol) {
+    problems.push('MIN_CLIENT_PROTOCOL cannot exceed AGENTS_PROTOCOL_VERSION')
   }
   if (current.minClientProtocol < base.minClientProtocol) {
     problems.push(`MIN_CLIENT_PROTOCOL went down from ${base.minClientProtocol} to ${current.minClientProtocol}`)

--- a/frontend/packages/ui/src/agents/assistant-panel.tsx
+++ b/frontend/packages/ui/src/agents/assistant-panel.tsx
@@ -101,7 +101,7 @@ import {
   encodeAssistantSessionRef,
   type AssistantSessionRef,
 } from './assistant-session-ref'
-import {AgentServerError, type AgentInfo} from './client'
+import {AgentProtocolError, AgentServerError, type AgentInfo} from './client'
 import type {AgentActivity} from '@seed-hypermedia/agents-protocol'
 import {describeAgentError, errorMessage} from './errors'
 import {useAssistantWindowContextLines} from './assistant-window-context'
@@ -221,8 +221,10 @@ export function AssistantPanel({
     storedSessionAgentId: storedSessionQuery.data?.session.agentId,
     // Only a refusal from the server gives the session up; a server that could not be reached may
     // simply be down (the desktop's local one is still booting on launch), so the session is held
-    // and its fetch keeps polling.
-    storedSessionUnavailable: storedSessionQuery.error instanceof AgentServerError,
+    // and its fetch keeps polling. A protocol mismatch is about the app's version, not the session,
+    // and the session is still there once the app updates.
+    storedSessionUnavailable:
+      storedSessionQuery.error instanceof AgentServerError && !(storedSessionQuery.error instanceof AgentProtocolError),
     agentsSettled,
     isDraft,
   })

--- a/frontend/packages/ui/src/agents/client.ts
+++ b/frontend/packages/ui/src/agents/client.ts
@@ -1,4 +1,11 @@
 import type * as AgentsProtocol from '@seed-hypermedia/agents-protocol'
+import {
+  AGENTS_PROTOCOL_HEADER,
+  AGENTS_PROTOCOL_VERSION,
+  IMPLICIT_PROTOCOL_VERSION,
+  MIN_SERVER_PROTOCOL,
+  declaredProtocolVersion,
+} from '@seed-hypermedia/agents-protocol'
 import * as blobs from '@shm/shared/blobs'
 import * as cbor from '@shm/shared/cbor'
 import {getAgentsPlatform} from './platform'
@@ -209,6 +216,9 @@ export async function signAgentAction(input: {accountUid: string; action: AgentA
           ...(delegation.capabilityBlob ? {capabilityBlob: delegation.capabilityBlob} : {}),
         }
       : {}),
+    // Signed with the rest: the server answers in this protocol's shape, or refuses if it no
+    // longer serves it (see `agents/protocol/PROTOCOL.md`).
+    protocol: AGENTS_PROTOCOL_VERSION,
     action: {...omitUndefined(input.action), ts: Date.now()},
   } as unknown as blobs.Blob)
 }
@@ -236,11 +246,52 @@ function omitUndefined<T>(value: T): T {
  */
 export class AgentServerError extends Error {
   readonly status: number
-  constructor(message: string, status: number) {
+  /** The server's machine-readable cause, when it sent one. */
+  readonly code?: AgentsProtocol.ErrorResponse['code']
+  constructor(message: string, status: number, code?: AgentsProtocol.ErrorResponse['code']) {
     super(message)
     this.name = 'AgentServerError'
     this.status = status
+    if (code) this.code = code
   }
+}
+
+/**
+ * The client and server speak protocol versions that cannot be reconciled: either the server has
+ * retired this app's version (`client_too_old`, the server said so) or the server is older than
+ * this app still supports (`server_too_old`, judged from the server's advertised version).
+ *
+ * Either way the fix is an update, of the app or of the server, and the message says which. Call
+ * sites treat it like any refusal: the content is not shown, the reason is.
+ */
+export class AgentProtocolError extends AgentServerError {
+  readonly mismatch: 'client_too_old' | 'server_too_old'
+  constructor(mismatch: AgentProtocolError['mismatch'], message: string, status: number) {
+    super(message, status, mismatch === 'client_too_old' ? 'protocol_too_old' : undefined)
+    this.name = 'AgentProtocolError'
+    this.mismatch = mismatch
+  }
+}
+
+/**
+ * The protocol version a server advertised on a response, read from its header. Servers from
+ * before protocol 2 send no header, which counts as protocol 1.
+ */
+export function serverProtocolOf(headers: Headers): number {
+  const raw = headers.get(AGENTS_PROTOCOL_HEADER)
+  if (raw === null) return IMPLICIT_PROTOCOL_VERSION
+  return declaredProtocolVersion(Number(raw))
+}
+
+/** Throws when a server's advertised protocol is older than this build still accepts. */
+export function assertServerProtocolSupported(headers: Headers): void {
+  const serverProtocol = serverProtocolOf(headers)
+  if (serverProtocol >= MIN_SERVER_PROTOCOL) return
+  throw new AgentProtocolError(
+    'server_too_old',
+    `This agents server speaks protocol ${serverProtocol}, but this app needs protocol ${MIN_SERVER_PROTOCOL} or newer. Update the server to continue.`,
+    0,
+  )
 }
 
 export async function sendAgentAction(input: {
@@ -258,10 +309,17 @@ export async function sendAgentAction(input: {
   })
   const decoded = cbor.decode<AgentsResponse>(new Uint8Array(await res.arrayBuffer()))
   if (!res.ok || decoded._ === 'Error') {
+    if (decoded._ === 'Error' && decoded.code === 'protocol_too_old') {
+      throw new AgentProtocolError('client_too_old', decoded.message, res.status)
+    }
     throw new AgentServerError(
       decoded._ === 'Error' ? decoded.message : `Agent server request failed: HTTP ${res.status}`,
       res.status,
+      decoded._ === 'Error' ? decoded.code : undefined,
     )
   }
+  // Checked after the server's own verdict: a too-old server that still managed to refuse the
+  // request has said something more specific than "too old".
+  assertServerProtocolSupported(res.headers)
   return decoded
 }

--- a/frontend/packages/ui/src/agents/client.ts
+++ b/frontend/packages/ui/src/agents/client.ts
@@ -2,8 +2,6 @@ import type * as AgentsProtocol from '@seed-hypermedia/agents-protocol'
 import {
   AGENTS_PROTOCOL_HEADER,
   AGENTS_PROTOCOL_VERSION,
-  IMPLICIT_PROTOCOL_VERSION,
-  MIN_SERVER_PROTOCOL,
   declaredProtocolVersion,
 } from '@seed-hypermedia/agents-protocol'
 import * as blobs from '@shm/shared/blobs'
@@ -146,6 +144,10 @@ export type AgentServerHealth = {
   codeExecReason?: string
   /** Machine-readable cause when codeExec is false (e.g. 'whp-disabled'), for targeted help UI. */
   codeExecReasonCode?: string
+  /** Wire protocol the server speaks; absent on servers from before protocol 2 (see agents/protocol/PROTOCOL.md). */
+  protocol?: number
+  /** Oldest client protocol the server still answers. Absent on servers from before protocol 2. */
+  minClientProtocol?: number
 }
 
 /** Normalizes an agent server URL for storage and fetch calls. */
@@ -257,41 +259,25 @@ export class AgentServerError extends Error {
 }
 
 /**
- * The client and server speak protocol versions that cannot be reconciled: either the server has
- * retired this app's version (`client_too_old`, the server said so) or the server is older than
- * this app still supports (`server_too_old`, judged from the server's advertised version).
- *
- * Either way the fix is an update, of the app or of the server, and the message says which. Call
- * sites treat it like any refusal: the content is not shown, the reason is.
+ * The server has retired the protocol version this app speaks (HTTP 426, `protocol_too_old`).
+ * Nothing about the request was wrong and the server is up: the fix is updating the app, and the
+ * message says so. It is not a "refusal" of the resource asked for, so call sites that give up a
+ * remembered resource on a refusal must not do so on this.
  */
 export class AgentProtocolError extends AgentServerError {
-  readonly mismatch: 'client_too_old' | 'server_too_old'
-  constructor(mismatch: AgentProtocolError['mismatch'], message: string, status: number) {
-    super(message, status, mismatch === 'client_too_old' ? 'protocol_too_old' : undefined)
+  constructor(message: string, status: number) {
+    super(message, status, 'protocol_too_old')
     this.name = 'AgentProtocolError'
-    this.mismatch = mismatch
   }
 }
 
 /**
  * The protocol version a server advertised on a response, read from its header. Servers from
- * before protocol 2 send no header, which counts as protocol 1.
+ * before protocol 2 send no header, which counts as protocol 1. For display and diagnostics: the
+ * client does not refuse older servers (see `agents/protocol/src/version.ts`).
  */
 export function serverProtocolOf(headers: Headers): number {
-  const raw = headers.get(AGENTS_PROTOCOL_HEADER)
-  if (raw === null) return IMPLICIT_PROTOCOL_VERSION
-  return declaredProtocolVersion(Number(raw))
-}
-
-/** Throws when a server's advertised protocol is older than this build still accepts. */
-export function assertServerProtocolSupported(headers: Headers): void {
-  const serverProtocol = serverProtocolOf(headers)
-  if (serverProtocol >= MIN_SERVER_PROTOCOL) return
-  throw new AgentProtocolError(
-    'server_too_old',
-    `This agents server speaks protocol ${serverProtocol}, but this app needs protocol ${MIN_SERVER_PROTOCOL} or newer. Update the server to continue.`,
-    0,
-  )
+  return declaredProtocolVersion(Number(headers.get(AGENTS_PROTOCOL_HEADER)))
 }
 
 export async function sendAgentAction(input: {
@@ -310,7 +296,7 @@ export async function sendAgentAction(input: {
   const decoded = cbor.decode<AgentsResponse>(new Uint8Array(await res.arrayBuffer()))
   if (!res.ok || decoded._ === 'Error') {
     if (decoded._ === 'Error' && decoded.code === 'protocol_too_old') {
-      throw new AgentProtocolError('client_too_old', decoded.message, res.status)
+      throw new AgentProtocolError(decoded.message, res.status)
     }
     throw new AgentServerError(
       decoded._ === 'Error' ? decoded.message : `Agent server request failed: HTTP ${res.status}`,
@@ -318,8 +304,5 @@ export async function sendAgentAction(input: {
       decoded._ === 'Error' ? decoded.code : undefined,
     )
   }
-  // Checked after the server's own verdict: a too-old server that still managed to refuse the
-  // request has said something more specific than "too old".
-  assertServerProtocolSupported(res.headers)
   return decoded
 }

--- a/frontend/packages/ui/src/agents/errors.ts
+++ b/frontend/packages/ui/src/agents/errors.ts
@@ -64,11 +64,10 @@ export function describeAgentError(
     }
   }
   if (error instanceof AgentProtocolError) {
-    // Not this request's fault and not an outage: the two sides need updating to talk again.
-    const outdated = error.mismatch === 'client_too_old' ? 'This app is out of date' : 'The server is out of date'
+    // Not this request's fault and not an outage: the app needs updating to talk to this server.
     return {
       tone: 'error',
-      title: serverLabel ? `${outdated} for ${serverLabel}` : outdated,
+      title: serverLabel ? `This app is out of date for ${serverLabel}` : 'This app is out of date',
       detail: error.message,
     }
   }

--- a/frontend/packages/ui/src/agents/errors.ts
+++ b/frontend/packages/ui/src/agents/errors.ts
@@ -1,5 +1,5 @@
 import type {NoticeTone} from '@shm/ui/notice'
-import {AgentServerError} from './client'
+import {AgentProtocolError, AgentServerError} from './client'
 
 /**
  * How a failed agent-server request should be shown.
@@ -61,6 +61,15 @@ export function describeAgentError(
       tone: 'warning',
       title: serverLabel ? `Can’t reach ${serverLabel}` : 'Can’t reach the agent server',
       detail: `${failed} because the server isn’t responding.`,
+    }
+  }
+  if (error instanceof AgentProtocolError) {
+    // Not this request's fault and not an outage: the two sides need updating to talk again.
+    const outdated = error.mismatch === 'client_too_old' ? 'This app is out of date' : 'The server is out of date'
+    return {
+      tone: 'error',
+      title: serverLabel ? `${outdated} for ${serverLabel}` : outdated,
+      detail: error.message,
     }
   }
   if (error instanceof AgentServerError) {


### PR DESCRIPTION
## Why

PR #1078 removed `sessions` from `GetAgentResponse` (sessions now come from the paginated `ListSessions`). The change typechecked, the `agents-stable` image auto-deployed within the hour, and every desktop still on 2026.9.4 or earlier started crashing at its root component:

```
TypeError: Cannot read properties of undefined (reading 'filter')
    at useSpaceAgents → useHasAnyAgent → Main
```

`useSpaceAgents` in those builds reads `response.sessions.filter(...)` unguarded, and `useHasAnyAgent` runs at the top of `Main`, so any site whose home document advertises agents takes the whole window down.

The root cause is structural, not this one field: the client and server share the TypeScript types in `agents/protocol`, so the compiler proves they agree **at one commit**. But they are not deployed together. A desktop release stays in use for weeks; the hosted servers redeploy on every push to main. Nothing in the repo expressed or enforced compatibility *across* commits. This PR adds that contract and the machinery to enforce it, and un-breaks the released desktops in the process.

## What

**1. A protocol version number.** `AGENTS_PROTOCOL_VERSION` in `agents/protocol/src/version.ts`, now `2`. A single integer, not semver: it goes up by one on any change an older client could be hurt by.

- Clients sign it into every envelope as `protocol`.
- Servers answer with it in the `X-Agents-Protocol` header (exposed for CORS) and in `/api/version` and `/api/health` (`protocol`, `minClientProtocol`).
- No version on the wire means protocol 1. That is what every pre-#1078 client sends, so the mechanism covers them retroactively.
- `MIN_CLIENT_PROTOCOL` (1): below it the server refuses with HTTP 426 and `{_: 'Error', code: 'protocol_too_old'}`, checked before signature verification.

**2. A compat layer on the server** (`agents/src/protocol-compat.ts`). `Service.message` reads the client's protocol, dispatches as before, and hands the response through `downgradeResponse`, which rewrites it into the shape that protocol expects. All shims live in that one file. The single shim today fills `GetAgentResponse.sessions` with the newest page of top-level sessions for protocol 1 clients, so 2026.9.4 stops crashing the moment this image deploys. Retiring a version later is deleting one block and raising `MIN_CLIENT_PROTOCOL`.

**3. Clean failure modes on the client.** `sendAgentAction` turns `protocol_too_old` into `AgentProtocolError`; `describeAgentError` shows it as "This app is out of date" instead of an error about the request, and the assistant panel keeps the remembered session through it. `AgentServerError` now carries the server's `code`; `AgentServerHealth` carries the server's `protocol` and `minClientProtocol`. Only the "old client, new server" direction is enforced anywhere: hosted servers deploy first and the desktop bundles its own server, so the reverse can only happen to a self-hosted server that fell behind, and that is an upgrade, not a protocol decision (reasoning in `version.ts`).

**4. A CI gate that would have caught #1078.** `agents/protocol/surface.json` is a snapshot of every action, every response, the envelope, and every named type they reach, extracted from the types with the TypeScript compiler (`agents/src/protocol-surface.ts`). Fields are written `name?: type`, so the snapshot diff in a PR reads like the type itself. The new `protocol` task in `test-agents.yml` runs `bun run protocol:check`, which:

- fails if the snapshot is stale (`bun run protocol:snapshot` regenerates it);
- diffs the working tree against the base branch's committed snapshot and classifies every change from the point of view of a client built from the base (what it reads must still be there; what it writes must still be accepted);
- fails on a breaking change unless `AGENTS_PROTOCOL_VERSION` went up **and** `PROTOCOL.md` has a `## Protocol <n>` entry.

Discriminated unions of objects are compared member by member, so adding an optional field to one trigger source or content part is additive, not a bump.

`bun test` also asserts the snapshot is current, so the gate is not CI-only.

**5. The rules, written down.** `agents/protocol/PROTOCOL.md`: the table of what counts as breaking in each direction, the four things to do when the check fails (prefer additive; else bump + changelog; keep a shim; or retire old clients deliberately), and the per-version changelog. `docs/signed-api.md` points to it.

## Risk assessment

| Risk | Likelihood | Impact | Mitigation |
| --- | --- | --- | --- |
| The protocol-1 shim runs an extra `ListSessions` query on every `GetAgent` from an old client | Certain, for old clients only | Low. One bounded (50 rows) keyset query per call, the same one the new sidebar issues anyway. Goes away as desktops auto-update. | Only fires when `protocol` is absent; new clients pay nothing. |
| A pre-#1078 desktop still behaves slightly differently: the agent page shows the newest 50 sessions, not all of them | Certain, for old clients only | Low. Degraded listing for an app version that was crashing before. | Documented in `PROTOCOL.md`. Gone on update. |
| Adding `protocol` to the signed envelope changes the signed bytes | Certain | None. The signature covers whatever the client encodes; `auth.verifyEnvelope` does not enumerate allowed keys, and older self-hosted servers ignore unknown fields. | Covered by every existing signed-envelope test passing unchanged. |
| The new response header could be stripped or duplicated by the proxy | Low | None today. The client reads it for diagnostics only. | Checked the prod Caddyfile: plain `reverse_proxy`, no header manipulation. |
| The classifier is strict: widening a union a client reads counts as breaking | Certain, occasionally | Friction. A benign change needs a version bump and a one-line changelog note. | Deliberate. Loosening the table in `PROTOCOL.md` is easy; a second crashed release is not. |
| The gate cannot compare on this PR itself: `main` has no `surface.json` yet | Certain | None. The check reports "skipping the compatibility diff" and passes; it bites from the next PR on. | Snapshot currency is still enforced here via `bun test`. |
| The protocol-version check runs before signature verification, so unauthenticated callers can get a 426 | Certain | None. The response says only which protocol numbers the server accepts, already public in `/api/version`. | — |
| `typescript` becomes a devDependency of `agents/` for the extractor | Certain | Low. Dev-only; the image build is unchanged. | Pinned to the monorepo's 5.8.3. |
| Websocket subscriptions: the client only logs `error` frames, so a retired client's subscribe failure is quiet | Certain, dormant while `MIN_CLIENT_PROTOCOL` = 1 | Low. HTTP calls show the notice; the frame now carries `code` for the client to react to. | Client-side handling is a follow-up. |

**Rollback:** revert the PR. Old clients would resume crashing on `GetAgent`, so if the shim itself misbehaves the better fix is to patch `protocol-compat.ts`.

**Verifying on prod after deploy:** `curl https://agentic.seed.hyper.media/api/version` should show `"protocol": 2, "minClientProtocol": 1`; a 2026.9.4 desktop opening a site with published agents should load.

## Self review

Findings from a review pass over the branch, and what was done about each:

I ran a multi-angle review over the branch (correctness, efficiency, reuse, simplification, altitude, conventions) and acted on it in a second commit. What it found and what I did:

**Fixed**

- **Shim cost on old clients.** The protocol-1 shim went through `#listSessions`, which also runs a whole-account agent listing that the shim discards, and it ran even for agents with no sessions. Now: a rows-only `#listSessionPage`, skipped entirely when `sessionCount` is 0. Note that desktop 2026.9.5 is also "protocol 1" on the wire (it predates the `protocol` field) but never reads `sessions`, so until it auto-updates it pays this cost for nothing. Bounded to one 50-row page.
- **Null body regressed 401 to 500.** Reading `envelope.protocol` before verification threw on a non-object body, escaping as a bare 500 with no CORS headers. `clientProtocolOf` now tolerates anything and lets verification answer 401 as before. Test added.
- **Legacy field on the shared type.** `GetAgentResponse.sessions?` was re-added to the public protocol type, which let protocol-2 clients typecheck against a field they are never sent (the original bug's family) and would make retiring protocol 1 itself look like a breaking change. Moved to `GetAgentResponseV1` in the compat file, cast at the boundary.
- **Half a mechanism.** `MIN_SERVER_PROTOCOL` and the client-side `server_too_old` verdict existed with nothing that would ever move them, since the CI gate only judges the "old client, new server" direction. Removed, with the reasoning written into `version.ts` and `PROTOCOL.md` (hosted servers deploy first; the desktop bundles its own server). The client still reads the server's version for display.
- **Two error classes for one condition.** `ProtocolTooOldError` existed only so `api-service` could catch it and rebuild an identical `APIError`, and any caller that forgot the try/catch would leak a bare 500. Replaced with `clientProtocolProblem()` returning the wire fields; `api-service` throws `APIError` directly.
- **Websocket refusals lost the code.** The WS `error` frame now carries `code`, so a retired client's subscribe failure is distinguishable. Additive on the frame type.
- **Protocol mismatch cleared the remembered session.** `assistant-panel` treats any `AgentServerError` as "the server refused this session" and drops it; the new subclass matched. Excluded, so the session is still selected after the app updates.
- **Snapshot determinism.** `localeCompare` sorted keys and members; that follows the ICU build and could make `surface.json` drift between machines. Now plain code-point order everywhere. Also stopped sorting the checker's own cached member array in place.
- **Union flattening made routine additive changes "breaking".** A union of objects rendered as one opaque string, so adding an optional field to one member of `AgentTriggerSource` counted as breaking in both directions. Discriminated unions (`_`/`type`/`kind`) are now compared member by member with the field rules; a new member is still breaking for readers. Six types in the snapshot benefit today; the string-literal unions stay whole, as documented.
- **`downgradeResponse` could not chain.** The comment promised descending shims but the block returned early. Now threads one value so a client several versions behind gets every step.
- **Duplicated CORS/header blocks.** `cbor.corsHeaders(methods)` is the single definition; `main.ts` uses it. Protocol fields moved into `BuildInfo` so `/api/version` and `/api/health` cannot disagree.
- **Smaller:** dead `dedupe` removed; regex-per-pair reachability replaced with a tokenizer; missing doc comments on three exported types; script validates the mode before touching git; CI always fetches the base so a `workflow_dispatch` run cannot silently skip the diff; `AgentServerHealth` typed with the new `protocol`/`minClientProtocol` fields.

**Accepted as is, with reasoning**

- Protocol-1 clients get the newest 50 top-level sessions rather than every session. Their sidebar only rendered the newest few, they filtered children themselves, and their agent page now shows a capped list instead of a crash. Noted in `PROTOCOL.md`'s Protocol 2 entry.
- Adding a member to a union a client reads is classified as breaking. Deliberate: exhaustive switches. The escape is a bump plus a one-line note.
- The `protocol` field lives in the signed body rather than a header. The websocket carries no request headers, and signing it means nobody can alter a real user's declaration in transit. The cost is that each envelope builder (`signAgentAction`, `createSignedEnvelope`) sets it; both do, and the server tests cover the omitted case.
- A separate `protocol` CI matrix leg costs ~10s of setup for under a second of work. Kept: it appears as its own named status check on the PR, which is worth the runner time for a gate.

**Follow-ups, not in this PR**

- Derive one compatibility state per server from the health query (which now carries `protocol` and `minClientProtocol`) and gate the server's UI once, instead of per-request errors, and react to `code` on WS error frames in the client. Both are dormant until `MIN_CLIENT_PROTOCOL` rises above 1.
- Envelope construction is duplicated between the UI client and the server-side test helper (pre-existing). A shared unsigned-envelope builder in the protocol package would let server tests exercise the real client shape.

## Testing

- `agents`: `bun test` — 509 pass (18 new for the extractor and classifier, 4 new for negotiation, the header, the protocol-1 shim, and the null-body 401). `bun run check` and `bun run protocol:check` pass.
- Typecheck passes for `agents`, `@shm/ui`, desktop, and web.
- Replayed #1078 against the committed snapshot: removing `sessions` fails the check naming `responses.GetAgentResponse.sessions`; bumping to 3 without a changelog entry fails naming the missing heading; adding the entry passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APT1yYPnXryaAcr2sAgDz6
