### PR TITLE
fix(editor): handle pasted gateway links without gwUrl

### DIFF
--- a/frontend/packages/editor/src/tiptap-extension-link/helpers/pasteHandler.test.ts
+++ b/frontend/packages/editor/src/tiptap-extension-link/helpers/pasteHandler.test.ts
@@ -108,6 +108,31 @@ describe('pasteHandler', () => {
     expect(view.state.doc.nodeAt(0)?.marks[0]?.attrs.href).toBe(resolvedUrl)
   })
 
+  it('resolves a custom-domain document URL when gwUrl is omitted', async () => {
+    const uid = 'z6Mkg7Cizn2g6h9sheDdF6JuHpHY95XK9LUAe6urCieoimC8'
+    const path = 'alan-kay-ideas/multi-agent-is-actor-model'
+    const url = `https://dream-machines-2.hyper.media/${path}`
+    const resolvedUrl = `hm://${uid}/${path}`
+    const view = createPasteView()
+    const plugin = pasteHandler({
+      editor: {schema} as any,
+      type: schema.marks.link,
+      gwUrl: undefined as any,
+      domainResolver: async (hostname) => {
+        expect(hostname).toBe('dream-machines-2.hyper.media')
+        return {registeredAccountUid: uid, isGateway: false}
+      },
+      checkWebUrl: async () => null,
+    })
+
+    const handled = plugin.props.handlePaste?.(view, {} as any, new Slice(Fragment.from(schema.text(url)), 0, 0))
+
+    expect(handled).toBe(true)
+    await flushPasteHandler()
+    expect(view.state.doc.textContent).toBe(resolvedUrl)
+    expect(view.state.doc.nodeAt(0)?.marks[0]?.attrs.href).toBe(resolvedUrl)
+  })
+
   it('uses the universal client to insert a pasted hm:// document URL as a titled link', async () => {
     const url = 'hm://abc/path'
     const view = createPasteView()

--- a/frontend/packages/editor/src/tiptap-extension-link/helpers/pasteHandler.test.ts
+++ b/frontend/packages/editor/src/tiptap-extension-link/helpers/pasteHandler.test.ts
@@ -83,6 +83,31 @@ describe('restoreBlockRangeSuffix', () => {
 })
 
 describe('pasteHandler', () => {
+  it('resolves a gateway-format URL when gwUrl is omitted', async () => {
+    const uid = 'z6Mkg7Cizn2g6h9sheDdF6JuHpHY95XK9LUAe6urCieoimC8'
+    const path = 'alan-kay-ideas/multi-agent-is-actor-model'
+    const url = `https://dream-machines-2.hyper.media/hm/${uid}/${path}`
+    const resolvedUrl = `hm://${uid}/${path}`
+    const view = createPasteView()
+    const plugin = pasteHandler({
+      editor: {schema} as any,
+      type: schema.marks.link,
+      gwUrl: undefined as any,
+      domainResolver: async (hostname) => {
+        expect(hostname).toBe('dream-machines-2.hyper.media')
+        return {registeredAccountUid: uid, isGateway: true}
+      },
+      checkWebUrl: async () => null,
+    })
+
+    const handled = plugin.props.handlePaste?.(view, {} as any, new Slice(Fragment.from(schema.text(url)), 0, 0))
+
+    expect(handled).toBe(true)
+    await flushPasteHandler()
+    expect(view.state.doc.textContent).toBe(resolvedUrl)
+    expect(view.state.doc.nodeAt(0)?.marks[0]?.attrs.href).toBe(resolvedUrl)
+  })
+
   it('uses the universal client to insert a pasted hm:// document URL as a titled link', async () => {
     const url = 'hm://abc/path'
     const view = createPasteView()

--- a/frontend/packages/shared/src/utils/entity-id-url.ts
+++ b/frontend/packages/shared/src/utils/entity-id-url.ts
@@ -946,7 +946,8 @@ export function isHypermediaScheme(url?: string) {
   return !!url?.startsWith(`${HYPERMEDIA_SCHEME}://`) || !!url?.startsWith('hm://')
 }
 
-export function isPublicGatewayLink(text: string, gwUrl: StateStream<string>) {
+export function isPublicGatewayLink(text: string, gwUrl?: StateStream<string>) {
+  if (!gwUrl) return false
   const matchesGateway = text.indexOf(gwUrl.get()) === 0
   return !!matchesGateway
 }


### PR DESCRIPTION
## Why now

Two web-editor reports reach the same synchronous failure:

- Copying a child link from an unreferenced-document card can fail instead of creating a canonical Hypermedia link ([#896](https://github.com/seed-hypermedia/seed/issues/896)).
- Pasting the reported custom-domain URL `https://dream-machines-2.hyper.media/alan-kay-ideas/multi-agent-is-actor-model` works in desktop but fails in web ([#899](https://github.com/seed-hypermedia/seed/issues/899)).

Both URLs are valid. The web editor configures link handling with `universalClient` and no `gwUrl`; the synchronous paste classifier calls `isPublicGatewayLink(text, undefined)` and dereferences `gwUrl.get()` before the existing asynchronous domain resolver can identify either Seed URL.

## What changed

Make the gateway stream optional at the `isPublicGatewayLink` boundary. When no configured gateway stream exists, the helper returns `false`, so the paste handler continues through its normal web-URL path. `resolveHypermediaUrl` can then use the domain resolver, canonicalize the copied URL to `hm://…`, and apply the normal link mark.

Production-shaped regressions cover both affected forms with `gwUrl` omitted:

- `/hm/<uid>/<path>` copied from a Seed gateway;
- the exact #899 custom-domain host and path, resolved through that domain's registered account.

Both assert that visible text and link target become the canonical HM URL.

## Why this approach

Absence of a configured *current gateway* does not make the pasted URL invalid and should not be exceptional. Returning `false` accurately answers the narrow synchronous question and preserves the existing domain-resolution fallback for arbitrary Seed sites. Injecting one `gwUrl` in the web host would recognize only that configured gateway and would not fix links copied from another site. Duplicating gateway parsing in the card or paste handler would bypass the shared resolver and create divergent URL behavior.

## Validation

At exact head `555c801c12eed2f054087810e20e678e642802b4`:

- focused `@shm/editor` paste-handler suite: 14/14 passing;
- the exact #899 URL resolves to `hm://z6Mkg7Cizn2g6h9sheDdF6JuHpHY95XK9LUAe6urCieoimC8/alan-kay-ideas/multi-agent-is-actor-model` in the regression;
- touched files pass pinned Prettier and `git diff --check`;
- exact-head Typecheck, Lint, shared/desktop/web units, editor E2E, and aggregate frontend checks pass; integration-tests is intentionally skipped.

The production guard remains one line; the additional commit only extends regression coverage.

## Follow-up / removal condition

A web smoke test that copies each form into the editor remains useful before merge. No temporary workaround or removal condition is introduced.

Closes #896
Closes #899