### PR TITLE
Auto-join spaces before signed-in comments

### DIFF
--- a/frontend/apps/desktop/src/components/__tests__/commenting.test.tsx
+++ b/frontend/apps/desktop/src/components/__tests__/commenting.test.tsx
@@ -6,10 +6,15 @@ import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
 import {afterEach, describe, expect, it, vi} from 'vitest'
 import {CommentBox} from '../commenting'
 
-const {writeCommentDraftMock, invalidateQueriesMock} = vi.hoisted(() => ({
-  writeCommentDraftMock: vi.fn(),
-  invalidateQueriesMock: vi.fn(),
-}))
+const {createCommentMock, invalidateQueriesMock, publishMock, subscribeContactMock, writeCommentDraftMock} = vi.hoisted(
+  () => ({
+    createCommentMock: vi.fn(),
+    invalidateQueriesMock: vi.fn(),
+    publishMock: vi.fn(),
+    subscribeContactMock: vi.fn(),
+    writeCommentDraftMock: vi.fn(),
+  }),
+)
 
 vi.mock('@/grpc-client', () => ({
   grpcClient: {},
@@ -66,12 +71,22 @@ vi.mock('@seed-hypermedia/client', async (importOriginal) => {
   return {
     ...actual,
     commentRecordIdFromBlob: vi.fn(),
-    createComment: vi.fn(),
+    createComment: createCommentMock,
   }
 })
 
 vi.mock('@shm/editor/comment-editor', () => ({
-  CommentEditor: ({onContentChange}: {onContentChange?: (blocks: any[]) => void}) => {
+  CommentEditor: ({
+    onContentChange,
+    submitButton,
+  }: {
+    onContentChange?: (blocks: any[]) => void
+    submitButton?: (props: {
+      getContent: () => Promise<{blockNodes: any[]}>
+      reset: () => void
+      disabled: boolean
+    }) => React.ReactNode | undefined
+  }) => {
     useEffect(() => {
       onContentChange?.([
         {
@@ -85,7 +100,11 @@ vi.mock('@shm/editor/comment-editor', () => ({
       ])
     }, [onContentChange])
 
-    return <div data-testid="comment-editor" />
+    return (
+      <div data-testid="comment-editor">
+        {submitButton?.({getContent: async () => ({blockNodes: []}), reset: vi.fn(), disabled: false})}
+      </div>
+    )
   },
 }))
 
@@ -101,6 +120,11 @@ vi.mock('@shm/shared/client/.generated/documents/v3alpha/documents_pb', async ()
     },
   }
 })
+
+vi.mock('../desktop-intents', () => ({
+  useContactSubscribeIntent: () => subscribeContactMock,
+  useDesktopAccountIntent: () => ({content: null, requireAccount: vi.fn()}),
+}))
 
 vi.mock('@shm/shared/models/comments', () => ({
   useDocumentComments: () => ({data: {comments: []}}),
@@ -130,9 +154,13 @@ vi.mock('@shm/shared/optimistic-comment', () => ({
 
 vi.mock('@shm/shared/routing', () => ({
   useUniversalClient: () => ({
-    getSigner: vi.fn(),
-    publish: vi.fn(),
+    getSigner: vi.fn(() => ({})),
+    publish: publishMock,
   }),
+}))
+
+vi.mock('@shm/ui/tooltip', () => ({
+  Tooltip: ({children}: {children: React.ReactNode}) => children,
 }))
 
 vi.mock('@shm/shared/utils/navigation', () => ({
@@ -142,7 +170,7 @@ vi.mock('@shm/shared/utils/navigation', () => ({
 }))
 ;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
 
-function renderCommentBox() {
+function renderCommentBox(docUid = 'alice') {
   const container = document.createElement('div')
   document.body.appendChild(container)
   const root = createRoot(container)
@@ -156,7 +184,7 @@ function renderCommentBox() {
   act(() => {
     root.render(
       <QueryClientProvider client={queryClient}>
-        <CommentBox docId={hmId('alice', {path: ['doc']})} />
+        <CommentBox docId={hmId(docUid, {path: ['doc']})} />
       </QueryClientProvider>,
     )
   })
@@ -203,5 +231,33 @@ describe('CommentBox draft persistence', () => {
       quotingBlockId: undefined,
       context: undefined,
     })
+  })
+})
+
+describe('CommentBox site membership', () => {
+  it('joins a remote site before a logged-in account publishes its first comment', async () => {
+    subscribeContactMock.mockResolvedValue(undefined)
+    createCommentMock.mockReturnValue(new Promise(() => {}))
+
+    const {container, root} = renderCommentBox('site-account')
+    const submit = container.querySelector('button')
+    expect(submit).not.toBeNull()
+
+    await act(async () => {
+      submit?.click()
+    })
+
+    await vi.waitFor(() => {
+      expect(subscribeContactMock).toHaveBeenCalledWith({
+        accountUid: 'alice',
+        subjectUid: 'site-account',
+        subscribe: 'site',
+      })
+    })
+    expect(subscribeContactMock.mock.invocationCallOrder[0]).toBeLessThan(
+      createCommentMock.mock.invocationCallOrder[0]!,
+    )
+
+    cleanupRendered(root, container)
   })
 })

--- a/frontend/apps/desktop/src/components/__tests__/desktop-intents.test.tsx
+++ b/frontend/apps/desktop/src/components/__tests__/desktop-intents.test.tsx
@@ -52,7 +52,7 @@ vi.mock('../desktop-auth-dialog', () => ({
   useDesktopAuthDialog: () => ({content: null, open: vi.fn()}),
 }))
 
-import {useJoinSiteIntent} from '../desktop-intents'
+import {useContactSubscribeIntent, useJoinSiteIntent} from '../desktop-intents'
 
 function renderHook<T>(useHook: () => T) {
   let result: T
@@ -73,6 +73,24 @@ function cleanupRendered(root: Root, container: HTMLDivElement) {
   act(() => root.unmount())
   container.remove()
 }
+
+describe('desktop contact subscription intent', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not republish an existing site subscription', async () => {
+    requestMock.mockResolvedValue([{id: 'contact-1', subject: 'z6MkJoinedSite', name: '', subscribe: {site: true}}])
+    const {container, root, result} = renderHook(useContactSubscribeIntent)
+    try {
+      await result()({accountUid: 'z6MkJoiningAccount', subjectUid: 'z6MkJoinedSite', subscribe: 'site'})
+      expect(createContactMock).not.toHaveBeenCalled()
+      expect(publishMock).not.toHaveBeenCalled()
+    } finally {
+      cleanupRendered(root, container)
+    }
+  })
+})
 
 describe('desktop Join site intent', () => {
   afterEach(() => {

--- a/frontend/apps/desktop/src/components/commenting.tsx
+++ b/frontend/apps/desktop/src/components/commenting.tsx
@@ -402,6 +402,9 @@ function CommentBoxImpl(props: {
         const targetDoc = targetEntity.data?.type === 'document' ? targetEntity.data.document : undefined
         const targetVersion = targetDoc?.version
         const signer = getSigner(account.id.uid)
+        if (account.id.uid !== docId.uid) {
+          await subscribeContact({accountUid: account.id.uid, subjectUid: docId.uid, subscribe: 'site'})
+        }
 
         // Wrap getContent to capture block nodes before they're consumed by createComment
         let capturedBlocks: HMBlockNode[] = []
@@ -458,6 +461,7 @@ function CommentBoxImpl(props: {
       quotingRange?.end,
       quoting,
       writeRecentSigner,
+      subscribeContact,
     ],
   )
 

--- a/frontend/apps/desktop/src/components/desktop-intents.tsx
+++ b/frontend/apps/desktop/src/components/desktop-intents.tsx
@@ -55,6 +55,7 @@ export function useContactSubscribeIntent() {
       if (!universalClient.getSigner) throw new Error('Signing not available')
       const contacts = await universalClient.request('AccountContacts', input.accountUid)
       const existingContact = contacts.find((contact) => contact.subject === input.subjectUid)
+      if (existingContact?.subscribe?.[input.subscribe]) return
       const signer = universalClient.getSigner(input.accountUid)
       const hadLegacyProfile = existingContact && !existingContact.subscribe
       const nextSubscribe = {


### PR DESCRIPTION
## Why now

Issue #794 records the product decision that posting a first comment should automatically join the remote space. The linked June discussion shows a signed-in account successfully commenting without becoming a member, and Eric confirms that this is a bug.

Current main still has an asymmetric desktop path: account creation followed by a stored comment calls `subscribeContact` before publication, while an already signed-in account goes directly to `createComment`. That makes the reported behavior reachable specifically for existing accounts.

Closes #794.

## What changed

- Before a signed-in account publishes to another account's document, create or update its site-subscription contact through the existing desktop contact intent.
- Skip the join for comments on the account's own space.
- Make the contact intent idempotent when the requested site/profile subscription is already present, preventing repeat comments from signing and publishing redundant contact updates.

## Why this approach

The existing `useContactSubscribeIntent` already preserves legacy profile subscriptions, signs the right contact mutation, publishes it, and invalidates membership queries. Reusing it keeps the logged-in path aligned with the existing post-account-creation path instead of duplicating contact construction in comment code. Joining before `createComment` preserves the stated invariant: a failed join cannot silently publish another non-member comment.

The idempotent guard belongs inside the shared intent, where all callers benefit and authoritative contacts are already loaded. A component-local cached membership check could be stale and would still allow other callers to republish identical contacts.

## Validation

At exact head `473714dd7187dc6685438bfdc5522730c5524251`:

- Before repair, the production component regression observed zero site-subscription calls for a logged-in remote-site comment.
- After repair, focused `commenting` and `desktop-intents` suites pass 4/4.
- The regression verifies subscription occurs before comment construction.
- Idempotency coverage verifies an existing site subscription publishes no new contact.
- All touched files pass pinned Prettier and `git diff --check`.
- Exact-head CI passes Typecheck, Lint, web/shared/desktop unit tests, editor E2E, and the aggregate check; integration tests are intentionally skipped.

## Follow-up / removal condition

Web's delegated/pending-comment flow has separate membership handling and is unchanged. If comment participation policy becomes explicit opt-in rather than automatic join, both desktop comment paths should remove this pre-publication subscription together rather than diverge again.
