### PR TITLE
feat(agents): default new-agent prompt embeds the shared skill document

### DIFF
--- a/agents/docs/prompt-injection-map.md
+++ b/agents/docs/prompt-injection-map.md
@@ -150,8 +150,8 @@ Ranked by exposure. Everything here is untrusted content that reaches the model.
   (`hm://z6Mko5npVz4Bx9Rf4vkRUf2swvb568SDbhLwStaha3HzgrLS/resources/skill`, published at
   https://seed.hyper.media/resources/skill) — see `defaultAgentSystemPrompt` in
   `frontend/packages/ui/src/agents/dialogs.tsx`. User-editable, becomes `AgentDefinition.systemPrompt`; the service
-  inlines the embedded document when it resolves the prompt, so whoever can edit that document shapes every new
-  agent's prompt.
+  inlines the embedded document when it resolves the prompt, so whoever can edit that document shapes every new agent's
+  prompt.
 - **Prompt tab** (`pages/agents/detail.tsx`) edits those blocks with the Seed block editor; the server normalizes and
   resolves them to markdown before use.
 - **System prompt dialog** (`pages/agents/session.tsx`) shows `systemPromptMarkdown` — the exact prompt that would be

--- a/agents/docs/prompt-injection-map.md
+++ b/agents/docs/prompt-injection-map.md
@@ -146,8 +146,12 @@ Ranked by exposure. Everything here is untrusted content that reaches the model.
 - **Assistant panel** (`frontend/apps/desktop/src/components/assistant-panel.tsx`) is a client of the agents service; it
   builds no system prompt of its own. It contributes window context as `context` content parts (line 562). The old
   `app-chat.ts` / `chat-provider-options.ts` local-assistant prompt path is gone.
-- **Default new-agent prompt**: `You are a helpful agent.` (`frontend/apps/desktop/src/pages/agents/dialogs.tsx:698`),
-  user-editable, becomes `AgentDefinition.systemPrompt`.
+- **Default new-agent prompt**: a single Embed block of the shared skill document
+  (`hm://z6Mko5npVz4Bx9Rf4vkRUf2swvb568SDbhLwStaha3HzgrLS/resources/skill`, published at
+  https://seed.hyper.media/resources/skill) — see `defaultAgentSystemPrompt` in
+  `frontend/packages/ui/src/agents/dialogs.tsx`. User-editable, becomes `AgentDefinition.systemPrompt`; the service
+  inlines the embedded document when it resolves the prompt, so whoever can edit that document shapes every new
+  agent's prompt.
 - **Prompt tab** (`pages/agents/detail.tsx`) edits those blocks with the Seed block editor; the server normalizes and
   resolves them to markdown before use.
 - **System prompt dialog** (`pages/agents/session.tsx`) shows `systemPromptMarkdown` — the exact prompt that would be

--- a/frontend/packages/editor/src/comment-editor-draft-content.test.ts
+++ b/frontend/packages/editor/src/comment-editor-draft-content.test.ts
@@ -1,0 +1,45 @@
+import type {HMBlockNode} from '@seed-hypermedia/client/hm-types'
+import {describe, expect, it} from 'vitest'
+import {blocksHaveDraftContent} from './comment-editor-draft-content'
+
+function paragraph(text: string): HMBlockNode {
+  return {block: {id: 'p', type: 'Paragraph', text, attributes: {}, annotations: []}}
+}
+
+describe('blocksHaveDraftContent', () => {
+  it('is empty for no blocks or whitespace-only paragraphs', () => {
+    expect(blocksHaveDraftContent(undefined)).toBe(false)
+    expect(blocksHaveDraftContent([])).toBe(false)
+    expect(blocksHaveDraftContent([paragraph('   ')])).toBe(false)
+  })
+
+  it('counts text and children', () => {
+    expect(blocksHaveDraftContent([paragraph('hello')])).toBe(true)
+    expect(blocksHaveDraftContent([{...paragraph(''), children: [paragraph('child')]}])).toBe(true)
+  })
+
+  it('counts an embed-only draft as content', () => {
+    // Regression: the default agent system prompt is a single Embed block with no text, and the
+    // editor collapsed it to the "Start a Discussion" placeholder as if the draft were empty.
+    const embed: HMBlockNode = {
+      block: {
+        id: 'e',
+        type: 'Embed',
+        text: '',
+        link: 'hm://z6Mko5npVz4Bx9Rf4vkRUf2swvb568SDbhLwStaha3HzgrLS/resources/skill',
+        attributes: {childrenType: 'Group', view: 'Content'},
+        annotations: [],
+      },
+    }
+    expect(blocksHaveDraftContent([embed])).toBe(true)
+  })
+
+  it('counts non-text blocks such as queries and images', () => {
+    const query = {block: {id: 'q', type: 'Query', attributes: {}}} as unknown as HMBlockNode
+    const image = {
+      block: {id: 'i', type: 'Image', text: '', link: 'ipfs://abc', attributes: {}},
+    } as unknown as HMBlockNode
+    expect(blocksHaveDraftContent([query])).toBe(true)
+    expect(blocksHaveDraftContent([image])).toBe(true)
+  })
+})

--- a/frontend/packages/editor/src/comment-editor-draft-content.ts
+++ b/frontend/packages/editor/src/comment-editor-draft-content.ts
@@ -1,0 +1,20 @@
+import type {HMBlockNode} from '@seed-hypermedia/client/hm-types'
+
+/** Block types whose content lives in `text` alone, so an empty text means an empty block. */
+const TEXT_ONLY_BLOCK_TYPES = new Set(['Paragraph', 'Heading'])
+
+/**
+ * Whether initial draft blocks carry anything worth showing expanded. Text and children count,
+ * and so do link-bearing or non-text blocks (Embed, Image, File, Query, …) that have no text of
+ * their own — an embed-only draft is content, not an empty editor.
+ */
+export function blocksHaveDraftContent(blocks: HMBlockNode[] | undefined): boolean {
+  if (!blocks || blocks.length === 0) return false
+  return blocks.some((node) => {
+    const block = node.block as {type: string; text?: unknown; link?: unknown}
+    if (typeof block.text === 'string' && block.text.trim().length > 0) return true
+    if (node.children && node.children.length > 0) return true
+    if (typeof block.link === 'string' && block.link.length > 0) return true
+    return !TEXT_ONLY_BLOCK_TYPES.has(block.type)
+  })
+}

--- a/frontend/packages/editor/src/comment-editor.tsx
+++ b/frontend/packages/editor/src/comment-editor.tsx
@@ -1,6 +1,7 @@
 import type {DomainResolverFn} from '@seed-hypermedia/client'
 import type {EditorBlock} from '@seed-hypermedia/client/editor-types'
 import {HMBlockNode, HMMetadata} from '@seed-hypermedia/client/hm-types'
+import {blocksHaveDraftContent} from './comment-editor-draft-content'
 import {hmBlocksToEditorContent} from '@seed-hypermedia/client/hmblock-to-editorblock'
 import {packReferenceUrl, useOpenUrl, useUniversalClient, writeableStateStream} from '@shm/shared'
 import {useAccount} from '@shm/shared/models/entity'
@@ -383,20 +384,7 @@ export function CommentEditor({
     submitOnEnter,
   )
   // Check if we have non-empty draft content
-  const hasDraftContent =
-    initialBlocks &&
-    initialBlocks.length > 0 &&
-    initialBlocks.some((block) => {
-      // Check if block has text content (for paragraph-like blocks)
-      if ('text' in block.block && typeof block.block.text === 'string' && block.block.text.trim().length > 0) {
-        return true
-      }
-      // Check if block has children
-      if (block.children && block.children.length > 0) {
-        return true
-      }
-      return false
-    })
+  const hasDraftContent = blocksHaveDraftContent(initialBlocks)
   const [isExpanded, setIsExpanded] = useState(() => focusOnMount || hasDraftContent || false)
   const openUrl = useOpenUrl()
   const [isDraggingOver, setIsDraggingOver] = useState(false)

--- a/frontend/packages/ui/src/agents/dialogs.tsx
+++ b/frontend/packages/ui/src/agents/dialogs.tsx
@@ -17,7 +17,7 @@ import {
   useUpdateSigningIdentity,
 } from './models'
 import {useNavigate} from './navigation'
-import {keyfile, markdownBlockNodesToHMBlockNodes, parseMarkdown} from '@seed-hypermedia/client'
+import {keyfile} from '@seed-hypermedia/client'
 import type {HMBlockNode} from '@seed-hypermedia/client/hm-types'
 import {hmId} from '@shm/shared'
 import {useAccount} from '@shm/shared/models/entity'
@@ -56,6 +56,29 @@ import {AgentPromptEditor, promptBlocksForRequest} from './prompt-editor'
 import {ProviderIcon} from './provider-icons'
 import {isSubscriptionSignInAvailable, SubscriptionSignIn} from './provider-oauth'
 import {PROVIDER_METADATA, PROVIDER_TYPE_ORDER, providerLabel} from './provider-registry'
+
+/** The shared agent skill document that a new agent's system prompt embeds by default. */
+export const DEFAULT_AGENT_SKILL_URL = 'hm://z6Mko5npVz4Bx9Rf4vkRUf2swvb568SDbhLwStaha3HzgrLS/resources/skill'
+
+/**
+ * A new agent's default system prompt is a single Embed of the shared skill document rather than
+ * inline text, so every new agent picks up the current published guidance when the service
+ * resolves the embed into the model-facing prompt.
+ */
+export function defaultAgentSystemPrompt(): HMBlockNode[] {
+  return [
+    {
+      block: {
+        id: 'default-skill',
+        type: 'Embed',
+        text: '',
+        link: DEFAULT_AGENT_SKILL_URL,
+        attributes: {childrenType: 'Group', view: 'Content'},
+        annotations: [],
+      },
+    },
+  ]
+}
 
 export function ModelProvidersDialog({
   input,
@@ -906,9 +929,7 @@ export function CreateAgentDialog({
   const [reasoningLevel, setReasoningLevel] = useState<ReasoningLevel | undefined>(undefined)
   const [thoroughness, setThoroughness] = useState<Thoroughness>('normal')
   const [enabledModels, setEnabledModels] = useState<AgentModelRef[]>([])
-  const [systemPrompt, setSystemPrompt] = useState<HMBlockNode[]>(() =>
-    markdownBlockNodesToHMBlockNodes(parseMarkdown('You are a helpful agent.').tree),
-  )
+  const [systemPrompt, setSystemPrompt] = useState<HMBlockNode[]>(defaultAgentSystemPrompt)
   const [creating, setCreating] = useState(false)
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- New agents used to start with the inline system prompt `You are a helpful agent.` The default is now a single **Embed block** of the shared skill document, `hm://z6Mko5npVz4Bx9Rf4vkRUf2swvb568SDbhLwStaha3HzgrLS/resources/skill` (published at https://seed.hyper.media/resources/skill). The agents service already inlines Embed blocks when it resolves prompt blocks into the model-facing prompt, so every new agent picks up the current published guidance with no server change.
- Fixes a comment-editor bug this surfaced: the collapsed "Start a Discussion" placeholder was shown whenever the initial blocks had no text and no children, so an embed-only draft rendered as an empty editor until clicked. The draft-content check now lives in `comment-editor-draft-content.ts` and counts link-bearing and non-text blocks (Embed, Image, File, Query, …) as content.
- Updates `agents/docs/prompt-injection-map.md`, which described the old default; it now notes that whoever can edit the skill document shapes every new agent's prompt.

## Test plan

- [x] `blocksHaveDraftContent` unit tests: empty/whitespace, text, children, embed-only, query and image blocks
- [x] Existing `comment-editor-content-change` test still passes
- [x] `tsc --noEmit` on `@shm/ui` and `@shm/editor`; prettier clean
- [ ] Desktop: New Agent dialog opens with the skill embed visible in the prompt editor (not the collapsed placeholder); created agent's Prompt tab shows the embed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NokUPPTTAB3J2rofiEB7Pm
