### PR TITLE
Fix focused comments hidden during resource discovery

### DIFF
--- a/frontend/packages/ui/src/__tests__/comments.test.tsx
+++ b/frontend/packages/ui/src/__tests__/comments.test.tsx
@@ -17,39 +17,39 @@ const {
   useResourceMock,
   onBookmarkToggleMock,
 } = vi.hoisted(() => {
-    const focusedComment = {
-      id: 'alice/comment',
-      version: 'focused-version',
-      author: 'alice',
-      targetAccount: 'alice',
-      targetPath: 'doc',
-      targetVersion: 'document-version',
-      content: [{block: {id: 'text', type: 'Paragraph', text: 'A comment worth saving'}}],
-      createTime: {seconds: 0, nanos: 0},
-      updateTime: {seconds: 0, nanos: 0},
-      visibility: 'PUBLIC',
-    }
-    const parentComment = {...focusedComment, id: 'alice/parent', version: 'parent-version'}
+  const focusedComment = {
+    id: 'alice/comment',
+    version: 'focused-version',
+    author: 'alice',
+    targetAccount: 'alice',
+    targetPath: 'doc',
+    targetVersion: 'document-version',
+    content: [{block: {id: 'text', type: 'Paragraph', text: 'A comment worth saving'}}],
+    createTime: {seconds: 0, nanos: 0},
+    updateTime: {seconds: 0, nanos: 0},
+    visibility: 'PUBLIC',
+  }
+  const parentComment = {...focusedComment, id: 'alice/parent', version: 'parent-version'}
 
-    return {
-      focusedComment,
-      parentComment,
-      useCommentParentsMock: vi.fn<() => any>(() => null),
-      useDocumentCommentsMock: vi.fn<() => any>(() => ({
-        data: null,
-        error: null,
-        isLoading: true,
-      })),
-      useResourceMock: vi.fn<() => any>(() => ({
-        data: {type: 'comment', comment: focusedComment},
-        error: null,
-        isDiscovering: false,
-        isFetching: false,
-        isLoading: false,
-      })),
-      onBookmarkToggleMock: vi.fn(),
-    }
-  })
+  return {
+    focusedComment,
+    parentComment,
+    useCommentParentsMock: vi.fn<() => any>(() => null),
+    useDocumentCommentsMock: vi.fn<() => any>(() => ({
+      data: null,
+      error: null,
+      isLoading: true,
+    })),
+    useResourceMock: vi.fn<() => any>(() => ({
+      data: {type: 'comment', comment: focusedComment},
+      error: null,
+      isDiscovering: false,
+      isFetching: false,
+      isLoading: false,
+    })),
+    onBookmarkToggleMock: vi.fn(),
+  }
+})
 
 vi.mock('@shm/shared', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@shm/shared')>()

--- a/frontend/packages/ui/src/__tests__/comments.test.tsx
+++ b/frontend/packages/ui/src/__tests__/comments.test.tsx
@@ -9,8 +9,14 @@ import {TooltipProvider} from '../tooltip'
 ;(globalThis as typeof globalThis & {React?: typeof React; IS_REACT_ACT_ENVIRONMENT?: boolean}).React = React
 ;(globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
 
-const {focusedComment, parentComment, useCommentParentsMock, useDocumentCommentsMock, onBookmarkToggleMock} =
-  vi.hoisted(() => {
+const {
+  focusedComment,
+  parentComment,
+  useCommentParentsMock,
+  useDocumentCommentsMock,
+  useResourceMock,
+  onBookmarkToggleMock,
+} = vi.hoisted(() => {
     const focusedComment = {
       id: 'alice/comment',
       version: 'focused-version',
@@ -33,6 +39,13 @@ const {focusedComment, parentComment, useCommentParentsMock, useDocumentComments
         data: null,
         error: null,
         isLoading: true,
+      })),
+      useResourceMock: vi.fn<() => any>(() => ({
+        data: {type: 'comment', comment: focusedComment},
+        error: null,
+        isDiscovering: false,
+        isFetching: false,
+        isLoading: false,
       })),
       onBookmarkToggleMock: vi.fn(),
     }
@@ -72,13 +85,7 @@ vi.mock('@shm/shared/models/entity', () => ({
   useAccount: () => ({data: {metadata: {name: 'Alice'}}}),
   useIsCurrentUser: () => false,
   useResources: () => [],
-  useResource: () => ({
-    data: {type: 'comment', comment: focusedComment},
-    error: null,
-    isDiscovering: false,
-    isFetching: false,
-    isLoading: false,
-  }),
+  useResource: useResourceMock,
 }))
 
 vi.mock('@shm/shared/readonly-viewer-context', () => ({
@@ -134,6 +141,13 @@ afterEach(() => {
   container = null
   useCommentParentsMock.mockReturnValue(null)
   useDocumentCommentsMock.mockReturnValue({data: null, error: null, isLoading: true})
+  useResourceMock.mockReturnValue({
+    data: {type: 'comment', comment: focusedComment},
+    error: null,
+    isDiscovering: false,
+    isFetching: false,
+    isLoading: false,
+  })
   Reflect.deleteProperty(HTMLElement.prototype, 'scrollIntoView')
   vi.useRealTimers()
   onBookmarkToggleMock.mockReset()
@@ -162,6 +176,45 @@ describe('CommentDiscussions', () => {
     act(() => vi.advanceTimersByTime(100))
 
     expect(scrollIntoView).toHaveBeenCalledWith({behavior: 'instant', block: 'start'})
+  })
+
+  it('renders a listed focused comment while its resource fallback is still discovering', () => {
+    useDocumentCommentsMock.mockReturnValue({
+      data: {comments: [focusedComment], authors: {}},
+      error: null,
+      isLoading: false,
+    })
+    useResourceMock.mockReturnValue({
+      data: {type: 'not-found'},
+      error: null,
+      isDiscovering: true,
+      isFetching: true,
+      isLoading: false,
+    })
+
+    renderCommentDiscussions()
+
+    expect(document.body.querySelector('button[aria-label="Add Comment to Bookmarks"]')).not.toBeNull()
+  })
+
+  it('does not render stale fallback data for another comment', () => {
+    useDocumentCommentsMock.mockReturnValue({
+      data: {comments: [], authors: {}},
+      error: null,
+      isLoading: false,
+    })
+    useResourceMock.mockReturnValue({
+      data: {type: 'comment', comment: parentComment},
+      error: null,
+      isDiscovering: false,
+      isFetching: true,
+      isLoading: false,
+      isPreviousData: true,
+    })
+
+    renderCommentDiscussions()
+
+    expect(document.body.querySelector('button[aria-label="Add Comment to Bookmarks"]')).toBeNull()
   })
 
   it('bookmarks a comment snapshot from the comment header', () => {

--- a/frontend/packages/ui/src/comments.tsx
+++ b/frontend/packages/ui/src/comments.tsx
@@ -124,7 +124,9 @@ export function CommentDiscussions({
   const focusedComment = useMemo(() => {
     const listedComment = commentsService.data?.comments?.find((c) => c.id === commentId)
     if (listedComment) return listedComment
-    if (commentResource.data?.type === 'comment') return commentResource.data.comment
+    if (commentResource.data?.type === 'comment' && commentResource.data.comment.id === commentId) {
+      return commentResource.data.comment
+    }
     return null
   }, [commentsService.data?.comments, commentId, commentResource.data])
 
@@ -136,10 +138,11 @@ export function CommentDiscussions({
   // Wait for the resource query to fully settle before deciding deleted/not-found, so we don't
   // flash "This comment was deleted." while peer sync is still in flight (issue #435).
   const isFocusedCommentLoading =
-    commentResource.isFetching ||
-    commentResource.isLoading ||
-    commentResource.isDiscovering ||
-    (!commentResource.data && !commentResource.error)
+    !focusedComment &&
+    (commentResource.isFetching ||
+      commentResource.isLoading ||
+      commentResource.isDiscovering ||
+      (!commentResource.data && !commentResource.error))
   const isFocusedCommentDeleted = commentResource.data?.type === 'tombstone'
   const showDeletedPreview = !!showDeletedContent && isFocusedCommentDeleted && !!deletedLastVersion
   const showDeletedPreviewLoading = !!showDeletedContent && isFocusedCommentDeleted && deletedVersions.isLoading


### PR DESCRIPTION
## Why now

Issue #757 reports broken comment links and edited-comment embeds. On exact packaged desktop baseline `2d8bab5bd`, the copied-style `/:comments/<author>/<tsid>` route reaches the target document and shows a Comments count of 1, but the focused comment body never renders ([reproduction evidence](https://github.com/seed-hypermedia/seed/issues/757#issuecomment-5641520951)).

The document comment list has already resolved the requested comment, while the independent subscribed Resource fallback can remain in desktop peer discovery. `CommentDiscussions` treated that fallback as authoritative loading state and replaced the valid listed comment with a spinner.

## What changed

- Render the exact focused comment as soon as `ListComments` supplies it, without waiting for the fallback Resource query.
- Accept fallback comment data only when its ID matches the requested comment, preventing React Query's retained previous data from rendering comment A at comment B's route.
- Add focused regressions for both discovery and stale fallback data.

## Why this approach

The route parser, route state, and document comment loader are already correct—the reproduced panel count proves the list data arrived. Changing routing or cache keys would broaden risk without addressing the conflicting loading sources. The repair instead makes the existing list result authoritative and retains Resource discovery only as a fallback for comments absent from the list. Tombstone/deleted-preview behavior is unchanged.

## Validation

- New regression failed on unmodified baseline: 1 failed, 5 passed.
- Focused UI suite after repair: 7/7 passed.
- `git diff --check` passed.
- UI package typecheck was attempted locally but exceeded the 512 MiB executor limit (Node OOM at 256 MiB; process killed at 420 MiB). CI remains required for full type validation.

Packaged acceptance must be rerun unchanged at this PR head before the bug is called verified.

## Follow-up

Rerun the exact packaged desktop acceptance and evaluate web behavior. No workaround or removal condition is introduced; this preserves Resource lookup as the fallback path.


### Packaged verification

`VERIFIED` on the exact PR head `43d0646cc9438b17b6f069ac45fe33680b125960` using the packaged Electron app from [fork-safe artifact run 34665869969](https://github.com/ion-lion/seed/actions/runs/34665869969). The isolated fixture preflight returned HTTP 200 for the home document, target document, and edited comment. The exact `/:comments/<author>/<tsid>` route rendered the edited focused-comment body in the first post-navigation sample, and the titlebar displayed that exact comment route.

Artifact SHA-256: `b952f565ca90908ce00b571c260a333c3e5621aa588d7ecb7d3e12855a0de817`; verification summary SHA-256: `7c896624da511a4c8b5bdb01d43ea3033d1af7e0203528aaec0d626df1e7b827`. A subsequent Playwright `Control+L` probe timed out after the product assertion had passed; this is recorded as harness noise rather than evidence against the focused-comment repair.
