### PR TITLE
fix(editor): enable image gallery in read-only content

### DIFF
--- a/frontend/packages/editor/src/readonly-viewer.tsx
+++ b/frontend/packages/editor/src/readonly-viewer.tsx
@@ -7,8 +7,10 @@ import {
   useOpenUrl,
   useUniversalAppContext,
 } from '@shm/shared'
+import {useImageUrl} from '@shm/ui/get-file-url'
 import {useCallback, useEffect, useMemo} from 'react'
 import {useBlockNote} from './blocknote'
+import {ImageGalleryOverlay} from './blocknote/react'
 import {BlockHoverActionsPositioner} from './blocknote/react/BlockHoverActions/BlockHoverActionsPositioner'
 import {PredictionConeDebugOverlay} from './blocknote/react/BlockHoverActions/PredictionConeDebugOverlay'
 import {RangeSelectionPositioner} from './blocknote/react/RangeSelection/RangeSelectionPositioner'
@@ -55,6 +57,7 @@ export function ReadOnlyViewer({
   onComment,
 }: ReadOnlyViewerProps) {
   const openUrl = useOpenUrl()
+  const getImageUrl = useImageUrl()
   const {hmUrlHref, openRouteNewWindow, origin, originHomeId, experiments} = useUniversalAppContext()
   const renderHref = useCallback(
     (url: string) =>
@@ -128,6 +131,7 @@ export function ReadOnlyViewer({
       >
         <ReadOnlyBlockNoteView editor={editor}>
           <>
+            <ImageGalleryOverlay editor={editor} resolveImageUrl={getImageUrl} />
             {hasHoverActions && (
               <BlockHoverActionsPositioner
                 editor={editor}


### PR DESCRIPTION
## Why now

Images rendered inside comments do not open the full-screen gallery on double-click, even though document images do ([#796](https://github.com/seed-hypermedia/seed/issues/796)). Comments use the shared `ReadOnlyViewer`; that viewer already creates a BlockNote instance with `ImageGalleryPlugin`, but unlike `DocumentEditor` it never mounts the React `ImageGalleryOverlay`. The plugin can update its state, yet no gallery UI observes or renders that state.

## What changed

Mount the existing `ImageGalleryOverlay` inside `ReadOnlyViewer` and pass it the same app-aware `useImageUrl()` resolver used by other image surfaces. This enables the existing plugin behavior for comments and every other read-only viewer without changing comment routing, block actions, or selection behavior.

## Why this approach

The missing boundary is presentation, not event handling: viewer-mode BlockNote already owns the image-gallery plugin. Reusing the existing overlay and resolver matches `DocumentEditor`, preserves web proxy/optimized URLs and desktop daemon file URLs, and avoids duplicating double-click or next/previous logic in comment components. A comment-only wrapper was rejected because it would leave other read-only surfaces inconsistent and couple gallery behavior to one caller.

## Validation

Before rebase:

- the existing `readonly-viewer-gallery.test.tsx` reproduced the missing overlay (1/1 failing)
- after this four-line production change, focused gallery/image tests passed 3/3
- Prettier and `git diff --check` passed

The commit rebased without conflicts onto current `main` at `1d35e974`; `readonly-viewer.tsx` had not changed since the original base, and post-rebase `git diff --check` passes. Package typecheck previously exceeded the constrained executor's memory and was not reported as a local pass; the complete exact-head GitHub frontend check set now passes, including typecheck.

## Follow-up

Before merge, smoke-test a multi-image comment in web and desktop to confirm double-click, next/previous navigation, and resolved URLs end to end. No temporary workaround or removal condition is introduced.

Closes #796