### PR TITLE
Fix duplicate comment mention notifications

### DIFF
--- a/frontend/apps/notify/app/email-notifier.test.ts
+++ b/frontend/apps/notify/app/email-notifier.test.ts
@@ -4,7 +4,9 @@ import {Code, ConnectError} from '@connectrpc/connect'
 import type {HMBlockNode} from '@seed-hypermedia/client/hm-types'
 import type {Event} from '@shm/shared'
 import {
+  getDedicatedCommentMentionTargets,
   getEventId,
+  hasDedicatedCommentMentionEvent,
   getMentionsOfDocument,
   isNotificationEventTooOld,
   isTransientGrpcUnavailableError,
@@ -55,11 +57,13 @@ function createMentionEvent(
     sourceCid?: string | undefined
     target?: string | undefined
     mentionType?: string | undefined
+    sourceType?: string | undefined
   } = {},
 ): PlainMessage<Event> {
   const sourceCid = 'sourceCid' in input ? input.sourceCid : TEST_CID_1
   const target = 'target' in input ? input.target : `hm://${TEST_ACCOUNT}`
   const mentionType = 'mentionType' in input ? input.mentionType : ''
+  const sourceType = 'sourceType' in input ? input.sourceType : 'doc/Embed'
   const sourceBlob: any = {
     author: TEST_ACCOUNT,
     createTime: toTimestamp(Date.UTC(2026, 0, 1, 12, 0, 0)),
@@ -67,7 +71,7 @@ function createMentionEvent(
   if (sourceCid !== undefined) sourceBlob.cid = sourceCid
   const value: any = {
     source: `hm://${TEST_ACCOUNT}`,
-    sourceType: 'doc/Embed',
+    sourceType,
     sourceContext: 'block-1',
     sourceBlob,
     isExactVersion: false,
@@ -88,6 +92,39 @@ function createMentionEvent(
     observeTime: toTimestamp(Date.UTC(2026, 0, 1, 12, 0, 0)) as PlainMessage<Event>['observeTime'],
   }
 }
+
+describe('getDedicatedCommentMentionTargets', () => {
+  it('maps comment mention events by source blob and account target', () => {
+    const commentMention = createMentionEvent({
+      sourceCid: TEST_CID_1,
+      target: `hm://${TEST_ACCOUNT}/:profile`,
+      sourceType: 'comment/Embed',
+    })
+    const documentMention = createMentionEvent({
+      sourceCid: TEST_CID_2,
+      target: `hm://${TEST_ACCOUNT}`,
+      sourceType: 'doc/Embed',
+    })
+
+    expect(getDedicatedCommentMentionTargets([commentMention, documentMention])).toEqual(
+      new Map([[TEST_CID_1, new Set([TEST_ACCOUNT])]]),
+    )
+  })
+})
+
+describe('hasDedicatedCommentMentionEvent', () => {
+  const targets = new Map([[TEST_CID_1, new Set([TEST_ACCOUNT])]])
+
+  it('defers only recipients covered by both comment content and a companion event', () => {
+    expect(hasDedicatedCommentMentionEvent(new Set([TEST_ACCOUNT]), targets, TEST_CID_1, TEST_ACCOUNT)).toBe(true)
+    expect(hasDedicatedCommentMentionEvent(new Set(['other-account']), targets, TEST_CID_1, TEST_ACCOUNT)).toBe(false)
+    expect(hasDedicatedCommentMentionEvent(new Set([TEST_ACCOUNT]), targets, TEST_CID_1, 'other-account')).toBe(false)
+  })
+
+  it('does not defer an account-home document citation excluded from body mentions', () => {
+    expect(hasDedicatedCommentMentionEvent(new Set(), targets, TEST_CID_1, TEST_ACCOUNT)).toBe(false)
+  })
+})
 
 describe('isNotificationEventTooOld', () => {
   it('accepts events seen within the last hour', () => {

--- a/frontend/apps/notify/app/email-notifier.ts
+++ b/frontend/apps/notify/app/email-notifier.ts
@@ -1222,7 +1222,7 @@ async function evaluateEventForNotifications(
       threadRoot: comment.threadRoot ?? null,
     })
     await evaluateNewCommentForNotifications(comment, allSubscriptions, appendNotification, eventMeta, {
-      blobCid,
+      blobCid: blobCid ?? undefined,
       dedicatedCommentMentionTargets: options.dedicatedCommentMentionTargets,
     })
   }

--- a/frontend/apps/notify/app/email-notifier.ts
+++ b/frontend/apps/notify/app/email-notifier.ts
@@ -606,12 +606,7 @@ async function collectNotificationsForEvents({
     })
   }
 
-  const mentionSourceBlobCids = new Set<string>()
-  for (const event of events) {
-    if (event.data.case !== 'newMention') continue
-    const sourceBlobCid = normalizeCidString(event.data.value?.sourceBlob?.cid)
-    if (sourceBlobCid) mentionSourceBlobCids.add(sourceBlobCid)
-  }
+  const dedicatedCommentMentionTargets = getDedicatedCommentMentionTargets(events)
 
   logNotifDebug('notification evaluation start', {
     eventCount: events.length,
@@ -644,7 +639,9 @@ async function collectNotificationsForEvents({
     }
     const notificationCountBefore = Object.values(notificationsToSend).reduce((count, items) => count + items.length, 0)
     try {
-      await evaluateEventForNotifications(event, subscriptions, appendNotification, {mentionSourceBlobCids})
+      await evaluateEventForNotifications(event, subscriptions, appendNotification, {
+        dedicatedCommentMentionTargets,
+      })
     } catch (error: any) {
       reportError('Error evaluating event for notifications: ' + error.message)
     }
@@ -1078,6 +1075,34 @@ function getEventAtMs(event: PlainMessage<Event>): number {
   return Date.now()
 }
 
+export function hasDedicatedCommentMentionEvent(
+  mentionedAccountUids: Set<string>,
+  targetsBySourceCid: Map<string, Set<string>>,
+  sourceCid: string | undefined,
+  accountUid: string,
+): boolean {
+  return Boolean(
+    mentionedAccountUids.has(accountUid) && sourceCid && targetsBySourceCid.get(sourceCid)?.has(accountUid),
+  )
+}
+
+/** Maps each comment blob to accounts whose dedicated mention event owns delivery. */
+export function getDedicatedCommentMentionTargets(events: PlainMessage<Event>[]): Map<string, Set<string>> {
+  const targetsBySourceCid = new Map<string, Set<string>>()
+  for (const event of events) {
+    if (event.data.case !== 'newMention') continue
+    const mention = event.data.value
+    if (!mention?.sourceType?.startsWith('comment/')) continue
+    const sourceCid = normalizeCidString(mention.sourceBlob?.cid)
+    const targetAccountUid = getMentionedAccountUid(mention.target)
+    if (!sourceCid || !targetAccountUid) continue
+    const targets = targetsBySourceCid.get(sourceCid) ?? new Set<string>()
+    targets.add(targetAccountUid)
+    targetsBySourceCid.set(sourceCid, targets)
+  }
+  return targetsBySourceCid
+}
+
 /**
  * Returns whether an event falls outside the notification replay window.
  */
@@ -1089,7 +1114,7 @@ async function evaluateEventForNotifications(
   event: PlainMessage<Event>,
   allSubscriptions: NotificationSubscription[],
   appendNotification: (subscription: NotificationSubscription, notif: Notification) => Promise<void>,
-  options: {mentionSourceBlobCids: Set<string>},
+  options: {dedicatedCommentMentionTargets: Map<string, Set<string>>},
 ) {
   const eventTime = normalizeDate(event.eventTime)
   const observeTime = normalizeDate(event.observeTime)
@@ -1185,7 +1210,6 @@ async function evaluateEventForNotifications(
     const rawComment = toPlainMessage(serverComment)
     const comment = HMCommentSchema.parse(rawComment)
     const blobCid = normalizeCidString(blob.cid)
-    const includeMentionsFromBody = !blobCid || !options.mentionSourceBlobCids.has(blobCid)
     logNotifVerbose('comment blob loaded', {
       eventId: eventMeta.eventId,
       eventAtMs: eventMeta.eventAtMs,
@@ -1196,10 +1220,10 @@ async function evaluateEventForNotifications(
       targetPath: comment.targetPath ?? null,
       replyParent: comment.replyParent ?? null,
       threadRoot: comment.threadRoot ?? null,
-      includeMentionsFromBody,
     })
     await evaluateNewCommentForNotifications(comment, allSubscriptions, appendNotification, eventMeta, {
-      includeMentionsFromBody,
+      blobCid,
+      dedicatedCommentMentionTargets: options.dedicatedCommentMentionTargets,
     })
   }
 }
@@ -1556,7 +1580,10 @@ async function evaluateNewCommentForNotifications(
   allSubscriptions: NotificationSubscription[],
   appendNotification: (subscription: NotificationSubscription, notif: Notification) => Promise<void>,
   eventMeta: NotificationEventMeta,
-  options: {includeMentionsFromBody: boolean},
+  options: {
+    blobCid: string | undefined
+    dedicatedCommentMentionTargets: Map<string, Set<string>>
+  },
 ) {
   logNotifDebug('evaluate comment notification', {
     eventId: eventMeta.eventId,
@@ -1564,7 +1591,6 @@ async function evaluateNewCommentForNotifications(
     commentAuthor: comment.author,
     targetAccount: comment.targetAccount,
     hasReplyParent: Boolean(comment.replyParent),
-    includeMentionsFromBody: options.includeMentionsFromBody,
   })
   const parentStartTime = Date.now()
   const parentComments = await getParentComments(comment)
@@ -1641,9 +1667,7 @@ async function evaluateNewCommentForNotifications(
   })
 
   // Get all mentioned users in this comment
-  const mentionedUsers = options.includeMentionsFromBody
-    ? extractMentionedAccountUidsFromComment(comment)
-    : new Set<string>()
+  const mentionedUsers = extractMentionedAccountUidsFromComment(comment)
   const resolvedNames = await resolveContentReferenceNames(comment.content)
 
   // Get the parent comment author for reply notifications
@@ -1685,6 +1709,12 @@ async function evaluateNewCommentForNotifications(
       isTopLevelComment: !comment.threadRoot,
       parentCommentAuthorUid: parentCommentAuthor,
       mentionedAccountUids: mentionedUsers,
+      hasDedicatedMentionEvent: hasDedicatedCommentMentionEvent(
+        mentionedUsers,
+        options.dedicatedCommentMentionTargets,
+        options.blobCid,
+        sub.id,
+      ),
     })
 
     logNotifVerbose('comment notification candidate evaluated', {

--- a/frontend/packages/shared/src/models/__tests__/notification-event-classifier.test.ts
+++ b/frontend/packages/shared/src/models/__tests__/notification-event-classifier.test.ts
@@ -47,6 +47,20 @@ describe('classifyCommentNotificationForAccount', () => {
     expect(reason).toBe('discussion')
   })
 
+  it('defers a covered comment mention to its dedicated mention event', () => {
+    const reason = classifyCommentNotificationForAccount({
+      subscriptionAccountUid: 'alice',
+      commentAuthorUid: 'bob',
+      targetAccountUid: 'alice',
+      targetAuthorUids: ['alice'],
+      isTopLevelComment: true,
+      parentCommentAuthorUid: null,
+      mentionedAccountUids: new Set(['alice']),
+      hasDedicatedMentionEvent: true,
+    })
+    expect(reason).toBeNull()
+  })
+
   it('classifies top-level comments on collaborated documents as discussion', () => {
     const reason = classifyCommentNotificationForAccount({
       subscriptionAccountUid: 'alice',

--- a/frontend/packages/shared/src/models/notification-event-classifier.ts
+++ b/frontend/packages/shared/src/models/notification-event-classifier.ts
@@ -71,9 +71,10 @@ export function classifyCommentNotificationForAccount(input: {
   isTopLevelComment: boolean
   parentCommentAuthorUid: string | null | undefined
   mentionedAccountUids: Set<string>
+  hasDedicatedMentionEvent?: boolean
 }): NotificationReason | null {
   const isSelfAuthored = input.commentAuthorUid === input.subscriptionAccountUid
-  if (isSelfAuthored) return null
+  if (isSelfAuthored || input.hasDedicatedMentionEvent) return null
   if (input.parentCommentAuthorUid === input.subscriptionAccountUid) return 'reply'
   const isTargetAuthor = Boolean(input.targetAuthorUids?.includes(input.subscriptionAccountUid))
   if (input.isTopLevelComment && (input.targetAccountUid === input.subscriptionAccountUid || isTargetAuthor)) {


### PR DESCRIPTION
## Why now

Issue #703, reported on 2026-06-01, identifies a user-visible delivery gap rather than a new regression: a comment that mentions the document author can generate two notifications. Current activity construction intentionally emits both the comment blob and a companion `newMention` event. The notifier already used same-batch source-CID detection to avoid extracting the body mention twice, but normal comment precedence still classified the blob as a discussion/reply for the owner or parent author, while the companion event separately classified as a mention.

## What changed

- Map dedicated `comment/*` mention events by source comment CID and recipient account.
- Defer the comment-blob notification only when that exact recipient is both mentioned in the parsed comment body and covered by a companion mention event.
- Keep fallback body classification for recipients/events without a companion mention, and preserve document citations (including account-home document citations).

## Why this approach

Deduplicating only by feed event ID cannot work because the blob and mention are intentionally distinct events, and it would still send duplicate immediate emails. Globally suppressing comment-blob mentions would lose compatibility when a companion event is absent. Recipient-specific precedence preserves those fallbacks while making the dedicated event authoritative for the overlapping logical mention.

## Validation

- Baseline focused regression: 1 failed / 12 passed (`discussion` returned where the companion mention should own delivery).
- Exact-head focused tests: 27/27 passed across notifier event mapping/precedence and shared comment classification.
- Exact-head CI at `e37299ec2`: Typecheck, Lint, web/shared/desktop units, editor E2E, and aggregate checks passed: https://github.com/seed-hypermedia/seed/actions/runs/34703819761
- Prettier and `git diff --check` pass.

## Follow-up / removal condition

The source-CID fallback can be simplified only if the activity API guarantees and tests atomic delivery of each comment blob with all companion mention events. Until then, retain body-based fallback for uncovered recipients.

Closes #703
