### PR TITLE
Fix desktop back navigation after first publish

### DIFF
--- a/frontend/apps/desktop/src/pages/desktop-resource.tsx
+++ b/frontend/apps/desktop/src/pages/desktop-resource.tsx
@@ -617,8 +617,6 @@ export default function DesktopResourcePage() {
 
   // Create publishDocument actor that uses the stored publish mutation ref.
   // Account UID flows through machine context → actor input (no closure deps).
-  const navigateRef = useRef(navigate)
-  navigateRef.current = navigate
   const broadcastWindowEvent = useBroadcastWindowEvent()
   const broadcastWindowEventRef = useRef(broadcastWindowEvent)
   broadcastWindowEventRef.current = broadcastWindowEvent
@@ -691,7 +689,8 @@ export default function DesktopResourcePage() {
         // navigate this window to the new URL and broadcast the change so any
         // other window stuck on the old draft URL can react.
         if (pathChanged) {
-          navigateRef.current({key: 'document', id: newRouteId})
+          // Replace the temporary draft route so Back cannot revisit a deleted draft.
+          replaceRouteRef.current({key: 'document', id: newRouteId} as any)
           broadcastWindowEventRef.current({
             type: 'document_path_changed',
             oldId: oldRouteId.id,


### PR DESCRIPTION
## Why now
Seed issue #598 reports that after publishing a new desktop document, Back returns to the deleted draft's temporary route. Exact current main `4b356bfb2` reproduces this in packaged Electron: first publish changes `/-<draft-id>` to the slug, but Back restores the placeholder and `New Document` editor state.

The unified editor already computes the real published route. Its first-publish callback pushed that route, leaving the temporary entry beneath it; the legacy publish flow and cross-window rename handler already use replacement.

## What changed
Replace the current unified-editor route when first publish changes the document path, rather than pushing the published route. This removes the obsolete draft entry while preserving the route before document creation as the Back destination.

## Why this approach
Changing the navigation reducer would affect every route transition. Deleting drafts later or masking Not Found would retain a semantically invalid history entry. Reusing the existing replace navigation is the narrow fix and matches the legacy flow.

## Validation
- Packaged exact-main Electron reproduction: https://github.com/ion-lion/seed/actions/runs/34736620180
- Baseline source manifest verified; artifact SHA-256 `c2b137728a98704c8feaad4339073127d5944b5dd1c97779608e441395476d3a`
- `git diff --check` passes.
- Local desktop TypeScript validation exceeded the 512 MiB executor; exact-head CI and packaged acceptance are pending.

## Follow-up
Run the unchanged Electron acceptance on the exact fix SHA. The acceptance requires Back to return to the pre-creation document route, never the temporary `/-<draft-id>` route.