### PR TITLE
Prevent empty comment publication

### DIFF
--- a/frontend/packages/client/__tests__/comment.test.ts
+++ b/frontend/packages/client/__tests__/comment.test.ts
@@ -38,6 +38,42 @@ function makeBlocks(text: string): HMBlockNode[] {
 }
 
 describe('createComment', () => {
+  it.each([
+    {name: 'no blocks', content: []},
+    {name: 'a blank paragraph', content: makeBlocks('   ')},
+  ])('rejects $name before signing', async ({content}) => {
+    const signer = makeSigner()
+
+    await expect(
+      createComment(
+        {
+          content,
+          docId: TEST_DOC_ID,
+          docVersion: 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi',
+        },
+        signer,
+      ),
+    ).rejects.toThrow('Cannot create an empty comment')
+    expect(signer.sign).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty quoted reply instead of publishing a quote-only wrapper', async () => {
+    const signer = makeSigner()
+
+    await expect(
+      createComment(
+        {
+          content: [],
+          docId: TEST_DOC_ID,
+          docVersion: 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi',
+          quotingBlockId: 'quoted-block',
+        },
+        signer,
+      ),
+    ).rejects.toThrow('Cannot create an empty comment')
+    expect(signer.sign).not.toHaveBeenCalled()
+  })
+
   it('creates a publish-ready payload from content', async () => {
     const signer = makeSigner()
     const publishInput = await createComment(
@@ -203,6 +239,24 @@ describe('createComment', () => {
 })
 
 describe('updateComment', () => {
+  it('rejects blank updates before signing', async () => {
+    const signer = makeSigner()
+
+    await expect(
+      updateComment(
+        {
+          commentId: 'z6MkrbYsRzKb1VABdvhsDSAk6JK8fAszKsyHhcaZigYeWCou/zb2rhiKhUepk2',
+          targetAccount: TEST_DOC_ID.uid,
+          targetPath: '/test-doc',
+          targetVersion: 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi',
+          content: makeBlocks('   '),
+        },
+        signer,
+      ),
+    ).rejects.toThrow('Cannot update a comment with empty content')
+    expect(signer.sign).not.toHaveBeenCalled()
+  })
+
   it('creates a publish-ready payload that preserves reply metadata', async () => {
     const signer = makeSigner()
     const publishInput = await updateComment(

--- a/frontend/packages/client/src/comment.ts
+++ b/frontend/packages/client/src/comment.ts
@@ -448,21 +448,24 @@ async function resolveCommentContentAndBlobs(input: CreateCommentInput): Promise
       input.prepareAttachments || defaultPrepareAttachments,
     )
     return {
-      content: wrapQuotedContent(trimTrailingEmptyBlocks(rawBlockNodes), input),
+      content: trimTrailingEmptyBlocks(rawBlockNodes),
       blobs,
     }
   }
 
   return {
-    content: wrapQuotedContent(trimTrailingEmptyBlocks(input.content), input),
+    content: trimTrailingEmptyBlocks(input.content),
     blobs: input.blobs || [],
   }
 }
 
 export async function createComment(input: CreateCommentInput, signer: AnySigner): Promise<HMPublishBlobsInput> {
-  const {content, blobs} = await resolveCommentContentAndBlobs(input)
+  const {content: unquotedContent, blobs} = await resolveCommentContentAndBlobs(input)
+  if (unquotedContent.length === 0) {
+    throw new Error('Cannot create an empty comment')
+  }
   const comment = await createCommentBlob({
-    content,
+    content: wrapQuotedContent(unquotedContent, input),
     docId: input.docId,
     docVersion: input.docVersion,
     signer,
@@ -536,9 +539,12 @@ export async function updateComment(input: UpdateCommentInput, signer: AnySigner
     throw new Error(`Invalid comment ID format: ${input.commentId}`)
   }
 
-  const signerKey = await signerPublicKey(signer)
   cleanContentOfUndefined(input.content)
   const trimmedContent = trimTrailingEmptyBlocks(input.content)
+  if (trimmedContent.length === 0) {
+    throw new Error('Cannot update a comment with empty content')
+  }
+  const signerKey = await signerPublicKey(signer)
 
   const comment: Record<string, unknown> = {
     type: 'Comment',


### PR DESCRIPTION
## Why now
Issue #799 reports that the comment UI can publish blank comments. The shared client normalized trailing blank editor paragraphs but then still signed and returned a publishable Comment blob with an empty body. The same gap existed for comment updates, where an empty body is especially ambiguous with the tombstone representation used by deletion.

Closes #799.

## What changed
- Reject new comments when normalization leaves no content, before signing.
- Validate before quote wrapping so an empty quoted reply cannot become a quote-only Embed and bypass the invariant.
- Reject blank comment updates before signing.
- Preserve non-text structured blocks and list containers; the existing trimming classifier only removes empty trailing Paragraph/Heading leaf blocks.

## Why this approach
The invariant lives in `@seed-hypermedia/client`, the shared publication boundary used by desktop, web, mobile, CLI, and pending-intent paths. UI-only button disabling would leave alternate and future callers able to publish the same invalid blob. Validation occurs after editor normalization but before signing, rather than adding a second broad “has content” definition that could reject valid images, embeds, files, lists, or other structured content.

## Validation
- `vitest --run frontend/packages/client/__tests__/comment.test.ts`: 11/11 passed.
- Repository-pinned Prettier 3.1.1: both touched files pass.
- `git diff --check`: passed.

Regression coverage includes zero blocks, whitespace-only paragraphs, quote-only attempts, and blank updates; existing structured-list and quote tests remain green.

## Follow-up / removal condition
No workaround or removal condition. Individual composers may additionally disable submit for UX, but the shared boundary must remain authoritative.