### PR TITLE
Fix mobile document panel routing

### DIFF
--- a/frontend/packages/ui/src/__tests__/resource-page-common.test.ts
+++ b/frontend/packages/ui/src/__tests__/resource-page-common.test.ts
@@ -1,5 +1,6 @@
 import {hmId, type NavRoute} from '@shm/shared'
 import {describe, expect, it, vi} from 'vitest'
+import {createDocumentVersionsPanelRoute} from '../document-versions-panel'
 import {
   getDocumentResourceRouteKey,
   getCommentReplyPanelRoute,
@@ -20,7 +21,23 @@ import {
   getCitationsTargetId,
   orderDocumentMenuItems,
   BACK_TO_TOP_SCROLL_OFFSET,
+  getMobilePanelPresentation,
+  getMobilePanelTitle,
 } from '../resource-page-common'
+
+describe('mobile document panel routing', () => {
+  const docId = hmId('alice', {path: ['doc']})
+
+  it('keeps discussions specialized while routing versions and options to their own panel bodies', () => {
+    expect(getMobilePanelPresentation({key: 'comments', id: docId})).toBe('discussions')
+    expect(getMobilePanelPresentation(createDocumentVersionsPanelRoute(docId))).toBe('panel')
+    expect(getMobilePanelPresentation({key: 'options'})).toBe('panel')
+  })
+
+  it('labels the filtered versions activity route as versions history', () => {
+    expect(getMobilePanelTitle(createDocumentVersionsPanelRoute(docId))).toBe('Versions history')
+  })
+})
 
 describe('back to top visibility', () => {
   it('uses a 200px visibility threshold', () => {

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -897,6 +897,18 @@ function getPanelTitle(panelKey: string | null): string {
   }
 }
 
+/** Selects the mobile sheet body for a document panel route. */
+export function getMobilePanelPresentation(panelRoute: DocumentPanelRoute | null): 'discussions' | 'panel' | null {
+  if (!panelRoute) return null
+  return panelRoute.key === 'comments' ? 'discussions' : 'panel'
+}
+
+/** Gets the route-aware title for a mobile document panel. */
+export function getMobilePanelTitle(panelRoute: DocumentPanelRoute | null): string {
+  if (isDocumentVersionsPanelRoute(panelRoute)) return 'Versions history'
+  return getPanelTitle(panelRoute?.key ?? null)
+}
+
 export function ResourcePage({
   docId,
   resourceId,
@@ -2927,50 +2939,63 @@ function DocumentBody({
         </div>
 
         {mobilePanelOpen && (
-          <MobilePanelSheet isOpen={mobilePanelOpen} title={getPanelTitle(panelKey)} onClose={handlePanelClose}>
-            <DiscussionsPageContent
-              docId={commentsPanelTarget.docId}
-              showTitle={false}
-              showOpenInPanel={false}
-              contentMaxWidth={contentMaxWidth}
-              targetDomain={siteUrl}
-              openComment={commentsPanelTarget.openComment}
-              targetBlockId={panelRoute?.key === 'comments' ? panelRoute.targetBlockId : undefined}
-              blockId={panelRoute?.key === 'comments' ? panelRoute.blockId : undefined}
-              blockRange={panelRoute?.key === 'comments' ? panelRoute.blockRange : undefined}
-              commentEditor={
-                CommentEditor ? (
-                  <CommentEditor
-                    key={
-                      panelRoute?.key === 'comments'
-                        ? getCommentEditorRouteKey({
-                            openComment: panelRoute.openComment,
-                            targetBlockId: panelRoute.targetBlockId,
-                            blockRange: panelRoute.blockRange,
-                          })
-                        : undefined
-                    }
-                    docId={commentsPanelTarget.docId}
-                    quotingBlockId={panelRoute?.key === 'comments' ? panelRoute.targetBlockId : undefined}
-                    quotingRange={
-                      panelRoute?.key === 'comments' ? extractQuotingRange(panelRoute.blockRange) : undefined
-                    }
-                    commentId={commentsPanelTarget.openComment}
-                    isReplying={
-                      panelRoute?.key === 'comments' ? panelRoute.isReplying ?? !!panelRoute.openComment : false
-                    }
-                    replyCommentVersion={panelRoute?.key === 'comments' ? panelRoute.replyCommentVersion : undefined}
-                    rootReplyCommentVersion={
-                      panelRoute?.key === 'comments' ? panelRoute.rootReplyCommentVersion : undefined
-                    }
-                    // On mobile, opening the keyboard during the sheet entrance
-                    // causes visible viewport jumps. Let the drawer settle and
-                    // let users tap the composer when they are ready to type.
-                    focusOnMount={false}
-                  />
-                ) : undefined
-              }
-            />
+          <MobilePanelSheet isOpen={mobilePanelOpen} title={getMobilePanelTitle(panelRoute)} onClose={handlePanelClose}>
+            {getMobilePanelPresentation(panelRoute) === 'discussions' ? (
+              <DiscussionsPageContent
+                docId={commentsPanelTarget.docId}
+                showTitle={false}
+                showOpenInPanel={false}
+                contentMaxWidth={contentMaxWidth}
+                targetDomain={siteUrl}
+                openComment={commentsPanelTarget.openComment}
+                targetBlockId={panelRoute?.key === 'comments' ? panelRoute.targetBlockId : undefined}
+                blockId={panelRoute?.key === 'comments' ? panelRoute.blockId : undefined}
+                blockRange={panelRoute?.key === 'comments' ? panelRoute.blockRange : undefined}
+                commentEditor={
+                  CommentEditor ? (
+                    <CommentEditor
+                      key={
+                        panelRoute?.key === 'comments'
+                          ? getCommentEditorRouteKey({
+                              openComment: panelRoute.openComment,
+                              targetBlockId: panelRoute.targetBlockId,
+                              blockRange: panelRoute.blockRange,
+                            })
+                          : undefined
+                      }
+                      docId={commentsPanelTarget.docId}
+                      quotingBlockId={panelRoute?.key === 'comments' ? panelRoute.targetBlockId : undefined}
+                      quotingRange={
+                        panelRoute?.key === 'comments' ? extractQuotingRange(panelRoute.blockRange) : undefined
+                      }
+                      commentId={commentsPanelTarget.openComment}
+                      isReplying={
+                        panelRoute?.key === 'comments' ? panelRoute.isReplying ?? !!panelRoute.openComment : false
+                      }
+                      replyCommentVersion={panelRoute?.key === 'comments' ? panelRoute.replyCommentVersion : undefined}
+                      rootReplyCommentVersion={
+                        panelRoute?.key === 'comments' ? panelRoute.rootReplyCommentVersion : undefined
+                      }
+                      // On mobile, opening the keyboard during the sheet entrance
+                      // causes visible viewport jumps. Let the drawer settle and
+                      // let users tap the composer when they are ready to type.
+                      focusOnMount={false}
+                    />
+                  ) : undefined
+                }
+              />
+            ) : panelRoute ? (
+              <PanelContentRenderer
+                panelRoute={panelRoute}
+                docId={docId}
+                document={document}
+                contentMaxWidth={contentMaxWidth}
+                CommentEditor={CommentEditor}
+                siteUrl={siteUrl}
+                fileUpload={fileUpload}
+                draftVersionEntry={draftVersionEntry}
+              />
+            ) : null}
           </MobilePanelSheet>
         )}
       </>


### PR DESCRIPTION
## Why now

Issue #809 reports that **Versions** and **Document Settings** both open Discussions on narrow/mobile layouts. The regression came from [`ab84ec405`](https://github.com/seed-hypermedia/seed/commit/ab84ec40582ea3393f5c496575c0ae963e7eb0d4) (2026-02-26): URL routing was expanded so any panel key opens the mobile sheet, while the sheet body remained hard-coded to `DiscussionsPageContent`. Distinct Versions and Options routes therefore reached the right sheet with the wrong content.

Closes #809.

## What changed

- Classify mobile document panels as the specialized Discussions presentation or the shared panel presentation.
- Keep the existing mobile Discussions composer behavior, including delayed keyboard focus.
- Route Versions, Document Options, and other non-comment panel routes through the existing `PanelContentRenderer` already used on desktop.
- Give the filtered Versions activity route its canonical **Versions history** title.

## Why this approach

The routes themselves are already correct and distinct, so changing menu navigation would hide the symptom rather than repair the rendering boundary. Reusing `PanelContentRenderer` avoids a second mobile-only switch and keeps future panel types aligned across responsive layouts. Comments remain specialized because their mobile composer intentionally suppresses focus during the sheet entrance.

## Validation

At exact head `05a906c6eef503c72c6bc7e410484051f727dc88`:

- Before repair, the focused regression failed exactly for Versions (`expected "panel", received "discussions"`), with 48/49 tests passing.
- After repair, `resource-page-common.test.ts` passes 49/49.
- Typecheck, Lint, shared/desktop/web units, editor E2E, and the aggregate frontend check pass in CI.
- Both touched files pass pinned Prettier formatting and `git diff --check`.

## Follow-up / removal condition

No compatibility workaround was added. The comments-specific branch can be removed if `CommentsPanelContent` later gains an explicit mobile focus policy, allowing every mobile route to use the generic renderer without changing keyboard behavior.
