### PR TITLE
Prevent failed discovery from growing scope index

### DIFF
--- a/backend/hmnet/syncing/rbsr_index.go
+++ b/backend/hmnet/syncing/rbsr_index.go
@@ -233,6 +233,16 @@ func loadIndexedScopes(ctx context.Context, db *sqlitex.Pool, dkeys colx.HashSet
 					if err := materializeScope(conn, id, dkey); err != nil {
 						return err
 					}
+					shouldKeep, err := scopeHasItemsOrResource(conn, id, dkey)
+					if err != nil {
+						return err
+					}
+					if !shouldKeep {
+						if err := sqlitex.Exec(conn, qDeleteScope(), nil, id); err != nil {
+							return err
+						}
+						continue
+					}
 				}
 				scopeIDs = append(scopeIDs, id)
 			}
@@ -319,8 +329,22 @@ const qMaterializeReplace = `
 
 var qMaterializeClear = dqb.Str(`DELETE FROM rbsr_item WHERE scope = :scope;`)
 
+var qScopeHasItemsOrResource = dqb.Str(`SELECT
+	EXISTS(SELECT 1 FROM rbsr_item WHERE scope = :scope)
+	OR EXISTS(SELECT 1 FROM resources WHERE iri = :iri);`)
+
+var qDeleteScope = dqb.Str(`DELETE FROM rbsr_scope WHERE id = :scope;`)
+
 var qMarkMaterialized = dqb.Str(`
 	UPDATE rbsr_scope SET materialized = 1, last_access = :now WHERE id = :scope;`)
+
+func scopeHasItemsOrResource(conn *sqlite.Conn, scopeID int64, dkey DiscoveryKey) (keep bool, err error) {
+	err = sqlitex.Exec(conn, qScopeHasItemsOrResource(), func(stmt *sqlite.Stmt) error {
+		keep = stmt.ColumnInt64(0) != 0
+		return nil
+	}, scopeID, string(dkey.IRI))
+	return keep, err
+}
 
 // materializeScope (re)builds a scope's persisted blob set from collectBlobs —
 // the one place the expensive closure runs. Idempotent: it clears and refills

--- a/backend/hmnet/syncing/rbsr_index_test.go
+++ b/backend/hmnet/syncing/rbsr_index_test.go
@@ -144,6 +144,62 @@ func TestRbsrIndex_ResolveScopeIdempotent(t *testing.T) {
 	}))
 }
 
+func TestLoadIndexedScopes_DropsEmptyScopes(t *testing.T) {
+	t.Parallel()
+	db, base := oracleFixture(t)
+	ctx := context.Background()
+	missing := DiscoveryKey{IRI: blob.IRI(base + "/does-not-exist"), Recursive: true}
+
+	var previousSequence int64
+	for range 2 {
+		store := newAuthorizedTreeStore()
+		_, err := loadIndexedScopes(ctx, db, colx.HashSet[DiscoveryKey]{missing: {}}, store)
+		require.NoError(t, err)
+		require.NoError(t, store.Seal())
+		require.Zero(t, store.Size())
+
+		var scopes int
+		var sequence int64
+		require.NoError(t, db.WithSave(ctx, func(conn *sqlite.Conn) error {
+			if err := sqlitex.Exec(conn, `SELECT COUNT(*) FROM rbsr_scope WHERE iri = ?`, func(stmt *sqlite.Stmt) error {
+				scopes = stmt.ColumnInt(0)
+				return nil
+			}, string(missing.IRI)); err != nil {
+				return err
+			}
+			return sqlitex.Exec(conn, `SELECT seq FROM sqlite_sequence WHERE name = 'rbsr_scope'`, func(stmt *sqlite.Stmt) error {
+				sequence = stmt.ColumnInt64(0)
+				return nil
+			})
+		}))
+		require.Zero(t, scopes, "empty discovery scopes must not persist")
+		require.Greater(t, sequence, previousSequence, "deleted scope IDs must not be reused")
+		previousSequence = sequence
+	}
+}
+
+func TestLoadIndexedScopes_KeepsKnownEmptyResource(t *testing.T) {
+	t.Parallel()
+	db, base := oracleFixture(t)
+	ctx := context.Background()
+	known := DiscoveryKey{IRI: blob.IRI(base + "/known-empty"), Recursive: true}
+
+	require.NoError(t, db.WithTx(ctx, func(conn *sqlite.Conn) error {
+		return sqlitex.Exec(conn, `INSERT INTO resources (iri) VALUES (?)`, nil, string(known.IRI))
+	}))
+	_, err := loadIndexedScopes(ctx, db, colx.HashSet[DiscoveryKey]{known: {}}, newAuthorizedTreeStore())
+	require.NoError(t, err)
+
+	var scopes int
+	require.NoError(t, db.WithSave(ctx, func(conn *sqlite.Conn) error {
+		return sqlitex.Exec(conn, `SELECT COUNT(*) FROM rbsr_scope WHERE iri = ? AND materialized = 1`, func(stmt *sqlite.Stmt) error {
+			scopes = stmt.ColumnInt(0)
+			return nil
+		}, string(known.IRI))
+	}))
+	require.Equal(t, 1, scopes, "known resources remain indexed even before they have eligible blobs")
+}
+
 // TestLoadIndexedScopes_ClientPathMatchesLegacy covers the client store build:
 // the shared three-phase load must produce the same store as the legacy
 // per-call rebuild — both on the cold (materializing) first call and the warm

--- a/backend/storage/schema.sql
+++ b/backend/storage/schema.sql
@@ -519,7 +519,9 @@ CREATE TABLE embeddings_index (
 -- rbsr_item holds the resolved blob set for the scope, maintained incrementally
 -- by the syncing oracle so reconciliation no longer rebuilds the set per round.
 CREATE TABLE rbsr_scope (
-    id INTEGER PRIMARY KEY,
+    -- AUTOINCREMENT prevents a deleted empty scope ID from being reused while
+    -- an in-flight reader or verifier still holds that numeric identity.
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
     -- The discovery key's resource IRI.
     iri TEXT NOT NULL,
     -- Reconciliation scope kind: 0=exact (IRI only), 1=depth_one (direct

--- a/backend/storage/storage_migrations.go
+++ b/backend/storage/storage_migrations.go
@@ -63,6 +63,30 @@ type migration struct {
 //
 // In case of even the most minor doubts, consult with the team before adding a new migration, and submit the code to review if needed.
 var migrations = []migration{
+	// Rebuild the derived RBSR index with non-reusable scope IDs. Empty scopes
+	// can now be discarded after a failed/nonexistent discovery without letting
+	// an in-flight reader mistake a later row for the deleted scope. Rebuilding
+	// also removes empty rows accumulated before that cleanup existed.
+	{Version: "2026-09-12.040000", Run: func(_ *Store, conn *sqlite.Conn) error {
+		return sqlitex.ExecScript(conn, sqlfmt(`
+			DROP TABLE IF EXISTS rbsr_item;
+			DROP TABLE IF EXISTS rbsr_scope;
+			CREATE TABLE rbsr_scope (
+			    id INTEGER PRIMARY KEY AUTOINCREMENT,
+			    iri TEXT NOT NULL,
+			    kind INTEGER NOT NULL,
+			    materialized INTEGER NOT NULL DEFAULT 0,
+			    last_access INTEGER NOT NULL DEFAULT 0,
+			    UNIQUE (iri, kind)
+			);
+			CREATE TABLE rbsr_item (
+			    scope INTEGER NOT NULL REFERENCES rbsr_scope (id) ON UPDATE CASCADE ON DELETE CASCADE,
+			    blob INTEGER NOT NULL REFERENCES blobs (id) ON UPDATE CASCADE ON DELETE CASCADE,
+			    PRIMARY KEY (scope, blob)
+			) WITHOUT ROWID;
+			CREATE INDEX rbsr_item_by_blob ON rbsr_item (blob);
+		`))
+	}},
 	// Add independently backfilled summaries of references in published
 	// document content. This is intentionally additive and does not schedule a
 	// full blob reindex; the bounded document-fields worker populates it.


### PR DESCRIPTION
## Why now

Issue #957 shows that each syntactically valid nonexistent discovery path can leave a durable `rbsr_scope` row. The public discovery API accepts remote-only resources by design, so rejecting unknown IRIs before synchronization would break legitimate discovery. With scope eviction currently disabled, arbitrary unique paths can otherwise grow the derived index without bound.

Closes #957.

## What changed

After cold materialization, the maintained index now discards a scope only when it has neither eligible `rbsr_item` rows nor a locally known resource. Known-but-empty resources remain indexed so incremental maintenance can populate them when blobs arrive.

The RBSR tables are derived, so a migration rebuilds them and clears already-accumulated empty rows. Scope IDs now use SQLite `AUTOINCREMENT`; this prevents a deleted ID from being reassigned while an in-flight reader or shadow verifier still carries that numeric identity.

## Why this approach

- An API-level existence check was rejected because remote-only resources must remain discoverable.
- Deleting every empty scope was rejected because known resources can legitimately have no currently eligible/downloaded blobs and still need incremental maintenance.
- Plain row deletion with `INTEGER PRIMARY KEY` was rejected because SQLite may reuse the deleted maximum ID, racing code that carries scope IDs across transactions.
- The migration rebuild is appropriate because both RBSR tables are derived and lazily rematerialized; it also removes historical pollution without a separate cleanup scan.

## Validation

- Regression on unmodified main `4b356bfb29a801a6ad310e16942e3f1dc72a66fd`: `TestLoadIndexedScopes_DropsEmptyScopes` fails because one empty row persists.
- Focused fixed tests pass, including repeated missing-path retries, non-reused IDs, known-empty resource retention, and legacy-store parity.
- `go test -vet=off -p 1 ./backend/hmnet/syncing -count=1` passes.
- `go test -vet=off -p 1 ./backend/storage -count=1` passes, including snapshot migration parity.
- `git diff --check` passes.

`./dev gen //backend/...` could not run in this executor because the checkout lacks the repository's required direnv/Please environment. Draft CI remains the authoritative generated-code and complete backend check.

## Follow-up

Request rate limiting can independently bound CPU/network work before materialization. It is not required to stop durable empty-row growth and should be evaluated separately rather than coupling API admission policy to this derived-index fix.
