### PR TITLE
Restore historical citations to the activity feed

### DIFF
--- a/backend/api/activity/v1alpha/activity.go
+++ b/backend/api/activity/v1alpha/activity.go
@@ -82,6 +82,12 @@ type feedCursor struct {
 	key         string
 }
 
+type citationPageToken struct {
+	CursorValue int64 `json:"v"`
+	BlobID      int64 `json:"b"`
+	LinkID      int64 `json:"l"`
+}
+
 var resourcePattern = regexp.MustCompile(`^hm://[a-zA-Z0-9*]+/?[a-zA-Z0-9*-/]*$`)
 
 // NewServer creates a new Server.
@@ -154,8 +160,15 @@ func buildMainEventsQuery(filtersStr string, orderByObserved bool) string {
 // ListEvents list all the events seen locally.
 func (srv *Server) ListEvents(ctx context.Context, req *activity.ListEventsRequest) (*activity.ListEventsResponse, error) {
 	var cursorValue int64 = math.MaxInt64
+	var cursorBlobID int64 = math.MaxInt64
+	var cursorLinkID int64
 	if req.PageToken != "" {
-		if err := apiutil.DecodePageToken(req.PageToken, &cursorValue, nil); err != nil {
+		var token citationPageToken
+		if err := apiutil.DecodePageToken(req.PageToken, &token, nil); err == nil {
+			cursorValue = token.CursorValue
+			cursorBlobID = token.BlobID
+			cursorLinkID = token.LinkID
+		} else if err := apiutil.DecodePageToken(req.PageToken, &cursorValue, nil); err != nil {
 			return nil, fmt.Errorf("failed to decode page token: %w", err)
 		}
 	}
@@ -167,6 +180,7 @@ func (srv *Server) ListEvents(ctx context.Context, req *activity.ListEventsReque
 	srv.log.Debug("Listing events", zap.Int64("cursor_value", cursorValue), zap.String("order", req.Order.String()))
 	var filtersStr string
 	var authorsJSON, linkTypesJSON string
+	var citationFilter, blobOnlyFilter bool
 
 	filterResource := "*"
 	noResourceFilter := req.FilterResource == "" || req.FilterResource == "*"
@@ -248,6 +262,7 @@ func (srv *Server) ListEvents(ctx context.Context, req *activity.ListEventsReque
 	if len(req.FilterEventType) > 0 {
 		filtersStr += "lower(" + storage.StructuralBlobsType.String() + ") in ("
 		linkTypesJSON = "["
+		citationTypesSeen := make(map[string]struct{}, 4)
 		for i, eventType := range req.FilterEventType {
 			// Hardcode this to prevent injection attacks
 			if strings.ToLower(eventType) != "capability" &&
@@ -263,15 +278,29 @@ func (srv *Server) ListEvents(ctx context.Context, req *activity.ListEventsReque
 				strings.ToLower(eventType) != "doc/button" {
 				return nil, fmt.Errorf("Invalid event type filter [%s]: Only Capability | Ref | Comment | DagPB | Profile | Contact | Comment/Target | Comment/Embed | Doc/Embed | Doc/Link | Doc/Button are supported at the moment", eventType)
 			}
+			normalizedType := strings.ToLower(eventType)
 			if i > 0 {
 				filtersStr += ", "
 			}
-			filtersStr += "'" + strings.ToLower(eventType) + "'"
-			linkTypesJSON += "\"" + strings.ToLower(eventType) + "\", "
+			filtersStr += "'" + normalizedType + "'"
+			linkTypesJSON += "\"" + normalizedType + "\", "
+			switch normalizedType {
+			case "comment/embed", "doc/embed", "doc/link", "doc/button":
+				citationTypesSeen[normalizedType] = struct{}{}
+			}
 		}
 		if len(linkTypesJSON) > 1 {
 			linkTypesJSON = strings.TrimSuffix(linkTypesJSON, ", ")
 		}
+		// The citations route historically filters on the four modern link
+		// types above. Older document citations were indexed as Ref links, but
+		// adding Ref to the shared blob predicate would also surface ordinary
+		// document updates. Widen only the mention-link predicate instead.
+		citationFilter = len(req.FilterEventType) == 4 && len(citationTypesSeen) == 4
+		if citationFilter {
+			linkTypesJSON += ", \"ref\""
+		}
+		blobOnlyFilter = len(req.FilterEventType) == 1 && strings.EqualFold(req.FilterEventType[0], "ref")
 		linkTypesJSON += "]"
 		filtersStr += ") AND "
 	}
@@ -454,9 +483,19 @@ func (srv *Server) ListEvents(ctx context.Context, req *activity.ListEventsReque
 	// Smallest cursor value returned by the mentions DB fetch (same contract
 	// as mainScanFloor).
 	var mentionsScanFloor int64
+	// Final raw mention row consumed by the SQL LIMIT. Citation pagination
+	// advances from this tuple rather than the final post-dedup survivor, so a
+	// duplicate discarded in Go cannot reappear on the next request.
+	var mentionsRawCursor feedCursor
 
 	// Add mentions to the events list
 	if err := srv.db.WithSave(ctx, func(conn *sqlite.Conn) error {
+		// Ref is both a structural document-update blob and a historical
+		// citation link type. The versions route asks for Ref blobs only; do
+		// not let Ref links enter that feed as mentions.
+		if blobOnlyFilter {
+			return nil
+		}
 		// In the unfiltered (noResourceFilter) path we skip the IRI→id
 		// resolution entirely and use the no-targets variant of the
 		// mentions query — the IN(...) list would otherwise blow up to
@@ -497,6 +536,15 @@ func (srv *Server) ListEvents(ctx context.Context, req *activity.ListEventsReque
 		if !orderByObserved {
 			queryStr = strings.Replace(queryStr, "structural_blobs.id <= :idx", "structural_blobs.ts <= :idx", 1)
 		}
+		if citationFilter {
+			cursorColumn := "structural_blobs.id"
+			if !orderByObserved {
+				cursorColumn = "structural_blobs.ts"
+			}
+			queryStr = strings.Replace(queryStr, cursorColumn+" <= :idx",
+				"("+cursorColumn+" < :idx OR ("+cursorColumn+" = :idx AND (structural_blobs.id < :cursor_blob_id OR (structural_blobs.id = :cursor_blob_id AND resource_links.id > :cursor_link_id))))", 1)
+			args = append(args, cursorBlobID, cursorLinkID)
+		}
 
 		if len(authorsJSON) > 2 {
 			queryStr += authorsFilterMentions
@@ -506,7 +554,11 @@ func (srv *Server) ListEvents(ctx context.Context, req *activity.ListEventsReque
 			queryStr += linkTypesFilterMentions
 			args = append(args, linkTypesJSON)
 		}
-		if orderByObserved {
+		if citationFilter && orderByObserved {
+			queryStr += limitCitationMentionsByObserved
+		} else if citationFilter {
+			queryStr += limitCitationMentionsByClaimed
+		} else if orderByObserved {
 			queryStr += limitMentionsByObserved
 		} else {
 			queryStr += limitMentionsByClaimed
@@ -580,6 +632,12 @@ func (srv *Server) ListEvents(ctx context.Context, req *activity.ListEventsReque
 				cursor = blobID
 			}
 			mentionsScanFloor = cursor
+			mentionsRawCursor = feedCursor{
+				cursorValue: cursor,
+				blobID:      blobID,
+				kind:        feedCursorKindMention,
+				linkID:      linkID,
+			}
 			eventCursors = append(eventCursors, feedCursor{
 				cursorValue: cursor,
 				blobID:      blobID,
@@ -701,13 +759,30 @@ func (srv *Server) ListEvents(ctx context.Context, req *activity.ListEventsReque
 			}
 		}
 		if minCursor != 0 {
-			nextPageToken = apiutil.EncodePageToken(minCursor-1, nil)
+			if citationFilter {
+				boundary := mentionsRawCursor
+				nextPageToken = apiutil.EncodePageToken(citationPageToken{
+					CursorValue: boundary.cursorValue,
+					BlobID:      boundary.blobID,
+					LinkID:      boundary.linkID,
+				}, nil)
+			} else {
+				nextPageToken = apiutil.EncodePageToken(minCursor-1, nil)
+			}
 		}
 	} else if pageLen == 0 && rawHasMore && coverageFloor > 0 {
 		// Everything on this page was clamped or filtered out, but the DB has
 		// more rows. Emit a token at the coverage boundary so the client can
 		// keep paging instead of dead-ending on an empty page.
-		nextPageToken = apiutil.EncodePageToken(coverageFloor-1, nil)
+		if citationFilter && mentionsRawCursor.cursorValue != 0 {
+			nextPageToken = apiutil.EncodePageToken(citationPageToken{
+				CursorValue: mentionsRawCursor.cursorValue,
+				BlobID:      mentionsRawCursor.blobID,
+				LinkID:      mentionsRawCursor.linkID,
+			}, nil)
+		} else {
+			nextPageToken = apiutil.EncodePageToken(coverageFloor-1, nil)
+		}
 	}
 
 	return &activity.ListEventsResponse{
@@ -818,7 +893,10 @@ func filterDeletedAndDedupEvents(
 				continue
 			}
 			seenMentionGroup[groupKey] = struct{}{}
-			key := nm.Target + "\x00" + nm.SourceType + "\x00" + e.Account + "\x00" + strconv.FormatInt(e.EventTime.AsTime().UnixNano(), 10)
+			key := strings.Join([]string{
+				nm.Target, nm.SourceType, e.Account, strconv.FormatInt(e.EventTime.AsTime().UnixNano(), 10),
+				nm.Source, nm.TargetVersion, nm.TargetFragment,
+			}, "\x00")
 			if _, ok := seen[key]; ok {
 				continue
 			}
@@ -1104,5 +1182,15 @@ LIMIT :page_size;
 
 var limitMentionsByClaimed = `
 ORDER BY structural_blobs.ts DESC
+LIMIT :page_size;
+`
+
+var limitCitationMentionsByObserved = `
+ORDER BY structural_blobs.id DESC, resource_links.id ASC
+LIMIT :page_size;
+`
+
+var limitCitationMentionsByClaimed = `
+ORDER BY structural_blobs.ts DESC, structural_blobs.id DESC, resource_links.id ASC
 LIMIT :page_size;
 `

--- a/backend/api/activity/v1alpha/activity_test.go
+++ b/backend/api/activity/v1alpha/activity_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ipfs/go-cid"
 	"github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -538,6 +539,87 @@ func TestListEventsEmitsNextTokenWhenClampEmptiesPage(t *testing.T) {
 	require.True(t, gotMention,
 		"the clamped comment must still be delivered: an emptied page must emit a token, not dead-end")
 	require.Greater(t, pages, 1, "the first page is emptied by the clamp, so a second page must be requested")
+}
+
+func TestListEventsCitationFilterIncludesLegacyRefMentionWithoutRefBlob(t *testing.T) {
+	alice := newTestServer(t, "alice")
+	ctx := context.Background()
+
+	author, err := core.DecodePrincipal("z6Mkv1LjkRosErBhmqrkmb5sDxXNs6EzBDSD8ktywpYLLGuC")
+	require.NoError(t, err)
+
+	sourceIRI := "hm://" + author.String() + "/historical-source"
+	targetIRI := "hm://" + author.String() + "/citation-target"
+	changeHash, err := multihash.Sum([]byte("historical citation Change"), multihash.SHA2_256, -1)
+	require.NoError(t, err)
+	refHash, err := multihash.Sum([]byte("published source Ref"), multihash.SHA2_256, -1)
+	require.NoError(t, err)
+	targetHash, err := multihash.Sum([]byte("ordinary target Ref update"), multihash.SHA2_256, -1)
+	require.NoError(t, err)
+
+	require.NoError(t, alice.db.WithTx(ctx, func(conn *sqlite.Conn) error {
+		if err := sqlitex.Exec(conn, `INSERT INTO public_keys (id, principal) VALUES (1, ?);`, nil, []byte(author)); err != nil {
+			return err
+		}
+		if err := sqlitex.Exec(conn, `INSERT INTO blobs (id, multihash, codec, data, size, insert_time) VALUES (10, ?, ?, ?, 1, 10), (11, ?, ?, ?, 1, 11), (20, ?, ?, ?, 1, 20);`, nil,
+			[]byte(changeHash), int64(0x71), []byte{1}, []byte(refHash), int64(0x71), []byte{2}, []byte(targetHash), int64(0x71), []byte{3}); err != nil {
+			return err
+		}
+		if err := sqlitex.Exec(conn, `INSERT INTO resources (id, iri, owner, genesis_blob, create_time) VALUES (1, ?, 1, 10, 0), (2, ?, 1, 20, 0);`, nil, sourceIRI, targetIRI); err != nil {
+			return err
+		}
+		if err := sqlitex.Exec(conn, `INSERT INTO document_generations (resource, generation, genesis, genesis_change_time) VALUES (1, 0, ?, 0), (2, 0, ?, 0);`, nil, sourceIRI, targetIRI); err != nil {
+			return err
+		}
+		if err := sqlitex.Exec(conn, `INSERT INTO structural_blobs (id, type, ts, author, resource, genesis_blob, extra_attrs) VALUES (10, 'Change', 1000, 1, 1, 10, '{}'), (11, 'Ref', 1100, 1, 1, 10, '{}'), (20, 'Ref', 2000, 1, 2, 20, '{}');`, nil); err != nil {
+			return err
+		}
+		if err := sqlitex.Exec(conn, `INSERT INTO blob_links (source, target, type) VALUES (11, 10, 'Ref/head');`, nil); err != nil {
+			return err
+		}
+		return sqlitex.Exec(conn, `INSERT INTO resource_links (id, source, target, type, is_pinned, extra_attrs) VALUES (30, 10, 2, 'Ref', 0, '{"f":"one"}'), (31, 10, 2, 'Ref', 0, '{"f":"one"}'), (32, 10, 2, 'Ref', 0, '{"f":"two"}'), (33, 10, 2, 'Ref', 0, '{"f":"three"}');`, nil)
+	}))
+
+	var citationEvents []*activity.Event
+	var pageToken string
+	for {
+		citations, err := alice.ListEvents(ctx, &activity.ListEventsRequest{
+			PageSize:        2,
+			PageToken:       pageToken,
+			FilterResource:  targetIRI,
+			FilterEventType: []string{"comment/Embed", "doc/Embed", "doc/Link", "doc/Button"},
+		})
+		require.NoError(t, err)
+		citationEvents = append(citationEvents, citations.Events...)
+		if citations.NextPageToken == "" {
+			break
+		}
+		pageToken = citations.NextPageToken
+	}
+	require.Len(t, citationEvents, 3, "same-timestamp citations must survive pagination without re-emitting duplicate links")
+
+	fragments := make([]string, 0, len(citationEvents))
+	for _, event := range citationEvents {
+		mention := event.GetNewMention()
+		require.NotNil(t, mention)
+		require.Nil(t, event.GetNewBlob(), "citation mode must not expose document-update Ref blobs")
+		require.Equal(t, "Ref", mention.GetSourceType())
+		require.Equal(t, sourceIRI, mention.GetSource())
+		require.Equal(t, targetIRI, mention.GetTarget())
+		require.Equal(t, cid.NewCidV1(uint64(0x71), changeHash).String(), mention.GetSourceBlob().GetCid())
+		fragments = append(fragments, mention.GetTargetFragment())
+	}
+	require.ElementsMatch(t, []string{"one", "two", "three"}, fragments)
+
+	versions, err := alice.ListEvents(ctx, &activity.ListEventsRequest{
+		PageSize:        10,
+		FilterResource:  targetIRI,
+		FilterEventType: []string{"Ref"},
+	})
+	require.NoError(t, err)
+	require.Len(t, versions.Events, 1)
+	require.NotNil(t, versions.Events[0].GetNewBlob())
+	require.Nil(t, versions.Events[0].GetNewMention(), "versions mode must not expose historical citation links")
 }
 
 func TestListEventsCommentMentionSourceDocumentUsesCommentTarget(t *testing.T) {

--- a/frontend/packages/shared/src/__tests__/activity-service.test.ts
+++ b/frontend/packages/shared/src/__tests__/activity-service.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it, vi} from 'vitest'
-import {getFeedEventId, loadCitationEvent, loadContactEvent} from '../models/activity-service'
+import {getEventType, getFeedEventId, loadCitationEvent, loadContactEvent} from '../models/activity-service'
 
 const TEST_CID = 'bafkreigh2akiscaildcuj3pww4f2ptib34dm5x3dpljubjkbzfgutz5jum'
 
@@ -166,6 +166,33 @@ describe('loadCitationEvent', () => {
       warnSpy.mockRestore()
       errorSpy.mockRestore()
     }
+  })
+})
+
+describe('getEventType', () => {
+  it('classifies a Ref-backed mention as a citation, not a document update', () => {
+    expect(
+      getEventType({
+        account: 'z6Mks-test-author',
+        eventTime: null,
+        observeTime: null,
+        newMention: {
+          source: 'hm://z6Mks-test-author/source',
+          sourceType: 'Ref',
+          sourceBlob: {cid: TEST_CID, author: 'z6Mks-test-author'},
+          target: 'hm://z6Mks-test-target/document',
+        },
+      } as any),
+    ).toBe('citation')
+
+    expect(
+      getEventType({
+        account: 'z6Mks-test-author',
+        eventTime: null,
+        observeTime: null,
+        newBlob: {blobType: 'Ref'},
+      } as any),
+    ).toBe('ref')
   })
 })
 

--- a/frontend/packages/shared/src/models/activity-service.ts
+++ b/frontend/packages/shared/src/models/activity-service.ts
@@ -160,6 +160,10 @@ export function getEventType(event: HMActivityEvent): string | null {
     // For newMention events, sourceType contains the full type like "doc/Embed" or "comment/Link"
     const sourceType = event.newMention.sourceType?.toLowerCase()
 
+    if (sourceType === 'ref') {
+      return 'citation'
+    }
+
     if (sourceType) {
       return sourceType
     }


### PR DESCRIPTION
## Why now

Issue #583 reports that the citation count is much larger than the citation activity list. The live report still reproduces: `InteractionSummary` counts 24 deduplicated citations, while exhausting the citation `ListEvents` feed returns only the 3 Comment-backed rows.

The two APIs had drifted across Seed's citation representations. `ListCitations` still synthesizes document citations from historical `resource_links.type = 'Ref'` rows sourced by Change blobs and their publishing Ref. The activity route filters only the four modern link types (`comment/Embed`, `doc/Embed`, `doc/Link`, `doc/Button`), so those historical rows never enter the feed. If a Ref-backed mention is returned, the frontend also classifies it as a document update and sends it to `loadRefEvent`, which rejects mention events.

Origin: https://github.com/seed-hypermedia/seed/issues/583

## What changed

- Treat the exact four-type citation request as citation mode and widen only its mention-link predicate to include historical `Ref` links.
- Keep structural Ref blobs out of citation mode, and keep the exact `['Ref']` versions request blob-only.
- Classify `newMention.sourceType = 'Ref'` as a citation while leaving `newBlob.blobType = 'Ref'` as a document update.
- Give citation mode a compound `(time, blob id, link id)` cursor, advanced from the last raw SQL row, so same-timestamp historical links are neither skipped nor repeated after request-local dedup.
- Include source/version/fragment in the mention dedup identity so distinct citations from the same author and timestamp survive.

## Why this approach

Adding `Ref` to the route's shared event-type list is unsafe: the backend applies that list to both structural blob types and resource-link types, which would mix ordinary document updates into Citations. Reindexing or dropping historical citations would also make the activity list disagree with the existing interaction count.

This patch keeps the wire API compatible and narrows the compatibility behavior to the exact existing citation and versions filters. The compound cursor is required because the live historical data contains many citation links with one claimed timestamp; a scalar `timestamp - 1` token permanently skips the remainder.

## Validation

- `CGO_CFLAGS='-O0 -g0' GOMEMLIMIT=320MiB GOMAXPROCS=1 go test -vet=off -p 1 ./backend/api/activity/v1alpha -count=1` — pass.
- Production-shaped backend fixture: Change-sourced Ref citation, publishing Ref, separate target Ref update, four same-timestamp links including one logical duplicate, `PageSize=2`; all pages return three unique citations exactly once, while Versions returns only the target Ref blob.
- Committed frontend classification regression — pass under a bounded Bun harness (1 test, 2 expectations).
- Repository Prettier check for both touched frontend files — pass.
- `git diff --check` — pass.

Immutable validation record: ipfs://bafkreicf2krb7miujswvdqyel2d2fuqb4rszrvdodozefefv2tmaxepx4e

## Follow-up / removal condition

The exact-filter detection is a compatibility shim around an API that conflates structural blob filters with mention-link filters. Replace it when `ListEvents` gains separate first-class blob/link filters, or remove the legacy widening after historical Ref citations are deliberately reindexed to modern link types and parity is verified on existing documents.
