### PR TITLE
fix(site): let owners hide the home collaborator bar

### DIFF
--- a/frontend/apps/cli/src/commands/document.ts
+++ b/frontend/apps/cli/src/commands/document.ts
@@ -1042,6 +1042,7 @@ const METADATA_KEYS: (keyof HMMetadata)[] = [
   'layout',
   'showOutline',
   'showActivity',
+  'showCollaborators',
   'contentWidth',
   'childrenType',
   'seedExperimentalLogo',

--- a/frontend/packages/client/__tests__/markdown-lossless.test.ts
+++ b/frontend/packages/client/__tests__/markdown-lossless.test.ts
@@ -335,6 +335,7 @@ describe('lossless: metadata', () => {
       seedExperimentalHomeOrder: 'UpdatedFirst',
       showOutline: true,
       showActivity: false,
+      showCollaborators: false,
       contentWidth: 'L',
       childrenType: 'Ordered',
       theme: {headerLayout: 'Center'},

--- a/frontend/packages/client/src/blocks-to-markdown.ts
+++ b/frontend/packages/client/src/blocks-to-markdown.ts
@@ -62,6 +62,7 @@ const FM_KEY_ORDER = [
   'childrenType',
   'showOutline',
   'showActivity',
+  'showCollaborators',
   'seedExperimentalLogo',
   'seedExperimentalHomeOrder',
   'importCategories',

--- a/frontend/packages/client/src/hm-types.ts
+++ b/frontend/packages/client/src/hm-types.ts
@@ -590,6 +590,7 @@ export const HMDocumentMetadataSchema = z
     seedExperimentalHomeOrder: z.union([z.literal('UpdatedFirst'), z.literal('CreatedFirst')]).optional(),
     showOutline: z.boolean().optional(),
     showActivity: z.boolean().optional(),
+    showCollaborators: z.boolean().optional(),
     contentWidth: z.union([z.literal('S'), z.literal('M'), z.literal('L')]).optional(),
     childrenType: HMBlockChildrenTypeSchema.optional(),
     theme: z
@@ -639,6 +640,7 @@ export const DOCUMENT_ATTRIBUTE_DESCRIPTIONS: Readonly<Record<string, string>> =
   seedExperimentalHomeOrder: 'Legacy ordering preference for a space home page.',
   showOutline: 'Whether to show the document outline.',
   showActivity: 'Whether to show document activity and tools.',
+  showCollaborators: 'Whether to show the collaborator bar on a space home page.',
   contentWidth: 'Width of the document content area.',
   childrenType: 'Layout of the document’s root-level blocks.',
   theme: 'Visual settings for a space.',

--- a/frontend/packages/client/src/markdown-to-blocks.ts
+++ b/frontend/packages/client/src/markdown-to-blocks.ts
@@ -793,7 +793,7 @@ const METADATA_STRING_KEYS = [
 ] as const
 
 /** Boolean-typed metadata keys. */
-const METADATA_BOOLEAN_KEYS = ['showOutline', 'showActivity'] as const
+const METADATA_BOOLEAN_KEYS = ['showOutline', 'showActivity', 'showCollaborators'] as const
 
 /**
  * Strip YAML frontmatter (--- delimited) from markdown content.

--- a/frontend/packages/ui/src/__tests__/options-panel.test.tsx
+++ b/frontend/packages/ui/src/__tests__/options-panel.test.tsx
@@ -25,6 +25,7 @@ afterEach(() => {
 })
 
 function renderOptionsPanel(isHomeDoc: boolean) {
+  const onMetadata = vi.fn()
   act(() => {
     root.render(
       <TooltipProvider>
@@ -40,12 +41,13 @@ function renderOptionsPanel(isHomeDoc: boolean) {
               showActivity: true,
             } as any
           }
-          onMetadata={vi.fn()}
+          onMetadata={onMetadata}
           fileUpload={vi.fn()}
         />
       </TooltipProvider>,
     )
   })
+  return onMetadata
 }
 
 describe('OptionsPanel document metadata fields', () => {
@@ -66,6 +68,19 @@ describe('OptionsPanel document metadata fields', () => {
     expect(container.textContent).not.toContain('Summary')
     expect(container.textContent).not.toContain('Cover Image')
     expect(container.textContent).not.toContain('Document Options')
+  })
+
+  it('stages collaborator visibility only for a space home document', () => {
+    const onMetadata = renderOptionsPanel(true)
+    const toggle = container.querySelector<HTMLButtonElement>('#collaborators')
+
+    expect(toggle).not.toBeNull()
+    expect(toggle?.getAttribute('aria-checked')).toBe('true')
+    act(() => toggle?.click())
+    expect(onMetadata).toHaveBeenCalledWith({showCollaborators: false})
+
+    renderOptionsPanel(false)
+    expect(container.querySelector('#collaborators')).toBeNull()
   })
 
   it('removes title, icon, cover, and summary controls for regular documents', () => {

--- a/frontend/packages/ui/src/__tests__/resource-page-shell.test.tsx
+++ b/frontend/packages/ui/src/__tests__/resource-page-shell.test.tsx
@@ -5,7 +5,7 @@ import {createContext, useContext, useState} from 'react'
 import {createPortal} from 'react-dom'
 import {createRoot, type Root} from 'react-dom/client'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
-import {DocumentViewContent, PageWrapper} from '../resource-page-common'
+import {DocumentViewContent, PageWrapper, shouldShowCollaboratorsBar} from '../resource-page-common'
 ;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
 
 vi.mock('../use-media', () => ({useMedia: () => ({xs: false})}))
@@ -169,6 +169,27 @@ describe('PageWrapper edit navigation pane portal', () => {
     })
 
     expect(container.querySelector('[data-testid="edit-nav-pane-target"]')?.textContent).toContain('edit nav context')
+  })
+})
+
+describe('shouldShowCollaboratorsBar', () => {
+  const visible = {
+    isHomeDoc: true,
+    activeView: 'content' as const,
+    isLoading: false,
+    memberCount: 2,
+  }
+
+  it('defaults to visible and honors an explicit home-page opt-out', () => {
+    expect(shouldShowCollaboratorsBar(visible)).toBe(true)
+    expect(shouldShowCollaboratorsBar({...visible, showCollaborators: false})).toBe(false)
+  })
+
+  it('stays hidden outside a loaded home content view with members', () => {
+    expect(shouldShowCollaboratorsBar({...visible, isHomeDoc: false})).toBe(false)
+    expect(shouldShowCollaboratorsBar({...visible, activeView: 'all-documents'})).toBe(false)
+    expect(shouldShowCollaboratorsBar({...visible, isLoading: true})).toBe(false)
+    expect(shouldShowCollaboratorsBar({...visible, memberCount: 0})).toBe(false)
   })
 })
 

--- a/frontend/packages/ui/src/form-fields.tsx
+++ b/frontend/packages/ui/src/form-fields.tsx
@@ -101,7 +101,7 @@ export function SwitchField({label, id, ...props}: SwitchProps & {label: string;
       <Label htmlFor={id} size="sm" className="text-muted-foreground flex-1">
         {label}
       </Label>
-      <Switch {...props} />
+      <Switch id={id} {...props} />
     </div>
   )
 }

--- a/frontend/packages/ui/src/options-panel.tsx
+++ b/frontend/packages/ui/src/options-panel.tsx
@@ -36,6 +36,7 @@ export function OptionsPanel({
             <OriginalPublishDate metadata={metadata} onMetadata={onMetadata} />
             <ContentWidth metadata={metadata} onMetadata={onMetadata} />
             <ActivityVisibility metadata={metadata} onMetadata={onMetadata} />
+            <CollaboratorVisibility metadata={metadata} onMetadata={onMetadata} />
           </>
         ) : (
           <>
@@ -282,6 +283,27 @@ function ActivityVisibility({
         checked={metadata.showActivity !== false}
         onCheckedChange={(value) => {
           onMetadata({showActivity: value})
+        }}
+      />
+    </div>
+  )
+}
+
+function CollaboratorVisibility({
+  metadata,
+  onMetadata,
+}: {
+  metadata: HMMetadata
+  onMetadata: (values: Partial<HMMetadata>) => void
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <SwitchField
+        label="Show Collaborators"
+        id="collaborators"
+        checked={metadata.showCollaborators !== false}
+        onCheckedChange={(value) => {
+          onMetadata({showCollaborators: value})
         }}
       />
     </div>

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -423,6 +423,23 @@ export function orderDocumentMenuItems(items: MenuItemType[]): MenuItemType[] {
   return orderedItems
 }
 
+/** Returns whether a space home page should show its collaborator summary bar. */
+export function shouldShowCollaboratorsBar({
+  isHomeDoc,
+  showCollaborators,
+  activeView,
+  isLoading,
+  memberCount,
+}: {
+  isHomeDoc: boolean
+  showCollaborators?: boolean
+  activeView: ActiveView
+  isLoading: boolean
+  memberCount: number
+}): boolean {
+  return isHomeDoc && showCollaborators !== false && activeView !== 'all-documents' && !isLoading && memberCount > 0
+}
+
 /** Returns a stable key for the exact document resource being viewed, including version state. */
 export function getDocumentResourceRouteKey(id: UnpackedHypermediaId): string {
   return `${id.id}@${id.version ?? ''}@${id.latest ? 'latest' : ''}`
@@ -2705,14 +2722,17 @@ function DocumentBody({
             className={cn(mainContentProps.className, 'flex flex-col', isCollection && '!w-full !max-w-none')}
             style={isCollection ? {...mainContentProps.style, maxWidth: undefined} : mainContentProps.style}
           >
-            {isHomeDoc &&
-              activeView !== 'all-documents' &&
-              !siteMembers.isInitialLoading &&
-              siteMembers.members.length > 0 && (
-                <div className="pt-4">
-                  <MembersFacepile members={siteMembers.members} siteId={siteId} />
-                </div>
-              )}
+            {shouldShowCollaboratorsBar({
+              isHomeDoc,
+              showCollaborators: metadata?.showCollaborators,
+              activeView,
+              isLoading: siteMembers.isInitialLoading,
+              memberCount: siteMembers.members.length,
+            }) && (
+              <div className="pt-4">
+                <MembersFacepile members={siteMembers.members} siteId={siteId} />
+              </div>
+            )}
             {!isHomeDoc &&
               (canEditCurrentRoute ? (
                 <EditableDocumentHeader
@@ -2744,14 +2764,17 @@ function DocumentBody({
           className={cn('mx-auto flex w-full flex-col px-4')}
           style={{maxWidth: isCollection ? undefined : contentMaxWidth}}
         >
-          {isHomeDoc &&
-            activeView !== 'all-documents' &&
-            !siteMembers.isInitialLoading &&
-            siteMembers.members.length > 0 && (
-              <div className="pt-4">
-                <MembersFacepile members={siteMembers.members} siteId={siteId} />
-              </div>
-            )}
+          {shouldShowCollaboratorsBar({
+            isHomeDoc,
+            showCollaborators: metadata?.showCollaborators,
+            activeView,
+            isLoading: siteMembers.isInitialLoading,
+            memberCount: siteMembers.members.length,
+          }) && (
+            <div className="pt-4">
+              <MembersFacepile members={siteMembers.members} siteId={siteId} />
+            </div>
+          )}
           {!isHomeDoc &&
             (canEditCurrentRoute ? (
               <EditableDocumentHeader
@@ -2928,49 +2951,53 @@ function DocumentBody({
 
         {mobilePanelOpen && (
           <MobilePanelSheet isOpen={mobilePanelOpen} title={getPanelTitle(panelKey)} onClose={handlePanelClose}>
-            <DiscussionsPageContent
-              docId={commentsPanelTarget.docId}
-              showTitle={false}
-              showOpenInPanel={false}
-              contentMaxWidth={contentMaxWidth}
-              targetDomain={siteUrl}
-              openComment={commentsPanelTarget.openComment}
-              targetBlockId={panelRoute?.key === 'comments' ? panelRoute.targetBlockId : undefined}
-              blockId={panelRoute?.key === 'comments' ? panelRoute.blockId : undefined}
-              blockRange={panelRoute?.key === 'comments' ? panelRoute.blockRange : undefined}
-              commentEditor={
-                CommentEditor ? (
-                  <CommentEditor
-                    key={
-                      panelRoute?.key === 'comments'
-                        ? getCommentEditorRouteKey({
-                            openComment: panelRoute.openComment,
-                            targetBlockId: panelRoute.targetBlockId,
-                            blockRange: panelRoute.blockRange,
-                          })
-                        : undefined
-                    }
-                    docId={commentsPanelTarget.docId}
-                    quotingBlockId={panelRoute?.key === 'comments' ? panelRoute.targetBlockId : undefined}
-                    quotingRange={
-                      panelRoute?.key === 'comments' ? extractQuotingRange(panelRoute.blockRange) : undefined
-                    }
-                    commentId={commentsPanelTarget.openComment}
-                    isReplying={
-                      panelRoute?.key === 'comments' ? panelRoute.isReplying ?? !!panelRoute.openComment : false
-                    }
-                    replyCommentVersion={panelRoute?.key === 'comments' ? panelRoute.replyCommentVersion : undefined}
-                    rootReplyCommentVersion={
-                      panelRoute?.key === 'comments' ? panelRoute.rootReplyCommentVersion : undefined
-                    }
-                    // On mobile, opening the keyboard during the sheet entrance
-                    // causes visible viewport jumps. Let the drawer settle and
-                    // let users tap the composer when they are ready to type.
-                    focusOnMount={false}
-                  />
-                ) : undefined
-              }
-            />
+            {panelRoute?.key === 'options' ? (
+              <DocumentOptionsPanel docId={docId} fileUpload={fileUpload} />
+            ) : (
+              <DiscussionsPageContent
+                docId={commentsPanelTarget.docId}
+                showTitle={false}
+                showOpenInPanel={false}
+                contentMaxWidth={contentMaxWidth}
+                targetDomain={siteUrl}
+                openComment={commentsPanelTarget.openComment}
+                targetBlockId={panelRoute?.key === 'comments' ? panelRoute.targetBlockId : undefined}
+                blockId={panelRoute?.key === 'comments' ? panelRoute.blockId : undefined}
+                blockRange={panelRoute?.key === 'comments' ? panelRoute.blockRange : undefined}
+                commentEditor={
+                  CommentEditor ? (
+                    <CommentEditor
+                      key={
+                        panelRoute?.key === 'comments'
+                          ? getCommentEditorRouteKey({
+                              openComment: panelRoute.openComment,
+                              targetBlockId: panelRoute.targetBlockId,
+                              blockRange: panelRoute.blockRange,
+                            })
+                          : undefined
+                      }
+                      docId={commentsPanelTarget.docId}
+                      quotingBlockId={panelRoute?.key === 'comments' ? panelRoute.targetBlockId : undefined}
+                      quotingRange={
+                        panelRoute?.key === 'comments' ? extractQuotingRange(panelRoute.blockRange) : undefined
+                      }
+                      commentId={commentsPanelTarget.openComment}
+                      isReplying={
+                        panelRoute?.key === 'comments' ? panelRoute.isReplying ?? !!panelRoute.openComment : false
+                      }
+                      replyCommentVersion={panelRoute?.key === 'comments' ? panelRoute.replyCommentVersion : undefined}
+                      rootReplyCommentVersion={
+                        panelRoute?.key === 'comments' ? panelRoute.rootReplyCommentVersion : undefined
+                      }
+                      // On mobile, opening the keyboard during the sheet entrance
+                      // causes visible viewport jumps. Let the drawer settle and
+                      // let users tap the composer when they are ready to type.
+                      focusOnMount={false}
+                    />
+                  ) : undefined
+                }
+              />
+            )}
           </MobilePanelSheet>
         )}
       </>


### PR DESCRIPTION
## Why now

Issue #668 reports that the always-on “N members collaborating” bar occupies the most valuable above-the-fold space on site landing pages, even when collaboration metadata is not part of the site’s editorial pitch. The bar is rendered only for a space home document, but owners had no persisted control over it.

## What changed

- Add optional home-document metadata `showCollaborators`; omitted remains visible for backward compatibility.
- Add a **Show Collaborators** switch to home-document settings only.
- Honor the flag in both desktop and mobile branches of the shared resource page, so desktop and web render consistently.
- Make document options reachable in the mobile panel, where the menu previously opened discussion content regardless of the `options` route.
- Preserve the setting through typed metadata, Markdown frontmatter, CLI create/update/draft flows, and canonical Markdown export.
- Associate shared switch labels with their controls via the existing `id` prop.

## Why this approach

The bar exists only on the space home page, and Seed already treats that signed home-document metadata as the portable source for site presentation choices such as activity visibility, content width, and header layout. A home-document field therefore behaves as a site-wide setting without adding server-local site configuration that would be lost across gateways. A per-document flag would imply unsupported behavior on pages where the bar is never rendered.

The field is optional and opt-out (`!== false`), preserving every existing site until an owner explicitly changes it.

## Validation

Exact head `2af1121d6c77d671ab6fc4c2abd2cc340c2099a0` on `main` `b378d7e3233ed1a75d23edfc5a786448073ae53d`:

- client Markdown lossless suite: 67/67 passed, including `showCollaborators: false` round-trip;
- client TypeScript check passed;
- CLI TypeScript check passed;
- pinned Prettier check for all ten touched files passed;
- `git diff --check` passed.

- [Exact-head frontend CI](https://github.com/seed-hypermedia/seed/actions/runs/34543570914) passed Typecheck, Lint, web/shared/desktop unit tests, editor E2E, and the aggregate check. Generic integration tests were skipped by workflow design.

The focused local jsdom UI run could not start because an interrupted dependency installation left an incompatible hoisted `lru-cache`; exact-head GitHub CI subsequently executed and passed the committed UI tests.

## Follow-up

If Seed later introduces a distinct signed, portable space-settings resource, migrate this and the existing home presentation fields together rather than creating gateway-local divergence.

Fixes #668.
