### PR TITLE
fix(desktop): hide private docs from unrelated selected accounts

### DIFF
--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -45,6 +45,7 @@ import {useHackyAuthorsSubscriptions} from '@/use-hacky-authors-subscriptions'
 import {convertBlocksToMarkdown} from '@/utils/blocks-to-markdown'
 import {getPublishedResourceIdForDraftRoute} from '@/utils/draft-route'
 import {fileUpload} from '@/utils/file-upload'
+import {isPrivateDocumentDenied} from '@/utils/private-document-access'
 import {useNavigate} from '@/utils/useNavigate'
 import {useBroadcastWindowEvent, useListenAppEvent} from '@/utils/window-events'
 import {
@@ -1256,6 +1257,7 @@ export default function DesktopResourcePage() {
                     docId={docId}
                     resourceId={documentResourceId}
                     canEdit={canEdit}
+                    accessDenied={isPrivateDocumentDenied(doc?.visibility, canEdit)}
                     CommentEditor={CommentBox}
                     optionsMenuItems={menuItems}
                     fileBrowserCreateMenuItem={fileBrowserCreateMenuItem}

--- a/frontend/apps/desktop/src/utils/__tests__/private-document-access.test.ts
+++ b/frontend/apps/desktop/src/utils/__tests__/private-document-access.test.ts
@@ -1,0 +1,14 @@
+import {describe, expect, it} from 'vitest'
+import {isPrivateDocumentDenied} from '../private-document-access'
+
+describe('isPrivateDocumentDenied', () => {
+  it('denies private content without selected-account access', () => {
+    expect(isPrivateDocumentDenied('PRIVATE', false)).toBe(true)
+  })
+  it('allows private content for an owner or collaborator', () => {
+    expect(isPrivateDocumentDenied('PRIVATE', true)).toBe(false)
+  })
+  it('never hides public content', () => {
+    expect(isPrivateDocumentDenied('PUBLIC', false)).toBe(false)
+  })
+})

--- a/frontend/apps/desktop/src/utils/private-document-access.ts
+++ b/frontend/apps/desktop/src/utils/private-document-access.ts
@@ -1,0 +1,6 @@
+import type {HMDocument} from '@seed-hypermedia/client/hm-types'
+
+/** Fail closed in desktop when the selected identity cannot act on a private document. */
+export function isPrivateDocumentDenied(visibility: HMDocument['visibility'] | undefined, canEdit: boolean) {
+  return visibility === 'PRIVATE' && !canEdit
+}

--- a/frontend/packages/ui/src/resource-page-common.tsx
+++ b/frontend/packages/ui/src/resource-page-common.tsx
@@ -846,6 +846,8 @@ export interface ResourcePageProps {
   inlineInsert?: ReactNode
   /** Whether the current user can edit this document (drives the state machine guard). */
   canEdit?: boolean
+  /** Force the private-document permission state even when the local data service can read the resource. */
+  accessDenied?: boolean
   /** Optional provided machine (with actors) for desktop editing support. */
   machine?: typeof documentMachine
   /** Optional XState inspect callback for debugging. Gated by developerTools flag. */
@@ -929,6 +931,7 @@ export function ResourcePage({
   onFollowClick,
   inlineInsert,
   canEdit = false,
+  accessDenied = false,
   machine,
   inspect,
   inspectStore,
@@ -1170,7 +1173,7 @@ export function ResourcePage({
   }
 
   // Handle private document (permission denied) — persistent state, always unmount.
-  if (resource.data?.type === 'error' && resource.data.message.toLowerCase().includes('permission')) {
+  if (accessDenied || (resource.data?.type === 'error' && resource.data.message.toLowerCase().includes('permission'))) {
     return (
       <PageWrapper
         siteHomeId={siteHomeId}


### PR DESCRIPTION
## Why now

Fixes #664.

The reported sequence is local and account-relative: account A owns an unshared private document, then selecting account B still leaves A's content visible. Exact-main packaged Electron (`4b356bfb29a801a6ad310e16942e3f1dc72a66fd`) reproduces that sequence with a signer-valid legacy private Ref: after switching A → B, `ISSUE_664_A_PRIVATE_MARKER` remains rendered.

Private creation is currently disabled by containment commit [`0f897c776`](https://github.com/seed-hypermedia/seed/commit/0f897c776f2611fd9a95fd983f6db158b9d1053f), but existing private documents remain readable by the trusted local daemon. The exact source/decision analysis is recorded in [the issue](https://github.com/seed-hypermedia/seed/issues/664#issuecomment-5648279107).

## What changed

- Desktop now maps a private document that the selected identity cannot edit to the existing `Private Document` permission state.
- The guard is evaluated on every selected-identity change, so already-rendered private content is unmounted when switching accounts.
- The shared resource page accepts an explicit platform access-denied signal; web behavior and daemon behavior are unchanged.

## Why this approach

Desktop's selected identity is presentation/authoring state; it is not sent as an authenticated daemon reader and is absent from Resource query keys. Changing daemon authorization here would require a broader security model across local RPC authentication, listings, direct fetches, redirects/comments, blobs, and caches.

The issue explicitly describes confusing UI on a node already trusted as A rather than a node-boundary disclosure, so this draft implements the narrow UI-containment interpretation. It reuses the same owner/writer capability decision already used for editing: owners and invited collaborators retain access, while unrelated selected accounts fail closed. Reusing `PagePrivate` also keeps direct document routes from leaking already-loaded content.

## Validation

- **Baseline:** `REPRODUCED` in packaged Electron from exact main `4b356bfb`; A's private marker remained visible after the account switch to B. Trace, screenshot, fixture response, package checksum, and console/request diagnostics are retained in Ion's issue artifact directory.
- `vitest ... private-document-access.test.ts --environment node --pool=threads`: **3/3 passed**.
- Exact-head frontend CI is fully green at `8c535448a` (Typecheck, Lint, web/shared/desktop units, editor E2E, aggregate).
- **Packaged Electron:** `VERIFIED` from exact-head package [run `34718178644`](https://github.com/ion-lion/seed/actions/runs/34718178644). The unchanged acceptance (SHA-256 `389fa243…`) rendered the marker for A, removed it after switching to B, and rendered `Private Document`. Verification summary SHA-256: `4d699888…`.

## Follow-up / removal condition

If Seed later promotes selected identity to an authenticated daemon reader principal, this desktop override should be removed in favor of authoritative permission errors from the daemon after equivalent direct-route and listing coverage exists. Listing/search suppression beyond the current selected document remains a separate scope decision if the issue reporter expects it.