### PR TITLE
fix(notifications): open document mentions at the source block

### DIFF
--- a/frontend/apps/desktop/src/pages/__tests__/notification-source-context.test.ts
+++ b/frontend/apps/desktop/src/pages/__tests__/notification-source-context.test.ts
@@ -1,0 +1,23 @@
+import {notificationRouteForPayload} from '@shm/shared/models/notification-helpers'
+import {describe, expect, it} from 'vitest'
+
+describe('document mention notification anchor review', () => {
+  it('routes a document mention to the source block carried by sourceContext', () => {
+    const route = notificationRouteForPayload({
+      feedEventId: 'mention-event-1',
+      eventAtMs: 1_000,
+      reason: 'mention',
+      eventType: 'citation',
+      author: {uid: 'author', name: 'Alice', icon: null},
+      target: {uid: 'source', path: ['doc'], name: 'Source Doc'},
+      commentId: null,
+      sourceId: null,
+      citationType: null,
+      sourceContext: 'block-1',
+    } as any)
+
+    expect(route?.key).toBe('document')
+    if (route?.key !== 'document') throw new Error('expected document route')
+    expect(route.id.blockRef).toBe('block-1')
+  })
+})

--- a/frontend/apps/emails/notifier.tsx
+++ b/frontend/apps/emails/notifier.tsx
@@ -984,6 +984,7 @@ export type Notification =
       eventId?: string
       eventAtMs?: number
       source: 'comment' | 'document'
+      sourceContext?: string
       comment?: HMComment
       resolvedNames?: Record<string, string>
     }

--- a/frontend/apps/notify/app/email-notifier.test.ts
+++ b/frontend/apps/notify/app/email-notifier.test.ts
@@ -1,15 +1,22 @@
-import {describe, expect, it} from 'vitest'
+import {describe, expect, it, vi} from 'vitest'
 import type {PlainMessage} from '@bufbuild/protobuf'
 import {Code, ConnectError} from '@connectrpc/connect'
 import type {HMBlockNode} from '@seed-hypermedia/client/hm-types'
 import type {Event} from '@shm/shared'
+import {requestAPI} from './notify-request'
 import {
+  evaluateMentionEventForNotifications,
   getEventId,
   isNotificationEventTooOld,
   isTransientGrpcUnavailableError,
   matchesCursorEvent,
   resolveContentReferenceNames,
 } from './email-notifier'
+
+vi.mock('./notify-request', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./notify-request')>()
+  return {...actual, requestAPI: vi.fn()}
+})
 
 const TEST_CID_1 = 'bafkreigh2akiscaildcuj3pww4f2ptib34dm5x3dpljubjkbzfgutz5jum'
 const TEST_CID_2 = 'bafy2bzacedexveqjcytw4trm6a4lxgxyssrg3ubxyro6rp5o4lo545qcl3imw'
@@ -87,6 +94,47 @@ function createMentionEvent(
     observeTime: toTimestamp(Date.UTC(2026, 0, 1, 12, 0, 0)) as PlainMessage<Event>['observeTime'],
   }
 }
