### PR TITLE
Improve account and document mentions across desktop and web

### DIFF
--- a/frontend/apps/desktop/src/app-recents.ts
+++ b/frontend/apps/desktop/src/app-recents.ts
@@ -1,3 +1,4 @@
+import {loadAccount} from '@shm/shared/api-account'
 import {getDocumentTitle} from '@shm/shared/content'
 import {queryKeys} from '@shm/shared/models/query-keys'
 import {RecentsResult} from '@shm/shared/models/recents'
@@ -51,6 +52,11 @@ export async function updateRecentRoute(route: NavRoute) {
     } catch {
       // Document not found or other error - use default name
     }
+  }
+  if (route.key === 'profile' || route.key === 'site-profile') {
+    const uid = route.key === 'site-profile' ? route.accountUid ?? route.id.uid : route.id.uid
+    const account = await loadAccount(grpcClient, uid)
+    name = account.type === 'account' ? account.metadata?.name || uid : uid
   }
   if (!url) return
   updateRecents((state: RecentsState): RecentsState => {

--- a/frontend/apps/desktop/src/components/__tests__/commenting.test.tsx
+++ b/frontend/apps/desktop/src/components/__tests__/commenting.test.tsx
@@ -126,7 +126,8 @@ vi.mock('../desktop-intents', () => ({
   useDesktopAccountIntent: () => ({content: null, requireAccount: vi.fn()}),
 }))
 
-vi.mock('@shm/shared/models/comments', () => ({
+vi.mock('@shm/shared/models/comments', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@shm/shared/models/comments')>()),
   useDocumentComments: () => ({data: {comments: []}}),
 }))
 

--- a/frontend/apps/desktop/src/components/commenting.tsx
+++ b/frontend/apps/desktop/src/components/commenting.tsx
@@ -16,17 +16,18 @@ import {
   UnpackedHypermediaId,
 } from '@seed-hypermedia/client/hm-types'
 import {CommentEditor, type CommentEditorSubmitHandle} from '@shm/editor/comment-editor'
-import {queryClient, queryKeys} from '@shm/shared'
+import {hmId, queryClient, queryKeys} from '@shm/shared'
 import {BlockNode} from '@shm/shared/client/.generated/documents/v3alpha/documents_pb'
 import type {InlineEditCommentProps} from '@shm/shared/comments-service-provider'
 import {hasBlockContent} from '@shm/shared/content'
-import {useDocumentComments} from '@shm/shared/models/comments'
+import {getMentionThreadContext, useDocumentComments} from '@shm/shared/models/comments'
 import {useContacts} from '@shm/shared/models/contacts'
 import {useResource} from '@shm/shared/models/entity'
 import {invalidateQueries} from '@shm/shared/models/query-client'
 import {applyOptimisticComment, buildOptimisticComment, navigateToComment} from '@shm/shared/optimistic-comment'
 import {useUniversalClient} from '@shm/shared/routing'
 import {useNavRoute} from '@shm/shared/utils/navigation'
+import {entityQueryPathToHmIdPath} from '@shm/shared/utils/path-api'
 import {Button} from '@shm/ui/button'
 import {toast} from '@shm/ui/toast'
 import {Tooltip} from '@shm/ui/tooltip'
@@ -101,6 +102,15 @@ function CommentBoxImpl(props: {
   // Use route-provided version data first, fall back to resolved values from comments service
   const finalReplyVersion = props.replyCommentVersion || resolvedReply?.replyCommentVersion
   const finalRootVersion = props.rootReplyCommentVersion || resolvedReply?.rootReplyCommentVersion
+  const mentionThread = useMemo(
+    () =>
+      getMentionThreadContext(commentsService.data?.comments, {
+        replyCommentId: commentId,
+        replyCommentVersion: finalReplyVersion,
+        rootReplyCommentVersion: finalRootVersion,
+      }),
+    [commentsService.data?.comments, commentId, finalReplyVersion, finalRootVersion],
+  )
 
   const draft = useCommentDraft(
     quotingBlockId ? {...docId, blockRef: quotingBlockId, blockRange: quotingRange ?? null} : docId,
@@ -500,7 +510,10 @@ function CommentBoxImpl(props: {
               }
             : undefined
         }
-        perspectiveAccountUid={selectedAccountId}
+        perspectiveAccountUid={account?.id.uid ?? selectedAccountId}
+        mentionThread={mentionThread}
+        siteUid={docId.uid}
+        documentId={docId}
         submitButton={({getContent, reset, disabled}) => (
           <Tooltip
             content={account ? `Publish Comment as "${account.metadata?.name}"` : 'Create an account to comment'}
@@ -580,7 +593,9 @@ function InlineEditBox({comment, onSave, onCancel, isSaving}: InlineEditCommentP
         universalClient={universalClient}
         domainResolver={domainResolver}
         account={account ? {id: account.id, metadata: account.metadata} : undefined}
-        perspectiveAccountUid={selectedAccountId}
+        perspectiveAccountUid={comment.author}
+        siteUid={comment.targetAccount}
+        documentId={hmId(comment.targetAccount, {path: entityQueryPathToHmIdPath(comment.targetPath)})}
         submitButton={({getContent, reset, disabled}) => (
           <>
             <Button variant="ghost" size="icon" onClick={onCancel} disabled={isSaving}>

--- a/frontend/apps/desktop/src/utils/navigation-container.tsx
+++ b/frontend/apps/desktop/src/utils/navigation-container.tsx
@@ -1,6 +1,6 @@
 import {desktopUniversalClient} from '@/desktop-universal-client'
 import {ipc} from '@/ipc'
-import {useSelectedAccountContacts} from '@shm/shared/models/contacts'
+import {SelectedAccountContactsProvider} from '@shm/shared/models/contacts'
 import {useGatewayUrl} from '@/models/gateway-settings'
 import {client} from '@/trpc'
 import {reportTelemetry, TelemetryStage, telemetryKeyForRoute} from '@/telemetry'
@@ -81,8 +81,6 @@ export function NavigationContainer({children}: {children: ReactNode}) {
 
   const experiments = useExperiments().data
 
-  const contacts = useSelectedAccountContacts()
-
   const pushAfterActionRef = useRef<ReturnType<typeof usePushAfterAction>>()
 
   return (
@@ -139,7 +137,6 @@ export function NavigationContainer({children}: {children: ReactNode}) {
         navigation.dispatch({type: 'selectedIdentity', value: keyId})
       }}
       universalClient={desktopUniversalClient}
-      contacts={contacts.data}
       broadcastEvent={(event: AppEvent) => {
         // @ts-expect-error
         window.ipc?.broadcast(event)
@@ -157,11 +154,13 @@ export function NavigationContainer({children}: {children: ReactNode}) {
         pushAfterActionRef.current?.({id, trigger: 'publish'})
       }}
     >
-      <NavContextProvider value={navigation}>
-        <PushAfterActionSetter pushAfterActionRef={pushAfterActionRef} />
-        {children}
-        <DevTools />
-      </NavContextProvider>
+      <SelectedAccountContactsProvider>
+        <NavContextProvider value={navigation}>
+          <PushAfterActionSetter pushAfterActionRef={pushAfterActionRef} />
+          {children}
+          <DevTools />
+        </NavContextProvider>
+      </SelectedAccountContactsProvider>
     </UniversalAppProvider>
   )
 }

--- a/frontend/apps/notify/app/email-notifier.test.ts
+++ b/frontend/apps/notify/app/email-notifier.test.ts
@@ -5,6 +5,7 @@ import type {HMBlockNode} from '@seed-hypermedia/client/hm-types'
 import type {Event} from '@shm/shared'
 import {
   getEventId,
+  getMentionsOfDocument,
   isNotificationEventTooOld,
   isTransientGrpcUnavailableError,
   matchesCursorEvent,
@@ -271,4 +272,50 @@ describe('resolveContentReferenceNames', () => {
       'hm://doc-owner/projects/roadmap': 'Roadmap',
     })
   })
+})
+
+describe('explicit mention identities in notification content', () => {
+  it('resolves home-document and legacy account names independently even with identical URLs', async () => {
+    const content = [
+      {
+        block: {
+          id: 'p',
+          type: 'Paragraph',
+          attributes: {},
+          text: '\uFFFC\uFFFC',
+          annotations: [
+            {type: 'Embed', link: 'hm://alice', starts: [0], ends: [1], attributes: {mentionKind: 'document'}},
+            {type: 'Embed', link: 'hm://alice', starts: [1], ends: [2]},
+          ],
+        },
+        children: [],
+      },
+    ] as HMBlockNode[]
+    const names = await resolveContentReferenceNames(content, async (_id, kind) =>
+      kind === 'document' ? 'Alice home' : 'Alice profile',
+    )
+    expect(names).toEqual({'document:hm://alice': 'Alice home', 'hm://alice': 'Alice profile'})
+  })
+})
+
+it('does not classify explicit home-document mentions as account mentions in document changes', () => {
+  const document = {
+    content: [
+      {
+        block: {
+          id: 'p',
+          type: 'Paragraph',
+          attributes: {},
+          text: '\uFFFC',
+          annotations: [
+            {type: 'Embed', link: 'hm://alice', starts: [0], ends: [1], attributes: {mentionKind: 'document'}},
+            {type: 'Embed', link: 'hm://bob', starts: [1], ends: [2]},
+            {type: 'Embed', link: 'hm://carol/:profile', starts: [2], ends: [3], attributes: {mentionKind: 'account'}},
+          ],
+        },
+        children: [],
+      },
+    ],
+  }
+  expect(getMentionsOfDocument(document as any)).toEqual({p: new Set(['bob', 'carol'])})
 })

--- a/frontend/apps/notify/app/email-notifier.ts
+++ b/frontend/apps/notify/app/email-notifier.ts
@@ -33,6 +33,7 @@ import {
   classifyCommentNotificationForAccount,
   extractMentionedAccountUidsFromComment,
   getMentionedAccountUid,
+  getCitationMentionKind,
 } from '@shm/shared/models/notification-event-classifier'
 import {CID} from 'multiformats'
 import {
@@ -1262,17 +1263,20 @@ async function getAccountMetadata(accountId: string): Promise<HMMetadata | null>
 /** Resolves inline content references to display names for notification emails. */
 export async function resolveContentReferenceNames(
   content: HMBlockNode[] | null | undefined,
-  resolveReferenceName: (id: UnpackedHypermediaId) => Promise<string | null> = resolveContentReferenceName,
+  resolveReferenceName: (
+    id: UnpackedHypermediaId,
+    mentionKind?: 'account' | 'document',
+  ) => Promise<string | null> = resolveContentReferenceName,
 ): Promise<Record<string, string> | undefined> {
   if (!content?.length) return undefined
 
   const names: Record<string, string> = {}
-  const links = new Map<string, UnpackedHypermediaId>()
+  const links = new Map<string, {id: UnpackedHypermediaId; mentionKind?: 'account' | 'document'}>()
   collectInlineEmbedReferenceLinks(content, links)
 
-  for (const [link, refId] of links) {
+  for (const [link, ref] of links) {
     try {
-      const name = await resolveReferenceName(refId)
+      const name = await resolveReferenceName(ref.id, ref.mentionKind)
       if (name) names[link] = name
     } catch (error: any) {
       reportError(`Error resolving content reference ${link}: ${error.message}`)
@@ -1282,23 +1286,32 @@ export async function resolveContentReferenceNames(
   return Object.keys(names).length ? names : undefined
 }
 
-function collectInlineEmbedReferenceLinks(content: HMBlockNode[], links: Map<string, UnpackedHypermediaId>) {
+function collectInlineEmbedReferenceLinks(
+  content: HMBlockNode[],
+  links: Map<string, {id: UnpackedHypermediaId; mentionKind?: 'account' | 'document'}>,
+) {
   for (const blockNode of content) {
     const annotations = getAnnotations(blockNode.block)
     if (annotations) {
       for (const annotation of annotations) {
-        if (annotation.type !== 'Embed' || !annotation.link || links.has(annotation.link)) continue
+        if (annotation.type !== 'Embed' || !annotation.link) continue
+        const mentionKind = annotation.attributes?.mentionKind
+        const key = mentionKind ? `${mentionKind}:${annotation.link}` : annotation.link
+        if (links.has(key)) continue
         const refId = unpackHmId(annotation.link)
-        if (refId) links.set(annotation.link, refId)
+        if (refId) links.set(key, {id: refId, mentionKind})
       }
     }
     if (blockNode.children?.length) collectInlineEmbedReferenceLinks(blockNode.children, links)
   }
 }
 
-async function resolveContentReferenceName(id: UnpackedHypermediaId): Promise<string | null> {
+async function resolveContentReferenceName(
+  id: UnpackedHypermediaId,
+  mentionKind?: 'account' | 'document',
+): Promise<string | null> {
   const mentionedAccountUid = getMentionedAccountUid(id)
-  if (mentionedAccountUid) {
+  if (mentionedAccountUid && mentionKind !== 'document') {
     const metadata = await getAccountMetadata(mentionedAccountUid)
     return metadata?.name?.trim() || 'Untitled Profile'
   }
@@ -1456,6 +1469,7 @@ async function evaluateMentionEventForNotifications(
 
   let mentionUrl: string
   let mentionComment: HMComment | undefined
+  let sourceContent: HMBlockNode[] = []
   let mentionResolvedNames: Record<string, string> | undefined
   if (isCommentMention) {
     const sourceCommentId = unpackHmId(mentionEvent.source)
@@ -1476,18 +1490,28 @@ async function evaluateMentionEventForNotifications(
         })
         const rawComment = toPlainMessage(serverComment)
         mentionComment = HMCommentSchema.parse(rawComment)
+        sourceContent = mentionComment.content
         mentionResolvedNames = await resolveContentReferenceNames(mentionComment.content)
       }
     } catch (error: any) {
       reportError(`Error loading mention comment ${mentionEvent.sourceBlob?.cid}: ${error.message}`)
     }
   } else {
+    const sourceDocument = await getDocument(
+      hmId(sourceId.uid, {
+        path: sourceId.path,
+        version: mentionEvent.sourceBlob?.cid || sourceId.version || null,
+      }),
+    )
+    sourceContent = sourceDocument?.content || []
     mentionUrl = await buildVerifiedResourceUrl(sourceDocId.uid, {
       siteUrl,
       siteOwnerUid: sourceDocId.uid,
       path: sourceDocId.path,
     })
   }
+
+  if (getCitationMentionKind(sourceContent, targetId, mentionEvent.sourceContext) === 'document') return
 
   for (const sub of allSubscriptions) {
     if (!sub.notifyAllMentions || sub.id !== targetAccountUid) continue
@@ -2026,7 +2050,8 @@ async function loadRefEvent(event: PlainMessage<Event>) {
 
 type MentionMap = Record<string, Set<string>> // block id -> set of account ids
 
-function getMentionsOfDocument(document: HMDocument): MentionMap {
+/** Collects person mentions by block, excluding explicit document mentions. */
+export function getMentionsOfDocument(document: HMDocument): MentionMap {
   const mentionMap: MentionMap = {}
   extractMentionsFromBlockNodes(document.content, mentionMap)
   return mentionMap
@@ -2044,7 +2069,7 @@ function extractMentionsFromBlockNode(blockNode: HMBlockNode, mentionMap: Mentio
   const annotations = getAnnotations(block)
   if (annotations) {
     for (const annotation of annotations) {
-      if (annotation.type !== 'Embed') continue
+      if (annotation.type !== 'Embed' || annotation.attributes?.mentionKind === 'document') continue
       const mentionedAccountUid = getMentionedAccountUid(annotation.link)
       if (!mentionedAccountUid) continue
       mentionMap[block.id] = mentionMap[block.id] ?? new Set()

--- a/frontend/apps/web/app/commenting.tsx
+++ b/frontend/apps/web/app/commenting.tsx
@@ -25,12 +25,13 @@ import {
 } from '@shm/shared'
 import type {InlineEditCommentProps} from '@shm/shared/comments-service-provider'
 import {NOTIFY_SERVICE_HOST} from '@shm/shared/constants'
-import {useDocumentComments} from '@shm/shared/models/comments'
+import {getMentionThreadContext, useDocumentComments} from '@shm/shared/models/comments'
 import {useAccount} from '@shm/shared/models/entity'
 import {invalidateQueries, useQueryClient} from '@shm/shared/models/query-client'
 import {applyOptimisticComment, buildOptimisticComment, navigateToComment} from '@shm/shared/optimistic-comment'
 import {useTxString} from '@shm/shared/translation'
 import {useNavigate, useNavRoute} from '@shm/shared/utils/navigation'
+import {entityQueryPathToHmIdPath} from '@shm/shared/utils/path-api'
 import {Button, buttonVariants} from '@shm/ui/button'
 import {DialogTitle} from '@shm/ui/components/dialog'
 import {EmailNotificationsSuccess} from '@shm/ui/email-notifications'
@@ -107,6 +108,15 @@ export default function WebCommenting({
   const replyCommentVersion = replyCommentVersionProp || resolvedReply?.replyCommentVersion
   const rootReplyCommentVersion = rootReplyCommentVersionProp || resolvedReply?.rootReplyCommentVersion
   const isReplyEditor = isReplying || !!replyCommentId || !!commentId
+  const mentionThread = useMemo(
+    () =>
+      getMentionThreadContext(commentsService.data?.comments, {
+        replyCommentId,
+        replyCommentVersion,
+        rootReplyCommentVersion,
+      }),
+    [commentsService.data?.comments, replyCommentId, replyCommentVersion, rootReplyCommentVersion],
+  )
 
   // Use draft persistence
   const {
@@ -470,7 +480,10 @@ export default function WebCommenting({
           )
         }}
         account={myAccount.data}
-        perspectiveAccountUid={myAccount.data?.id.uid} // TODO: figure out if this is the correct value
+        perspectiveAccountUid={myAccount.data?.id.uid}
+        mentionThread={mentionThread}
+        siteUid={docId.uid}
+        documentId={docId}
       />
       {createAccountContent}
       {emailNotificationsPromptContent}
@@ -755,6 +768,9 @@ export function WebInlineEditBox({comment, onSave, onCancel, isSaving}: InlineEd
         importWebFile={(url) => importWebFile(url)}
         handleFileAttachment={(file) => handleFileAttachment(file)}
         universalClient={client}
+        perspectiveAccountUid={comment.author}
+        siteUid={comment.targetAccount}
+        documentId={hmId(comment.targetAccount, {path: entityQueryPathToHmIdPath(comment.targetPath)})}
         hideAvatar
         submitButton={({getContent, reset, disabled}) => (
           <>

--- a/frontend/apps/web/app/local-db-recents.integration.test.ts
+++ b/frontend/apps/web/app/local-db-recents.integration.test.ts
@@ -12,11 +12,12 @@ global.window = {
 // Mock the origin variable that local-db.ts uses
 ;(global as any).origin = TEST_ORIGIN
 
+import {hmId} from '@shm/shared/utils/entity-id-url'
 import {RecentsResult} from '@shm/shared/models/recents'
 import {indexedDB} from 'fake-indexeddb'
 import 'fake-indexeddb/auto'
 import {afterEach, beforeEach, describe, expect, it} from 'vitest'
-import {addRecent, clearRecents, deleteRecent, getRecents, resetDB} from './local-db-recents'
+import {addRecent, clearRecents, deleteRecent, getRecents, resetDB, recordRecentRoute} from './local-db-recents'
 
 const DB_NAME = 'recents-db-01'
 
@@ -239,5 +240,25 @@ describe('local-db-recents integration', () => {
       // Always close the database connection
       db.close()
     }
+  })
+  it('records profiles separately from home documents', async () => {
+    const db = await resetDB(indexedDB)
+    try {
+      await recordRecentRoute({key: 'profile', id: hmId('alice')}, 'Alice')
+      await recordRecentRoute({key: 'document', id: hmId('alice', {version: 'v1'})}, 'Home')
+      await recordRecentRoute({key: 'document', id: hmId('alice', {version: 'v2'})}, 'Home updated')
+      const recents = await getRecents()
+      expect(recents.map((recent) => recent.id.id).sort()).toEqual(['hm://alice', 'hm://alice/:profile'])
+      expect(recents.find((recent) => recent.id.id === 'hm://alice')?.name).toBe('Home updated')
+    } finally {
+      db.close()
+    }
+  })
+
+  it('tolerates unavailable local storage for reading and recording', async () => {
+    const db = await resetDB(indexedDB)
+    db.close()
+    await expect(getRecents()).resolves.toEqual([])
+    await expect(recordRecentRoute({key: 'profile', id: hmId('alice')}, 'Alice')).resolves.toBeNull()
   })
 })

--- a/frontend/apps/web/app/local-db-recents.ts
+++ b/frontend/apps/web/app/local-db-recents.ts
@@ -1,4 +1,5 @@
 import {unpackHmId} from '@shm/shared'
+import {getRecentsRouteEntityUrl, type NavRoute} from '@shm/shared/routes'
 import {RecentsResult} from '@shm/shared/models/recents'
 
 const DB_NAME = 'recents-db-01'
@@ -190,6 +191,26 @@ export async function addRecent(id: string, name: string): Promise<RecentsResult
  * @returns Array of recent items
  */
 export async function getRecents(): Promise<RecentsResult[]> {
+  try {
+    return await readRecents()
+  } catch {
+    // Local history is optional, including in storage-restricted browsers.
+    return []
+  }
+}
+
+/** Records a canonical route visit without letting unavailable storage interrupt navigation. */
+export async function recordRecentRoute(route: NavRoute, name: string): Promise<RecentsResult | null> {
+  const id = getRecentsRouteEntityUrl(route)
+  if (!id) return null
+  try {
+    return await addRecent(id, name)
+  } catch {
+    return null
+  }
+}
+
+async function readRecents(): Promise<RecentsResult[]> {
   const db = await getDB()
   const tx = db.transaction(RECENTS_STORE_NAME, 'readonly')
   const store = tx.objectStore(RECENTS_STORE_NAME)

--- a/frontend/apps/web/app/providers.tsx
+++ b/frontend/apps/web/app/providers.tsx
@@ -1,3 +1,4 @@
+import {SelectedAccountContactsProvider} from '@shm/shared/models/contacts'
 import {useLocation, useNavigate, useNavigation} from '@remix-run/react'
 import {UnpackedHypermediaId} from '@seed-hypermedia/client'
 import {NavRoute, OptimizedImageSize, routeToHref, UniversalAppProvider} from '@shm/shared'
@@ -5,8 +6,20 @@ import {DAEMON_FILE_URL, SEED_ASSET_HOST, SITE_BASE_URL} from '@shm/shared/const
 import {languagePacks} from '@shm/shared/language-packs'
 import {registerQueryClient} from '@shm/shared/models/query-client'
 import {ReadOnlyViewerComponent, ReadOnlyViewerProvider} from '@shm/shared/readonly-viewer-context'
-import {defaultRoute} from '@shm/shared/routes'
-import {isHttpUrl, NavAction, NavContextProvider, NavState, navStateReducer} from '@shm/shared/utils/navigation'
+import {getDocumentTitle} from '@shm/shared/content'
+import {queryAccount, queryResource} from '@shm/shared/models/queries'
+import {queryKeys} from '@shm/shared/models/query-keys'
+import {unpackHmId} from '@shm/shared/utils/entity-id-url'
+import {recordRecentRoute} from './local-db-recents'
+import {defaultRoute, getRecentsRouteEntityUrl} from '@shm/shared/routes'
+import {
+  isHttpUrl,
+  useNavRoute,
+  NavAction,
+  NavContextProvider,
+  NavState,
+  navStateReducer,
+} from '@shm/shared/utils/navigation'
 import {AssistantPanelProvider} from './assistant-panel-state'
 import {SiteContextPublisher} from './site-context-bridge'
 import {WebDocumentMaintenance} from './document-maintenance'
@@ -23,6 +36,46 @@ import {createContext, useContext, useEffect, useMemo, useState} from 'react'
 import {keyPairStore} from './auth'
 import {webUniversalClient} from './universal-client'
 import {isPerfEnabled, markNavEnd, markNavStart} from './web-perf-marks'
+
+function WebRecentVisitRecorder() {
+  const route = useNavRoute()
+  const url = getRecentsRouteEntityUrl(route)
+  const queryClient = useQueryClient()
+  useEffect(() => {
+    if (!url) return
+    const id = unpackHmId(url)
+    if (!id) return
+    let cancelled = false
+    const visitedRoute: NavRoute = id.path?.[0] === ':profile' ? {key: 'profile', id} : {key: 'document', id}
+    async function record() {
+      let name = id!.uid
+      try {
+        if (visitedRoute.key === 'profile') {
+          const account = await queryClient.fetchQuery(queryAccount(webUniversalClient, id!.uid))
+          if (account) name = account.metadata?.name || name
+        } else {
+          const resource = await queryClient.fetchQuery(queryResource(webUniversalClient, id!))
+          if (resource?.type === 'document') name = getDocumentTitle(resource.document) || name
+        }
+      } catch {
+        // Keep the visit even when its display metadata cannot be loaded.
+      }
+      if (cancelled) return
+      const recent = await recordRecentRoute(visitedRoute, name)
+      if (recent) {
+        await Promise.all([
+          queryClient.invalidateQueries([queryKeys.RECENTS]),
+          queryClient.invalidateQueries([queryKeys.SEARCH, 'inlineMentions']),
+        ])
+      }
+    }
+    void record()
+    return () => {
+      cancelled = true
+    }
+  }, [url, queryClient])
+  return null
+}
 
 function getSelectedIdentity(): string | null {
   const kp = keyPairStore.get()
@@ -381,10 +434,13 @@ export function WebSiteProvider(props: {
         })
       }}
     >
-      <NavContextProvider value={navigation}>
-        <SiteContextPublisher />
-        {props.children}
-      </NavContextProvider>
+      <SelectedAccountContactsProvider>
+        <NavContextProvider value={navigation}>
+          <SiteContextPublisher />
+          <WebRecentVisitRecorder />
+          {props.children}
+        </NavContextProvider>
+      </SelectedAccountContactsProvider>
     </UniversalAppProvider>
   )
 }

--- a/frontend/packages/client/__tests__/resolved-markdown.test.ts
+++ b/frontend/packages/client/__tests__/resolved-markdown.test.ts
@@ -218,3 +218,35 @@ describe('resolved markdown', () => {
     expect(markdown).toContain('hi [@Alice Example](hm://alice/:profile)')
   })
 })
+
+it('resolves an explicit home document independently from a legacy account at the same URL', async () => {
+  const c = client({
+    'Account:hm://alice': {type: 'account', metadata: {name: 'Alice'}},
+    'Resource:hm://alice': {type: 'document', document: doc('Home Page', [])},
+  })
+  const markdown = await documentToResolvedMarkdown(
+    doc('Root', [
+      paragraph('p', '￼', [{type: 'Embed', link: 'hm://alice', starts: [0], ends: [1]}]),
+      paragraph('q', '￼', [
+        {type: 'Embed', link: 'hm://alice', starts: [0], ends: [1], attributes: {mentionKind: 'document'}},
+      ]),
+    ]),
+    {client: c},
+  )
+  expect(markdown).toContain('[@Alice](hm://alice)')
+  expect(markdown).toContain('[Home Page](hm://alice)')
+})
+
+it('does not duplicate the @ prefix in resolved account mention names', async () => {
+  const c = client({'Account:hm://alice': {type: 'account', metadata: {name: '@Alice'}}})
+  const markdown = await documentToResolvedMarkdown(
+    doc('Root', [
+      paragraph('p1', '\uFFFC', [
+        {type: 'Embed', starts: [0], ends: [1], link: 'hm://alice/:profile', attributes: {mentionKind: 'account'}},
+      ]),
+    ]),
+    {client: c},
+  )
+  expect(markdown).toContain('[@Alice](hm://alice/:profile)')
+  expect(markdown).not.toContain('@@Alice')
+})

--- a/frontend/packages/client/src/blocks-to-markdown.ts
+++ b/frontend/packages/client/src/blocks-to-markdown.ts
@@ -1099,8 +1099,8 @@ async function resolveInlineEmbed(ann: HMAnnotation, type: 'open' | 'close', ctx
   if (!link) return '[↗ embed'
 
   try {
-    const resolved = await resolveReference(link, ctx)
-    const prefix = resolved.type === 'account' ? '@' : ''
+    const resolved = await resolveReference(link, ctx, ann.type === 'Embed' ? ann.attributes?.mentionKind : undefined)
+    const prefix = resolved.type === 'account' && !resolved.label.startsWith('@') ? '@' : ''
     return `[${prefix}${resolved.label}`
   } catch {
     return `[↗ ${fallbackLabel(link)}`
@@ -1147,20 +1147,25 @@ async function resolveEmbeddedResource(link: string, ctx: ResolveContext): Promi
   return resolved
 }
 
-async function resolveReference(link: string, ctx: ResolveContext): Promise<ResolvedReference> {
-  const cached = ctx.cache.get(link)
+async function resolveReference(
+  link: string,
+  ctx: ResolveContext,
+  mentionKind?: 'account' | 'document',
+): Promise<ResolvedReference> {
+  const cacheKey = `${mentionKind || 'legacy'}:${link}`
+  const cached = ctx.cache.get(cacheKey)
   if (cached) return cached
   const id = unpackHmId(link)
   if (!id) throw new Error('Invalid HM link')
 
   let resolved: ResolvedReference
   const profileAccountUid = id.path?.[0] === ':profile' ? id.path[1] || id.uid : !id.path?.length ? id.uid : null
-  if (profileAccountUid) {
+  if (profileAccountUid && mentionKind !== 'document') {
     try {
       const account = await ctx.client.request('Account', profileAccountUid)
       if (account.type === 'account') {
         resolved = {label: account.metadata?.name || fallbackUid(profileAccountUid), type: 'account'}
-        ctx.cache.set(link, resolved)
+        ctx.cache.set(cacheKey, resolved)
         return resolved
       }
     } catch {
@@ -1196,7 +1201,7 @@ async function resolveReference(link: string, ctx: ResolveContext): Promise<Reso
   } else {
     resolved = {label: fallbackLabel(link), type: 'unknown'}
   }
-  ctx.cache.set(link, resolved)
+  ctx.cache.set(cacheKey, resolved)
   return resolved
 }
 

--- a/frontend/packages/client/src/editor-types.ts
+++ b/frontend/packages/client/src/editor-types.ts
@@ -211,6 +211,8 @@ export interface EditorLink {
 }
 
 export interface EditorInlineEmbed {
+  /** Explicit identity for new mentions; absent on legacy references. */
+  mentionKind?: 'account' | 'document'
   type: 'inline-embed'
   link: string
   styles: EditorInlineStyles | {}

--- a/frontend/packages/client/src/editorblock-to-hmblock.ts
+++ b/frontend/packages/client/src/editorblock-to-hmblock.ts
@@ -141,6 +141,7 @@ export function editorBlockToHMBlock(editorBlock: EditorBlock): HMBlock {
       textFamily?: string
     }
     href?: string
+    mentionKind?: 'account' | 'document'
     link?: string
   }
 
@@ -176,7 +177,12 @@ export function editorBlockToHMBlock(editorBlock: EditorBlock): HMBlock {
     }
 
     if (leaf.type == 'inline-embed') {
-      annotations.addSpan('Embed', {link: leaf.link!}, start, end)
+      annotations.addSpan(
+        'Embed',
+        {link: leaf.link!, ...(leaf.mentionKind ? {mentionKind: leaf.mentionKind} : {})},
+        start,
+        end,
+      )
     }
 
     if (leaf.type == 'link') {

--- a/frontend/packages/client/src/hm-types.ts
+++ b/frontend/packages/client/src/hm-types.ts
@@ -120,6 +120,7 @@ export const InlineEmbedAnnotationSchema = z
   .object({
     type: z.literal('Embed'),
     ...baseAnnotationProperties,
+    attributes: z.object({mentionKind: z.enum(['account', 'document']).optional()}).optional(),
     link: z.string(),
   })
   .strict()
@@ -1543,6 +1544,43 @@ export const HMSearchRequestSchema = z.object({
 })
 export type HMSearchRequest = z.infer<typeof HMSearchRequestSchema>
 
+/** A published entity eligible for the account or document mention picker. */
+export const HMMentionCandidateSchema = z.object({
+  id: unpackedHmIdSchema,
+  type: z.enum(['account', 'document']),
+  title: z.string(),
+  icon: z.string(),
+  parentNames: z.array(z.string()),
+  searchQuery: z.string(),
+  /** Requested account identity before the daemon resolves an account alias. */
+  sourceAccountUid: z.string().optional(),
+  publicName: z.string().optional(),
+  petname: z.string().optional(),
+  activityTime: z.number().optional(),
+  activityType: z.enum(['publication', 'comment']).optional(),
+  accountRole: z.enum(['site-owner', 'site-editor', 'document-editor', 'site-follower']).optional(),
+  sameSite: z.boolean(),
+  issuedContact: z.boolean(),
+  hint: z.string().optional(),
+})
+/** Shared mention candidate shape; visit timestamps remain local to the client. */
+export type HMMentionCandidate = z.infer<typeof HMMentionCandidateSchema>
+/** Bounded request for one mention mode with optional acting-account/site context. */
+export const HMMentionCandidatesRequestSchema = z.object({
+  key: z.literal('MentionCandidates'),
+  input: z.object({
+    mode: z.enum(['account', 'document']),
+    query: z.string().trim(),
+    perspectiveAccountUid: z.string().optional(),
+    siteUid: z.string().optional(),
+    documentId: unpackedHmIdSchema.optional(),
+    seedIds: z.array(unpackedHmIdSchema).max(20).optional(),
+  }),
+  output: z.array(HMMentionCandidateSchema).max(100),
+})
+/** Universal-client request for mention candidates. */
+export type HMMentionCandidatesRequest = z.infer<typeof HMMentionCandidatesRequestSchema>
+
 export const HMQueryRequestSchema = z.object({
   key: z.literal('Query'),
   input: HMQuerySchema,
@@ -2065,6 +2103,7 @@ export const HMGetRequestSchema = z.discriminatedUnion('key', [
   HMAccountRequestSchema,
   HMCommentRequestSchema,
   HMSearchRequestSchema,
+  HMMentionCandidatesRequestSchema,
   HMQueryRequestSchema,
   HMQueryBlockRequestSchema,
   HMAccountContactsRequestSchema,
@@ -2103,6 +2142,7 @@ export const HMRequestSchema = z.discriminatedUnion('key', [
   HMAccountRequestSchema,
   HMCommentRequestSchema,
   HMSearchRequestSchema,
+  HMMentionCandidatesRequestSchema,
   HMQueryRequestSchema,
   HMQueryBlockRequestSchema,
   HMAccountContactsRequestSchema,

--- a/frontend/packages/client/src/hmblock-to-editorblock.ts
+++ b/frontend/packages/client/src/hmblock-to-editorblock.ts
@@ -273,6 +273,7 @@ export function hmBlockToEditorBlock(block: HMBlock): EditorBlock {
         type: 'inline-embed',
         styles: {},
         link: inlineEmbed.link,
+        ...(inlineEmbed.mentionKind ? {mentionKind: inlineEmbed.mentionKind} : {}),
       } as EditorInlineEmbed)
       skipToCodepoint(inlineEmbed.end)
       textStart = i
@@ -566,13 +567,16 @@ export function hmBlockToEditorBlock(block: HMBlock): EditorBlock {
     return annotationsChanged
   }
 
-  function findInlineEmbedStartingAt(pos: number): {link: string; end: number} | null {
+  function findInlineEmbedStartingAt(
+    pos: number,
+  ): {link: string; end: number; mentionKind?: 'account' | 'document'} | null {
     const blockAnnotations = (block as any).annotations as unknown[] | undefined
     if (!blockAnnotations) return null
 
     for (const annotation of blockAnnotations) {
       const annotationData = annotation as unknown as {
         type?: string
+        attributes?: {mentionKind?: 'account' | 'document'}
         link?: string
         starts?: number[]
         ends?: number[]
@@ -585,7 +589,7 @@ export function hmBlockToEditorBlock(block: HMBlock): EditorBlock {
       const end = annotationData.ends?.[spanIndex]
       if (typeof end !== 'number' || end <= pos) continue
 
-      return {link: annotationData.link || '', end}
+      return {link: annotationData.link || '', end, mentionKind: annotationData.attributes?.mentionKind}
     }
 
     return null

--- a/frontend/packages/client/src/mention-contract.test.ts
+++ b/frontend/packages/client/src/mention-contract.test.ts
@@ -1,0 +1,44 @@
+import {describe, expect, it} from 'vitest'
+import {editorBlockToHMBlock} from './editorblock-to-hmblock'
+import {hmBlocksToEditorContent} from './hmblock-to-editorblock'
+import {InlineEmbedAnnotationSchema} from './hm-types'
+import type {EditorBlock} from './editor-types'
+
+describe('mention reference contract', () => {
+  it('preserves explicit kinds and does not merge them with legacy references', () => {
+    const content = [undefined, 'account', 'document'].map((mentionKind) => ({
+      type: 'inline-embed',
+      link: 'hm://alice',
+      styles: {},
+      ...(mentionKind ? {mentionKind} : {}),
+    }))
+    const block = editorBlockToHMBlock({id: 'p', type: 'paragraph', props: {}, children: [], content} as EditorBlock)
+    expect((block as any).annotations.map((a: any) => a.attributes)).toEqual([
+      {},
+      {mentionKind: 'account'},
+      {mentionKind: 'document'},
+    ])
+    expect(hmBlocksToEditorContent([{block, children: []}])[0]?.content).toEqual(content)
+  })
+  it('accepts mention metadata without changing legacy annotations', () => {
+    const legacy = {type: 'Embed', link: 'hm://alice', starts: [0], ends: [1]}
+    expect(InlineEmbedAnnotationSchema.parse(legacy)).toEqual(legacy)
+    expect(InlineEmbedAnnotationSchema.parse({...legacy, attributes: {mentionKind: 'document'}}).attributes).toEqual({
+      mentionKind: 'document',
+    })
+  })
+})
+
+it('does not collide with a legacy URL ending in a mention-kind suffix', () => {
+  const block = editorBlockToHMBlock({
+    id: 'p',
+    type: 'paragraph',
+    props: {},
+    children: [],
+    content: [
+      {type: 'inline-embed', link: 'hm://alice/foo-document', styles: {}},
+      {type: 'inline-embed', link: 'hm://alice/foo', mentionKind: 'document', styles: {}},
+    ],
+  })
+  expect((block as any).annotations).toHaveLength(2)
+})

--- a/frontend/packages/client/src/unicode.ts
+++ b/frontend/packages/client/src/unicode.ts
@@ -57,7 +57,7 @@ export class AnnotationSet {
   _annotationId(type: string, attributes: {[key: string]: string} | null) {
     if (attributes) {
       if (attributes.link) {
-        return `${type}-${attributes.link}`
+        return JSON.stringify([type, attributes.link, attributes.mentionKind || null])
       }
 
       if (attributes.href) {

--- a/frontend/packages/editor/e2e/test-app/TestEditor.tsx
+++ b/frontend/packages/editor/e2e/test-app/TestEditor.tsx
@@ -1,12 +1,15 @@
+import {SelectedAccountContactsProvider} from '@shm/shared/models/contacts'
+import {useStream} from '@shm/shared/use-stream'
 import '@/blocknote/core/style.css'
 import '@/editor.css'
 import '@shm/ui/hm-prose.css'
 import {HMFormattingToolbar} from '@shm/editor/hm-formatting-toolbar'
 import {HypermediaLinkPreview} from '@shm/editor/hm-link-preview'
-import {SearchResultItem, UniversalAppProvider, writeableStateStream} from '@shm/shared'
+import {hmId, SearchResultItem, UniversalAppProvider, writeableStateStream} from '@shm/shared'
 import {NavContextProvider} from '@shm/shared/utils/navigation'
 import {DocumentMachineProvider, useDocumentMachineRef} from '@shm/shared/models/use-document-machine'
 import {DocumentEditor} from '../../src/document-editor'
+import {CommentEditor} from '../../src/comment-editor'
 import {DraftActionsContext, type DraftActions} from '../../src/draft-actions-context'
 import {TooltipProvider} from '@shm/ui/tooltip'
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
@@ -138,9 +141,50 @@ function mockQueryDocInfo(name: string) {
   }
 }
 
+const [selectMentionAccount, mentionAccount] = writeableStateStream<string | null>(
+  new URLSearchParams(window.location.search).get('petnames') === '1' ? 'viewer-a' : null,
+)
+;(window as any).TEST_SELECT_MENTION_ACCOUNT = selectMentionAccount
+
 // Mock universal context client for document search tests
 const mockUniversalClient = {
   request: async (method: string, params: any) => {
+    if (method === 'AccountContacts') {
+      const name = params === 'viewer-a' ? 'Burdi' : params === 'viewer-b' ? 'Buddy' : ''
+      return name
+        ? [{id: params + '/contact', account: params, subject: 'bafy-mention-account', name, signer: params}]
+        : []
+    }
+    if (method === 'MentionCandidates') {
+      const account = params.mode === 'account'
+      const petname =
+        account &&
+        (params.perspectiveAccountUid === 'viewer-a'
+          ? 'Burdi'
+          : params.perspectiveAccountUid === 'viewer-b'
+            ? 'Buddy'
+            : undefined)
+      return [
+        {
+          id: hmId('bafy-mention-account', account ? {} : {version: 'v-current'}),
+          type: params.mode,
+          title: petname || (account ? 'Alice' : 'Home document'),
+          petname: petname || undefined,
+          publicName: account ? 'Alice Public' : undefined,
+          icon: '',
+          parentNames: [],
+          searchQuery: params.query,
+          sameSite: true,
+          issuedContact: account,
+          activityTime: Date.now() - 120_000,
+          activityType: 'publication',
+          accountRole: account ? 'site-editor' : undefined,
+        },
+      ].filter((candidate) => candidate.title.toLowerCase().includes(params.query.toLowerCase()))
+    }
+    if (method === 'Account') {
+      return {id: hmId(params), metadata: {name: 'Alice'}}
+    }
     if (method === 'Search') {
       return {entities: [mockHmDoc]}
     }
@@ -561,6 +605,7 @@ function RealModeApp({fixtureName}: {fixtureName: FixtureName}) {
 }
 
 export function TestEditor() {
+  const selectedMentionAccount = useStream(mentionAccount)
   const fixtureName = getFixtureFromUrl()
   const sp = new URLSearchParams(window.location.search)
   const real = sp.get('real') === '1'
@@ -570,6 +615,7 @@ export function TestEditor() {
         <QueryClientProvider client={mockQueryClient}>
           <NavContextProvider value={navContext}>
             <UniversalAppProvider
+              selectedIdentity={mentionAccount}
               universalClient={mockUniversalClient as any}
               openUrl={(url?: string, newWindow?: boolean) => {
                 const w = window as any
@@ -582,7 +628,37 @@ export function TestEditor() {
                 w.TEST_OPEN_ROUTE.push(args)
               }}
             >
-              <RealModeApp fixtureName={fixtureName} />
+              <SelectedAccountContactsProvider>
+                {sp.get('comment') === '1' ? (
+                  <div data-testid="comment-harness">
+                    <CommentEditor
+                      hideAvatar
+                      focusOnMount
+                      submitOnEnter
+                      universalClient={mockUniversalClient as any}
+                      documentId={editModeId}
+                      siteUid={editModeId.uid}
+                      perspectiveAccountUid={selectedMentionAccount || 'bafy-writer'}
+                      mentionThread={
+                        sp.get('thread') === '1'
+                          ? {
+                              replyAuthorUid: 'bafy-mention-account',
+                              participants: [{uid: 'bafy-mention-account', latestCommentTime: Date.now() - 120_000}],
+                            }
+                          : undefined
+                      }
+                      handleSubmit={() => {
+                        document
+                          .querySelector('[data-testid="comment-harness"]')
+                          ?.setAttribute('data-submitted', 'true')
+                      }}
+                      submitButton={() => <button type="button">Submit comment</button>}
+                    />
+                  </div>
+                ) : (
+                  <RealModeApp fixtureName={fixtureName} />
+                )}
+              </SelectedAccountContactsProvider>
             </UniversalAppProvider>
           </NavContextProvider>
         </QueryClientProvider>

--- a/frontend/packages/editor/e2e/test-app/TestEditor.tsx
+++ b/frontend/packages/editor/e2e/test-app/TestEditor.tsx
@@ -701,7 +701,6 @@ function RawModeApp({fixtureName}: {fixtureName: FixtureName}) {
         }),
       ],
     },
-    // @ts-expect-error
     initialContent: fixtures[fixtureName],
   })
 

--- a/frontend/packages/editor/e2e/tests/mentions.e2e.ts
+++ b/frontend/packages/editor/e2e/tests/mentions.e2e.ts
@@ -1,0 +1,147 @@
+import {expect, test, type Page} from '@playwright/test'
+
+async function openEditor(page: Page) {
+  await page.goto('/?real=1&fixture=empty')
+  await page.waitForFunction(() => !!window.TEST_EDITOR && !!window.TEST_MACHINE)
+  await page.evaluate(() => window.TEST_MACHINE.send({type: 'edit.start'}))
+  const paragraph = page.locator('[data-id="p-empty"] [data-content-type="paragraph"]')
+  await paragraph.click()
+  await expect(page.locator('.ProseMirror').first()).toHaveAttribute('contenteditable', 'true')
+}
+
+test('account and home-document mentions have distinct stored destinations', async ({page}) => {
+  await openEditor(page)
+  await page.keyboard.type('@Alice')
+  await expect(page.getByRole('option', {name: /Alice/}).first()).toBeVisible()
+  await expect(page.getByRole('option', {name: /Alice/}).first()).toBeEnabled()
+  await expect(page.getByRole('option', {name: /Alice/}).first()).toContainText('Published 2m ago · Site editor')
+  await page.keyboard.press('Enter')
+  const account = page.locator('[data-inline-embed]').first()
+  await expect(account).toContainText('@Alice')
+  await expect(account).toHaveAttribute('data-inline-embed', /\/:profile$/)
+  await page.keyboard.type('[[Home')
+  await expect(page.getByRole('option', {name: /Home/}).first()).toBeVisible()
+  await expect(page.getByRole('option', {name: /Home/}).first()).toBeEnabled()
+  await page.keyboard.press('Enter')
+  const document = page.locator('[data-inline-embed]').nth(1)
+  await expect(document).not.toContainText('@')
+  await expect(document).toHaveAttribute('data-inline-embed', /\?v=v-current&l$/)
+  const mentions = await page.evaluate(() => {
+    const result: {link: string; mentionKind: string}[] = []
+    window.TEST_EDITOR.editor!._tiptapEditor.state.doc.descendants((node: any) => {
+      if (node.type.name === 'inline-embed') result.push(node.attrs)
+    })
+    return result
+  })
+  expect(mentions.map((mention) => mention.mentionKind)).toEqual(['account', 'document'])
+  expect(mentions[1]!.link).not.toContain(':profile')
+  const savedKinds = await page.evaluate(() =>
+    window.TEST_EDITOR.getBlocks().flatMap((block: any) =>
+      (block.content || []).filter((item: any) => item.type === 'inline-embed').map((item: any) => item.mentionKind),
+    ),
+  )
+  expect(savedKinds).toEqual(['account', 'document'])
+})
+
+test('cancelling an autocomplete preserves the typed query', async ({page}) => {
+  await openEditor(page)
+  await page.keyboard.type('[[Home')
+  await expect(page.getByRole('option', {name: /Home/}).first()).toBeVisible()
+  await page.keyboard.press('Escape')
+  await expect(page.getByRole('listbox')).toHaveCount(0)
+  await expect(page.locator('[data-id="p-empty"]')).toContainText('[[Home')
+  await expect(page.locator('[data-inline-embed]')).toHaveCount(0)
+})
+
+test('comment mentions select without submitting the comment', async ({page}) => {
+  await page.goto('/?real=1&comment=1&thread=1')
+  const composer = page.locator('[data-testid="comment-harness"] .ProseMirror')
+  await composer.click()
+  await page.keyboard.type('@Alice')
+  await expect(page.getByRole('option', {name: /Alice/}).first()).toBeEnabled()
+  await expect(page.getByRole('option', {name: /Alice/}).first()).toContainText('Replied 2m ago · Replying to')
+  await page.keyboard.press('Enter')
+  await expect(page.locator('[data-inline-embed]').first()).toHaveAttribute('data-inline-embed', /\/:profile$/)
+  await page.keyboard.type('[[Home')
+  await expect(page.getByRole('option', {name: /Home/}).first()).toBeEnabled()
+  await page.keyboard.press('Enter')
+  await expect(page.locator('[data-inline-embed]').nth(1)).toHaveAttribute('data-inline-embed', /\?v=v-current&l$/)
+  await expect(page.getByTestId('comment-harness')).not.toHaveAttribute('data-submitted', 'true')
+})
+
+test.describe('mobile mention picker', () => {
+  test.use({viewport: {width: 390, height: 844}, isMobile: true, hasTouch: true})
+
+  test('opens a dedicated account picker and inserts at the saved caret', async ({page}) => {
+    await openEditor(page)
+    await page.keyboard.insertText('@')
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await expect(dialog).toHaveCSS('animation-name', 'mention-mobile-in')
+    await dialog.getByRole('textbox').fill('Alice')
+    await expect(dialog.getByRole('option', {name: /Alice/}).first()).toContainText('Published 2m ago · Site editor')
+    await dialog.getByRole('option', {name: /Alice/}).first().click()
+    await expect(dialog).toHaveCount(0)
+    await expect(page.locator('[data-inline-embed]').first()).toHaveAttribute('data-inline-embed', /\/:profile$/)
+    await page.keyboard.insertText('after')
+    await expect(page.locator('[data-id="p-empty"]')).toContainText('after')
+    await page.emulateMedia({reducedMotion: 'reduce'})
+    await page.keyboard.insertText(' @')
+    await expect(dialog).toBeVisible()
+    await expect(dialog).toHaveCSS('animation-name', 'none')
+    await dialog.getByRole('button', {name: 'Cancel mention'}).click()
+    await expect(page.locator('.ProseMirror').first()).toBeFocused()
+  })
+
+  test('comment toolbar opens a document-only picker', async ({page}) => {
+    await page.goto('/?real=1&comment=1')
+    await page.locator('[data-testid="comment-harness"] .ProseMirror').click()
+    await page.getByRole('button', {name: 'Link document', exact: true}).last().click()
+    const dialog = page.getByRole('dialog')
+    await expect(dialog.getByRole('heading', {name: 'Link document'})).toBeVisible()
+    await dialog.getByRole('textbox').fill('Home')
+    await dialog.getByRole('option', {name: /Home/}).first().click()
+    await expect(dialog).toHaveCount(0)
+    await expect(page.locator('[data-inline-embed]').first()).toHaveAttribute('data-inline-embed', /\?v=v-current&l$/)
+  })
+})
+
+test('popover motion respects reduced motion and does not restart on search updates', async ({page}) => {
+  await openEditor(page)
+  await page.keyboard.type('@')
+  const box = page.locator('.tippy-box[data-animation="mention-popover"]')
+  await expect(box).toBeVisible()
+  await expect(box).toHaveCSS('transition-duration', '0.18s')
+  await page.keyboard.type('Alice')
+  await expect(page.getByRole('option', {name: /Alice/}).first()).toBeEnabled()
+  await expect(box).toHaveAttribute('data-state', 'visible')
+  await page.keyboard.press('Escape')
+  await expect(box).toHaveCount(0)
+  await expect(page.locator('.ProseMirror').first()).toBeFocused()
+
+  await page.emulateMedia({reducedMotion: 'reduce'})
+  await page.keyboard.press('Space')
+  await page.keyboard.type('@')
+  await expect(box).toBeVisible()
+  await expect(box).toHaveCSS('transition-duration', '0s')
+  await page.keyboard.press('Escape')
+  await expect(box).toHaveCount(0)
+})
+
+test('inserted comment mentions follow the selected viewer petnames without changing their target', async ({page}) => {
+  await page.goto('/?real=1&comment=1&petnames=1')
+  await page.locator('[data-testid="comment-harness"] .ProseMirror').click()
+  await page.keyboard.type('@burdi')
+  await expect(page.getByRole('option', {name: /Burdi/}).first()).toBeEnabled()
+  await page.keyboard.press('Enter')
+  const mention = page.locator('[data-inline-embed]').first()
+  await expect(mention).toContainText('@Burdi')
+  const destination = await mention.getAttribute('data-inline-embed')
+  await page.evaluate(() => (window as any).TEST_SELECT_MENTION_ACCOUNT('viewer-b'))
+  await expect(mention).toContainText('@Buddy')
+  await page.evaluate(() => (window as any).TEST_SELECT_MENTION_ACCOUNT(null))
+  await expect(mention).toContainText('@Alice')
+  await page.evaluate(() => (window as any).TEST_SELECT_MENTION_ACCOUNT('viewer-a'))
+  await expect(mention).toContainText('@Burdi')
+  await expect(mention).toHaveAttribute('data-inline-embed', destination!)
+})

--- a/frontend/packages/editor/package.json
+++ b/frontend/packages/editor/package.json
@@ -52,6 +52,7 @@
     "@unified-latex/unified-latex-types": "^1.8.0",
     "@unified-latex/unified-latex-util-parse": "^1.8.0",
     "@unified-latex/unified-latex-util-visit": "^1.8.0",
+    "@xstate/react": "4.1.3",
     "happy-dom": "20.8.9",
     "hast-util-from-dom": "4.2.0",
     "highlight.js": "11.9.0",
@@ -74,6 +75,7 @@
     "remark-rehype": "10.1.0",
     "remark-stringify": "10.0.2",
     "unist-util-visit": "^5.0.0",
+    "xstate": "5.19.2",
     "y-prosemirror": "1.2.1",
     "y-protocols": "1.0.5",
     "yjs": "13.6.4"

--- a/frontend/packages/editor/src/blocknote/core/BlockNoteEditor.ts
+++ b/frontend/packages/editor/src/blocknote/core/BlockNoteEditor.ts
@@ -213,13 +213,6 @@ export class BlockNoteEditor<BSchema extends BlockSchema = HMBlockSchema> {
   public readonly schema: BSchema
   public ready = false
 
-  // @ts-expect-error
-  public inlineEmbedOptions: InlineMentionsResult = {
-    Profiles: [],
-    Documents: [],
-    Recents: [],
-  }
-
   public readonly dragStateManager: DragStateManager | null
   public readonly editorDragId: string | null
   public readonly sideMenu: SideMenuProsemirrorPlugin<BSchema> | null

--- a/frontend/packages/editor/src/blocknote/core/api/formatConversions/formatConversions.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/formatConversions/formatConversions.ts
@@ -21,7 +21,6 @@ export async function blocksToHTML<BSchema extends BlockSchema>(
   const serializer = DOMSerializer.fromSchema(schema)
 
   for (const block of blocks) {
-    // @ts-expect-error
     const node = blockToNode(block, schema)
     const htmlNode = serializer.serializeNode(node)
     htmlParentElement.appendChild(htmlNode)

--- a/frontend/packages/editor/src/blocknote/core/api/nodeConversions/nodeConversions.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/nodeConversions/nodeConversions.ts
@@ -113,6 +113,8 @@ export function inlineContentToNodes(blockContent: PartialInlineContent[], schem
         schema.nodes['inline-embed'].create({
           // @ts-expect-error
           link: content.link,
+          // @ts-expect-error inline embeds extend BlockNote inline content.
+          mentionKind: content.mentionKind,
         }),
       )
     } else {
@@ -250,6 +252,7 @@ function contentNodeToInlineContent(contentNode: Node) {
       content.push({
         type: node.type.name,
         link: node.attrs.link,
+        ...(node.attrs.mentionKind ? {mentionKind: node.attrs.mentionKind} : {}),
       })
 
       currentContent = undefined

--- a/frontend/packages/editor/src/blocknote/core/api/nodeConversions/nodeConversions.ts
+++ b/frontend/packages/editor/src/blocknote/core/api/nodeConversions/nodeConversions.ts
@@ -106,17 +106,8 @@ export function inlineContentToNodes(blockContent: PartialInlineContent[], schem
       nodes.push(...linkToNodes(content, schema))
     } else if (content.type === 'text') {
       nodes.push(...styledTextArrayToNodes([content], schema))
-      // @ts-expect-error
-    } else if (content.type == 'inline-embed') {
-      nodes.push(
-        // @ts-ignore
-        schema.nodes['inline-embed'].create({
-          // @ts-expect-error
-          link: content.link,
-          // @ts-expect-error inline embeds extend BlockNote inline content.
-          mentionKind: content.mentionKind,
-        }),
-      )
+    } else if (content.type === 'inline-embed') {
+      nodes.push(schema.node('inline-embed', {link: content.link, mentionKind: content.mentionKind}))
     } else {
       throw new UnreachableCaseError(content)
     }

--- a/frontend/packages/editor/src/blocknote/core/extensions/Blocks/api/inlineContentTypes.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/Blocks/api/inlineContentTypes.ts
@@ -48,4 +48,4 @@ export type PartialLink = Omit<BNLink, 'content'> & {
 }
 
 export type InlineContent = StyledText | BNLink | InlineEmbed
-export type PartialInlineContent = StyledText | PartialLink
+export type PartialInlineContent = StyledText | PartialLink | InlineEmbed

--- a/frontend/packages/editor/src/blocknote/core/extensions/Blocks/api/inlineContentTypes.ts
+++ b/frontend/packages/editor/src/blocknote/core/extensions/Blocks/api/inlineContentTypes.ts
@@ -36,9 +36,11 @@ export type BNLink = {
   content: StyledText[]
 }
 
+/** An inline entity reference; legacy references omit the explicit kind. */
 export type InlineEmbed = {
   type: 'inline-embed'
   link: string
+  mentionKind?: 'account' | 'document'
 }
 
 export type PartialLink = Omit<BNLink, 'content'> & {

--- a/frontend/packages/editor/src/comment-editor.tsx
+++ b/frontend/packages/editor/src/comment-editor.tsx
@@ -1,9 +1,10 @@
+import type {MentionThreadContext} from '@shm/shared/models/mention-ranking'
 import type {DomainResolverFn} from '@seed-hypermedia/client'
 import type {EditorBlock} from '@seed-hypermedia/client/editor-types'
-import {HMBlockNode, HMMetadata} from '@seed-hypermedia/client/hm-types'
+import {HMBlockNode, HMMetadata, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {blocksHaveDraftContent} from './comment-editor-draft-content'
 import {hmBlocksToEditorContent} from '@seed-hypermedia/client/hmblock-to-editorblock'
-import {packReferenceUrl, useOpenUrl, useUniversalClient, writeableStateStream} from '@shm/shared'
+import {useOpenUrl, useUniversalClient, writeableStateStream} from '@shm/shared'
 import {useAccount} from '@shm/shared/models/entity'
 import {useTx} from '@shm/shared/translation'
 import type {UniversalClient} from '@shm/shared/universal-client'
@@ -21,7 +22,6 @@ import {insertOrUpdateBlock} from './blocknote/core/extensions/SlashMenu/default
 import {FILE_DROP_INSERTED_EVENT} from './blocknote/core/extensions/DragMedia/DragExtension'
 import {HyperMediaEditorView} from './editor-view'
 import {createHypermediaDocLinkPlugin} from './hypermedia-link-plugin'
-import {MobileMentionsDialog} from './mobile-mentions-dialog'
 import {MobileSlashDialog} from './mobile-slash-dialog'
 import {mentionSuggestionPluginKey} from './mention-suggestion-plugin'
 import {slashMenuPluginKey} from './blocknote/core/extensions/SlashMenu/SlashMenuPlugin'
@@ -176,19 +176,6 @@ export function useCommentEditor(
                   handleKeyDown(view, event) {
                     if (!isMobileDevice()) return false
 
-                    if (event.key === '@' && onMobileMentionTriggerRef.current) {
-                      const {selection} = view.state
-                      const $from = selection.$from
-                      const textBeforeCursor = $from.parent.textContent.substring(0, $from.parentOffset)
-                      const isAtStart = textBeforeCursor.length === 0
-                      const isAfterSpace = textBeforeCursor.endsWith(' ')
-
-                      if (isAtStart || isAfterSpace) {
-                        onMobileMentionTriggerRef.current()
-                        return true
-                      }
-                    }
-
                     if (event.key === '/' && onMobileSlashTriggerRef.current) {
                       const {selection} = view.state
                       const $from = selection.$from
@@ -282,6 +269,9 @@ export function CommentEditor({
   focusOnMount,
   isReplying,
   perspectiveAccountUid,
+  siteUid,
+  documentId,
+  mentionThread,
   initialBlocks,
   onContentChange,
   onAvatarPress,
@@ -326,6 +316,10 @@ export function CommentEditor({
   focusOnMount?: boolean
   isReplying?: boolean
   perspectiveAccountUid?: string | null | undefined
+  siteUid?: string
+  documentId?: UnpackedHypermediaId
+  /** Loaded participants in the conversation being replied to. */
+  mentionThread?: MentionThreadContext
   initialBlocks?: HMBlockNode[]
   onContentChange?: (blocks: HMBlockNode[], mediaRefs?: Record<string, string>) => void
   onAvatarPress?: () => void
@@ -366,7 +360,6 @@ export function CommentEditor({
   const [submitTrigger, setSubmitTrigger] = useState(0)
   const submitCallbackRef = useRef<(() => void) | null>(null)
   const isMobile = useMobile()
-  const [isMentionsDialogOpen, setIsMentionsDialogOpen] = useState(false)
   const [isSlashDialogOpen, setIsSlashDialogOpen] = useState(false)
   const toolbarRef = useRef<HTMLDivElement>(null)
   const contextUniversalClient = useUniversalClient()
@@ -374,7 +367,7 @@ export function CommentEditor({
   const {editor} = useCommentEditor(
     perspectiveAccountUid,
     () => setSubmitTrigger((prev) => prev + 1),
-    isMobile ? () => setIsMentionsDialogOpen(true) : undefined,
+    undefined,
     isMobile ? () => setIsSlashDialogOpen(true) : undefined,
     importWebFile,
     handleFileAttachment,
@@ -1059,7 +1052,14 @@ export function CommentEditor({
             }}
           >
             {isExpanded ? (
-              <HyperMediaEditorView editor={editor} openUrl={openUrl} perspectiveAccountUid={perspectiveAccountUid} />
+              <HyperMediaEditorView
+                editor={editor}
+                openUrl={openUrl}
+                perspectiveAccountUid={perspectiveAccountUid}
+                mentionThread={mentionThread}
+                siteUid={siteUid}
+                documentId={documentId}
+              />
             ) : (
               <Button
                 onClick={() => {
@@ -1080,8 +1080,23 @@ export function CommentEditor({
             <div ref={toolbarRef} className={cn('mx-2 mb-2 flex gap-2', isMobile ? 'justify-between' : 'justify-end')}>
               {isExpanded && isMobile && (
                 <div className="flex items-center gap-2">
-                  <Button size="icon" variant="ghost" className="size-8" onClick={() => setIsMentionsDialogOpen(true)}>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="size-8"
+                    aria-label="Mention account"
+                    onClick={() => editor.mentionMenu?.open('account')}
+                  >
                     <AtSignIcon className="size-4" />
+                  </Button>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="size-8"
+                    aria-label="Link document"
+                    onClick={() => editor.mentionMenu?.open('document')}
+                  >
+                    [[
                   </Button>
 
                   <Button size="icon" variant="ghost" className="size-8" onClick={handleImageClick}>
@@ -1109,18 +1124,6 @@ export function CommentEditor({
       {/* Mobile dialogs */}
       {isMobile && (
         <>
-          <MobileMentionsDialog
-            isOpen={isMentionsDialogOpen}
-            onClose={() => setIsMentionsDialogOpen(false)}
-            onSelect={(mention) => {
-              const {state, schema} = editor._tiptapEditor
-              const node = schema.nodes['inline-embed'].create({link: packReferenceUrl(mention.id)}, schema.text(' '))
-              editor._tiptapEditor.view.dispatch(state.tr.replaceSelectionWith(node).scrollIntoView())
-              setIsMentionsDialogOpen(false)
-              setTimeout(() => editor._tiptapEditor.commands.focus(), 100)
-            }}
-            perspectiveAccountUid={perspectiveAccountUid}
-          />
           <MobileSlashDialog isOpen={isSlashDialogOpen} onClose={() => setIsSlashDialogOpen(false)} editor={editor} />
         </>
       )}

--- a/frontend/packages/editor/src/document-editor.tsx
+++ b/frontend/packages/editor/src/document-editor.tsx
@@ -166,6 +166,9 @@ export function DocumentEditor({
   const getImageUrl = useImageUrl()
   const onCreateInlineDraft = useDraftActions()?.onCreateInlineDraft
   const actorRef = useDocumentMachineRef()
+  const actingAccountUid = useDocumentSelector(
+    (snapshot) => snapshot.context.signingAccountId ?? snapshot.context.publishAccountUid,
+  )
   const canEdit = useDocumentSelector(selectCanEdit)
   const isEditing = useDocumentSelector(selectIsEditing)
   const renderHref = useCallback(
@@ -714,7 +717,12 @@ export function DocumentEditor({
               <SideMenuPositioner editor={editor} />
               <SlashMenuPositioner editor={editor} />
               <LinkMenuPositioner editor={editor} />
-              <MentionMenuPositioner editor={editor} perspectiveAccountUid={perspectiveAccountUid} />
+              <MentionMenuPositioner
+                editor={editor}
+                perspectiveAccountUid={actingAccountUid ?? perspectiveAccountUid}
+                siteUid={resourceId.uid}
+                documentId={resourceId}
+              />
               <HyperlinkToolbarPositioner
                 // @ts-expect-error
                 hyperlinkToolbar={HypermediaLinkPreview}

--- a/frontend/packages/editor/src/editor-view.tsx
+++ b/frontend/packages/editor/src/editor-view.tsx
@@ -1,3 +1,5 @@
+import type {MentionThreadContext} from '@shm/shared/models/mention-ranking'
+import type {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import '@/blocknote/core/style.css'
 import '@/editor.css'
 import {
@@ -16,9 +18,15 @@ export function HyperMediaEditorView({
   editor,
   openUrl,
   perspectiveAccountUid,
+  siteUid,
+  documentId,
+  mentionThread,
 }: {
   editor: HyperMediaEditor
   openUrl: (url: string, newWindow?: boolean) => void
+  siteUid?: string
+  documentId?: UnpackedHypermediaId
+  mentionThread?: MentionThreadContext
   perspectiveAccountUid?: string | null
 }) {
   const editable = editor.isEditable
@@ -38,7 +46,13 @@ export function HyperMediaEditorView({
         // @ts-expect-error
         openUrl={openUrl}
       />
-      <MentionMenuPositioner editor={editor} perspectiveAccountUid={perspectiveAccountUid} />
+      <MentionMenuPositioner
+        editor={editor}
+        perspectiveAccountUid={perspectiveAccountUid}
+        siteUid={siteUid}
+        documentId={documentId}
+        mentionThread={mentionThread}
+      />
     </BlockNoteView>
   )
 }

--- a/frontend/packages/editor/src/editor.css
+++ b/frontend/packages/editor/src/editor.css
@@ -610,3 +610,69 @@ html[data-debug-blocks='1'] .blockChildren[data-list-type='Grid'] {
 .dark [data-content-type='code-block'] {
   background-color: rgba(0, 0, 0, 0.5) !important;
 }
+
+:root {
+  --mention-motion-enter: 180ms;
+  --mention-motion-exit: 100ms;
+  --mention-motion-pop: cubic-bezier(0.2, 0.8, 0.2, 1.12);
+  --mention-motion-settle: cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.tippy-box[data-animation='mention-popover'] {
+  transform-origin: top left;
+  transition-property: opacity, transform, visibility;
+  transition-timing-function: var(--mention-motion-pop);
+}
+.tippy-box[data-animation='mention-popover'][data-placement^='top'] {
+  transform-origin: bottom left;
+}
+.tippy-box[data-animation='mention-popover'][data-state='hidden'] {
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(-0.25rem) scale(0.97);
+  transition-timing-function: var(--mention-motion-settle);
+}
+.tippy-box[data-animation='mention-popover'][data-placement^='top'][data-state='hidden'] {
+  transform: translateY(0.25rem) scale(0.97);
+}
+.tippy-box[data-animation='mention-popover'][data-state='visible'] {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.mention-mobile-dialog[data-state='open'] {
+  animation: mention-mobile-in var(--mention-motion-enter) var(--mention-motion-settle) both;
+}
+.mention-mobile-dialog[data-state='closed'] {
+  pointer-events: none;
+  animation: mention-mobile-out var(--mention-motion-exit) var(--mention-motion-settle) both;
+}
+@keyframes mention-mobile-in {
+  from {
+    opacity: 0;
+    transform: translateY(0.75rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@keyframes mention-mobile-out {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(0.5rem);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .tippy-box[data-animation='mention-popover'] {
+    transition-duration: 0s !important;
+    transform: none !important;
+  }
+  .mention-mobile-dialog[data-state] {
+    animation: none;
+  }
+}

--- a/frontend/packages/editor/src/hm-formatting-toolbar.tsx
+++ b/frontend/packages/editor/src/hm-formatting-toolbar.tsx
@@ -416,6 +416,28 @@ export function HMFormattingToolbar<Schema extends Record<string, BlockSpec<stri
             ))}
 
             {/* Link button - different for mobile/desktop */}
+            {isMobile && props.editor.isEditable && (
+              <>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  aria-label="Mention account"
+                  onClick={() => props.editor.mentionMenu?.open('account')}
+                >
+                  @
+                </Button>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  aria-label="Link document"
+                  onClick={() => props.editor.mentionMenu?.open('document')}
+                >
+                  [[
+                </Button>
+              </>
+            )}
             {isMobile ? (
               <MobileLinkToolbarButton editor={props.editor} />
             ) : (

--- a/frontend/packages/editor/src/mention-menu-machine.test.ts
+++ b/frontend/packages/editor/src/mention-menu-machine.test.ts
@@ -1,0 +1,151 @@
+import type {InlineMentionsResult} from '@shm/shared/models/inline-mentions'
+import {hmId} from '@shm/shared/utils/entity-id-url'
+import {createActor, fromCallback} from 'xstate'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {mentionMenuMachine, MentionSearchFn} from './mention-menu-machine'
+import {MentionMode} from './mention-suggestion-plugin'
+
+let sendPluginUpdate: (update: {active: boolean; query?: string; mode?: MentionMode}) => void
+const machine = mentionMenuMachine.provide({
+  actors: {
+    pluginListener: fromCallback(({sendBack}) => {
+      sendPluginUpdate = ({active, query = '', mode = 'account'}) =>
+        sendBack({type: 'plugin.updated', active, query, mode, decorationId: 'dec-1'})
+    }),
+    scrollListener: fromCallback(() => {}),
+  },
+})
+function item(uid: string, type: MentionMode = 'account'): InlineMentionsResult[number] {
+  return {
+    id: hmId(uid, {
+      path: type === 'document' ? ['doc'] : undefined,
+      version: type === 'document' ? 'v1' : undefined,
+      latest: type === 'document',
+    }),
+    title: uid,
+    icon: '',
+    parentNames: [],
+    searchQuery: '',
+    type,
+    sameSite: false,
+    issuedContact: false,
+  }
+}
+function setup(search: MentionSearchFn) {
+  const editor = {
+    domElement: document.createElement('div'),
+    mentionMenu: {onKeyboard: null, insertMention: vi.fn(), close: vi.fn()},
+  }
+  const actor = createActor(machine, {input: {editor: editor as any, search}}).start()
+  return {actor, editor}
+}
+const flush = () => vi.advanceTimersByTimeAsync(0)
+describe('mentionMenuMachine', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+  it('loads initial suggestions immediately in account mode', async () => {
+    const search = vi.fn(async () => [item('a')])
+    const {actor} = setup(search)
+    expect(actor.getSnapshot().matches('closed')).toBe(true)
+    sendPluginUpdate({active: true})
+    await flush()
+    expect(search).toHaveBeenCalledWith('', undefined, {mode: 'account', siteUid: undefined, documentId: undefined})
+    expect(actor.getSnapshot().context.suggestions).toHaveLength(1)
+    actor.stop()
+  })
+  it('debounces query updates and refuses stale selection during refresh', async () => {
+    const search = vi.fn(async () => [item('a')])
+    const {actor, editor} = setup(search)
+    sendPluginUpdate({active: true})
+    await flush()
+    sendPluginUpdate({active: true, query: 'a'})
+    actor.send({type: 'menu.key', key: 'Enter'})
+    expect(editor.mentionMenu.insertMention).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(100)
+    sendPluginUpdate({active: true, query: 'ab'})
+    await vi.advanceTimersByTimeAsync(149)
+    expect(search).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(search).toHaveBeenCalledTimes(2)
+    actor.stop()
+  })
+  it('uses explicit profile and latest-document links with mentionKind', async () => {
+    const {actor, editor} = setup(async (_q, _uid, options) => [item('a', options!.mode)])
+    sendPluginUpdate({active: true})
+    await flush()
+    actor.send({type: 'menu.key', key: 'Enter'})
+    expect(editor.mentionMenu.insertMention).toHaveBeenCalledWith('hm://a/:profile', 'account')
+    sendPluginUpdate({active: true, mode: 'document'})
+    await vi.advanceTimersByTimeAsync(150)
+    actor.send({type: 'menu.key', key: 'Enter'})
+    expect(editor.mentionMenu.insertMention).toHaveBeenLastCalledWith(expect.stringContaining('v=v1'), 'document')
+    actor.stop()
+  })
+  it('keeps long empty searches open and supports retry after failure', async () => {
+    const search = vi.fn<MentionSearchFn>().mockRejectedValueOnce(new Error('offline')).mockResolvedValueOnce([])
+    const {actor} = setup(search)
+    sendPluginUpdate({active: true, query: 'nothinghere'})
+    await flush()
+    expect(actor.getSnapshot().context.error).toBe(true)
+    actor.send({type: 'menu.retry'})
+    expect(actor.getSnapshot().matches({open: 'searching'})).toBe(true)
+    expect(actor.getSnapshot().context.error).toBe(false)
+    await flush()
+    expect(actor.getSnapshot().matches({open: 'loaded'})).toBe(true)
+    expect(actor.getSnapshot().context.error).toBe(false)
+    actor.stop()
+  })
+  it('wraps flat navigation and preserves the highlighted identity after refresh', async () => {
+    const {actor} = setup(async (q) => (q ? [item('b'), item('a')] : [item('a'), item('b')]))
+    sendPluginUpdate({active: true})
+    await flush()
+    actor.send({type: 'menu.key', key: 'ArrowUp'})
+    expect(actor.getSnapshot().context.selected).toBe(1)
+    sendPluginUpdate({active: true, query: 'b'})
+    await vi.advanceTimersByTimeAsync(150)
+    expect(actor.getSnapshot().context.selected).toBe(0)
+    actor.stop()
+  })
+  it('ignores a late response after the mode changes', async () => {
+    let resolve!: (value: InlineMentionsResult) => void
+    const {actor} = setup((_q, _uid, options) =>
+      options!.mode === 'account'
+        ? new Promise((r) => {
+            resolve = r
+          })
+        : Promise.resolve([item('doc', 'document')]),
+    )
+    sendPluginUpdate({active: true})
+    sendPluginUpdate({active: true, mode: 'document'})
+    await vi.advanceTimersByTimeAsync(150)
+    resolve([item('old')])
+    await flush()
+    expect(actor.getSnapshot().context.suggestions[0]?.type).toBe('document')
+    actor.stop()
+  })
+  it('does not insert stale results after a failed refresh', async () => {
+    const search = vi
+      .fn<MentionSearchFn>()
+      .mockResolvedValueOnce([item('a')])
+      .mockRejectedValueOnce(new Error('offline'))
+    const {actor, editor} = setup(search)
+    sendPluginUpdate({active: true})
+    await flush()
+    sendPluginUpdate({active: true, query: 'different'})
+    await vi.advanceTimersByTimeAsync(150)
+    actor.send({type: 'menu.key', key: 'Enter'})
+    actor.send({type: 'menu.select', item: item('a')})
+    expect(editor.mentionMenu.insertMention).not.toHaveBeenCalled()
+    actor.stop()
+  })
+  it('passes identity and site context and refreshes on changes', async () => {
+    const search = vi.fn(async () => [])
+    const {actor} = setup(search)
+    sendPluginUpdate({active: true})
+    await flush()
+    actor.send({type: 'options.updated', search, perspectiveAccountUid: 'writer', siteUid: 'site'})
+    await vi.advanceTimersByTimeAsync(150)
+    expect(search).toHaveBeenLastCalledWith('', 'writer', {mode: 'account', siteUid: 'site', documentId: undefined})
+    actor.stop()
+  })
+})

--- a/frontend/packages/editor/src/mention-menu-machine.ts
+++ b/frontend/packages/editor/src/mention-menu-machine.ts
@@ -1,0 +1,329 @@
+import {emptyInlineMentions, InlineMentionsResult} from '@shm/shared/models/inline-mentions'
+import type {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import type {MentionMode} from './mention-suggestion-plugin'
+import {hmId, packHmId} from '@shm/shared/utils/entity-id-url'
+import {assign, fromCallback, fromPromise, setup} from 'xstate'
+import type {BlockNoteEditor} from './blocknote/core/BlockNoteEditor'
+import type {MentionMenuKey} from './mention-menu-plugin'
+import {mentionSuggestionPluginKey} from './mention-suggestion-plugin'
+
+/** Fetches a single ranked list for one mention mode. */
+export type MentionSearchFn = (
+  query: string,
+  perspectiveAccountUid?: string | null,
+  options?: {mode: MentionMode; siteUid?: string; documentId?: UnpackedHypermediaId},
+) => Promise<InlineMentionsResult>
+
+function readDecorationRect(editor: BlockNoteEditor<any>, decorationId: string | undefined): DOMRect | undefined {
+  if (!decorationId) return undefined
+  return editor.domElement.querySelector(`[data-decoration-id="${decorationId}"]`)?.getBoundingClientRect()
+}
+
+function insertMentionItem(editor: BlockNoteEditor<any>, item: InlineMentionsResult[number]) {
+  if (item.type === 'document' && !item.id.version) return
+  const id =
+    item.type === 'account'
+      ? hmId(item.id.uid, {path: [':profile']})
+      : hmId(item.id.uid, {path: item.id.path, version: item.id.version, latest: true})
+  editor.mentionMenu?.insertMention(packHmId(id), item.type)
+}
+
+type MentionMenuEvent =
+  | {type: 'plugin.updated'; active: boolean; query: string; decorationId: string | undefined; mode?: MentionMode}
+  | {type: 'menu.scrolled'}
+  | {type: 'menu.query'; query: string}
+  | {type: 'menu.retry'}
+  | {type: 'menu.key'; key: MentionMenuKey}
+  | {type: 'menu.select'; item: InlineMentionsResult[number]}
+  | {
+      type: 'options.updated'
+      search: MentionSearchFn
+      perspectiveAccountUid?: string | null
+      siteUid?: string
+      documentId?: UnpackedHypermediaId
+    }
+
+type MentionMenuContext = {
+  editor: BlockNoteEditor<any>
+  search: MentionSearchFn
+  perspectiveAccountUid: string | null | undefined
+  query: string
+  decorationId: string | undefined
+  referencePos: DOMRect | undefined
+  suggestions: InlineMentionsResult
+  selected: number
+  mode: MentionMode
+  siteUid?: string
+  documentId?: UnpackedHypermediaId
+  error: boolean
+}
+
+type MentionMenuInput = {
+  editor: BlockNoteEditor<any>
+  search: MentionSearchFn
+  perspectiveAccountUid?: string | null
+  siteUid?: string
+  documentId?: UnpackedHypermediaId
+}
+
+/**
+ * Mirrors the mention suggestion plugin state into the machine on every editor
+ * transaction: whether the menu is active, the current `@query`, and the
+ * decoration id used to anchor the popup.
+ */
+const pluginListener = fromCallback<MentionMenuEvent, {editor: BlockNoteEditor<any>}>(({sendBack, input}) => {
+  const tiptap = input.editor._tiptapEditor
+  const onTransaction = () => {
+    const state = mentionSuggestionPluginKey.getState(tiptap.state)
+    if (state?.suspended || state?.composing) return
+    sendBack({
+      type: 'plugin.updated',
+      active: !!state?.active,
+      decorationId: state?.decorationId,
+      mode: state?.mode,
+      query:
+        state?.active && state.queryStartPos !== undefined
+          ? tiptap.state.doc
+              .textBetween(state.queryStartPos, state.to)
+              .replace(state.mode === 'document' ? /\]\]$/ : /$^/, '')
+          : '',
+    })
+  }
+  tiptap.on('transaction', onTransaction)
+  return () => tiptap.off('transaction', onTransaction)
+})
+
+/**
+ * Tracks the scrollable ancestor of the editor while the menu is open so the
+ * popup position can be re-read when the document scrolls.
+ */
+const scrollListener = fromCallback<MentionMenuEvent, {editor: BlockNoteEditor<any>}>(({sendBack, input}) => {
+  const scrollEl =
+    input.editor.domElement.closest('[data-radix-scroll-area-viewport]') ??
+    document.getElementById('scroll-page-wrapper') ??
+    document.documentElement
+  const onScroll = () => sendBack({type: 'menu.scrolled'})
+  scrollEl.addEventListener('scroll', onScroll, {passive: true})
+  return () => scrollEl.removeEventListener('scroll', onScroll)
+})
+
+const mentionSearch = fromPromise<
+  InlineMentionsResult,
+  {
+    query: string
+    perspectiveAccountUid: string | null | undefined
+    search: MentionSearchFn
+    mode: MentionMode
+    siteUid?: string
+    documentId?: UnpackedHypermediaId
+  }
+>(({input}) =>
+  input.search(input.query, input.perspectiveAccountUid, {
+    mode: input.mode,
+    siteUid: input.siteUid,
+    documentId: input.documentId,
+  }),
+)
+
+/**
+ * State machine driving the `@` mention menu: the ProseMirror plugin owns the
+ * trigger/decoration lifecycle and reports it through `plugin.updated`; the
+ * machine owns query debouncing, search results, keyboard selection, popup
+ * anchoring, and the commands sent back into the editor.
+ */
+export const mentionMenuMachine = setup({
+  types: {
+    context: {} as MentionMenuContext,
+    events: {} as MentionMenuEvent,
+    input: {} as MentionMenuInput,
+  },
+  actors: {
+    pluginListener,
+    scrollListener,
+    mentionSearch,
+  },
+  guards: {
+    canSelectItem: ({context, event}) =>
+      !context.error &&
+      event.type === 'menu.select' &&
+      event.item.type === context.mode &&
+      context.suggestions.includes(event.item),
+    canSelectHighlighted: ({context, event}) =>
+      !context.error &&
+      event.type === 'menu.key' &&
+      event.key === 'Enter' &&
+      context.suggestions[context.selected]?.type === context.mode,
+    pluginActive: ({event}) => event.type === 'plugin.updated' && event.active,
+    pluginInactive: ({event}) => event.type === 'plugin.updated' && !event.active,
+    queryChanged: ({context, event}) =>
+      event.type === 'plugin.updated' &&
+      (event.query !== context.query || (event.mode !== undefined && event.mode !== context.mode)),
+    keyIs: ({event}, params: {key: MentionMenuKey}) => event.type === 'menu.key' && event.key === params.key,
+  },
+  actions: {
+    syncPluginState: assign(({context, event}) => {
+      if (event.type !== 'plugin.updated') return {}
+      return {
+        query: event.query,
+        mode: event.mode || 'account',
+        decorationId: event.decorationId,
+        referencePos: readDecorationRect(context.editor, event.decorationId),
+      }
+    }),
+    resetMenu: assign({
+      query: '',
+      decorationId: undefined,
+      referencePos: undefined,
+      suggestions: () => emptyInlineMentions(),
+      selected: 0,
+    }),
+    applySuggestions: assign(({context, event}) => {
+      const suggestions = (event as any).output as InlineMentionsResult
+      const previous = context.suggestions[context.selected]
+      const index = previous ? suggestions.findIndex((item) => item.id.id === previous.id.id) : -1
+      return {suggestions, selected: Math.max(0, index), error: false}
+    }),
+    updateOptions: assign(({event}) => {
+      if (event.type !== 'options.updated') return {}
+      return {
+        search: event.search,
+        perspectiveAccountUid: event.perspectiveAccountUid,
+        siteUid: event.siteUid,
+        documentId: event.documentId,
+        suggestions: emptyInlineMentions(),
+      }
+    }),
+    refreshAnchor: assign({
+      referencePos: ({context}) => readDecorationRect(context.editor, context.decorationId),
+    }),
+    bindKeyboard: ({context, self}) => {
+      const menu = context.editor.mentionMenu
+      if (menu) {
+        menu.onKeyboard = (key) => self.send({type: 'menu.key', key})
+      }
+    },
+    unbindKeyboard: ({context}) => {
+      const menu = context.editor.mentionMenu
+      if (menu) menu.onKeyboard = null
+    },
+    selectPrev: assign({
+      selected: ({context}) => (context.selected - 1 + context.suggestions.length) % (context.suggestions.length || 1),
+    }),
+    selectNext: assign({selected: ({context}) => (context.selected + 1) % (context.suggestions.length || 1)}),
+    insertSelected: ({context}) => {
+      const item = context.suggestions[context.selected]
+      if (item) insertMentionItem(context.editor, item)
+    },
+    insertItem: ({context, event}) => {
+      if (event.type === 'menu.select') insertMentionItem(context.editor, event.item)
+    },
+    setQuery: assign(({event}) => (event.type === 'menu.query' ? {query: event.query} : {})),
+    setError: assign({error: true}),
+    clearError: assign({error: false}),
+    checkInsert: assign(({context, event}) => {
+      const item = event.type === 'menu.select' ? event.item : context.suggestions[context.selected]
+      return {error: !!item && item.type === 'document' && !item.id.version}
+    }),
+    logSearchError: ({event}) => console.warn('Mention search failed', (event as any).error),
+  },
+}).createMachine({
+  id: 'mentionMenu',
+  context: ({input}) => ({
+    editor: input.editor,
+    search: input.search,
+    perspectiveAccountUid: input.perspectiveAccountUid,
+    mode: 'account',
+    siteUid: input.siteUid,
+    documentId: input.documentId,
+    error: false,
+    query: '',
+    decorationId: undefined,
+    referencePos: undefined,
+    suggestions: emptyInlineMentions(),
+    selected: 0,
+  }),
+  invoke: {
+    src: 'pluginListener',
+    input: ({context}) => ({editor: context.editor}),
+  },
+  on: {
+    'options.updated': {actions: 'updateOptions'},
+  },
+  initial: 'closed',
+  states: {
+    closed: {
+      on: {
+        'plugin.updated': {
+          guard: 'pluginActive',
+          target: 'open',
+          actions: 'syncPluginState',
+        },
+      },
+    },
+    open: {
+      entry: 'bindKeyboard',
+      exit: 'unbindKeyboard',
+      invoke: {
+        src: 'scrollListener',
+        input: ({context}) => ({editor: context.editor}),
+      },
+      initial: 'searching',
+      states: {
+        debouncing: {
+          entry: 'clearError',
+          after: {
+            150: {target: 'searching'},
+          },
+        },
+        searching: {
+          entry: 'clearError',
+          invoke: {
+            src: 'mentionSearch',
+            input: ({context}) => ({
+              query: context.query,
+              perspectiveAccountUid: context.perspectiveAccountUid,
+              search: context.search,
+              mode: context.mode,
+              siteUid: context.siteUid,
+              documentId: context.documentId,
+            }),
+            onDone: {target: 'loaded', actions: 'applySuggestions'},
+            onError: {
+              target: 'loaded',
+              actions: ['logSearchError', 'setError'],
+            },
+          },
+        },
+        loaded: {
+          on: {
+            'menu.key': {guard: 'canSelectHighlighted', actions: ['checkInsert', 'insertSelected']},
+            'menu.select': {guard: 'canSelectItem', actions: ['checkInsert', 'insertItem']},
+          },
+        },
+      },
+      on: {
+        'plugin.updated': [
+          {
+            guard: 'pluginInactive',
+            target: 'closed',
+            actions: 'resetMenu',
+          },
+          {
+            guard: 'queryChanged',
+            target: '.debouncing',
+            actions: 'syncPluginState',
+          },
+          {actions: 'syncPluginState'},
+        ],
+        'menu.query': {target: '.debouncing', actions: 'setQuery'},
+        'menu.retry': {target: '.searching'},
+        'menu.scrolled': {actions: 'refreshAnchor'},
+        'menu.key': [
+          {guard: {type: 'keyIs', params: {key: 'ArrowUp'}}, actions: 'selectPrev'},
+          {guard: {type: 'keyIs', params: {key: 'ArrowDown'}}, actions: 'selectNext'},
+        ],
+        'options.updated': {target: '.debouncing', actions: 'updateOptions'},
+      },
+    },
+  },
+})

--- a/frontend/packages/editor/src/mention-menu-plugin.test.ts
+++ b/frontend/packages/editor/src/mention-menu-plugin.test.ts
@@ -1,0 +1,62 @@
+import {Schema} from 'prosemirror-model'
+import {EditorState, TextSelection} from 'prosemirror-state'
+import {describe, expect, it} from 'vitest'
+import {MentionMenuProsemirrorPlugin} from './mention-menu-plugin'
+import {mentionSuggestionPluginKey} from './mention-suggestion-plugin'
+const schema = new Schema({
+  nodes: {
+    doc: {content: 'paragraph+'},
+    paragraph: {content: 'inline*'},
+    text: {group: 'inline'},
+    'inline-embed': {inline: true, group: 'inline', atom: true, attrs: {link: {}, mentionKind: {default: null}}},
+  },
+})
+function setup() {
+  const editor = {_tiptapEditor: {view: undefined as any}}
+  const menu = new MentionMenuProsemirrorPlugin(editor as any)
+  const doc = schema.node('doc', null, [schema.node('paragraph')])
+  const view = {
+    state: EditorState.create({schema, doc, plugins: [menu.plugin]}),
+    dispatch(tr: any) {
+      this.state = this.state.apply(tr)
+    },
+  }
+  editor._tiptapEditor.view = view
+  return {menu, view}
+}
+describe('shared mention insertion', () => {
+  it('consumes both brackets and preserves the explicit document kind', () => {
+    const {menu, view} = setup()
+    view.dispatch(view.state.tr.insertText('[['))
+    view.dispatch(view.state.tr.insertText('Doc]]'))
+    view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, 6)))
+    menu.insertMention('hm://site/doc?v=abc&l', 'document')
+    expect(view.state.doc.textContent).toBe(' ')
+    expect(view.state.doc.firstChild!.firstChild!.attrs).toEqual({
+      link: 'hm://site/doc?v=abc&l',
+      mentionKind: 'document',
+    })
+    expect(view.state.selection.from).toBe(3)
+  })
+  it('restores a selected toolbar range on cancel without modifying text', () => {
+    const {menu, view} = setup()
+    view.dispatch(view.state.tr.insertText('Hello world'))
+    view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, 1, 6)))
+    menu.open('account')
+    menu.suspend()
+    view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, 12)))
+    menu.close()
+    expect(view.state.selection.from).toBe(1)
+    expect(view.state.selection.to).toBe(6)
+    expect(view.state.doc.textContent).toBe('Hello world')
+  })
+  it('refuses insertion when the saved trigger range has been removed', () => {
+    const {menu, view} = setup()
+    view.dispatch(view.state.tr.insertText('@'))
+    menu.suspend()
+    view.dispatch(view.state.tr.delete(1, 2))
+    menu.insertMention('hm://a/:profile', 'account')
+    expect(view.state.doc.textContent).toBe('')
+    expect(mentionSuggestionPluginKey.getState(view.state)?.active).toBe(false)
+  })
+})

--- a/frontend/packages/editor/src/mention-menu-plugin.ts
+++ b/frontend/packages/editor/src/mention-menu-plugin.ts
@@ -1,105 +1,76 @@
 import {Fragment} from 'prosemirror-model'
-import {Plugin} from 'prosemirror-state'
+import {Plugin, TextSelection} from 'prosemirror-state'
 import {BlockNoteEditor} from './blocknote/core/BlockNoteEditor'
 import {BlockSchema} from './blocknote/core/extensions/Blocks/api/blockTypes'
-import {EventEmitter} from './blocknote/core/shared/EventEmitter'
 import {
   createMentionSuggestionPlugin,
   MentionPluginState,
+  MentionMode,
   mentionSuggestionPluginKey,
 } from './mention-suggestion-plugin'
 
-export type MentionMenuState = {
-  show: boolean
-  referencePos: DOMRect | undefined
-  query: string
-}
+/** Navigation key pressed while the mention menu is active. */
+export type MentionMenuKey = 'ArrowUp' | 'ArrowDown' | 'Enter' | 'Escape'
 
-type MentionMenuEvents = {
-  update: MentionMenuState
-  keyboard: {key: 'ArrowUp' | 'ArrowDown' | 'Enter' | 'Escape'}
-}
-
-/** Bridge between the ProseMirror mention plugin and React UI. */
-export class MentionMenuProsemirrorPlugin<BSchema extends BlockSchema> extends EventEmitter<MentionMenuEvents> {
+/**
+ * Owns the mention suggestion ProseMirror plugin. React reads the plugin state
+ * through {@link mentionSuggestionPluginKey} (active flag, query start and
+ * decoration id) instead of subscribing to emitted state; this class only
+ * exposes the commands that must dispatch back into the editor.
+ */
+export class MentionMenuProsemirrorPlugin<BSchema extends BlockSchema> {
   public readonly plugin: Plugin
-  private deactivateFn: (view: import('prosemirror-view').EditorView) => void
-  private currentState: MentionPluginState = {active: false, queryStartPos: undefined, decorationId: undefined}
+  /** Called when the user presses a navigation key while the menu is active. */
+  public onKeyboard: ((key: MentionMenuKey) => void) | null = null
 
   constructor(private readonly editor: BlockNoteEditor<BSchema>) {
-    super()
-
-    const {plugin, deactivate} = createMentionSuggestionPlugin({
-      onStateChange: (state, query) => {
-        this.currentState = state
-        const referencePos = this.getReferencePos()
-        this.emit('update', {
-          show: state.active,
-          referencePos,
-          query,
-        })
-      },
-      onKeyboard: (key) => {
-        this.emit('keyboard', {key})
-      },
-      getReferencePos: () => this.getReferencePos(),
+    const {plugin} = createMentionSuggestionPlugin({
+      onKeyboard: (key) => this.onKeyboard?.(key),
     })
-
     this.plugin = plugin
-    this.deactivateFn = deactivate
-  }
-
-  /** Subscribe to popup show/hide/query changes. */
-  public onUpdate(callback: (state: MentionMenuState) => void) {
-    return this.on('update', callback)
-  }
-
-  /** Subscribe to keyboard navigation events. */
-  public onKeyboard(callback: (event: {key: 'ArrowUp' | 'ArrowDown' | 'Enter' | 'Escape'}) => void) {
-    return this.on('keyboard', callback)
   }
 
   /** Close the mention popup. */
   public close() {
     const view = this.editor._tiptapEditor.view
     if (view) {
-      this.deactivateFn(view)
+      const saved = mentionSuggestionPluginKey.getState(view.state)
+      const tr = view.state.tr.setMeta(mentionSuggestionPluginKey, {deactivate: true})
+      if (saved?.active && saved.suspended)
+        tr.setSelection(
+          TextSelection.create(view.state.doc, saved.from === saved.queryStartPos ? saved.from : saved.to, saved.to),
+        )
+      view.dispatch(tr)
     }
   }
 
-  /** Signal that the query returned no results and has enough chars to auto-close. */
-  public closeNoResults() {
+  /** Open a picker at the current selection, without inserting a textual trigger. */
+  public open(mode: MentionMode) {
     const view = this.editor._tiptapEditor.view
-    if (view) {
-      view.dispatch(view.state.tr.setMeta(mentionSuggestionPluginKey, {closeNoResults: true}))
-    }
+    view.dispatch(view.state.tr.setMeta(mentionSuggestionPluginKey, {activate: true, mode}))
   }
 
-  /** Replace the `@query` range with an inline-embed node + trailing space. */
-  public insertMention(link: string) {
+  /** Keep the replacement range while the mobile dialog owns focus. */
+  public suspend(suspended = true) {
     const view = this.editor._tiptapEditor.view
-    if (!view) return
+    view.dispatch(view.state.tr.setMeta(mentionSuggestionPluginKey, {suspend: suspended}))
+  }
 
+  /** Replace the saved trigger/query selection with one atomic inline mention. */
+  public insertMention(link: string, mentionKind: MentionMode = 'account') {
+    const view = this.editor._tiptapEditor.view
     const state = mentionSuggestionPluginKey.getState(view.state) as MentionPluginState
-    if (!state.active || !state.queryStartPos) return
-
-    const from = state.queryStartPos - 1
-    const to = view.state.selection.from
-    const node = view.state.schema.nodes['inline-embed']?.create({link})
+    if (!state.active) return
+    let to = state.to
+    if (
+      mentionKind === 'document' &&
+      view.state.doc.textBetween(to, Math.min(to + 2, view.state.doc.content.size)) === ']]'
+    )
+      to += 2
+    const node = view.state.schema.nodes['inline-embed']?.create({link, mentionKind})
     if (!node) return
-
-    this.deactivateFn(view)
-    view.dispatch(view.state.tr.replaceWith(from, to, Fragment.fromArray([node, view.state.schema.text(' ')])))
-  }
-
-  /** The current decoration ID, if the mention menu is active. */
-  public get decorationId(): string | undefined {
-    return this.currentState.decorationId
-  }
-
-  private getReferencePos(): DOMRect | undefined {
-    if (!this.currentState.active || !this.currentState.decorationId) return undefined
-    const decorationNode = document.querySelector(`[data-decoration-id="${this.currentState.decorationId}"]`)
-    return decorationNode?.getBoundingClientRect()
+    const tr = view.state.tr.replaceWith(state.from, to, Fragment.fromArray([node, view.state.schema.text(' ')]))
+    tr.setSelection(TextSelection.create(tr.doc, state.from + node.nodeSize + 1))
+    view.dispatch(tr.setMeta(mentionSuggestionPluginKey, {deactivate: true}).scrollIntoView())
   }
 }

--- a/frontend/packages/editor/src/mention-menu-positioner.tsx
+++ b/frontend/packages/editor/src/mention-menu-positioner.tsx
@@ -1,277 +1,159 @@
-import {InlineMentionsResult, useInlineMentions} from '@shm/shared/models/inline-mentions'
-import type {SearchResultItem as SearchResultData} from '@shm/shared/models/search'
-import {packHmId, packReferenceUrl} from '@shm/shared/utils/entity-id-url'
-import {useDebounce} from '@shm/shared/utils/use-debounce'
-import {SearchResultItem} from '@shm/ui/search'
-import {SizableText} from '@shm/ui/text'
-import {TooltipProvider} from '@shm/ui/tooltip'
+import {mentionCandidateSubtitle} from '@shm/shared/models/mention-ranking'
+import {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import type {MentionThreadContext} from '@shm/shared/models/mention-ranking'
+import {useInlineMentionsSearch} from '@shm/shared/models/inline-mentions'
+import {LoadedHMIcon} from '@shm/ui/hm-icon'
 import Tippy from '@tippyjs/react'
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {useActorRef, useSelector} from '@xstate/react'
+import {useEffect, useId, useRef, useState} from 'react'
 import {BlockNoteEditor} from './blocknote/core/BlockNoteEditor'
 import {BlockSchema} from './blocknote/core/extensions/Blocks/api/blockTypes'
-import type {MentionMenuState} from './mention-menu-plugin'
+import {mentionMenuMachine} from './mention-menu-machine'
+import {MobileMentionsDialog} from './mobile-mentions-dialog'
+import {useMobile} from './use-mobile'
 
-const groupsOrder = ['Contacts', 'Recents', 'Profiles', 'Documents'] as const
-type GroupKey = (typeof groupsOrder)[number]
-
-function isOptionsEmpty(obj: InlineMentionsResult) {
-  return Object.values(obj).every((value) => value.length === 0)
-}
-
-function getVisibleGroups(suggestions: InlineMentionsResult): GroupKey[] {
-  return groupsOrder.filter((g) => suggestions[g].length > 0)
-}
-
+/** Shared mention controller, presented as an anchored list or a mobile dialog. */
 export function MentionMenuPositioner<BSchema extends BlockSchema>({
   editor,
   perspectiveAccountUid,
+  siteUid,
+  documentId,
+  mentionThread,
 }: {
   editor: BlockNoteEditor<BSchema>
   perspectiveAccountUid?: string | null
+  siteUid?: string
+  documentId?: UnpackedHypermediaId
+  mentionThread?: MentionThreadContext
 }) {
-  const [show, setShow] = useState(false)
-  const [query, setQuery] = useState('')
-  const referencePos = useRef<DOMRect>()
-  const decorationIdRef = useRef<string>()
-  const scroller = useRef<HTMLElement | null>(null)
-  const [scrollTick, setScrollTick] = useState(0)
-
-  const debouncedQuery = useDebounce(query, 250)
-  const {onMentionsQuery} = useInlineMentions(perspectiveAccountUid)
-
-  const [suggestions, setSuggestions] = useState<InlineMentionsResult>({
-    Recents: [],
-    Profiles: [],
-    Documents: [],
-    Contacts: [],
-  })
-
-  const [index, setIndex] = useState<[GroupKey, number]>(['Recents', 0])
-  const [hasFetched, setHasFetched] = useState(false)
-  const itemRefs = useRef<Record<string, HTMLDivElement | null>>({})
-
-  const refreshReferencePos = useCallback(() => {
-    if (!decorationIdRef.current) return
-    const el = document.querySelector(`[data-decoration-id="${decorationIdRef.current}"]`)
-    if (el) {
-      referencePos.current = el.getBoundingClientRect()
-      setScrollTick((t) => t + 1)
-    }
-  }, [])
-
+  const search = useInlineMentionsSearch(mentionThread)
+  const actor = useActorRef(mentionMenuMachine, {input: {editor, search, perspectiveAccountUid, siteUid, documentId}})
+  const snapshot = useSelector(actor, (s) => s)
+  const show = snapshot.matches('open')
+  const lastOpen = useRef(snapshot)
   useEffect(() => {
-    setTimeout(() => {
-      scroller.current = document.getElementById('scroll-page-wrapper')
-    }, 100)
-  }, [])
-
-  useEffect(() => {
-    if (!show) return
-    // Prefer the editor's nearest scroll ancestor over the global page scroller.
-    const scrollEl =
-      editor.domElement.closest('[data-radix-scroll-area-viewport]') ?? scroller.current ?? document.documentElement
-    if (!scrollEl) return
-
-    const onScroll = () => refreshReferencePos()
-    scrollEl.addEventListener('scroll', onScroll, {passive: true})
-    return () => scrollEl.removeEventListener('scroll', onScroll)
-  }, [show, editor, refreshReferencePos])
-
-  useEffect(() => {
-    if (!editor.mentionMenu) return
-    return editor.mentionMenu.onUpdate((state: MentionMenuState) => {
-      setShow(state.show)
-      setQuery(state.query)
-      referencePos.current = state.referencePos
-      if (state.show) {
-        decorationIdRef.current = editor.mentionMenu!.decorationId
-      }
-      if (!state.show) {
-        setSuggestions({Recents: [], Profiles: [], Documents: [], Contacts: []})
-        setIndex(['Recents', 0])
-        setHasFetched(false)
-        decorationIdRef.current = undefined
-      }
-    })
-  }, [editor])
-
-  useEffect(() => {
-    if (!editor.mentionMenu) return
-    return editor.mentionMenu.onKeyboard(({key}) => {
-      if (key === 'ArrowUp') {
-        setIndex((prev) => {
-          const [group, idx] = prev
-          const groups = getVisibleGroups(suggestions)
-          if (groups.length === 0) return prev
-          if (idx > 0) return [group, idx - 1]
-          const groupIdx = groups.indexOf(group)
-          if (groupIdx <= 0) {
-            const lastGroup = groups[groups.length - 1]!
-            return [lastGroup, suggestions[lastGroup].length - 1]
-          }
-          const prevGroup = groups[groupIdx - 1]!
-          return [prevGroup, suggestions[prevGroup].length - 1]
-        })
-      } else if (key === 'ArrowDown') {
-        setIndex((prev) => {
-          const [group, idx] = prev
-          const groups = getVisibleGroups(suggestions)
-          if (groups.length === 0) return prev
-          if (idx < suggestions[group].length - 1) return [group, idx + 1]
-          const groupIdx = groups.indexOf(group)
-          if (groupIdx >= groups.length - 1) return [groups[0]!, 0]
-          return [groups[groupIdx + 1]!, 0]
-        })
-      } else if (key === 'Enter') {
-        handleSelect()
-      }
-    })
-  }, [editor, suggestions, index])
-
-  function handleSelect() {
-    const [group, idx] = index
-    const groups = getVisibleGroups(suggestions)
-    if (groups.indexOf(group) >= 0 && idx < suggestions[group].length) {
-      const item = suggestions[group][idx]
-      if (item) {
-        editor.mentionMenu?.insertMention(packReferenceUrl({...item.id, latest: !item.id.blockRef}))
-      }
-    }
-  }
-
-  useEffect(() => {
-    if (!show) return
-    let isActive = true
-    onMentionsQuery(debouncedQuery).then((results: InlineMentionsResult) => {
-      if (!isActive) return
-      setSuggestions((prev) => ({...prev, ...results}))
-      setHasFetched(true)
-      if (isOptionsEmpty(results) && debouncedQuery.length > 5) {
-        editor.mentionMenu?.closeNoResults()
-      }
-    })
-    return () => {
-      isActive = false
-    }
-  }, [debouncedQuery, show])
-
-  useEffect(() => {
-    const firstGroup = groupsOrder.find((g) => suggestions[g].length > 0)
-    if (firstGroup) {
-      setIndex([firstGroup, 0])
-    }
-  }, [suggestions])
-
-  useEffect(() => {
-    const el = itemRefs.current[`${index[0]}-${index[1]}`]
-    if (el) {
-      el.scrollIntoView({behavior: 'smooth', block: 'nearest'})
-    }
-  }, [index])
-
-  const groups = useMemo(() => getVisibleGroups(suggestions), [suggestions])
-
-  const getReferenceClientRect = useMemo(
-    () => {
-      if (!referencePos.current) return undefined
-      const rect = referencePos.current
-      return () =>
-        ({
-          top: rect.top,
-          right: rect.right,
-          bottom: rect.bottom,
-          left: rect.left,
-          width: rect.width,
-          height: rect.height,
-          x: rect.left,
-          y: rect.top,
-          toJSON: () => {},
-        }) as DOMRect
-    },
-    [referencePos.current, scrollTick], // eslint-disable-line
+    if (show) lastOpen.current = snapshot
+  }, [show, snapshot])
+  // Keep the final rows visible during the exit transition, not the reset menu.
+  const displaySnapshot = show ? snapshot : lastOpen.current
+  const {suggestions, selected, referencePos, mode, query, error} = displaySnapshot.context
+  const loading = !displaySnapshot.matches({open: 'loaded'})
+  const [reducedMotion, setReducedMotion] = useState(
+    () => typeof window !== 'undefined' && !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches,
   )
-
-  function selectItem(item: SearchResultData) {
-    editor.mentionMenu?.insertMention(packReferenceUrl({...item.id, latest: !item.id.blockRef}))
-  }
-
-  const hasResults = groups.length > 0
-
-  const content = useMemo(() => {
+  useEffect(() => {
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const update = () => setReducedMotion(media.matches)
+    update()
+    media.addEventListener('change', update)
+    return () => media.removeEventListener('change', update)
+  }, [])
+  const mobile = useMobile()
+  const listId = useId()
+  const rows = useRef<Array<HTMLButtonElement | null>>([])
+  useEffect(() => {
+    actor.send({type: 'options.updated', search, perspectiveAccountUid, siteUid, documentId})
+  }, [actor, search, perspectiveAccountUid, siteUid, documentId])
+  useEffect(() => {
+    if (show) editor.mentionMenu?.suspend(mobile)
+  }, [editor, show, mobile])
+  useEffect(() => {
+    rows.current[selected]?.scrollIntoView({block: 'nearest'})
+  }, [selected])
+  useEffect(() => {
+    const dom = editor.domElement
+    if (show && !mobile) {
+      dom.setAttribute('aria-autocomplete', 'list')
+      dom.setAttribute('aria-controls', listId)
+      dom.setAttribute('aria-expanded', 'true')
+      if (suggestions[selected]) dom.setAttribute('aria-activedescendant', `${listId}-${selected}`)
+      else dom.removeAttribute('aria-activedescendant')
+    }
+    return () => {
+      for (const attribute of ['aria-autocomplete', 'aria-controls', 'aria-expanded', 'aria-activedescendant'])
+        dom.removeAttribute(attribute)
+    }
+  }, [editor, show, mobile, listId, selected, suggestions])
+  const close = () => editor.mentionMenu?.close()
+  if (mobile)
     return (
-      <TooltipProvider>
-        <div className="border-border bg-background flex max-h-[10em] w-[20em] flex-col overflow-y-auto rounded border shadow-lg">
-          {hasFetched && !hasResults && (
-            <div className="flex gap-2 bg-white px-4 py-2 dark:bg-black">
-              <SizableText size="sm" className="flex-1">
-                No Results
-              </SizableText>
-            </div>
-          )}
-          {groups.map((group) => (
-            <div className="border-border flex flex-col last:border-b-0" key={group}>
-              <div className="flex gap-2 bg-white px-4 py-2 dark:bg-black">
-                <SizableText size="sm" className="text-muted-foreground flex-1">
-                  {group}
-                </SizableText>
-                {suggestions[group].length >= 1 ? (
-                  <SizableText size="xs" className="text-muted-foreground">
-                    {suggestions[group].length === 1 ? '1 item' : `${suggestions[group].length} items`}
-                  </SizableText>
-                ) : null}
-              </div>
-              {suggestions[group].map((item, i) => {
-                const [currentGroup, currentIdx] = index
-                const title = item.title || item.id.uid
-                return (
-                  <div
-                    key={`${group}-${item.id.id}`}
-                    ref={(el: HTMLDivElement | null) => {
-                      itemRefs.current[`${group}-${i}`] = el
-                    }}
-                    onPointerDown={(e) => {
-                      if (e.button !== 0) return
-                      e.preventDefault()
-                      selectItem(item)
-                    }}
-                  >
-                    <SearchResultItem
-                      selected={currentGroup === group && currentIdx === i}
-                      item={{
-                        // @ts-expect-error id is not in SearchResult but used by the component
-                        id: item.id,
-                        key: packHmId(item.id),
-                        title,
-                        path: item.parentNames,
-                        icon: item.icon,
-                        onFocus: () => {},
-                        onMouseEnter: () => {},
-                        onSelect: () => selectItem(item),
-                        subtitle: 'Document',
-                        searchQuery: item.searchQuery,
-                        versionTime: item.versionTime || '',
-                      }}
-                    />
-                  </div>
-                )
-              })}
-            </div>
-          ))}
-        </div>
-      </TooltipProvider>
+      <MobileMentionsDialog
+        isOpen={show}
+        onClose={close}
+        onSelect={(item) => actor.send({type: 'menu.select', item})}
+        mode={mode}
+        query={query}
+        onQuery={(query) => actor.send({type: 'menu.query', query})}
+        results={suggestions}
+        loading={loading}
+        error={error}
+        onRetry={() => actor.send({type: 'menu.retry'})}
+        onRestoreFocus={() => editor._tiptapEditor.view.focus()}
+      />
     )
-  }, [suggestions, groups, index, editor, hasResults, hasFetched])
-
+  const content = (
+    <div
+      id={listId}
+      role="listbox"
+      aria-label={mode === 'account' ? 'Accounts' : 'Documents'}
+      aria-busy={loading}
+      className="border-border bg-background flex max-h-64 w-80 flex-col overflow-y-auto rounded border shadow-lg"
+    >
+      {loading && (
+        <p role="status" className="text-muted-foreground px-4 py-2">
+          Searching…
+        </p>
+      )}
+      {error && (
+        <p role="alert" className="px-4 py-2">
+          Unable to load mentions or resolve the published version.{' '}
+          <button onClick={() => actor.send({type: 'menu.retry'})}>Retry</button>
+        </p>
+      )}
+      {!loading && !error && !suggestions.length && (
+        <p role="status" className="text-muted-foreground px-4 py-2">
+          No {mode === 'account' ? 'accounts' : 'documents'} found
+        </p>
+      )}
+      {suggestions.map((item, i) => (
+        <button
+          id={`${listId}-${i}`}
+          key={item.id.id}
+          ref={(el) => {
+            rows.current[i] = el
+          }}
+          role="option"
+          aria-selected={selected === i}
+          disabled={loading || error}
+          className={`flex min-h-12 items-center gap-3 px-4 py-2 text-left ${
+            selected === i ? 'bg-accent' : 'hover:bg-accent'
+          }`}
+          onPointerDown={(event) => {
+            if (event.button !== 0 || loading || error) return
+            event.preventDefault()
+          }}
+          onClick={() => actor.send({type: 'menu.select', item})}
+        >
+          <LoadedHMIcon id={item.id} size={24} />
+          <span className="flex min-w-0 flex-col">
+            <span className="truncate">{item.title || item.id.uid}</span>
+            <span className="text-muted-foreground text-xs" title={item.type === 'account' ? item.id.uid : undefined}>
+              {mentionCandidateSubtitle(item)}
+            </span>
+          </span>
+        </button>
+      ))}
+    </div>
+  )
   return (
     <Tippy
-      // Always append to document.body so the popup escapes any container
-      // stacking context.
       appendTo={document.body}
       content={content}
-      getReferenceClientRect={getReferenceClientRect}
-      interactive={true}
+      getReferenceClientRect={referencePos ? () => referencePos : () => editor.domElement.getBoundingClientRect()}
+      interactive
       visible={show}
-      animation={'fade'}
+      animation="mention-popover"
+      duration={reducedMotion ? 0 : [180, 100]}
       placement="bottom-start"
       zIndex={100000}
     />

--- a/frontend/packages/editor/src/mention-petnames.test.tsx
+++ b/frontend/packages/editor/src/mention-petnames.test.tsx
@@ -1,0 +1,91 @@
+import {act} from 'react-dom/test-utils'
+import {createRoot} from 'react-dom/client'
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import {afterEach, expect, it, vi} from 'vitest'
+import {UniversalAppProvider} from '@shm/shared/routing'
+import {SelectedAccountContactsProvider} from '@shm/shared/models/contacts'
+import {queryAccount, queryContactsOfAccount} from '@shm/shared/models/queries'
+import {writeableStateStream} from '@shm/shared/utils/stream'
+import {hmId} from '@shm/shared/utils/entity-id-url'
+import type {HMContactRecord} from '@seed-hypermedia/client/hm-types'
+import {MentionToken} from './mentions-plugin'
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+afterEach(() => vi.useRealTimers())
+
+it('renders petnames for the selected account and updates existing mentions without leaking previous contacts', async () => {
+  vi.useFakeTimers()
+  const contacts = (account: string, name: string): HMContactRecord[] => [
+    {id: account + '/contact', account, subject: 'alex', name, signer: account},
+  ]
+  let resolveContacts!: (value: HMContactRecord[]) => void
+  const client = {
+    request: vi.fn(
+      () =>
+        new Promise<HMContactRecord[]>((resolve) => {
+          resolveContacts = resolve
+        }),
+    ),
+  } as any
+  const cache = new QueryClient({
+    defaultOptions: {queries: {staleTime: Infinity, keepPreviousData: true, retry: false}},
+  })
+  cache.setQueryData(queryAccount(client, 'alex').queryKey, {id: hmId('alex'), metadata: {name: 'Alex Burdiyan'}})
+  cache.setQueryData(queryContactsOfAccount(client, 'viewer-a').queryKey, contacts('viewer-a', 'Burdi'))
+  const [select, selectedIdentity] = writeableStateStream<string | null>('viewer-a')
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  try {
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={cache}>
+          <UniversalAppProvider
+            universalClient={client}
+            selectedIdentity={selectedIdentity}
+            openUrl={() => {}}
+            openRoute={() => {}}
+          >
+            <SelectedAccountContactsProvider>
+              <MentionToken value="hm://alex/:profile" mentionKind="account" />
+            </SelectedAccountContactsProvider>
+          </UniversalAppProvider>
+        </QueryClientProvider>,
+      )
+    })
+    expect(container.textContent).toBe('@Burdi')
+
+    await act(async () => {
+      select('viewer-b')
+    })
+    expect(container.textContent).toBe('@Alex Burdiyan')
+    expect(client.request).toHaveBeenCalledWith('AccountContacts', 'viewer-b', expect.anything())
+    await act(async () => {
+      resolveContacts(contacts('viewer-b', 'Alex B'))
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(container.textContent).toBe('@Alex B')
+
+    await act(async () => {
+      select('viewer-a')
+    })
+    expect(container.textContent).toBe('@Burdi')
+    await act(async () => {
+      cache.setQueryData(queryContactsOfAccount(client, 'viewer-a').queryKey, contacts('viewer-a', 'Buddy'))
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(container.textContent).toBe('@Buddy')
+    await act(async () => {
+      cache.setQueryData(queryContactsOfAccount(client, 'viewer-a').queryKey, contacts('viewer-a', ''))
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(container.textContent).toBe('@Alex Burdiyan')
+    await act(async () => {
+      select(null)
+    })
+    expect(container.textContent).toBe('@Alex Burdiyan')
+  } finally {
+    await act(async () => root.unmount())
+    container.remove()
+    cache.clear()
+  }
+})

--- a/frontend/packages/editor/src/mention-suggestion-plugin.test.ts
+++ b/frontend/packages/editor/src/mention-suggestion-plugin.test.ts
@@ -1,0 +1,74 @@
+import {Schema} from 'prosemirror-model'
+import {EditorState, TextSelection} from 'prosemirror-state'
+import {describe, expect, it} from 'vitest'
+import {createMentionSuggestionPlugin, mentionSuggestionPluginKey} from './mention-suggestion-plugin'
+
+const schema = new Schema({
+  nodes: {doc: {content: 'paragraph+'}, paragraph: {content: 'text*'}, text: {}},
+  marks: {code: {}, link: {}},
+})
+function state(text = '') {
+  const doc = schema.node('doc', null, [schema.node('paragraph', null, text ? schema.text(text) : undefined)])
+  return EditorState.create({
+    schema,
+    doc,
+    selection: TextSelection.create(doc, text.length + 1),
+    plugins: [createMentionSuggestionPlugin({onKeyboard: () => {}}).plugin],
+  })
+}
+describe('mention triggers', () => {
+  it.each([
+    ['@', 'account'],
+    ['[[', 'document'],
+  ])('recognizes typed %s from document transactions', (trigger, mode) => {
+    let s = state()
+    for (const char of trigger) s = s.apply(s.tr.insertText(char))
+    expect(mentionSuggestionPluginKey.getState(s)).toMatchObject({active: true, mode, from: 1, to: trigger.length + 1})
+  })
+  it.each(['email@', 'word[['])('does not activate inside %s', (text) => {
+    let s = state()
+    s = s.apply(s.tr.insertText(text))
+    expect(mentionSuggestionPluginKey.getState(s).active).toBe(false)
+  })
+  it('preserves typed text and does not reopen after cancellation', () => {
+    let s = state()
+    s = s.apply(s.tr.insertText('@'))
+    s = s.apply(s.tr.setMeta(mentionSuggestionPluginKey, {deactivate: true}))
+    s = s.apply(s.tr.insertText('a'))
+    expect(s.doc.textContent).toBe('@a')
+    expect(mentionSuggestionPluginKey.getState(s).active).toBe(false)
+  })
+  it('deactivates when the trigger is deleted', () => {
+    let s = state()
+    s = s.apply(s.tr.insertText('@'))
+    s = s.apply(s.tr.delete(1, 2))
+    expect(mentionSuggestionPluginKey.getState(s).active).toBe(false)
+  })
+  it('does not activate in code or link marks', () => {
+    for (const mark of [schema.marks.code!, schema.marks.link!]) {
+      let s = state()
+      s = s.apply(s.tr.addStoredMark(mark.create()).insertText('@'))
+      expect(mentionSuggestionPluginKey.getState(s).active).toBe(false)
+    }
+  })
+  it('waits for composition to finish before opening the picker', () => {
+    let s = state()
+    s = s.apply(s.tr.insertText('@Alice').setMeta('composition', 1))
+    expect(mentionSuggestionPluginKey.getState(s)?.active).toBe(false)
+    s = s.apply(s.tr.setMeta(mentionSuggestionPluginKey, {composing: false}))
+    expect(mentionSuggestionPluginKey.getState(s)).toMatchObject({
+      active: true,
+      mode: 'account',
+      from: 1,
+      to: 7,
+      queryStartPos: 2,
+    })
+  })
+  it('maps a suspended range during unrelated edits', () => {
+    let s = state('Hello ')
+    s = s.apply(s.tr.insertText('[['))
+    s = s.apply(s.tr.setMeta(mentionSuggestionPluginKey, {suspend: true}))
+    s = s.apply(s.tr.insertText('X', 1))
+    expect(mentionSuggestionPluginKey.getState(s)).toMatchObject({active: true, from: 8, to: 10, suspended: true})
+  })
+})

--- a/frontend/packages/editor/src/mention-suggestion-plugin.ts
+++ b/frontend/packages/editor/src/mention-suggestion-plugin.ts
@@ -1,162 +1,145 @@
 import {Plugin, PluginKey} from 'prosemirror-state'
 import {Decoration, DecorationSet, EditorView} from 'prosemirror-view'
 
-export const mentionSuggestionPluginKey = new PluginKey('MentionSuggestionPlugin')
-
-/** State tracked by the mention suggestion ProseMirror plugin. */
+/** Shared trigger mode for account and document mentions. */
+export type MentionMode = 'account' | 'document'
+/** State key for mention ranges, including ranges held by a mobile dialog. */
+export const mentionSuggestionPluginKey = new PluginKey<MentionPluginState>('MentionSuggestionPlugin')
+/** The replacement range is mapped through every document transaction. */
 export type MentionPluginState = {
   active: boolean
-  queryStartPos: number | undefined
-  decorationId: string | undefined
+  mode: MentionMode
+  from: number
+  to: number
+  queryStartPos: number
+  decorationId?: string
+  suspended: boolean
+  composing?: boolean
 }
-
-function getDefaultState(): MentionPluginState {
-  return {
-    active: false,
-    queryStartPos: undefined,
-    decorationId: undefined,
-  }
+const inactive: MentionPluginState = {
+  active: false,
+  mode: 'account',
+  from: 0,
+  to: 0,
+  queryStartPos: 0,
+  suspended: false,
 }
-
-/**
- * Creates a ProseMirror plugin that activates on `@` trigger and intercepts
- * keyboard events while the mention popup is open.
- */
+/** Recognizes text transactions, including mobile keyboards and IME, without intercepting character input. */
 export function createMentionSuggestionPlugin(opts: {
-  onStateChange: (state: MentionPluginState, query: string) => void
   onKeyboard: (key: 'ArrowUp' | 'ArrowDown' | 'Enter' | 'Escape') => void
-  getReferencePos: () => DOMRect | undefined
 }) {
-  const deactivate = (view: EditorView) => {
+  let domComposing: boolean | undefined
+  const deactivate = (view: EditorView) =>
     view.dispatch(view.state.tr.setMeta(mentionSuggestionPluginKey, {deactivate: true}))
-  }
-
   const plugin = new Plugin<MentionPluginState>({
     key: mentionSuggestionPluginKey,
-
     state: {
-      init(): MentionPluginState {
-        return getDefaultState()
-      },
-
-      apply(transaction, prev, _oldState, newState): MentionPluginState {
-        if (transaction.getMeta('orderedListIndexing') !== undefined) {
-          return prev
-        }
-
-        if (transaction.getMeta(mentionSuggestionPluginKey)?.activate) {
+      init: () => inactive,
+      apply(tr, prev, _old, next) {
+        const meta = tr.getMeta(mentionSuggestionPluginKey)
+        const composing =
+          meta?.composing ?? domComposing ?? (tr.getMeta('composition') !== undefined || !!prev.composing)
+        if (meta?.deactivate) return inactive
+        if (meta?.activate)
           return {
             active: true,
-            queryStartPos: newState.selection.from,
-            decorationId: `mention_${Math.floor(Math.random() * 0xffffffff)}`,
+            mode: meta.mode || 'account',
+            from: next.selection.from,
+            to: next.selection.to,
+            queryStartPos: next.selection.from,
+            suspended: false,
+            decorationId: `mention_${next.selection.from}`,
+          }
+        if (prev.active) {
+          const start = tr.mapping.mapResult(prev.from, 1)
+          const end = tr.mapping.mapResult(prev.to, -1)
+          const queryStartPos = tr.mapping.map(prev.queryStartPos, -1)
+          if (start.deletedAcross || end.deletedAcross) return inactive
+          const from = tr.mapping.map(prev.from, -1)
+          if (
+            prev.queryStartPos > prev.from &&
+            next.doc.textBetween(from, queryStartPos) !== (prev.mode === 'account' ? '@' : '[[')
+          )
+            return inactive
+          if (!prev.suspended && next.selection.$from.parent !== next.doc.resolve(from).parent) return inactive
+          const suspended = meta?.suspend ?? prev.suspended
+          if (suspended) return {...prev, from: start.pos, to: end.pos, queryStartPos, suspended: true}
+          if (!next.selection.empty || next.selection.from < queryStartPos || tr.getMeta('pointer')) return inactive
+          return {
+            ...prev,
+            from: tr.mapping.map(prev.from, -1),
+            to: next.selection.from,
+            queryStartPos,
+            composing,
+            suspended: false,
           }
         }
-
-        if (!prev.active) {
-          return prev
-        }
-
+        if (composing) return {...prev, composing}
+        if ((!tr.docChanged && meta?.composing !== false) || !next.selection.empty) return prev
+        const {$from} = next.selection
         if (
-          newState.selection.from !== newState.selection.to ||
-          transaction.getMeta(mentionSuggestionPluginKey)?.deactivate ||
-          transaction.getMeta('focus') ||
-          transaction.getMeta('blur') ||
-          transaction.getMeta('pointer') ||
-          newState.selection.from < prev.queryStartPos!
-        ) {
-          return getDefaultState()
+          $from.parent.type.spec.code ||
+          $from.marks().some((mark) => mark.type.name === 'code' || mark.type.name === 'link')
+        )
+          return prev
+        const before = $from.parent.textBetween(0, $from.parentOffset, undefined, '\ufffc')
+        const match = (
+          meta?.composing === false ? /(?:^|[\s([{])(@|\[\[)([^@\[\]\n]*)$/ : /(?:^|[\s([{])(@|\[\[)$/
+        ).exec(before)
+        if (!match) return prev
+        const trigger = match[1]!
+        return {
+          active: true,
+          mode: trigger === '@' ? 'account' : 'document',
+          from: $from.pos - trigger.length - (match[2]?.length || 0),
+          to: $from.pos,
+          queryStartPos: $from.pos - (match[2]?.length || 0),
+          suspended: false,
+          decorationId: `mention_${$from.pos}`,
         }
-
-        if (transaction.getMeta(mentionSuggestionPluginKey)?.closeNoResults) {
-          return getDefaultState()
-        }
-
-        return prev
       },
     },
-
-    view() {
-      return {
-        update(view) {
-          const state: MentionPluginState = mentionSuggestionPluginKey.getState(view.state)
-          let query = ''
-          if (state.active && state.queryStartPos !== undefined) {
-            query = view.state.doc.textBetween(state.queryStartPos, view.state.selection.from)
-          }
-          opts.onStateChange(state, query)
-        },
-      }
-    },
-
     props: {
-      handleKeyDown(view, event) {
-        const menuIsActive = (this as Plugin).getState(view.state).active
-
-        if (event.key === '@' && !menuIsActive) {
-          const {state} = view
-          const {selection} = state
-
-          if (selection.from !== selection.to) return false
-
-          const posBefore = selection.$from.pos - 1
-          const isStart = !selection.$from.parent.textContent.length || selection.$from.parentOffset === 0
-
-          if (!isStart) {
-            const charBefore = state.doc.textBetween(posBefore, posBefore + 1, undefined, '\ufffc')
-            if (charBefore !== ' ') return false
-          }
-
-          view.dispatch(state.tr.insertText('@').scrollIntoView().setMeta(mentionSuggestionPluginKey, {activate: true}))
-          return true
-        }
-
-        if (!menuIsActive) {
+      handleDOMEvents: {
+        compositionstart(view) {
+          domComposing = true
+          view.dispatch(view.state.tr.setMeta(mentionSuggestionPluginKey, {composing: true}))
           return false
-        }
-
-        if (event.key === 'ArrowUp') {
-          opts.onKeyboard('ArrowUp')
-          return true
-        }
-        if (event.key === 'ArrowDown') {
-          opts.onKeyboard('ArrowDown')
-          return true
-        }
-        if (event.key === 'Enter') {
-          opts.onKeyboard('Enter')
-          return true
-        }
+        },
+        compositionend(view) {
+          domComposing = false
+          view.dispatch(view.state.tr.setMeta(mentionSuggestionPluginKey, {composing: false}))
+          return false
+        },
+      },
+      handleKeyDown(view, event) {
+        if (event.isComposing || view.composing || !mentionSuggestionPluginKey.getState(view.state)?.active)
+          return false
         if (event.key === 'Escape') {
           deactivate(view)
           return true
         }
-
+        if (event.key === 'Enter' || event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+          opts.onKeyboard(event.key)
+          return true
+        }
         return false
       },
-
       handleClick(view) {
-        const state: MentionPluginState = (this as Plugin).getState(view.state)
-        if (state.active) {
-          deactivate(view)
-        }
+        if (mentionSuggestionPluginKey.getState(view.state)?.active) deactivate(view)
       },
-
       decorations(state) {
-        const pluginState: MentionPluginState = (this as Plugin).getState(state)
-        if (!pluginState.active || !pluginState.queryStartPos || !pluginState.decorationId) {
-          return null
-        }
-
+        const s = mentionSuggestionPluginKey.getState(state)
+        if (!s?.active || s.from === s.queryStartPos) return null
         return DecorationSet.create(state.doc, [
-          Decoration.inline(pluginState.queryStartPos - 1, pluginState.queryStartPos, {
+          Decoration.inline(s.from, s.queryStartPos, {
             nodeName: 'span',
             class: 'suggestion-decorator',
-            'data-decoration-id': pluginState.decorationId,
+            'data-decoration-id': s.decorationId!,
           }),
         ])
       },
     },
   })
-
   return {plugin, deactivate}
 }

--- a/frontend/packages/editor/src/mentions-plugin.test.ts
+++ b/frontend/packages/editor/src/mentions-plugin.test.ts
@@ -1,5 +1,11 @@
 import {describe, expect, it} from 'vitest'
-import {createInlineEmbedNode, inlineEmbedClipboardText} from './mentions-plugin'
+import {createInlineEmbedNode, inlineEmbedClipboardText, MentionToken} from './mentions-plugin'
+import {createElement} from 'react'
+import {renderToStaticMarkup} from 'react-dom/server'
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import {UniversalAppProvider} from '@shm/shared/routing'
+import {queryAccount, queryResource} from '@shm/shared/models/queries'
+import {unpackHmId} from '@shm/shared'
 
 describe('inlineEmbedClipboardText', () => {
   it('serializes inline embeds to a non-empty clipboard fallback', () => {
@@ -21,5 +27,63 @@ describe('inlineEmbedClipboardText', () => {
         }),
       ]),
     )
+  })
+})
+
+it('preserves mention kind in rich clipboard HTML', () => {
+  const node = createInlineEmbedNode()
+  expect(node.config.addAttributes?.()).toHaveProperty('mentionKind')
+  const html = node.config.renderHTML?.({
+    node: {attrs: {link: 'hm://alice', mentionKind: 'document'}},
+    HTMLAttributes: {link: 'hm://alice'},
+  } as any)
+  expect(html?.[1]).toHaveProperty('data-mention-kind', 'document')
+})
+
+describe('mention labels', () => {
+  function renderMention(link: string, mentionKind?: 'account' | 'document', name = 'Alice') {
+    const client = {request: async () => null} as any
+    const queryClient = new QueryClient({defaultOptions: {queries: {staleTime: Infinity}}})
+    queryClient.setQueryData(queryAccount(client, 'alice').queryKey, {metadata: {name}})
+    for (const id of [unpackHmId('hm://alice'), unpackHmId('hm://alice/page')]) {
+      queryClient.setQueryData(queryResource(client, id).queryKey, {
+        type: 'document',
+        document: {metadata: {name: 'Home document'}},
+      })
+    }
+    const html = renderToStaticMarkup(
+      createElement(
+        QueryClientProvider,
+        {client: queryClient},
+        createElement(
+          UniversalAppProvider,
+          {universalClient: client, openUrl: () => {}, openRoute: () => {}},
+          createElement(MentionToken, {value: link, mentionKind}),
+        ),
+      ),
+    )
+    queryClient.clear()
+    return html
+  }
+
+  it.each([
+    ['hm://alice/:profile', 'account'],
+    ['hm://alice/:profile', undefined],
+    ['hm://alice', undefined],
+  ] as const)('prefixes account label %s (%s) with @', (link, kind) => {
+    expect(renderMention(link, kind)).toContain('>@Alice<')
+  })
+
+  it('does not duplicate an existing @ in a profile name or petname', () => {
+    expect(renderMention('hm://alice/:profile', 'account', '@Alice')).toContain('>@Alice<')
+  })
+
+  it.each([
+    ['hm://alice', 'document'],
+    ['hm://alice/page', 'document'],
+    ['hm://alice/page', undefined],
+  ] as const)('keeps document label %s (%s) unprefixed', (link, kind) => {
+    expect(renderMention(link, kind)).toContain('>Home document<')
+    expect(renderMention(link, kind)).not.toContain('@Home document')
   })
 })

--- a/frontend/packages/editor/src/mentions-plugin.tsx
+++ b/frontend/packages/editor/src/mentions-plugin.tsx
@@ -29,7 +29,12 @@ export function createInlineEmbedNode() {
     renderHTML({node, HTMLAttributes}) {
       return [
         'a',
-        {...HTMLAttributes, href: HTMLAttributes.link, 'data-inline-embed': HTMLAttributes.link},
+        {
+          ...HTMLAttributes,
+          href: HTMLAttributes.link,
+          'data-inline-embed': HTMLAttributes.link,
+          ...(node.attrs.mentionKind ? {'data-mention-kind': node.attrs.mentionKind} : {}),
+        },
         inlineEmbedClipboardText(node.attrs.link),
       ]
     },
@@ -44,7 +49,8 @@ export function createInlineEmbedNode() {
           getAttrs: (dom) => {
             if (dom instanceof HTMLElement) {
               var value = dom.getAttribute('data-inline-embed')
-              return {link: value}
+              const kind = dom.getAttribute('data-mention-kind')
+              return {link: value, mentionKind: kind === 'account' || kind === 'document' ? kind : null}
             }
             return false
           },
@@ -55,7 +61,8 @@ export function createInlineEmbedNode() {
           getAttrs: (dom) => {
             if (dom instanceof HTMLElement) {
               var value = dom.getAttribute('data-inline-embed')
-              return {link: value}
+              const kind = dom.getAttribute('data-mention-kind')
+              return {link: value, mentionKind: kind === 'account' || kind === 'document' ? kind : null}
             }
             return false
           },
@@ -64,6 +71,7 @@ export function createInlineEmbedNode() {
     },
     addAttributes() {
       return {
+        mentionKind: {default: null, rendered: false},
         link: {
           default: '',
         },
@@ -112,18 +120,26 @@ function InlineEmbedNodeComponent(props: any) {
       as={isEditable ? 'span' : 'a'}
       className={`inline-embed-token ${props.selected ? 'selected' : ''}`}
       data-inline-embed={props.node.attrs.link}
+      data-mention-kind={props.node.attrs.mentionKind || undefined}
       {...wrapperProps}
     >
-      <MentionToken value={props.node.attrs.link} selected={props.selected} />
+      <MentionToken
+        value={props.node.attrs.link}
+        mentionKind={props.node.attrs.mentionKind}
+        selected={props.selected}
+      />
     </NodeViewWrapper>
   )
 }
 
-export function MentionToken(props: {value: string; selected?: boolean}) {
+/** Renders explicit mention identities while preserving legacy root-account references. */
+export function MentionToken(props: {value: string; mentionKind?: 'account' | 'document'; selected?: boolean}) {
   const unpackedRef = unpackHmId(props.value)
   const profileAccountUid = unpackedRef?.path?.[0] === ':profile' ? unpackedRef.path[1] || unpackedRef.uid : null
 
-  if (profileAccountUid) {
+  if (unpackedRef && props.mentionKind === 'document') {
+    return <DocumentMention unpackedRef={unpackedRef} {...props} />
+  } else if (profileAccountUid) {
     return <ContactMention accountUid={profileAccountUid} highlightId={hmId(profileAccountUid)} {...props} />
   } else if (unpackedRef && unpackedRef.path && unpackedRef.path.length > 0) {
     return <DocumentMention unpackedRef={unpackedRef} {...props} />
@@ -166,7 +182,7 @@ function ContactMention({
 
   return (
     <MentionText selected={selected} {...highlight(highlightId)}>
-      {meta.name}
+      {meta.name.startsWith('@') ? meta.name : `@${meta.name}`}
     </MentionText>
   )
 }

--- a/frontend/packages/editor/src/mobile-mentions-dialog.test.tsx
+++ b/frontend/packages/editor/src/mobile-mentions-dialog.test.tsx
@@ -1,0 +1,44 @@
+import {createRoot} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+import {MobileMentionsDialog} from './mobile-mentions-dialog'
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+describe('mobile mention viewport', () => {
+  afterEach(() => vi.unstubAllGlobals())
+  it('resizes and repositions with the visible keyboard viewport', () => {
+    const viewport = Object.assign(new EventTarget(), {height: 600, offsetTop: 0})
+    vi.stubGlobal('visualViewport', viewport)
+    const container = document.createElement('div')
+    document.body.append(container)
+    const root = createRoot(container)
+    act(() =>
+      root.render(
+        <MobileMentionsDialog
+          isOpen
+          onClose={() => {}}
+          onSelect={() => {}}
+          mode="document"
+          query=""
+          onQuery={() => {}}
+          results={[]}
+          loading={false}
+          error={false}
+          onRetry={() => {}}
+          onRestoreFocus={() => {}}
+        />,
+      ),
+    )
+    const dialog = document.querySelector('[role="dialog"]') as HTMLElement
+    expect(dialog.style.height).toBe('600px')
+    act(() => {
+      viewport.height = 320
+      viewport.offsetTop = 40
+      viewport.dispatchEvent(new Event('resize'))
+    })
+    expect(dialog.style.height).toBe('320px')
+    expect(dialog.style.top).toBe('40px')
+    act(() => root.unmount())
+    container.remove()
+  })
+})

--- a/frontend/packages/editor/src/mobile-mentions-dialog.tsx
+++ b/frontend/packages/editor/src/mobile-mentions-dialog.tsx
@@ -1,153 +1,140 @@
-import {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
-import {InlineMentionsResult, useInlineMentions} from '@shm/shared/models/inline-mentions'
+import {mentionCandidateSubtitle} from '@shm/shared/models/mention-ranking'
+import {InlineMentionsResult} from '@shm/shared/models/inline-mentions'
 import {Button} from '@shm/ui/button'
 import {Dialog, DialogContent, DialogHeader, DialogTitle} from '@shm/ui/components/dialog'
 import {Input} from '@shm/ui/components/input'
 import {LoadedHMIcon} from '@shm/ui/hm-icon'
-import {Search, X} from '@shm/ui/icons'
-import {SizableText} from '@shm/ui/text'
-import {useEffect, useState} from 'react'
+import {X} from '@shm/ui/icons'
+import {useEffect, useLayoutEffect, useRef, useState} from 'react'
+import {MentionMode} from './mention-suggestion-plugin'
 
-interface MobileMentionsDialogProps {
+/** Mobile presentation of the same ranked suggestions and insertion operation as desktop. */
+export function MobileMentionsDialog({
+  isOpen,
+  onClose,
+  onSelect,
+  mode,
+  query,
+  onQuery,
+  results,
+  loading,
+  error,
+  onRetry,
+  onRestoreFocus,
+}: {
   isOpen: boolean
   onClose: () => void
-  onSelect: (mention: {id: UnpackedHypermediaId; label: string; type: string}) => void
-  perspectiveAccountUid?: string | null | undefined
-}
-
-export function MobileMentionsDialog({isOpen, onClose, onSelect, perspectiveAccountUid}: MobileMentionsDialogProps) {
-  const [searchQuery, setSearchQuery] = useState('')
-  const [results, setResults] = useState<InlineMentionsResult>({
-    Profiles: [],
-    Documents: [],
-    Recents: [],
-    Contacts: [],
-  })
-  const [isLoading, setIsLoading] = useState(false)
-  const {onMentionsQuery} = useInlineMentions(perspectiveAccountUid)
-
+  onSelect: (item: InlineMentionsResult[number]) => void
+  mode: MentionMode
+  query: string
+  onQuery: (query: string) => void
+  results: InlineMentionsResult
+  loading: boolean
+  error: boolean
+  onRetry: () => void
+  onRestoreFocus: () => void
+}) {
+  const wasOpen = useRef(isOpen)
   useEffect(() => {
-    if (!isOpen) {
-      setSearchQuery('')
-      setResults({Profiles: [], Documents: [], Recents: [], Contacts: []})
-      return
+    if (wasOpen.current && !isOpen) onRestoreFocus()
+    wasOpen.current = isOpen
+  }, [isOpen, onRestoreFocus])
+  const [viewportBounds, setViewportBounds] = useState<{height: number; top: number}>()
+  useLayoutEffect(() => {
+    if (!isOpen || !window.visualViewport) return
+    const viewport = window.visualViewport
+    const update = () => setViewportBounds({height: viewport.height, top: viewport.offsetTop})
+    update()
+    viewport.addEventListener('resize', update)
+    viewport.addEventListener('scroll', update)
+    return () => {
+      viewport.removeEventListener('resize', update)
+      viewport.removeEventListener('scroll', update)
     }
-
-    const search = async () => {
-      setIsLoading(true)
-      try {
-        const mentionResults = await onMentionsQuery(searchQuery)
-        setResults(mentionResults)
-      } catch (error) {
-        console.error('Failed to search mentions:', error)
-      } finally {
-        setIsLoading(false)
-      }
-    }
-
-    const timeoutId = setTimeout(search, 300)
-    return () => clearTimeout(timeoutId)
-  }, [searchQuery, isOpen])
-
-  const handleSelectMention = (item: any) => {
-    onSelect({
-      id: item.id,
-      label: item.title || item.label || 'Unknown',
-      type: item.type,
-    })
-    onClose()
-  }
-
-  const allResults = [...results.Contacts, ...results.Profiles, ...results.Documents, ...results.Recents]
-
+  }, [isOpen])
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="h-[100dvh] max-h-[100dvh] w-full max-w-full rounded-none p-0" showCloseButton={false}>
+      <DialogContent
+        className="mention-mobile-dialog top-0 h-dvh max-h-dvh w-full max-w-full translate-y-0 rounded-none p-0"
+        style={
+          viewportBounds
+            ? {height: viewportBounds.height, maxHeight: viewportBounds.height, top: viewportBounds.top}
+            : undefined
+        }
+        aria-describedby={undefined}
+        showCloseButton={false}
+        onCloseAutoFocus={(event) => {
+          event.preventDefault()
+          onRestoreFocus()
+        }}
+      >
         <div className="flex h-full flex-col overflow-hidden">
           <DialogHeader className="border-b p-4">
             <div className="flex items-center justify-between">
-              <DialogTitle>Mention Contact, Profile, or Document</DialogTitle>
-              <Button size="icon" variant="ghost" onClick={onClose} className="size-8">
+              <DialogTitle>{mode === 'account' ? 'Mention account' : 'Link document'}</DialogTitle>
+              <Button size="icon" variant="ghost" aria-label="Cancel mention" onClick={onClose}>
                 <X className="size-4" />
               </Button>
             </div>
           </DialogHeader>
-
           <div className="border-b p-4">
-            <div className="relative">
-              <Search className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
-              <Input
-                placeholder="Search for people, profiles, or documents…"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="pl-10"
-                autoFocus
-              />
-            </div>
+            <Input
+              aria-label={mode === 'account' ? 'Search accounts' : 'Search documents'}
+              placeholder={mode === 'account' ? 'Search accounts…' : 'Search documents…'}
+              value={query}
+              onChange={(event) => onQuery(event.target.value)}
+              autoFocus
+            />
           </div>
-
-          <div className="flex-1 overflow-y-auto">
-            {isLoading ? (
-              <div className="flex items-center justify-center py-8">
-                <SizableText className="text-muted-foreground">Searching…</SizableText>
-              </div>
-            ) : allResults.length === 0 ? (
-              <div className="flex items-center justify-center py-8">
-                <SizableText className="text-muted-foreground">
-                  {searchQuery ? 'No results found' : 'Start typing to search…'}
-                </SizableText>
-              </div>
-            ) : (
-              <div className="divide-y">
-                {results.Contacts.length > 0 && (
-                  <MentionSection title="Contacts" items={results.Contacts} onSelect={handleSelectMention} />
-                )}
-                {results.Profiles.length > 0 && (
-                  <MentionSection title="Profiles" items={results.Profiles} onSelect={handleSelectMention} />
-                )}
-                {results.Documents.length > 0 && (
-                  <MentionSection title="Documents" items={results.Documents} onSelect={handleSelectMention} />
-                )}
-                {results.Recents.length > 0 && searchQuery === '' && (
-                  <MentionSection title="Recent" items={results.Recents} onSelect={handleSelectMention} />
-                )}
+          <div
+            className="min-h-0 flex-1 overflow-y-auto"
+            role="listbox"
+            aria-label={mode === 'account' ? 'Accounts' : 'Documents'}
+            aria-busy={loading}
+          >
+            {loading && (
+              <p role="status" className="text-muted-foreground p-4">
+                Searching…
+              </p>
+            )}
+            {error && (
+              <div role="alert" className="p-4">
+                Unable to load mentions or resolve the published version.{' '}
+                <Button variant="ghost" onClick={onRetry}>
+                  Retry
+                </Button>
               </div>
             )}
+            {!loading && !error && !results.length && (
+              <p role="status" className="text-muted-foreground p-4">
+                No {mode === 'account' ? 'accounts' : 'documents'} found
+              </p>
+            )}
+            {results.map((item) => (
+              <Button
+                key={item.id.id}
+                role="option"
+                aria-selected={false}
+                disabled={loading || error}
+                variant="ghost"
+                className="h-auto min-h-12 w-full justify-start gap-3 px-4 py-3"
+                onClick={() => onSelect(item)}
+              >
+                <LoadedHMIcon id={item.id} size={32} />
+                <span className="flex min-w-0 flex-col items-start text-left">
+                  <span>{item.title || item.id.uid}</span>
+                  <span
+                    className="text-muted-foreground text-xs"
+                    title={item.type === 'account' ? item.id.uid : undefined}
+                  >
+                    {mentionCandidateSubtitle(item)}
+                  </span>
+                </span>
+              </Button>
+            ))}
           </div>
         </div>
       </DialogContent>
     </Dialog>
-  )
-}
-
-function MentionSection({title, items, onSelect}: {title: string; items: any[]; onSelect: (item: any) => void}) {
-  if (items.length === 0) return null
-
-  return (
-    <div className="py-2">
-      <SizableText size="xs" weight="medium" className="text-muted-foreground px-4 py-2">
-        {title}
-      </SizableText>
-      {items.map((item) => (
-        <Button
-          key={item.id.id}
-          variant="ghost"
-          className="h-auto w-full justify-start px-4 py-3"
-          onClick={() => onSelect(item)}
-        >
-          <div className="flex items-center gap-3">
-            <LoadedHMIcon id={item.id} size={32} />
-            <div className="flex flex-col items-start">
-              <SizableText>{item.title || 'Untitled'}</SizableText>
-              {item.subtitle && (
-                <SizableText size="xs" className="text-muted-foreground">
-                  {item.subtitle}
-                </SizableText>
-              )}
-            </div>
-          </div>
-        </Button>
-      ))}
-    </div>
   )
 }

--- a/frontend/packages/editor/src/ssr-render.test.tsx
+++ b/frontend/packages/editor/src/ssr-render.test.tsx
@@ -3,12 +3,13 @@
 // happy-dom, React node views via renderToString. Visual parity against the
 // live editor is verified separately by apps/web/scripts/ssr-parity-check.mjs.
 import type {HMBlockNode} from '@seed-hypermedia/client/hm-types'
-import {queryQueryBlock} from '@shm/shared/models/queries'
+import {queryAccount, queryResource, queryQueryBlock} from '@shm/shared/models/queries'
 import {QueryClient} from '@tanstack/react-query'
-import {describe, expect, it} from 'vitest'
+import {describe, expect, it, vi} from 'vitest'
 import {hmBlockToEditorBlock} from '@seed-hypermedia/client/hmblock-to-editorblock'
 import {getQueryBlockInput} from './query-block-input'
 import {renderDocumentToHTML} from './ssr-render'
+import {unpackHmId} from '@shm/shared'
 
 const APP_CONTEXT = {
   origin: 'http://localhost:3000',
@@ -298,5 +299,48 @@ describe('renderDocumentToHTML', () => {
     ] as any)
     expect(html).toContain('href="http://localhost:3000/docs/page"')
     expect(html).toContain('data-hm-link="hm://uid1/docs/page"')
+  })
+})
+
+describe('server-rendered mention labels', () => {
+  it('renders prefixed account labels and unprefixed home document labels before hydration', () => {
+    const queryClient = new QueryClient()
+    const client = {request: vi.fn(async () => null)} as any
+    queryClient.setQueryData(queryAccount(client, 'alice').queryKey, {metadata: {name: 'Alice'}})
+    queryClient.setQueryData(queryResource(client, unpackHmId('hm://alice')).queryKey, {
+      type: 'document',
+      document: {metadata: {name: 'Home document'}},
+    })
+    const html = renderDocumentToHTML(
+      [
+        {
+          block: {
+            id: 'mentions',
+            type: 'Paragraph',
+            text: '\uFFFC and \uFFFC',
+            attributes: {},
+            annotations: [
+              {
+                type: 'Embed',
+                link: 'hm://alice/:profile',
+                starts: [0],
+                ends: [1],
+                attributes: {mentionKind: 'account'},
+              },
+              {type: 'Embed', link: 'hm://alice', starts: [6], ends: [7], attributes: {mentionKind: 'document'}},
+            ],
+          },
+          children: [],
+        },
+      ] as any,
+      {queryClient, appContext: {...APP_CONTEXT, universalClient: client}},
+    )
+    expect(client.request).not.toHaveBeenCalled()
+    expect(html).toContain('>@Alice<')
+    expect(html).toContain('>Home document<')
+    expect(html).not.toContain('@Home document')
+    expect(html).toContain('data-mention-kind="account"')
+    expect(html).toContain('href="/hm/alice/:profile"')
+    queryClient.clear()
   })
 })

--- a/frontend/packages/editor/src/ssr-render.tsx
+++ b/frontend/packages/editor/src/ssr-render.tsx
@@ -46,6 +46,7 @@ import {blockToNode} from './blocknote/core/api/nodeConversions/nodeConversions'
 import editorStyles from './blocknote/core/editor.module.css'
 import blockStyles from './blocknote/core/extensions/Blocks/nodes/Block.module.css'
 import {hmBlockSchema} from './schema'
+import {MentionToken} from './mentions-plugin'
 import {setSSREmbedRenderer} from './ssr-embed-renderer'
 import {CodeBlockScroller} from './tiptap-extension-code-block/code-block-view'
 import {getHighlightRuns} from './tiptap-extension-code-block/lowlight-plugin'
@@ -205,6 +206,23 @@ function renderUncached(blocks: HMBlockNode[], opts: SSRRenderOpts): string | nu
   // 4. Post-process: React node-view blocks, code highlighting, link hrefs.
   const blockById = indexEditorBlocks(editorBlocks)
   renderReactBlocks(target, blockById, opts)
+  for (const mention of Array.from(target.querySelectorAll('a[data-inline-embed]'))) {
+    const value = mention.getAttribute('data-inline-embed') || ''
+    const kind = mention.getAttribute('data-mention-kind')
+    mention.classList.add('inline-embed-token')
+    mention.innerHTML = renderToString(
+      <QueryClientProvider client={opts.queryClient}>
+        <UniversalAppProvider
+          openUrl={() => {}}
+          openRoute={() => {}}
+          universalClient={undefined as any}
+          {...(opts.appContext || {})}
+        >
+          <MentionToken value={value} mentionKind={kind === 'account' || kind === 'document' ? kind : undefined} />
+        </UniversalAppProvider>
+      </QueryClientProvider>,
+    )
+  }
   renderCodeBlocks(target, blockById)
   addTrailingBreaks(target)
   rewriteLinkHrefs(target, opts.renderHref)

--- a/frontend/packages/shared/src/__tests__/content-refs.test.ts
+++ b/frontend/packages/shared/src/__tests__/content-refs.test.ts
@@ -533,3 +533,20 @@ describe('extractAllContentRefs from editor draft blocks', () => {
     expect(hasQueryBlockTargetingSelf(editorBlocksToHMBlockNodes(draftBlocks), 'uid1', null)).toBe(true)
   })
 })
+
+it('preserves explicit mention kind when extracting references', () => {
+  const refs = extractAllContentRefs([
+    {
+      block: {
+        id: 'p',
+        type: 'Paragraph',
+        text: '\uFFFC',
+        annotations: [
+          {type: 'Embed', link: 'hm://alice', starts: [0], ends: [1], attributes: {mentionKind: 'document'}},
+        ],
+      },
+      children: [],
+    },
+  ] as any)
+  expect(refs[0]).toHaveProperty('mentionKind', 'document')
+})

--- a/frontend/packages/shared/src/__tests__/content-to-text.test.ts
+++ b/frontend/packages/shared/src/__tests__/content-to-text.test.ts
@@ -834,3 +834,51 @@ describe('documentToText', () => {
     expect(result).toBe('Block 1 - included\n\nBlock 2 - included')
   })
 })
+
+it('keeps explicit home-document labels separate from legacy account labels', () => {
+  expect(
+    contentToText({
+      content: [
+        {
+          block: {
+            type: 'Paragraph',
+            id: 'p',
+            text: '\uFFFC \uFFFC',
+            annotations: [
+              {type: 'Embed', link: 'hm://alice', starts: [0], ends: [1]},
+              {type: 'Embed', link: 'hm://alice', starts: [2], ends: [3], attributes: {mentionKind: 'document'}},
+            ],
+          },
+          children: [],
+        },
+      ] as any,
+      resolvedNames: {'hm://alice': 'Alice', 'document:hm://alice': 'Home Page'},
+    }),
+  ).toBe('Alice Home Page')
+})
+
+it('resolves profile account names without requiring a home document', async () => {
+  const grpcClient = createMockGrpcClient({
+    root: {
+      content: [
+        {
+          block: {
+            type: 'Paragraph',
+            text: '\uFFFC',
+            annotations: [
+              {
+                type: 'Embed',
+                link: 'hm://alice/:profile',
+                starts: [0],
+                ends: [1],
+                attributes: {mentionKind: 'account'},
+              },
+            ],
+          },
+        },
+      ],
+    },
+  })
+  Object.assign(grpcClient.documents, {getAccount: vi.fn(async () => ({profile: {name: 'Alice'}}))})
+  expect(await documentToText({documentId: hmId('root'), grpcClient, options: {}})).toBe('[Alice]')
+})

--- a/frontend/packages/shared/src/__tests__/routes.test.ts
+++ b/frontend/packages/shared/src/__tests__/routes.test.ts
@@ -6,6 +6,7 @@ import {
   createInspectNavRoute,
   createRouteFromInspectNavRoute,
   defaultRoute,
+  getRecentsRouteEntityUrl,
   navRouteSchema,
   replaceRouteDocumentId,
   type NavRoute,
@@ -1046,5 +1047,27 @@ describe('comment permalink version (?v pins the comment version)', () => {
       openComment: 'z6Mk/z6FC',
       openCommentVersion: 'bafyCommentVersion',
     })
+  })
+})
+
+describe('recent route identity', () => {
+  test('keeps profile visits distinct from home documents', () => {
+    expect(getRecentsRouteEntityUrl({key: 'profile', id: hmId('alice')})).toBe('hm://alice/:profile')
+    expect(getRecentsRouteEntityUrl({key: 'document', id: hmId('alice', {version: 'old'})})).toBe('hm://alice')
+  })
+  test('records the viewed account, not the hosting site', () => {
+    expect(
+      getRecentsRouteEntityUrl({key: 'site-profile', id: hmId('site'), accountUid: 'alice', tab: 'following'}),
+    ).toBe('hm://alice/:profile')
+    expect(getRecentsRouteEntityUrl({key: 'site-profile', id: hmId('site'), tab: 'profile'})).toBe('hm://site/:profile')
+  })
+  test('ignores document version and panel changes', () => {
+    expect(
+      getRecentsRouteEntityUrl({
+        key: 'document',
+        id: hmId('alice', {path: ['post'], version: 'old', blockRef: 'block'}),
+      }),
+    ).toBe('hm://alice/post')
+    expect(getRecentsRouteEntityUrl({key: 'draft', id: 'draft'} as NavRoute)).toBeNull()
   })
 })

--- a/frontend/packages/shared/src/api-mention-candidates.test.ts
+++ b/frontend/packages/shared/src/api-mention-candidates.test.ts
@@ -1,0 +1,300 @@
+import {describe, expect, it, vi} from 'vitest'
+import {Code, ConnectError} from '@connectrpc/connect'
+import {Struct, Timestamp} from '@bufbuild/protobuf'
+import {deserialize} from 'superjson'
+import {handleApiRequest} from './api-server'
+import {MentionCandidates} from './api-mention-candidates'
+import type {GRPCClient} from './grpc-client'
+import {Contact, Account} from './client/.generated/documents/v3alpha/documents_pb'
+import {Capability, Role} from './client/.generated/documents/v3alpha/access_control_pb'
+import {Event} from './client/.generated/activity/v1alpha/activity_pb'
+import {rankMentionCandidates} from './models/mention-ranking'
+import {hmId} from './utils/entity-id-url'
+
+// The remote daemon is the boundary; use realistic gRPC shapes and assert the public result.
+function daemon() {
+  return {
+    entities: {
+      searchEntities: vi.fn(async () => ({
+        entities: [
+          {id: 'hm://alice', type: 'profile', content: 'Alice'},
+          {id: 'hm://space', type: 'document', content: 'Old home title'},
+        ],
+      })),
+    },
+    documents: {
+      getAccount: vi.fn(async ({id}: {id: string}) => new Account({id, profile: {name: 'Alice'}})),
+      getDocumentInfo: vi.fn(async ({account, path}: {account: string; path: string}) => ({
+        account,
+        path,
+        version: 'current-head',
+        metadata: Struct.fromJson({name: 'Current home'}),
+        updateTime: Timestamp.fromDate(new Date('2026-09-10')),
+      })),
+      listDocuments: vi.fn(async () => ({documents: []})),
+      listAccounts: vi.fn(async () => ({accounts: [] as Account[]})),
+      listContacts: vi.fn(async () => ({contacts: [] as Contact[]})),
+    },
+    activityFeed: {listEvents: vi.fn(async () => ({events: [] as Event[]}))},
+    accessControl: {listCapabilities: vi.fn(async () => ({capabilities: [] as Capability[]}))},
+  }
+}
+describe('mention candidate service', () => {
+  it('serves account candidates through the HTTP route with editor context', async () => {
+    const client = daemon()
+    const url = new URL('http://localhost/api/MentionCandidates')
+    url.searchParams.set('mode', 'account')
+    url.searchParams.set('query', 'Alice')
+    url.searchParams.set('perspectiveAccountUid', 'viewer')
+    url.searchParams.set('siteUid', 'space')
+    url.searchParams.set('documentId', JSON.stringify(hmId('space', {path: ['page']})))
+    url.searchParams.set('seedIds', JSON.stringify([hmId('alice', {path: [':profile']})]))
+    const result = await handleApiRequest(url, client as unknown as GRPCClient, vi.fn())
+    expect(result.status).toBe(200)
+    expect(deserialize(JSON.parse(result.body))).toEqual([
+      expect.objectContaining({type: 'account', id: expect.objectContaining({uid: 'alice'})}),
+      expect.objectContaining({type: 'account', sameSite: true, id: expect.objectContaining({uid: 'space'})}),
+    ])
+    expect(client.documents.getDocumentInfo).not.toHaveBeenCalled()
+  })
+
+  it('returns profile-only accounts without resolving a home document', async () => {
+    const client = daemon()
+    const result = await MentionCandidates.getData(
+      client as unknown as GRPCClient,
+      {mode: 'account', query: 'Alice'},
+      async () => {
+        throw new Error('unexpected daemon query')
+      },
+    )
+    expect(result.map((c) => [c.type, c.id.uid])).toEqual([['account', 'alice']])
+    expect(client.documents.getDocumentInfo).not.toHaveBeenCalled()
+  })
+  it('uses the verified document head and latest flag, never a profile search hit', async () => {
+    const client = daemon()
+    client.entities.searchEntities.mockResolvedValue({
+      entities: [{id: 'hm://space', type: 'title', content: 'Old home title'}],
+    })
+    const result = await MentionCandidates.getData(
+      client as unknown as GRPCClient,
+      {mode: 'document', query: 'home'},
+      async () => {
+        throw new Error('unexpected daemon query')
+      },
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      type: 'document',
+      title: 'Current home',
+      id: {uid: 'space', path: [], version: 'current-head', latest: true},
+    })
+  })
+  it('omits unpublished or inaccessible documents instead of producing account links', async () => {
+    const client = daemon()
+    client.documents.getDocumentInfo.mockRejectedValue(new Error('not found'))
+    expect(
+      await MentionCandidates.getData(client as unknown as GRPCClient, {mode: 'document', query: 'home'}, async () => {
+        throw new Error('unexpected daemon query')
+      }),
+    ).toEqual([])
+  })
+  it('accepts document title matches and verifies profile hits as home documents', async () => {
+    const client = daemon()
+    client.entities.searchEntities.mockResolvedValue({
+      entities: [
+        {id: 'hm://space/page', type: 'title', content: 'Page'},
+        {id: 'hm://alice', type: 'profile', content: 'Alice'},
+      ],
+    })
+    const result = await MentionCandidates.getData(
+      client as unknown as GRPCClient,
+      {mode: 'document', query: 'a'},
+      async () => {
+        throw new Error('unexpected daemon query')
+      },
+    )
+    expect(result.map((c) => c.id.uid).sort()).toEqual(['alice', 'space'])
+  })
+  it('limits simultaneous metadata lookups to eight', async () => {
+    const client = daemon()
+    let active = 0
+    let peak = 0
+    client.documents.getAccount.mockImplementation(async ({id}) => {
+      active++
+      peak = Math.max(peak, active)
+      await Promise.resolve()
+      active--
+      return new Account({id, profile: {name: id}})
+    })
+    await MentionCandidates.getData(
+      client as unknown as GRPCClient,
+      {mode: 'account', query: '', seedIds: Array.from({length: 20}, (_, i) => hmId(`a${i}`))},
+      async () => {
+        throw new Error('unexpected daemon query')
+      },
+    )
+    expect(peak).toBe(8)
+  })
+  it('does not let a full following list exclude an active external account', async () => {
+    const client = daemon()
+    client.documents.listContacts.mockResolvedValue({
+      contacts: Array.from({length: 100}, (_, i) => new Contact({subject: `contact${i}`, name: `Person ${i}`})),
+    })
+    client.activityFeed.listEvents.mockResolvedValue({
+      events: [
+        new Event({
+          account: 'external',
+          eventTime: Timestamp.fromDate(new Date()),
+          data: {case: 'newBlob', value: {blobType: 'Comment', author: 'external'}},
+        }),
+      ],
+    })
+    const result = await MentionCandidates.getData(
+      client as unknown as GRPCClient,
+      {mode: 'account', query: '', perspectiveAccountUid: 'viewer'},
+      async () => {
+        throw new Error('unexpected daemon query')
+      },
+    )
+    expect(result.length).toBeLessThanOrEqual(100)
+    expect(result.some((candidate) => candidate.id.uid === 'external')).toBe(true)
+  })
+  it('preserves an exact petname match beside a full page of broad public matches', async () => {
+    const client = daemon()
+    client.entities.searchEntities.mockResolvedValue({
+      entities: Array.from({length: 100}, (_, i) => ({
+        id: `hm://public${i}`,
+        type: 'profile',
+        content: 'Alice Person',
+      })),
+    })
+    client.documents.listContacts.mockResolvedValue({contacts: [new Contact({subject: 'friend', name: 'Buddy'})]})
+    const result = await MentionCandidates.getData(
+      client as unknown as GRPCClient,
+      {mode: 'account', query: 'Buddy', perspectiveAccountUid: 'viewer'},
+      async () => {
+        throw new Error('unexpected daemon query')
+      },
+    )
+    expect(rankMentionCandidates(result, 'Buddy', [])[0]?.id.uid).toBe('friend')
+  })
+  it('resolves aliases while preserving the acting account petname', async () => {
+    const client = daemon()
+    client.documents.getAccount.mockImplementation(
+      async ({id}) => new Account({id, aliasAccount: id === 'alias' ? 'canonical' : '', profile: {name: 'Public'}}),
+    )
+    client.documents.listContacts.mockResolvedValue({contacts: [new Contact({subject: 'alias', name: 'Friend'})]})
+    const result = await MentionCandidates.getData(
+      client as unknown as GRPCClient,
+      {mode: 'account', query: '', perspectiveAccountUid: 'viewer'},
+      async () => {
+        throw new Error('unexpected daemon query')
+      },
+    )
+    expect(result[0]).toMatchObject({
+      id: {uid: 'canonical'},
+      sourceAccountUid: 'alias',
+      petname: 'Friend',
+      publicName: 'Public',
+      issuedContact: true,
+    })
+  })
+  it('offers known accounts when there is no query, following or recorded activity', async () => {
+    const client = daemon()
+    client.documents.listAccounts.mockResolvedValue({accounts: [new Account({id: 'quiet', profile: {name: 'Quiet'}})]})
+    const result = await MentionCandidates.getData(
+      client as unknown as GRPCClient,
+      {mode: 'account', query: ''},
+      async () => {
+        throw new Error('unexpected daemon query')
+      },
+    )
+    expect(result.map((c) => c.id.uid)).toEqual(['quiet'])
+  })
+  it('preserves a matching petname returned by search beyond the first contacts page', async () => {
+    const client = daemon()
+    client.entities.searchEntities.mockResolvedValue({
+      entities: [{id: 'hm://friend', type: 'contact', content: 'Buddy'}],
+    })
+    const result = await MentionCandidates.getData(
+      client as unknown as GRPCClient,
+      {mode: 'account', query: 'Buddy', perspectiveAccountUid: 'viewer'},
+      async () => {
+        throw new Error('unexpected daemon query')
+      },
+    )
+    expect(result[0]).toMatchObject({title: 'Buddy', petname: 'Buddy', issuedContact: true})
+  })
+  it.each([Code.Unavailable, Code.DeadlineExceeded])(
+    'retains a verified document head on retryable refresh failure %s',
+    async (code) => {
+      const client = daemon()
+      const input = {mode: 'document' as const, query: '', seedIds: [hmId('space', {path: ['page']})]}
+      const queryDaemon = async () => {
+        throw new Error('unexpected daemon query')
+      }
+      vi.useFakeTimers()
+      try {
+        const first = await MentionCandidates.getData(client as unknown as GRPCClient, input, queryDaemon)
+        expect(first[0]?.id.version).toBe('current-head')
+        vi.setSystemTime(Date.now() + 16_000)
+        client.documents.getDocumentInfo.mockRejectedValue(new ConnectError('offline', code))
+        const offline = await MentionCandidates.getData(client as unknown as GRPCClient, input, queryDaemon)
+        expect(offline[0]?.id).toMatchObject({version: 'current-head', latest: true})
+      } finally {
+        vi.useRealTimers()
+      }
+    },
+  )
+  it.each([Code.NotFound, Code.PermissionDenied])(
+    'does not retain a document head after definitive access failure %s',
+    async (code) => {
+      const client = daemon()
+      const input = {mode: 'document' as const, query: '', seedIds: [hmId('space', {path: ['page']})]}
+      const queryDaemon = async () => {
+        throw new Error('unexpected daemon query')
+      }
+      vi.useFakeTimers()
+      try {
+        expect(await MentionCandidates.getData(client as unknown as GRPCClient, input, queryDaemon)).toHaveLength(1)
+        vi.setSystemTime(Date.now() + 16_000)
+        client.documents.getDocumentInfo.mockRejectedValue(new ConnectError('gone', code))
+        expect(await MentionCandidates.getData(client as unknown as GRPCClient, input, queryDaemon)).toEqual([])
+      } finally {
+        vi.useRealTimers()
+      }
+    },
+  )
+})
+
+it('distinguishes site editors, document editors, followers and the owner', async () => {
+  const client = daemon()
+  client.documents.listContacts.mockResolvedValue({
+    contacts: [new Contact({account: 'follower', metadata: Struct.fromJson({subscribe: {site: true}})})],
+  })
+  client.accessControl.listCapabilities.mockResolvedValue({
+    capabilities: [
+      new Capability({delegate: 'editor', path: '', role: Role.WRITER}),
+      new Capability({delegate: 'local', path: '/page', role: Role.WRITER}),
+      new Capability({delegate: 'root-only', path: '', isExact: true, role: Role.WRITER}),
+      new Capability({delegate: 'editor', path: '/page', role: Role.WRITER}),
+    ],
+  })
+  const result = await MentionCandidates.getData(
+    client as unknown as GRPCClient,
+    {
+      mode: 'account',
+      query: '',
+      siteUid: 'site',
+      documentId: hmId('site', {path: ['page']}),
+    },
+    vi.fn(),
+  )
+  expect(Object.fromEntries(result.map((c) => [c.id.uid, c.accountRole]))).toEqual({
+    site: 'site-owner',
+    follower: 'site-follower',
+    editor: 'site-editor',
+    local: 'document-editor',
+    'root-only': 'document-editor',
+  })
+})

--- a/frontend/packages/shared/src/api-mention-candidates.ts
+++ b/frontend/packages/shared/src/api-mention-candidates.ts
@@ -1,0 +1,264 @@
+import type {HMMentionCandidate, HMMentionCandidatesRequest} from '@seed-hypermedia/client/hm-types'
+import {Code, ConnectError} from '@connectrpc/connect'
+import {loadAccount} from './api-account'
+import {EntityKindFilter} from './client/.generated/entities/v1alpha/entities_pb'
+import type {HMRequestImplementation} from './api-types'
+import type {GRPCClient} from './grpc-client'
+import {Role} from './client/.generated/documents/v3alpha/access_control_pb'
+import {FeedOrder} from './client/.generated/activity/v1alpha/activity_pb'
+import {hmId, unpackHmId} from './utils/entity-id-url'
+import {entityQueryPathToHmIdPath, hmIdPathToEntityQueryPath} from './utils/path-api'
+
+const LIMIT = 100
+const caches = new WeakMap<GRPCClient, Map<string, {expires: number; value: Promise<unknown>}>>()
+
+// Public metadata and graph lookups are reused across queries, but never across daemon clients.
+function cached<T>(client: GRPCClient, key: string, get: () => Promise<T>, retainVerifiedHead = false): Promise<T> {
+  let cache = caches.get(client)
+  if (!cache) {
+    cache = new Map()
+    caches.set(client, cache)
+  }
+  const existing = cache.get(key)
+  if (existing && existing.expires > Date.now()) return existing.value as Promise<T>
+  if (cache.size > 500) cache.clear()
+  const value = get().catch((error) => {
+    if (
+      retainVerifiedHead &&
+      existing &&
+      error instanceof ConnectError &&
+      (error.code === Code.Unavailable || error.code === Code.DeadlineExceeded)
+    ) {
+      return existing.value as Promise<T>
+    }
+    cache.delete(key)
+    throw error
+  })
+  cache.set(key, {expires: Date.now() + 15_000, value})
+  return value
+}
+
+/** Mode-specific bounded mention discovery, using raw search types and current published heads. */
+export const MentionCandidates: HMRequestImplementation<HMMentionCandidatesRequest> = {
+  async getData(client, input) {
+    const query = input.query.trim()
+    const [search, contacts, members, capabilities, events, directory, knownAccounts] = await Promise.all([
+      query
+        ? client.entities.searchEntities({
+            query,
+            loggedAccountUid: input.perspectiveAccountUid,
+            includeBody: false,
+            pageSize: LIMIT,
+            entityKindFilter:
+              input.mode === 'account'
+                ? [EntityKindFilter.ENTITY_KIND_SPACE, EntityKindFilter.ENTITY_KIND_CONTACT]
+                : [EntityKindFilter.ENTITY_KIND_SPACE, EntityKindFilter.ENTITY_KIND_DOCUMENT],
+          })
+        : undefined,
+      input.perspectiveAccountUid
+        ? client.documents
+            .listContacts({filter: {case: 'account', value: input.perspectiveAccountUid}, pageSize: LIMIT})
+            .catch(() => undefined)
+        : undefined,
+      input.siteUid
+        ? cached(client, `members:${input.siteUid}`, () =>
+            client.documents.listContacts({filter: {case: 'subject', value: input.siteUid!}, pageSize: LIMIT}),
+          ).catch(() => undefined)
+        : undefined,
+      input.siteUid
+        ? cached(client, `caps:${input.siteUid}:${input.documentId?.path?.join('/') || ''}`, () =>
+            client.accessControl.listCapabilities({
+              account: input.siteUid!,
+              path: hmIdPathToEntityQueryPath(input.documentId?.path ?? null),
+              pageSize: LIMIT,
+            }),
+          ).catch(() => undefined)
+        : undefined,
+      cached(client, 'mention-activity', () =>
+        client.activityFeed.listEvents({
+          pageSize: LIMIT,
+          filterEventType: ['Ref', 'Comment'],
+          order: FeedOrder.CLAIMED_TIME,
+        }),
+      ).catch(() => undefined),
+      input.mode === 'document'
+        ? cached(client, `mention-documents:${input.siteUid || ''}`, () =>
+            client.documents.listDocuments({account: input.siteUid, pageSize: LIMIT}),
+          ).catch(() => undefined)
+        : undefined,
+      input.mode === 'account' && !query
+        ? cached(client, 'mention-known-accounts', () => client.documents.listAccounts({pageSize: LIMIT})).catch(
+            () => undefined,
+          )
+        : undefined,
+    ])
+    const contactNames = new Map(contacts?.contacts.map((c) => [c.subject, c.name]))
+    // Search can find a matching issued contact beyond the bounded first contacts page.
+    if (input.perspectiveAccountUid)
+      search?.entities.forEach((entity) => {
+        if (entity.type !== 'contact') return
+        const id = unpackHmId(entity.id)
+        if (id && !contactNames.has(id.uid)) contactNames.set(id.uid, entity.content)
+      })
+    const accountRoles = new Map<string, NonNullable<HMMentionCandidate['accountRole']>>()
+    if (input.siteUid) accountRoles.set(input.siteUid, 'site-owner')
+    members?.contacts.forEach((c) => {
+      if ((c.metadata?.toJson() as {subscribe?: {site?: boolean}})?.subscribe?.site && !accountRoles.has(c.account))
+        accountRoles.set(c.account, 'site-follower')
+    })
+    capabilities?.capabilities.forEach((c) => {
+      if (c.role !== Role.WRITER) return
+      const current = accountRoles.get(c.delegate)
+      if (current === 'site-owner' || current === 'site-editor') return
+      accountRoles.set(c.delegate, c.path || c.isExact ? 'document-editor' : 'site-editor')
+    })
+    const siteMembers = new Set(accountRoles.keys())
+    const activity = new Map<string, {time: number; type: 'publication' | 'comment'}>()
+    const ids = new Map<string, ReturnType<typeof hmId>>()
+    const add = (id: ReturnType<typeof hmId>) => {
+      const key = input.mode === 'account' ? id.uid : `${id.uid}:${JSON.stringify(id.path || [])}`
+      if (!ids.has(key)) ids.set(key, id)
+    }
+    // Matches enter the bounded pool before contextual candidates.
+    search?.entities.forEach((entity) => {
+      const id = unpackHmId(entity.id)
+      if (!id) return
+      if (
+        input.mode === 'account' &&
+        (entity.type === 'profile' || entity.type === 'contact' || (!id.path?.length && entity.type === 'title'))
+      )
+        add(hmId(id.uid))
+      if (input.mode === 'document' && ['document', 'title', 'profile'].includes(entity.type))
+        add(hmId(id.uid, {path: id.path}))
+    })
+    input.seedIds?.slice(0, 20).forEach((id) => {
+      add(id)
+    })
+    if (input.mode === 'account') {
+      contactNames.forEach((_name, uid) => add(hmId(uid)))
+      siteMembers.forEach((uid) => add(hmId(uid)))
+    }
+    events?.events.forEach((event) => {
+      if (event.data.case !== 'newBlob') return
+      const blob = event.data.value
+      if (blob.blobType !== 'Ref' && blob.blobType !== 'Comment') return
+      const author = event.account || blob.author
+      const time = event.eventTime?.toDate().getTime()
+      if (author && time !== undefined && (!activity.has(author) || activity.get(author)!.time < time))
+        activity.set(author, {time, type: blob.blobType === 'Comment' ? 'comment' : 'publication'})
+      if (input.mode === 'account' && author) add(hmId(author))
+      if (input.mode === 'document' && blob.blobType === 'Ref') {
+        const id = unpackHmId(blob.resource)
+        if (id) add(id)
+      }
+    })
+    directory?.documents.forEach((doc) => add(hmId(doc.account, {path: entityQueryPathToHmIdPath(doc.path)})))
+    knownAccounts?.accounts.forEach((account) => add(hmId(account.id)))
+    // Interleave contextual sources so a large following list cannot exclude activity/site seeds.
+    const matching = new Set(
+      search?.entities.map((e) => unpackHmId(e.id)?.uid + ':' + JSON.stringify(unpackHmId(e.id)?.path || [])),
+    )
+    const all = Array.from(ids.values())
+    const groups = [
+      all.filter((id) => matching.has(id.uid + ':' + JSON.stringify(id.path || []))),
+      all.filter(
+        (id) =>
+          input.seedIds?.some(
+            (seed) =>
+              seed.uid === id.uid &&
+              (input.mode === 'account' || JSON.stringify(seed.path || []) === JSON.stringify(id.path || [])),
+          ),
+      ),
+      all
+        .filter((id) => contactNames.has(id.uid))
+        .sort(
+          (a, b) =>
+            Number(contactNames.get(b.uid)?.toLocaleLowerCase().startsWith(query.toLocaleLowerCase())) -
+            Number(contactNames.get(a.uid)?.toLocaleLowerCase().startsWith(query.toLocaleLowerCase())),
+        ),
+      all.filter((id) => siteMembers.has(id.uid) || id.uid === input.siteUid),
+      all.filter((id) => activity.has(id.uid)),
+      all,
+    ]
+    const selected = new Map<string, ReturnType<typeof hmId>>()
+    for (let round = 0; round < LIMIT && selected.size < LIMIT; round++) {
+      for (const group of groups) {
+        const id = group[round]
+        if (id && selected.size < LIMIT) selected.set(input.mode === 'account' ? id.uid : id.id, id)
+      }
+    }
+    const pending = Array.from(selected.values())
+    const results: HMMentionCandidate[] = []
+    let index = 0
+    await Promise.all(
+      Array.from({length: Math.min(8, pending.length)}, async () => {
+        while (index < pending.length) {
+          const id = pending[index++]!
+          try {
+            if (input.mode === 'account') {
+              const account = await cached(client, `account:${id.uid}`, () => loadAccount(client, id.uid))
+              if (account.type !== 'account') continue
+              const uid = account.id.uid
+              const metadata = account.metadata || {}
+              const petname = contactNames.get(uid) ?? contactNames.get(id.uid)
+              const recentActivity = await cached(client, `mention-activity:${uid}`, () =>
+                client.activityFeed.listEvents({
+                  pageSize: 1,
+                  filterAuthors: [uid],
+                  filterEventType: ['Ref', 'Comment'],
+                  order: FeedOrder.CLAIMED_TIME,
+                }),
+              ).catch(() => undefined)
+              const recentEvent = recentActivity?.events[0]
+              if (recentEvent?.eventTime && recentEvent.data.case === 'newBlob')
+                activity.set(uid, {
+                  time: recentEvent.eventTime.toDate().getTime(),
+                  type: recentEvent.data.value.blobType === 'Comment' ? 'comment' : 'publication',
+                })
+              results.push({
+                id: hmId(uid),
+                type: 'account',
+                sourceAccountUid: id.uid,
+                title: petname || metadata.name || uid,
+                publicName: metadata.name,
+                petname,
+                icon: metadata.icon || '',
+                parentNames: [],
+                searchQuery: query,
+                sameSite: siteMembers.has(uid) || siteMembers.has(id.uid),
+                accountRole: accountRoles.get(uid) ?? accountRoles.get(id.uid),
+                issuedContact: contactNames.has(uid) || contactNames.has(id.uid),
+                activityTime: activity.get(uid)?.time,
+                activityType: activity.get(uid)?.type,
+              })
+            } else {
+              const doc = await cached(
+                client,
+                `document:${id.uid}:${JSON.stringify(id.path || [])}`,
+                () => client.documents.getDocumentInfo({account: id.uid, path: hmIdPathToEntityQueryPath(id.path)}),
+                true,
+              )
+              if (!doc.version) continue
+              const metadata = doc.metadata?.toJson() as {name?: string; icon?: string} | undefined
+              results.push({
+                id: hmId(doc.account, {path: entityQueryPathToHmIdPath(doc.path), version: doc.version, latest: true}),
+                type: 'document',
+                title: metadata?.name || doc.path || 'Home document',
+                icon: metadata?.icon || '',
+                parentNames: [doc.account, ...(id.path || []).slice(0, -1)],
+                searchQuery: query,
+                sameSite: doc.account === input.siteUid,
+                issuedContact: false,
+                activityTime: doc.updateTime?.toDate().getTime() ?? doc.createTime?.toDate().getTime(),
+                activityType: 'publication',
+              })
+            }
+          } catch {
+            // An unavailable or unpublished target must never become a different mention kind.
+          }
+        }
+      }),
+    )
+    return results
+  },
+}

--- a/frontend/packages/shared/src/api.ts
+++ b/frontend/packages/shared/src/api.ts
@@ -28,6 +28,7 @@ import {QueryBlock} from './api-query-block'
 import {Resource, ResourceParams} from './api-resource'
 import {ResourceMetadata, ResourceMetadataParams} from './api-resource-metadata'
 import {Search} from './api-search'
+import {MentionCandidates} from './api-mention-candidates'
 import {HMRequestImplementation, HMRequestParams} from './api-types'
 
 export const APIQueries = {
@@ -38,6 +39,7 @@ export const APIQueries = {
   AccountContacts,
   SubjectContacts,
   Search,
+  MentionCandidates,
   Query,
   QueryBlock,
   ListComments,

--- a/frontend/packages/shared/src/content-to-text.ts
+++ b/frontend/packages/shared/src/content-to-text.ts
@@ -1,4 +1,5 @@
 import {GRPCClient} from '.'
+import {accountMetadataFromAccount} from './account-metadata'
 import {HMBlock, HMBlockNode, HMComment, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {unpackHmId} from './utils/entity-id-url'
 import {hmIdPathToEntityQueryPath} from './utils/path-api'
@@ -70,7 +71,11 @@ function blockToPlainText(block: HMBlock, resolvedNames: Readonly<Record<string,
 
   const embeds = new Map<number, string>()
   for (const annotation of annotations) {
-    const name = annotation.type === 'Embed' ? resolvedNames[annotation.link] : undefined
+    const kind = annotation.attributes?.mentionKind
+    const name =
+      annotation.type === 'Embed'
+        ? (kind ? resolvedNames[`${kind}:${annotation.link}`] : undefined) ?? resolvedNames[annotation.link]
+        : undefined
     if (!name) continue
     annotation.starts?.forEach((start: number) => embeds.set(start, name))
   }
@@ -235,7 +240,9 @@ async function processAnnotations(text: string, annotations: any[], context: Con
   const resolvedNames: Record<string, string> = {}
   for (const annotation of annotations) {
     if (annotation.type === 'Embed' && annotation.link) {
-      resolvedNames[annotation.link] = `[${await resolveInlineEmbed(annotation.link, context)}]`
+      const kind = annotation.attributes?.mentionKind
+      const key = kind ? `${kind}:${annotation.link}` : annotation.link
+      resolvedNames[key] = `[${await resolveInlineEmbed(annotation.link, context, kind)}]`
     }
   }
   return contentToText({
@@ -248,7 +255,11 @@ async function processAnnotations(text: string, annotations: any[], context: Con
 /**
  * Resolves an inline embed link to a document name
  */
-async function resolveInlineEmbed(link: string, context: ConversionContext): Promise<string> {
+async function resolveInlineEmbed(
+  link: string,
+  context: ConversionContext,
+  mentionKind?: 'account' | 'document',
+): Promise<string> {
   const id = unpackHmId(link)
 
   if (!id) {
@@ -263,10 +274,16 @@ async function resolveInlineEmbed(link: string, context: ConversionContext): Pro
   }
 
   try {
+    if (mentionKind !== 'document' && (mentionKind === 'account' || id.path?.[0] === ':profile')) {
+      const account = await context.grpcClient.documents.getAccount({
+        id: id.path?.[0] === ':profile' ? id.path[1] || id.uid : id.uid,
+      })
+      return accountMetadataFromAccount(account).name || id.uid
+    }
     const document = await context.grpcClient.documents.getDocument({
       account: id.uid,
       path: hmIdPathToEntityQueryPath(id.path),
-      version: id.version || undefined,
+      version: id.latest ? undefined : id.version || undefined,
     })
 
     return (document.metadata as any)?.name || 'Untitled Document'
@@ -312,7 +329,7 @@ async function processEmbedBlock(block: HMBlock, context: ConversionContext): Pr
     const document = await context.grpcClient.documents.getDocument({
       account: id.uid,
       path: hmIdPathToEntityQueryPath(id.path),
-      version: id.version || undefined,
+      version: id.latest ? undefined : id.version || undefined,
     })
 
     if (!document.content) {

--- a/frontend/packages/shared/src/content.ts
+++ b/frontend/packages/shared/src/content.ts
@@ -186,7 +186,9 @@ export function queryBlockSortedItems({
   return reverse ? res.reverse() : res
 }
 
+/** A content reference, retaining explicit inline mention identity when present. */
 export type RefDefinition = {
+  mentionKind?: 'account' | 'document'
   blockId: string
   link: string
   refId: any
@@ -212,6 +214,7 @@ export function extractRefs(children: HMBlockNode[], skipCards?: boolean): RefDe
           blockId: block.block.id,
           link: annotation.link,
           refId: unpackHmId(annotation.link),
+          ...(annotation.attributes?.mentionKind ? {mentionKind: annotation.attributes.mentionKind} : {}),
         })
       }
     })
@@ -243,6 +246,7 @@ export function extractAllContentRefs(children: HMBlockNode[]): RefDefinition[] 
           blockId: block.block.id,
           link: annotation.link,
           refId: unpackHmId(annotation.link),
+          ...(annotation.attributes?.mentionKind ? {mentionKind: annotation.attributes.mentionKind} : {}),
         })
       }
       if (annotation.type === 'Link' && annotation.link) {

--- a/frontend/packages/shared/src/models/__tests__/notification-event-classifier.test.ts
+++ b/frontend/packages/shared/src/models/__tests__/notification-event-classifier.test.ts
@@ -1,8 +1,11 @@
 import {describe, expect, it} from 'vitest'
+import {hmId} from '../../utils/entity-id-url'
 import {
   classifyCommentNotificationForAccount,
+  classifyNotificationEvent,
   extractMentionedAccountUidsFromComment,
   getMentionedAccountUid,
+  getCitationMentionKind,
 } from '../notification-event-classifier'
 
 function makeCommentWithMention(link: string) {
@@ -99,4 +102,39 @@ describe('extractMentionedAccountUidsFromComment', () => {
       new Set(['alice']),
     )
   })
+})
+
+it('does not notify an account for an explicit home document mention', () => {
+  const comment = makeCommentWithMention('hm://alice?v=published&l')
+  Object.assign(comment.content[0]!.block.annotations[0]!, {attributes: {mentionKind: 'document'}})
+  expect(extractMentionedAccountUidsFromComment(comment)).toEqual(new Set())
+})
+
+it('does not classify explicit home document citations as account mentions', () => {
+  expect(
+    classifyNotificationEvent(
+      {type: 'citation', citationType: 'd', mentionKind: 'document', target: {id: {uid: 'alice', path: []}}} as any,
+      'alice',
+    ),
+  ).toBeNull()
+  expect(
+    classifyNotificationEvent(
+      {type: 'citation', citationType: 'd', target: {id: {uid: 'alice', path: []}}} as any,
+      'alice',
+    ),
+  ).toBe('mention')
+})
+
+it('derives citation identity from matching source blocks and preserves mixed legacy references', () => {
+  const comment = makeCommentWithMention('hm://alice?v=captured&l')
+  Object.assign(comment.content[0]!.block.annotations[0]!, {attributes: {mentionKind: 'document'}})
+  expect(getCitationMentionKind(comment.content, hmId('alice'), 'block-1')).toBe('document')
+  expect(getCitationMentionKind(comment.content, hmId('alice'), 'other-block')).toBeUndefined()
+  expect(getCitationMentionKind(comment.content, hmId('bob'))).toBeUndefined()
+  comment.content.push({
+    ...makeCommentWithMention('hm://alice').content[0]!,
+    block: {...makeCommentWithMention('hm://alice').content[0]!.block, id: 'legacy'},
+  })
+  expect(getCitationMentionKind(comment.content, hmId('alice'))).toBeUndefined()
+  expect(getCitationMentionKind(comment.content, hmId('alice'), 'block-1')).toBe('document')
 })

--- a/frontend/packages/shared/src/models/activity-service.ts
+++ b/frontend/packages/shared/src/models/activity-service.ts
@@ -10,6 +10,7 @@ import {
   UnpackedHypermediaId,
 } from '@seed-hypermedia/client/hm-types'
 import {CID} from 'multiformats'
+import {getCitationMentionKind} from './notification-event-classifier'
 import {FeedOrder} from '../client/.generated/activity/v1alpha/activity_pb'
 import {Mention} from '../client/.generated/entities/v1alpha/entities_pb'
 import {prepareHMComment, prepareHMDocument} from '../document-utils'
@@ -123,6 +124,8 @@ export type LoadedRefEvent = {
 }
 
 export type LoadedCitationEvent = {
+  /** Explicit source mention identity, absent for legacy or mixed references. */
+  mentionKind?: 'account' | 'document'
   id: string
   type: 'citation'
   citationType: 'd' | 'c' // 'd' = document reference, 'c' = comment reference
@@ -623,12 +626,14 @@ export async function loadCitationEvent(
 
     // Fetch source document metadata (best effort; keep event if metadata fails)
     let sourceMetadata: HMMetadata | undefined
+    let sourceContent: HMDocument['content'] = []
     try {
       const sourceDocument = await cache.getDocument({
         account: sourceUnpacked.uid,
         path: sourceUnpacked.path?.length ? `/${sourceUnpacked.path.join('/')}` : '',
         version: sourceVersion || undefined,
       })
+      if (sourceDocument && citationType === 'd') sourceContent = prepareHMDocument(sourceDocument).content
       sourceMetadata = sourceDocument?.metadata?.toJson({
         emitDefaultValues: true,
         enumAsInteger: false,
@@ -697,9 +702,16 @@ export async function loadCitationEvent(
       }
     }
 
+    const mentionKind = getCitationMentionKind(
+      comment?.content || sourceContent || [],
+      targetId,
+      event.newMention.sourceContext,
+    )
+
     return {
       id: eventId,
       type: 'citation',
+      mentionKind,
       citationType,
       author,
       time: event.eventTime || '',

--- a/frontend/packages/shared/src/models/comments.test.ts
+++ b/frontend/packages/shared/src/models/comments.test.ts
@@ -1,0 +1,49 @@
+import {describe, expect, it} from 'vitest'
+import type {HMComment} from '@seed-hypermedia/client/hm-types'
+import {getMentionThreadContext} from './comments'
+
+function comment(id: string, author: string, threadRoot?: string, seconds = 1): HMComment {
+  return {
+    id,
+    author,
+    version: id + '-v2',
+    threadRoot,
+    threadRootVersion: threadRoot ? threadRoot + '-v1' : undefined,
+    targetAccount: 'site',
+    targetVersion: 'v1',
+    content: [],
+    visibility: 'PUBLIC',
+    createTime: {seconds, nanos: 0},
+    updateTime: {seconds, nanos: 0},
+  }
+}
+
+describe('reply mention context', () => {
+  const comments = [
+    comment('root', 'alice'),
+    comment('reply', 'bob', 'root', 2),
+    comment('nested', 'bob', 'root', 3),
+    comment('other', 'eve'),
+  ]
+  it('includes only the current thread, deduplicates authors, and identifies the direct reply author', () => {
+    expect(getMentionThreadContext(comments, {replyCommentId: 'reply'})).toEqual({
+      replyAuthorUid: 'bob',
+      participants: [
+        {uid: 'alice', isThreadAuthor: true, latestCommentTime: 1000},
+        {uid: 'bob', isThreadAuthor: false, latestCommentTime: 3000},
+      ],
+    })
+  })
+  it('resolves replies by version when no comment ID was passed', () => {
+    expect(getMentionThreadContext(comments, {replyCommentVersion: 'reply-v2'})?.replyAuthorUid).toBe('bob')
+  })
+  it('does not boost document authors or unrelated comments outside a reply', () => {
+    expect(getMentionThreadContext(comments, {})).toBeUndefined()
+    expect(getMentionThreadContext(comments, {replyCommentId: 'missing'})).toBeUndefined()
+  })
+  it('uses a known root version when the reply parent has not loaded', () => {
+    expect(
+      getMentionThreadContext(comments, {rootReplyCommentVersion: 'root-v1'})?.participants?.map((p) => p.uid),
+    ).toEqual(['alice', 'bob'])
+  })
+})

--- a/frontend/packages/shared/src/models/comments.ts
+++ b/frontend/packages/shared/src/models/comments.ts
@@ -1,4 +1,6 @@
-import {UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {HMComment, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import type {MentionThreadContext} from './mention-ranking'
+import {normalizeDate} from '../utils/date'
 import {useQuery} from '@tanstack/react-query'
 import {useUniversalClient} from '../routing'
 import {
@@ -37,4 +39,41 @@ export function useCommentVersions(commentId: string | null | undefined) {
 export function useCommentReplyCount({id}: {id: string}) {
   const client = useUniversalClient()
   return useQuery(queryCommentReplyCount(client, id))
+}
+
+/** Builds local mention relevance from loaded comments in the thread being replied to. */
+export function getMentionThreadContext(
+  comments: HMComment[] | undefined,
+  reply: {replyCommentId?: string | null; replyCommentVersion?: string | null; rootReplyCommentVersion?: string | null},
+): MentionThreadContext | undefined {
+  if (!comments?.length) return undefined
+  const parent = comments.find(
+    (c) =>
+      (reply.replyCommentId && c.id === reply.replyCommentId) ||
+      (reply.replyCommentVersion && c.version === reply.replyCommentVersion),
+  )
+  const rootVersion = reply.rootReplyCommentVersion || parent?.threadRootVersion || parent?.version
+  const rootId =
+    parent?.threadRoot ||
+    parent?.id ||
+    comments.find((c) => rootVersion && c.version === rootVersion)?.id ||
+    comments.find((c) => rootVersion && c.threadRootVersion === rootVersion)?.threadRoot
+  if (!rootId && !rootVersion) return undefined
+  const participants = new Map<string, NonNullable<MentionThreadContext['participants']>[number]>()
+  for (const comment of comments) {
+    if (
+      !(rootId && (comment.id === rootId || comment.threadRoot === rootId)) &&
+      !(rootVersion && (comment.version === rootVersion || comment.threadRootVersion === rootVersion))
+    )
+      continue
+    const existing = participants.get(comment.author)
+    const time = normalizeDate(comment.createTime)?.getTime()
+    participants.set(comment.author, {
+      uid: comment.author,
+      isThreadAuthor: !!existing?.isThreadAuthor || comment.id === rootId,
+      latestCommentTime:
+        time === undefined ? existing?.latestCommentTime : Math.max(existing?.latestCommentTime ?? time, time),
+    })
+  }
+  return {replyAuthorUid: parent?.author, participants: Array.from(participants.values())}
 }

--- a/frontend/packages/shared/src/models/contacts.ts
+++ b/frontend/packages/shared/src/models/contacts.ts
@@ -7,7 +7,8 @@ import {ContactSubscribe} from '@seed-hypermedia/client/contact'
 import type {HMContact, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {useMutation, useQueries, useQuery} from '@tanstack/react-query'
 import {getContactMetadata} from '../content'
-import {useUniversalClient} from '../routing'
+import {UniversalAppContext, useUniversalAppContext, useUniversalClient} from '../routing'
+import {createElement, type ReactNode} from 'react'
 import {hmId} from '../utils/entity-id-url'
 import {useAccount, useAccounts, useResources, useSelectedAccountId} from './entity'
 import {queryContactsOfAccount, queryContactsOfSubject} from './queries'
@@ -53,6 +54,7 @@ export function useSaveContact() {
       }
     },
     onSuccess: (_, contact) => {
+      invalidateQueries([queryKeys.SEARCH, 'inlineMentions'])
       invalidateQueries([queryKeys.CONTACTS_SUBJECT, contact.subjectUid])
       invalidateQueries([queryKeys.CONTACTS_ACCOUNT, contact.accountUid])
       invalidateQueries([queryKeys.DOCUMENT_COLLABORATORS, contact.subjectUid])
@@ -77,6 +79,7 @@ export function useDeleteContact() {
       await client.publish(await deleteContactBlob({contactId: contact.id}, signer))
     },
     onSuccess: (_, contact) => {
+      invalidateQueries([queryKeys.SEARCH, 'inlineMentions'])
       invalidateQueries([queryKeys.CONTACTS_SUBJECT, contact.subject])
       invalidateQueries([queryKeys.CONTACTS_ACCOUNT, contact.account])
       invalidateQueries([queryKeys.DOCUMENT_COLLABORATORS, contact.subject])
@@ -104,6 +107,13 @@ export function useContactListsOfAccount(accountUids: string[]) {
 export function useSelectedAccountContacts() {
   const selectedAccount = useSelectedAccountId()
   return useContactListOfAccount(selectedAccount)
+}
+
+/** Supplies live, selected-viewer petnames beneath the platform's identity/client provider. */
+export function SelectedAccountContactsProvider({children}: {children: ReactNode}) {
+  const context = useUniversalAppContext()
+  const contacts = useSelectedAccountContacts()
+  return createElement(UniversalAppContext.Provider, {value: {...context, contacts: contacts.data}}, children)
 }
 
 export function useContact(id: UnpackedHypermediaId | undefined) {

--- a/frontend/packages/shared/src/models/inline-mentions.test.ts
+++ b/frontend/packages/shared/src/models/inline-mentions.test.ts
@@ -1,0 +1,95 @@
+import {afterEach, describe, expect, it, vi} from 'vitest'
+import type {UniversalClient} from '../universal-client'
+import {hmId} from '../utils/entity-id-url'
+import {queryInlineMentions} from './inline-mentions'
+import {onQueryCacheError, queryClient} from './query-client'
+
+afterEach(() => queryClient.clear())
+
+describe('mention request failures', () => {
+  it('reports failures locally without automatic retries or an error boundary', () => {
+    const options = queryInlineMentions({} as UniversalClient, '')
+    expect(options).toMatchObject({retry: false, useErrorBoundary: false, meta: {handlesErrorLocally: true}})
+  })
+
+  it('does not dispatch global error toasts for locally handled failures', async () => {
+    const onGlobalError = vi.fn()
+    onQueryCacheError(onGlobalError)
+    const error = new Error('Unknown query key: MentionCandidates')
+    await expect(
+      queryClient.fetchQuery({
+        queryKey: ['mention-error-regression'],
+        queryFn: () => Promise.reject(error),
+        retry: false,
+        meta: {handlesErrorLocally: true},
+      }),
+    ).rejects.toBe(error)
+    expect(onGlobalError).not.toHaveBeenCalled()
+    await expect(
+      queryClient.fetchQuery({
+        queryKey: ['unhandled-error-regression'],
+        queryFn: () => Promise.reject(error),
+        retry: false,
+      }),
+    ).rejects.toBe(error)
+    expect(onGlobalError).toHaveBeenCalledOnce()
+  })
+})
+
+describe('reply mention search', () => {
+  const thread = {
+    replyAuthorUid: 'bob',
+    participants: [{uid: 'alice', isThreadAuthor: true}, {uid: 'bob'}, {uid: 'bob'}],
+  }
+  it('seeds thread accounts before local recents and separates thread query caches', async () => {
+    const request = vi.fn(async (_key: string, _input: unknown) => [])
+    const client = {request, fetchRecents: async () => []} as unknown as UniversalClient
+    const options = queryInlineMentions(client, '', undefined, {thread})
+    await options.queryFn()
+    expect(request.mock.calls[0]?.[1]).toMatchObject({
+      mode: 'account',
+      seedIds: [{uid: 'bob'}, {uid: 'alice'}],
+    })
+    expect(options.queryKey).not.toEqual(queryInlineMentions(client, '').queryKey)
+  })
+  it('does not seed thread accounts or vary document queries by reply context', async () => {
+    const request = vi.fn(async (_key: string, _input: unknown) => [])
+    const client = {request, fetchRecents: async () => []} as unknown as UniversalClient
+    const options = queryInlineMentions(client, '', undefined, {mode: 'document', thread})
+    await options.queryFn()
+    expect(request.mock.calls[0]?.[1]).toMatchObject({mode: 'document', seedIds: []})
+    expect(options.queryKey).toEqual(queryInlineMentions(client, '', undefined, {mode: 'document'}).queryKey)
+  })
+})
+
+it('keeps alias resolution seeds but excludes the resolved selected account from reply results', async () => {
+  const request = vi.fn(async (_key: string, _input: unknown) => [
+    {
+      id: hmId('current-self'),
+      sourceAccountUid: 'self',
+      type: 'account',
+      title: 'Self',
+      icon: '',
+      parentNames: [],
+      searchQuery: '',
+      sameSite: false,
+      issuedContact: false,
+    },
+    {
+      id: hmId('other'),
+      type: 'account',
+      title: 'Other',
+      icon: '',
+      parentNames: [],
+      searchQuery: '',
+      sameSite: false,
+      issuedContact: false,
+    },
+  ])
+  const client = {request, fetchRecents: async () => []} as unknown as UniversalClient
+  const results = await queryInlineMentions(client, '', 'self', {
+    thread: {replyAuthorUid: 'self', participants: [{uid: 'self'}, {uid: 'other'}]},
+  }).queryFn()
+  expect(request.mock.calls[0]?.[1]).toMatchObject({seedIds: [{uid: 'self'}, {uid: 'other'}]})
+  expect(results.map((c) => c.id.uid)).toEqual(['other'])
+})

--- a/frontend/packages/shared/src/models/inline-mentions.ts
+++ b/frontend/packages/shared/src/models/inline-mentions.ts
@@ -1,75 +1,133 @@
-import {useEffect, useRef} from 'react'
+import type {HMMentionCandidate, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
+import {useQuery} from '@tanstack/react-query'
+import {useCallback} from 'react'
 import {useUniversalClient} from '../routing'
-import {useRecents} from './recents'
-import {SearchResultItem} from './search'
+import type {UniversalClient} from '../universal-client'
+import {hmId} from '../utils/entity-id-url'
+import {rankMentionCandidates, type MentionThreadContext} from './mention-ranking'
+import {getQueryClient} from './query-client'
+import {queryKeys} from './query-keys'
 
-export function useInlineMentions(perspectiveAccountUid?: string | null | undefined) {
-  const client = useUniversalClient()
-  const recents = useRecents()
-  const recentsRef = useRef<SearchResultItem[]>([])
-  useEffect(() => {
-    recentsRef.current =
-      recents.data?.map((recent) => ({
-        id: recent.id,
-        title: recent.name,
-        subtitle: '',
-        icon: '',
-        parentNames: [],
-        searchQuery: '',
-        type: 'document',
-      })) ?? []
-  }, [recents])
+/** Flat mention suggestions shared by desktop and mobile pickers. */
+export type InlineMentionsResult = HMMentionCandidate[]
+/** Context for mode-specific personalized mention suggestions. */
+export type InlineMentionOptions = {
+  mode?: 'account' | 'document'
+  siteUid?: string
+  documentId?: UnpackedHypermediaId
+  thread?: MentionThreadContext
+}
+/** Fresh empty result for reset state. */
+export function emptyInlineMentions(): InlineMentionsResult {
+  return []
+}
 
-  async function onMentionsQuery(query: string) {
-    const resp = await client.request('Search', {
-      query,
-      perspectiveAccountUid: perspectiveAccountUid || undefined,
-      includeBody: false,
-      pageSize: 20,
-    })
-    const alreadySeenIds = new Set<string>()
-    const entities: SearchResultItem[] = []
-    resp.entities.forEach((result) => {
-      if (!alreadySeenIds.has(result.id.id)) {
-        alreadySeenIds.add(result.id.id)
-        entities.push(result)
-      }
-    })
-    const emptyRespose: InlineMentionsResult = {
-      Profiles: [],
-      Documents: [],
-      Recents: [],
-      Contacts: [],
-    }
-    if (!entities.length) {
-      return {
-        Profiles: [],
-        Documents: [],
-        Contacts: [],
-        Recents: recentsRef.current,
-      } as InlineMentionsResult
-    }
-    const response = entities.reduce((acc: InlineMentionsResult, entity) => {
-      if (entity.type === 'contact') {
-        acc.Contacts.push(entity)
-      } else if (entity.id?.path?.length) {
-        acc.Documents.push(entity)
-      } else {
-        acc.Profiles.push(entity)
-      }
-      return acc
-    }, emptyRespose)
-    return response
-  }
-
+/** Cached mention query with local-only visit ranking and bounded seed IDs. */
+export function queryInlineMentions(
+  client: UniversalClient,
+  query: string,
+  perspectiveAccountUid?: string,
+  options: InlineMentionOptions = {},
+) {
+  const mode = options.mode || 'account'
+  const thread =
+    mode === 'account' && options.thread ? {...options.thread, selectedAccountUid: perspectiveAccountUid} : undefined
   return {
-    onMentionsQuery,
+    queryKey: [
+      queryKeys.SEARCH,
+      'inlineMentions',
+      perspectiveAccountUid ?? null,
+      mode,
+      options.siteUid ?? null,
+      options.documentId?.id ?? null,
+      query,
+      thread ?? null,
+    ] as const,
+    staleTime: 15_000,
+    // The picker owns its error and explicit Retry action, not the global toast/boundary.
+    retry: false,
+    useErrorBoundary: false,
+    meta: {handlesErrorLocally: true},
+    queryFn: async ({signal}: {signal?: AbortSignal} = {}): Promise<InlineMentionsResult> => {
+      const recents = await getQueryClient().fetchQuery({
+        queryKey: [queryKeys.RECENTS],
+        queryFn: async () => {
+          try {
+            const result = await client.fetchRecents?.()
+            return Array.isArray(result) ? result : []
+          } catch {
+            return []
+          }
+        },
+      })
+      const threadUids = [
+        ...(thread?.replyAuthorUid ? [thread.replyAuthorUid] : []),
+        ...(thread?.participants || [])
+          .slice()
+          .sort(
+            (a, b) =>
+              Number(!!b.isThreadAuthor) - Number(!!a.isThreadAuthor) ||
+              (b.latestCommentTime ?? 0) - (a.latestCommentTime ?? 0),
+          )
+          .map((p) => p.uid),
+      ]
+      const seedIds = [
+        ...Array.from(new Set(threadUids)).map((uid) => hmId(uid, {path: [':profile']})),
+        ...recents.filter((r) => (mode === 'account') === (r.id.path?.[0] === ':profile')).map((r) => r.id),
+      ]
+      const seenSeeds = new Set<string>()
+      const candidates = await client.request(
+        'MentionCandidates',
+        {
+          query,
+          mode,
+          perspectiveAccountUid,
+          siteUid: options.siteUid,
+          documentId: options.documentId,
+          seedIds: seedIds
+            .filter((id) => {
+              const key = mode === 'account' ? id.uid : id.id
+              if (seenSeeds.has(key)) return false
+              seenSeeds.add(key)
+              return true
+            })
+            .slice(0, 20),
+        },
+        {signal},
+      )
+      return rankMentionCandidates(candidates, query, recents, Date.now(), thread)
+    },
   }
 }
 
-export type InlineMentionsResult = {
-  Profiles: Array<SearchResultItem>
-  Documents: Array<SearchResultItem>
-  Recents: Array<SearchResultItem>
-  Contacts: Array<SearchResultItem>
+/** Declarative mention search, with identical candidate ordering on all platforms. */
+export function useInlineMentions(
+  query: string,
+  {
+    enabled = true,
+    perspectiveAccountUid,
+    ...options
+  }: InlineMentionOptions & {enabled?: boolean; perspectiveAccountUid?: string | null} = {},
+) {
+  const client = useUniversalClient()
+  const result = useQuery({...queryInlineMentions(client, query, perspectiveAccountUid || undefined, options), enabled})
+  return {
+    suggestions: result.data ?? emptyInlineMentions(),
+    isFetched: result.isFetched,
+    isFetching: result.isFetching,
+    isError: result.isError,
+    refetch: result.refetch,
+  }
+}
+
+/** Stable async fetcher backed by the shared query cache for the mention controller. */
+export function useInlineMentionsSearch(thread?: MentionThreadContext) {
+  const client = useUniversalClient()
+  return useCallback(
+    (query: string, perspectiveAccountUid?: string | null, options: InlineMentionOptions = {}) =>
+      getQueryClient().fetchQuery(
+        queryInlineMentions(client, query, perspectiveAccountUid || undefined, {...options, thread}),
+      ),
+    [client, thread],
+  )
 }

--- a/frontend/packages/shared/src/models/mention-ranking.test.ts
+++ b/frontend/packages/shared/src/models/mention-ranking.test.ts
@@ -1,0 +1,193 @@
+import {describe, expect, it} from 'vitest'
+import {mentionCandidateSubtitle, rankMentionCandidates} from './mention-ranking'
+import {hmId} from '../utils/entity-id-url'
+import type {HMMentionCandidate} from '@seed-hypermedia/client/hm-types'
+const now = Date.UTC(2026, 8, 11)
+function account(uid: string, title: string, extra: Partial<HMMentionCandidate> = {}): HMMentionCandidate {
+  return {
+    id: hmId(uid),
+    type: 'account',
+    title,
+    icon: '',
+    parentNames: [],
+    searchQuery: '',
+    sameSite: false,
+    issuedContact: false,
+    ...extra,
+  }
+}
+describe('mention ranking', () => {
+  it('keeps exact matches ahead of contextual prefix matches', () => {
+    const exact = account('a', 'Alex')
+    const boosted = account('b', 'Alexander', {sameSite: true, issuedContact: true, activityTime: now})
+    expect(rankMentionCandidates([boosted, exact], 'Alex', [], now).map((c) => c.id.uid)).toEqual(['a', 'b'])
+  })
+  it('allows recent visits and activity to outweigh contacts and site membership', () => {
+    const old = account('old', 'Old', {sameSite: true, issuedContact: true})
+    const recent = account('recent', 'Recent', {activityTime: now})
+    expect(
+      rankMentionCandidates(
+        [old, recent],
+        '',
+        [{id: hmId('recent', {path: [':profile']}), time: now, name: 'Recent'}],
+        now,
+      )[0]?.id.uid,
+    ).toBe('recent')
+  })
+  it('matches both public names and petnames and excludes unrelated seeds', () => {
+    expect(
+      rankMentionCandidates(
+        [account('a', 'Buddy', {publicName: 'Alice'}), account('b', 'Bob', {issuedContact: true})],
+        'Alice',
+        [],
+        now,
+      ).map((c) => c.id.uid),
+    ).toEqual(['a'])
+  })
+  it('deduplicates versions and does not boost a home document from a profile visit', () => {
+    const doc = {...account('a', 'Home'), type: 'document' as const, id: hmId('a', {version: 'v1', latest: true})}
+    const results = rankMentionCandidates(
+      [doc, {...doc, id: hmId('a', {version: 'v2', latest: true})}],
+      '',
+      [{id: hmId('a', {path: [':profile']}), time: now, name: 'A'}],
+      now,
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0]?.hint).toBe('Home document')
+  })
+  it('labels issued contacts without assuming a profile-follow subscription', () => {
+    expect(rankMentionCandidates([account('site', 'Site', {issuedContact: true})], '', [], now)[0]?.hint).toBe(
+      'Contact',
+    )
+  })
+})
+
+describe('mention context and subtitles', () => {
+  it('shows factual activity and a site role instead of an account ID', () => {
+    const [candidate] = rankMentionCandidates(
+      [
+        account('a', 'Alice', {
+          activityTime: now - 120_000,
+          activityType: 'publication',
+          accountRole: 'site-editor',
+        }),
+      ],
+      '',
+      [],
+      now,
+    )
+    expect(candidate?.hint).toBe('Published 2m ago · Site editor')
+    expect(mentionCandidateSubtitle(candidate!)).toBe('Published 2m ago · Site editor')
+  })
+  it('uses comment activity and contact fallback without calling followers members', () => {
+    expect(
+      rankMentionCandidates(
+        [
+          account('a', 'Alice', {
+            activityTime: now - 120_000,
+            activityType: 'comment',
+            accountRole: 'site-follower',
+          }),
+        ],
+        '',
+        [],
+        now,
+      )[0]?.hint,
+    ).toBe('Commented 2m ago · Site follower')
+    expect(rankMentionCandidates([account('a', 'Alice', {sameSite: true})], '', [], now)[0]?.hint).toBeUndefined()
+  })
+  it('uses public name as fallback and a clean short ID only without useful hints', () => {
+    expect(
+      mentionCandidateSubtitle(account('long-account-identifier', 'Buddy', {petname: 'Buddy', publicName: 'Alice'})),
+    ).toBe('Alice')
+    expect(mentionCandidateSubtitle(account('long-account-identifier', 'Alice'))).toBe('long-acc…tifier')
+  })
+  it('boosts direct reply authors ahead of thread participants but keeps exact text first', () => {
+    const context = {participants: [{uid: 'b'}, {uid: 'c'}], replyAuthorUid: 'c'}
+    expect(
+      rankMentionCandidates(
+        [account('a', 'Alex'), account('b', 'Alexander'), account('c', 'Alexander')],
+        '',
+        [],
+        now,
+        context,
+      ).map((c) => c.id.uid),
+    ).toEqual(['c', 'b', 'a'])
+    expect(
+      rankMentionCandidates(
+        [account('a', 'Alex'), account('b', 'Alexander'), account('c', 'Alexander')],
+        'Alex',
+        [],
+        now,
+        context,
+      ).map((c) => c.id.uid),
+    ).toEqual(['a', 'c', 'b'])
+  })
+  it('does not boost documents and describes known thread activity', () => {
+    const context = {
+      participants: [
+        {uid: 'b', latestCommentTime: now - 120_000},
+        {uid: 'a', isThreadAuthor: true},
+      ],
+    }
+    expect(rankMentionCandidates([account('b', 'Bob')], '', [], now, context)[0]?.hint).toBe(
+      'Replied 2m ago · In this thread',
+    )
+    expect(rankMentionCandidates([account('a', 'Alice')], '', [], now, context)[0]?.hint).toBe('Thread author')
+    const docs = [account('a', 'A'), account('b', 'B')].map((c) => ({...c, type: 'document' as const}))
+    expect(rankMentionCandidates(docs, '', [], now, {...context, replyAuthorUid: 'b'}).map((c) => c.id.uid)).toEqual([
+      'a',
+      'b',
+    ])
+  })
+})
+
+it('describes thread-author comment activity without implying it was a reply', () => {
+  const thread = {participants: [{uid: 'author', isThreadAuthor: true, latestCommentTime: now - 120_000}]}
+  expect(rankMentionCandidates([account('author', 'Author')], '', [], now, thread)[0]?.hint).toBe(
+    'Commented 2m ago · Thread author',
+  )
+})
+
+it('preserves reply identity through account aliases regardless of candidate arrival order', () => {
+  const oldBea = 'z6MkgHKiUr9ijJTTgNfrt6uCn85q1wMzu1fVyP5KXLyKjwgE'
+  const currentBea = 'z6MkkGNjfnikRkxK9EaxMPYy3HYxNGkRyXTWxxRtynB2kyeb'
+  const canonical = account(currentBea, 'Bea')
+  const alias = account(currentBea, 'Bea', {sourceAccountUid: oldBea})
+  const other = account('unrelated', 'Bea', {activityTime: now, sameSite: true, issuedContact: true})
+  for (const candidates of [
+    [canonical, other, alias],
+    [alias, other, canonical],
+  ]) {
+    const result = rankMentionCandidates(candidates, 'be', [], now, {
+      replyAuthorUid: oldBea,
+      participants: [{uid: oldBea, isThreadAuthor: true, latestCommentTime: now - 120_000}],
+    })
+    expect(result.map((c) => c.id.uid)).toEqual([currentBea, 'unrelated'])
+    expect(result[0]?.hint).toBe('Commented 2m ago · Replying to')
+    expect(result[1]?.hint).not.toContain('Replying to')
+  }
+})
+
+it('excludes the selected reply account and its aliases, but not another account with the same name', () => {
+  const candidates = [
+    account('self', 'Demo'),
+    account('self', 'Demo', {sourceAccountUid: 'old-self'}),
+    account('other', 'Demo'),
+  ]
+  for (const selectedAccountUid of ['self', 'old-self']) {
+    expect(
+      rankMentionCandidates(candidates, '', [], now, {
+        selectedAccountUid,
+        replyAuthorUid: 'old-self',
+        participants: [{uid: 'old-self'}, {uid: 'other'}],
+      }).map((c) => c.id.uid),
+    ).toEqual(['other'])
+  }
+  expect(rankMentionCandidates(candidates, '', [], now).map((c) => c.id.uid)).toEqual(['other', 'self'])
+})
+
+it('does not exclude documents owned by the selected reply account', () => {
+  const document = {...account('self', 'Home'), type: 'document' as const}
+  expect(rankMentionCandidates([document], '', [], now, {selectedAccountUid: 'self'})).toHaveLength(1)
+})

--- a/frontend/packages/shared/src/models/mention-ranking.ts
+++ b/frontend/packages/shared/src/models/mention-ranking.ts
@@ -1,0 +1,170 @@
+import type {HMMentionCandidate} from '@seed-hypermedia/client/hm-types'
+import type {RecentsResult} from './recents'
+
+const DAY = 86_400_000
+const VISIT_HALF_LIFE = 7 * DAY
+const ACTIVITY_HALF_LIFE = 14 * DAY
+
+const accountRoleLabels = {
+  'site-owner': 'Site owner',
+  'site-editor': 'Site editor',
+  'document-editor': 'Document editor',
+  'site-follower': 'Site follower',
+}
+
+/** Loaded conversation participants used only for account mention relevance. */
+export type MentionThreadContext = {
+  participants?: {uid: string; latestCommentTime?: number; isThreadAuthor?: boolean}[]
+  replyAuthorUid?: string
+  /** The acting account is omitted from reply suggestions, including known aliases. */
+  selectedAccountUid?: string
+}
+
+function timeAgo(time: number, now: number) {
+  const elapsed = Math.max(0, now - time)
+  if (elapsed < 60_000) return 'just now'
+  if (elapsed < 3_600_000) return `${Math.floor(elapsed / 60_000)}m ago`
+  if (elapsed < DAY) return `${Math.floor(elapsed / 3_600_000)}h ago`
+  if (elapsed < 365 * DAY) return `${Math.floor(elapsed / DAY)}d ago`
+  return `${Math.floor(elapsed / (365 * DAY))}y ago`
+}
+
+/** Shared desktop/mobile subtitle, keeping account IDs only as a last-resort hint. */
+export function mentionCandidateSubtitle(candidate: HMMentionCandidate) {
+  const publicName = candidate.petname && candidate.publicName !== candidate.petname ? candidate.publicName : undefined
+  const hint = [candidate.hint, publicName].filter(Boolean).join(' · ')
+  if (hint) return hint
+  if (candidate.type === 'document') return candidate.parentNames.join(' / ')
+  const uid = candidate.id.uid
+  return uid.length > 16 ? `${uid.slice(0, 8)}…${uid.slice(-6)}` : uid
+}
+
+/** Canonical key distinguishing account profiles from home documents and ignoring versions. */
+export function mentionCandidateKey(id: HMMentionCandidate['id'], mode: HMMentionCandidate['type']) {
+  return `${mode}:${id.uid}:${mode === 'document' ? JSON.stringify(id.path || []) : ''}`
+}
+
+/** Deterministic text-first ranking with blended local and public relevance signals. */
+export function rankMentionCandidates(
+  candidates: HMMentionCandidate[],
+  query: string,
+  recents: RecentsResult[],
+  now = Date.now(),
+  thread: MentionThreadContext = {},
+): HMMentionCandidate[] {
+  const normalized = query.trim().toLocaleLowerCase()
+  const visits = new Map(
+    recents.map((r) => [mentionCandidateKey(r.id, r.id.path?.[0] === ':profile' ? 'account' : 'document'), r.time]),
+  )
+  const participants = new Map(thread.participants?.map((participant) => [participant.uid, participant]))
+  // Alias and canonical search hits can arrive in either order. Collect identities
+  // before deduplicating so the winning row keeps the thread's original author ID.
+  const accountIdentities = new Map<string, Set<string>>()
+  for (const candidate of candidates) {
+    if (candidate.type !== 'account') continue
+    const identities = accountIdentities.get(candidate.id.uid) || new Set([candidate.id.uid])
+    if (candidate.sourceAccountUid) identities.add(candidate.sourceAccountUid)
+    accountIdentities.set(candidate.id.uid, identities)
+  }
+  const seen = new Set<string>()
+  return candidates
+    .flatMap((candidate) => {
+      if (
+        candidate.type === 'account' &&
+        thread.selectedAccountUid &&
+        accountIdentities.get(candidate.id.uid)?.has(thread.selectedAccountUid)
+      )
+        return []
+      const key = mentionCandidateKey(candidate.id, candidate.type)
+      if (seen.has(key)) return []
+      seen.add(key)
+      const labels = [
+        candidate.title,
+        candidate.publicName,
+        candidate.petname,
+        candidate.id.uid,
+        candidate.id.path?.join('/'),
+      ]
+        .filter((v): v is string => !!v)
+        .map((v) => v.toLocaleLowerCase())
+      let tier = normalized ? 4 : 0
+      for (const label of labels) {
+        if (label === normalized) tier = Math.min(tier, 0)
+        else if (label.startsWith(normalized)) tier = Math.min(tier, 1)
+        else if (normalized.split(/\s+/).every((token) => label.includes(token))) tier = Math.min(tier, 2)
+        else {
+          let at = 0
+          for (const char of label) if (char === normalized[at]) at++
+          if (at === normalized.length) tier = Math.min(tier, 3)
+        }
+      }
+      if (tier === 4) return []
+      const visit = visits.get(key)
+      const visitScore = visit === undefined ? 0 : Math.pow(0.5, Math.max(0, now - visit) / VISIT_HALF_LIFE)
+      const activityScore =
+        candidate.activityTime === undefined
+          ? 0
+          : Math.pow(0.5, Math.max(0, now - candidate.activityTime) / ACTIVITY_HALF_LIFE)
+      const identities = candidate.type === 'account' ? accountIdentities.get(candidate.id.uid) : undefined
+      const matchingParticipants = Array.from(identities || []).flatMap((uid) => participants.get(uid) || [])
+      const participant = matchingParticipants.length
+        ? {
+            isThreadAuthor: matchingParticipants.some((p) => p.isThreadAuthor),
+            latestCommentTime: matchingParticipants.reduce<number | undefined>(
+              (latest, p) =>
+                p.latestCommentTime === undefined
+                  ? latest
+                  : Math.max(latest ?? p.latestCommentTime, p.latestCommentTime),
+              undefined,
+            ),
+          }
+        : undefined
+      const directReply = !!thread.replyAuthorUid && !!identities?.has(thread.replyAuthorUid)
+      const score =
+        2 * visitScore +
+        1.5 * activityScore +
+        Number(candidate.sameSite) +
+        Number(candidate.type === 'account' && candidate.issuedContact) +
+        (directReply ? 5 : participant ? 3 : 0)
+      const activityHint =
+        candidate.activityTime === undefined
+          ? undefined
+          : `${candidate.activityType === 'comment' ? 'Commented' : 'Published'} ${timeAgo(
+              candidate.activityTime,
+              now,
+            )}`
+      const visitHint = visit === undefined ? undefined : `Visited ${timeAgo(visit, now)}`
+      let hint: string | undefined
+      if (candidate.type === 'account') {
+        const relationship = directReply
+          ? 'Replying to'
+          : participant?.isThreadAuthor
+            ? 'Thread author'
+            : participant
+              ? 'In this thread'
+              : candidate.accountRole
+                ? accountRoleLabels[candidate.accountRole]
+                : candidate.issuedContact
+                  ? 'Contact'
+                  : undefined
+        const activity =
+          participant?.latestCommentTime === undefined
+            ? activityHint
+            : `${participant.isThreadAuthor ? 'Commented' : 'Replied'} ${timeAgo(participant.latestCommentTime, now)}`
+        hint =
+          [activity || (!relationship ? visitHint : undefined), relationship].filter(Boolean).join(' · ') || undefined
+      } else {
+        hint = activityHint || visitHint || (candidate.sameSite ? 'In this space' : undefined)
+        if (!candidate.id.path?.length) hint = ['Home document', hint].filter(Boolean).join(' · ')
+      }
+      return [{candidate: {...candidate, hint}, tier, score, key}]
+    })
+    .sort(
+      (a, b) =>
+        a.tier - b.tier ||
+        b.score - a.score ||
+        a.candidate.title.localeCompare(b.candidate.title) ||
+        a.key.localeCompare(b.key),
+    )
+    .map((v) => v.candidate)
+}

--- a/frontend/packages/shared/src/models/notification-event-classifier.ts
+++ b/frontend/packages/shared/src/models/notification-event-classifier.ts
@@ -1,7 +1,7 @@
-import {getAnnotations} from '../content'
+import {extractAllContentRefs, getAnnotations} from '../content'
 import {HMBlockNode, HMComment, UnpackedHypermediaId} from '@seed-hypermedia/client/hm-types'
 import {unpackHmId} from '../utils/entity-id-url'
-import {LoadedEventWithNotifMeta} from './activity-service'
+import type {LoadedEventWithNotifMeta} from './activity-service'
 
 /**
  * Resolves the account UID referenced by a mention target when it points to
@@ -17,11 +17,28 @@ export function getMentionedAccountUid(target: string | UnpackedHypermediaId | n
   return null
 }
 
+/** Resolves explicit citation identity without reinterpreting legacy or mixed references. */
+export function getCitationMentionKind(
+  content: HMBlockNode[],
+  targetId: UnpackedHypermediaId,
+  sourceContext?: string,
+): 'account' | 'document' | undefined {
+  const matchingRefs = extractAllContentRefs(content).filter(
+    (ref) =>
+      ref.refId?.uid === targetId.uid &&
+      (ref.refId.path || []).join('/') === (targetId.path || []).join('/') &&
+      (!sourceContext || ref.blockId === sourceContext),
+  )
+  if (matchingRefs.length && matchingRefs.every((ref) => ref.mentionKind === 'document')) return 'document'
+  if (matchingRefs.length && matchingRefs.every((ref) => ref.mentionKind === 'account')) return 'account'
+  return undefined
+}
+
 function collectMentionedAccountUidsFromBlock(block: HMBlockNode, accountUids: Set<string>) {
   const annotations = getAnnotations(block.block)
   if (Array.isArray(annotations)) {
     for (const annotation of annotations) {
-      if (annotation.type !== 'Embed') continue
+      if (annotation.type !== 'Embed' || annotation.attributes?.mentionKind === 'document') continue
       const mentionedAccountUid = getMentionedAccountUid(annotation.link)
       if (mentionedAccountUid) accountUids.add(mentionedAccountUid)
     }
@@ -71,6 +88,7 @@ export function classifyNotificationEvent(
   accountUid: string,
 ): NotificationReason | null {
   if (event.type === 'citation') {
+    if (event.mentionKind === 'document') return null
     // Comment citations that target documents are mirrored by comment blob events.
     // Suppress them here to avoid duplicate discussion notifications in desktop inbox.
     if (event.citationType === 'c' && event.target?.id?.path?.length) {

--- a/frontend/packages/shared/src/models/queries.ts
+++ b/frontend/packages/shared/src/models/queries.ts
@@ -481,6 +481,8 @@ export function queryContactsOfSubject(client: UniversalClient, uid: string | un
 export function queryContactsOfAccount(client: UniversalClient, uid: string | null | undefined) {
   return {
     queryKey: [queryKeys.CONTACTS_ACCOUNT, uid] as const,
+    // Never show the previous identity's petnames while another account's contacts load.
+    keepPreviousData: false,
     queryFn: async ({signal}: {signal?: AbortSignal} = {}): Promise<HMContactRecord[]> => {
       if (!uid) return []
       return client.request('AccountContacts', uid, {signal})

--- a/frontend/packages/shared/src/models/query-client.ts
+++ b/frontend/packages/shared/src/models/query-client.ts
@@ -1,4 +1,5 @@
 import {Query, QueryCache, QueryClient, type QueryKey} from '@tanstack/react-query'
+import {queryKeys} from './query-keys'
 
 // Re-export for consumers to avoid duplicate package instances
 export {QueryClientProvider, useQueryClient} from '@tanstack/react-query'
@@ -12,6 +13,7 @@ export function onQueryCacheError(handler: (error: unknown, query: Query) => voi
 export const queryClient = new QueryClient({
   queryCache: new QueryCache({
     onError: (err, query) => {
+      if (query.meta?.handlesErrorLocally) return
       queryCacheErrorSubscriptions.forEach((handler) => handler(err, query))
     },
   }),
@@ -69,6 +71,9 @@ export type InvalidateQueriesOptions = {
 }
 
 export function invalidateQueries(queryKey: QueryKey, options?: InvalidateQueriesOptions) {
+  if (queryKey[0] === queryKeys.RECENTS) {
+    invalidateQueries([queryKeys.SEARCH, 'inlineMentions'], options)
+  }
   // Always invalidate the registered client directly
   if (registeredClient) {
     registeredClient.invalidateQueries({queryKey, refetchType: options?.refetchType})

--- a/frontend/packages/shared/src/routes.ts
+++ b/frontend/packages/shared/src/routes.ts
@@ -463,7 +463,12 @@ export const navRouteSchema = z.discriminatedUnion('key', [
 ])
 export type NavRoute = z.infer<typeof navRouteSchema>
 
+/** Returns a version-independent visited entity, keeping profiles distinct from home documents. */
 export function getRecentsRouteEntityUrl(route: NavRoute) {
+  if (route.key === 'profile' || route.key === 'site-profile') {
+    const uid = route.key === 'site-profile' ? route.accountUid ?? route.id.uid : route.id.uid
+    return hmId(uid, {path: [':profile']}).id
+  }
   // this is used to uniquely identify an item for the recents list. So it references the entity without specifying version
   if (route.key === 'document') return route.id.id
   if (route.key === 'inspect') return route.id.id

--- a/frontend/packages/ui/src/__tests__/comments.test.tsx
+++ b/frontend/packages/ui/src/__tests__/comments.test.tsx
@@ -70,6 +70,7 @@ vi.mock('@shm/shared/models/comments', () => ({
 
 vi.mock('@shm/shared/models/entity', () => ({
   useAccount: () => ({data: {metadata: {name: 'Alice'}}}),
+  useAccounts: (ids: Array<string | null>) => ids.map((id) => ({data: id ? {metadata: {name: 'Alice'}} : undefined})),
   useIsCurrentUser: () => false,
   useResources: () => [],
   useResource: () => ({

--- a/frontend/packages/ui/src/__tests__/following.test.tsx
+++ b/frontend/packages/ui/src/__tests__/following.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import React from 'react'
+import {renderToStaticMarkup} from 'react-dom/server'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {FollowingContent} from '../following'
+;(globalThis as typeof globalThis & {React?: typeof React}).React = React
+
+const state = vi.hoisted(() => ({
+  viewerContacts: [] as {subject: string; name: string; subscribe?: {profile?: boolean; site?: boolean}}[],
+}))
+vi.mock('@shm/shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@shm/shared')>()),
+  useContactListOfAccount: () => ({
+    data: [{id: 'contact', subject: 'alice', name: 'Someone else’s nickname', subscribe: {profile: true}}],
+  }),
+  useRouteLink: (route: {key: string}) => ({href: `/${route.key}`}),
+}))
+vi.mock('@shm/shared/models/contacts', () => ({useSelectedAccountContacts: () => ({data: state.viewerContacts})}))
+vi.mock('@shm/shared/models/entity', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@shm/shared/models/entity')>()),
+  useAccountsMetadata: () => ({data: {alice: {metadata: {name: 'Public Alice'}}}}),
+}))
+vi.mock('../hm-icon', () => ({HMIcon: () => null}))
+
+beforeEach(() => {
+  state.viewerContacts = []
+})
+describe('FollowingContent viewer names', () => {
+  it('never uses the viewed account’s contact names', () => {
+    const html = renderToStaticMarkup(<FollowingContent accountUid="someone-else" />)
+    expect(html).toContain('Public Alice')
+    expect(html).not.toContain('Someone else’s nickname')
+    expect(html).toContain('href="/profile"')
+  })
+  it('shows the viewer’s followed contact name alongside the public identity', () => {
+    state.viewerContacts = [{subject: 'alice', name: 'My Ally', subscribe: {profile: true}}]
+    const html = renderToStaticMarkup(<FollowingContent accountUid="someone-else" />)
+    expect(html).toContain('My Ally')
+    expect(html).toContain('Public Alice')
+  })
+  it('supports legacy following contacts but not site-only subscriptions', () => {
+    state.viewerContacts = [{subject: 'alice', name: 'Legacy Ally'}]
+    expect(renderToStaticMarkup(<FollowingContent accountUid="someone-else" />)).toContain('Legacy Ally')
+    state.viewerContacts = [{subject: 'alice', name: 'Site name', subscribe: {site: true}}]
+    expect(renderToStaticMarkup(<FollowingContent accountUid="someone-else" />)).not.toContain('Site name')
+  })
+})

--- a/frontend/packages/ui/src/__tests__/profile-name.test.tsx
+++ b/frontend/packages/ui/src/__tests__/profile-name.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import React from 'react'
+import {createRoot, type Root} from 'react-dom/client'
+import {act} from 'react-dom/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {ProfileName} from '../profile-name'
+;(globalThis as typeof globalThis & {React?: typeof React}).React = React
+
+let container: HTMLDivElement
+let root: Root
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+function render(props: React.ComponentProps<typeof ProfileName>) {
+  act(() => root.render(<ProfileName {...props} />))
+}
+function click(label: string) {
+  act(() => container.querySelector(`[aria-label="${label}"]`)!.dispatchEvent(new MouseEvent('click', {bubbles: true})))
+}
+function change(value: string) {
+  act(() => {
+    const input = container.querySelector('input')!
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!.call(input, value)
+    input.dispatchEvent(new Event('input', {bubbles: true}))
+  })
+}
+async function key(key: string) {
+  await act(async () =>
+    container.querySelector('input')!.dispatchEvent(new KeyboardEvent('keydown', {key, bubbles: true})),
+  )
+}
+describe('ProfileName', () => {
+  it('shows public identity alongside a petname but no editor without a save action', () => {
+    render({publicName: 'Public Alice', petname: 'Alice'})
+    expect(container.querySelector('h1')?.textContent).toBe('Alice')
+    expect(container.textContent).toContain('Public Alice')
+    expect(container.querySelector('button')).toBeNull()
+  })
+  it('edits on double click, discloses publication, trims and saves on Enter', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    render({publicName: 'Alice', onSave})
+    act(() => container.querySelector('h1')!.dispatchEvent(new MouseEvent('dblclick', {bubbles: true})))
+    expect(container.textContent).toContain('published')
+    change('  Ally  ')
+    await key('Enter')
+    expect(onSave).toHaveBeenCalledWith('Ally')
+    expect(container.querySelector('input')).toBeNull()
+  })
+  it('does not save on blur and cancels with Escape or X', async () => {
+    const onSave = vi.fn()
+    render({publicName: 'Alice', petname: 'Ally', onSave})
+    click('Edit contact name')
+    change('Discard')
+    act(() => container.querySelector('input')!.dispatchEvent(new FocusEvent('focusout', {bubbles: true})))
+    expect(onSave).not.toHaveBeenCalled()
+    await key('Escape')
+    expect(container.querySelector('input')).toBeNull()
+    click('Edit contact name')
+    expect(container.querySelector('input')!.value).toBe('Ally')
+    click('Cancel contact name')
+    expect(onSave).not.toHaveBeenCalled()
+  })
+  it('clears a petname with an empty value and keeps failed input for retry', async () => {
+    const onSave = vi.fn().mockRejectedValueOnce(new Error('offline')).mockResolvedValue(undefined)
+    render({publicName: 'Alice', petname: 'Ally', onSave})
+    click('Edit contact name')
+    change('   ')
+    await key('Enter')
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('Try again')
+    expect(container.querySelector('input')!.value).toBe('   ')
+    await act(async () => click('Save contact name'))
+    expect(onSave).toHaveBeenLastCalledWith('')
+    expect(container.querySelector('input')).toBeNull()
+  })
+  it('disables repeat submissions until saving completes and restores pencil focus', async () => {
+    let finish!: () => void
+    const onSave = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve
+        }),
+    )
+    render({publicName: 'Alice', onSave})
+    click('Edit contact name')
+    change('Ally')
+    await key('Enter')
+    expect(container.querySelector('input')!.disabled).toBe(true)
+    expect(container.querySelector<HTMLButtonElement>('[aria-label="Save contact name"]')!.disabled).toBe(true)
+    click('Save contact name')
+    expect(onSave).toHaveBeenCalledOnce()
+    await act(async () => finish())
+    expect(document.activeElement?.getAttribute('aria-label')).toBe('Edit contact name')
+  })
+
+  it('resets an edit when keyed to a different viewing identity', () => {
+    const onSave = vi.fn()
+    act(() => root.render(<ProfileName key="viewer-a" publicName="Alice" petname="Ally" onSave={onSave} />))
+    click('Edit contact name')
+    change('Unsaved')
+    act(() => root.render(<ProfileName key="viewer-b" publicName="Alice" petname="Alice B" onSave={onSave} />))
+    expect(container.querySelector('input')).toBeNull()
+    expect(container.querySelector('h1')?.textContent).toBe('Alice B')
+    expect(onSave).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/packages/ui/src/account-page.tsx
+++ b/frontend/packages/ui/src/account-page.tsx
@@ -1,7 +1,16 @@
 import {HMMetadataPayload} from '@seed-hypermedia/client/hm-types'
-import {hmId, hostnameStripProtocol, ProfileTab, useDomain, useFollowProfile, useRouteLink} from '@shm/shared'
+import {
+  hasProfileSubscription,
+  hmId,
+  hostnameStripProtocol,
+  ProfileTab,
+  useDomain,
+  useFollowProfile,
+  useRouteLink,
+} from '@shm/shared'
+import {useSaveContact, useSelectedAccountContacts} from '@shm/shared/models/contacts'
 import {IS_DESKTOP} from '@shm/shared/constants'
-import {useAccount, useResource} from '@shm/shared/models/entity'
+import {useAccount, useResource, useSelectedAccountId} from '@shm/shared/models/entity'
 import {ActivityIcon, AlertCircle, Check, LucideIcon, Rss, UserCheck, Users} from 'lucide-react'
 import {ReactNode} from 'react'
 import {Button} from './button'
@@ -16,6 +25,7 @@ import {Pencil} from './icons'
 import {MembershipContent} from './membership'
 import {PageLayout} from './page-layout'
 import {PageTabItem, PageTabs} from './page-tabs'
+import {ProfileName} from './profile-name'
 
 export type SiteAccountTab = 'profile' | 'membership' | 'followers' | 'following'
 
@@ -142,6 +152,12 @@ export function AccountPage({
     profileUid: accountUid,
   })
 
+  const viewerUid = useSelectedAccountId()
+  const viewerContacts = useSelectedAccountContacts()
+  const saveContact = useSaveContact()
+  const contact = viewerContacts.data?.find(
+    (contact) => contact.subject === accountUid && hasProfileSubscription(contact),
+  )
   const handleFollowClick = onFollowClick ?? followProfile
 
   return (
@@ -149,15 +165,32 @@ export function AccountPage({
       <PageLayout contentMaxWidth={720}>
         <div className="space-y-6 py-8">
           <div className="m-4 flex-col space-y-6">
-            <div className="flex items-center gap-4">
+            <div className="flex flex-wrap items-center gap-4">
               <HMIcon
                 id={hmId(accountUid)}
                 size={64}
                 icon={account.data?.metadata?.icon}
                 name={account.data?.metadata?.name}
               />
-              <div className="min-w-0 flex-1 space-y-1">
-                <h1 className="truncate text-2xl font-bold">{account.data?.metadata?.name || accountUid}</h1>
+              <div className="min-w-40 flex-1 space-y-1">
+                <ProfileName
+                  key={`${viewerUid}:${accountUid}:${contact?.id || ''}`}
+                  publicName={account.data?.metadata?.name || accountUid}
+                  petname={!isOwnAccount ? contact?.name : undefined}
+                  onSave={
+                    !isOwnAccount && viewerUid && contact
+                      ? async (name) => {
+                          await saveContact.mutateAsync({
+                            accountUid: viewerUid,
+                            subjectUid: accountUid,
+                            name,
+                            editId: contact.id,
+                            subscribe: contact.subscribe,
+                          })
+                        }
+                      : undefined
+                  }
+                />
                 <SiteLink account={account.data} />
               </div>
               <div className="flex items-center gap-2">

--- a/frontend/packages/ui/src/comments.tsx
+++ b/frontend/packages/ui/src/comments.tsx
@@ -39,12 +39,11 @@ import {
   useDocumentComments,
   useDocumentDiscussions,
 } from '@shm/shared/models/comments'
-import {useIsCurrentUser, useResource, useResources} from '@shm/shared/models/entity'
+import {useAccounts, useIsCurrentUser, useResource, useResources} from '@shm/shared/models/entity'
 import {useReadOnlyViewer} from '@shm/shared/readonly-viewer-context'
 import {getRoutePanel} from '@shm/shared/routes'
 import {useTxString} from '@shm/shared/translation'
 import {useNavigate, useNavRoute} from '@shm/shared/utils/navigation'
-import {unpackHmId} from '@shm/shared/utils/entity-id-url'
 import {Bookmark, Link, MessageSquare, Pencil, Trash2, X} from 'lucide-react'
 import {memo, ReactNode, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react'
 import {SelectionContent} from './accessories'
@@ -630,29 +629,49 @@ export const Comment = memo(function Comment({
   const {contacts, origin: appOrigin} = useUniversalAppContext()
 
   const bookmarkRefs = useMemo(
-    () => Array.from(new Map(extractAllContentRefs(comment.content).map((ref) => [ref.link, ref])).values()),
+    () =>
+      Array.from(
+        new Map(
+          extractAllContentRefs(comment.content).map((ref) => [
+            ref.mentionKind ? `${ref.mentionKind}:${ref.link}` : ref.link,
+            ref,
+          ]),
+        ).values(),
+      ),
     [comment.content],
   )
-  const bookmarkRefIds = useMemo(
-    () => bookmarkRefs.map(({refId}) => (refId.path?.[0] === ':profile' ? hmId(refId.path[1] || refId.uid) : refId)),
+  const bookmarkAccountIds = useMemo(
+    () =>
+      bookmarkRefs.map(({refId, mentionKind}) =>
+        mentionKind !== 'document' &&
+        (mentionKind === 'account' || refId?.path?.[0] === ':profile' || !refId?.path?.length)
+          ? refId?.path?.[0] === ':profile'
+            ? refId.path[1] || refId.uid
+            : refId?.uid
+          : null,
+      ),
     [bookmarkRefs],
   )
+  const bookmarkRefIds = useMemo(
+    () => bookmarkRefs.map(({refId}, index) => (bookmarkAccountIds[index] ? null : refId)),
+    [bookmarkRefs, bookmarkAccountIds],
+  )
+  const bookmarkAccounts = useAccounts(bookmarkAccountIds)
   const bookmarkRefResources = useResources(bookmarkRefIds, {subscribed: true})
   const bookmarkResolvedNames = useMemo(() => {
     const names: Record<string, string> = {}
     bookmarkRefs.forEach((ref, index) => {
-      const id = unpackHmId(ref.link)
-      const resource = bookmarkRefResources[index]?.data
-      if (!id || resource?.type !== 'document') return
-
-      const profileAccountUid = id.path?.[0] === ':profile' ? id.path[1] || id.uid : null
-      names[ref.link] =
-        profileAccountUid || !id.path?.length
-          ? getContactMetadata(profileAccountUid || id.uid, resource.document.metadata, contacts).name
-          : getDocumentTitle(resource.document)
+      const key = ref.mentionKind ? `${ref.mentionKind}:${ref.link}` : ref.link
+      const accountUid = bookmarkAccountIds[index]
+      if (accountUid) {
+        names[key] = getContactMetadata(accountUid, bookmarkAccounts[index]?.data?.metadata, contacts).name
+      } else {
+        const resource = bookmarkRefResources[index]?.data
+        if (resource?.type === 'document') names[key] = getDocumentTitle(resource.document)
+      }
     })
     return names
-  }, [bookmarkRefs, bookmarkRefResources, contacts])
+  }, [bookmarkRefs, bookmarkAccountIds, bookmarkAccounts, bookmarkRefResources, contacts])
 
   const authorHmId = comment.author || authorId ? hmId(authorId || comment.author) : null
   const docId = getCommentTargetId(comment)

--- a/frontend/packages/ui/src/following.tsx
+++ b/frontend/packages/ui/src/following.tsx
@@ -1,4 +1,5 @@
 import {hasProfileSubscription, hmId, useContactListOfAccount, useRouteLink} from '@shm/shared'
+import {useSelectedAccountContacts} from '@shm/shared/models/contacts'
 import {useAccountsMetadata} from '@shm/shared/models/entity'
 import {useMemo} from 'react'
 import {HMIcon} from './hm-icon'
@@ -8,6 +9,7 @@ import {SizableText} from './text'
 /** Shows accounts that this account is following (contacts with profile subscription). */
 export function FollowingContent({siteUid, accountUid}: {siteUid?: string | null; accountUid: string}) {
   const allContacts = useContactListOfAccount(accountUid)
+  const viewerContacts = useSelectedAccountContacts()
   // Filter to only show contacts with profile subscription (explicit or implicit for legacy)
   // Deduplicate by subject (account being followed)
   const following = useMemo(() => {
@@ -45,6 +47,11 @@ export function FollowingContent({siteUid, accountUid}: {siteUid?: string | null
             key={contact.id}
             accountUid={contact.subject}
             metadata={accountData?.metadata}
+            petname={
+              viewerContacts.data?.find(
+                (viewerContact) => viewerContact.subject === contact.subject && hasProfileSubscription(viewerContact),
+              )?.name
+            }
             siteUid={siteUid}
           />
         )
@@ -57,10 +64,12 @@ export function FollowingContent({siteUid, accountUid}: {siteUid?: string | null
 function FollowingItem({
   accountUid,
   metadata,
+  petname,
   siteUid,
 }: {
   accountUid: string
   metadata?: {name?: string; icon?: string} | null
+  petname?: string
   siteUid?: string | null
 }) {
   const linkProps = useRouteLink(
@@ -83,8 +92,13 @@ function FollowingItem({
       <HMIcon id={hmId(accountUid)} size={40} icon={metadata?.icon} name={metadata?.name} />
       <div className="min-w-0 flex-1">
         <SizableText weight="medium" className="truncate">
-          {metadata?.name || 'Untitled'}
+          {petname || metadata?.name || accountUid}
         </SizableText>
+        {petname && petname !== metadata?.name && (
+          <SizableText color="muted" size="sm" className="truncate">
+            {metadata?.name || accountUid}
+          </SizableText>
+        )}
       </div>
     </a>
   )

--- a/frontend/packages/ui/src/profile-name.tsx
+++ b/frontend/packages/ui/src/profile-name.tsx
@@ -1,0 +1,129 @@
+import {Check, Pencil, X} from 'lucide-react'
+import {useEffect, useId, useRef, useState} from 'react'
+import {Button} from './button'
+import {Input} from './components/input'
+
+/** Displays a public profile identity and optionally edits the viewer's published contact name. */
+export function ProfileName({
+  publicName,
+  petname,
+  onSave,
+}: {
+  publicName: string
+  petname?: string
+  onSave?: (name: string) => Promise<void>
+}) {
+  const [editing, setEditing] = useState(false)
+  const [value, setValue] = useState(petname || '')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState(false)
+  const pending = useRef(false)
+  const editButton = useRef<HTMLButtonElement>(null)
+  const descriptionId = useId()
+  const wasEditing = useRef(false)
+  useEffect(() => {
+    if (wasEditing.current && !editing) editButton.current?.focus()
+    wasEditing.current = editing
+  }, [editing])
+  const beginEditing = () => {
+    if (!onSave) return
+    setValue(petname || '')
+    setError(false)
+    setEditing(true)
+  }
+  const close = () => {
+    setEditing(false)
+  }
+  const save = async () => {
+    if (!onSave || pending.current) return
+    pending.current = true
+    setSaving(true)
+    setError(false)
+    try {
+      await onSave(value.trim())
+      close()
+    } catch {
+      setError(true)
+    } finally {
+      pending.current = false
+      setSaving(false)
+    }
+  }
+  return (
+    <div className="flex min-w-0 flex-col gap-1">
+      {editing ? (
+        <>
+          <div className="flex items-center gap-1" aria-busy={saving}>
+            <Input
+              autoFocus
+              aria-label="Contact name"
+              aria-describedby={descriptionId}
+              value={value}
+              placeholder={publicName}
+              disabled={saving}
+              onChangeText={setValue}
+              onKeyDown={(event) => {
+                if (event.nativeEvent.isComposing) return
+                if (event.key === 'Enter') {
+                  event.preventDefault()
+                  void save()
+                } else if (event.key === 'Escape') {
+                  event.preventDefault()
+                  close()
+                }
+              }}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="Save contact name"
+              disabled={saving}
+              loading={saving}
+              onClick={() => void save()}
+            >
+              <Check className="size-4" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="Cancel contact name"
+              disabled={saving}
+              onClick={close}
+            >
+              <X className="size-4" />
+            </Button>
+          </div>
+          <p id={descriptionId} className="text-muted-foreground text-xs">
+            Contact names are published, not private. Leave blank to use the public name.
+          </p>
+          {error && (
+            <p role="alert" className="text-destructive text-sm">
+              Could not save contact name. Try again.
+            </p>
+          )}
+        </>
+      ) : (
+        <div className="flex min-w-0 items-center gap-1">
+          <h1 className="truncate text-2xl font-bold" onDoubleClick={beginEditing}>
+            {petname || publicName}
+          </h1>
+          {onSave && (
+            <Button
+              ref={editButton}
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="Edit contact name"
+              onClick={beginEditing}
+            >
+              <Pencil className="size-4" />
+            </Button>
+          )}
+        </div>
+      )}
+      {petname && petname !== publicName && <p className="text-muted-foreground truncate text-sm">{publicName}</p>}
+    </div>
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1601,6 +1601,9 @@ importers:
       '@unified-latex/unified-latex-util-visit':
         specifier: ^1.8.0
         version: 1.8.3
+      '@xstate/react':
+        specifier: 4.1.3
+        version: 4.1.3(@types/react@18.2.64)(react@18.2.0)(xstate@5.19.2)
       happy-dom:
         specifier: 20.8.9
         version: 20.8.9
@@ -1667,6 +1670,9 @@ importers:
       unist-util-visit:
         specifier: 4.1.2
         version: 4.1.2
+      xstate:
+        specifier: 5.19.2
+        version: 5.19.2
       y-prosemirror:
         specifier: 1.2.1
         version: 1.2.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.3)(y-protocols@1.0.5)(yjs@13.6.4)


### PR DESCRIPTION
## Summary
- Separate account mentions (`@`, profile navigation and visible prefix) from published document mentions (`[[`, latest-version navigation).
- Share relevance ranking across desktop and web: contacts, site context, visits and activity, plus reply-thread participants and author hints. Exclude the selected account from reply suggestions, including account aliases.
- Add profile petname editing and viewer-specific petnames that update in autocomplete and rendered mentions when the selected account changes.
- Improve keyboard/mobile picker behavior and accessible show/hide animations; preserve mention types through editing, serialization and rendering.

The project Markdown writeups are intentionally excluded.

## Validation
- Passed: desktop production packaging (`./dev build-desktop`) and web production build (`pnpm web:prod`).
- Passed: workspace typechecking and whole-workspace formatting.
- Passed: shared (1,263), web (246), UI (497), and notification (96) tests.
- Passed previously: all 7 editor mention browser tests using the harness at http://localhost:5180.
- Desktop: 818 tests passed; the live AI session-titling integration timed out waiting for a generated sidebar title, including on a standalone retry.
- Editor: the full suite still has the previously observed gallery-mount and SSR table-search assertion failures.
- Client: previously observed search-fixture and local-vault environment failures remain.
- Local Agent CI could not start because Docker is unavailable. Dependency audit previously reported 23 vulnerabilities. Full CI is not claimed green.

## Manual smoke test
- In document editors and comment boxes, use `@` to select an account and confirm its mention opens the profile; use `[[` to select a published document and confirm latest-version navigation.
- Reply to a thread: verify author/participant relevance hints, ranking, and exclusion of the selected account.
- Save a contact petname, insert a mention, then switch accounts: verify names reflect each viewer's own contacts without retaining the previous viewer's petname.
- On mobile web and desktop, verify keyboard selection, dismissal, opening/closing motion and reduced-motion behavior.