+
+describe('evaluateMentionEventForNotifications', () => {
+  it('carries a modern document mention sourceContext into the notification', async () => {
+    vi.mocked(requestAPI).mockImplementation(async (resource) => {
+      if (resource === 'ResourceMetadata') return {metadata: {name: 'Source Doc'}} as any
+      if (resource === 'Account') return {type: 'account', metadata: {name: 'Alice'}} as any
+      throw new Error(`Unexpected resource request: ${resource}`)
+    })
+    const appendNotification = vi.fn<Parameters<typeof evaluateMentionEventForNotifications>[2]>(async () => {})
+    const event = createMentionEvent()
+    if (event.data.case !== 'newMention') throw new Error('expected mention event')
+
+    await evaluateMentionEventForNotifications(
+      event.data.value,
+      [
+        {
+          id: TEST_ACCOUNT,
+          email: null,
+          adminToken: null,
+          shouldSendEmail: false,
+          source: 'inbox-registration',
+          notifyAllMentions: true,
+          notifyAllReplies: false,
+          notifyAllDiscussions: false,
+          notifyOwnedDocChange: false,
+          notifySiteDiscussions: false,
+        },
+      ],
+      appendNotification,
+      {eventId: 'mention-event-1', eventAtMs: Date.UTC(2026, 0, 1, 12, 0, 0)},
+      TEST_ACCOUNT,
+    )
+
+    expect(appendNotification).toHaveBeenCalledOnce()
+    expect(appendNotification.mock.calls[0]?.[1]).toMatchObject({
+      reason: 'mention',
+      source: 'document',
+      sourceContext: 'block-1',
+    })
+  })
+})
 
 describe('isNotificationEventTooOld', () => {
   it('accepts events seen within the last hour', () => {

--- a/frontend/apps/notify/app/email-notifier.ts
+++ b/frontend/apps/notify/app/email-notifier.ts
@@ -1379,7 +1379,7 @@ async function buildVerifiedResourceUrl(
   })
 }
 
-async function evaluateMentionEventForNotifications(
+export async function evaluateMentionEventForNotifications(
   mentionEvent: any,
   allSubscriptions: NotificationSubscription[],
   appendNotification: (subscription: NotificationSubscription, notif: Notification) => Promise<void>,
@@ -1496,6 +1496,7 @@ async function evaluateMentionEventForNotifications(
     await appendNotification(sub, {
       reason: 'mention',
       source: isCommentMention ? 'comment' : 'document',
+      sourceContext: mentionEvent.sourceContext || undefined,
       authorAccountId,
       authorMeta,
       targetMeta,

--- a/frontend/apps/notify/app/notification-payload.test.ts
+++ b/frontend/apps/notify/app/notification-payload.test.ts
@@ -1,0 +1,21 @@
+import {NotificationPayloadSchema} from '../../../packages/shared/src/models/notification-payload'
+import {describe, expect, it} from 'vitest'
+
+const basePayload = {
+  feedEventId: 'mention-event-1',
+  eventAtMs: 1_000,
+  reason: 'mention',
+  eventType: 'citation',
+  author: {uid: 'author', name: 'Alice', icon: null},
+  target: {uid: 'source', path: ['doc'], name: 'Source Doc'},
+  commentId: null,
+  sourceId: null,
+  citationType: 'd',
+}
+
+describe('notification sourceContext compatibility review', () => {
+  it('accepts old payloads and preserves a new optional sourceContext', () => {
+    expect(NotificationPayloadSchema.parse(basePayload).sourceContext).toBeUndefined()
+    expect(NotificationPayloadSchema.parse({...basePayload, sourceContext: 'block-1'}).sourceContext).toBe('block-1')
+  })
+})

--- a/frontend/apps/notify/app/notification-persistence.test.ts
+++ b/frontend/apps/notify/app/notification-persistence.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, it} from 'vitest'
+import {notificationToPayload} from './notification-persistence'
+
+describe('document mention notification anchor persistence review', () => {
+  it('retains sourceContext from a document mention', () => {
+    const payload = notificationToPayload(
+      {
+        reason: 'mention',
+        source: 'document',
+        authorAccountId: 'author',
+        authorMeta: null,
+        targetMeta: {name: 'Source Doc'},
+        subjectAccountId: 'mentioned',
+        subjectAccountMeta: null,
+        targetId: {
+          id: 'hm://source/doc',
+          uid: 'source',
+          path: ['doc'],
+          version: null,
+          blockRef: null,
+          blockRange: null,
+          hostname: null,
+          scheme: null,
+          latest: null,
+        },
+        url: 'https://example.test/hm/source/doc',
+        sourceContext: 'block-1',
+      } as any,
+      'event-1',
+      1_000,
+    ) as any
+
+    expect(payload.sourceContext).toBe('block-1')
+  })
+})

--- a/frontend/apps/notify/app/notification-persistence.ts
+++ b/frontend/apps/notify/app/notification-persistence.ts
@@ -26,6 +26,7 @@ export function notificationToPayload(notif: Notification, eventId: string, even
       commentId: notif.comment?.id ?? null,
       sourceId: null,
       citationType: null,
+      sourceContext: notif.sourceContext ?? null,
     }
   }
 

--- a/frontend/packages/shared/src/models/notification-helpers.ts
+++ b/frontend/packages/shared/src/models/notification-helpers.ts
@@ -30,7 +30,10 @@ export function notificationRouteForPayload(payload: NotificationPayload): NavRo
   if (payload.eventType === 'citation') {
     if (!payload.sourceId && !payload.target.uid) return null
     const sourceUid = payload.sourceId || payload.target.uid
-    const sourceId = hmId(sourceUid, {path: payload.target.path ?? undefined})
+    const sourceId = hmId(sourceUid, {
+      path: payload.target.path ?? undefined,
+      blockRef: payload.sourceContext || undefined,
+    })
     if (payload.citationType === 'c' && payload.commentId) {
       return {
         key: 'comments',

--- a/frontend/packages/shared/src/models/notification-payload.ts
+++ b/frontend/packages/shared/src/models/notification-payload.ts
@@ -34,6 +34,7 @@ export const NotificationPayloadSchema = z.object({
   commentId: z.string().nullable(),
   sourceId: z.string().nullable(),
   citationType: z.enum(['d', 'c']).nullable(),
+  sourceContext: z.string().nullable().optional(),
 })
 export type NotificationPayload = z.infer<typeof NotificationPayloadSchema>
 


### PR DESCRIPTION
## Why now

Clicking a document-mention notification opens the mentioned document at its top instead of the exact block that contains the mention ([#362](https://github.com/seed-hypermedia/seed/issues/362)). The modern activity event already provides that block ID as `newMention.sourceContext`, but notification construction drops it before inbox persistence. Desktop routing therefore has only the source document UID/path and cannot construct a block-level HM ID.

## What changed

- Retain `newMention.sourceContext` while constructing a modern mention notification.
- Carry it through persisted inbox JSON and the shared notification payload schema.
- Reconstruct the desktop route with `blockRef` when the context is present.
- Preserve historical behavior for omitted, `null`, or empty contexts: those notifications still open the document root.

## Why this approach

This repairs the existing modern `newMention` pipeline at the point where information is lost, rather than inferring an anchor later. It deliberately does not alter the legacy Ref/MentionMap path: that path has a block-ID/account-ID lookup mismatch, and a naive repair could duplicate emails when a publication emits both Ref and modern `newMention` events. Comment mentions also keep their separate `commentId`/`openComment` route.

## Validation

Before rebase, focused tests passed:

- notify: 12/12 (`email-notifier`, payload, persistence)
- desktop: 26/26 (source-context routing and notification behavior)
- includes a direct producer assertion and a production-shaped `citationType: null` route fixture

The commit was rebased without conflicts onto current `main` at `1d35e974`; none of the touched existing production files changed between its original base and current main, and `git diff --check` passes. Initial exact-head CI caught that the new assertion inspected argument 1 of an untyped zero-argument Vitest mock (`TS2493`). The mock now derives its callable signature directly from `Parameters<typeof evaluateMentionEventForNotifications>[2]`, so the assertion remains type-safe as the callback evolves; the complete exact-head frontend check set now passes.

## Follow-up

A real desktop click/scroll smoke test remains useful before merge. Any legacy MentionMap repair should be separate and gated by an exactly-once regression covering paired Ref + `newMention` delivery.

Closes #362